### PR TITLE
[reggen] Generate a single we/re signal per register in reg_top

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -104,184 +104,149 @@ module adc_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_qs;
   logic intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
-  logic intr_enable_we;
-  logic intr_test_wd;
   logic intr_test_we;
-  logic alert_test_wd;
+  logic intr_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic adc_en_ctl_we;
   logic adc_en_ctl_adc_enable_qs;
   logic adc_en_ctl_adc_enable_wd;
-  logic adc_en_ctl_adc_enable_we;
   logic adc_en_ctl_oneshot_mode_qs;
   logic adc_en_ctl_oneshot_mode_wd;
-  logic adc_en_ctl_oneshot_mode_we;
+  logic adc_pd_ctl_we;
   logic adc_pd_ctl_lp_mode_qs;
   logic adc_pd_ctl_lp_mode_wd;
-  logic adc_pd_ctl_lp_mode_we;
   logic [3:0] adc_pd_ctl_pwrup_time_qs;
   logic [3:0] adc_pd_ctl_pwrup_time_wd;
-  logic adc_pd_ctl_pwrup_time_we;
   logic [23:0] adc_pd_ctl_wakeup_time_qs;
   logic [23:0] adc_pd_ctl_wakeup_time_wd;
-  logic adc_pd_ctl_wakeup_time_we;
+  logic adc_lp_sample_ctl_we;
   logic [7:0] adc_lp_sample_ctl_qs;
   logic [7:0] adc_lp_sample_ctl_wd;
-  logic adc_lp_sample_ctl_we;
+  logic adc_sample_ctl_we;
   logic [15:0] adc_sample_ctl_qs;
   logic [15:0] adc_sample_ctl_wd;
-  logic adc_sample_ctl_we;
+  logic adc_fsm_rst_we;
   logic adc_fsm_rst_qs;
   logic adc_fsm_rst_wd;
-  logic adc_fsm_rst_we;
+  logic adc_chn0_filter_ctl_0_we;
   logic [9:0] adc_chn0_filter_ctl_0_min_v_0_qs;
   logic [9:0] adc_chn0_filter_ctl_0_min_v_0_wd;
-  logic adc_chn0_filter_ctl_0_min_v_0_we;
   logic adc_chn0_filter_ctl_0_cond_0_qs;
   logic adc_chn0_filter_ctl_0_cond_0_wd;
-  logic adc_chn0_filter_ctl_0_cond_0_we;
   logic [9:0] adc_chn0_filter_ctl_0_max_v_0_qs;
   logic [9:0] adc_chn0_filter_ctl_0_max_v_0_wd;
-  logic adc_chn0_filter_ctl_0_max_v_0_we;
+  logic adc_chn0_filter_ctl_1_we;
   logic [9:0] adc_chn0_filter_ctl_1_min_v_1_qs;
   logic [9:0] adc_chn0_filter_ctl_1_min_v_1_wd;
-  logic adc_chn0_filter_ctl_1_min_v_1_we;
   logic adc_chn0_filter_ctl_1_cond_1_qs;
   logic adc_chn0_filter_ctl_1_cond_1_wd;
-  logic adc_chn0_filter_ctl_1_cond_1_we;
   logic [9:0] adc_chn0_filter_ctl_1_max_v_1_qs;
   logic [9:0] adc_chn0_filter_ctl_1_max_v_1_wd;
-  logic adc_chn0_filter_ctl_1_max_v_1_we;
+  logic adc_chn0_filter_ctl_2_we;
   logic [9:0] adc_chn0_filter_ctl_2_min_v_2_qs;
   logic [9:0] adc_chn0_filter_ctl_2_min_v_2_wd;
-  logic adc_chn0_filter_ctl_2_min_v_2_we;
   logic adc_chn0_filter_ctl_2_cond_2_qs;
   logic adc_chn0_filter_ctl_2_cond_2_wd;
-  logic adc_chn0_filter_ctl_2_cond_2_we;
   logic [9:0] adc_chn0_filter_ctl_2_max_v_2_qs;
   logic [9:0] adc_chn0_filter_ctl_2_max_v_2_wd;
-  logic adc_chn0_filter_ctl_2_max_v_2_we;
+  logic adc_chn0_filter_ctl_3_we;
   logic [9:0] adc_chn0_filter_ctl_3_min_v_3_qs;
   logic [9:0] adc_chn0_filter_ctl_3_min_v_3_wd;
-  logic adc_chn0_filter_ctl_3_min_v_3_we;
   logic adc_chn0_filter_ctl_3_cond_3_qs;
   logic adc_chn0_filter_ctl_3_cond_3_wd;
-  logic adc_chn0_filter_ctl_3_cond_3_we;
   logic [9:0] adc_chn0_filter_ctl_3_max_v_3_qs;
   logic [9:0] adc_chn0_filter_ctl_3_max_v_3_wd;
-  logic adc_chn0_filter_ctl_3_max_v_3_we;
+  logic adc_chn0_filter_ctl_4_we;
   logic [9:0] adc_chn0_filter_ctl_4_min_v_4_qs;
   logic [9:0] adc_chn0_filter_ctl_4_min_v_4_wd;
-  logic adc_chn0_filter_ctl_4_min_v_4_we;
   logic adc_chn0_filter_ctl_4_cond_4_qs;
   logic adc_chn0_filter_ctl_4_cond_4_wd;
-  logic adc_chn0_filter_ctl_4_cond_4_we;
   logic [9:0] adc_chn0_filter_ctl_4_max_v_4_qs;
   logic [9:0] adc_chn0_filter_ctl_4_max_v_4_wd;
-  logic adc_chn0_filter_ctl_4_max_v_4_we;
+  logic adc_chn0_filter_ctl_5_we;
   logic [9:0] adc_chn0_filter_ctl_5_min_v_5_qs;
   logic [9:0] adc_chn0_filter_ctl_5_min_v_5_wd;
-  logic adc_chn0_filter_ctl_5_min_v_5_we;
   logic adc_chn0_filter_ctl_5_cond_5_qs;
   logic adc_chn0_filter_ctl_5_cond_5_wd;
-  logic adc_chn0_filter_ctl_5_cond_5_we;
   logic [9:0] adc_chn0_filter_ctl_5_max_v_5_qs;
   logic [9:0] adc_chn0_filter_ctl_5_max_v_5_wd;
-  logic adc_chn0_filter_ctl_5_max_v_5_we;
+  logic adc_chn0_filter_ctl_6_we;
   logic [9:0] adc_chn0_filter_ctl_6_min_v_6_qs;
   logic [9:0] adc_chn0_filter_ctl_6_min_v_6_wd;
-  logic adc_chn0_filter_ctl_6_min_v_6_we;
   logic adc_chn0_filter_ctl_6_cond_6_qs;
   logic adc_chn0_filter_ctl_6_cond_6_wd;
-  logic adc_chn0_filter_ctl_6_cond_6_we;
   logic [9:0] adc_chn0_filter_ctl_6_max_v_6_qs;
   logic [9:0] adc_chn0_filter_ctl_6_max_v_6_wd;
-  logic adc_chn0_filter_ctl_6_max_v_6_we;
+  logic adc_chn0_filter_ctl_7_we;
   logic [9:0] adc_chn0_filter_ctl_7_min_v_7_qs;
   logic [9:0] adc_chn0_filter_ctl_7_min_v_7_wd;
-  logic adc_chn0_filter_ctl_7_min_v_7_we;
   logic adc_chn0_filter_ctl_7_cond_7_qs;
   logic adc_chn0_filter_ctl_7_cond_7_wd;
-  logic adc_chn0_filter_ctl_7_cond_7_we;
   logic [9:0] adc_chn0_filter_ctl_7_max_v_7_qs;
   logic [9:0] adc_chn0_filter_ctl_7_max_v_7_wd;
-  logic adc_chn0_filter_ctl_7_max_v_7_we;
+  logic adc_chn1_filter_ctl_0_we;
   logic [9:0] adc_chn1_filter_ctl_0_min_v_0_qs;
   logic [9:0] adc_chn1_filter_ctl_0_min_v_0_wd;
-  logic adc_chn1_filter_ctl_0_min_v_0_we;
   logic adc_chn1_filter_ctl_0_cond_0_qs;
   logic adc_chn1_filter_ctl_0_cond_0_wd;
-  logic adc_chn1_filter_ctl_0_cond_0_we;
   logic [9:0] adc_chn1_filter_ctl_0_max_v_0_qs;
   logic [9:0] adc_chn1_filter_ctl_0_max_v_0_wd;
-  logic adc_chn1_filter_ctl_0_max_v_0_we;
+  logic adc_chn1_filter_ctl_1_we;
   logic [9:0] adc_chn1_filter_ctl_1_min_v_1_qs;
   logic [9:0] adc_chn1_filter_ctl_1_min_v_1_wd;
-  logic adc_chn1_filter_ctl_1_min_v_1_we;
   logic adc_chn1_filter_ctl_1_cond_1_qs;
   logic adc_chn1_filter_ctl_1_cond_1_wd;
-  logic adc_chn1_filter_ctl_1_cond_1_we;
   logic [9:0] adc_chn1_filter_ctl_1_max_v_1_qs;
   logic [9:0] adc_chn1_filter_ctl_1_max_v_1_wd;
-  logic adc_chn1_filter_ctl_1_max_v_1_we;
+  logic adc_chn1_filter_ctl_2_we;
   logic [9:0] adc_chn1_filter_ctl_2_min_v_2_qs;
   logic [9:0] adc_chn1_filter_ctl_2_min_v_2_wd;
-  logic adc_chn1_filter_ctl_2_min_v_2_we;
   logic adc_chn1_filter_ctl_2_cond_2_qs;
   logic adc_chn1_filter_ctl_2_cond_2_wd;
-  logic adc_chn1_filter_ctl_2_cond_2_we;
   logic [9:0] adc_chn1_filter_ctl_2_max_v_2_qs;
   logic [9:0] adc_chn1_filter_ctl_2_max_v_2_wd;
-  logic adc_chn1_filter_ctl_2_max_v_2_we;
+  logic adc_chn1_filter_ctl_3_we;
   logic [9:0] adc_chn1_filter_ctl_3_min_v_3_qs;
   logic [9:0] adc_chn1_filter_ctl_3_min_v_3_wd;
-  logic adc_chn1_filter_ctl_3_min_v_3_we;
   logic adc_chn1_filter_ctl_3_cond_3_qs;
   logic adc_chn1_filter_ctl_3_cond_3_wd;
-  logic adc_chn1_filter_ctl_3_cond_3_we;
   logic [9:0] adc_chn1_filter_ctl_3_max_v_3_qs;
   logic [9:0] adc_chn1_filter_ctl_3_max_v_3_wd;
-  logic adc_chn1_filter_ctl_3_max_v_3_we;
+  logic adc_chn1_filter_ctl_4_we;
   logic [9:0] adc_chn1_filter_ctl_4_min_v_4_qs;
   logic [9:0] adc_chn1_filter_ctl_4_min_v_4_wd;
-  logic adc_chn1_filter_ctl_4_min_v_4_we;
   logic adc_chn1_filter_ctl_4_cond_4_qs;
   logic adc_chn1_filter_ctl_4_cond_4_wd;
-  logic adc_chn1_filter_ctl_4_cond_4_we;
   logic [9:0] adc_chn1_filter_ctl_4_max_v_4_qs;
   logic [9:0] adc_chn1_filter_ctl_4_max_v_4_wd;
-  logic adc_chn1_filter_ctl_4_max_v_4_we;
+  logic adc_chn1_filter_ctl_5_we;
   logic [9:0] adc_chn1_filter_ctl_5_min_v_5_qs;
   logic [9:0] adc_chn1_filter_ctl_5_min_v_5_wd;
-  logic adc_chn1_filter_ctl_5_min_v_5_we;
   logic adc_chn1_filter_ctl_5_cond_5_qs;
   logic adc_chn1_filter_ctl_5_cond_5_wd;
-  logic adc_chn1_filter_ctl_5_cond_5_we;
   logic [9:0] adc_chn1_filter_ctl_5_max_v_5_qs;
   logic [9:0] adc_chn1_filter_ctl_5_max_v_5_wd;
-  logic adc_chn1_filter_ctl_5_max_v_5_we;
+  logic adc_chn1_filter_ctl_6_we;
   logic [9:0] adc_chn1_filter_ctl_6_min_v_6_qs;
   logic [9:0] adc_chn1_filter_ctl_6_min_v_6_wd;
-  logic adc_chn1_filter_ctl_6_min_v_6_we;
   logic adc_chn1_filter_ctl_6_cond_6_qs;
   logic adc_chn1_filter_ctl_6_cond_6_wd;
-  logic adc_chn1_filter_ctl_6_cond_6_we;
   logic [9:0] adc_chn1_filter_ctl_6_max_v_6_qs;
   logic [9:0] adc_chn1_filter_ctl_6_max_v_6_wd;
-  logic adc_chn1_filter_ctl_6_max_v_6_we;
+  logic adc_chn1_filter_ctl_7_we;
   logic [9:0] adc_chn1_filter_ctl_7_min_v_7_qs;
   logic [9:0] adc_chn1_filter_ctl_7_min_v_7_wd;
-  logic adc_chn1_filter_ctl_7_min_v_7_we;
   logic adc_chn1_filter_ctl_7_cond_7_qs;
   logic adc_chn1_filter_ctl_7_cond_7_wd;
-  logic adc_chn1_filter_ctl_7_cond_7_we;
   logic [9:0] adc_chn1_filter_ctl_7_max_v_7_qs;
   logic [9:0] adc_chn1_filter_ctl_7_max_v_7_wd;
-  logic adc_chn1_filter_ctl_7_max_v_7_we;
   logic [1:0] adc_chn_val_0_adc_chn_value_ext_0_qs;
   logic [9:0] adc_chn_val_0_adc_chn_value_0_qs;
   logic [1:0] adc_chn_val_0_adc_chn_value_intr_ext_0_qs;
@@ -290,108 +255,78 @@ module adc_ctrl_reg_top (
   logic [9:0] adc_chn_val_1_adc_chn_value_1_qs;
   logic [1:0] adc_chn_val_1_adc_chn_value_intr_ext_1_qs;
   logic [9:0] adc_chn_val_1_adc_chn_value_intr_1_qs;
+  logic adc_wakeup_ctl_we;
   logic adc_wakeup_ctl_chn0_1_filter0_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter0_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter0_en_we;
   logic adc_wakeup_ctl_chn0_1_filter1_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter1_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter1_en_we;
   logic adc_wakeup_ctl_chn0_1_filter2_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter2_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter2_en_we;
   logic adc_wakeup_ctl_chn0_1_filter3_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter3_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter3_en_we;
   logic adc_wakeup_ctl_chn0_1_filter4_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter4_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter4_en_we;
   logic adc_wakeup_ctl_chn0_1_filter5_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter5_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter5_en_we;
   logic adc_wakeup_ctl_chn0_1_filter6_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter6_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter6_en_we;
   logic adc_wakeup_ctl_chn0_1_filter7_en_qs;
   logic adc_wakeup_ctl_chn0_1_filter7_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter7_en_we;
+  logic adc_wakeup_status_we;
   logic adc_wakeup_status_cc_sink_det_qs;
   logic adc_wakeup_status_cc_sink_det_wd;
-  logic adc_wakeup_status_cc_sink_det_we;
   logic adc_wakeup_status_cc_1a5_sink_det_qs;
   logic adc_wakeup_status_cc_1a5_sink_det_wd;
-  logic adc_wakeup_status_cc_1a5_sink_det_we;
   logic adc_wakeup_status_cc_3a0_sink_det_qs;
   logic adc_wakeup_status_cc_3a0_sink_det_wd;
-  logic adc_wakeup_status_cc_3a0_sink_det_we;
   logic adc_wakeup_status_cc_src_det_qs;
   logic adc_wakeup_status_cc_src_det_wd;
-  logic adc_wakeup_status_cc_src_det_we;
   logic adc_wakeup_status_cc_1a5_src_det_qs;
   logic adc_wakeup_status_cc_1a5_src_det_wd;
-  logic adc_wakeup_status_cc_1a5_src_det_we;
   logic adc_wakeup_status_cc_src_det_flip_qs;
   logic adc_wakeup_status_cc_src_det_flip_wd;
-  logic adc_wakeup_status_cc_src_det_flip_we;
   logic adc_wakeup_status_cc_1a5_src_det_flip_qs;
   logic adc_wakeup_status_cc_1a5_src_det_flip_wd;
-  logic adc_wakeup_status_cc_1a5_src_det_flip_we;
   logic adc_wakeup_status_cc_discon_qs;
   logic adc_wakeup_status_cc_discon_wd;
-  logic adc_wakeup_status_cc_discon_we;
+  logic adc_intr_ctl_we;
   logic adc_intr_ctl_chn0_1_filter0_en_qs;
   logic adc_intr_ctl_chn0_1_filter0_en_wd;
-  logic adc_intr_ctl_chn0_1_filter0_en_we;
   logic adc_intr_ctl_chn0_1_filter1_en_qs;
   logic adc_intr_ctl_chn0_1_filter1_en_wd;
-  logic adc_intr_ctl_chn0_1_filter1_en_we;
   logic adc_intr_ctl_chn0_1_filter2_en_qs;
   logic adc_intr_ctl_chn0_1_filter2_en_wd;
-  logic adc_intr_ctl_chn0_1_filter2_en_we;
   logic adc_intr_ctl_chn0_1_filter3_en_qs;
   logic adc_intr_ctl_chn0_1_filter3_en_wd;
-  logic adc_intr_ctl_chn0_1_filter3_en_we;
   logic adc_intr_ctl_chn0_1_filter4_en_qs;
   logic adc_intr_ctl_chn0_1_filter4_en_wd;
-  logic adc_intr_ctl_chn0_1_filter4_en_we;
   logic adc_intr_ctl_chn0_1_filter5_en_qs;
   logic adc_intr_ctl_chn0_1_filter5_en_wd;
-  logic adc_intr_ctl_chn0_1_filter5_en_we;
   logic adc_intr_ctl_chn0_1_filter6_en_qs;
   logic adc_intr_ctl_chn0_1_filter6_en_wd;
-  logic adc_intr_ctl_chn0_1_filter6_en_we;
   logic adc_intr_ctl_chn0_1_filter7_en_qs;
   logic adc_intr_ctl_chn0_1_filter7_en_wd;
-  logic adc_intr_ctl_chn0_1_filter7_en_we;
   logic adc_intr_ctl_oneshot_intr_en_qs;
   logic adc_intr_ctl_oneshot_intr_en_wd;
-  logic adc_intr_ctl_oneshot_intr_en_we;
+  logic adc_intr_status_we;
   logic adc_intr_status_cc_sink_det_qs;
   logic adc_intr_status_cc_sink_det_wd;
-  logic adc_intr_status_cc_sink_det_we;
   logic adc_intr_status_cc_1a5_sink_det_qs;
   logic adc_intr_status_cc_1a5_sink_det_wd;
-  logic adc_intr_status_cc_1a5_sink_det_we;
   logic adc_intr_status_cc_3a0_sink_det_qs;
   logic adc_intr_status_cc_3a0_sink_det_wd;
-  logic adc_intr_status_cc_3a0_sink_det_we;
   logic adc_intr_status_cc_src_det_qs;
   logic adc_intr_status_cc_src_det_wd;
-  logic adc_intr_status_cc_src_det_we;
   logic adc_intr_status_cc_1a5_src_det_qs;
   logic adc_intr_status_cc_1a5_src_det_wd;
-  logic adc_intr_status_cc_1a5_src_det_we;
   logic adc_intr_status_cc_src_det_flip_qs;
   logic adc_intr_status_cc_src_det_flip_wd;
-  logic adc_intr_status_cc_src_det_flip_we;
   logic adc_intr_status_cc_1a5_src_det_flip_qs;
   logic adc_intr_status_cc_1a5_src_det_flip_wd;
-  logic adc_intr_status_cc_1a5_src_det_flip_we;
   logic adc_intr_status_cc_discon_qs;
   logic adc_intr_status_cc_discon_wd;
-  logic adc_intr_status_cc_discon_we;
   logic adc_intr_status_oneshot_qs;
   logic adc_intr_status_oneshot_wd;
-  logic adc_intr_status_oneshot_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -492,7 +427,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_en_ctl_adc_enable_we),
+    .we     (adc_en_ctl_we),
     .wd     (adc_en_ctl_adc_enable_wd),
 
     // from internal hardware
@@ -518,7 +453,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_en_ctl_oneshot_mode_we),
+    .we     (adc_en_ctl_we),
     .wd     (adc_en_ctl_oneshot_mode_wd),
 
     // from internal hardware
@@ -546,7 +481,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_pd_ctl_lp_mode_we),
+    .we     (adc_pd_ctl_we),
     .wd     (adc_pd_ctl_lp_mode_wd),
 
     // from internal hardware
@@ -572,7 +507,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_pd_ctl_pwrup_time_we),
+    .we     (adc_pd_ctl_we),
     .wd     (adc_pd_ctl_pwrup_time_wd),
 
     // from internal hardware
@@ -598,7 +533,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_pd_ctl_wakeup_time_we),
+    .we     (adc_pd_ctl_we),
     .wd     (adc_pd_ctl_wakeup_time_wd),
 
     // from internal hardware
@@ -709,7 +644,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_0_min_v_0_we),
+    .we     (adc_chn0_filter_ctl_0_we),
     .wd     (adc_chn0_filter_ctl_0_min_v_0_wd),
 
     // from internal hardware
@@ -735,7 +670,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_0_cond_0_we),
+    .we     (adc_chn0_filter_ctl_0_we),
     .wd     (adc_chn0_filter_ctl_0_cond_0_wd),
 
     // from internal hardware
@@ -761,7 +696,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_0_max_v_0_we),
+    .we     (adc_chn0_filter_ctl_0_we),
     .wd     (adc_chn0_filter_ctl_0_max_v_0_wd),
 
     // from internal hardware
@@ -790,7 +725,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_1_min_v_1_we),
+    .we     (adc_chn0_filter_ctl_1_we),
     .wd     (adc_chn0_filter_ctl_1_min_v_1_wd),
 
     // from internal hardware
@@ -816,7 +751,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_1_cond_1_we),
+    .we     (adc_chn0_filter_ctl_1_we),
     .wd     (adc_chn0_filter_ctl_1_cond_1_wd),
 
     // from internal hardware
@@ -842,7 +777,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_1_max_v_1_we),
+    .we     (adc_chn0_filter_ctl_1_we),
     .wd     (adc_chn0_filter_ctl_1_max_v_1_wd),
 
     // from internal hardware
@@ -871,7 +806,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_2_min_v_2_we),
+    .we     (adc_chn0_filter_ctl_2_we),
     .wd     (adc_chn0_filter_ctl_2_min_v_2_wd),
 
     // from internal hardware
@@ -897,7 +832,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_2_cond_2_we),
+    .we     (adc_chn0_filter_ctl_2_we),
     .wd     (adc_chn0_filter_ctl_2_cond_2_wd),
 
     // from internal hardware
@@ -923,7 +858,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_2_max_v_2_we),
+    .we     (adc_chn0_filter_ctl_2_we),
     .wd     (adc_chn0_filter_ctl_2_max_v_2_wd),
 
     // from internal hardware
@@ -952,7 +887,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_3_min_v_3_we),
+    .we     (adc_chn0_filter_ctl_3_we),
     .wd     (adc_chn0_filter_ctl_3_min_v_3_wd),
 
     // from internal hardware
@@ -978,7 +913,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_3_cond_3_we),
+    .we     (adc_chn0_filter_ctl_3_we),
     .wd     (adc_chn0_filter_ctl_3_cond_3_wd),
 
     // from internal hardware
@@ -1004,7 +939,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_3_max_v_3_we),
+    .we     (adc_chn0_filter_ctl_3_we),
     .wd     (adc_chn0_filter_ctl_3_max_v_3_wd),
 
     // from internal hardware
@@ -1033,7 +968,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_4_min_v_4_we),
+    .we     (adc_chn0_filter_ctl_4_we),
     .wd     (adc_chn0_filter_ctl_4_min_v_4_wd),
 
     // from internal hardware
@@ -1059,7 +994,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_4_cond_4_we),
+    .we     (adc_chn0_filter_ctl_4_we),
     .wd     (adc_chn0_filter_ctl_4_cond_4_wd),
 
     // from internal hardware
@@ -1085,7 +1020,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_4_max_v_4_we),
+    .we     (adc_chn0_filter_ctl_4_we),
     .wd     (adc_chn0_filter_ctl_4_max_v_4_wd),
 
     // from internal hardware
@@ -1114,7 +1049,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_5_min_v_5_we),
+    .we     (adc_chn0_filter_ctl_5_we),
     .wd     (adc_chn0_filter_ctl_5_min_v_5_wd),
 
     // from internal hardware
@@ -1140,7 +1075,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_5_cond_5_we),
+    .we     (adc_chn0_filter_ctl_5_we),
     .wd     (adc_chn0_filter_ctl_5_cond_5_wd),
 
     // from internal hardware
@@ -1166,7 +1101,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_5_max_v_5_we),
+    .we     (adc_chn0_filter_ctl_5_we),
     .wd     (adc_chn0_filter_ctl_5_max_v_5_wd),
 
     // from internal hardware
@@ -1195,7 +1130,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_6_min_v_6_we),
+    .we     (adc_chn0_filter_ctl_6_we),
     .wd     (adc_chn0_filter_ctl_6_min_v_6_wd),
 
     // from internal hardware
@@ -1221,7 +1156,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_6_cond_6_we),
+    .we     (adc_chn0_filter_ctl_6_we),
     .wd     (adc_chn0_filter_ctl_6_cond_6_wd),
 
     // from internal hardware
@@ -1247,7 +1182,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_6_max_v_6_we),
+    .we     (adc_chn0_filter_ctl_6_we),
     .wd     (adc_chn0_filter_ctl_6_max_v_6_wd),
 
     // from internal hardware
@@ -1276,7 +1211,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_7_min_v_7_we),
+    .we     (adc_chn0_filter_ctl_7_we),
     .wd     (adc_chn0_filter_ctl_7_min_v_7_wd),
 
     // from internal hardware
@@ -1302,7 +1237,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_7_cond_7_we),
+    .we     (adc_chn0_filter_ctl_7_we),
     .wd     (adc_chn0_filter_ctl_7_cond_7_wd),
 
     // from internal hardware
@@ -1328,7 +1263,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn0_filter_ctl_7_max_v_7_we),
+    .we     (adc_chn0_filter_ctl_7_we),
     .wd     (adc_chn0_filter_ctl_7_max_v_7_wd),
 
     // from internal hardware
@@ -1359,7 +1294,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_0_min_v_0_we),
+    .we     (adc_chn1_filter_ctl_0_we),
     .wd     (adc_chn1_filter_ctl_0_min_v_0_wd),
 
     // from internal hardware
@@ -1385,7 +1320,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_0_cond_0_we),
+    .we     (adc_chn1_filter_ctl_0_we),
     .wd     (adc_chn1_filter_ctl_0_cond_0_wd),
 
     // from internal hardware
@@ -1411,7 +1346,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_0_max_v_0_we),
+    .we     (adc_chn1_filter_ctl_0_we),
     .wd     (adc_chn1_filter_ctl_0_max_v_0_wd),
 
     // from internal hardware
@@ -1440,7 +1375,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_1_min_v_1_we),
+    .we     (adc_chn1_filter_ctl_1_we),
     .wd     (adc_chn1_filter_ctl_1_min_v_1_wd),
 
     // from internal hardware
@@ -1466,7 +1401,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_1_cond_1_we),
+    .we     (adc_chn1_filter_ctl_1_we),
     .wd     (adc_chn1_filter_ctl_1_cond_1_wd),
 
     // from internal hardware
@@ -1492,7 +1427,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_1_max_v_1_we),
+    .we     (adc_chn1_filter_ctl_1_we),
     .wd     (adc_chn1_filter_ctl_1_max_v_1_wd),
 
     // from internal hardware
@@ -1521,7 +1456,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_2_min_v_2_we),
+    .we     (adc_chn1_filter_ctl_2_we),
     .wd     (adc_chn1_filter_ctl_2_min_v_2_wd),
 
     // from internal hardware
@@ -1547,7 +1482,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_2_cond_2_we),
+    .we     (adc_chn1_filter_ctl_2_we),
     .wd     (adc_chn1_filter_ctl_2_cond_2_wd),
 
     // from internal hardware
@@ -1573,7 +1508,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_2_max_v_2_we),
+    .we     (adc_chn1_filter_ctl_2_we),
     .wd     (adc_chn1_filter_ctl_2_max_v_2_wd),
 
     // from internal hardware
@@ -1602,7 +1537,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_3_min_v_3_we),
+    .we     (adc_chn1_filter_ctl_3_we),
     .wd     (adc_chn1_filter_ctl_3_min_v_3_wd),
 
     // from internal hardware
@@ -1628,7 +1563,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_3_cond_3_we),
+    .we     (adc_chn1_filter_ctl_3_we),
     .wd     (adc_chn1_filter_ctl_3_cond_3_wd),
 
     // from internal hardware
@@ -1654,7 +1589,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_3_max_v_3_we),
+    .we     (adc_chn1_filter_ctl_3_we),
     .wd     (adc_chn1_filter_ctl_3_max_v_3_wd),
 
     // from internal hardware
@@ -1683,7 +1618,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_4_min_v_4_we),
+    .we     (adc_chn1_filter_ctl_4_we),
     .wd     (adc_chn1_filter_ctl_4_min_v_4_wd),
 
     // from internal hardware
@@ -1709,7 +1644,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_4_cond_4_we),
+    .we     (adc_chn1_filter_ctl_4_we),
     .wd     (adc_chn1_filter_ctl_4_cond_4_wd),
 
     // from internal hardware
@@ -1735,7 +1670,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_4_max_v_4_we),
+    .we     (adc_chn1_filter_ctl_4_we),
     .wd     (adc_chn1_filter_ctl_4_max_v_4_wd),
 
     // from internal hardware
@@ -1764,7 +1699,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_5_min_v_5_we),
+    .we     (adc_chn1_filter_ctl_5_we),
     .wd     (adc_chn1_filter_ctl_5_min_v_5_wd),
 
     // from internal hardware
@@ -1790,7 +1725,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_5_cond_5_we),
+    .we     (adc_chn1_filter_ctl_5_we),
     .wd     (adc_chn1_filter_ctl_5_cond_5_wd),
 
     // from internal hardware
@@ -1816,7 +1751,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_5_max_v_5_we),
+    .we     (adc_chn1_filter_ctl_5_we),
     .wd     (adc_chn1_filter_ctl_5_max_v_5_wd),
 
     // from internal hardware
@@ -1845,7 +1780,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_6_min_v_6_we),
+    .we     (adc_chn1_filter_ctl_6_we),
     .wd     (adc_chn1_filter_ctl_6_min_v_6_wd),
 
     // from internal hardware
@@ -1871,7 +1806,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_6_cond_6_we),
+    .we     (adc_chn1_filter_ctl_6_we),
     .wd     (adc_chn1_filter_ctl_6_cond_6_wd),
 
     // from internal hardware
@@ -1897,7 +1832,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_6_max_v_6_we),
+    .we     (adc_chn1_filter_ctl_6_we),
     .wd     (adc_chn1_filter_ctl_6_max_v_6_wd),
 
     // from internal hardware
@@ -1926,7 +1861,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_7_min_v_7_we),
+    .we     (adc_chn1_filter_ctl_7_we),
     .wd     (adc_chn1_filter_ctl_7_min_v_7_wd),
 
     // from internal hardware
@@ -1952,7 +1887,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_7_cond_7_we),
+    .we     (adc_chn1_filter_ctl_7_we),
     .wd     (adc_chn1_filter_ctl_7_cond_7_wd),
 
     // from internal hardware
@@ -1978,7 +1913,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_chn1_filter_ctl_7_max_v_7_we),
+    .we     (adc_chn1_filter_ctl_7_we),
     .wd     (adc_chn1_filter_ctl_7_max_v_7_wd),
 
     // from internal hardware
@@ -2223,7 +2158,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter0_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter0_en_wd),
 
     // from internal hardware
@@ -2249,7 +2184,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter1_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter1_en_wd),
 
     // from internal hardware
@@ -2275,7 +2210,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter2_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter2_en_wd),
 
     // from internal hardware
@@ -2301,7 +2236,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter3_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter3_en_wd),
 
     // from internal hardware
@@ -2327,7 +2262,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter4_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter4_en_wd),
 
     // from internal hardware
@@ -2353,7 +2288,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter5_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter5_en_wd),
 
     // from internal hardware
@@ -2379,7 +2314,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter6_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter6_en_wd),
 
     // from internal hardware
@@ -2405,7 +2340,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_ctl_chn0_1_filter7_en_we),
+    .we     (adc_wakeup_ctl_we),
     .wd     (adc_wakeup_ctl_chn0_1_filter7_en_wd),
 
     // from internal hardware
@@ -2433,7 +2368,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_sink_det_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_sink_det_wd),
 
     // from internal hardware
@@ -2459,7 +2394,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_1a5_sink_det_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_1a5_sink_det_wd),
 
     // from internal hardware
@@ -2485,7 +2420,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_3a0_sink_det_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_3a0_sink_det_wd),
 
     // from internal hardware
@@ -2511,7 +2446,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_src_det_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_src_det_wd),
 
     // from internal hardware
@@ -2537,7 +2472,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_1a5_src_det_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_1a5_src_det_wd),
 
     // from internal hardware
@@ -2563,7 +2498,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_src_det_flip_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_src_det_flip_wd),
 
     // from internal hardware
@@ -2589,7 +2524,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_1a5_src_det_flip_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_1a5_src_det_flip_wd),
 
     // from internal hardware
@@ -2615,7 +2550,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_wakeup_status_cc_discon_we),
+    .we     (adc_wakeup_status_we),
     .wd     (adc_wakeup_status_cc_discon_wd),
 
     // from internal hardware
@@ -2643,7 +2578,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter0_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter0_en_wd),
 
     // from internal hardware
@@ -2669,7 +2604,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter1_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter1_en_wd),
 
     // from internal hardware
@@ -2695,7 +2630,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter2_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter2_en_wd),
 
     // from internal hardware
@@ -2721,7 +2656,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter3_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter3_en_wd),
 
     // from internal hardware
@@ -2747,7 +2682,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter4_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter4_en_wd),
 
     // from internal hardware
@@ -2773,7 +2708,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter5_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter5_en_wd),
 
     // from internal hardware
@@ -2799,7 +2734,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter6_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter6_en_wd),
 
     // from internal hardware
@@ -2825,7 +2760,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_chn0_1_filter7_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_chn0_1_filter7_en_wd),
 
     // from internal hardware
@@ -2851,7 +2786,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_ctl_oneshot_intr_en_we),
+    .we     (adc_intr_ctl_we),
     .wd     (adc_intr_ctl_oneshot_intr_en_wd),
 
     // from internal hardware
@@ -2879,7 +2814,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_sink_det_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_sink_det_wd),
 
     // from internal hardware
@@ -2905,7 +2840,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_1a5_sink_det_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_1a5_sink_det_wd),
 
     // from internal hardware
@@ -2931,7 +2866,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_3a0_sink_det_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_3a0_sink_det_wd),
 
     // from internal hardware
@@ -2957,7 +2892,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_src_det_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_src_det_wd),
 
     // from internal hardware
@@ -2983,7 +2918,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_1a5_src_det_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_1a5_src_det_wd),
 
     // from internal hardware
@@ -3009,7 +2944,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_src_det_flip_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_src_det_flip_wd),
 
     // from internal hardware
@@ -3035,7 +2970,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_1a5_src_det_flip_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_1a5_src_det_flip_wd),
 
     // from internal hardware
@@ -3061,7 +2996,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_cc_discon_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_cc_discon_wd),
 
     // from internal hardware
@@ -3087,7 +3022,7 @@ module adc_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (adc_intr_status_oneshot_we),
+    .we     (adc_intr_status_we),
     .wd     (adc_intr_status_oneshot_wd),
 
     // from internal hardware
@@ -3178,287 +3113,222 @@ module adc_ctrl_reg_top (
                (addr_hit[29] & (|(ADC_CTRL_PERMIT[29] & ~reg_be))) |
                (addr_hit[30] & (|(ADC_CTRL_PERMIT[30] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
+
   assign intr_test_wd = reg_wdata[0];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
-  assign alert_test_wd = reg_wdata[0];
 
-  assign adc_en_ctl_adc_enable_we = addr_hit[4] & reg_we & !reg_error;
+  assign alert_test_wd = reg_wdata[0];
+  assign adc_en_ctl_we = addr_hit[4] & reg_we & !reg_error;
+
   assign adc_en_ctl_adc_enable_wd = reg_wdata[0];
 
-  assign adc_en_ctl_oneshot_mode_we = addr_hit[4] & reg_we & !reg_error;
   assign adc_en_ctl_oneshot_mode_wd = reg_wdata[1];
+  assign adc_pd_ctl_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign adc_pd_ctl_lp_mode_we = addr_hit[5] & reg_we & !reg_error;
   assign adc_pd_ctl_lp_mode_wd = reg_wdata[0];
 
-  assign adc_pd_ctl_pwrup_time_we = addr_hit[5] & reg_we & !reg_error;
   assign adc_pd_ctl_pwrup_time_wd = reg_wdata[7:4];
 
-  assign adc_pd_ctl_wakeup_time_we = addr_hit[5] & reg_we & !reg_error;
   assign adc_pd_ctl_wakeup_time_wd = reg_wdata[31:8];
-
   assign adc_lp_sample_ctl_we = addr_hit[6] & reg_we & !reg_error;
+
   assign adc_lp_sample_ctl_wd = reg_wdata[7:0];
-
   assign adc_sample_ctl_we = addr_hit[7] & reg_we & !reg_error;
+
   assign adc_sample_ctl_wd = reg_wdata[15:0];
-
   assign adc_fsm_rst_we = addr_hit[8] & reg_we & !reg_error;
-  assign adc_fsm_rst_wd = reg_wdata[0];
 
-  assign adc_chn0_filter_ctl_0_min_v_0_we = addr_hit[9] & reg_we & !reg_error;
+  assign adc_fsm_rst_wd = reg_wdata[0];
+  assign adc_chn0_filter_ctl_0_we = addr_hit[9] & reg_we & !reg_error;
+
   assign adc_chn0_filter_ctl_0_min_v_0_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_0_cond_0_we = addr_hit[9] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_0_cond_0_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_0_max_v_0_we = addr_hit[9] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_0_max_v_0_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_1_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_1_min_v_1_we = addr_hit[10] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_1_min_v_1_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_1_cond_1_we = addr_hit[10] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_1_cond_1_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_1_max_v_1_we = addr_hit[10] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_1_max_v_1_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_2_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_2_min_v_2_we = addr_hit[11] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_2_min_v_2_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_2_cond_2_we = addr_hit[11] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_2_cond_2_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_2_max_v_2_we = addr_hit[11] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_2_max_v_2_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_3_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_3_min_v_3_we = addr_hit[12] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_3_min_v_3_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_3_cond_3_we = addr_hit[12] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_3_cond_3_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_3_max_v_3_we = addr_hit[12] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_3_max_v_3_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_4_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_4_min_v_4_we = addr_hit[13] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_4_min_v_4_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_4_cond_4_we = addr_hit[13] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_4_cond_4_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_4_max_v_4_we = addr_hit[13] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_4_max_v_4_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_5_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_5_min_v_5_we = addr_hit[14] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_5_min_v_5_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_5_cond_5_we = addr_hit[14] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_5_cond_5_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_5_max_v_5_we = addr_hit[14] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_5_max_v_5_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_6_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_6_min_v_6_we = addr_hit[15] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_6_min_v_6_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_6_cond_6_we = addr_hit[15] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_6_cond_6_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_6_max_v_6_we = addr_hit[15] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_6_max_v_6_wd = reg_wdata[27:18];
+  assign adc_chn0_filter_ctl_7_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_7_min_v_7_we = addr_hit[16] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_7_min_v_7_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_7_cond_7_we = addr_hit[16] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_7_cond_7_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_7_max_v_7_we = addr_hit[16] & reg_we & !reg_error;
   assign adc_chn0_filter_ctl_7_max_v_7_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_0_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_0_min_v_0_we = addr_hit[17] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_0_min_v_0_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_0_cond_0_we = addr_hit[17] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_0_cond_0_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_0_max_v_0_we = addr_hit[17] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_0_max_v_0_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_1_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_1_min_v_1_we = addr_hit[18] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_1_min_v_1_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_1_cond_1_we = addr_hit[18] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_1_cond_1_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_1_max_v_1_we = addr_hit[18] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_1_max_v_1_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_2_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_2_min_v_2_we = addr_hit[19] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_2_min_v_2_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_2_cond_2_we = addr_hit[19] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_2_cond_2_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_2_max_v_2_we = addr_hit[19] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_2_max_v_2_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_3_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_3_min_v_3_we = addr_hit[20] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_3_min_v_3_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_3_cond_3_we = addr_hit[20] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_3_cond_3_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_3_max_v_3_we = addr_hit[20] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_3_max_v_3_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_4_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_4_min_v_4_we = addr_hit[21] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_4_min_v_4_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_4_cond_4_we = addr_hit[21] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_4_cond_4_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_4_max_v_4_we = addr_hit[21] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_4_max_v_4_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_5_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_5_min_v_5_we = addr_hit[22] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_5_min_v_5_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_5_cond_5_we = addr_hit[22] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_5_cond_5_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_5_max_v_5_we = addr_hit[22] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_5_max_v_5_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_6_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_6_min_v_6_we = addr_hit[23] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_6_min_v_6_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_6_cond_6_we = addr_hit[23] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_6_cond_6_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_6_max_v_6_we = addr_hit[23] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_6_max_v_6_wd = reg_wdata[27:18];
+  assign adc_chn1_filter_ctl_7_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_7_min_v_7_we = addr_hit[24] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_7_min_v_7_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_7_cond_7_we = addr_hit[24] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_7_cond_7_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_7_max_v_7_we = addr_hit[24] & reg_we & !reg_error;
   assign adc_chn1_filter_ctl_7_max_v_7_wd = reg_wdata[27:18];
+  assign adc_wakeup_ctl_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign adc_wakeup_ctl_chn0_1_filter0_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter0_en_wd = reg_wdata[0];
 
-  assign adc_wakeup_ctl_chn0_1_filter1_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter1_en_wd = reg_wdata[1];
 
-  assign adc_wakeup_ctl_chn0_1_filter2_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter2_en_wd = reg_wdata[2];
 
-  assign adc_wakeup_ctl_chn0_1_filter3_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter3_en_wd = reg_wdata[3];
 
-  assign adc_wakeup_ctl_chn0_1_filter4_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter4_en_wd = reg_wdata[4];
 
-  assign adc_wakeup_ctl_chn0_1_filter5_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter5_en_wd = reg_wdata[5];
 
-  assign adc_wakeup_ctl_chn0_1_filter6_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter6_en_wd = reg_wdata[6];
 
-  assign adc_wakeup_ctl_chn0_1_filter7_en_we = addr_hit[27] & reg_we & !reg_error;
   assign adc_wakeup_ctl_chn0_1_filter7_en_wd = reg_wdata[7];
+  assign adc_wakeup_status_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign adc_wakeup_status_cc_sink_det_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_sink_det_wd = reg_wdata[0];
 
-  assign adc_wakeup_status_cc_1a5_sink_det_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_1a5_sink_det_wd = reg_wdata[1];
 
-  assign adc_wakeup_status_cc_3a0_sink_det_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_3a0_sink_det_wd = reg_wdata[2];
 
-  assign adc_wakeup_status_cc_src_det_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_src_det_wd = reg_wdata[3];
 
-  assign adc_wakeup_status_cc_1a5_src_det_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_1a5_src_det_wd = reg_wdata[4];
 
-  assign adc_wakeup_status_cc_src_det_flip_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_src_det_flip_wd = reg_wdata[5];
 
-  assign adc_wakeup_status_cc_1a5_src_det_flip_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_1a5_src_det_flip_wd = reg_wdata[6];
 
-  assign adc_wakeup_status_cc_discon_we = addr_hit[28] & reg_we & !reg_error;
   assign adc_wakeup_status_cc_discon_wd = reg_wdata[7];
+  assign adc_intr_ctl_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign adc_intr_ctl_chn0_1_filter0_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter0_en_wd = reg_wdata[0];
 
-  assign adc_intr_ctl_chn0_1_filter1_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter1_en_wd = reg_wdata[1];
 
-  assign adc_intr_ctl_chn0_1_filter2_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter2_en_wd = reg_wdata[2];
 
-  assign adc_intr_ctl_chn0_1_filter3_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter3_en_wd = reg_wdata[3];
 
-  assign adc_intr_ctl_chn0_1_filter4_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter4_en_wd = reg_wdata[4];
 
-  assign adc_intr_ctl_chn0_1_filter5_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter5_en_wd = reg_wdata[5];
 
-  assign adc_intr_ctl_chn0_1_filter6_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter6_en_wd = reg_wdata[6];
 
-  assign adc_intr_ctl_chn0_1_filter7_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_chn0_1_filter7_en_wd = reg_wdata[7];
 
-  assign adc_intr_ctl_oneshot_intr_en_we = addr_hit[29] & reg_we & !reg_error;
   assign adc_intr_ctl_oneshot_intr_en_wd = reg_wdata[8];
+  assign adc_intr_status_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign adc_intr_status_cc_sink_det_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_sink_det_wd = reg_wdata[0];
 
-  assign adc_intr_status_cc_1a5_sink_det_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_1a5_sink_det_wd = reg_wdata[1];
 
-  assign adc_intr_status_cc_3a0_sink_det_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_3a0_sink_det_wd = reg_wdata[2];
 
-  assign adc_intr_status_cc_src_det_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_src_det_wd = reg_wdata[3];
 
-  assign adc_intr_status_cc_1a5_src_det_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_1a5_src_det_wd = reg_wdata[4];
 
-  assign adc_intr_status_cc_src_det_flip_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_src_det_flip_wd = reg_wdata[5];
 
-  assign adc_intr_status_cc_1a5_src_det_flip_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_1a5_src_det_flip_wd = reg_wdata[6];
 
-  assign adc_intr_status_cc_discon_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_cc_discon_wd = reg_wdata[7];
 
-  assign adc_intr_status_oneshot_we = addr_hit[30] & reg_we & !reg_error;
   assign adc_intr_status_oneshot_wd = reg_wdata[8];
 
   // Read data return

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -104,94 +104,82 @@ module aes_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic alert_test_we;
   logic alert_test_recov_ctrl_update_err_wd;
-  logic alert_test_recov_ctrl_update_err_we;
   logic alert_test_fatal_fault_wd;
-  logic alert_test_fatal_fault_we;
-  logic [31:0] key_share0_0_wd;
   logic key_share0_0_we;
-  logic [31:0] key_share0_1_wd;
+  logic [31:0] key_share0_0_wd;
   logic key_share0_1_we;
-  logic [31:0] key_share0_2_wd;
+  logic [31:0] key_share0_1_wd;
   logic key_share0_2_we;
-  logic [31:0] key_share0_3_wd;
+  logic [31:0] key_share0_2_wd;
   logic key_share0_3_we;
-  logic [31:0] key_share0_4_wd;
+  logic [31:0] key_share0_3_wd;
   logic key_share0_4_we;
-  logic [31:0] key_share0_5_wd;
+  logic [31:0] key_share0_4_wd;
   logic key_share0_5_we;
-  logic [31:0] key_share0_6_wd;
+  logic [31:0] key_share0_5_wd;
   logic key_share0_6_we;
-  logic [31:0] key_share0_7_wd;
+  logic [31:0] key_share0_6_wd;
   logic key_share0_7_we;
-  logic [31:0] key_share1_0_wd;
+  logic [31:0] key_share0_7_wd;
   logic key_share1_0_we;
-  logic [31:0] key_share1_1_wd;
+  logic [31:0] key_share1_0_wd;
   logic key_share1_1_we;
-  logic [31:0] key_share1_2_wd;
+  logic [31:0] key_share1_1_wd;
   logic key_share1_2_we;
-  logic [31:0] key_share1_3_wd;
+  logic [31:0] key_share1_2_wd;
   logic key_share1_3_we;
-  logic [31:0] key_share1_4_wd;
+  logic [31:0] key_share1_3_wd;
   logic key_share1_4_we;
-  logic [31:0] key_share1_5_wd;
+  logic [31:0] key_share1_4_wd;
   logic key_share1_5_we;
-  logic [31:0] key_share1_6_wd;
+  logic [31:0] key_share1_5_wd;
   logic key_share1_6_we;
-  logic [31:0] key_share1_7_wd;
+  logic [31:0] key_share1_6_wd;
   logic key_share1_7_we;
-  logic [31:0] iv_0_wd;
+  logic [31:0] key_share1_7_wd;
   logic iv_0_we;
-  logic [31:0] iv_1_wd;
+  logic [31:0] iv_0_wd;
   logic iv_1_we;
-  logic [31:0] iv_2_wd;
+  logic [31:0] iv_1_wd;
   logic iv_2_we;
-  logic [31:0] iv_3_wd;
+  logic [31:0] iv_2_wd;
   logic iv_3_we;
-  logic [31:0] data_in_0_wd;
+  logic [31:0] iv_3_wd;
   logic data_in_0_we;
-  logic [31:0] data_in_1_wd;
+  logic [31:0] data_in_0_wd;
   logic data_in_1_we;
-  logic [31:0] data_in_2_wd;
+  logic [31:0] data_in_1_wd;
   logic data_in_2_we;
-  logic [31:0] data_in_3_wd;
+  logic [31:0] data_in_2_wd;
   logic data_in_3_we;
-  logic [31:0] data_out_0_qs;
+  logic [31:0] data_in_3_wd;
   logic data_out_0_re;
-  logic [31:0] data_out_1_qs;
+  logic [31:0] data_out_0_qs;
   logic data_out_1_re;
-  logic [31:0] data_out_2_qs;
+  logic [31:0] data_out_1_qs;
   logic data_out_2_re;
-  logic [31:0] data_out_3_qs;
+  logic [31:0] data_out_2_qs;
   logic data_out_3_re;
+  logic [31:0] data_out_3_qs;
+  logic ctrl_shadowed_re;
+  logic ctrl_shadowed_we;
   logic ctrl_shadowed_operation_qs;
   logic ctrl_shadowed_operation_wd;
-  logic ctrl_shadowed_operation_we;
-  logic ctrl_shadowed_operation_re;
   logic [5:0] ctrl_shadowed_mode_qs;
   logic [5:0] ctrl_shadowed_mode_wd;
-  logic ctrl_shadowed_mode_we;
-  logic ctrl_shadowed_mode_re;
   logic [2:0] ctrl_shadowed_key_len_qs;
   logic [2:0] ctrl_shadowed_key_len_wd;
-  logic ctrl_shadowed_key_len_we;
-  logic ctrl_shadowed_key_len_re;
   logic ctrl_shadowed_manual_operation_qs;
   logic ctrl_shadowed_manual_operation_wd;
-  logic ctrl_shadowed_manual_operation_we;
-  logic ctrl_shadowed_manual_operation_re;
   logic ctrl_shadowed_force_zero_masks_qs;
   logic ctrl_shadowed_force_zero_masks_wd;
-  logic ctrl_shadowed_force_zero_masks_we;
-  logic ctrl_shadowed_force_zero_masks_re;
+  logic trigger_we;
   logic trigger_start_wd;
-  logic trigger_start_we;
   logic trigger_key_iv_data_in_clear_wd;
-  logic trigger_key_iv_data_in_clear_we;
   logic trigger_data_out_clear_wd;
-  logic trigger_data_out_clear_we;
   logic trigger_prng_reseed_wd;
-  logic trigger_prng_reseed_we;
   logic status_idle_qs;
   logic status_stall_qs;
   logic status_output_lost_qs;
@@ -208,7 +196,7 @@ module aes_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ctrl_update_err (
     .re     (1'b0),
-    .we     (alert_test_recov_ctrl_update_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ctrl_update_err_wd),
     .d      ('0),
     .qre    (),
@@ -223,7 +211,7 @@ module aes_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault (
     .re     (1'b0),
-    .we     (alert_test_fatal_fault_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
@@ -741,8 +729,8 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_operation (
-    .re     (ctrl_shadowed_operation_re),
-    .we     (ctrl_shadowed_operation_we),
+    .re     (ctrl_shadowed_re),
+    .we     (ctrl_shadowed_we),
     .wd     (ctrl_shadowed_operation_wd),
     .d      (hw2reg.ctrl_shadowed.operation.d),
     .qre    (reg2hw.ctrl_shadowed.operation.re),
@@ -756,8 +744,8 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (6)
   ) u_ctrl_shadowed_mode (
-    .re     (ctrl_shadowed_mode_re),
-    .we     (ctrl_shadowed_mode_we),
+    .re     (ctrl_shadowed_re),
+    .we     (ctrl_shadowed_we),
     .wd     (ctrl_shadowed_mode_wd),
     .d      (hw2reg.ctrl_shadowed.mode.d),
     .qre    (reg2hw.ctrl_shadowed.mode.re),
@@ -771,8 +759,8 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_ctrl_shadowed_key_len (
-    .re     (ctrl_shadowed_key_len_re),
-    .we     (ctrl_shadowed_key_len_we),
+    .re     (ctrl_shadowed_re),
+    .we     (ctrl_shadowed_we),
     .wd     (ctrl_shadowed_key_len_wd),
     .d      (hw2reg.ctrl_shadowed.key_len.d),
     .qre    (reg2hw.ctrl_shadowed.key_len.re),
@@ -786,8 +774,8 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_manual_operation (
-    .re     (ctrl_shadowed_manual_operation_re),
-    .we     (ctrl_shadowed_manual_operation_we),
+    .re     (ctrl_shadowed_re),
+    .we     (ctrl_shadowed_we),
     .wd     (ctrl_shadowed_manual_operation_wd),
     .d      (hw2reg.ctrl_shadowed.manual_operation.d),
     .qre    (reg2hw.ctrl_shadowed.manual_operation.re),
@@ -801,8 +789,8 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_force_zero_masks (
-    .re     (ctrl_shadowed_force_zero_masks_re),
-    .we     (ctrl_shadowed_force_zero_masks_we),
+    .re     (ctrl_shadowed_re),
+    .we     (ctrl_shadowed_we),
     .wd     (ctrl_shadowed_force_zero_masks_wd),
     .d      (hw2reg.ctrl_shadowed.force_zero_masks.d),
     .qre    (reg2hw.ctrl_shadowed.force_zero_masks.re),
@@ -824,7 +812,7 @@ module aes_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (trigger_start_we),
+    .we     (trigger_we),
     .wd     (trigger_start_wd),
 
     // from internal hardware
@@ -850,7 +838,7 @@ module aes_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (trigger_key_iv_data_in_clear_we),
+    .we     (trigger_we),
     .wd     (trigger_key_iv_data_in_clear_wd),
 
     // from internal hardware
@@ -876,7 +864,7 @@ module aes_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (trigger_data_out_clear_we),
+    .we     (trigger_we),
     .wd     (trigger_data_out_clear_wd),
 
     // from internal hardware
@@ -902,7 +890,7 @@ module aes_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (trigger_prng_reseed_we),
+    .we     (trigger_we),
     .wd     (trigger_prng_reseed_wd),
 
     // from internal hardware
@@ -1179,123 +1167,107 @@ module aes_reg_top (
                (addr_hit[30] & (|(AES_PERMIT[30] & ~reg_be))) |
                (addr_hit[31] & (|(AES_PERMIT[31] & ~reg_be)))));
   end
+  assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_recov_ctrl_update_err_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ctrl_update_err_wd = reg_wdata[0];
 
-  assign alert_test_fatal_fault_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_fault_wd = reg_wdata[1];
-
   assign key_share0_0_we = addr_hit[1] & reg_we & !reg_error;
+
   assign key_share0_0_wd = reg_wdata[31:0];
-
   assign key_share0_1_we = addr_hit[2] & reg_we & !reg_error;
+
   assign key_share0_1_wd = reg_wdata[31:0];
-
   assign key_share0_2_we = addr_hit[3] & reg_we & !reg_error;
+
   assign key_share0_2_wd = reg_wdata[31:0];
-
   assign key_share0_3_we = addr_hit[4] & reg_we & !reg_error;
+
   assign key_share0_3_wd = reg_wdata[31:0];
-
   assign key_share0_4_we = addr_hit[5] & reg_we & !reg_error;
+
   assign key_share0_4_wd = reg_wdata[31:0];
-
   assign key_share0_5_we = addr_hit[6] & reg_we & !reg_error;
+
   assign key_share0_5_wd = reg_wdata[31:0];
-
   assign key_share0_6_we = addr_hit[7] & reg_we & !reg_error;
+
   assign key_share0_6_wd = reg_wdata[31:0];
-
   assign key_share0_7_we = addr_hit[8] & reg_we & !reg_error;
+
   assign key_share0_7_wd = reg_wdata[31:0];
-
   assign key_share1_0_we = addr_hit[9] & reg_we & !reg_error;
+
   assign key_share1_0_wd = reg_wdata[31:0];
-
   assign key_share1_1_we = addr_hit[10] & reg_we & !reg_error;
+
   assign key_share1_1_wd = reg_wdata[31:0];
-
   assign key_share1_2_we = addr_hit[11] & reg_we & !reg_error;
+
   assign key_share1_2_wd = reg_wdata[31:0];
-
   assign key_share1_3_we = addr_hit[12] & reg_we & !reg_error;
+
   assign key_share1_3_wd = reg_wdata[31:0];
-
   assign key_share1_4_we = addr_hit[13] & reg_we & !reg_error;
+
   assign key_share1_4_wd = reg_wdata[31:0];
-
   assign key_share1_5_we = addr_hit[14] & reg_we & !reg_error;
+
   assign key_share1_5_wd = reg_wdata[31:0];
-
   assign key_share1_6_we = addr_hit[15] & reg_we & !reg_error;
+
   assign key_share1_6_wd = reg_wdata[31:0];
-
   assign key_share1_7_we = addr_hit[16] & reg_we & !reg_error;
+
   assign key_share1_7_wd = reg_wdata[31:0];
-
   assign iv_0_we = addr_hit[17] & reg_we & !reg_error;
+
   assign iv_0_wd = reg_wdata[31:0];
-
   assign iv_1_we = addr_hit[18] & reg_we & !reg_error;
+
   assign iv_1_wd = reg_wdata[31:0];
-
   assign iv_2_we = addr_hit[19] & reg_we & !reg_error;
+
   assign iv_2_wd = reg_wdata[31:0];
-
   assign iv_3_we = addr_hit[20] & reg_we & !reg_error;
+
   assign iv_3_wd = reg_wdata[31:0];
-
   assign data_in_0_we = addr_hit[21] & reg_we & !reg_error;
+
   assign data_in_0_wd = reg_wdata[31:0];
-
   assign data_in_1_we = addr_hit[22] & reg_we & !reg_error;
+
   assign data_in_1_wd = reg_wdata[31:0];
-
   assign data_in_2_we = addr_hit[23] & reg_we & !reg_error;
+
   assign data_in_2_wd = reg_wdata[31:0];
-
   assign data_in_3_we = addr_hit[24] & reg_we & !reg_error;
+
   assign data_in_3_wd = reg_wdata[31:0];
-
   assign data_out_0_re = addr_hit[25] & reg_re & !reg_error;
-
   assign data_out_1_re = addr_hit[26] & reg_re & !reg_error;
-
   assign data_out_2_re = addr_hit[27] & reg_re & !reg_error;
-
   assign data_out_3_re = addr_hit[28] & reg_re & !reg_error;
+  assign ctrl_shadowed_re = addr_hit[29] & reg_re & !reg_error;
+  assign ctrl_shadowed_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign ctrl_shadowed_operation_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_operation_wd = reg_wdata[0];
-  assign ctrl_shadowed_operation_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_mode_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_mode_wd = reg_wdata[6:1];
-  assign ctrl_shadowed_mode_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_key_len_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_key_len_wd = reg_wdata[9:7];
-  assign ctrl_shadowed_key_len_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_manual_operation_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_manual_operation_wd = reg_wdata[10];
-  assign ctrl_shadowed_manual_operation_re = addr_hit[29] & reg_re & !reg_error;
 
-  assign ctrl_shadowed_force_zero_masks_we = addr_hit[29] & reg_we & !reg_error;
   assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[11];
-  assign ctrl_shadowed_force_zero_masks_re = addr_hit[29] & reg_re & !reg_error;
+  assign trigger_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign trigger_start_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_start_wd = reg_wdata[0];
 
-  assign trigger_key_iv_data_in_clear_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_key_iv_data_in_clear_wd = reg_wdata[1];
 
-  assign trigger_data_out_clear_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_data_out_clear_wd = reg_wdata[2];
 
-  assign trigger_prng_reseed_we = addr_hit[30] & reg_we & !reg_error;
   assign trigger_prng_reseed_wd = reg_wdata[3];
 
   // Read data return

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -104,403 +104,358 @@ module alert_handler_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_classa_qs;
   logic intr_state_classa_wd;
-  logic intr_state_classa_we;
   logic intr_state_classb_qs;
   logic intr_state_classb_wd;
-  logic intr_state_classb_we;
   logic intr_state_classc_qs;
   logic intr_state_classc_wd;
-  logic intr_state_classc_we;
   logic intr_state_classd_qs;
   logic intr_state_classd_wd;
-  logic intr_state_classd_we;
+  logic intr_enable_we;
   logic intr_enable_classa_qs;
   logic intr_enable_classa_wd;
-  logic intr_enable_classa_we;
   logic intr_enable_classb_qs;
   logic intr_enable_classb_wd;
-  logic intr_enable_classb_we;
   logic intr_enable_classc_qs;
   logic intr_enable_classc_wd;
-  logic intr_enable_classc_we;
   logic intr_enable_classd_qs;
   logic intr_enable_classd_wd;
-  logic intr_enable_classd_we;
+  logic intr_test_we;
   logic intr_test_classa_wd;
-  logic intr_test_classa_we;
   logic intr_test_classb_wd;
-  logic intr_test_classb_we;
   logic intr_test_classc_wd;
-  logic intr_test_classc_we;
   logic intr_test_classd_wd;
-  logic intr_test_classd_we;
+  logic ping_timer_regwen_we;
   logic ping_timer_regwen_qs;
   logic ping_timer_regwen_wd;
-  logic ping_timer_regwen_we;
+  logic ping_timeout_cyc_we;
   logic [15:0] ping_timeout_cyc_qs;
   logic [15:0] ping_timeout_cyc_wd;
-  logic ping_timeout_cyc_we;
+  logic ping_timer_en_we;
   logic ping_timer_en_qs;
   logic ping_timer_en_wd;
-  logic ping_timer_en_we;
+  logic alert_regwen_0_we;
   logic alert_regwen_0_qs;
   logic alert_regwen_0_wd;
-  logic alert_regwen_0_we;
+  logic alert_regwen_1_we;
   logic alert_regwen_1_qs;
   logic alert_regwen_1_wd;
-  logic alert_regwen_1_we;
+  logic alert_regwen_2_we;
   logic alert_regwen_2_qs;
   logic alert_regwen_2_wd;
-  logic alert_regwen_2_we;
+  logic alert_regwen_3_we;
   logic alert_regwen_3_qs;
   logic alert_regwen_3_wd;
-  logic alert_regwen_3_we;
+  logic alert_en_0_we;
   logic alert_en_0_qs;
   logic alert_en_0_wd;
-  logic alert_en_0_we;
+  logic alert_en_1_we;
   logic alert_en_1_qs;
   logic alert_en_1_wd;
-  logic alert_en_1_we;
+  logic alert_en_2_we;
   logic alert_en_2_qs;
   logic alert_en_2_wd;
-  logic alert_en_2_we;
+  logic alert_en_3_we;
   logic alert_en_3_qs;
   logic alert_en_3_wd;
-  logic alert_en_3_we;
+  logic alert_class_0_we;
   logic [1:0] alert_class_0_qs;
   logic [1:0] alert_class_0_wd;
-  logic alert_class_0_we;
+  logic alert_class_1_we;
   logic [1:0] alert_class_1_qs;
   logic [1:0] alert_class_1_wd;
-  logic alert_class_1_we;
+  logic alert_class_2_we;
   logic [1:0] alert_class_2_qs;
   logic [1:0] alert_class_2_wd;
-  logic alert_class_2_we;
+  logic alert_class_3_we;
   logic [1:0] alert_class_3_qs;
   logic [1:0] alert_class_3_wd;
-  logic alert_class_3_we;
+  logic alert_cause_0_we;
   logic alert_cause_0_qs;
   logic alert_cause_0_wd;
-  logic alert_cause_0_we;
+  logic alert_cause_1_we;
   logic alert_cause_1_qs;
   logic alert_cause_1_wd;
-  logic alert_cause_1_we;
+  logic alert_cause_2_we;
   logic alert_cause_2_qs;
   logic alert_cause_2_wd;
-  logic alert_cause_2_we;
+  logic alert_cause_3_we;
   logic alert_cause_3_qs;
   logic alert_cause_3_wd;
-  logic alert_cause_3_we;
+  logic loc_alert_regwen_0_we;
   logic loc_alert_regwen_0_qs;
   logic loc_alert_regwen_0_wd;
-  logic loc_alert_regwen_0_we;
+  logic loc_alert_regwen_1_we;
   logic loc_alert_regwen_1_qs;
   logic loc_alert_regwen_1_wd;
-  logic loc_alert_regwen_1_we;
+  logic loc_alert_regwen_2_we;
   logic loc_alert_regwen_2_qs;
   logic loc_alert_regwen_2_wd;
-  logic loc_alert_regwen_2_we;
+  logic loc_alert_regwen_3_we;
   logic loc_alert_regwen_3_qs;
   logic loc_alert_regwen_3_wd;
-  logic loc_alert_regwen_3_we;
+  logic loc_alert_regwen_4_we;
   logic loc_alert_regwen_4_qs;
   logic loc_alert_regwen_4_wd;
-  logic loc_alert_regwen_4_we;
+  logic loc_alert_en_0_we;
   logic loc_alert_en_0_qs;
   logic loc_alert_en_0_wd;
-  logic loc_alert_en_0_we;
+  logic loc_alert_en_1_we;
   logic loc_alert_en_1_qs;
   logic loc_alert_en_1_wd;
-  logic loc_alert_en_1_we;
+  logic loc_alert_en_2_we;
   logic loc_alert_en_2_qs;
   logic loc_alert_en_2_wd;
-  logic loc_alert_en_2_we;
+  logic loc_alert_en_3_we;
   logic loc_alert_en_3_qs;
   logic loc_alert_en_3_wd;
-  logic loc_alert_en_3_we;
+  logic loc_alert_en_4_we;
   logic loc_alert_en_4_qs;
   logic loc_alert_en_4_wd;
-  logic loc_alert_en_4_we;
+  logic loc_alert_class_0_we;
   logic [1:0] loc_alert_class_0_qs;
   logic [1:0] loc_alert_class_0_wd;
-  logic loc_alert_class_0_we;
+  logic loc_alert_class_1_we;
   logic [1:0] loc_alert_class_1_qs;
   logic [1:0] loc_alert_class_1_wd;
-  logic loc_alert_class_1_we;
+  logic loc_alert_class_2_we;
   logic [1:0] loc_alert_class_2_qs;
   logic [1:0] loc_alert_class_2_wd;
-  logic loc_alert_class_2_we;
+  logic loc_alert_class_3_we;
   logic [1:0] loc_alert_class_3_qs;
   logic [1:0] loc_alert_class_3_wd;
-  logic loc_alert_class_3_we;
+  logic loc_alert_class_4_we;
   logic [1:0] loc_alert_class_4_qs;
   logic [1:0] loc_alert_class_4_wd;
-  logic loc_alert_class_4_we;
+  logic loc_alert_cause_0_we;
   logic loc_alert_cause_0_qs;
   logic loc_alert_cause_0_wd;
-  logic loc_alert_cause_0_we;
+  logic loc_alert_cause_1_we;
   logic loc_alert_cause_1_qs;
   logic loc_alert_cause_1_wd;
-  logic loc_alert_cause_1_we;
+  logic loc_alert_cause_2_we;
   logic loc_alert_cause_2_qs;
   logic loc_alert_cause_2_wd;
-  logic loc_alert_cause_2_we;
+  logic loc_alert_cause_3_we;
   logic loc_alert_cause_3_qs;
   logic loc_alert_cause_3_wd;
-  logic loc_alert_cause_3_we;
+  logic loc_alert_cause_4_we;
   logic loc_alert_cause_4_qs;
   logic loc_alert_cause_4_wd;
-  logic loc_alert_cause_4_we;
+  logic classa_regwen_we;
   logic classa_regwen_qs;
   logic classa_regwen_wd;
-  logic classa_regwen_we;
+  logic classa_ctrl_we;
   logic classa_ctrl_en_qs;
   logic classa_ctrl_en_wd;
-  logic classa_ctrl_en_we;
   logic classa_ctrl_lock_qs;
   logic classa_ctrl_lock_wd;
-  logic classa_ctrl_lock_we;
   logic classa_ctrl_en_e0_qs;
   logic classa_ctrl_en_e0_wd;
-  logic classa_ctrl_en_e0_we;
   logic classa_ctrl_en_e1_qs;
   logic classa_ctrl_en_e1_wd;
-  logic classa_ctrl_en_e1_we;
   logic classa_ctrl_en_e2_qs;
   logic classa_ctrl_en_e2_wd;
-  logic classa_ctrl_en_e2_we;
   logic classa_ctrl_en_e3_qs;
   logic classa_ctrl_en_e3_wd;
-  logic classa_ctrl_en_e3_we;
   logic [1:0] classa_ctrl_map_e0_qs;
   logic [1:0] classa_ctrl_map_e0_wd;
-  logic classa_ctrl_map_e0_we;
   logic [1:0] classa_ctrl_map_e1_qs;
   logic [1:0] classa_ctrl_map_e1_wd;
-  logic classa_ctrl_map_e1_we;
   logic [1:0] classa_ctrl_map_e2_qs;
   logic [1:0] classa_ctrl_map_e2_wd;
-  logic classa_ctrl_map_e2_we;
   logic [1:0] classa_ctrl_map_e3_qs;
   logic [1:0] classa_ctrl_map_e3_wd;
-  logic classa_ctrl_map_e3_we;
+  logic classa_clr_regwen_we;
   logic classa_clr_regwen_qs;
   logic classa_clr_regwen_wd;
-  logic classa_clr_regwen_we;
-  logic classa_clr_wd;
   logic classa_clr_we;
-  logic [15:0] classa_accum_cnt_qs;
+  logic classa_clr_wd;
   logic classa_accum_cnt_re;
+  logic [15:0] classa_accum_cnt_qs;
+  logic classa_accum_thresh_we;
   logic [15:0] classa_accum_thresh_qs;
   logic [15:0] classa_accum_thresh_wd;
-  logic classa_accum_thresh_we;
+  logic classa_timeout_cyc_we;
   logic [31:0] classa_timeout_cyc_qs;
   logic [31:0] classa_timeout_cyc_wd;
-  logic classa_timeout_cyc_we;
+  logic classa_phase0_cyc_we;
   logic [31:0] classa_phase0_cyc_qs;
   logic [31:0] classa_phase0_cyc_wd;
-  logic classa_phase0_cyc_we;
+  logic classa_phase1_cyc_we;
   logic [31:0] classa_phase1_cyc_qs;
   logic [31:0] classa_phase1_cyc_wd;
-  logic classa_phase1_cyc_we;
+  logic classa_phase2_cyc_we;
   logic [31:0] classa_phase2_cyc_qs;
   logic [31:0] classa_phase2_cyc_wd;
-  logic classa_phase2_cyc_we;
+  logic classa_phase3_cyc_we;
   logic [31:0] classa_phase3_cyc_qs;
   logic [31:0] classa_phase3_cyc_wd;
-  logic classa_phase3_cyc_we;
-  logic [31:0] classa_esc_cnt_qs;
   logic classa_esc_cnt_re;
-  logic [2:0] classa_state_qs;
+  logic [31:0] classa_esc_cnt_qs;
   logic classa_state_re;
+  logic [2:0] classa_state_qs;
+  logic classb_regwen_we;
   logic classb_regwen_qs;
   logic classb_regwen_wd;
-  logic classb_regwen_we;
+  logic classb_ctrl_we;
   logic classb_ctrl_en_qs;
   logic classb_ctrl_en_wd;
-  logic classb_ctrl_en_we;
   logic classb_ctrl_lock_qs;
   logic classb_ctrl_lock_wd;
-  logic classb_ctrl_lock_we;
   logic classb_ctrl_en_e0_qs;
   logic classb_ctrl_en_e0_wd;
-  logic classb_ctrl_en_e0_we;
   logic classb_ctrl_en_e1_qs;
   logic classb_ctrl_en_e1_wd;
-  logic classb_ctrl_en_e1_we;
   logic classb_ctrl_en_e2_qs;
   logic classb_ctrl_en_e2_wd;
-  logic classb_ctrl_en_e2_we;
   logic classb_ctrl_en_e3_qs;
   logic classb_ctrl_en_e3_wd;
-  logic classb_ctrl_en_e3_we;
   logic [1:0] classb_ctrl_map_e0_qs;
   logic [1:0] classb_ctrl_map_e0_wd;
-  logic classb_ctrl_map_e0_we;
   logic [1:0] classb_ctrl_map_e1_qs;
   logic [1:0] classb_ctrl_map_e1_wd;
-  logic classb_ctrl_map_e1_we;
   logic [1:0] classb_ctrl_map_e2_qs;
   logic [1:0] classb_ctrl_map_e2_wd;
-  logic classb_ctrl_map_e2_we;
   logic [1:0] classb_ctrl_map_e3_qs;
   logic [1:0] classb_ctrl_map_e3_wd;
-  logic classb_ctrl_map_e3_we;
+  logic classb_clr_regwen_we;
   logic classb_clr_regwen_qs;
   logic classb_clr_regwen_wd;
-  logic classb_clr_regwen_we;
-  logic classb_clr_wd;
   logic classb_clr_we;
-  logic [15:0] classb_accum_cnt_qs;
+  logic classb_clr_wd;
   logic classb_accum_cnt_re;
+  logic [15:0] classb_accum_cnt_qs;
+  logic classb_accum_thresh_we;
   logic [15:0] classb_accum_thresh_qs;
   logic [15:0] classb_accum_thresh_wd;
-  logic classb_accum_thresh_we;
+  logic classb_timeout_cyc_we;
   logic [31:0] classb_timeout_cyc_qs;
   logic [31:0] classb_timeout_cyc_wd;
-  logic classb_timeout_cyc_we;
+  logic classb_phase0_cyc_we;
   logic [31:0] classb_phase0_cyc_qs;
   logic [31:0] classb_phase0_cyc_wd;
-  logic classb_phase0_cyc_we;
+  logic classb_phase1_cyc_we;
   logic [31:0] classb_phase1_cyc_qs;
   logic [31:0] classb_phase1_cyc_wd;
-  logic classb_phase1_cyc_we;
+  logic classb_phase2_cyc_we;
   logic [31:0] classb_phase2_cyc_qs;
   logic [31:0] classb_phase2_cyc_wd;
-  logic classb_phase2_cyc_we;
+  logic classb_phase3_cyc_we;
   logic [31:0] classb_phase3_cyc_qs;
   logic [31:0] classb_phase3_cyc_wd;
-  logic classb_phase3_cyc_we;
-  logic [31:0] classb_esc_cnt_qs;
   logic classb_esc_cnt_re;
-  logic [2:0] classb_state_qs;
+  logic [31:0] classb_esc_cnt_qs;
   logic classb_state_re;
+  logic [2:0] classb_state_qs;
+  logic classc_regwen_we;
   logic classc_regwen_qs;
   logic classc_regwen_wd;
-  logic classc_regwen_we;
+  logic classc_ctrl_we;
   logic classc_ctrl_en_qs;
   logic classc_ctrl_en_wd;
-  logic classc_ctrl_en_we;
   logic classc_ctrl_lock_qs;
   logic classc_ctrl_lock_wd;
-  logic classc_ctrl_lock_we;
   logic classc_ctrl_en_e0_qs;
   logic classc_ctrl_en_e0_wd;
-  logic classc_ctrl_en_e0_we;
   logic classc_ctrl_en_e1_qs;
   logic classc_ctrl_en_e1_wd;
-  logic classc_ctrl_en_e1_we;
   logic classc_ctrl_en_e2_qs;
   logic classc_ctrl_en_e2_wd;
-  logic classc_ctrl_en_e2_we;
   logic classc_ctrl_en_e3_qs;
   logic classc_ctrl_en_e3_wd;
-  logic classc_ctrl_en_e3_we;
   logic [1:0] classc_ctrl_map_e0_qs;
   logic [1:0] classc_ctrl_map_e0_wd;
-  logic classc_ctrl_map_e0_we;
   logic [1:0] classc_ctrl_map_e1_qs;
   logic [1:0] classc_ctrl_map_e1_wd;
-  logic classc_ctrl_map_e1_we;
   logic [1:0] classc_ctrl_map_e2_qs;
   logic [1:0] classc_ctrl_map_e2_wd;
-  logic classc_ctrl_map_e2_we;
   logic [1:0] classc_ctrl_map_e3_qs;
   logic [1:0] classc_ctrl_map_e3_wd;
-  logic classc_ctrl_map_e3_we;
+  logic classc_clr_regwen_we;
   logic classc_clr_regwen_qs;
   logic classc_clr_regwen_wd;
-  logic classc_clr_regwen_we;
-  logic classc_clr_wd;
   logic classc_clr_we;
-  logic [15:0] classc_accum_cnt_qs;
+  logic classc_clr_wd;
   logic classc_accum_cnt_re;
+  logic [15:0] classc_accum_cnt_qs;
+  logic classc_accum_thresh_we;
   logic [15:0] classc_accum_thresh_qs;
   logic [15:0] classc_accum_thresh_wd;
-  logic classc_accum_thresh_we;
+  logic classc_timeout_cyc_we;
   logic [31:0] classc_timeout_cyc_qs;
   logic [31:0] classc_timeout_cyc_wd;
-  logic classc_timeout_cyc_we;
+  logic classc_phase0_cyc_we;
   logic [31:0] classc_phase0_cyc_qs;
   logic [31:0] classc_phase0_cyc_wd;
-  logic classc_phase0_cyc_we;
+  logic classc_phase1_cyc_we;
   logic [31:0] classc_phase1_cyc_qs;
   logic [31:0] classc_phase1_cyc_wd;
-  logic classc_phase1_cyc_we;
+  logic classc_phase2_cyc_we;
   logic [31:0] classc_phase2_cyc_qs;
   logic [31:0] classc_phase2_cyc_wd;
-  logic classc_phase2_cyc_we;
+  logic classc_phase3_cyc_we;
   logic [31:0] classc_phase3_cyc_qs;
   logic [31:0] classc_phase3_cyc_wd;
-  logic classc_phase3_cyc_we;
-  logic [31:0] classc_esc_cnt_qs;
   logic classc_esc_cnt_re;
-  logic [2:0] classc_state_qs;
+  logic [31:0] classc_esc_cnt_qs;
   logic classc_state_re;
+  logic [2:0] classc_state_qs;
+  logic classd_regwen_we;
   logic classd_regwen_qs;
   logic classd_regwen_wd;
-  logic classd_regwen_we;
+  logic classd_ctrl_we;
   logic classd_ctrl_en_qs;
   logic classd_ctrl_en_wd;
-  logic classd_ctrl_en_we;
   logic classd_ctrl_lock_qs;
   logic classd_ctrl_lock_wd;
-  logic classd_ctrl_lock_we;
   logic classd_ctrl_en_e0_qs;
   logic classd_ctrl_en_e0_wd;
-  logic classd_ctrl_en_e0_we;
   logic classd_ctrl_en_e1_qs;
   logic classd_ctrl_en_e1_wd;
-  logic classd_ctrl_en_e1_we;
   logic classd_ctrl_en_e2_qs;
   logic classd_ctrl_en_e2_wd;
-  logic classd_ctrl_en_e2_we;
   logic classd_ctrl_en_e3_qs;
   logic classd_ctrl_en_e3_wd;
-  logic classd_ctrl_en_e3_we;
   logic [1:0] classd_ctrl_map_e0_qs;
   logic [1:0] classd_ctrl_map_e0_wd;
-  logic classd_ctrl_map_e0_we;
   logic [1:0] classd_ctrl_map_e1_qs;
   logic [1:0] classd_ctrl_map_e1_wd;
-  logic classd_ctrl_map_e1_we;
   logic [1:0] classd_ctrl_map_e2_qs;
   logic [1:0] classd_ctrl_map_e2_wd;
-  logic classd_ctrl_map_e2_we;
   logic [1:0] classd_ctrl_map_e3_qs;
   logic [1:0] classd_ctrl_map_e3_wd;
-  logic classd_ctrl_map_e3_we;
+  logic classd_clr_regwen_we;
   logic classd_clr_regwen_qs;
   logic classd_clr_regwen_wd;
-  logic classd_clr_regwen_we;
-  logic classd_clr_wd;
   logic classd_clr_we;
-  logic [15:0] classd_accum_cnt_qs;
+  logic classd_clr_wd;
   logic classd_accum_cnt_re;
+  logic [15:0] classd_accum_cnt_qs;
+  logic classd_accum_thresh_we;
   logic [15:0] classd_accum_thresh_qs;
   logic [15:0] classd_accum_thresh_wd;
-  logic classd_accum_thresh_we;
+  logic classd_timeout_cyc_we;
   logic [31:0] classd_timeout_cyc_qs;
   logic [31:0] classd_timeout_cyc_wd;
-  logic classd_timeout_cyc_we;
+  logic classd_phase0_cyc_we;
   logic [31:0] classd_phase0_cyc_qs;
   logic [31:0] classd_phase0_cyc_wd;
-  logic classd_phase0_cyc_we;
+  logic classd_phase1_cyc_we;
   logic [31:0] classd_phase1_cyc_qs;
   logic [31:0] classd_phase1_cyc_wd;
-  logic classd_phase1_cyc_we;
+  logic classd_phase2_cyc_we;
   logic [31:0] classd_phase2_cyc_qs;
   logic [31:0] classd_phase2_cyc_wd;
-  logic classd_phase2_cyc_we;
+  logic classd_phase3_cyc_we;
   logic [31:0] classd_phase3_cyc_qs;
   logic [31:0] classd_phase3_cyc_wd;
-  logic classd_phase3_cyc_we;
-  logic [31:0] classd_esc_cnt_qs;
   logic classd_esc_cnt_re;
-  logic [2:0] classd_state_qs;
+  logic [31:0] classd_esc_cnt_qs;
   logic classd_state_re;
+  logic [2:0] classd_state_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -515,7 +470,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classa_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classa_wd),
 
     // from internal hardware
@@ -541,7 +496,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classb_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classb_wd),
 
     // from internal hardware
@@ -567,7 +522,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classc_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classc_wd),
 
     // from internal hardware
@@ -593,7 +548,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classd_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classd_wd),
 
     // from internal hardware
@@ -621,7 +576,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classa_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classa_wd),
 
     // from internal hardware
@@ -647,7 +602,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classb_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classb_wd),
 
     // from internal hardware
@@ -673,7 +628,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classc_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classc_wd),
 
     // from internal hardware
@@ -699,7 +654,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classd_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classd_wd),
 
     // from internal hardware
@@ -722,7 +677,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classa (
     .re     (1'b0),
-    .we     (intr_test_classa_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classa_wd),
     .d      ('0),
     .qre    (),
@@ -737,7 +692,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classb (
     .re     (1'b0),
-    .we     (intr_test_classb_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classb_wd),
     .d      ('0),
     .qre    (),
@@ -752,7 +707,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classc (
     .re     (1'b0),
-    .we     (intr_test_classc_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classc_wd),
     .d      ('0),
     .qre    (),
@@ -767,7 +722,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classd (
     .re     (1'b0),
-    .we     (intr_test_classd_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classd_wd),
     .d      ('0),
     .qre    (),
@@ -1885,7 +1840,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_wd),
 
     // from internal hardware
@@ -1911,7 +1866,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_lock_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_lock_wd),
 
     // from internal hardware
@@ -1937,7 +1892,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e0_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -1963,7 +1918,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e1_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -1989,7 +1944,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e2_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -2015,7 +1970,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e3_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -2041,7 +1996,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e0_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -2067,7 +2022,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e1_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -2093,7 +2048,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e2_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -2119,7 +2074,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e3_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -2438,7 +2393,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_wd),
 
     // from internal hardware
@@ -2464,7 +2419,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_lock_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_lock_wd),
 
     // from internal hardware
@@ -2490,7 +2445,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e0_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -2516,7 +2471,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e1_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -2542,7 +2497,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e2_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -2568,7 +2523,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e3_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -2594,7 +2549,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e0_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -2620,7 +2575,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e1_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -2646,7 +2601,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e2_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -2672,7 +2627,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e3_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -2991,7 +2946,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_wd),
 
     // from internal hardware
@@ -3017,7 +2972,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_lock_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_lock_wd),
 
     // from internal hardware
@@ -3043,7 +2998,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e0_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -3069,7 +3024,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e1_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -3095,7 +3050,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e2_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -3121,7 +3076,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e3_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -3147,7 +3102,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e0_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -3173,7 +3128,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e1_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -3199,7 +3154,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e2_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -3225,7 +3180,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e3_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -3544,7 +3499,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_wd),
 
     // from internal hardware
@@ -3570,7 +3525,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_lock_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_lock_wd),
 
     // from internal hardware
@@ -3596,7 +3551,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e0_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -3622,7 +3577,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e1_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -3648,7 +3603,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e2_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -3674,7 +3629,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e3_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -3700,7 +3655,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e0_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -3726,7 +3681,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e1_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -3752,7 +3707,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e2_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -3778,7 +3733,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e3_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -4259,410 +4214,353 @@ module alert_handler_reg_top (
                (addr_hit[92] & (|(ALERT_HANDLER_PERMIT[92] & ~reg_be))) |
                (addr_hit[93] & (|(ALERT_HANDLER_PERMIT[93] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_classa_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classa_wd = reg_wdata[0];
 
-  assign intr_state_classb_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classb_wd = reg_wdata[1];
 
-  assign intr_state_classc_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classc_wd = reg_wdata[2];
 
-  assign intr_state_classd_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classd_wd = reg_wdata[3];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_classa_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classa_wd = reg_wdata[0];
 
-  assign intr_enable_classb_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classb_wd = reg_wdata[1];
 
-  assign intr_enable_classc_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classc_wd = reg_wdata[2];
 
-  assign intr_enable_classd_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classd_wd = reg_wdata[3];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_classa_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classa_wd = reg_wdata[0];
 
-  assign intr_test_classb_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classb_wd = reg_wdata[1];
 
-  assign intr_test_classc_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classc_wd = reg_wdata[2];
 
-  assign intr_test_classd_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classd_wd = reg_wdata[3];
-
   assign ping_timer_regwen_we = addr_hit[3] & reg_we & !reg_error;
+
   assign ping_timer_regwen_wd = reg_wdata[0];
-
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & !reg_error;
+
   assign ping_timeout_cyc_wd = reg_wdata[15:0];
-
   assign ping_timer_en_we = addr_hit[5] & reg_we & !reg_error;
+
   assign ping_timer_en_wd = reg_wdata[0];
-
   assign alert_regwen_0_we = addr_hit[6] & reg_we & !reg_error;
+
   assign alert_regwen_0_wd = reg_wdata[0];
-
   assign alert_regwen_1_we = addr_hit[7] & reg_we & !reg_error;
+
   assign alert_regwen_1_wd = reg_wdata[0];
-
   assign alert_regwen_2_we = addr_hit[8] & reg_we & !reg_error;
+
   assign alert_regwen_2_wd = reg_wdata[0];
-
   assign alert_regwen_3_we = addr_hit[9] & reg_we & !reg_error;
+
   assign alert_regwen_3_wd = reg_wdata[0];
-
   assign alert_en_0_we = addr_hit[10] & reg_we & !reg_error;
+
   assign alert_en_0_wd = reg_wdata[0];
-
   assign alert_en_1_we = addr_hit[11] & reg_we & !reg_error;
+
   assign alert_en_1_wd = reg_wdata[0];
-
   assign alert_en_2_we = addr_hit[12] & reg_we & !reg_error;
+
   assign alert_en_2_wd = reg_wdata[0];
-
   assign alert_en_3_we = addr_hit[13] & reg_we & !reg_error;
+
   assign alert_en_3_wd = reg_wdata[0];
-
   assign alert_class_0_we = addr_hit[14] & reg_we & !reg_error;
+
   assign alert_class_0_wd = reg_wdata[1:0];
-
   assign alert_class_1_we = addr_hit[15] & reg_we & !reg_error;
+
   assign alert_class_1_wd = reg_wdata[1:0];
-
   assign alert_class_2_we = addr_hit[16] & reg_we & !reg_error;
+
   assign alert_class_2_wd = reg_wdata[1:0];
-
   assign alert_class_3_we = addr_hit[17] & reg_we & !reg_error;
+
   assign alert_class_3_wd = reg_wdata[1:0];
-
   assign alert_cause_0_we = addr_hit[18] & reg_we & !reg_error;
+
   assign alert_cause_0_wd = reg_wdata[0];
-
   assign alert_cause_1_we = addr_hit[19] & reg_we & !reg_error;
+
   assign alert_cause_1_wd = reg_wdata[0];
-
   assign alert_cause_2_we = addr_hit[20] & reg_we & !reg_error;
+
   assign alert_cause_2_wd = reg_wdata[0];
-
   assign alert_cause_3_we = addr_hit[21] & reg_we & !reg_error;
+
   assign alert_cause_3_wd = reg_wdata[0];
-
   assign loc_alert_regwen_0_we = addr_hit[22] & reg_we & !reg_error;
+
   assign loc_alert_regwen_0_wd = reg_wdata[0];
-
   assign loc_alert_regwen_1_we = addr_hit[23] & reg_we & !reg_error;
+
   assign loc_alert_regwen_1_wd = reg_wdata[0];
-
   assign loc_alert_regwen_2_we = addr_hit[24] & reg_we & !reg_error;
+
   assign loc_alert_regwen_2_wd = reg_wdata[0];
-
   assign loc_alert_regwen_3_we = addr_hit[25] & reg_we & !reg_error;
+
   assign loc_alert_regwen_3_wd = reg_wdata[0];
-
   assign loc_alert_regwen_4_we = addr_hit[26] & reg_we & !reg_error;
+
   assign loc_alert_regwen_4_wd = reg_wdata[0];
-
   assign loc_alert_en_0_we = addr_hit[27] & reg_we & !reg_error;
+
   assign loc_alert_en_0_wd = reg_wdata[0];
-
   assign loc_alert_en_1_we = addr_hit[28] & reg_we & !reg_error;
+
   assign loc_alert_en_1_wd = reg_wdata[0];
-
   assign loc_alert_en_2_we = addr_hit[29] & reg_we & !reg_error;
+
   assign loc_alert_en_2_wd = reg_wdata[0];
-
   assign loc_alert_en_3_we = addr_hit[30] & reg_we & !reg_error;
+
   assign loc_alert_en_3_wd = reg_wdata[0];
-
   assign loc_alert_en_4_we = addr_hit[31] & reg_we & !reg_error;
+
   assign loc_alert_en_4_wd = reg_wdata[0];
-
   assign loc_alert_class_0_we = addr_hit[32] & reg_we & !reg_error;
+
   assign loc_alert_class_0_wd = reg_wdata[1:0];
-
   assign loc_alert_class_1_we = addr_hit[33] & reg_we & !reg_error;
+
   assign loc_alert_class_1_wd = reg_wdata[1:0];
-
   assign loc_alert_class_2_we = addr_hit[34] & reg_we & !reg_error;
+
   assign loc_alert_class_2_wd = reg_wdata[1:0];
-
   assign loc_alert_class_3_we = addr_hit[35] & reg_we & !reg_error;
+
   assign loc_alert_class_3_wd = reg_wdata[1:0];
-
   assign loc_alert_class_4_we = addr_hit[36] & reg_we & !reg_error;
+
   assign loc_alert_class_4_wd = reg_wdata[1:0];
-
   assign loc_alert_cause_0_we = addr_hit[37] & reg_we & !reg_error;
+
   assign loc_alert_cause_0_wd = reg_wdata[0];
-
   assign loc_alert_cause_1_we = addr_hit[38] & reg_we & !reg_error;
+
   assign loc_alert_cause_1_wd = reg_wdata[0];
-
   assign loc_alert_cause_2_we = addr_hit[39] & reg_we & !reg_error;
+
   assign loc_alert_cause_2_wd = reg_wdata[0];
-
   assign loc_alert_cause_3_we = addr_hit[40] & reg_we & !reg_error;
+
   assign loc_alert_cause_3_wd = reg_wdata[0];
-
   assign loc_alert_cause_4_we = addr_hit[41] & reg_we & !reg_error;
+
   assign loc_alert_cause_4_wd = reg_wdata[0];
-
   assign classa_regwen_we = addr_hit[42] & reg_we & !reg_error;
-  assign classa_regwen_wd = reg_wdata[0];
 
-  assign classa_ctrl_en_we = addr_hit[43] & reg_we & !reg_error;
+  assign classa_regwen_wd = reg_wdata[0];
+  assign classa_ctrl_we = addr_hit[43] & reg_we & !reg_error;
+
   assign classa_ctrl_en_wd = reg_wdata[0];
 
-  assign classa_ctrl_lock_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_lock_wd = reg_wdata[1];
 
-  assign classa_ctrl_en_e0_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classa_ctrl_en_e1_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_e2_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classa_ctrl_en_e3_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classa_ctrl_map_e0_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classa_ctrl_map_e1_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classa_ctrl_map_e2_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classa_ctrl_map_e3_we = addr_hit[43] & reg_we & !reg_error;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classa_clr_regwen_we = addr_hit[44] & reg_we & !reg_error;
+
   assign classa_clr_regwen_wd = reg_wdata[0];
-
   assign classa_clr_we = addr_hit[45] & reg_we & !reg_error;
+
   assign classa_clr_wd = reg_wdata[0];
-
   assign classa_accum_cnt_re = addr_hit[46] & reg_re & !reg_error;
-
   assign classa_accum_thresh_we = addr_hit[47] & reg_we & !reg_error;
+
   assign classa_accum_thresh_wd = reg_wdata[15:0];
-
   assign classa_timeout_cyc_we = addr_hit[48] & reg_we & !reg_error;
+
   assign classa_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase0_cyc_we = addr_hit[49] & reg_we & !reg_error;
+
   assign classa_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase1_cyc_we = addr_hit[50] & reg_we & !reg_error;
+
   assign classa_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase2_cyc_we = addr_hit[51] & reg_we & !reg_error;
+
   assign classa_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase3_cyc_we = addr_hit[52] & reg_we & !reg_error;
+
   assign classa_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classa_esc_cnt_re = addr_hit[53] & reg_re & !reg_error;
-
   assign classa_state_re = addr_hit[54] & reg_re & !reg_error;
-
   assign classb_regwen_we = addr_hit[55] & reg_we & !reg_error;
-  assign classb_regwen_wd = reg_wdata[0];
 
-  assign classb_ctrl_en_we = addr_hit[56] & reg_we & !reg_error;
+  assign classb_regwen_wd = reg_wdata[0];
+  assign classb_ctrl_we = addr_hit[56] & reg_we & !reg_error;
+
   assign classb_ctrl_en_wd = reg_wdata[0];
 
-  assign classb_ctrl_lock_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_lock_wd = reg_wdata[1];
 
-  assign classb_ctrl_en_e0_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classb_ctrl_en_e1_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classb_ctrl_en_e2_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classb_ctrl_en_e3_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classb_ctrl_map_e0_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classb_ctrl_map_e1_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classb_ctrl_map_e2_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classb_ctrl_map_e3_we = addr_hit[56] & reg_we & !reg_error;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classb_clr_regwen_we = addr_hit[57] & reg_we & !reg_error;
+
   assign classb_clr_regwen_wd = reg_wdata[0];
-
   assign classb_clr_we = addr_hit[58] & reg_we & !reg_error;
+
   assign classb_clr_wd = reg_wdata[0];
-
   assign classb_accum_cnt_re = addr_hit[59] & reg_re & !reg_error;
-
   assign classb_accum_thresh_we = addr_hit[60] & reg_we & !reg_error;
+
   assign classb_accum_thresh_wd = reg_wdata[15:0];
-
   assign classb_timeout_cyc_we = addr_hit[61] & reg_we & !reg_error;
+
   assign classb_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase0_cyc_we = addr_hit[62] & reg_we & !reg_error;
+
   assign classb_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase1_cyc_we = addr_hit[63] & reg_we & !reg_error;
+
   assign classb_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase2_cyc_we = addr_hit[64] & reg_we & !reg_error;
+
   assign classb_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase3_cyc_we = addr_hit[65] & reg_we & !reg_error;
+
   assign classb_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classb_esc_cnt_re = addr_hit[66] & reg_re & !reg_error;
-
   assign classb_state_re = addr_hit[67] & reg_re & !reg_error;
-
   assign classc_regwen_we = addr_hit[68] & reg_we & !reg_error;
-  assign classc_regwen_wd = reg_wdata[0];
 
-  assign classc_ctrl_en_we = addr_hit[69] & reg_we & !reg_error;
+  assign classc_regwen_wd = reg_wdata[0];
+  assign classc_ctrl_we = addr_hit[69] & reg_we & !reg_error;
+
   assign classc_ctrl_en_wd = reg_wdata[0];
 
-  assign classc_ctrl_lock_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_lock_wd = reg_wdata[1];
 
-  assign classc_ctrl_en_e0_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classc_ctrl_en_e1_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classc_ctrl_en_e2_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classc_ctrl_en_e3_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classc_ctrl_map_e0_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classc_ctrl_map_e1_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classc_ctrl_map_e2_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classc_ctrl_map_e3_we = addr_hit[69] & reg_we & !reg_error;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classc_clr_regwen_we = addr_hit[70] & reg_we & !reg_error;
+
   assign classc_clr_regwen_wd = reg_wdata[0];
-
   assign classc_clr_we = addr_hit[71] & reg_we & !reg_error;
+
   assign classc_clr_wd = reg_wdata[0];
-
   assign classc_accum_cnt_re = addr_hit[72] & reg_re & !reg_error;
-
   assign classc_accum_thresh_we = addr_hit[73] & reg_we & !reg_error;
+
   assign classc_accum_thresh_wd = reg_wdata[15:0];
-
   assign classc_timeout_cyc_we = addr_hit[74] & reg_we & !reg_error;
+
   assign classc_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase0_cyc_we = addr_hit[75] & reg_we & !reg_error;
+
   assign classc_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase1_cyc_we = addr_hit[76] & reg_we & !reg_error;
+
   assign classc_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase2_cyc_we = addr_hit[77] & reg_we & !reg_error;
+
   assign classc_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase3_cyc_we = addr_hit[78] & reg_we & !reg_error;
+
   assign classc_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classc_esc_cnt_re = addr_hit[79] & reg_re & !reg_error;
-
   assign classc_state_re = addr_hit[80] & reg_re & !reg_error;
-
   assign classd_regwen_we = addr_hit[81] & reg_we & !reg_error;
-  assign classd_regwen_wd = reg_wdata[0];
 
-  assign classd_ctrl_en_we = addr_hit[82] & reg_we & !reg_error;
+  assign classd_regwen_wd = reg_wdata[0];
+  assign classd_ctrl_we = addr_hit[82] & reg_we & !reg_error;
+
   assign classd_ctrl_en_wd = reg_wdata[0];
 
-  assign classd_ctrl_lock_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_lock_wd = reg_wdata[1];
 
-  assign classd_ctrl_en_e0_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classd_ctrl_en_e1_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classd_ctrl_en_e2_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classd_ctrl_en_e3_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classd_ctrl_map_e0_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classd_ctrl_map_e1_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classd_ctrl_map_e2_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classd_ctrl_map_e3_we = addr_hit[82] & reg_we & !reg_error;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classd_clr_regwen_we = addr_hit[83] & reg_we & !reg_error;
+
   assign classd_clr_regwen_wd = reg_wdata[0];
-
   assign classd_clr_we = addr_hit[84] & reg_we & !reg_error;
+
   assign classd_clr_wd = reg_wdata[0];
-
   assign classd_accum_cnt_re = addr_hit[85] & reg_re & !reg_error;
-
   assign classd_accum_thresh_we = addr_hit[86] & reg_we & !reg_error;
+
   assign classd_accum_thresh_wd = reg_wdata[15:0];
-
   assign classd_timeout_cyc_we = addr_hit[87] & reg_we & !reg_error;
+
   assign classd_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase0_cyc_we = addr_hit[88] & reg_we & !reg_error;
+
   assign classd_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase1_cyc_we = addr_hit[89] & reg_we & !reg_error;
+
   assign classd_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase2_cyc_we = addr_hit[90] & reg_we & !reg_error;
+
   assign classd_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase3_cyc_we = addr_hit[91] & reg_we & !reg_error;
+
   assign classd_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classd_esc_cnt_re = addr_hit[92] & reg_re & !reg_error;
-
   assign classd_state_re = addr_hit[93] & reg_re & !reg_error;
 
   // Read data return

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -104,49 +104,45 @@ module aon_timer_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic wkup_ctrl_we;
   logic wkup_ctrl_enable_qs;
   logic wkup_ctrl_enable_wd;
-  logic wkup_ctrl_enable_we;
   logic [11:0] wkup_ctrl_prescaler_qs;
   logic [11:0] wkup_ctrl_prescaler_wd;
-  logic wkup_ctrl_prescaler_we;
+  logic wkup_thold_we;
   logic [31:0] wkup_thold_qs;
   logic [31:0] wkup_thold_wd;
-  logic wkup_thold_we;
+  logic wkup_count_we;
   logic [31:0] wkup_count_qs;
   logic [31:0] wkup_count_wd;
-  logic wkup_count_we;
+  logic wdog_regwen_we;
   logic wdog_regwen_qs;
   logic wdog_regwen_wd;
-  logic wdog_regwen_we;
+  logic wdog_ctrl_we;
   logic wdog_ctrl_enable_qs;
   logic wdog_ctrl_enable_wd;
-  logic wdog_ctrl_enable_we;
   logic wdog_ctrl_pause_in_sleep_qs;
   logic wdog_ctrl_pause_in_sleep_wd;
-  logic wdog_ctrl_pause_in_sleep_we;
+  logic wdog_bark_thold_we;
   logic [31:0] wdog_bark_thold_qs;
   logic [31:0] wdog_bark_thold_wd;
-  logic wdog_bark_thold_we;
+  logic wdog_bite_thold_we;
   logic [31:0] wdog_bite_thold_qs;
   logic [31:0] wdog_bite_thold_wd;
-  logic wdog_bite_thold_we;
+  logic wdog_count_we;
   logic [31:0] wdog_count_qs;
   logic [31:0] wdog_count_wd;
-  logic wdog_count_we;
+  logic intr_state_we;
   logic intr_state_wkup_timer_expired_qs;
   logic intr_state_wkup_timer_expired_wd;
-  logic intr_state_wkup_timer_expired_we;
   logic intr_state_wdog_timer_expired_qs;
   logic intr_state_wdog_timer_expired_wd;
-  logic intr_state_wdog_timer_expired_we;
+  logic intr_test_we;
   logic intr_test_wkup_timer_expired_wd;
-  logic intr_test_wkup_timer_expired_we;
   logic intr_test_wdog_timer_expired_wd;
-  logic intr_test_wdog_timer_expired_we;
+  logic wkup_cause_we;
   logic wkup_cause_qs;
   logic wkup_cause_wd;
-  logic wkup_cause_we;
 
   // Register instances
   // R[wkup_ctrl]: V(False)
@@ -161,7 +157,7 @@ module aon_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_ctrl_enable_we),
+    .we     (wkup_ctrl_we),
     .wd     (wkup_ctrl_enable_wd),
 
     // from internal hardware
@@ -187,7 +183,7 @@ module aon_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_ctrl_prescaler_we),
+    .we     (wkup_ctrl_we),
     .wd     (wkup_ctrl_prescaler_wd),
 
     // from internal hardware
@@ -296,7 +292,7 @@ module aon_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wdog_ctrl_enable_we & wdog_regwen_qs),
+    .we     (wdog_ctrl_we & wdog_regwen_qs),
     .wd     (wdog_ctrl_enable_wd),
 
     // from internal hardware
@@ -322,7 +318,7 @@ module aon_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wdog_ctrl_pause_in_sleep_we & wdog_regwen_qs),
+    .we     (wdog_ctrl_we & wdog_regwen_qs),
     .wd     (wdog_ctrl_pause_in_sleep_wd),
 
     // from internal hardware
@@ -431,7 +427,7 @@ module aon_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_wkup_timer_expired_we),
+    .we     (intr_state_we),
     .wd     (intr_state_wkup_timer_expired_wd),
 
     // from internal hardware
@@ -457,7 +453,7 @@ module aon_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_wdog_timer_expired_we),
+    .we     (intr_state_we),
     .wd     (intr_state_wdog_timer_expired_wd),
 
     // from internal hardware
@@ -480,7 +476,7 @@ module aon_timer_reg_top (
     .DW    (1)
   ) u_intr_test_wkup_timer_expired (
     .re     (1'b0),
-    .we     (intr_test_wkup_timer_expired_we),
+    .we     (intr_test_we),
     .wd     (intr_test_wkup_timer_expired_wd),
     .d      ('0),
     .qre    (),
@@ -495,7 +491,7 @@ module aon_timer_reg_top (
     .DW    (1)
   ) u_intr_test_wdog_timer_expired (
     .re     (1'b0),
-    .we     (intr_test_wdog_timer_expired_we),
+    .we     (intr_test_we),
     .wd     (intr_test_wdog_timer_expired_wd),
     .d      ('0),
     .qre    (),
@@ -567,50 +563,46 @@ module aon_timer_reg_top (
                (addr_hit[ 9] & (|(AON_TIMER_PERMIT[ 9] & ~reg_be))) |
                (addr_hit[10] & (|(AON_TIMER_PERMIT[10] & ~reg_be)))));
   end
+  assign wkup_ctrl_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign wkup_ctrl_enable_we = addr_hit[0] & reg_we & !reg_error;
   assign wkup_ctrl_enable_wd = reg_wdata[0];
 
-  assign wkup_ctrl_prescaler_we = addr_hit[0] & reg_we & !reg_error;
   assign wkup_ctrl_prescaler_wd = reg_wdata[12:1];
-
   assign wkup_thold_we = addr_hit[1] & reg_we & !reg_error;
+
   assign wkup_thold_wd = reg_wdata[31:0];
-
   assign wkup_count_we = addr_hit[2] & reg_we & !reg_error;
+
   assign wkup_count_wd = reg_wdata[31:0];
-
   assign wdog_regwen_we = addr_hit[3] & reg_we & !reg_error;
-  assign wdog_regwen_wd = reg_wdata[0];
 
-  assign wdog_ctrl_enable_we = addr_hit[4] & reg_we & !reg_error;
+  assign wdog_regwen_wd = reg_wdata[0];
+  assign wdog_ctrl_we = addr_hit[4] & reg_we & !reg_error;
+
   assign wdog_ctrl_enable_wd = reg_wdata[0];
 
-  assign wdog_ctrl_pause_in_sleep_we = addr_hit[4] & reg_we & !reg_error;
   assign wdog_ctrl_pause_in_sleep_wd = reg_wdata[1];
-
   assign wdog_bark_thold_we = addr_hit[5] & reg_we & !reg_error;
+
   assign wdog_bark_thold_wd = reg_wdata[31:0];
-
   assign wdog_bite_thold_we = addr_hit[6] & reg_we & !reg_error;
+
   assign wdog_bite_thold_wd = reg_wdata[31:0];
-
   assign wdog_count_we = addr_hit[7] & reg_we & !reg_error;
-  assign wdog_count_wd = reg_wdata[31:0];
 
-  assign intr_state_wkup_timer_expired_we = addr_hit[8] & reg_we & !reg_error;
+  assign wdog_count_wd = reg_wdata[31:0];
+  assign intr_state_we = addr_hit[8] & reg_we & !reg_error;
+
   assign intr_state_wkup_timer_expired_wd = reg_wdata[0];
 
-  assign intr_state_wdog_timer_expired_we = addr_hit[8] & reg_we & !reg_error;
   assign intr_state_wdog_timer_expired_wd = reg_wdata[1];
+  assign intr_test_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign intr_test_wkup_timer_expired_we = addr_hit[9] & reg_we & !reg_error;
   assign intr_test_wkup_timer_expired_wd = reg_wdata[0];
 
-  assign intr_test_wdog_timer_expired_we = addr_hit[9] & reg_we & !reg_error;
   assign intr_test_wdog_timer_expired_wd = reg_wdata[1];
-
   assign wkup_cause_we = addr_hit[10] & reg_we & !reg_error;
+
   assign wkup_cause_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -104,18 +104,16 @@ module clkmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic clk_enables_we;
   logic clk_enables_clk_fixed_peri_en_qs;
   logic clk_enables_clk_fixed_peri_en_wd;
-  logic clk_enables_clk_fixed_peri_en_we;
   logic clk_enables_clk_usb_48mhz_peri_en_qs;
   logic clk_enables_clk_usb_48mhz_peri_en_wd;
-  logic clk_enables_clk_usb_48mhz_peri_en_we;
+  logic clk_hints_we;
   logic clk_hints_clk_main_aes_hint_qs;
   logic clk_hints_clk_main_aes_hint_wd;
-  logic clk_hints_clk_main_aes_hint_we;
   logic clk_hints_clk_main_hmac_hint_qs;
   logic clk_hints_clk_main_hmac_hint_wd;
-  logic clk_hints_clk_main_hmac_hint_we;
   logic clk_hints_status_clk_main_aes_val_qs;
   logic clk_hints_status_clk_main_hmac_val_qs;
 
@@ -132,7 +130,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_enables_clk_fixed_peri_en_we),
+    .we     (clk_enables_we),
     .wd     (clk_enables_clk_fixed_peri_en_wd),
 
     // from internal hardware
@@ -158,7 +156,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_enables_clk_usb_48mhz_peri_en_we),
+    .we     (clk_enables_we),
     .wd     (clk_enables_clk_usb_48mhz_peri_en_wd),
 
     // from internal hardware
@@ -186,7 +184,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_hints_clk_main_aes_hint_we),
+    .we     (clk_hints_we),
     .wd     (clk_hints_clk_main_aes_hint_wd),
 
     // from internal hardware
@@ -212,7 +210,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_hints_clk_main_hmac_hint_we),
+    .we     (clk_hints_we),
     .wd     (clk_hints_clk_main_hmac_hint_wd),
 
     // from internal hardware
@@ -301,17 +299,15 @@ module clkmgr_reg_top (
                (addr_hit[1] & (|(CLKMGR_PERMIT[1] & ~reg_be))) |
                (addr_hit[2] & (|(CLKMGR_PERMIT[2] & ~reg_be)))));
   end
+  assign clk_enables_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign clk_enables_clk_fixed_peri_en_we = addr_hit[0] & reg_we & !reg_error;
   assign clk_enables_clk_fixed_peri_en_wd = reg_wdata[0];
 
-  assign clk_enables_clk_usb_48mhz_peri_en_we = addr_hit[0] & reg_we & !reg_error;
   assign clk_enables_clk_usb_48mhz_peri_en_wd = reg_wdata[1];
+  assign clk_hints_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign clk_hints_clk_main_aes_hint_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
 
-  assign clk_hints_clk_main_hmac_hint_we = addr_hit[1] & reg_we & !reg_error;
   assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
 
   // Read data return

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -104,73 +104,61 @@ module csrng_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_cs_cmd_req_done_qs;
   logic intr_state_cs_cmd_req_done_wd;
-  logic intr_state_cs_cmd_req_done_we;
   logic intr_state_cs_entropy_req_qs;
   logic intr_state_cs_entropy_req_wd;
-  logic intr_state_cs_entropy_req_we;
   logic intr_state_cs_hw_inst_exc_qs;
   logic intr_state_cs_hw_inst_exc_wd;
-  logic intr_state_cs_hw_inst_exc_we;
   logic intr_state_cs_fatal_err_qs;
   logic intr_state_cs_fatal_err_wd;
-  logic intr_state_cs_fatal_err_we;
+  logic intr_enable_we;
   logic intr_enable_cs_cmd_req_done_qs;
   logic intr_enable_cs_cmd_req_done_wd;
-  logic intr_enable_cs_cmd_req_done_we;
   logic intr_enable_cs_entropy_req_qs;
   logic intr_enable_cs_entropy_req_wd;
-  logic intr_enable_cs_entropy_req_we;
   logic intr_enable_cs_hw_inst_exc_qs;
   logic intr_enable_cs_hw_inst_exc_wd;
-  logic intr_enable_cs_hw_inst_exc_we;
   logic intr_enable_cs_fatal_err_qs;
   logic intr_enable_cs_fatal_err_wd;
-  logic intr_enable_cs_fatal_err_we;
+  logic intr_test_we;
   logic intr_test_cs_cmd_req_done_wd;
-  logic intr_test_cs_cmd_req_done_we;
   logic intr_test_cs_entropy_req_wd;
-  logic intr_test_cs_entropy_req_we;
   logic intr_test_cs_hw_inst_exc_wd;
-  logic intr_test_cs_hw_inst_exc_we;
   logic intr_test_cs_fatal_err_wd;
-  logic intr_test_cs_fatal_err_we;
-  logic alert_test_wd;
   logic alert_test_we;
-  logic regwen_qs;
+  logic alert_test_wd;
   logic regwen_re;
+  logic regwen_qs;
+  logic ctrl_we;
   logic ctrl_enable_qs;
   logic ctrl_enable_wd;
-  logic ctrl_enable_we;
   logic ctrl_aes_cipher_disable_qs;
   logic ctrl_aes_cipher_disable_wd;
-  logic ctrl_aes_cipher_disable_we;
   logic [3:0] ctrl_fifo_depth_sts_sel_qs;
   logic [3:0] ctrl_fifo_depth_sts_sel_wd;
-  logic ctrl_fifo_depth_sts_sel_we;
   logic [23:0] sum_sts_qs;
-  logic [31:0] cmd_req_wd;
   logic cmd_req_we;
+  logic [31:0] cmd_req_wd;
   logic sw_cmd_sts_cmd_rdy_qs;
   logic sw_cmd_sts_cmd_sts_qs;
+  logic genbits_vld_re;
   logic genbits_vld_genbits_vld_qs;
-  logic genbits_vld_genbits_vld_re;
   logic genbits_vld_genbits_fips_qs;
-  logic genbits_vld_genbits_fips_re;
-  logic [31:0] genbits_qs;
   logic genbits_re;
-  logic halt_main_sm_wd;
+  logic [31:0] genbits_qs;
   logic halt_main_sm_we;
+  logic halt_main_sm_wd;
   logic main_sm_sts_qs;
+  logic int_state_num_we;
   logic [3:0] int_state_num_qs;
   logic [3:0] int_state_num_wd;
-  logic int_state_num_we;
-  logic [31:0] int_state_val_qs;
   logic int_state_val_re;
+  logic [31:0] int_state_val_qs;
+  logic hw_exc_sts_we;
   logic [14:0] hw_exc_sts_qs;
   logic [14:0] hw_exc_sts_wd;
-  logic hw_exc_sts_we;
   logic err_code_sfifo_cmd_err_qs;
   logic err_code_sfifo_genbits_err_qs;
   logic err_code_sfifo_cmdreq_err_qs;
@@ -196,11 +184,11 @@ module csrng_reg_top (
   logic err_code_fifo_write_err_qs;
   logic err_code_fifo_read_err_qs;
   logic err_code_fifo_state_err_qs;
+  logic err_code_test_we;
   logic [4:0] err_code_test_qs;
   logic [4:0] err_code_test_wd;
-  logic err_code_test_we;
-  logic [1:0] sel_tracking_sm_wd;
   logic sel_tracking_sm_we;
+  logic [1:0] sel_tracking_sm_wd;
   logic [31:0] tracking_sm_obs_qs;
 
   // Register instances
@@ -216,7 +204,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_cs_cmd_req_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_cs_cmd_req_done_wd),
 
     // from internal hardware
@@ -242,7 +230,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_cs_entropy_req_we),
+    .we     (intr_state_we),
     .wd     (intr_state_cs_entropy_req_wd),
 
     // from internal hardware
@@ -268,7 +256,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_cs_hw_inst_exc_we),
+    .we     (intr_state_we),
     .wd     (intr_state_cs_hw_inst_exc_wd),
 
     // from internal hardware
@@ -294,7 +282,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_cs_fatal_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_cs_fatal_err_wd),
 
     // from internal hardware
@@ -322,7 +310,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_cs_cmd_req_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_cs_cmd_req_done_wd),
 
     // from internal hardware
@@ -348,7 +336,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_cs_entropy_req_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_cs_entropy_req_wd),
 
     // from internal hardware
@@ -374,7 +362,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_cs_hw_inst_exc_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_cs_hw_inst_exc_wd),
 
     // from internal hardware
@@ -400,7 +388,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_cs_fatal_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_cs_fatal_err_wd),
 
     // from internal hardware
@@ -423,7 +411,7 @@ module csrng_reg_top (
     .DW    (1)
   ) u_intr_test_cs_cmd_req_done (
     .re     (1'b0),
-    .we     (intr_test_cs_cmd_req_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_cs_cmd_req_done_wd),
     .d      ('0),
     .qre    (),
@@ -438,7 +426,7 @@ module csrng_reg_top (
     .DW    (1)
   ) u_intr_test_cs_entropy_req (
     .re     (1'b0),
-    .we     (intr_test_cs_entropy_req_we),
+    .we     (intr_test_we),
     .wd     (intr_test_cs_entropy_req_wd),
     .d      ('0),
     .qre    (),
@@ -453,7 +441,7 @@ module csrng_reg_top (
     .DW    (1)
   ) u_intr_test_cs_hw_inst_exc (
     .re     (1'b0),
-    .we     (intr_test_cs_hw_inst_exc_we),
+    .we     (intr_test_we),
     .wd     (intr_test_cs_hw_inst_exc_wd),
     .d      ('0),
     .qre    (),
@@ -468,7 +456,7 @@ module csrng_reg_top (
     .DW    (1)
   ) u_intr_test_cs_fatal_err (
     .re     (1'b0),
-    .we     (intr_test_cs_fatal_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_cs_fatal_err_wd),
     .d      ('0),
     .qre    (),
@@ -522,7 +510,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_enable_we),
+    .we     (ctrl_we),
     .wd     (ctrl_enable_wd),
 
     // from internal hardware
@@ -548,7 +536,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_aes_cipher_disable_we),
+    .we     (ctrl_we),
     .wd     (ctrl_aes_cipher_disable_wd),
 
     // from internal hardware
@@ -574,7 +562,7 @@ module csrng_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_fifo_depth_sts_sel_we),
+    .we     (ctrl_we),
     .wd     (ctrl_fifo_depth_sts_sel_wd),
 
     // from internal hardware
@@ -704,7 +692,7 @@ module csrng_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_genbits_vld_genbits_vld (
-    .re     (genbits_vld_genbits_vld_re),
+    .re     (genbits_vld_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.genbits_vld.genbits_vld.d),
@@ -719,7 +707,7 @@ module csrng_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_genbits_vld_genbits_fips (
-    .re     (genbits_vld_genbits_fips_re),
+    .re     (genbits_vld_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.genbits_vld.genbits_fips.d),
@@ -1656,81 +1644,64 @@ module csrng_reg_top (
                (addr_hit[18] & (|(CSRNG_PERMIT[18] & ~reg_be))) |
                (addr_hit[19] & (|(CSRNG_PERMIT[19] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_cs_cmd_req_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_state_cs_entropy_req_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_entropy_req_wd = reg_wdata[1];
 
-  assign intr_state_cs_hw_inst_exc_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_hw_inst_exc_wd = reg_wdata[2];
 
-  assign intr_state_cs_fatal_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_cs_fatal_err_wd = reg_wdata[3];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_cs_cmd_req_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_enable_cs_entropy_req_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_entropy_req_wd = reg_wdata[1];
 
-  assign intr_enable_cs_hw_inst_exc_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_hw_inst_exc_wd = reg_wdata[2];
 
-  assign intr_enable_cs_fatal_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_cs_fatal_err_wd = reg_wdata[3];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_cs_cmd_req_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_test_cs_entropy_req_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_entropy_req_wd = reg_wdata[1];
 
-  assign intr_test_cs_hw_inst_exc_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_hw_inst_exc_wd = reg_wdata[2];
 
-  assign intr_test_cs_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_cs_fatal_err_wd = reg_wdata[3];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
   assign regwen_re = addr_hit[4] & reg_re & !reg_error;
+  assign ctrl_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign ctrl_enable_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_enable_wd = reg_wdata[0];
 
-  assign ctrl_aes_cipher_disable_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_aes_cipher_disable_wd = reg_wdata[1];
 
-  assign ctrl_fifo_depth_sts_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_fifo_depth_sts_sel_wd = reg_wdata[19:16];
-
   assign cmd_req_we = addr_hit[7] & reg_we & !reg_error;
+
   assign cmd_req_wd = reg_wdata[31:0];
-
-  assign genbits_vld_genbits_vld_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign genbits_vld_genbits_fips_re = addr_hit[9] & reg_re & !reg_error;
-
+  assign genbits_vld_re = addr_hit[9] & reg_re & !reg_error;
   assign genbits_re = addr_hit[10] & reg_re & !reg_error;
-
   assign halt_main_sm_we = addr_hit[11] & reg_we & !reg_error;
+
   assign halt_main_sm_wd = reg_wdata[0];
-
   assign int_state_num_we = addr_hit[13] & reg_we & !reg_error;
+
   assign int_state_num_wd = reg_wdata[3:0];
-
   assign int_state_val_re = addr_hit[14] & reg_re & !reg_error;
-
   assign hw_exc_sts_we = addr_hit[15] & reg_we & !reg_error;
+
   assign hw_exc_sts_wd = reg_wdata[14:0];
-
   assign err_code_test_we = addr_hit[17] & reg_we & !reg_error;
-  assign err_code_test_wd = reg_wdata[4:0];
 
+  assign err_code_test_wd = reg_wdata[4:0];
   assign sel_tracking_sm_we = addr_hit[18] & reg_we & !reg_error;
+
   assign sel_tracking_sm_wd = reg_wdata[1:0];
 
   // Read data return

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -104,53 +104,47 @@ module edn_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_edn_cmd_req_done_qs;
   logic intr_state_edn_cmd_req_done_wd;
-  logic intr_state_edn_cmd_req_done_we;
   logic intr_state_edn_fatal_err_qs;
   logic intr_state_edn_fatal_err_wd;
-  logic intr_state_edn_fatal_err_we;
+  logic intr_enable_we;
   logic intr_enable_edn_cmd_req_done_qs;
   logic intr_enable_edn_cmd_req_done_wd;
-  logic intr_enable_edn_cmd_req_done_we;
   logic intr_enable_edn_fatal_err_qs;
   logic intr_enable_edn_fatal_err_wd;
-  logic intr_enable_edn_fatal_err_we;
+  logic intr_test_we;
   logic intr_test_edn_cmd_req_done_wd;
-  logic intr_test_edn_cmd_req_done_we;
   logic intr_test_edn_fatal_err_wd;
-  logic intr_test_edn_fatal_err_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic regwen_we;
   logic regwen_qs;
   logic regwen_wd;
-  logic regwen_we;
+  logic ctrl_we;
   logic ctrl_edn_enable_qs;
   logic ctrl_edn_enable_wd;
-  logic ctrl_edn_enable_we;
   logic ctrl_cmd_fifo_rst_qs;
   logic ctrl_cmd_fifo_rst_wd;
-  logic ctrl_cmd_fifo_rst_we;
   logic [1:0] ctrl_hw_req_mode_qs;
   logic [1:0] ctrl_hw_req_mode_wd;
-  logic ctrl_hw_req_mode_we;
+  logic sum_sts_we;
   logic sum_sts_req_mode_sm_sts_qs;
   logic sum_sts_req_mode_sm_sts_wd;
-  logic sum_sts_req_mode_sm_sts_we;
   logic sum_sts_boot_inst_ack_qs;
   logic sum_sts_boot_inst_ack_wd;
-  logic sum_sts_boot_inst_ack_we;
-  logic [31:0] sw_cmd_req_wd;
   logic sw_cmd_req_we;
+  logic [31:0] sw_cmd_req_wd;
   logic sw_cmd_sts_cmd_rdy_qs;
   logic sw_cmd_sts_cmd_sts_qs;
-  logic [31:0] reseed_cmd_wd;
   logic reseed_cmd_we;
-  logic [31:0] generate_cmd_wd;
+  logic [31:0] reseed_cmd_wd;
   logic generate_cmd_we;
+  logic [31:0] generate_cmd_wd;
+  logic max_num_reqs_between_reseeds_we;
   logic [31:0] max_num_reqs_between_reseeds_qs;
   logic [31:0] max_num_reqs_between_reseeds_wd;
-  logic max_num_reqs_between_reseeds_we;
   logic err_code_sfifo_rescmd_err_qs;
   logic err_code_sfifo_gencmd_err_qs;
   logic err_code_edn_ack_sm_err_qs;
@@ -158,9 +152,9 @@ module edn_reg_top (
   logic err_code_fifo_write_err_qs;
   logic err_code_fifo_read_err_qs;
   logic err_code_fifo_state_err_qs;
+  logic err_code_test_we;
   logic [4:0] err_code_test_qs;
   logic [4:0] err_code_test_wd;
-  logic err_code_test_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -175,7 +169,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_edn_cmd_req_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_edn_cmd_req_done_wd),
 
     // from internal hardware
@@ -201,7 +195,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_edn_fatal_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_edn_fatal_err_wd),
 
     // from internal hardware
@@ -229,7 +223,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_edn_cmd_req_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_edn_cmd_req_done_wd),
 
     // from internal hardware
@@ -255,7 +249,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_edn_fatal_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_edn_fatal_err_wd),
 
     // from internal hardware
@@ -278,7 +272,7 @@ module edn_reg_top (
     .DW    (1)
   ) u_intr_test_edn_cmd_req_done (
     .re     (1'b0),
-    .we     (intr_test_edn_cmd_req_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_edn_cmd_req_done_wd),
     .d      ('0),
     .qre    (),
@@ -293,7 +287,7 @@ module edn_reg_top (
     .DW    (1)
   ) u_intr_test_edn_fatal_err (
     .re     (1'b0),
-    .we     (intr_test_edn_fatal_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_edn_fatal_err_wd),
     .d      ('0),
     .qre    (),
@@ -358,7 +352,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_edn_enable_we),
+    .we     (ctrl_we),
     .wd     (ctrl_edn_enable_wd),
 
     // from internal hardware
@@ -384,7 +378,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_cmd_fifo_rst_we),
+    .we     (ctrl_we),
     .wd     (ctrl_cmd_fifo_rst_wd),
 
     // from internal hardware
@@ -410,7 +404,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_hw_req_mode_we),
+    .we     (ctrl_we),
     .wd     (ctrl_hw_req_mode_wd),
 
     // from internal hardware
@@ -438,7 +432,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sum_sts_req_mode_sm_sts_we),
+    .we     (sum_sts_we),
     .wd     (sum_sts_req_mode_sm_sts_wd),
 
     // from internal hardware
@@ -464,7 +458,7 @@ module edn_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sum_sts_boot_inst_ack_we),
+    .we     (sum_sts_we),
     .wd     (sum_sts_boot_inst_ack_wd),
 
     // from internal hardware
@@ -861,59 +855,53 @@ module edn_reg_top (
                (addr_hit[12] & (|(EDN_PERMIT[12] & ~reg_be))) |
                (addr_hit[13] & (|(EDN_PERMIT[13] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_edn_cmd_req_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_edn_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_state_edn_fatal_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_edn_fatal_err_wd = reg_wdata[1];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_edn_cmd_req_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_edn_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_enable_edn_fatal_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_edn_fatal_err_wd = reg_wdata[1];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_edn_cmd_req_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_edn_cmd_req_done_wd = reg_wdata[0];
 
-  assign intr_test_edn_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_edn_fatal_err_wd = reg_wdata[1];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
   assign regwen_we = addr_hit[4] & reg_we & !reg_error;
-  assign regwen_wd = reg_wdata[0];
 
-  assign ctrl_edn_enable_we = addr_hit[5] & reg_we & !reg_error;
+  assign regwen_wd = reg_wdata[0];
+  assign ctrl_we = addr_hit[5] & reg_we & !reg_error;
+
   assign ctrl_edn_enable_wd = reg_wdata[0];
 
-  assign ctrl_cmd_fifo_rst_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_cmd_fifo_rst_wd = reg_wdata[1];
 
-  assign ctrl_hw_req_mode_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_hw_req_mode_wd = reg_wdata[3:2];
+  assign sum_sts_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign sum_sts_req_mode_sm_sts_we = addr_hit[6] & reg_we & !reg_error;
   assign sum_sts_req_mode_sm_sts_wd = reg_wdata[0];
 
-  assign sum_sts_boot_inst_ack_we = addr_hit[6] & reg_we & !reg_error;
   assign sum_sts_boot_inst_ack_wd = reg_wdata[1];
-
   assign sw_cmd_req_we = addr_hit[7] & reg_we & !reg_error;
+
   assign sw_cmd_req_wd = reg_wdata[31:0];
-
   assign reseed_cmd_we = addr_hit[9] & reg_we & !reg_error;
+
   assign reseed_cmd_wd = reg_wdata[31:0];
-
   assign generate_cmd_we = addr_hit[10] & reg_we & !reg_error;
+
   assign generate_cmd_wd = reg_wdata[31:0];
-
   assign max_num_reqs_between_reseeds_we = addr_hit[11] & reg_we & !reg_error;
-  assign max_num_reqs_between_reseeds_wd = reg_wdata[31:0];
 
+  assign max_num_reqs_between_reseeds_wd = reg_wdata[31:0];
   assign err_code_test_we = addr_hit[13] & reg_we & !reg_error;
+
   assign err_code_test_wd = reg_wdata[4:0];
 
   // Read data return

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -104,278 +104,214 @@ module entropy_src_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_es_entropy_valid_qs;
   logic intr_state_es_entropy_valid_wd;
-  logic intr_state_es_entropy_valid_we;
   logic intr_state_es_health_test_failed_qs;
   logic intr_state_es_health_test_failed_wd;
-  logic intr_state_es_health_test_failed_we;
   logic intr_state_es_observe_fifo_ready_qs;
   logic intr_state_es_observe_fifo_ready_wd;
-  logic intr_state_es_observe_fifo_ready_we;
   logic intr_state_es_fatal_err_qs;
   logic intr_state_es_fatal_err_wd;
-  logic intr_state_es_fatal_err_we;
+  logic intr_enable_we;
   logic intr_enable_es_entropy_valid_qs;
   logic intr_enable_es_entropy_valid_wd;
-  logic intr_enable_es_entropy_valid_we;
   logic intr_enable_es_health_test_failed_qs;
   logic intr_enable_es_health_test_failed_wd;
-  logic intr_enable_es_health_test_failed_we;
   logic intr_enable_es_observe_fifo_ready_qs;
   logic intr_enable_es_observe_fifo_ready_wd;
-  logic intr_enable_es_observe_fifo_ready_we;
   logic intr_enable_es_fatal_err_qs;
   logic intr_enable_es_fatal_err_wd;
-  logic intr_enable_es_fatal_err_we;
+  logic intr_test_we;
   logic intr_test_es_entropy_valid_wd;
-  logic intr_test_es_entropy_valid_we;
   logic intr_test_es_health_test_failed_wd;
-  logic intr_test_es_health_test_failed_we;
   logic intr_test_es_observe_fifo_ready_wd;
-  logic intr_test_es_observe_fifo_ready_we;
   logic intr_test_es_fatal_err_wd;
-  logic intr_test_es_fatal_err_we;
+  logic alert_test_we;
   logic alert_test_recov_alert_wd;
-  logic alert_test_recov_alert_we;
   logic alert_test_fatal_alert_wd;
-  logic alert_test_fatal_alert_we;
-  logic regwen_qs;
   logic regwen_re;
+  logic regwen_qs;
   logic [7:0] rev_abi_revision_qs;
   logic [7:0] rev_hw_revision_qs;
   logic [7:0] rev_chip_type_qs;
+  logic conf_we;
   logic [1:0] conf_enable_qs;
   logic [1:0] conf_enable_wd;
-  logic conf_enable_we;
   logic conf_boot_bypass_disable_qs;
   logic conf_boot_bypass_disable_wd;
-  logic conf_boot_bypass_disable_we;
   logic conf_repcnt_disable_qs;
   logic conf_repcnt_disable_wd;
-  logic conf_repcnt_disable_we;
   logic conf_adaptp_disable_qs;
   logic conf_adaptp_disable_wd;
-  logic conf_adaptp_disable_we;
   logic conf_bucket_disable_qs;
   logic conf_bucket_disable_wd;
-  logic conf_bucket_disable_we;
   logic conf_markov_disable_qs;
   logic conf_markov_disable_wd;
-  logic conf_markov_disable_we;
   logic conf_health_test_clr_qs;
   logic conf_health_test_clr_wd;
-  logic conf_health_test_clr_we;
   logic conf_rng_bit_en_qs;
   logic conf_rng_bit_en_wd;
-  logic conf_rng_bit_en_we;
   logic [1:0] conf_rng_bit_sel_qs;
   logic [1:0] conf_rng_bit_sel_wd;
-  logic conf_rng_bit_sel_we;
   logic conf_extht_enable_qs;
   logic conf_extht_enable_wd;
-  logic conf_extht_enable_we;
   logic conf_repcnts_disable_qs;
   logic conf_repcnts_disable_wd;
-  logic conf_repcnts_disable_we;
+  logic rate_we;
   logic [15:0] rate_qs;
   logic [15:0] rate_wd;
-  logic rate_we;
+  logic entropy_control_we;
   logic entropy_control_es_route_qs;
   logic entropy_control_es_route_wd;
-  logic entropy_control_es_route_we;
   logic entropy_control_es_type_qs;
   logic entropy_control_es_type_wd;
-  logic entropy_control_es_type_we;
-  logic [31:0] entropy_data_qs;
   logic entropy_data_re;
+  logic [31:0] entropy_data_qs;
+  logic health_test_windows_we;
   logic [15:0] health_test_windows_fips_window_qs;
   logic [15:0] health_test_windows_fips_window_wd;
-  logic health_test_windows_fips_window_we;
   logic [15:0] health_test_windows_bypass_window_qs;
   logic [15:0] health_test_windows_bypass_window_wd;
-  logic health_test_windows_bypass_window_we;
+  logic repcnt_thresholds_re;
+  logic repcnt_thresholds_we;
   logic [15:0] repcnt_thresholds_fips_thresh_qs;
   logic [15:0] repcnt_thresholds_fips_thresh_wd;
-  logic repcnt_thresholds_fips_thresh_we;
-  logic repcnt_thresholds_fips_thresh_re;
   logic [15:0] repcnt_thresholds_bypass_thresh_qs;
   logic [15:0] repcnt_thresholds_bypass_thresh_wd;
-  logic repcnt_thresholds_bypass_thresh_we;
-  logic repcnt_thresholds_bypass_thresh_re;
+  logic repcnts_thresholds_re;
+  logic repcnts_thresholds_we;
   logic [15:0] repcnts_thresholds_fips_thresh_qs;
   logic [15:0] repcnts_thresholds_fips_thresh_wd;
-  logic repcnts_thresholds_fips_thresh_we;
-  logic repcnts_thresholds_fips_thresh_re;
   logic [15:0] repcnts_thresholds_bypass_thresh_qs;
   logic [15:0] repcnts_thresholds_bypass_thresh_wd;
-  logic repcnts_thresholds_bypass_thresh_we;
-  logic repcnts_thresholds_bypass_thresh_re;
+  logic adaptp_hi_thresholds_re;
+  logic adaptp_hi_thresholds_we;
   logic [15:0] adaptp_hi_thresholds_fips_thresh_qs;
   logic [15:0] adaptp_hi_thresholds_fips_thresh_wd;
-  logic adaptp_hi_thresholds_fips_thresh_we;
-  logic adaptp_hi_thresholds_fips_thresh_re;
   logic [15:0] adaptp_hi_thresholds_bypass_thresh_qs;
   logic [15:0] adaptp_hi_thresholds_bypass_thresh_wd;
-  logic adaptp_hi_thresholds_bypass_thresh_we;
-  logic adaptp_hi_thresholds_bypass_thresh_re;
+  logic adaptp_lo_thresholds_re;
+  logic adaptp_lo_thresholds_we;
   logic [15:0] adaptp_lo_thresholds_fips_thresh_qs;
   logic [15:0] adaptp_lo_thresholds_fips_thresh_wd;
-  logic adaptp_lo_thresholds_fips_thresh_we;
-  logic adaptp_lo_thresholds_fips_thresh_re;
   logic [15:0] adaptp_lo_thresholds_bypass_thresh_qs;
   logic [15:0] adaptp_lo_thresholds_bypass_thresh_wd;
-  logic adaptp_lo_thresholds_bypass_thresh_we;
-  logic adaptp_lo_thresholds_bypass_thresh_re;
+  logic bucket_thresholds_re;
+  logic bucket_thresholds_we;
   logic [15:0] bucket_thresholds_fips_thresh_qs;
   logic [15:0] bucket_thresholds_fips_thresh_wd;
-  logic bucket_thresholds_fips_thresh_we;
-  logic bucket_thresholds_fips_thresh_re;
   logic [15:0] bucket_thresholds_bypass_thresh_qs;
   logic [15:0] bucket_thresholds_bypass_thresh_wd;
-  logic bucket_thresholds_bypass_thresh_we;
-  logic bucket_thresholds_bypass_thresh_re;
+  logic markov_hi_thresholds_re;
+  logic markov_hi_thresholds_we;
   logic [15:0] markov_hi_thresholds_fips_thresh_qs;
   logic [15:0] markov_hi_thresholds_fips_thresh_wd;
-  logic markov_hi_thresholds_fips_thresh_we;
-  logic markov_hi_thresholds_fips_thresh_re;
   logic [15:0] markov_hi_thresholds_bypass_thresh_qs;
   logic [15:0] markov_hi_thresholds_bypass_thresh_wd;
-  logic markov_hi_thresholds_bypass_thresh_we;
-  logic markov_hi_thresholds_bypass_thresh_re;
+  logic markov_lo_thresholds_re;
+  logic markov_lo_thresholds_we;
   logic [15:0] markov_lo_thresholds_fips_thresh_qs;
   logic [15:0] markov_lo_thresholds_fips_thresh_wd;
-  logic markov_lo_thresholds_fips_thresh_we;
-  logic markov_lo_thresholds_fips_thresh_re;
   logic [15:0] markov_lo_thresholds_bypass_thresh_qs;
   logic [15:0] markov_lo_thresholds_bypass_thresh_wd;
-  logic markov_lo_thresholds_bypass_thresh_we;
-  logic markov_lo_thresholds_bypass_thresh_re;
+  logic extht_hi_thresholds_re;
+  logic extht_hi_thresholds_we;
   logic [15:0] extht_hi_thresholds_fips_thresh_qs;
   logic [15:0] extht_hi_thresholds_fips_thresh_wd;
-  logic extht_hi_thresholds_fips_thresh_we;
-  logic extht_hi_thresholds_fips_thresh_re;
   logic [15:0] extht_hi_thresholds_bypass_thresh_qs;
   logic [15:0] extht_hi_thresholds_bypass_thresh_wd;
-  logic extht_hi_thresholds_bypass_thresh_we;
-  logic extht_hi_thresholds_bypass_thresh_re;
+  logic extht_lo_thresholds_re;
+  logic extht_lo_thresholds_we;
   logic [15:0] extht_lo_thresholds_fips_thresh_qs;
   logic [15:0] extht_lo_thresholds_fips_thresh_wd;
-  logic extht_lo_thresholds_fips_thresh_we;
-  logic extht_lo_thresholds_fips_thresh_re;
   logic [15:0] extht_lo_thresholds_bypass_thresh_qs;
   logic [15:0] extht_lo_thresholds_bypass_thresh_wd;
-  logic extht_lo_thresholds_bypass_thresh_we;
-  logic extht_lo_thresholds_bypass_thresh_re;
+  logic repcnt_hi_watermarks_re;
   logic [15:0] repcnt_hi_watermarks_fips_watermark_qs;
-  logic repcnt_hi_watermarks_fips_watermark_re;
   logic [15:0] repcnt_hi_watermarks_bypass_watermark_qs;
-  logic repcnt_hi_watermarks_bypass_watermark_re;
+  logic repcnts_hi_watermarks_re;
   logic [15:0] repcnts_hi_watermarks_fips_watermark_qs;
-  logic repcnts_hi_watermarks_fips_watermark_re;
   logic [15:0] repcnts_hi_watermarks_bypass_watermark_qs;
-  logic repcnts_hi_watermarks_bypass_watermark_re;
+  logic adaptp_hi_watermarks_re;
   logic [15:0] adaptp_hi_watermarks_fips_watermark_qs;
-  logic adaptp_hi_watermarks_fips_watermark_re;
   logic [15:0] adaptp_hi_watermarks_bypass_watermark_qs;
-  logic adaptp_hi_watermarks_bypass_watermark_re;
+  logic adaptp_lo_watermarks_re;
   logic [15:0] adaptp_lo_watermarks_fips_watermark_qs;
-  logic adaptp_lo_watermarks_fips_watermark_re;
   logic [15:0] adaptp_lo_watermarks_bypass_watermark_qs;
-  logic adaptp_lo_watermarks_bypass_watermark_re;
+  logic extht_hi_watermarks_re;
   logic [15:0] extht_hi_watermarks_fips_watermark_qs;
-  logic extht_hi_watermarks_fips_watermark_re;
   logic [15:0] extht_hi_watermarks_bypass_watermark_qs;
-  logic extht_hi_watermarks_bypass_watermark_re;
+  logic extht_lo_watermarks_re;
   logic [15:0] extht_lo_watermarks_fips_watermark_qs;
-  logic extht_lo_watermarks_fips_watermark_re;
   logic [15:0] extht_lo_watermarks_bypass_watermark_qs;
-  logic extht_lo_watermarks_bypass_watermark_re;
+  logic bucket_hi_watermarks_re;
   logic [15:0] bucket_hi_watermarks_fips_watermark_qs;
-  logic bucket_hi_watermarks_fips_watermark_re;
   logic [15:0] bucket_hi_watermarks_bypass_watermark_qs;
-  logic bucket_hi_watermarks_bypass_watermark_re;
+  logic markov_hi_watermarks_re;
   logic [15:0] markov_hi_watermarks_fips_watermark_qs;
-  logic markov_hi_watermarks_fips_watermark_re;
   logic [15:0] markov_hi_watermarks_bypass_watermark_qs;
-  logic markov_hi_watermarks_bypass_watermark_re;
+  logic markov_lo_watermarks_re;
   logic [15:0] markov_lo_watermarks_fips_watermark_qs;
-  logic markov_lo_watermarks_fips_watermark_re;
   logic [15:0] markov_lo_watermarks_bypass_watermark_qs;
-  logic markov_lo_watermarks_bypass_watermark_re;
-  logic [31:0] repcnt_total_fails_qs;
   logic repcnt_total_fails_re;
-  logic [31:0] repcnts_total_fails_qs;
+  logic [31:0] repcnt_total_fails_qs;
   logic repcnts_total_fails_re;
-  logic [31:0] adaptp_hi_total_fails_qs;
+  logic [31:0] repcnts_total_fails_qs;
   logic adaptp_hi_total_fails_re;
-  logic [31:0] adaptp_lo_total_fails_qs;
+  logic [31:0] adaptp_hi_total_fails_qs;
   logic adaptp_lo_total_fails_re;
-  logic [31:0] bucket_total_fails_qs;
+  logic [31:0] adaptp_lo_total_fails_qs;
   logic bucket_total_fails_re;
-  logic [31:0] markov_hi_total_fails_qs;
+  logic [31:0] bucket_total_fails_qs;
   logic markov_hi_total_fails_re;
-  logic [31:0] markov_lo_total_fails_qs;
+  logic [31:0] markov_hi_total_fails_qs;
   logic markov_lo_total_fails_re;
-  logic [31:0] extht_hi_total_fails_qs;
+  logic [31:0] markov_lo_total_fails_qs;
   logic extht_hi_total_fails_re;
-  logic [31:0] extht_lo_total_fails_qs;
+  logic [31:0] extht_hi_total_fails_qs;
   logic extht_lo_total_fails_re;
+  logic [31:0] extht_lo_total_fails_qs;
+  logic alert_threshold_we;
   logic [31:0] alert_threshold_qs;
   logic [31:0] alert_threshold_wd;
-  logic alert_threshold_we;
-  logic [31:0] alert_summary_fail_counts_qs;
   logic alert_summary_fail_counts_re;
+  logic [31:0] alert_summary_fail_counts_qs;
+  logic alert_fail_counts_re;
   logic [3:0] alert_fail_counts_repcnt_fail_count_qs;
-  logic alert_fail_counts_repcnt_fail_count_re;
   logic [3:0] alert_fail_counts_adaptp_hi_fail_count_qs;
-  logic alert_fail_counts_adaptp_hi_fail_count_re;
   logic [3:0] alert_fail_counts_adaptp_lo_fail_count_qs;
-  logic alert_fail_counts_adaptp_lo_fail_count_re;
   logic [3:0] alert_fail_counts_bucket_fail_count_qs;
-  logic alert_fail_counts_bucket_fail_count_re;
   logic [3:0] alert_fail_counts_markov_hi_fail_count_qs;
-  logic alert_fail_counts_markov_hi_fail_count_re;
   logic [3:0] alert_fail_counts_markov_lo_fail_count_qs;
-  logic alert_fail_counts_markov_lo_fail_count_re;
   logic [3:0] alert_fail_counts_repcnts_fail_count_qs;
-  logic alert_fail_counts_repcnts_fail_count_re;
+  logic extht_fail_counts_re;
   logic [3:0] extht_fail_counts_extht_hi_fail_count_qs;
-  logic extht_fail_counts_extht_hi_fail_count_re;
   logic [3:0] extht_fail_counts_extht_lo_fail_count_qs;
-  logic extht_fail_counts_extht_lo_fail_count_re;
+  logic fw_ov_control_we;
   logic fw_ov_control_fw_ov_mode_qs;
   logic fw_ov_control_fw_ov_mode_wd;
-  logic fw_ov_control_fw_ov_mode_we;
   logic fw_ov_control_fw_ov_entropy_insert_qs;
   logic fw_ov_control_fw_ov_entropy_insert_wd;
-  logic fw_ov_control_fw_ov_entropy_insert_we;
-  logic [31:0] fw_ov_rd_data_qs;
   logic fw_ov_rd_data_re;
-  logic [31:0] fw_ov_wr_data_wd;
+  logic [31:0] fw_ov_rd_data_qs;
   logic fw_ov_wr_data_we;
+  logic [31:0] fw_ov_wr_data_wd;
+  logic observe_fifo_thresh_we;
   logic [6:0] observe_fifo_thresh_qs;
   logic [6:0] observe_fifo_thresh_wd;
-  logic observe_fifo_thresh_we;
+  logic debug_status_re;
   logic [2:0] debug_status_entropy_fifo_depth_qs;
-  logic debug_status_entropy_fifo_depth_re;
   logic [2:0] debug_status_sha3_fsm_qs;
-  logic debug_status_sha3_fsm_re;
   logic debug_status_sha3_block_pr_qs;
-  logic debug_status_sha3_block_pr_re;
   logic debug_status_sha3_squeezing_qs;
-  logic debug_status_sha3_squeezing_re;
   logic debug_status_sha3_absorbed_qs;
-  logic debug_status_sha3_absorbed_re;
   logic debug_status_sha3_err_qs;
-  logic debug_status_sha3_err_re;
   logic debug_status_main_sm_idle_qs;
-  logic debug_status_main_sm_idle_re;
   logic [7:0] debug_status_main_sm_state_qs;
-  logic debug_status_main_sm_state_re;
+  logic seed_we;
   logic [3:0] seed_qs;
   logic [3:0] seed_wd;
-  logic seed_we;
   logic err_code_sfifo_esrng_err_qs;
   logic err_code_sfifo_observe_err_qs;
   logic err_code_sfifo_esfinal_err_qs;
@@ -384,9 +320,9 @@ module entropy_src_reg_top (
   logic err_code_fifo_write_err_qs;
   logic err_code_fifo_read_err_qs;
   logic err_code_fifo_state_err_qs;
+  logic err_code_test_we;
   logic [4:0] err_code_test_qs;
   logic [4:0] err_code_test_wd;
-  logic err_code_test_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -401,7 +337,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_es_entropy_valid_we),
+    .we     (intr_state_we),
     .wd     (intr_state_es_entropy_valid_wd),
 
     // from internal hardware
@@ -427,7 +363,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_es_health_test_failed_we),
+    .we     (intr_state_we),
     .wd     (intr_state_es_health_test_failed_wd),
 
     // from internal hardware
@@ -453,7 +389,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_es_observe_fifo_ready_we),
+    .we     (intr_state_we),
     .wd     (intr_state_es_observe_fifo_ready_wd),
 
     // from internal hardware
@@ -479,7 +415,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_es_fatal_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_es_fatal_err_wd),
 
     // from internal hardware
@@ -507,7 +443,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_es_entropy_valid_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_es_entropy_valid_wd),
 
     // from internal hardware
@@ -533,7 +469,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_es_health_test_failed_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_es_health_test_failed_wd),
 
     // from internal hardware
@@ -559,7 +495,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_es_observe_fifo_ready_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_es_observe_fifo_ready_wd),
 
     // from internal hardware
@@ -585,7 +521,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_es_fatal_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_es_fatal_err_wd),
 
     // from internal hardware
@@ -608,7 +544,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_intr_test_es_entropy_valid (
     .re     (1'b0),
-    .we     (intr_test_es_entropy_valid_we),
+    .we     (intr_test_we),
     .wd     (intr_test_es_entropy_valid_wd),
     .d      ('0),
     .qre    (),
@@ -623,7 +559,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_intr_test_es_health_test_failed (
     .re     (1'b0),
-    .we     (intr_test_es_health_test_failed_we),
+    .we     (intr_test_we),
     .wd     (intr_test_es_health_test_failed_wd),
     .d      ('0),
     .qre    (),
@@ -638,7 +574,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_intr_test_es_observe_fifo_ready (
     .re     (1'b0),
-    .we     (intr_test_es_observe_fifo_ready_we),
+    .we     (intr_test_we),
     .wd     (intr_test_es_observe_fifo_ready_wd),
     .d      ('0),
     .qre    (),
@@ -653,7 +589,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_intr_test_es_fatal_err (
     .re     (1'b0),
-    .we     (intr_test_es_fatal_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_es_fatal_err_wd),
     .d      ('0),
     .qre    (),
@@ -670,7 +606,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_alert_test_recov_alert (
     .re     (1'b0),
-    .we     (alert_test_recov_alert_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
@@ -685,7 +621,7 @@ module entropy_src_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_alert (
     .re     (1'b0),
-    .we     (alert_test_fatal_alert_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
@@ -740,7 +676,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_enable_we),
+    .we     (conf_we),
     .wd     (conf_enable_wd),
 
     // from internal hardware
@@ -766,7 +702,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_boot_bypass_disable_we),
+    .we     (conf_we),
     .wd     (conf_boot_bypass_disable_wd),
 
     // from internal hardware
@@ -792,7 +728,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_repcnt_disable_we),
+    .we     (conf_we),
     .wd     (conf_repcnt_disable_wd),
 
     // from internal hardware
@@ -818,7 +754,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_adaptp_disable_we),
+    .we     (conf_we),
     .wd     (conf_adaptp_disable_wd),
 
     // from internal hardware
@@ -844,7 +780,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_bucket_disable_we),
+    .we     (conf_we),
     .wd     (conf_bucket_disable_wd),
 
     // from internal hardware
@@ -870,7 +806,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_markov_disable_we),
+    .we     (conf_we),
     .wd     (conf_markov_disable_wd),
 
     // from internal hardware
@@ -896,7 +832,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_health_test_clr_we),
+    .we     (conf_we),
     .wd     (conf_health_test_clr_wd),
 
     // from internal hardware
@@ -922,7 +858,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_rng_bit_en_we),
+    .we     (conf_we),
     .wd     (conf_rng_bit_en_wd),
 
     // from internal hardware
@@ -948,7 +884,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_rng_bit_sel_we),
+    .we     (conf_we),
     .wd     (conf_rng_bit_sel_wd),
 
     // from internal hardware
@@ -974,7 +910,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_extht_enable_we),
+    .we     (conf_we),
     .wd     (conf_extht_enable_wd),
 
     // from internal hardware
@@ -1000,7 +936,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_repcnts_disable_we),
+    .we     (conf_we),
     .wd     (conf_repcnts_disable_wd),
 
     // from internal hardware
@@ -1055,7 +991,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (entropy_control_es_route_we & regwen_qs),
+    .we     (entropy_control_we & regwen_qs),
     .wd     (entropy_control_es_route_wd),
 
     // from internal hardware
@@ -1081,7 +1017,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (entropy_control_es_type_we & regwen_qs),
+    .we     (entropy_control_we & regwen_qs),
     .wd     (entropy_control_es_type_wd),
 
     // from internal hardware
@@ -1125,7 +1061,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (health_test_windows_fips_window_we & regwen_qs),
+    .we     (health_test_windows_we & regwen_qs),
     .wd     (health_test_windows_fips_window_wd),
 
     // from internal hardware
@@ -1151,7 +1087,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (health_test_windows_bypass_window_we & regwen_qs),
+    .we     (health_test_windows_we & regwen_qs),
     .wd     (health_test_windows_bypass_window_wd),
 
     // from internal hardware
@@ -1173,8 +1109,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnt_thresholds_fips_thresh (
-    .re     (repcnt_thresholds_fips_thresh_re),
-    .we     (repcnt_thresholds_fips_thresh_we & regwen_qs),
+    .re     (repcnt_thresholds_re),
+    .we     (repcnt_thresholds_we & regwen_qs),
     .wd     (repcnt_thresholds_fips_thresh_wd),
     .d      (hw2reg.repcnt_thresholds.fips_thresh.d),
     .qre    (),
@@ -1188,8 +1124,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnt_thresholds_bypass_thresh (
-    .re     (repcnt_thresholds_bypass_thresh_re),
-    .we     (repcnt_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (repcnt_thresholds_re),
+    .we     (repcnt_thresholds_we & regwen_qs),
     .wd     (repcnt_thresholds_bypass_thresh_wd),
     .d      (hw2reg.repcnt_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1205,8 +1141,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnts_thresholds_fips_thresh (
-    .re     (repcnts_thresholds_fips_thresh_re),
-    .we     (repcnts_thresholds_fips_thresh_we & regwen_qs),
+    .re     (repcnts_thresholds_re),
+    .we     (repcnts_thresholds_we & regwen_qs),
     .wd     (repcnts_thresholds_fips_thresh_wd),
     .d      (hw2reg.repcnts_thresholds.fips_thresh.d),
     .qre    (),
@@ -1220,8 +1156,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnts_thresholds_bypass_thresh (
-    .re     (repcnts_thresholds_bypass_thresh_re),
-    .we     (repcnts_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (repcnts_thresholds_re),
+    .we     (repcnts_thresholds_we & regwen_qs),
     .wd     (repcnts_thresholds_bypass_thresh_wd),
     .d      (hw2reg.repcnts_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1237,8 +1173,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_hi_thresholds_fips_thresh (
-    .re     (adaptp_hi_thresholds_fips_thresh_re),
-    .we     (adaptp_hi_thresholds_fips_thresh_we & regwen_qs),
+    .re     (adaptp_hi_thresholds_re),
+    .we     (adaptp_hi_thresholds_we & regwen_qs),
     .wd     (adaptp_hi_thresholds_fips_thresh_wd),
     .d      (hw2reg.adaptp_hi_thresholds.fips_thresh.d),
     .qre    (),
@@ -1252,8 +1188,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_hi_thresholds_bypass_thresh (
-    .re     (adaptp_hi_thresholds_bypass_thresh_re),
-    .we     (adaptp_hi_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (adaptp_hi_thresholds_re),
+    .we     (adaptp_hi_thresholds_we & regwen_qs),
     .wd     (adaptp_hi_thresholds_bypass_thresh_wd),
     .d      (hw2reg.adaptp_hi_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1269,8 +1205,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_lo_thresholds_fips_thresh (
-    .re     (adaptp_lo_thresholds_fips_thresh_re),
-    .we     (adaptp_lo_thresholds_fips_thresh_we & regwen_qs),
+    .re     (adaptp_lo_thresholds_re),
+    .we     (adaptp_lo_thresholds_we & regwen_qs),
     .wd     (adaptp_lo_thresholds_fips_thresh_wd),
     .d      (hw2reg.adaptp_lo_thresholds.fips_thresh.d),
     .qre    (),
@@ -1284,8 +1220,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_lo_thresholds_bypass_thresh (
-    .re     (adaptp_lo_thresholds_bypass_thresh_re),
-    .we     (adaptp_lo_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (adaptp_lo_thresholds_re),
+    .we     (adaptp_lo_thresholds_we & regwen_qs),
     .wd     (adaptp_lo_thresholds_bypass_thresh_wd),
     .d      (hw2reg.adaptp_lo_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1301,8 +1237,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_bucket_thresholds_fips_thresh (
-    .re     (bucket_thresholds_fips_thresh_re),
-    .we     (bucket_thresholds_fips_thresh_we & regwen_qs),
+    .re     (bucket_thresholds_re),
+    .we     (bucket_thresholds_we & regwen_qs),
     .wd     (bucket_thresholds_fips_thresh_wd),
     .d      (hw2reg.bucket_thresholds.fips_thresh.d),
     .qre    (),
@@ -1316,8 +1252,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_bucket_thresholds_bypass_thresh (
-    .re     (bucket_thresholds_bypass_thresh_re),
-    .we     (bucket_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (bucket_thresholds_re),
+    .we     (bucket_thresholds_we & regwen_qs),
     .wd     (bucket_thresholds_bypass_thresh_wd),
     .d      (hw2reg.bucket_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1333,8 +1269,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_hi_thresholds_fips_thresh (
-    .re     (markov_hi_thresholds_fips_thresh_re),
-    .we     (markov_hi_thresholds_fips_thresh_we & regwen_qs),
+    .re     (markov_hi_thresholds_re),
+    .we     (markov_hi_thresholds_we & regwen_qs),
     .wd     (markov_hi_thresholds_fips_thresh_wd),
     .d      (hw2reg.markov_hi_thresholds.fips_thresh.d),
     .qre    (),
@@ -1348,8 +1284,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_hi_thresholds_bypass_thresh (
-    .re     (markov_hi_thresholds_bypass_thresh_re),
-    .we     (markov_hi_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (markov_hi_thresholds_re),
+    .we     (markov_hi_thresholds_we & regwen_qs),
     .wd     (markov_hi_thresholds_bypass_thresh_wd),
     .d      (hw2reg.markov_hi_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1365,8 +1301,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_lo_thresholds_fips_thresh (
-    .re     (markov_lo_thresholds_fips_thresh_re),
-    .we     (markov_lo_thresholds_fips_thresh_we & regwen_qs),
+    .re     (markov_lo_thresholds_re),
+    .we     (markov_lo_thresholds_we & regwen_qs),
     .wd     (markov_lo_thresholds_fips_thresh_wd),
     .d      (hw2reg.markov_lo_thresholds.fips_thresh.d),
     .qre    (),
@@ -1380,8 +1316,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_lo_thresholds_bypass_thresh (
-    .re     (markov_lo_thresholds_bypass_thresh_re),
-    .we     (markov_lo_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (markov_lo_thresholds_re),
+    .we     (markov_lo_thresholds_we & regwen_qs),
     .wd     (markov_lo_thresholds_bypass_thresh_wd),
     .d      (hw2reg.markov_lo_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1397,8 +1333,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_hi_thresholds_fips_thresh (
-    .re     (extht_hi_thresholds_fips_thresh_re),
-    .we     (extht_hi_thresholds_fips_thresh_we & regwen_qs),
+    .re     (extht_hi_thresholds_re),
+    .we     (extht_hi_thresholds_we & regwen_qs),
     .wd     (extht_hi_thresholds_fips_thresh_wd),
     .d      (hw2reg.extht_hi_thresholds.fips_thresh.d),
     .qre    (),
@@ -1412,8 +1348,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_hi_thresholds_bypass_thresh (
-    .re     (extht_hi_thresholds_bypass_thresh_re),
-    .we     (extht_hi_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (extht_hi_thresholds_re),
+    .we     (extht_hi_thresholds_we & regwen_qs),
     .wd     (extht_hi_thresholds_bypass_thresh_wd),
     .d      (hw2reg.extht_hi_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1429,8 +1365,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_lo_thresholds_fips_thresh (
-    .re     (extht_lo_thresholds_fips_thresh_re),
-    .we     (extht_lo_thresholds_fips_thresh_we & regwen_qs),
+    .re     (extht_lo_thresholds_re),
+    .we     (extht_lo_thresholds_we & regwen_qs),
     .wd     (extht_lo_thresholds_fips_thresh_wd),
     .d      (hw2reg.extht_lo_thresholds.fips_thresh.d),
     .qre    (),
@@ -1444,8 +1380,8 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_lo_thresholds_bypass_thresh (
-    .re     (extht_lo_thresholds_bypass_thresh_re),
-    .we     (extht_lo_thresholds_bypass_thresh_we & regwen_qs),
+    .re     (extht_lo_thresholds_re),
+    .we     (extht_lo_thresholds_we & regwen_qs),
     .wd     (extht_lo_thresholds_bypass_thresh_wd),
     .d      (hw2reg.extht_lo_thresholds.bypass_thresh.d),
     .qre    (),
@@ -1461,7 +1397,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnt_hi_watermarks_fips_watermark (
-    .re     (repcnt_hi_watermarks_fips_watermark_re),
+    .re     (repcnt_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.repcnt_hi_watermarks.fips_watermark.d),
@@ -1476,7 +1412,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnt_hi_watermarks_bypass_watermark (
-    .re     (repcnt_hi_watermarks_bypass_watermark_re),
+    .re     (repcnt_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.repcnt_hi_watermarks.bypass_watermark.d),
@@ -1493,7 +1429,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnts_hi_watermarks_fips_watermark (
-    .re     (repcnts_hi_watermarks_fips_watermark_re),
+    .re     (repcnts_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.repcnts_hi_watermarks.fips_watermark.d),
@@ -1508,7 +1444,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_repcnts_hi_watermarks_bypass_watermark (
-    .re     (repcnts_hi_watermarks_bypass_watermark_re),
+    .re     (repcnts_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.repcnts_hi_watermarks.bypass_watermark.d),
@@ -1525,7 +1461,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_hi_watermarks_fips_watermark (
-    .re     (adaptp_hi_watermarks_fips_watermark_re),
+    .re     (adaptp_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.adaptp_hi_watermarks.fips_watermark.d),
@@ -1540,7 +1476,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_hi_watermarks_bypass_watermark (
-    .re     (adaptp_hi_watermarks_bypass_watermark_re),
+    .re     (adaptp_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.adaptp_hi_watermarks.bypass_watermark.d),
@@ -1557,7 +1493,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_lo_watermarks_fips_watermark (
-    .re     (adaptp_lo_watermarks_fips_watermark_re),
+    .re     (adaptp_lo_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.adaptp_lo_watermarks.fips_watermark.d),
@@ -1572,7 +1508,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_adaptp_lo_watermarks_bypass_watermark (
-    .re     (adaptp_lo_watermarks_bypass_watermark_re),
+    .re     (adaptp_lo_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.adaptp_lo_watermarks.bypass_watermark.d),
@@ -1589,7 +1525,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_hi_watermarks_fips_watermark (
-    .re     (extht_hi_watermarks_fips_watermark_re),
+    .re     (extht_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.extht_hi_watermarks.fips_watermark.d),
@@ -1604,7 +1540,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_hi_watermarks_bypass_watermark (
-    .re     (extht_hi_watermarks_bypass_watermark_re),
+    .re     (extht_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.extht_hi_watermarks.bypass_watermark.d),
@@ -1621,7 +1557,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_lo_watermarks_fips_watermark (
-    .re     (extht_lo_watermarks_fips_watermark_re),
+    .re     (extht_lo_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.extht_lo_watermarks.fips_watermark.d),
@@ -1636,7 +1572,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_extht_lo_watermarks_bypass_watermark (
-    .re     (extht_lo_watermarks_bypass_watermark_re),
+    .re     (extht_lo_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.extht_lo_watermarks.bypass_watermark.d),
@@ -1653,7 +1589,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_bucket_hi_watermarks_fips_watermark (
-    .re     (bucket_hi_watermarks_fips_watermark_re),
+    .re     (bucket_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.bucket_hi_watermarks.fips_watermark.d),
@@ -1668,7 +1604,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_bucket_hi_watermarks_bypass_watermark (
-    .re     (bucket_hi_watermarks_bypass_watermark_re),
+    .re     (bucket_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.bucket_hi_watermarks.bypass_watermark.d),
@@ -1685,7 +1621,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_hi_watermarks_fips_watermark (
-    .re     (markov_hi_watermarks_fips_watermark_re),
+    .re     (markov_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.markov_hi_watermarks.fips_watermark.d),
@@ -1700,7 +1636,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_hi_watermarks_bypass_watermark (
-    .re     (markov_hi_watermarks_bypass_watermark_re),
+    .re     (markov_hi_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.markov_hi_watermarks.bypass_watermark.d),
@@ -1717,7 +1653,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_lo_watermarks_fips_watermark (
-    .re     (markov_lo_watermarks_fips_watermark_re),
+    .re     (markov_lo_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.markov_lo_watermarks.fips_watermark.d),
@@ -1732,7 +1668,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_markov_lo_watermarks_bypass_watermark (
-    .re     (markov_lo_watermarks_bypass_watermark_re),
+    .re     (markov_lo_watermarks_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.markov_lo_watermarks.bypass_watermark.d),
@@ -1936,7 +1872,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_repcnt_fail_count (
-    .re     (alert_fail_counts_repcnt_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.repcnt_fail_count.d),
@@ -1951,7 +1887,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_adaptp_hi_fail_count (
-    .re     (alert_fail_counts_adaptp_hi_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.adaptp_hi_fail_count.d),
@@ -1966,7 +1902,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_adaptp_lo_fail_count (
-    .re     (alert_fail_counts_adaptp_lo_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.adaptp_lo_fail_count.d),
@@ -1981,7 +1917,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_bucket_fail_count (
-    .re     (alert_fail_counts_bucket_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.bucket_fail_count.d),
@@ -1996,7 +1932,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_markov_hi_fail_count (
-    .re     (alert_fail_counts_markov_hi_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.markov_hi_fail_count.d),
@@ -2011,7 +1947,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_markov_lo_fail_count (
-    .re     (alert_fail_counts_markov_lo_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.markov_lo_fail_count.d),
@@ -2026,7 +1962,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_fail_counts_repcnts_fail_count (
-    .re     (alert_fail_counts_repcnts_fail_count_re),
+    .re     (alert_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.alert_fail_counts.repcnts_fail_count.d),
@@ -2043,7 +1979,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_extht_fail_counts_extht_hi_fail_count (
-    .re     (extht_fail_counts_extht_hi_fail_count_re),
+    .re     (extht_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.extht_fail_counts.extht_hi_fail_count.d),
@@ -2058,7 +1994,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_extht_fail_counts_extht_lo_fail_count (
-    .re     (extht_fail_counts_extht_lo_fail_count_re),
+    .re     (extht_fail_counts_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.extht_fail_counts.extht_lo_fail_count.d),
@@ -2081,7 +2017,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fw_ov_control_fw_ov_mode_we & regwen_qs),
+    .we     (fw_ov_control_we & regwen_qs),
     .wd     (fw_ov_control_fw_ov_mode_wd),
 
     // from internal hardware
@@ -2107,7 +2043,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fw_ov_control_fw_ov_entropy_insert_we & regwen_qs),
+    .we     (fw_ov_control_we & regwen_qs),
     .wd     (fw_ov_control_fw_ov_entropy_insert_wd),
 
     // from internal hardware
@@ -2188,7 +2124,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_debug_status_entropy_fifo_depth (
-    .re     (debug_status_entropy_fifo_depth_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.entropy_fifo_depth.d),
@@ -2203,7 +2139,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_debug_status_sha3_fsm (
-    .re     (debug_status_sha3_fsm_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.sha3_fsm.d),
@@ -2218,7 +2154,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_debug_status_sha3_block_pr (
-    .re     (debug_status_sha3_block_pr_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.sha3_block_pr.d),
@@ -2233,7 +2169,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_debug_status_sha3_squeezing (
-    .re     (debug_status_sha3_squeezing_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.sha3_squeezing.d),
@@ -2248,7 +2184,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_debug_status_sha3_absorbed (
-    .re     (debug_status_sha3_absorbed_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.sha3_absorbed.d),
@@ -2263,7 +2199,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_debug_status_sha3_err (
-    .re     (debug_status_sha3_err_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.sha3_err.d),
@@ -2278,7 +2214,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_debug_status_main_sm_idle (
-    .re     (debug_status_main_sm_idle_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.main_sm_idle.d),
@@ -2293,7 +2229,7 @@ module entropy_src_reg_top (
   prim_subreg_ext #(
     .DW    (8)
   ) u_debug_status_main_sm_state (
-    .re     (debug_status_main_sm_state_re),
+    .re     (debug_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.debug_status.main_sm_state.d),
@@ -2681,284 +2617,172 @@ module entropy_src_reg_top (
                (addr_hit[48] & (|(ENTROPY_SRC_PERMIT[48] & ~reg_be))) |
                (addr_hit[49] & (|(ENTROPY_SRC_PERMIT[49] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_es_entropy_valid_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_entropy_valid_wd = reg_wdata[0];
 
-  assign intr_state_es_health_test_failed_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_health_test_failed_wd = reg_wdata[1];
 
-  assign intr_state_es_observe_fifo_ready_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_observe_fifo_ready_wd = reg_wdata[2];
 
-  assign intr_state_es_fatal_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_es_fatal_err_wd = reg_wdata[3];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_es_entropy_valid_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_entropy_valid_wd = reg_wdata[0];
 
-  assign intr_enable_es_health_test_failed_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_health_test_failed_wd = reg_wdata[1];
 
-  assign intr_enable_es_observe_fifo_ready_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_observe_fifo_ready_wd = reg_wdata[2];
 
-  assign intr_enable_es_fatal_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_es_fatal_err_wd = reg_wdata[3];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_es_entropy_valid_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_entropy_valid_wd = reg_wdata[0];
 
-  assign intr_test_es_health_test_failed_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_health_test_failed_wd = reg_wdata[1];
 
-  assign intr_test_es_observe_fifo_ready_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_observe_fifo_ready_wd = reg_wdata[2];
 
-  assign intr_test_es_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_es_fatal_err_wd = reg_wdata[3];
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_recov_alert_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
-  assign alert_test_fatal_alert_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_alert_wd = reg_wdata[1];
-
   assign regwen_re = addr_hit[4] & reg_re & !reg_error;
+  assign conf_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign conf_enable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_enable_wd = reg_wdata[1:0];
 
-  assign conf_boot_bypass_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_boot_bypass_disable_wd = reg_wdata[3];
 
-  assign conf_repcnt_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_repcnt_disable_wd = reg_wdata[4];
 
-  assign conf_adaptp_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_adaptp_disable_wd = reg_wdata[5];
 
-  assign conf_bucket_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_bucket_disable_wd = reg_wdata[6];
 
-  assign conf_markov_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_markov_disable_wd = reg_wdata[7];
 
-  assign conf_health_test_clr_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_health_test_clr_wd = reg_wdata[8];
 
-  assign conf_rng_bit_en_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_rng_bit_en_wd = reg_wdata[9];
 
-  assign conf_rng_bit_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_rng_bit_sel_wd = reg_wdata[11:10];
 
-  assign conf_extht_enable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_extht_enable_wd = reg_wdata[12];
 
-  assign conf_repcnts_disable_we = addr_hit[6] & reg_we & !reg_error;
   assign conf_repcnts_disable_wd = reg_wdata[13];
-
   assign rate_we = addr_hit[7] & reg_we & !reg_error;
-  assign rate_wd = reg_wdata[15:0];
 
-  assign entropy_control_es_route_we = addr_hit[8] & reg_we & !reg_error;
+  assign rate_wd = reg_wdata[15:0];
+  assign entropy_control_we = addr_hit[8] & reg_we & !reg_error;
+
   assign entropy_control_es_route_wd = reg_wdata[0];
 
-  assign entropy_control_es_type_we = addr_hit[8] & reg_we & !reg_error;
   assign entropy_control_es_type_wd = reg_wdata[1];
-
   assign entropy_data_re = addr_hit[9] & reg_re & !reg_error;
+  assign health_test_windows_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign health_test_windows_fips_window_we = addr_hit[10] & reg_we & !reg_error;
   assign health_test_windows_fips_window_wd = reg_wdata[15:0];
 
-  assign health_test_windows_bypass_window_we = addr_hit[10] & reg_we & !reg_error;
   assign health_test_windows_bypass_window_wd = reg_wdata[31:16];
+  assign repcnt_thresholds_re = addr_hit[11] & reg_re & !reg_error;
+  assign repcnt_thresholds_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign repcnt_thresholds_fips_thresh_we = addr_hit[11] & reg_we & !reg_error;
   assign repcnt_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign repcnt_thresholds_fips_thresh_re = addr_hit[11] & reg_re & !reg_error;
 
-  assign repcnt_thresholds_bypass_thresh_we = addr_hit[11] & reg_we & !reg_error;
   assign repcnt_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign repcnt_thresholds_bypass_thresh_re = addr_hit[11] & reg_re & !reg_error;
+  assign repcnts_thresholds_re = addr_hit[12] & reg_re & !reg_error;
+  assign repcnts_thresholds_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign repcnts_thresholds_fips_thresh_we = addr_hit[12] & reg_we & !reg_error;
   assign repcnts_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign repcnts_thresholds_fips_thresh_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign repcnts_thresholds_bypass_thresh_we = addr_hit[12] & reg_we & !reg_error;
   assign repcnts_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign repcnts_thresholds_bypass_thresh_re = addr_hit[12] & reg_re & !reg_error;
+  assign adaptp_hi_thresholds_re = addr_hit[13] & reg_re & !reg_error;
+  assign adaptp_hi_thresholds_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign adaptp_hi_thresholds_fips_thresh_we = addr_hit[13] & reg_we & !reg_error;
   assign adaptp_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign adaptp_hi_thresholds_fips_thresh_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign adaptp_hi_thresholds_bypass_thresh_we = addr_hit[13] & reg_we & !reg_error;
   assign adaptp_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign adaptp_hi_thresholds_bypass_thresh_re = addr_hit[13] & reg_re & !reg_error;
+  assign adaptp_lo_thresholds_re = addr_hit[14] & reg_re & !reg_error;
+  assign adaptp_lo_thresholds_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign adaptp_lo_thresholds_fips_thresh_we = addr_hit[14] & reg_we & !reg_error;
   assign adaptp_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign adaptp_lo_thresholds_fips_thresh_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign adaptp_lo_thresholds_bypass_thresh_we = addr_hit[14] & reg_we & !reg_error;
   assign adaptp_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign adaptp_lo_thresholds_bypass_thresh_re = addr_hit[14] & reg_re & !reg_error;
+  assign bucket_thresholds_re = addr_hit[15] & reg_re & !reg_error;
+  assign bucket_thresholds_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign bucket_thresholds_fips_thresh_we = addr_hit[15] & reg_we & !reg_error;
   assign bucket_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign bucket_thresholds_fips_thresh_re = addr_hit[15] & reg_re & !reg_error;
 
-  assign bucket_thresholds_bypass_thresh_we = addr_hit[15] & reg_we & !reg_error;
   assign bucket_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign bucket_thresholds_bypass_thresh_re = addr_hit[15] & reg_re & !reg_error;
+  assign markov_hi_thresholds_re = addr_hit[16] & reg_re & !reg_error;
+  assign markov_hi_thresholds_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign markov_hi_thresholds_fips_thresh_we = addr_hit[16] & reg_we & !reg_error;
   assign markov_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign markov_hi_thresholds_fips_thresh_re = addr_hit[16] & reg_re & !reg_error;
 
-  assign markov_hi_thresholds_bypass_thresh_we = addr_hit[16] & reg_we & !reg_error;
   assign markov_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign markov_hi_thresholds_bypass_thresh_re = addr_hit[16] & reg_re & !reg_error;
+  assign markov_lo_thresholds_re = addr_hit[17] & reg_re & !reg_error;
+  assign markov_lo_thresholds_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign markov_lo_thresholds_fips_thresh_we = addr_hit[17] & reg_we & !reg_error;
   assign markov_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign markov_lo_thresholds_fips_thresh_re = addr_hit[17] & reg_re & !reg_error;
 
-  assign markov_lo_thresholds_bypass_thresh_we = addr_hit[17] & reg_we & !reg_error;
   assign markov_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign markov_lo_thresholds_bypass_thresh_re = addr_hit[17] & reg_re & !reg_error;
+  assign extht_hi_thresholds_re = addr_hit[18] & reg_re & !reg_error;
+  assign extht_hi_thresholds_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign extht_hi_thresholds_fips_thresh_we = addr_hit[18] & reg_we & !reg_error;
   assign extht_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign extht_hi_thresholds_fips_thresh_re = addr_hit[18] & reg_re & !reg_error;
 
-  assign extht_hi_thresholds_bypass_thresh_we = addr_hit[18] & reg_we & !reg_error;
   assign extht_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign extht_hi_thresholds_bypass_thresh_re = addr_hit[18] & reg_re & !reg_error;
+  assign extht_lo_thresholds_re = addr_hit[19] & reg_re & !reg_error;
+  assign extht_lo_thresholds_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign extht_lo_thresholds_fips_thresh_we = addr_hit[19] & reg_we & !reg_error;
   assign extht_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
-  assign extht_lo_thresholds_fips_thresh_re = addr_hit[19] & reg_re & !reg_error;
 
-  assign extht_lo_thresholds_bypass_thresh_we = addr_hit[19] & reg_we & !reg_error;
   assign extht_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign extht_lo_thresholds_bypass_thresh_re = addr_hit[19] & reg_re & !reg_error;
-
-  assign repcnt_hi_watermarks_fips_watermark_re = addr_hit[20] & reg_re & !reg_error;
-
-  assign repcnt_hi_watermarks_bypass_watermark_re = addr_hit[20] & reg_re & !reg_error;
-
-  assign repcnts_hi_watermarks_fips_watermark_re = addr_hit[21] & reg_re & !reg_error;
-
-  assign repcnts_hi_watermarks_bypass_watermark_re = addr_hit[21] & reg_re & !reg_error;
-
-  assign adaptp_hi_watermarks_fips_watermark_re = addr_hit[22] & reg_re & !reg_error;
-
-  assign adaptp_hi_watermarks_bypass_watermark_re = addr_hit[22] & reg_re & !reg_error;
-
-  assign adaptp_lo_watermarks_fips_watermark_re = addr_hit[23] & reg_re & !reg_error;
-
-  assign adaptp_lo_watermarks_bypass_watermark_re = addr_hit[23] & reg_re & !reg_error;
-
-  assign extht_hi_watermarks_fips_watermark_re = addr_hit[24] & reg_re & !reg_error;
-
-  assign extht_hi_watermarks_bypass_watermark_re = addr_hit[24] & reg_re & !reg_error;
-
-  assign extht_lo_watermarks_fips_watermark_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign extht_lo_watermarks_bypass_watermark_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign bucket_hi_watermarks_fips_watermark_re = addr_hit[26] & reg_re & !reg_error;
-
-  assign bucket_hi_watermarks_bypass_watermark_re = addr_hit[26] & reg_re & !reg_error;
-
-  assign markov_hi_watermarks_fips_watermark_re = addr_hit[27] & reg_re & !reg_error;
-
-  assign markov_hi_watermarks_bypass_watermark_re = addr_hit[27] & reg_re & !reg_error;
-
-  assign markov_lo_watermarks_fips_watermark_re = addr_hit[28] & reg_re & !reg_error;
-
-  assign markov_lo_watermarks_bypass_watermark_re = addr_hit[28] & reg_re & !reg_error;
-
+  assign repcnt_hi_watermarks_re = addr_hit[20] & reg_re & !reg_error;
+  assign repcnts_hi_watermarks_re = addr_hit[21] & reg_re & !reg_error;
+  assign adaptp_hi_watermarks_re = addr_hit[22] & reg_re & !reg_error;
+  assign adaptp_lo_watermarks_re = addr_hit[23] & reg_re & !reg_error;
+  assign extht_hi_watermarks_re = addr_hit[24] & reg_re & !reg_error;
+  assign extht_lo_watermarks_re = addr_hit[25] & reg_re & !reg_error;
+  assign bucket_hi_watermarks_re = addr_hit[26] & reg_re & !reg_error;
+  assign markov_hi_watermarks_re = addr_hit[27] & reg_re & !reg_error;
+  assign markov_lo_watermarks_re = addr_hit[28] & reg_re & !reg_error;
   assign repcnt_total_fails_re = addr_hit[29] & reg_re & !reg_error;
-
   assign repcnts_total_fails_re = addr_hit[30] & reg_re & !reg_error;
-
   assign adaptp_hi_total_fails_re = addr_hit[31] & reg_re & !reg_error;
-
   assign adaptp_lo_total_fails_re = addr_hit[32] & reg_re & !reg_error;
-
   assign bucket_total_fails_re = addr_hit[33] & reg_re & !reg_error;
-
   assign markov_hi_total_fails_re = addr_hit[34] & reg_re & !reg_error;
-
   assign markov_lo_total_fails_re = addr_hit[35] & reg_re & !reg_error;
-
   assign extht_hi_total_fails_re = addr_hit[36] & reg_re & !reg_error;
-
   assign extht_lo_total_fails_re = addr_hit[37] & reg_re & !reg_error;
-
   assign alert_threshold_we = addr_hit[38] & reg_we & !reg_error;
+
   assign alert_threshold_wd = reg_wdata[31:0];
-
   assign alert_summary_fail_counts_re = addr_hit[39] & reg_re & !reg_error;
+  assign alert_fail_counts_re = addr_hit[40] & reg_re & !reg_error;
+  assign extht_fail_counts_re = addr_hit[41] & reg_re & !reg_error;
+  assign fw_ov_control_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign alert_fail_counts_repcnt_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign alert_fail_counts_adaptp_hi_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign alert_fail_counts_adaptp_lo_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign alert_fail_counts_bucket_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign alert_fail_counts_markov_hi_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign alert_fail_counts_markov_lo_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign alert_fail_counts_repcnts_fail_count_re = addr_hit[40] & reg_re & !reg_error;
-
-  assign extht_fail_counts_extht_hi_fail_count_re = addr_hit[41] & reg_re & !reg_error;
-
-  assign extht_fail_counts_extht_lo_fail_count_re = addr_hit[41] & reg_re & !reg_error;
-
-  assign fw_ov_control_fw_ov_mode_we = addr_hit[42] & reg_we & !reg_error;
   assign fw_ov_control_fw_ov_mode_wd = reg_wdata[0];
 
-  assign fw_ov_control_fw_ov_entropy_insert_we = addr_hit[42] & reg_we & !reg_error;
   assign fw_ov_control_fw_ov_entropy_insert_wd = reg_wdata[1];
-
   assign fw_ov_rd_data_re = addr_hit[43] & reg_re & !reg_error;
-
   assign fw_ov_wr_data_we = addr_hit[44] & reg_we & !reg_error;
+
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
-
   assign observe_fifo_thresh_we = addr_hit[45] & reg_we & !reg_error;
+
   assign observe_fifo_thresh_wd = reg_wdata[6:0];
-
-  assign debug_status_entropy_fifo_depth_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_sha3_fsm_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_sha3_block_pr_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_sha3_squeezing_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_sha3_absorbed_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_sha3_err_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_main_sm_idle_re = addr_hit[46] & reg_re & !reg_error;
-
-  assign debug_status_main_sm_state_re = addr_hit[46] & reg_re & !reg_error;
-
+  assign debug_status_re = addr_hit[46] & reg_re & !reg_error;
   assign seed_we = addr_hit[47] & reg_we & !reg_error;
-  assign seed_wd = reg_wdata[3:0];
 
+  assign seed_wd = reg_wdata[3:0];
   assign err_code_test_we = addr_hit[49] & reg_we & !reg_error;
+
   assign err_code_test_wd = reg_wdata[4:0];
 
   // Read data return

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -157,1070 +157,808 @@ module flash_ctrl_core_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_prog_empty_qs;
   logic intr_state_prog_empty_wd;
-  logic intr_state_prog_empty_we;
   logic intr_state_prog_lvl_qs;
   logic intr_state_prog_lvl_wd;
-  logic intr_state_prog_lvl_we;
   logic intr_state_rd_full_qs;
   logic intr_state_rd_full_wd;
-  logic intr_state_rd_full_we;
   logic intr_state_rd_lvl_qs;
   logic intr_state_rd_lvl_wd;
-  logic intr_state_rd_lvl_we;
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
-  logic intr_state_op_done_we;
   logic intr_state_err_qs;
   logic intr_state_err_wd;
-  logic intr_state_err_we;
+  logic intr_enable_we;
   logic intr_enable_prog_empty_qs;
   logic intr_enable_prog_empty_wd;
-  logic intr_enable_prog_empty_we;
   logic intr_enable_prog_lvl_qs;
   logic intr_enable_prog_lvl_wd;
-  logic intr_enable_prog_lvl_we;
   logic intr_enable_rd_full_qs;
   logic intr_enable_rd_full_wd;
-  logic intr_enable_rd_full_we;
   logic intr_enable_rd_lvl_qs;
   logic intr_enable_rd_lvl_wd;
-  logic intr_enable_rd_lvl_we;
   logic intr_enable_op_done_qs;
   logic intr_enable_op_done_wd;
-  logic intr_enable_op_done_we;
   logic intr_enable_err_qs;
   logic intr_enable_err_wd;
-  logic intr_enable_err_we;
+  logic intr_test_we;
   logic intr_test_prog_empty_wd;
-  logic intr_test_prog_empty_we;
   logic intr_test_prog_lvl_wd;
-  logic intr_test_prog_lvl_we;
   logic intr_test_rd_full_wd;
-  logic intr_test_rd_full_we;
   logic intr_test_rd_lvl_wd;
-  logic intr_test_rd_lvl_we;
   logic intr_test_op_done_wd;
-  logic intr_test_op_done_we;
   logic intr_test_err_wd;
-  logic intr_test_err_we;
+  logic alert_test_we;
   logic alert_test_recov_err_wd;
-  logic alert_test_recov_err_we;
   logic alert_test_recov_mp_err_wd;
-  logic alert_test_recov_mp_err_we;
   logic alert_test_recov_ecc_err_wd;
-  logic alert_test_recov_ecc_err_we;
   logic alert_test_fatal_intg_err_wd;
-  logic alert_test_fatal_intg_err_we;
+  logic init_we;
   logic init_qs;
   logic init_wd;
-  logic init_we;
-  logic ctrl_regwen_qs;
   logic ctrl_regwen_re;
+  logic ctrl_regwen_qs;
+  logic control_we;
   logic control_start_qs;
   logic control_start_wd;
-  logic control_start_we;
   logic [1:0] control_op_qs;
   logic [1:0] control_op_wd;
-  logic control_op_we;
   logic control_prog_sel_qs;
   logic control_prog_sel_wd;
-  logic control_prog_sel_we;
   logic control_erase_sel_qs;
   logic control_erase_sel_wd;
-  logic control_erase_sel_we;
   logic control_partition_sel_qs;
   logic control_partition_sel_wd;
-  logic control_partition_sel_we;
   logic [1:0] control_info_sel_qs;
   logic [1:0] control_info_sel_wd;
-  logic control_info_sel_we;
   logic [11:0] control_num_qs;
   logic [11:0] control_num_wd;
-  logic control_num_we;
+  logic addr_we;
   logic [31:0] addr_qs;
   logic [31:0] addr_wd;
-  logic addr_we;
+  logic prog_type_en_we;
   logic prog_type_en_normal_qs;
   logic prog_type_en_normal_wd;
-  logic prog_type_en_normal_we;
   logic prog_type_en_repair_qs;
   logic prog_type_en_repair_wd;
-  logic prog_type_en_repair_we;
+  logic erase_suspend_we;
   logic erase_suspend_qs;
   logic erase_suspend_wd;
-  logic erase_suspend_we;
+  logic region_cfg_regwen_0_we;
   logic region_cfg_regwen_0_qs;
   logic region_cfg_regwen_0_wd;
-  logic region_cfg_regwen_0_we;
+  logic region_cfg_regwen_1_we;
   logic region_cfg_regwen_1_qs;
   logic region_cfg_regwen_1_wd;
-  logic region_cfg_regwen_1_we;
+  logic region_cfg_regwen_2_we;
   logic region_cfg_regwen_2_qs;
   logic region_cfg_regwen_2_wd;
-  logic region_cfg_regwen_2_we;
+  logic region_cfg_regwen_3_we;
   logic region_cfg_regwen_3_qs;
   logic region_cfg_regwen_3_wd;
-  logic region_cfg_regwen_3_we;
+  logic region_cfg_regwen_4_we;
   logic region_cfg_regwen_4_qs;
   logic region_cfg_regwen_4_wd;
-  logic region_cfg_regwen_4_we;
+  logic region_cfg_regwen_5_we;
   logic region_cfg_regwen_5_qs;
   logic region_cfg_regwen_5_wd;
-  logic region_cfg_regwen_5_we;
+  logic region_cfg_regwen_6_we;
   logic region_cfg_regwen_6_qs;
   logic region_cfg_regwen_6_wd;
-  logic region_cfg_regwen_6_we;
+  logic region_cfg_regwen_7_we;
   logic region_cfg_regwen_7_qs;
   logic region_cfg_regwen_7_wd;
-  logic region_cfg_regwen_7_we;
+  logic mp_region_cfg_0_we;
   logic mp_region_cfg_0_en_0_qs;
   logic mp_region_cfg_0_en_0_wd;
-  logic mp_region_cfg_0_en_0_we;
   logic mp_region_cfg_0_rd_en_0_qs;
   logic mp_region_cfg_0_rd_en_0_wd;
-  logic mp_region_cfg_0_rd_en_0_we;
   logic mp_region_cfg_0_prog_en_0_qs;
   logic mp_region_cfg_0_prog_en_0_wd;
-  logic mp_region_cfg_0_prog_en_0_we;
   logic mp_region_cfg_0_erase_en_0_qs;
   logic mp_region_cfg_0_erase_en_0_wd;
-  logic mp_region_cfg_0_erase_en_0_we;
   logic mp_region_cfg_0_scramble_en_0_qs;
   logic mp_region_cfg_0_scramble_en_0_wd;
-  logic mp_region_cfg_0_scramble_en_0_we;
   logic mp_region_cfg_0_ecc_en_0_qs;
   logic mp_region_cfg_0_ecc_en_0_wd;
-  logic mp_region_cfg_0_ecc_en_0_we;
   logic mp_region_cfg_0_he_en_0_qs;
   logic mp_region_cfg_0_he_en_0_wd;
-  logic mp_region_cfg_0_he_en_0_we;
   logic [8:0] mp_region_cfg_0_base_0_qs;
   logic [8:0] mp_region_cfg_0_base_0_wd;
-  logic mp_region_cfg_0_base_0_we;
   logic [9:0] mp_region_cfg_0_size_0_qs;
   logic [9:0] mp_region_cfg_0_size_0_wd;
-  logic mp_region_cfg_0_size_0_we;
+  logic mp_region_cfg_1_we;
   logic mp_region_cfg_1_en_1_qs;
   logic mp_region_cfg_1_en_1_wd;
-  logic mp_region_cfg_1_en_1_we;
   logic mp_region_cfg_1_rd_en_1_qs;
   logic mp_region_cfg_1_rd_en_1_wd;
-  logic mp_region_cfg_1_rd_en_1_we;
   logic mp_region_cfg_1_prog_en_1_qs;
   logic mp_region_cfg_1_prog_en_1_wd;
-  logic mp_region_cfg_1_prog_en_1_we;
   logic mp_region_cfg_1_erase_en_1_qs;
   logic mp_region_cfg_1_erase_en_1_wd;
-  logic mp_region_cfg_1_erase_en_1_we;
   logic mp_region_cfg_1_scramble_en_1_qs;
   logic mp_region_cfg_1_scramble_en_1_wd;
-  logic mp_region_cfg_1_scramble_en_1_we;
   logic mp_region_cfg_1_ecc_en_1_qs;
   logic mp_region_cfg_1_ecc_en_1_wd;
-  logic mp_region_cfg_1_ecc_en_1_we;
   logic mp_region_cfg_1_he_en_1_qs;
   logic mp_region_cfg_1_he_en_1_wd;
-  logic mp_region_cfg_1_he_en_1_we;
   logic [8:0] mp_region_cfg_1_base_1_qs;
   logic [8:0] mp_region_cfg_1_base_1_wd;
-  logic mp_region_cfg_1_base_1_we;
   logic [9:0] mp_region_cfg_1_size_1_qs;
   logic [9:0] mp_region_cfg_1_size_1_wd;
-  logic mp_region_cfg_1_size_1_we;
+  logic mp_region_cfg_2_we;
   logic mp_region_cfg_2_en_2_qs;
   logic mp_region_cfg_2_en_2_wd;
-  logic mp_region_cfg_2_en_2_we;
   logic mp_region_cfg_2_rd_en_2_qs;
   logic mp_region_cfg_2_rd_en_2_wd;
-  logic mp_region_cfg_2_rd_en_2_we;
   logic mp_region_cfg_2_prog_en_2_qs;
   logic mp_region_cfg_2_prog_en_2_wd;
-  logic mp_region_cfg_2_prog_en_2_we;
   logic mp_region_cfg_2_erase_en_2_qs;
   logic mp_region_cfg_2_erase_en_2_wd;
-  logic mp_region_cfg_2_erase_en_2_we;
   logic mp_region_cfg_2_scramble_en_2_qs;
   logic mp_region_cfg_2_scramble_en_2_wd;
-  logic mp_region_cfg_2_scramble_en_2_we;
   logic mp_region_cfg_2_ecc_en_2_qs;
   logic mp_region_cfg_2_ecc_en_2_wd;
-  logic mp_region_cfg_2_ecc_en_2_we;
   logic mp_region_cfg_2_he_en_2_qs;
   logic mp_region_cfg_2_he_en_2_wd;
-  logic mp_region_cfg_2_he_en_2_we;
   logic [8:0] mp_region_cfg_2_base_2_qs;
   logic [8:0] mp_region_cfg_2_base_2_wd;
-  logic mp_region_cfg_2_base_2_we;
   logic [9:0] mp_region_cfg_2_size_2_qs;
   logic [9:0] mp_region_cfg_2_size_2_wd;
-  logic mp_region_cfg_2_size_2_we;
+  logic mp_region_cfg_3_we;
   logic mp_region_cfg_3_en_3_qs;
   logic mp_region_cfg_3_en_3_wd;
-  logic mp_region_cfg_3_en_3_we;
   logic mp_region_cfg_3_rd_en_3_qs;
   logic mp_region_cfg_3_rd_en_3_wd;
-  logic mp_region_cfg_3_rd_en_3_we;
   logic mp_region_cfg_3_prog_en_3_qs;
   logic mp_region_cfg_3_prog_en_3_wd;
-  logic mp_region_cfg_3_prog_en_3_we;
   logic mp_region_cfg_3_erase_en_3_qs;
   logic mp_region_cfg_3_erase_en_3_wd;
-  logic mp_region_cfg_3_erase_en_3_we;
   logic mp_region_cfg_3_scramble_en_3_qs;
   logic mp_region_cfg_3_scramble_en_3_wd;
-  logic mp_region_cfg_3_scramble_en_3_we;
   logic mp_region_cfg_3_ecc_en_3_qs;
   logic mp_region_cfg_3_ecc_en_3_wd;
-  logic mp_region_cfg_3_ecc_en_3_we;
   logic mp_region_cfg_3_he_en_3_qs;
   logic mp_region_cfg_3_he_en_3_wd;
-  logic mp_region_cfg_3_he_en_3_we;
   logic [8:0] mp_region_cfg_3_base_3_qs;
   logic [8:0] mp_region_cfg_3_base_3_wd;
-  logic mp_region_cfg_3_base_3_we;
   logic [9:0] mp_region_cfg_3_size_3_qs;
   logic [9:0] mp_region_cfg_3_size_3_wd;
-  logic mp_region_cfg_3_size_3_we;
+  logic mp_region_cfg_4_we;
   logic mp_region_cfg_4_en_4_qs;
   logic mp_region_cfg_4_en_4_wd;
-  logic mp_region_cfg_4_en_4_we;
   logic mp_region_cfg_4_rd_en_4_qs;
   logic mp_region_cfg_4_rd_en_4_wd;
-  logic mp_region_cfg_4_rd_en_4_we;
   logic mp_region_cfg_4_prog_en_4_qs;
   logic mp_region_cfg_4_prog_en_4_wd;
-  logic mp_region_cfg_4_prog_en_4_we;
   logic mp_region_cfg_4_erase_en_4_qs;
   logic mp_region_cfg_4_erase_en_4_wd;
-  logic mp_region_cfg_4_erase_en_4_we;
   logic mp_region_cfg_4_scramble_en_4_qs;
   logic mp_region_cfg_4_scramble_en_4_wd;
-  logic mp_region_cfg_4_scramble_en_4_we;
   logic mp_region_cfg_4_ecc_en_4_qs;
   logic mp_region_cfg_4_ecc_en_4_wd;
-  logic mp_region_cfg_4_ecc_en_4_we;
   logic mp_region_cfg_4_he_en_4_qs;
   logic mp_region_cfg_4_he_en_4_wd;
-  logic mp_region_cfg_4_he_en_4_we;
   logic [8:0] mp_region_cfg_4_base_4_qs;
   logic [8:0] mp_region_cfg_4_base_4_wd;
-  logic mp_region_cfg_4_base_4_we;
   logic [9:0] mp_region_cfg_4_size_4_qs;
   logic [9:0] mp_region_cfg_4_size_4_wd;
-  logic mp_region_cfg_4_size_4_we;
+  logic mp_region_cfg_5_we;
   logic mp_region_cfg_5_en_5_qs;
   logic mp_region_cfg_5_en_5_wd;
-  logic mp_region_cfg_5_en_5_we;
   logic mp_region_cfg_5_rd_en_5_qs;
   logic mp_region_cfg_5_rd_en_5_wd;
-  logic mp_region_cfg_5_rd_en_5_we;
   logic mp_region_cfg_5_prog_en_5_qs;
   logic mp_region_cfg_5_prog_en_5_wd;
-  logic mp_region_cfg_5_prog_en_5_we;
   logic mp_region_cfg_5_erase_en_5_qs;
   logic mp_region_cfg_5_erase_en_5_wd;
-  logic mp_region_cfg_5_erase_en_5_we;
   logic mp_region_cfg_5_scramble_en_5_qs;
   logic mp_region_cfg_5_scramble_en_5_wd;
-  logic mp_region_cfg_5_scramble_en_5_we;
   logic mp_region_cfg_5_ecc_en_5_qs;
   logic mp_region_cfg_5_ecc_en_5_wd;
-  logic mp_region_cfg_5_ecc_en_5_we;
   logic mp_region_cfg_5_he_en_5_qs;
   logic mp_region_cfg_5_he_en_5_wd;
-  logic mp_region_cfg_5_he_en_5_we;
   logic [8:0] mp_region_cfg_5_base_5_qs;
   logic [8:0] mp_region_cfg_5_base_5_wd;
-  logic mp_region_cfg_5_base_5_we;
   logic [9:0] mp_region_cfg_5_size_5_qs;
   logic [9:0] mp_region_cfg_5_size_5_wd;
-  logic mp_region_cfg_5_size_5_we;
+  logic mp_region_cfg_6_we;
   logic mp_region_cfg_6_en_6_qs;
   logic mp_region_cfg_6_en_6_wd;
-  logic mp_region_cfg_6_en_6_we;
   logic mp_region_cfg_6_rd_en_6_qs;
   logic mp_region_cfg_6_rd_en_6_wd;
-  logic mp_region_cfg_6_rd_en_6_we;
   logic mp_region_cfg_6_prog_en_6_qs;
   logic mp_region_cfg_6_prog_en_6_wd;
-  logic mp_region_cfg_6_prog_en_6_we;
   logic mp_region_cfg_6_erase_en_6_qs;
   logic mp_region_cfg_6_erase_en_6_wd;
-  logic mp_region_cfg_6_erase_en_6_we;
   logic mp_region_cfg_6_scramble_en_6_qs;
   logic mp_region_cfg_6_scramble_en_6_wd;
-  logic mp_region_cfg_6_scramble_en_6_we;
   logic mp_region_cfg_6_ecc_en_6_qs;
   logic mp_region_cfg_6_ecc_en_6_wd;
-  logic mp_region_cfg_6_ecc_en_6_we;
   logic mp_region_cfg_6_he_en_6_qs;
   logic mp_region_cfg_6_he_en_6_wd;
-  logic mp_region_cfg_6_he_en_6_we;
   logic [8:0] mp_region_cfg_6_base_6_qs;
   logic [8:0] mp_region_cfg_6_base_6_wd;
-  logic mp_region_cfg_6_base_6_we;
   logic [9:0] mp_region_cfg_6_size_6_qs;
   logic [9:0] mp_region_cfg_6_size_6_wd;
-  logic mp_region_cfg_6_size_6_we;
+  logic mp_region_cfg_7_we;
   logic mp_region_cfg_7_en_7_qs;
   logic mp_region_cfg_7_en_7_wd;
-  logic mp_region_cfg_7_en_7_we;
   logic mp_region_cfg_7_rd_en_7_qs;
   logic mp_region_cfg_7_rd_en_7_wd;
-  logic mp_region_cfg_7_rd_en_7_we;
   logic mp_region_cfg_7_prog_en_7_qs;
   logic mp_region_cfg_7_prog_en_7_wd;
-  logic mp_region_cfg_7_prog_en_7_we;
   logic mp_region_cfg_7_erase_en_7_qs;
   logic mp_region_cfg_7_erase_en_7_wd;
-  logic mp_region_cfg_7_erase_en_7_we;
   logic mp_region_cfg_7_scramble_en_7_qs;
   logic mp_region_cfg_7_scramble_en_7_wd;
-  logic mp_region_cfg_7_scramble_en_7_we;
   logic mp_region_cfg_7_ecc_en_7_qs;
   logic mp_region_cfg_7_ecc_en_7_wd;
-  logic mp_region_cfg_7_ecc_en_7_we;
   logic mp_region_cfg_7_he_en_7_qs;
   logic mp_region_cfg_7_he_en_7_wd;
-  logic mp_region_cfg_7_he_en_7_we;
   logic [8:0] mp_region_cfg_7_base_7_qs;
   logic [8:0] mp_region_cfg_7_base_7_wd;
-  logic mp_region_cfg_7_base_7_we;
   logic [9:0] mp_region_cfg_7_size_7_qs;
   logic [9:0] mp_region_cfg_7_size_7_wd;
-  logic mp_region_cfg_7_size_7_we;
+  logic default_region_we;
   logic default_region_rd_en_qs;
   logic default_region_rd_en_wd;
-  logic default_region_rd_en_we;
   logic default_region_prog_en_qs;
   logic default_region_prog_en_wd;
-  logic default_region_prog_en_we;
   logic default_region_erase_en_qs;
   logic default_region_erase_en_wd;
-  logic default_region_erase_en_we;
   logic default_region_scramble_en_qs;
   logic default_region_scramble_en_wd;
-  logic default_region_scramble_en_we;
   logic default_region_ecc_en_qs;
   logic default_region_ecc_en_wd;
-  logic default_region_ecc_en_we;
   logic default_region_he_en_qs;
   logic default_region_he_en_wd;
-  logic default_region_he_en_we;
+  logic bank0_info0_regwen_0_we;
   logic bank0_info0_regwen_0_qs;
   logic bank0_info0_regwen_0_wd;
-  logic bank0_info0_regwen_0_we;
+  logic bank0_info0_regwen_1_we;
   logic bank0_info0_regwen_1_qs;
   logic bank0_info0_regwen_1_wd;
-  logic bank0_info0_regwen_1_we;
+  logic bank0_info0_regwen_2_we;
   logic bank0_info0_regwen_2_qs;
   logic bank0_info0_regwen_2_wd;
-  logic bank0_info0_regwen_2_we;
+  logic bank0_info0_regwen_3_we;
   logic bank0_info0_regwen_3_qs;
   logic bank0_info0_regwen_3_wd;
-  logic bank0_info0_regwen_3_we;
+  logic bank0_info0_regwen_4_we;
   logic bank0_info0_regwen_4_qs;
   logic bank0_info0_regwen_4_wd;
-  logic bank0_info0_regwen_4_we;
+  logic bank0_info0_regwen_5_we;
   logic bank0_info0_regwen_5_qs;
   logic bank0_info0_regwen_5_wd;
-  logic bank0_info0_regwen_5_we;
+  logic bank0_info0_regwen_6_we;
   logic bank0_info0_regwen_6_qs;
   logic bank0_info0_regwen_6_wd;
-  logic bank0_info0_regwen_6_we;
+  logic bank0_info0_regwen_7_we;
   logic bank0_info0_regwen_7_qs;
   logic bank0_info0_regwen_7_wd;
-  logic bank0_info0_regwen_7_we;
+  logic bank0_info0_regwen_8_we;
   logic bank0_info0_regwen_8_qs;
   logic bank0_info0_regwen_8_wd;
-  logic bank0_info0_regwen_8_we;
+  logic bank0_info0_regwen_9_we;
   logic bank0_info0_regwen_9_qs;
   logic bank0_info0_regwen_9_wd;
-  logic bank0_info0_regwen_9_we;
+  logic bank0_info0_page_cfg_0_we;
   logic bank0_info0_page_cfg_0_en_0_qs;
   logic bank0_info0_page_cfg_0_en_0_wd;
-  logic bank0_info0_page_cfg_0_en_0_we;
   logic bank0_info0_page_cfg_0_rd_en_0_qs;
   logic bank0_info0_page_cfg_0_rd_en_0_wd;
-  logic bank0_info0_page_cfg_0_rd_en_0_we;
   logic bank0_info0_page_cfg_0_prog_en_0_qs;
   logic bank0_info0_page_cfg_0_prog_en_0_wd;
-  logic bank0_info0_page_cfg_0_prog_en_0_we;
   logic bank0_info0_page_cfg_0_erase_en_0_qs;
   logic bank0_info0_page_cfg_0_erase_en_0_wd;
-  logic bank0_info0_page_cfg_0_erase_en_0_we;
   logic bank0_info0_page_cfg_0_scramble_en_0_qs;
   logic bank0_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info0_page_cfg_0_scramble_en_0_we;
   logic bank0_info0_page_cfg_0_ecc_en_0_qs;
   logic bank0_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info0_page_cfg_0_ecc_en_0_we;
   logic bank0_info0_page_cfg_0_he_en_0_qs;
   logic bank0_info0_page_cfg_0_he_en_0_wd;
-  logic bank0_info0_page_cfg_0_he_en_0_we;
+  logic bank0_info0_page_cfg_1_we;
   logic bank0_info0_page_cfg_1_en_1_qs;
   logic bank0_info0_page_cfg_1_en_1_wd;
-  logic bank0_info0_page_cfg_1_en_1_we;
   logic bank0_info0_page_cfg_1_rd_en_1_qs;
   logic bank0_info0_page_cfg_1_rd_en_1_wd;
-  logic bank0_info0_page_cfg_1_rd_en_1_we;
   logic bank0_info0_page_cfg_1_prog_en_1_qs;
   logic bank0_info0_page_cfg_1_prog_en_1_wd;
-  logic bank0_info0_page_cfg_1_prog_en_1_we;
   logic bank0_info0_page_cfg_1_erase_en_1_qs;
   logic bank0_info0_page_cfg_1_erase_en_1_wd;
-  logic bank0_info0_page_cfg_1_erase_en_1_we;
   logic bank0_info0_page_cfg_1_scramble_en_1_qs;
   logic bank0_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info0_page_cfg_1_scramble_en_1_we;
   logic bank0_info0_page_cfg_1_ecc_en_1_qs;
   logic bank0_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info0_page_cfg_1_ecc_en_1_we;
   logic bank0_info0_page_cfg_1_he_en_1_qs;
   logic bank0_info0_page_cfg_1_he_en_1_wd;
-  logic bank0_info0_page_cfg_1_he_en_1_we;
+  logic bank0_info0_page_cfg_2_we;
   logic bank0_info0_page_cfg_2_en_2_qs;
   logic bank0_info0_page_cfg_2_en_2_wd;
-  logic bank0_info0_page_cfg_2_en_2_we;
   logic bank0_info0_page_cfg_2_rd_en_2_qs;
   logic bank0_info0_page_cfg_2_rd_en_2_wd;
-  logic bank0_info0_page_cfg_2_rd_en_2_we;
   logic bank0_info0_page_cfg_2_prog_en_2_qs;
   logic bank0_info0_page_cfg_2_prog_en_2_wd;
-  logic bank0_info0_page_cfg_2_prog_en_2_we;
   logic bank0_info0_page_cfg_2_erase_en_2_qs;
   logic bank0_info0_page_cfg_2_erase_en_2_wd;
-  logic bank0_info0_page_cfg_2_erase_en_2_we;
   logic bank0_info0_page_cfg_2_scramble_en_2_qs;
   logic bank0_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank0_info0_page_cfg_2_scramble_en_2_we;
   logic bank0_info0_page_cfg_2_ecc_en_2_qs;
   logic bank0_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank0_info0_page_cfg_2_ecc_en_2_we;
   logic bank0_info0_page_cfg_2_he_en_2_qs;
   logic bank0_info0_page_cfg_2_he_en_2_wd;
-  logic bank0_info0_page_cfg_2_he_en_2_we;
+  logic bank0_info0_page_cfg_3_we;
   logic bank0_info0_page_cfg_3_en_3_qs;
   logic bank0_info0_page_cfg_3_en_3_wd;
-  logic bank0_info0_page_cfg_3_en_3_we;
   logic bank0_info0_page_cfg_3_rd_en_3_qs;
   logic bank0_info0_page_cfg_3_rd_en_3_wd;
-  logic bank0_info0_page_cfg_3_rd_en_3_we;
   logic bank0_info0_page_cfg_3_prog_en_3_qs;
   logic bank0_info0_page_cfg_3_prog_en_3_wd;
-  logic bank0_info0_page_cfg_3_prog_en_3_we;
   logic bank0_info0_page_cfg_3_erase_en_3_qs;
   logic bank0_info0_page_cfg_3_erase_en_3_wd;
-  logic bank0_info0_page_cfg_3_erase_en_3_we;
   logic bank0_info0_page_cfg_3_scramble_en_3_qs;
   logic bank0_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank0_info0_page_cfg_3_scramble_en_3_we;
   logic bank0_info0_page_cfg_3_ecc_en_3_qs;
   logic bank0_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank0_info0_page_cfg_3_ecc_en_3_we;
   logic bank0_info0_page_cfg_3_he_en_3_qs;
   logic bank0_info0_page_cfg_3_he_en_3_wd;
-  logic bank0_info0_page_cfg_3_he_en_3_we;
+  logic bank0_info0_page_cfg_4_we;
   logic bank0_info0_page_cfg_4_en_4_qs;
   logic bank0_info0_page_cfg_4_en_4_wd;
-  logic bank0_info0_page_cfg_4_en_4_we;
   logic bank0_info0_page_cfg_4_rd_en_4_qs;
   logic bank0_info0_page_cfg_4_rd_en_4_wd;
-  logic bank0_info0_page_cfg_4_rd_en_4_we;
   logic bank0_info0_page_cfg_4_prog_en_4_qs;
   logic bank0_info0_page_cfg_4_prog_en_4_wd;
-  logic bank0_info0_page_cfg_4_prog_en_4_we;
   logic bank0_info0_page_cfg_4_erase_en_4_qs;
   logic bank0_info0_page_cfg_4_erase_en_4_wd;
-  logic bank0_info0_page_cfg_4_erase_en_4_we;
   logic bank0_info0_page_cfg_4_scramble_en_4_qs;
   logic bank0_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank0_info0_page_cfg_4_scramble_en_4_we;
   logic bank0_info0_page_cfg_4_ecc_en_4_qs;
   logic bank0_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank0_info0_page_cfg_4_ecc_en_4_we;
   logic bank0_info0_page_cfg_4_he_en_4_qs;
   logic bank0_info0_page_cfg_4_he_en_4_wd;
-  logic bank0_info0_page_cfg_4_he_en_4_we;
+  logic bank0_info0_page_cfg_5_we;
   logic bank0_info0_page_cfg_5_en_5_qs;
   logic bank0_info0_page_cfg_5_en_5_wd;
-  logic bank0_info0_page_cfg_5_en_5_we;
   logic bank0_info0_page_cfg_5_rd_en_5_qs;
   logic bank0_info0_page_cfg_5_rd_en_5_wd;
-  logic bank0_info0_page_cfg_5_rd_en_5_we;
   logic bank0_info0_page_cfg_5_prog_en_5_qs;
   logic bank0_info0_page_cfg_5_prog_en_5_wd;
-  logic bank0_info0_page_cfg_5_prog_en_5_we;
   logic bank0_info0_page_cfg_5_erase_en_5_qs;
   logic bank0_info0_page_cfg_5_erase_en_5_wd;
-  logic bank0_info0_page_cfg_5_erase_en_5_we;
   logic bank0_info0_page_cfg_5_scramble_en_5_qs;
   logic bank0_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank0_info0_page_cfg_5_scramble_en_5_we;
   logic bank0_info0_page_cfg_5_ecc_en_5_qs;
   logic bank0_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank0_info0_page_cfg_5_ecc_en_5_we;
   logic bank0_info0_page_cfg_5_he_en_5_qs;
   logic bank0_info0_page_cfg_5_he_en_5_wd;
-  logic bank0_info0_page_cfg_5_he_en_5_we;
+  logic bank0_info0_page_cfg_6_we;
   logic bank0_info0_page_cfg_6_en_6_qs;
   logic bank0_info0_page_cfg_6_en_6_wd;
-  logic bank0_info0_page_cfg_6_en_6_we;
   logic bank0_info0_page_cfg_6_rd_en_6_qs;
   logic bank0_info0_page_cfg_6_rd_en_6_wd;
-  logic bank0_info0_page_cfg_6_rd_en_6_we;
   logic bank0_info0_page_cfg_6_prog_en_6_qs;
   logic bank0_info0_page_cfg_6_prog_en_6_wd;
-  logic bank0_info0_page_cfg_6_prog_en_6_we;
   logic bank0_info0_page_cfg_6_erase_en_6_qs;
   logic bank0_info0_page_cfg_6_erase_en_6_wd;
-  logic bank0_info0_page_cfg_6_erase_en_6_we;
   logic bank0_info0_page_cfg_6_scramble_en_6_qs;
   logic bank0_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank0_info0_page_cfg_6_scramble_en_6_we;
   logic bank0_info0_page_cfg_6_ecc_en_6_qs;
   logic bank0_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank0_info0_page_cfg_6_ecc_en_6_we;
   logic bank0_info0_page_cfg_6_he_en_6_qs;
   logic bank0_info0_page_cfg_6_he_en_6_wd;
-  logic bank0_info0_page_cfg_6_he_en_6_we;
+  logic bank0_info0_page_cfg_7_we;
   logic bank0_info0_page_cfg_7_en_7_qs;
   logic bank0_info0_page_cfg_7_en_7_wd;
-  logic bank0_info0_page_cfg_7_en_7_we;
   logic bank0_info0_page_cfg_7_rd_en_7_qs;
   logic bank0_info0_page_cfg_7_rd_en_7_wd;
-  logic bank0_info0_page_cfg_7_rd_en_7_we;
   logic bank0_info0_page_cfg_7_prog_en_7_qs;
   logic bank0_info0_page_cfg_7_prog_en_7_wd;
-  logic bank0_info0_page_cfg_7_prog_en_7_we;
   logic bank0_info0_page_cfg_7_erase_en_7_qs;
   logic bank0_info0_page_cfg_7_erase_en_7_wd;
-  logic bank0_info0_page_cfg_7_erase_en_7_we;
   logic bank0_info0_page_cfg_7_scramble_en_7_qs;
   logic bank0_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank0_info0_page_cfg_7_scramble_en_7_we;
   logic bank0_info0_page_cfg_7_ecc_en_7_qs;
   logic bank0_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank0_info0_page_cfg_7_ecc_en_7_we;
   logic bank0_info0_page_cfg_7_he_en_7_qs;
   logic bank0_info0_page_cfg_7_he_en_7_wd;
-  logic bank0_info0_page_cfg_7_he_en_7_we;
+  logic bank0_info0_page_cfg_8_we;
   logic bank0_info0_page_cfg_8_en_8_qs;
   logic bank0_info0_page_cfg_8_en_8_wd;
-  logic bank0_info0_page_cfg_8_en_8_we;
   logic bank0_info0_page_cfg_8_rd_en_8_qs;
   logic bank0_info0_page_cfg_8_rd_en_8_wd;
-  logic bank0_info0_page_cfg_8_rd_en_8_we;
   logic bank0_info0_page_cfg_8_prog_en_8_qs;
   logic bank0_info0_page_cfg_8_prog_en_8_wd;
-  logic bank0_info0_page_cfg_8_prog_en_8_we;
   logic bank0_info0_page_cfg_8_erase_en_8_qs;
   logic bank0_info0_page_cfg_8_erase_en_8_wd;
-  logic bank0_info0_page_cfg_8_erase_en_8_we;
   logic bank0_info0_page_cfg_8_scramble_en_8_qs;
   logic bank0_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank0_info0_page_cfg_8_scramble_en_8_we;
   logic bank0_info0_page_cfg_8_ecc_en_8_qs;
   logic bank0_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank0_info0_page_cfg_8_ecc_en_8_we;
   logic bank0_info0_page_cfg_8_he_en_8_qs;
   logic bank0_info0_page_cfg_8_he_en_8_wd;
-  logic bank0_info0_page_cfg_8_he_en_8_we;
+  logic bank0_info0_page_cfg_9_we;
   logic bank0_info0_page_cfg_9_en_9_qs;
   logic bank0_info0_page_cfg_9_en_9_wd;
-  logic bank0_info0_page_cfg_9_en_9_we;
   logic bank0_info0_page_cfg_9_rd_en_9_qs;
   logic bank0_info0_page_cfg_9_rd_en_9_wd;
-  logic bank0_info0_page_cfg_9_rd_en_9_we;
   logic bank0_info0_page_cfg_9_prog_en_9_qs;
   logic bank0_info0_page_cfg_9_prog_en_9_wd;
-  logic bank0_info0_page_cfg_9_prog_en_9_we;
   logic bank0_info0_page_cfg_9_erase_en_9_qs;
   logic bank0_info0_page_cfg_9_erase_en_9_wd;
-  logic bank0_info0_page_cfg_9_erase_en_9_we;
   logic bank0_info0_page_cfg_9_scramble_en_9_qs;
   logic bank0_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank0_info0_page_cfg_9_scramble_en_9_we;
   logic bank0_info0_page_cfg_9_ecc_en_9_qs;
   logic bank0_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank0_info0_page_cfg_9_ecc_en_9_we;
   logic bank0_info0_page_cfg_9_he_en_9_qs;
   logic bank0_info0_page_cfg_9_he_en_9_wd;
-  logic bank0_info0_page_cfg_9_he_en_9_we;
+  logic bank0_info1_regwen_we;
   logic bank0_info1_regwen_qs;
   logic bank0_info1_regwen_wd;
-  logic bank0_info1_regwen_we;
+  logic bank0_info1_page_cfg_we;
   logic bank0_info1_page_cfg_en_0_qs;
   logic bank0_info1_page_cfg_en_0_wd;
-  logic bank0_info1_page_cfg_en_0_we;
   logic bank0_info1_page_cfg_rd_en_0_qs;
   logic bank0_info1_page_cfg_rd_en_0_wd;
-  logic bank0_info1_page_cfg_rd_en_0_we;
   logic bank0_info1_page_cfg_prog_en_0_qs;
   logic bank0_info1_page_cfg_prog_en_0_wd;
-  logic bank0_info1_page_cfg_prog_en_0_we;
   logic bank0_info1_page_cfg_erase_en_0_qs;
   logic bank0_info1_page_cfg_erase_en_0_wd;
-  logic bank0_info1_page_cfg_erase_en_0_we;
   logic bank0_info1_page_cfg_scramble_en_0_qs;
   logic bank0_info1_page_cfg_scramble_en_0_wd;
-  logic bank0_info1_page_cfg_scramble_en_0_we;
   logic bank0_info1_page_cfg_ecc_en_0_qs;
   logic bank0_info1_page_cfg_ecc_en_0_wd;
-  logic bank0_info1_page_cfg_ecc_en_0_we;
   logic bank0_info1_page_cfg_he_en_0_qs;
   logic bank0_info1_page_cfg_he_en_0_wd;
-  logic bank0_info1_page_cfg_he_en_0_we;
+  logic bank0_info2_regwen_0_we;
   logic bank0_info2_regwen_0_qs;
   logic bank0_info2_regwen_0_wd;
-  logic bank0_info2_regwen_0_we;
+  logic bank0_info2_regwen_1_we;
   logic bank0_info2_regwen_1_qs;
   logic bank0_info2_regwen_1_wd;
-  logic bank0_info2_regwen_1_we;
+  logic bank0_info2_page_cfg_0_we;
   logic bank0_info2_page_cfg_0_en_0_qs;
   logic bank0_info2_page_cfg_0_en_0_wd;
-  logic bank0_info2_page_cfg_0_en_0_we;
   logic bank0_info2_page_cfg_0_rd_en_0_qs;
   logic bank0_info2_page_cfg_0_rd_en_0_wd;
-  logic bank0_info2_page_cfg_0_rd_en_0_we;
   logic bank0_info2_page_cfg_0_prog_en_0_qs;
   logic bank0_info2_page_cfg_0_prog_en_0_wd;
-  logic bank0_info2_page_cfg_0_prog_en_0_we;
   logic bank0_info2_page_cfg_0_erase_en_0_qs;
   logic bank0_info2_page_cfg_0_erase_en_0_wd;
-  logic bank0_info2_page_cfg_0_erase_en_0_we;
   logic bank0_info2_page_cfg_0_scramble_en_0_qs;
   logic bank0_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info2_page_cfg_0_scramble_en_0_we;
   logic bank0_info2_page_cfg_0_ecc_en_0_qs;
   logic bank0_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info2_page_cfg_0_ecc_en_0_we;
   logic bank0_info2_page_cfg_0_he_en_0_qs;
   logic bank0_info2_page_cfg_0_he_en_0_wd;
-  logic bank0_info2_page_cfg_0_he_en_0_we;
+  logic bank0_info2_page_cfg_1_we;
   logic bank0_info2_page_cfg_1_en_1_qs;
   logic bank0_info2_page_cfg_1_en_1_wd;
-  logic bank0_info2_page_cfg_1_en_1_we;
   logic bank0_info2_page_cfg_1_rd_en_1_qs;
   logic bank0_info2_page_cfg_1_rd_en_1_wd;
-  logic bank0_info2_page_cfg_1_rd_en_1_we;
   logic bank0_info2_page_cfg_1_prog_en_1_qs;
   logic bank0_info2_page_cfg_1_prog_en_1_wd;
-  logic bank0_info2_page_cfg_1_prog_en_1_we;
   logic bank0_info2_page_cfg_1_erase_en_1_qs;
   logic bank0_info2_page_cfg_1_erase_en_1_wd;
-  logic bank0_info2_page_cfg_1_erase_en_1_we;
   logic bank0_info2_page_cfg_1_scramble_en_1_qs;
   logic bank0_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info2_page_cfg_1_scramble_en_1_we;
   logic bank0_info2_page_cfg_1_ecc_en_1_qs;
   logic bank0_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info2_page_cfg_1_ecc_en_1_we;
   logic bank0_info2_page_cfg_1_he_en_1_qs;
   logic bank0_info2_page_cfg_1_he_en_1_wd;
-  logic bank0_info2_page_cfg_1_he_en_1_we;
+  logic bank1_info0_regwen_0_we;
   logic bank1_info0_regwen_0_qs;
   logic bank1_info0_regwen_0_wd;
-  logic bank1_info0_regwen_0_we;
+  logic bank1_info0_regwen_1_we;
   logic bank1_info0_regwen_1_qs;
   logic bank1_info0_regwen_1_wd;
-  logic bank1_info0_regwen_1_we;
+  logic bank1_info0_regwen_2_we;
   logic bank1_info0_regwen_2_qs;
   logic bank1_info0_regwen_2_wd;
-  logic bank1_info0_regwen_2_we;
+  logic bank1_info0_regwen_3_we;
   logic bank1_info0_regwen_3_qs;
   logic bank1_info0_regwen_3_wd;
-  logic bank1_info0_regwen_3_we;
+  logic bank1_info0_regwen_4_we;
   logic bank1_info0_regwen_4_qs;
   logic bank1_info0_regwen_4_wd;
-  logic bank1_info0_regwen_4_we;
+  logic bank1_info0_regwen_5_we;
   logic bank1_info0_regwen_5_qs;
   logic bank1_info0_regwen_5_wd;
-  logic bank1_info0_regwen_5_we;
+  logic bank1_info0_regwen_6_we;
   logic bank1_info0_regwen_6_qs;
   logic bank1_info0_regwen_6_wd;
-  logic bank1_info0_regwen_6_we;
+  logic bank1_info0_regwen_7_we;
   logic bank1_info0_regwen_7_qs;
   logic bank1_info0_regwen_7_wd;
-  logic bank1_info0_regwen_7_we;
+  logic bank1_info0_regwen_8_we;
   logic bank1_info0_regwen_8_qs;
   logic bank1_info0_regwen_8_wd;
-  logic bank1_info0_regwen_8_we;
+  logic bank1_info0_regwen_9_we;
   logic bank1_info0_regwen_9_qs;
   logic bank1_info0_regwen_9_wd;
-  logic bank1_info0_regwen_9_we;
+  logic bank1_info0_page_cfg_0_we;
   logic bank1_info0_page_cfg_0_en_0_qs;
   logic bank1_info0_page_cfg_0_en_0_wd;
-  logic bank1_info0_page_cfg_0_en_0_we;
   logic bank1_info0_page_cfg_0_rd_en_0_qs;
   logic bank1_info0_page_cfg_0_rd_en_0_wd;
-  logic bank1_info0_page_cfg_0_rd_en_0_we;
   logic bank1_info0_page_cfg_0_prog_en_0_qs;
   logic bank1_info0_page_cfg_0_prog_en_0_wd;
-  logic bank1_info0_page_cfg_0_prog_en_0_we;
   logic bank1_info0_page_cfg_0_erase_en_0_qs;
   logic bank1_info0_page_cfg_0_erase_en_0_wd;
-  logic bank1_info0_page_cfg_0_erase_en_0_we;
   logic bank1_info0_page_cfg_0_scramble_en_0_qs;
   logic bank1_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info0_page_cfg_0_scramble_en_0_we;
   logic bank1_info0_page_cfg_0_ecc_en_0_qs;
   logic bank1_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info0_page_cfg_0_ecc_en_0_we;
   logic bank1_info0_page_cfg_0_he_en_0_qs;
   logic bank1_info0_page_cfg_0_he_en_0_wd;
-  logic bank1_info0_page_cfg_0_he_en_0_we;
+  logic bank1_info0_page_cfg_1_we;
   logic bank1_info0_page_cfg_1_en_1_qs;
   logic bank1_info0_page_cfg_1_en_1_wd;
-  logic bank1_info0_page_cfg_1_en_1_we;
   logic bank1_info0_page_cfg_1_rd_en_1_qs;
   logic bank1_info0_page_cfg_1_rd_en_1_wd;
-  logic bank1_info0_page_cfg_1_rd_en_1_we;
   logic bank1_info0_page_cfg_1_prog_en_1_qs;
   logic bank1_info0_page_cfg_1_prog_en_1_wd;
-  logic bank1_info0_page_cfg_1_prog_en_1_we;
   logic bank1_info0_page_cfg_1_erase_en_1_qs;
   logic bank1_info0_page_cfg_1_erase_en_1_wd;
-  logic bank1_info0_page_cfg_1_erase_en_1_we;
   logic bank1_info0_page_cfg_1_scramble_en_1_qs;
   logic bank1_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info0_page_cfg_1_scramble_en_1_we;
   logic bank1_info0_page_cfg_1_ecc_en_1_qs;
   logic bank1_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info0_page_cfg_1_ecc_en_1_we;
   logic bank1_info0_page_cfg_1_he_en_1_qs;
   logic bank1_info0_page_cfg_1_he_en_1_wd;
-  logic bank1_info0_page_cfg_1_he_en_1_we;
+  logic bank1_info0_page_cfg_2_we;
   logic bank1_info0_page_cfg_2_en_2_qs;
   logic bank1_info0_page_cfg_2_en_2_wd;
-  logic bank1_info0_page_cfg_2_en_2_we;
   logic bank1_info0_page_cfg_2_rd_en_2_qs;
   logic bank1_info0_page_cfg_2_rd_en_2_wd;
-  logic bank1_info0_page_cfg_2_rd_en_2_we;
   logic bank1_info0_page_cfg_2_prog_en_2_qs;
   logic bank1_info0_page_cfg_2_prog_en_2_wd;
-  logic bank1_info0_page_cfg_2_prog_en_2_we;
   logic bank1_info0_page_cfg_2_erase_en_2_qs;
   logic bank1_info0_page_cfg_2_erase_en_2_wd;
-  logic bank1_info0_page_cfg_2_erase_en_2_we;
   logic bank1_info0_page_cfg_2_scramble_en_2_qs;
   logic bank1_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank1_info0_page_cfg_2_scramble_en_2_we;
   logic bank1_info0_page_cfg_2_ecc_en_2_qs;
   logic bank1_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank1_info0_page_cfg_2_ecc_en_2_we;
   logic bank1_info0_page_cfg_2_he_en_2_qs;
   logic bank1_info0_page_cfg_2_he_en_2_wd;
-  logic bank1_info0_page_cfg_2_he_en_2_we;
+  logic bank1_info0_page_cfg_3_we;
   logic bank1_info0_page_cfg_3_en_3_qs;
   logic bank1_info0_page_cfg_3_en_3_wd;
-  logic bank1_info0_page_cfg_3_en_3_we;
   logic bank1_info0_page_cfg_3_rd_en_3_qs;
   logic bank1_info0_page_cfg_3_rd_en_3_wd;
-  logic bank1_info0_page_cfg_3_rd_en_3_we;
   logic bank1_info0_page_cfg_3_prog_en_3_qs;
   logic bank1_info0_page_cfg_3_prog_en_3_wd;
-  logic bank1_info0_page_cfg_3_prog_en_3_we;
   logic bank1_info0_page_cfg_3_erase_en_3_qs;
   logic bank1_info0_page_cfg_3_erase_en_3_wd;
-  logic bank1_info0_page_cfg_3_erase_en_3_we;
   logic bank1_info0_page_cfg_3_scramble_en_3_qs;
   logic bank1_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank1_info0_page_cfg_3_scramble_en_3_we;
   logic bank1_info0_page_cfg_3_ecc_en_3_qs;
   logic bank1_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank1_info0_page_cfg_3_ecc_en_3_we;
   logic bank1_info0_page_cfg_3_he_en_3_qs;
   logic bank1_info0_page_cfg_3_he_en_3_wd;
-  logic bank1_info0_page_cfg_3_he_en_3_we;
+  logic bank1_info0_page_cfg_4_we;
   logic bank1_info0_page_cfg_4_en_4_qs;
   logic bank1_info0_page_cfg_4_en_4_wd;
-  logic bank1_info0_page_cfg_4_en_4_we;
   logic bank1_info0_page_cfg_4_rd_en_4_qs;
   logic bank1_info0_page_cfg_4_rd_en_4_wd;
-  logic bank1_info0_page_cfg_4_rd_en_4_we;
   logic bank1_info0_page_cfg_4_prog_en_4_qs;
   logic bank1_info0_page_cfg_4_prog_en_4_wd;
-  logic bank1_info0_page_cfg_4_prog_en_4_we;
   logic bank1_info0_page_cfg_4_erase_en_4_qs;
   logic bank1_info0_page_cfg_4_erase_en_4_wd;
-  logic bank1_info0_page_cfg_4_erase_en_4_we;
   logic bank1_info0_page_cfg_4_scramble_en_4_qs;
   logic bank1_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank1_info0_page_cfg_4_scramble_en_4_we;
   logic bank1_info0_page_cfg_4_ecc_en_4_qs;
   logic bank1_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank1_info0_page_cfg_4_ecc_en_4_we;
   logic bank1_info0_page_cfg_4_he_en_4_qs;
   logic bank1_info0_page_cfg_4_he_en_4_wd;
-  logic bank1_info0_page_cfg_4_he_en_4_we;
+  logic bank1_info0_page_cfg_5_we;
   logic bank1_info0_page_cfg_5_en_5_qs;
   logic bank1_info0_page_cfg_5_en_5_wd;
-  logic bank1_info0_page_cfg_5_en_5_we;
   logic bank1_info0_page_cfg_5_rd_en_5_qs;
   logic bank1_info0_page_cfg_5_rd_en_5_wd;
-  logic bank1_info0_page_cfg_5_rd_en_5_we;
   logic bank1_info0_page_cfg_5_prog_en_5_qs;
   logic bank1_info0_page_cfg_5_prog_en_5_wd;
-  logic bank1_info0_page_cfg_5_prog_en_5_we;
   logic bank1_info0_page_cfg_5_erase_en_5_qs;
   logic bank1_info0_page_cfg_5_erase_en_5_wd;
-  logic bank1_info0_page_cfg_5_erase_en_5_we;
   logic bank1_info0_page_cfg_5_scramble_en_5_qs;
   logic bank1_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank1_info0_page_cfg_5_scramble_en_5_we;
   logic bank1_info0_page_cfg_5_ecc_en_5_qs;
   logic bank1_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank1_info0_page_cfg_5_ecc_en_5_we;
   logic bank1_info0_page_cfg_5_he_en_5_qs;
   logic bank1_info0_page_cfg_5_he_en_5_wd;
-  logic bank1_info0_page_cfg_5_he_en_5_we;
+  logic bank1_info0_page_cfg_6_we;
   logic bank1_info0_page_cfg_6_en_6_qs;
   logic bank1_info0_page_cfg_6_en_6_wd;
-  logic bank1_info0_page_cfg_6_en_6_we;
   logic bank1_info0_page_cfg_6_rd_en_6_qs;
   logic bank1_info0_page_cfg_6_rd_en_6_wd;
-  logic bank1_info0_page_cfg_6_rd_en_6_we;
   logic bank1_info0_page_cfg_6_prog_en_6_qs;
   logic bank1_info0_page_cfg_6_prog_en_6_wd;
-  logic bank1_info0_page_cfg_6_prog_en_6_we;
   logic bank1_info0_page_cfg_6_erase_en_6_qs;
   logic bank1_info0_page_cfg_6_erase_en_6_wd;
-  logic bank1_info0_page_cfg_6_erase_en_6_we;
   logic bank1_info0_page_cfg_6_scramble_en_6_qs;
   logic bank1_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank1_info0_page_cfg_6_scramble_en_6_we;
   logic bank1_info0_page_cfg_6_ecc_en_6_qs;
   logic bank1_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank1_info0_page_cfg_6_ecc_en_6_we;
   logic bank1_info0_page_cfg_6_he_en_6_qs;
   logic bank1_info0_page_cfg_6_he_en_6_wd;
-  logic bank1_info0_page_cfg_6_he_en_6_we;
+  logic bank1_info0_page_cfg_7_we;
   logic bank1_info0_page_cfg_7_en_7_qs;
   logic bank1_info0_page_cfg_7_en_7_wd;
-  logic bank1_info0_page_cfg_7_en_7_we;
   logic bank1_info0_page_cfg_7_rd_en_7_qs;
   logic bank1_info0_page_cfg_7_rd_en_7_wd;
-  logic bank1_info0_page_cfg_7_rd_en_7_we;
   logic bank1_info0_page_cfg_7_prog_en_7_qs;
   logic bank1_info0_page_cfg_7_prog_en_7_wd;
-  logic bank1_info0_page_cfg_7_prog_en_7_we;
   logic bank1_info0_page_cfg_7_erase_en_7_qs;
   logic bank1_info0_page_cfg_7_erase_en_7_wd;
-  logic bank1_info0_page_cfg_7_erase_en_7_we;
   logic bank1_info0_page_cfg_7_scramble_en_7_qs;
   logic bank1_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank1_info0_page_cfg_7_scramble_en_7_we;
   logic bank1_info0_page_cfg_7_ecc_en_7_qs;
   logic bank1_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank1_info0_page_cfg_7_ecc_en_7_we;
   logic bank1_info0_page_cfg_7_he_en_7_qs;
   logic bank1_info0_page_cfg_7_he_en_7_wd;
-  logic bank1_info0_page_cfg_7_he_en_7_we;
+  logic bank1_info0_page_cfg_8_we;
   logic bank1_info0_page_cfg_8_en_8_qs;
   logic bank1_info0_page_cfg_8_en_8_wd;
-  logic bank1_info0_page_cfg_8_en_8_we;
   logic bank1_info0_page_cfg_8_rd_en_8_qs;
   logic bank1_info0_page_cfg_8_rd_en_8_wd;
-  logic bank1_info0_page_cfg_8_rd_en_8_we;
   logic bank1_info0_page_cfg_8_prog_en_8_qs;
   logic bank1_info0_page_cfg_8_prog_en_8_wd;
-  logic bank1_info0_page_cfg_8_prog_en_8_we;
   logic bank1_info0_page_cfg_8_erase_en_8_qs;
   logic bank1_info0_page_cfg_8_erase_en_8_wd;
-  logic bank1_info0_page_cfg_8_erase_en_8_we;
   logic bank1_info0_page_cfg_8_scramble_en_8_qs;
   logic bank1_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank1_info0_page_cfg_8_scramble_en_8_we;
   logic bank1_info0_page_cfg_8_ecc_en_8_qs;
   logic bank1_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank1_info0_page_cfg_8_ecc_en_8_we;
   logic bank1_info0_page_cfg_8_he_en_8_qs;
   logic bank1_info0_page_cfg_8_he_en_8_wd;
-  logic bank1_info0_page_cfg_8_he_en_8_we;
+  logic bank1_info0_page_cfg_9_we;
   logic bank1_info0_page_cfg_9_en_9_qs;
   logic bank1_info0_page_cfg_9_en_9_wd;
-  logic bank1_info0_page_cfg_9_en_9_we;
   logic bank1_info0_page_cfg_9_rd_en_9_qs;
   logic bank1_info0_page_cfg_9_rd_en_9_wd;
-  logic bank1_info0_page_cfg_9_rd_en_9_we;
   logic bank1_info0_page_cfg_9_prog_en_9_qs;
   logic bank1_info0_page_cfg_9_prog_en_9_wd;
-  logic bank1_info0_page_cfg_9_prog_en_9_we;
   logic bank1_info0_page_cfg_9_erase_en_9_qs;
   logic bank1_info0_page_cfg_9_erase_en_9_wd;
-  logic bank1_info0_page_cfg_9_erase_en_9_we;
   logic bank1_info0_page_cfg_9_scramble_en_9_qs;
   logic bank1_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank1_info0_page_cfg_9_scramble_en_9_we;
   logic bank1_info0_page_cfg_9_ecc_en_9_qs;
   logic bank1_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank1_info0_page_cfg_9_ecc_en_9_we;
   logic bank1_info0_page_cfg_9_he_en_9_qs;
   logic bank1_info0_page_cfg_9_he_en_9_wd;
-  logic bank1_info0_page_cfg_9_he_en_9_we;
+  logic bank1_info1_regwen_we;
   logic bank1_info1_regwen_qs;
   logic bank1_info1_regwen_wd;
-  logic bank1_info1_regwen_we;
+  logic bank1_info1_page_cfg_we;
   logic bank1_info1_page_cfg_en_0_qs;
   logic bank1_info1_page_cfg_en_0_wd;
-  logic bank1_info1_page_cfg_en_0_we;
   logic bank1_info1_page_cfg_rd_en_0_qs;
   logic bank1_info1_page_cfg_rd_en_0_wd;
-  logic bank1_info1_page_cfg_rd_en_0_we;
   logic bank1_info1_page_cfg_prog_en_0_qs;
   logic bank1_info1_page_cfg_prog_en_0_wd;
-  logic bank1_info1_page_cfg_prog_en_0_we;
   logic bank1_info1_page_cfg_erase_en_0_qs;
   logic bank1_info1_page_cfg_erase_en_0_wd;
-  logic bank1_info1_page_cfg_erase_en_0_we;
   logic bank1_info1_page_cfg_scramble_en_0_qs;
   logic bank1_info1_page_cfg_scramble_en_0_wd;
-  logic bank1_info1_page_cfg_scramble_en_0_we;
   logic bank1_info1_page_cfg_ecc_en_0_qs;
   logic bank1_info1_page_cfg_ecc_en_0_wd;
-  logic bank1_info1_page_cfg_ecc_en_0_we;
   logic bank1_info1_page_cfg_he_en_0_qs;
   logic bank1_info1_page_cfg_he_en_0_wd;
-  logic bank1_info1_page_cfg_he_en_0_we;
+  logic bank1_info2_regwen_0_we;
   logic bank1_info2_regwen_0_qs;
   logic bank1_info2_regwen_0_wd;
-  logic bank1_info2_regwen_0_we;
+  logic bank1_info2_regwen_1_we;
   logic bank1_info2_regwen_1_qs;
   logic bank1_info2_regwen_1_wd;
-  logic bank1_info2_regwen_1_we;
+  logic bank1_info2_page_cfg_0_we;
   logic bank1_info2_page_cfg_0_en_0_qs;
   logic bank1_info2_page_cfg_0_en_0_wd;
-  logic bank1_info2_page_cfg_0_en_0_we;
   logic bank1_info2_page_cfg_0_rd_en_0_qs;
   logic bank1_info2_page_cfg_0_rd_en_0_wd;
-  logic bank1_info2_page_cfg_0_rd_en_0_we;
   logic bank1_info2_page_cfg_0_prog_en_0_qs;
   logic bank1_info2_page_cfg_0_prog_en_0_wd;
-  logic bank1_info2_page_cfg_0_prog_en_0_we;
   logic bank1_info2_page_cfg_0_erase_en_0_qs;
   logic bank1_info2_page_cfg_0_erase_en_0_wd;
-  logic bank1_info2_page_cfg_0_erase_en_0_we;
   logic bank1_info2_page_cfg_0_scramble_en_0_qs;
   logic bank1_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info2_page_cfg_0_scramble_en_0_we;
   logic bank1_info2_page_cfg_0_ecc_en_0_qs;
   logic bank1_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info2_page_cfg_0_ecc_en_0_we;
   logic bank1_info2_page_cfg_0_he_en_0_qs;
   logic bank1_info2_page_cfg_0_he_en_0_wd;
-  logic bank1_info2_page_cfg_0_he_en_0_we;
+  logic bank1_info2_page_cfg_1_we;
   logic bank1_info2_page_cfg_1_en_1_qs;
   logic bank1_info2_page_cfg_1_en_1_wd;
-  logic bank1_info2_page_cfg_1_en_1_we;
   logic bank1_info2_page_cfg_1_rd_en_1_qs;
   logic bank1_info2_page_cfg_1_rd_en_1_wd;
-  logic bank1_info2_page_cfg_1_rd_en_1_we;
   logic bank1_info2_page_cfg_1_prog_en_1_qs;
   logic bank1_info2_page_cfg_1_prog_en_1_wd;
-  logic bank1_info2_page_cfg_1_prog_en_1_we;
   logic bank1_info2_page_cfg_1_erase_en_1_qs;
   logic bank1_info2_page_cfg_1_erase_en_1_wd;
-  logic bank1_info2_page_cfg_1_erase_en_1_we;
   logic bank1_info2_page_cfg_1_scramble_en_1_qs;
   logic bank1_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info2_page_cfg_1_scramble_en_1_we;
   logic bank1_info2_page_cfg_1_ecc_en_1_qs;
   logic bank1_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info2_page_cfg_1_ecc_en_1_we;
   logic bank1_info2_page_cfg_1_he_en_1_qs;
   logic bank1_info2_page_cfg_1_he_en_1_wd;
-  logic bank1_info2_page_cfg_1_he_en_1_we;
+  logic bank_cfg_regwen_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
-  logic bank_cfg_regwen_we;
+  logic mp_bank_cfg_we;
   logic mp_bank_cfg_erase_en_0_qs;
   logic mp_bank_cfg_erase_en_0_wd;
-  logic mp_bank_cfg_erase_en_0_we;
   logic mp_bank_cfg_erase_en_1_qs;
   logic mp_bank_cfg_erase_en_1_wd;
-  logic mp_bank_cfg_erase_en_1_we;
+  logic op_status_we;
   logic op_status_done_qs;
   logic op_status_done_wd;
-  logic op_status_done_we;
   logic op_status_err_qs;
   logic op_status_err_wd;
-  logic op_status_err_we;
   logic status_rd_full_qs;
   logic status_rd_empty_qs;
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
+  logic err_code_intr_en_we;
   logic err_code_intr_en_flash_err_en_qs;
   logic err_code_intr_en_flash_err_en_wd;
-  logic err_code_intr_en_flash_err_en_we;
   logic err_code_intr_en_flash_alert_en_qs;
   logic err_code_intr_en_flash_alert_en_wd;
-  logic err_code_intr_en_flash_alert_en_we;
   logic err_code_intr_en_mp_err_qs;
   logic err_code_intr_en_mp_err_wd;
-  logic err_code_intr_en_mp_err_we;
   logic err_code_intr_en_ecc_single_err_qs;
   logic err_code_intr_en_ecc_single_err_wd;
-  logic err_code_intr_en_ecc_single_err_we;
   logic err_code_intr_en_ecc_multi_err_qs;
   logic err_code_intr_en_ecc_multi_err_wd;
-  logic err_code_intr_en_ecc_multi_err_we;
+  logic err_code_we;
   logic err_code_flash_err_qs;
   logic err_code_flash_err_wd;
-  logic err_code_flash_err_we;
   logic err_code_flash_alert_qs;
   logic err_code_flash_alert_wd;
-  logic err_code_flash_alert_we;
   logic err_code_mp_err_qs;
   logic err_code_mp_err_wd;
-  logic err_code_mp_err_we;
   logic err_code_ecc_single_err_qs;
   logic err_code_ecc_single_err_wd;
-  logic err_code_ecc_single_err_we;
   logic err_code_ecc_multi_err_qs;
   logic err_code_ecc_multi_err_wd;
-  logic err_code_ecc_multi_err_we;
   logic [8:0] err_addr_qs;
+  logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_qs;
   logic [7:0] ecc_single_err_cnt_wd;
-  logic ecc_single_err_cnt_we;
   logic [19:0] ecc_single_err_addr_0_qs;
   logic [19:0] ecc_single_err_addr_1_qs;
+  logic ecc_multi_err_cnt_we;
   logic [7:0] ecc_multi_err_cnt_qs;
   logic [7:0] ecc_multi_err_cnt_wd;
-  logic ecc_multi_err_cnt_we;
   logic [19:0] ecc_multi_err_addr_0_qs;
   logic [19:0] ecc_multi_err_addr_1_qs;
+  logic phy_err_cfg_regwen_we;
   logic phy_err_cfg_regwen_qs;
   logic phy_err_cfg_regwen_wd;
-  logic phy_err_cfg_regwen_we;
+  logic phy_err_cfg_we;
   logic phy_err_cfg_qs;
   logic phy_err_cfg_wd;
-  logic phy_err_cfg_we;
+  logic phy_alert_cfg_we;
   logic phy_alert_cfg_alert_ack_qs;
   logic phy_alert_cfg_alert_ack_wd;
-  logic phy_alert_cfg_alert_ack_we;
   logic phy_alert_cfg_alert_trig_qs;
   logic phy_alert_cfg_alert_trig_wd;
-  logic phy_alert_cfg_alert_trig_we;
   logic phy_status_init_wip_qs;
   logic phy_status_prog_normal_avail_qs;
   logic phy_status_prog_repair_avail_qs;
+  logic scratch_we;
   logic [31:0] scratch_qs;
   logic [31:0] scratch_wd;
-  logic scratch_we;
+  logic fifo_lvl_we;
   logic [4:0] fifo_lvl_prog_qs;
   logic [4:0] fifo_lvl_prog_wd;
-  logic fifo_lvl_prog_we;
   logic [4:0] fifo_lvl_rd_qs;
   logic [4:0] fifo_lvl_rd_wd;
-  logic fifo_lvl_rd_we;
+  logic fifo_rst_we;
   logic fifo_rst_qs;
   logic fifo_rst_wd;
-  logic fifo_rst_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1235,7 +973,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_prog_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_prog_empty_wd),
 
     // from internal hardware
@@ -1261,7 +999,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_prog_lvl_we),
+    .we     (intr_state_we),
     .wd     (intr_state_prog_lvl_wd),
 
     // from internal hardware
@@ -1287,7 +1025,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rd_full_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rd_full_wd),
 
     // from internal hardware
@@ -1313,7 +1051,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rd_lvl_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rd_lvl_wd),
 
     // from internal hardware
@@ -1339,7 +1077,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_op_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_op_done_wd),
 
     // from internal hardware
@@ -1365,7 +1103,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_err_wd),
 
     // from internal hardware
@@ -1393,7 +1131,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_prog_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_prog_empty_wd),
 
     // from internal hardware
@@ -1419,7 +1157,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_prog_lvl_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_prog_lvl_wd),
 
     // from internal hardware
@@ -1445,7 +1183,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rd_full_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rd_full_wd),
 
     // from internal hardware
@@ -1471,7 +1209,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rd_lvl_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rd_lvl_wd),
 
     // from internal hardware
@@ -1497,7 +1235,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_op_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_op_done_wd),
 
     // from internal hardware
@@ -1523,7 +1261,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_err_wd),
 
     // from internal hardware
@@ -1546,7 +1284,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_prog_empty (
     .re     (1'b0),
-    .we     (intr_test_prog_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_prog_empty_wd),
     .d      ('0),
     .qre    (),
@@ -1561,7 +1299,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_prog_lvl (
     .re     (1'b0),
-    .we     (intr_test_prog_lvl_we),
+    .we     (intr_test_we),
     .wd     (intr_test_prog_lvl_wd),
     .d      ('0),
     .qre    (),
@@ -1576,7 +1314,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_rd_full (
     .re     (1'b0),
-    .we     (intr_test_rd_full_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rd_full_wd),
     .d      ('0),
     .qre    (),
@@ -1591,7 +1329,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_rd_lvl (
     .re     (1'b0),
-    .we     (intr_test_rd_lvl_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rd_lvl_wd),
     .d      ('0),
     .qre    (),
@@ -1606,7 +1344,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_op_done (
     .re     (1'b0),
-    .we     (intr_test_op_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_op_done_wd),
     .d      ('0),
     .qre    (),
@@ -1621,7 +1359,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_err (
     .re     (1'b0),
-    .we     (intr_test_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_err_wd),
     .d      ('0),
     .qre    (),
@@ -1638,7 +1376,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (alert_test_recov_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
@@ -1653,7 +1391,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_mp_err (
     .re     (1'b0),
-    .we     (alert_test_recov_mp_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_mp_err_wd),
     .d      ('0),
     .qre    (),
@@ -1668,7 +1406,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ecc_err (
     .re     (1'b0),
-    .we     (alert_test_recov_ecc_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ecc_err_wd),
     .d      ('0),
     .qre    (),
@@ -1683,7 +1421,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_intg_err (
     .re     (1'b0),
-    .we     (alert_test_fatal_intg_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_intg_err_wd),
     .d      ('0),
     .qre    (),
@@ -1748,7 +1486,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_start_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_start_wd),
 
     // from internal hardware
@@ -1774,7 +1512,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_op_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_op_wd),
 
     // from internal hardware
@@ -1800,7 +1538,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_prog_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_prog_sel_wd),
 
     // from internal hardware
@@ -1826,7 +1564,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_erase_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_erase_sel_wd),
 
     // from internal hardware
@@ -1852,7 +1590,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_partition_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_partition_sel_wd),
 
     // from internal hardware
@@ -1878,7 +1616,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_info_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_info_sel_wd),
 
     // from internal hardware
@@ -1904,7 +1642,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_num_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_num_wd),
 
     // from internal hardware
@@ -1959,7 +1697,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_normal_we),
+    .we     (prog_type_en_we),
     .wd     (prog_type_en_normal_wd),
 
     // from internal hardware
@@ -1985,7 +1723,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_repair_we),
+    .we     (prog_type_en_we),
     .wd     (prog_type_en_repair_wd),
 
     // from internal hardware
@@ -2260,7 +1998,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -2286,7 +2024,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_rd_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -2312,7 +2050,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_prog_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -2338,7 +2076,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_erase_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -2364,7 +2102,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_scramble_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -2390,7 +2128,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_ecc_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -2416,7 +2154,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_he_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -2442,7 +2180,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_base_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_base_0_wd),
 
     // from internal hardware
@@ -2468,7 +2206,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_size_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_size_0_wd),
 
     // from internal hardware
@@ -2497,7 +2235,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -2523,7 +2261,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_rd_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -2549,7 +2287,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_prog_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -2575,7 +2313,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_erase_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -2601,7 +2339,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_scramble_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -2627,7 +2365,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_ecc_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -2653,7 +2391,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_he_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -2679,7 +2417,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_base_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_base_1_wd),
 
     // from internal hardware
@@ -2705,7 +2443,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_size_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_size_1_wd),
 
     // from internal hardware
@@ -2734,7 +2472,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_en_2_wd),
 
     // from internal hardware
@@ -2760,7 +2498,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_rd_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_rd_en_2_wd),
 
     // from internal hardware
@@ -2786,7 +2524,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_prog_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_prog_en_2_wd),
 
     // from internal hardware
@@ -2812,7 +2550,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_erase_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_erase_en_2_wd),
 
     // from internal hardware
@@ -2838,7 +2576,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_scramble_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_scramble_en_2_wd),
 
     // from internal hardware
@@ -2864,7 +2602,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_ecc_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_ecc_en_2_wd),
 
     // from internal hardware
@@ -2890,7 +2628,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_he_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_he_en_2_wd),
 
     // from internal hardware
@@ -2916,7 +2654,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_base_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_base_2_wd),
 
     // from internal hardware
@@ -2942,7 +2680,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_size_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_size_2_wd),
 
     // from internal hardware
@@ -2971,7 +2709,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_en_3_wd),
 
     // from internal hardware
@@ -2997,7 +2735,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_rd_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_rd_en_3_wd),
 
     // from internal hardware
@@ -3023,7 +2761,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_prog_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_prog_en_3_wd),
 
     // from internal hardware
@@ -3049,7 +2787,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_erase_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_erase_en_3_wd),
 
     // from internal hardware
@@ -3075,7 +2813,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_scramble_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_scramble_en_3_wd),
 
     // from internal hardware
@@ -3101,7 +2839,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_ecc_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_ecc_en_3_wd),
 
     // from internal hardware
@@ -3127,7 +2865,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_he_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_he_en_3_wd),
 
     // from internal hardware
@@ -3153,7 +2891,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_base_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_base_3_wd),
 
     // from internal hardware
@@ -3179,7 +2917,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_size_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_size_3_wd),
 
     // from internal hardware
@@ -3208,7 +2946,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_en_4_wd),
 
     // from internal hardware
@@ -3234,7 +2972,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_rd_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_rd_en_4_wd),
 
     // from internal hardware
@@ -3260,7 +2998,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_prog_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_prog_en_4_wd),
 
     // from internal hardware
@@ -3286,7 +3024,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_erase_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_erase_en_4_wd),
 
     // from internal hardware
@@ -3312,7 +3050,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_scramble_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_scramble_en_4_wd),
 
     // from internal hardware
@@ -3338,7 +3076,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_ecc_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_ecc_en_4_wd),
 
     // from internal hardware
@@ -3364,7 +3102,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_he_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_he_en_4_wd),
 
     // from internal hardware
@@ -3390,7 +3128,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_base_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_base_4_wd),
 
     // from internal hardware
@@ -3416,7 +3154,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_size_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_size_4_wd),
 
     // from internal hardware
@@ -3445,7 +3183,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_en_5_wd),
 
     // from internal hardware
@@ -3471,7 +3209,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_rd_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_rd_en_5_wd),
 
     // from internal hardware
@@ -3497,7 +3235,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_prog_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_prog_en_5_wd),
 
     // from internal hardware
@@ -3523,7 +3261,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_erase_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_erase_en_5_wd),
 
     // from internal hardware
@@ -3549,7 +3287,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_scramble_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_scramble_en_5_wd),
 
     // from internal hardware
@@ -3575,7 +3313,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_ecc_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_ecc_en_5_wd),
 
     // from internal hardware
@@ -3601,7 +3339,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_he_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_he_en_5_wd),
 
     // from internal hardware
@@ -3627,7 +3365,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_base_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_base_5_wd),
 
     // from internal hardware
@@ -3653,7 +3391,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_size_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_size_5_wd),
 
     // from internal hardware
@@ -3682,7 +3420,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_en_6_wd),
 
     // from internal hardware
@@ -3708,7 +3446,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_rd_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_rd_en_6_wd),
 
     // from internal hardware
@@ -3734,7 +3472,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_prog_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_prog_en_6_wd),
 
     // from internal hardware
@@ -3760,7 +3498,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_erase_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_erase_en_6_wd),
 
     // from internal hardware
@@ -3786,7 +3524,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_scramble_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_scramble_en_6_wd),
 
     // from internal hardware
@@ -3812,7 +3550,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_ecc_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_ecc_en_6_wd),
 
     // from internal hardware
@@ -3838,7 +3576,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_he_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_he_en_6_wd),
 
     // from internal hardware
@@ -3864,7 +3602,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_base_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_base_6_wd),
 
     // from internal hardware
@@ -3890,7 +3628,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_size_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_size_6_wd),
 
     // from internal hardware
@@ -3919,7 +3657,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_en_7_wd),
 
     // from internal hardware
@@ -3945,7 +3683,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_rd_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_rd_en_7_wd),
 
     // from internal hardware
@@ -3971,7 +3709,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_prog_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_prog_en_7_wd),
 
     // from internal hardware
@@ -3997,7 +3735,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_erase_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_erase_en_7_wd),
 
     // from internal hardware
@@ -4023,7 +3761,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_scramble_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_scramble_en_7_wd),
 
     // from internal hardware
@@ -4049,7 +3787,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_ecc_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_ecc_en_7_wd),
 
     // from internal hardware
@@ -4075,7 +3813,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_he_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_he_en_7_wd),
 
     // from internal hardware
@@ -4101,7 +3839,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_base_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_base_7_wd),
 
     // from internal hardware
@@ -4127,7 +3865,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_size_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_size_7_wd),
 
     // from internal hardware
@@ -4156,7 +3894,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_rd_en_we),
+    .we     (default_region_we),
     .wd     (default_region_rd_en_wd),
 
     // from internal hardware
@@ -4182,7 +3920,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_prog_en_we),
+    .we     (default_region_we),
     .wd     (default_region_prog_en_wd),
 
     // from internal hardware
@@ -4208,7 +3946,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_erase_en_we),
+    .we     (default_region_we),
     .wd     (default_region_erase_en_wd),
 
     // from internal hardware
@@ -4234,7 +3972,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_scramble_en_we),
+    .we     (default_region_we),
     .wd     (default_region_scramble_en_wd),
 
     // from internal hardware
@@ -4260,7 +3998,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_ecc_en_we),
+    .we     (default_region_we),
     .wd     (default_region_ecc_en_wd),
 
     // from internal hardware
@@ -4286,7 +4024,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_he_en_we),
+    .we     (default_region_we),
     .wd     (default_region_he_en_wd),
 
     // from internal hardware
@@ -4588,7 +4326,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -4614,7 +4352,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_rd_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -4640,7 +4378,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_prog_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -4666,7 +4404,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_erase_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -4692,7 +4430,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_scramble_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -4718,7 +4456,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_ecc_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -4744,7 +4482,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_he_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -4773,7 +4511,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -4799,7 +4537,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_rd_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -4825,7 +4563,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_prog_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -4851,7 +4589,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_erase_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -4877,7 +4615,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_scramble_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -4903,7 +4641,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_ecc_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -4929,7 +4667,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_he_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -4958,7 +4696,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_en_2_wd),
 
     // from internal hardware
@@ -4984,7 +4722,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_rd_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_rd_en_2_wd),
 
     // from internal hardware
@@ -5010,7 +4748,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_prog_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_prog_en_2_wd),
 
     // from internal hardware
@@ -5036,7 +4774,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_erase_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_erase_en_2_wd),
 
     // from internal hardware
@@ -5062,7 +4800,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_scramble_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_scramble_en_2_wd),
 
     // from internal hardware
@@ -5088,7 +4826,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_ecc_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_ecc_en_2_wd),
 
     // from internal hardware
@@ -5114,7 +4852,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_he_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_he_en_2_wd),
 
     // from internal hardware
@@ -5143,7 +4881,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_en_3_wd),
 
     // from internal hardware
@@ -5169,7 +4907,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_rd_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_rd_en_3_wd),
 
     // from internal hardware
@@ -5195,7 +4933,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_prog_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_prog_en_3_wd),
 
     // from internal hardware
@@ -5221,7 +4959,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_erase_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_erase_en_3_wd),
 
     // from internal hardware
@@ -5247,7 +4985,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_scramble_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_scramble_en_3_wd),
 
     // from internal hardware
@@ -5273,7 +5011,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_ecc_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_ecc_en_3_wd),
 
     // from internal hardware
@@ -5299,7 +5037,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_he_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_he_en_3_wd),
 
     // from internal hardware
@@ -5328,7 +5066,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_en_4_wd),
 
     // from internal hardware
@@ -5354,7 +5092,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_rd_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_rd_en_4_wd),
 
     // from internal hardware
@@ -5380,7 +5118,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_prog_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_prog_en_4_wd),
 
     // from internal hardware
@@ -5406,7 +5144,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_erase_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_erase_en_4_wd),
 
     // from internal hardware
@@ -5432,7 +5170,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_scramble_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_scramble_en_4_wd),
 
     // from internal hardware
@@ -5458,7 +5196,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_ecc_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_ecc_en_4_wd),
 
     // from internal hardware
@@ -5484,7 +5222,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_he_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_he_en_4_wd),
 
     // from internal hardware
@@ -5513,7 +5251,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_en_5_wd),
 
     // from internal hardware
@@ -5539,7 +5277,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_rd_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_rd_en_5_wd),
 
     // from internal hardware
@@ -5565,7 +5303,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_prog_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_prog_en_5_wd),
 
     // from internal hardware
@@ -5591,7 +5329,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_erase_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_erase_en_5_wd),
 
     // from internal hardware
@@ -5617,7 +5355,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_scramble_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_scramble_en_5_wd),
 
     // from internal hardware
@@ -5643,7 +5381,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_ecc_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_ecc_en_5_wd),
 
     // from internal hardware
@@ -5669,7 +5407,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_he_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_he_en_5_wd),
 
     // from internal hardware
@@ -5698,7 +5436,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_en_6_wd),
 
     // from internal hardware
@@ -5724,7 +5462,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_rd_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_rd_en_6_wd),
 
     // from internal hardware
@@ -5750,7 +5488,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_prog_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_prog_en_6_wd),
 
     // from internal hardware
@@ -5776,7 +5514,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_erase_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_erase_en_6_wd),
 
     // from internal hardware
@@ -5802,7 +5540,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_scramble_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_scramble_en_6_wd),
 
     // from internal hardware
@@ -5828,7 +5566,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_ecc_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_ecc_en_6_wd),
 
     // from internal hardware
@@ -5854,7 +5592,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_he_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_he_en_6_wd),
 
     // from internal hardware
@@ -5883,7 +5621,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_en_7_wd),
 
     // from internal hardware
@@ -5909,7 +5647,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_rd_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_rd_en_7_wd),
 
     // from internal hardware
@@ -5935,7 +5673,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_prog_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_prog_en_7_wd),
 
     // from internal hardware
@@ -5961,7 +5699,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_erase_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_erase_en_7_wd),
 
     // from internal hardware
@@ -5987,7 +5725,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_scramble_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_scramble_en_7_wd),
 
     // from internal hardware
@@ -6013,7 +5751,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_ecc_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_ecc_en_7_wd),
 
     // from internal hardware
@@ -6039,7 +5777,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_he_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_he_en_7_wd),
 
     // from internal hardware
@@ -6068,7 +5806,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_en_8_wd),
 
     // from internal hardware
@@ -6094,7 +5832,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_rd_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_rd_en_8_wd),
 
     // from internal hardware
@@ -6120,7 +5858,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_prog_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_prog_en_8_wd),
 
     // from internal hardware
@@ -6146,7 +5884,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_erase_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_erase_en_8_wd),
 
     // from internal hardware
@@ -6172,7 +5910,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_scramble_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_scramble_en_8_wd),
 
     // from internal hardware
@@ -6198,7 +5936,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_ecc_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_ecc_en_8_wd),
 
     // from internal hardware
@@ -6224,7 +5962,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_he_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_he_en_8_wd),
 
     // from internal hardware
@@ -6253,7 +5991,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_en_9_wd),
 
     // from internal hardware
@@ -6279,7 +6017,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_rd_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_rd_en_9_wd),
 
     // from internal hardware
@@ -6305,7 +6043,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_prog_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_prog_en_9_wd),
 
     // from internal hardware
@@ -6331,7 +6069,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_erase_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_erase_en_9_wd),
 
     // from internal hardware
@@ -6357,7 +6095,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_scramble_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_scramble_en_9_wd),
 
     // from internal hardware
@@ -6383,7 +6121,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_ecc_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_ecc_en_9_wd),
 
     // from internal hardware
@@ -6409,7 +6147,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_he_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_he_en_9_wd),
 
     // from internal hardware
@@ -6469,7 +6207,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_en_0_wd),
 
     // from internal hardware
@@ -6495,7 +6233,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_rd_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_rd_en_0_wd),
 
     // from internal hardware
@@ -6521,7 +6259,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_prog_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_prog_en_0_wd),
 
     // from internal hardware
@@ -6547,7 +6285,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_erase_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_erase_en_0_wd),
 
     // from internal hardware
@@ -6573,7 +6311,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_scramble_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_scramble_en_0_wd),
 
     // from internal hardware
@@ -6599,7 +6337,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_ecc_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_ecc_en_0_wd),
 
     // from internal hardware
@@ -6625,7 +6363,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_he_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_he_en_0_wd),
 
     // from internal hardware
@@ -6712,7 +6450,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -6738,7 +6476,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_rd_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -6764,7 +6502,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_prog_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -6790,7 +6528,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_erase_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -6816,7 +6554,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_scramble_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -6842,7 +6580,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_ecc_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -6868,7 +6606,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_he_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -6897,7 +6635,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -6923,7 +6661,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_rd_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -6949,7 +6687,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_prog_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -6975,7 +6713,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_erase_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -7001,7 +6739,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_scramble_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -7027,7 +6765,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_ecc_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -7053,7 +6791,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_he_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -7356,7 +7094,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -7382,7 +7120,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_rd_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -7408,7 +7146,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_prog_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -7434,7 +7172,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_erase_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -7460,7 +7198,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_scramble_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -7486,7 +7224,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_ecc_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -7512,7 +7250,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_he_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -7541,7 +7279,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -7567,7 +7305,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_rd_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -7593,7 +7331,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_prog_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -7619,7 +7357,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_erase_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -7645,7 +7383,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_scramble_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -7671,7 +7409,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_ecc_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -7697,7 +7435,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_he_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -7726,7 +7464,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_en_2_wd),
 
     // from internal hardware
@@ -7752,7 +7490,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_rd_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_rd_en_2_wd),
 
     // from internal hardware
@@ -7778,7 +7516,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_prog_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_prog_en_2_wd),
 
     // from internal hardware
@@ -7804,7 +7542,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_erase_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_erase_en_2_wd),
 
     // from internal hardware
@@ -7830,7 +7568,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_scramble_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_scramble_en_2_wd),
 
     // from internal hardware
@@ -7856,7 +7594,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_ecc_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_ecc_en_2_wd),
 
     // from internal hardware
@@ -7882,7 +7620,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_he_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_he_en_2_wd),
 
     // from internal hardware
@@ -7911,7 +7649,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_en_3_wd),
 
     // from internal hardware
@@ -7937,7 +7675,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_rd_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_rd_en_3_wd),
 
     // from internal hardware
@@ -7963,7 +7701,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_prog_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_prog_en_3_wd),
 
     // from internal hardware
@@ -7989,7 +7727,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_erase_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_erase_en_3_wd),
 
     // from internal hardware
@@ -8015,7 +7753,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_scramble_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_scramble_en_3_wd),
 
     // from internal hardware
@@ -8041,7 +7779,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_ecc_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_ecc_en_3_wd),
 
     // from internal hardware
@@ -8067,7 +7805,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_he_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_he_en_3_wd),
 
     // from internal hardware
@@ -8096,7 +7834,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_en_4_wd),
 
     // from internal hardware
@@ -8122,7 +7860,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_rd_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_rd_en_4_wd),
 
     // from internal hardware
@@ -8148,7 +7886,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_prog_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_prog_en_4_wd),
 
     // from internal hardware
@@ -8174,7 +7912,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_erase_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_erase_en_4_wd),
 
     // from internal hardware
@@ -8200,7 +7938,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_scramble_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_scramble_en_4_wd),
 
     // from internal hardware
@@ -8226,7 +7964,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_ecc_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_ecc_en_4_wd),
 
     // from internal hardware
@@ -8252,7 +7990,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_he_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_he_en_4_wd),
 
     // from internal hardware
@@ -8281,7 +8019,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_en_5_wd),
 
     // from internal hardware
@@ -8307,7 +8045,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_rd_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_rd_en_5_wd),
 
     // from internal hardware
@@ -8333,7 +8071,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_prog_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_prog_en_5_wd),
 
     // from internal hardware
@@ -8359,7 +8097,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_erase_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_erase_en_5_wd),
 
     // from internal hardware
@@ -8385,7 +8123,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_scramble_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_scramble_en_5_wd),
 
     // from internal hardware
@@ -8411,7 +8149,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_ecc_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_ecc_en_5_wd),
 
     // from internal hardware
@@ -8437,7 +8175,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_he_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_he_en_5_wd),
 
     // from internal hardware
@@ -8466,7 +8204,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_en_6_wd),
 
     // from internal hardware
@@ -8492,7 +8230,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_rd_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_rd_en_6_wd),
 
     // from internal hardware
@@ -8518,7 +8256,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_prog_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_prog_en_6_wd),
 
     // from internal hardware
@@ -8544,7 +8282,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_erase_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_erase_en_6_wd),
 
     // from internal hardware
@@ -8570,7 +8308,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_scramble_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_scramble_en_6_wd),
 
     // from internal hardware
@@ -8596,7 +8334,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_ecc_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_ecc_en_6_wd),
 
     // from internal hardware
@@ -8622,7 +8360,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_he_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_he_en_6_wd),
 
     // from internal hardware
@@ -8651,7 +8389,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_en_7_wd),
 
     // from internal hardware
@@ -8677,7 +8415,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_rd_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_rd_en_7_wd),
 
     // from internal hardware
@@ -8703,7 +8441,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_prog_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_prog_en_7_wd),
 
     // from internal hardware
@@ -8729,7 +8467,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_erase_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_erase_en_7_wd),
 
     // from internal hardware
@@ -8755,7 +8493,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_scramble_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_scramble_en_7_wd),
 
     // from internal hardware
@@ -8781,7 +8519,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_ecc_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_ecc_en_7_wd),
 
     // from internal hardware
@@ -8807,7 +8545,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_he_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_he_en_7_wd),
 
     // from internal hardware
@@ -8836,7 +8574,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_en_8_wd),
 
     // from internal hardware
@@ -8862,7 +8600,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_rd_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_rd_en_8_wd),
 
     // from internal hardware
@@ -8888,7 +8626,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_prog_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_prog_en_8_wd),
 
     // from internal hardware
@@ -8914,7 +8652,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_erase_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_erase_en_8_wd),
 
     // from internal hardware
@@ -8940,7 +8678,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_scramble_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_scramble_en_8_wd),
 
     // from internal hardware
@@ -8966,7 +8704,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_ecc_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_ecc_en_8_wd),
 
     // from internal hardware
@@ -8992,7 +8730,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_he_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_he_en_8_wd),
 
     // from internal hardware
@@ -9021,7 +8759,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_en_9_wd),
 
     // from internal hardware
@@ -9047,7 +8785,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_rd_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_rd_en_9_wd),
 
     // from internal hardware
@@ -9073,7 +8811,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_prog_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_prog_en_9_wd),
 
     // from internal hardware
@@ -9099,7 +8837,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_erase_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_erase_en_9_wd),
 
     // from internal hardware
@@ -9125,7 +8863,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_scramble_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_scramble_en_9_wd),
 
     // from internal hardware
@@ -9151,7 +8889,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_ecc_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_ecc_en_9_wd),
 
     // from internal hardware
@@ -9177,7 +8915,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_he_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_he_en_9_wd),
 
     // from internal hardware
@@ -9237,7 +8975,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_en_0_wd),
 
     // from internal hardware
@@ -9263,7 +9001,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_rd_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_rd_en_0_wd),
 
     // from internal hardware
@@ -9289,7 +9027,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_prog_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_prog_en_0_wd),
 
     // from internal hardware
@@ -9315,7 +9053,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_erase_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_erase_en_0_wd),
 
     // from internal hardware
@@ -9341,7 +9079,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_scramble_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_scramble_en_0_wd),
 
     // from internal hardware
@@ -9367,7 +9105,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_ecc_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_ecc_en_0_wd),
 
     // from internal hardware
@@ -9393,7 +9131,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_he_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_he_en_0_wd),
 
     // from internal hardware
@@ -9480,7 +9218,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -9506,7 +9244,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_rd_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -9532,7 +9270,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_prog_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -9558,7 +9296,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_erase_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -9584,7 +9322,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_scramble_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -9610,7 +9348,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_ecc_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -9636,7 +9374,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_he_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -9665,7 +9403,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -9691,7 +9429,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_rd_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -9717,7 +9455,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_prog_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -9743,7 +9481,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_erase_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -9769,7 +9507,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_scramble_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -9795,7 +9533,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_ecc_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -9821,7 +9559,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_he_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -9879,7 +9617,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_erase_en_0_we & bank_cfg_regwen_qs),
+    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
     .wd     (mp_bank_cfg_erase_en_0_wd),
 
     // from internal hardware
@@ -9905,7 +9643,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_erase_en_1_we & bank_cfg_regwen_qs),
+    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
     .wd     (mp_bank_cfg_erase_en_1_wd),
 
     // from internal hardware
@@ -9934,7 +9672,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (op_status_done_we),
+    .we     (op_status_we),
     .wd     (op_status_done_wd),
 
     // from internal hardware
@@ -9960,7 +9698,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (op_status_err_we),
+    .we     (op_status_we),
     .wd     (op_status_err_wd),
 
     // from internal hardware
@@ -10120,7 +9858,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_flash_err_en_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_flash_err_en_wd),
 
     // from internal hardware
@@ -10146,7 +9884,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_flash_alert_en_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_flash_alert_en_wd),
 
     // from internal hardware
@@ -10172,7 +9910,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_mp_err_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_mp_err_wd),
 
     // from internal hardware
@@ -10198,7 +9936,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_ecc_single_err_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_ecc_single_err_wd),
 
     // from internal hardware
@@ -10224,7 +9962,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_ecc_multi_err_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_ecc_multi_err_wd),
 
     // from internal hardware
@@ -10252,7 +9990,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_flash_err_we),
+    .we     (err_code_we),
     .wd     (err_code_flash_err_wd),
 
     // from internal hardware
@@ -10278,7 +10016,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_flash_alert_we),
+    .we     (err_code_we),
     .wd     (err_code_flash_alert_wd),
 
     // from internal hardware
@@ -10304,7 +10042,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_mp_err_we),
+    .we     (err_code_we),
     .wd     (err_code_mp_err_wd),
 
     // from internal hardware
@@ -10330,7 +10068,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_ecc_single_err_we),
+    .we     (err_code_we),
     .wd     (err_code_ecc_single_err_wd),
 
     // from internal hardware
@@ -10356,7 +10094,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_ecc_multi_err_we),
+    .we     (err_code_we),
     .wd     (err_code_ecc_multi_err_wd),
 
     // from internal hardware
@@ -10631,7 +10369,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_alert_cfg_alert_ack_we),
+    .we     (phy_alert_cfg_we),
     .wd     (phy_alert_cfg_alert_ack_wd),
 
     // from internal hardware
@@ -10657,7 +10395,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_alert_cfg_alert_trig_we),
+    .we     (phy_alert_cfg_we),
     .wd     (phy_alert_cfg_alert_trig_wd),
 
     // from internal hardware
@@ -10792,7 +10530,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_lvl_prog_we),
+    .we     (fifo_lvl_we),
     .wd     (fifo_lvl_prog_wd),
 
     // from internal hardware
@@ -10818,7 +10556,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_lvl_rd_we),
+    .we     (fifo_lvl_we),
     .wd     (fifo_lvl_rd_wd),
 
     // from internal hardware
@@ -11072,1066 +10810,803 @@ module flash_ctrl_core_reg_top (
                (addr_hit[97] & (|(FLASH_CTRL_CORE_PERMIT[97] & ~reg_be))) |
                (addr_hit[98] & (|(FLASH_CTRL_CORE_PERMIT[98] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_prog_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_empty_wd = reg_wdata[0];
 
-  assign intr_state_prog_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_state_rd_full_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_full_wd = reg_wdata[2];
 
-  assign intr_state_rd_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_state_op_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_op_done_wd = reg_wdata[4];
 
-  assign intr_state_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_err_wd = reg_wdata[5];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_empty_wd = reg_wdata[0];
 
-  assign intr_enable_prog_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_enable_rd_full_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_full_wd = reg_wdata[2];
 
-  assign intr_enable_rd_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_enable_op_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_op_done_wd = reg_wdata[4];
 
-  assign intr_enable_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_err_wd = reg_wdata[5];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_prog_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_empty_wd = reg_wdata[0];
 
-  assign intr_test_prog_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_test_rd_full_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_full_wd = reg_wdata[2];
 
-  assign intr_test_rd_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_test_op_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_op_done_wd = reg_wdata[4];
 
-  assign intr_test_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_err_wd = reg_wdata[5];
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_recov_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_err_wd = reg_wdata[0];
 
-  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_mp_err_wd = reg_wdata[1];
 
-  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_ecc_err_wd = reg_wdata[2];
 
-  assign alert_test_fatal_intg_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_intg_err_wd = reg_wdata[3];
-
   assign init_we = addr_hit[4] & reg_we & !reg_error;
+
   assign init_wd = reg_wdata[0];
-
   assign ctrl_regwen_re = addr_hit[5] & reg_re & !reg_error;
+  assign control_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign control_start_we = addr_hit[6] & reg_we & !reg_error;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_op_we = addr_hit[6] & reg_we & !reg_error;
   assign control_op_wd = reg_wdata[5:4];
 
-  assign control_prog_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_prog_sel_wd = reg_wdata[6];
 
-  assign control_erase_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_erase_sel_wd = reg_wdata[7];
 
-  assign control_partition_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_partition_sel_wd = reg_wdata[8];
 
-  assign control_info_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_info_sel_wd = reg_wdata[10:9];
 
-  assign control_num_we = addr_hit[6] & reg_we & !reg_error;
   assign control_num_wd = reg_wdata[27:16];
-
   assign addr_we = addr_hit[7] & reg_we & !reg_error;
-  assign addr_wd = reg_wdata[31:0];
 
-  assign prog_type_en_normal_we = addr_hit[8] & reg_we & !reg_error;
+  assign addr_wd = reg_wdata[31:0];
+  assign prog_type_en_we = addr_hit[8] & reg_we & !reg_error;
+
   assign prog_type_en_normal_wd = reg_wdata[0];
 
-  assign prog_type_en_repair_we = addr_hit[8] & reg_we & !reg_error;
   assign prog_type_en_repair_wd = reg_wdata[1];
-
   assign erase_suspend_we = addr_hit[9] & reg_we & !reg_error;
+
   assign erase_suspend_wd = reg_wdata[0];
-
   assign region_cfg_regwen_0_we = addr_hit[10] & reg_we & !reg_error;
+
   assign region_cfg_regwen_0_wd = reg_wdata[0];
-
   assign region_cfg_regwen_1_we = addr_hit[11] & reg_we & !reg_error;
+
   assign region_cfg_regwen_1_wd = reg_wdata[0];
-
   assign region_cfg_regwen_2_we = addr_hit[12] & reg_we & !reg_error;
+
   assign region_cfg_regwen_2_wd = reg_wdata[0];
-
   assign region_cfg_regwen_3_we = addr_hit[13] & reg_we & !reg_error;
+
   assign region_cfg_regwen_3_wd = reg_wdata[0];
-
   assign region_cfg_regwen_4_we = addr_hit[14] & reg_we & !reg_error;
+
   assign region_cfg_regwen_4_wd = reg_wdata[0];
-
   assign region_cfg_regwen_5_we = addr_hit[15] & reg_we & !reg_error;
+
   assign region_cfg_regwen_5_wd = reg_wdata[0];
-
   assign region_cfg_regwen_6_we = addr_hit[16] & reg_we & !reg_error;
+
   assign region_cfg_regwen_6_wd = reg_wdata[0];
-
   assign region_cfg_regwen_7_we = addr_hit[17] & reg_we & !reg_error;
-  assign region_cfg_regwen_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[18] & reg_we & !reg_error;
+  assign region_cfg_regwen_7_wd = reg_wdata[0];
+  assign mp_region_cfg_0_we = addr_hit[18] & reg_we & !reg_error;
+
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
+  assign mp_region_cfg_1_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
+  assign mp_region_cfg_2_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
+  assign mp_region_cfg_3_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
+  assign mp_region_cfg_4_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
+  assign mp_region_cfg_5_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
+  assign mp_region_cfg_6_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
+  assign mp_region_cfg_7_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
+  assign default_region_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign default_region_rd_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_he_en_wd = reg_wdata[5];
-
   assign bank0_info0_regwen_0_we = addr_hit[27] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_1_we = addr_hit[28] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_1_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_2_we = addr_hit[29] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_2_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_3_we = addr_hit[30] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_3_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_4_we = addr_hit[31] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_4_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_5_we = addr_hit[32] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_5_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_6_we = addr_hit[33] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_6_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_7_we = addr_hit[34] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_7_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_8_we = addr_hit[35] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_8_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_9_we = addr_hit[36] & reg_we & !reg_error;
-  assign bank0_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[37] & reg_we & !reg_error;
+  assign bank0_info0_regwen_9_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_0_we = addr_hit[37] & reg_we & !reg_error;
+
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_1_we = addr_hit[38] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_2_we = addr_hit[39] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_3_we = addr_hit[40] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_4_we = addr_hit[41] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_5_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_6_we = addr_hit[43] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_7_we = addr_hit[44] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_8_we = addr_hit[45] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_9_we = addr_hit[46] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
-
   assign bank0_info1_regwen_we = addr_hit[47] & reg_we & !reg_error;
-  assign bank0_info1_regwen_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_en_0_we = addr_hit[48] & reg_we & !reg_error;
+  assign bank0_info1_regwen_wd = reg_wdata[0];
+  assign bank0_info1_page_cfg_we = addr_hit[48] & reg_we & !reg_error;
+
   assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
-
   assign bank0_info2_regwen_0_we = addr_hit[49] & reg_we & !reg_error;
+
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
-
   assign bank0_info2_regwen_1_we = addr_hit[50] & reg_we & !reg_error;
-  assign bank0_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[51] & reg_we & !reg_error;
+  assign bank0_info2_regwen_1_wd = reg_wdata[0];
+  assign bank0_info2_page_cfg_0_we = addr_hit[51] & reg_we & !reg_error;
+
   assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info2_page_cfg_1_we = addr_hit[52] & reg_we & !reg_error;
 
-  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
-
   assign bank1_info0_regwen_0_we = addr_hit[53] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_1_we = addr_hit[54] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_1_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_2_we = addr_hit[55] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_2_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_3_we = addr_hit[56] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_3_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_4_we = addr_hit[57] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_4_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_5_we = addr_hit[58] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_5_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_6_we = addr_hit[59] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_6_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_7_we = addr_hit[60] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_7_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_8_we = addr_hit[61] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_8_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_9_we = addr_hit[62] & reg_we & !reg_error;
-  assign bank1_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[63] & reg_we & !reg_error;
+  assign bank1_info0_regwen_9_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_0_we = addr_hit[63] & reg_we & !reg_error;
+
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_1_we = addr_hit[64] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_2_we = addr_hit[65] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_3_we = addr_hit[66] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_4_we = addr_hit[67] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_5_we = addr_hit[68] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_6_we = addr_hit[69] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_7_we = addr_hit[70] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_8_we = addr_hit[71] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_9_we = addr_hit[72] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
-
   assign bank1_info1_regwen_we = addr_hit[73] & reg_we & !reg_error;
-  assign bank1_info1_regwen_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_en_0_we = addr_hit[74] & reg_we & !reg_error;
+  assign bank1_info1_regwen_wd = reg_wdata[0];
+  assign bank1_info1_page_cfg_we = addr_hit[74] & reg_we & !reg_error;
+
   assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
-
   assign bank1_info2_regwen_0_we = addr_hit[75] & reg_we & !reg_error;
+
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
-
   assign bank1_info2_regwen_1_we = addr_hit[76] & reg_we & !reg_error;
-  assign bank1_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[77] & reg_we & !reg_error;
+  assign bank1_info2_regwen_1_wd = reg_wdata[0];
+  assign bank1_info2_page_cfg_0_we = addr_hit[77] & reg_we & !reg_error;
+
   assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info2_page_cfg_1_we = addr_hit[78] & reg_we & !reg_error;
 
-  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
-
   assign bank_cfg_regwen_we = addr_hit[79] & reg_we & !reg_error;
-  assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[80] & reg_we & !reg_error;
+  assign bank_cfg_regwen_wd = reg_wdata[0];
+  assign mp_bank_cfg_we = addr_hit[80] & reg_we & !reg_error;
+
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[80] & reg_we & !reg_error;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
+  assign op_status_we = addr_hit[81] & reg_we & !reg_error;
 
-  assign op_status_done_we = addr_hit[81] & reg_we & !reg_error;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[81] & reg_we & !reg_error;
   assign op_status_err_wd = reg_wdata[1];
+  assign err_code_intr_en_we = addr_hit[83] & reg_we & !reg_error;
 
-  assign err_code_intr_en_flash_err_en_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_flash_err_en_wd = reg_wdata[0];
 
-  assign err_code_intr_en_flash_alert_en_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_flash_alert_en_wd = reg_wdata[1];
 
-  assign err_code_intr_en_mp_err_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_mp_err_wd = reg_wdata[2];
 
-  assign err_code_intr_en_ecc_single_err_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_ecc_single_err_wd = reg_wdata[3];
 
-  assign err_code_intr_en_ecc_multi_err_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_ecc_multi_err_wd = reg_wdata[4];
+  assign err_code_we = addr_hit[84] & reg_we & !reg_error;
 
-  assign err_code_flash_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_flash_err_wd = reg_wdata[0];
 
-  assign err_code_flash_alert_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_flash_alert_wd = reg_wdata[1];
 
-  assign err_code_mp_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_mp_err_wd = reg_wdata[2];
 
-  assign err_code_ecc_single_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_ecc_single_err_wd = reg_wdata[3];
 
-  assign err_code_ecc_multi_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_ecc_multi_err_wd = reg_wdata[4];
-
   assign ecc_single_err_cnt_we = addr_hit[86] & reg_we & !reg_error;
+
   assign ecc_single_err_cnt_wd = reg_wdata[7:0];
-
   assign ecc_multi_err_cnt_we = addr_hit[89] & reg_we & !reg_error;
+
   assign ecc_multi_err_cnt_wd = reg_wdata[7:0];
-
   assign phy_err_cfg_regwen_we = addr_hit[92] & reg_we & !reg_error;
+
   assign phy_err_cfg_regwen_wd = reg_wdata[0];
-
   assign phy_err_cfg_we = addr_hit[93] & reg_we & !reg_error;
-  assign phy_err_cfg_wd = reg_wdata[0];
 
-  assign phy_alert_cfg_alert_ack_we = addr_hit[94] & reg_we & !reg_error;
+  assign phy_err_cfg_wd = reg_wdata[0];
+  assign phy_alert_cfg_we = addr_hit[94] & reg_we & !reg_error;
+
   assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
 
-  assign phy_alert_cfg_alert_trig_we = addr_hit[94] & reg_we & !reg_error;
   assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
-
   assign scratch_we = addr_hit[96] & reg_we & !reg_error;
-  assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[97] & reg_we & !reg_error;
+  assign scratch_wd = reg_wdata[31:0];
+  assign fifo_lvl_we = addr_hit[97] & reg_we & !reg_error;
+
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[97] & reg_we & !reg_error;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
-
   assign fifo_rst_we = addr_hit[98] & reg_we & !reg_error;
+
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -104,68 +104,62 @@ module gpio_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic [31:0] intr_state_qs;
   logic [31:0] intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic [31:0] intr_enable_qs;
   logic [31:0] intr_enable_wd;
-  logic intr_enable_we;
-  logic [31:0] intr_test_wd;
   logic intr_test_we;
-  logic alert_test_wd;
+  logic [31:0] intr_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
   logic [31:0] data_in_qs;
+  logic direct_out_re;
+  logic direct_out_we;
   logic [31:0] direct_out_qs;
   logic [31:0] direct_out_wd;
-  logic direct_out_we;
-  logic direct_out_re;
+  logic masked_out_lower_re;
+  logic masked_out_lower_we;
   logic [15:0] masked_out_lower_data_qs;
   logic [15:0] masked_out_lower_data_wd;
-  logic masked_out_lower_data_we;
-  logic masked_out_lower_data_re;
   logic [15:0] masked_out_lower_mask_wd;
-  logic masked_out_lower_mask_we;
+  logic masked_out_upper_re;
+  logic masked_out_upper_we;
   logic [15:0] masked_out_upper_data_qs;
   logic [15:0] masked_out_upper_data_wd;
-  logic masked_out_upper_data_we;
-  logic masked_out_upper_data_re;
   logic [15:0] masked_out_upper_mask_wd;
-  logic masked_out_upper_mask_we;
+  logic direct_oe_re;
+  logic direct_oe_we;
   logic [31:0] direct_oe_qs;
   logic [31:0] direct_oe_wd;
-  logic direct_oe_we;
-  logic direct_oe_re;
+  logic masked_oe_lower_re;
+  logic masked_oe_lower_we;
   logic [15:0] masked_oe_lower_data_qs;
   logic [15:0] masked_oe_lower_data_wd;
-  logic masked_oe_lower_data_we;
-  logic masked_oe_lower_data_re;
   logic [15:0] masked_oe_lower_mask_qs;
   logic [15:0] masked_oe_lower_mask_wd;
-  logic masked_oe_lower_mask_we;
-  logic masked_oe_lower_mask_re;
+  logic masked_oe_upper_re;
+  logic masked_oe_upper_we;
   logic [15:0] masked_oe_upper_data_qs;
   logic [15:0] masked_oe_upper_data_wd;
-  logic masked_oe_upper_data_we;
-  logic masked_oe_upper_data_re;
   logic [15:0] masked_oe_upper_mask_qs;
   logic [15:0] masked_oe_upper_mask_wd;
-  logic masked_oe_upper_mask_we;
-  logic masked_oe_upper_mask_re;
+  logic intr_ctrl_en_rising_we;
   logic [31:0] intr_ctrl_en_rising_qs;
   logic [31:0] intr_ctrl_en_rising_wd;
-  logic intr_ctrl_en_rising_we;
+  logic intr_ctrl_en_falling_we;
   logic [31:0] intr_ctrl_en_falling_qs;
   logic [31:0] intr_ctrl_en_falling_wd;
-  logic intr_ctrl_en_falling_we;
+  logic intr_ctrl_en_lvlhigh_we;
   logic [31:0] intr_ctrl_en_lvlhigh_qs;
   logic [31:0] intr_ctrl_en_lvlhigh_wd;
-  logic intr_ctrl_en_lvlhigh_we;
+  logic intr_ctrl_en_lvllow_we;
   logic [31:0] intr_ctrl_en_lvllow_qs;
   logic [31:0] intr_ctrl_en_lvllow_wd;
-  logic intr_ctrl_en_lvllow_we;
+  logic ctrl_en_input_filter_we;
   logic [31:0] ctrl_en_input_filter_qs;
   logic [31:0] ctrl_en_input_filter_wd;
-  logic ctrl_en_input_filter_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -303,8 +297,8 @@ module gpio_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_masked_out_lower_data (
-    .re     (masked_out_lower_data_re),
-    .we     (masked_out_lower_data_we),
+    .re     (masked_out_lower_re),
+    .we     (masked_out_lower_we),
     .wd     (masked_out_lower_data_wd),
     .d      (hw2reg.masked_out_lower.data.d),
     .qre    (),
@@ -319,7 +313,7 @@ module gpio_reg_top (
     .DW    (16)
   ) u_masked_out_lower_mask (
     .re     (1'b0),
-    .we     (masked_out_lower_mask_we),
+    .we     (masked_out_lower_we),
     .wd     (masked_out_lower_mask_wd),
     .d      (hw2reg.masked_out_lower.mask.d),
     .qre    (),
@@ -335,8 +329,8 @@ module gpio_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_masked_out_upper_data (
-    .re     (masked_out_upper_data_re),
-    .we     (masked_out_upper_data_we),
+    .re     (masked_out_upper_re),
+    .we     (masked_out_upper_we),
     .wd     (masked_out_upper_data_wd),
     .d      (hw2reg.masked_out_upper.data.d),
     .qre    (),
@@ -351,7 +345,7 @@ module gpio_reg_top (
     .DW    (16)
   ) u_masked_out_upper_mask (
     .re     (1'b0),
-    .we     (masked_out_upper_mask_we),
+    .we     (masked_out_upper_we),
     .wd     (masked_out_upper_mask_wd),
     .d      (hw2reg.masked_out_upper.mask.d),
     .qre    (),
@@ -383,8 +377,8 @@ module gpio_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_masked_oe_lower_data (
-    .re     (masked_oe_lower_data_re),
-    .we     (masked_oe_lower_data_we),
+    .re     (masked_oe_lower_re),
+    .we     (masked_oe_lower_we),
     .wd     (masked_oe_lower_data_wd),
     .d      (hw2reg.masked_oe_lower.data.d),
     .qre    (),
@@ -398,8 +392,8 @@ module gpio_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_masked_oe_lower_mask (
-    .re     (masked_oe_lower_mask_re),
-    .we     (masked_oe_lower_mask_we),
+    .re     (masked_oe_lower_re),
+    .we     (masked_oe_lower_we),
     .wd     (masked_oe_lower_mask_wd),
     .d      (hw2reg.masked_oe_lower.mask.d),
     .qre    (),
@@ -415,8 +409,8 @@ module gpio_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_masked_oe_upper_data (
-    .re     (masked_oe_upper_data_re),
-    .we     (masked_oe_upper_data_we),
+    .re     (masked_oe_upper_re),
+    .we     (masked_oe_upper_we),
     .wd     (masked_oe_upper_data_wd),
     .d      (hw2reg.masked_oe_upper.data.d),
     .qre    (),
@@ -430,8 +424,8 @@ module gpio_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_masked_oe_upper_mask (
-    .re     (masked_oe_upper_mask_re),
-    .we     (masked_oe_upper_mask_we),
+    .re     (masked_oe_upper_re),
+    .we     (masked_oe_upper_we),
     .wd     (masked_oe_upper_mask_wd),
     .d      (hw2reg.masked_oe_upper.mask.d),
     .qre    (),
@@ -621,70 +615,64 @@ module gpio_reg_top (
                (addr_hit[14] & (|(GPIO_PERMIT[14] & ~reg_be))) |
                (addr_hit[15] & (|(GPIO_PERMIT[15] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[31:0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[31:0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
+
   assign intr_test_wd = reg_wdata[31:0];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
-  assign direct_out_we = addr_hit[5] & reg_we & !reg_error;
-  assign direct_out_wd = reg_wdata[31:0];
   assign direct_out_re = addr_hit[5] & reg_re & !reg_error;
+  assign direct_out_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign masked_out_lower_data_we = addr_hit[6] & reg_we & !reg_error;
+  assign direct_out_wd = reg_wdata[31:0];
+  assign masked_out_lower_re = addr_hit[6] & reg_re & !reg_error;
+  assign masked_out_lower_we = addr_hit[6] & reg_we & !reg_error;
+
   assign masked_out_lower_data_wd = reg_wdata[15:0];
-  assign masked_out_lower_data_re = addr_hit[6] & reg_re & !reg_error;
 
-  assign masked_out_lower_mask_we = addr_hit[6] & reg_we & !reg_error;
   assign masked_out_lower_mask_wd = reg_wdata[31:16];
+  assign masked_out_upper_re = addr_hit[7] & reg_re & !reg_error;
+  assign masked_out_upper_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign masked_out_upper_data_we = addr_hit[7] & reg_we & !reg_error;
   assign masked_out_upper_data_wd = reg_wdata[15:0];
-  assign masked_out_upper_data_re = addr_hit[7] & reg_re & !reg_error;
 
-  assign masked_out_upper_mask_we = addr_hit[7] & reg_we & !reg_error;
   assign masked_out_upper_mask_wd = reg_wdata[31:16];
-
-  assign direct_oe_we = addr_hit[8] & reg_we & !reg_error;
-  assign direct_oe_wd = reg_wdata[31:0];
   assign direct_oe_re = addr_hit[8] & reg_re & !reg_error;
+  assign direct_oe_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign masked_oe_lower_data_we = addr_hit[9] & reg_we & !reg_error;
+  assign direct_oe_wd = reg_wdata[31:0];
+  assign masked_oe_lower_re = addr_hit[9] & reg_re & !reg_error;
+  assign masked_oe_lower_we = addr_hit[9] & reg_we & !reg_error;
+
   assign masked_oe_lower_data_wd = reg_wdata[15:0];
-  assign masked_oe_lower_data_re = addr_hit[9] & reg_re & !reg_error;
 
-  assign masked_oe_lower_mask_we = addr_hit[9] & reg_we & !reg_error;
   assign masked_oe_lower_mask_wd = reg_wdata[31:16];
-  assign masked_oe_lower_mask_re = addr_hit[9] & reg_re & !reg_error;
+  assign masked_oe_upper_re = addr_hit[10] & reg_re & !reg_error;
+  assign masked_oe_upper_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign masked_oe_upper_data_we = addr_hit[10] & reg_we & !reg_error;
   assign masked_oe_upper_data_wd = reg_wdata[15:0];
-  assign masked_oe_upper_data_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign masked_oe_upper_mask_we = addr_hit[10] & reg_we & !reg_error;
   assign masked_oe_upper_mask_wd = reg_wdata[31:16];
-  assign masked_oe_upper_mask_re = addr_hit[10] & reg_re & !reg_error;
-
   assign intr_ctrl_en_rising_we = addr_hit[11] & reg_we & !reg_error;
+
   assign intr_ctrl_en_rising_wd = reg_wdata[31:0];
-
   assign intr_ctrl_en_falling_we = addr_hit[12] & reg_we & !reg_error;
+
   assign intr_ctrl_en_falling_wd = reg_wdata[31:0];
-
   assign intr_ctrl_en_lvlhigh_we = addr_hit[13] & reg_we & !reg_error;
+
   assign intr_ctrl_en_lvlhigh_wd = reg_wdata[31:0];
-
   assign intr_ctrl_en_lvllow_we = addr_hit[14] & reg_we & !reg_error;
-  assign intr_ctrl_en_lvllow_wd = reg_wdata[31:0];
 
+  assign intr_ctrl_en_lvllow_wd = reg_wdata[31:0];
   assign ctrl_en_input_filter_we = addr_hit[15] & reg_we & !reg_error;
+
   assign ctrl_en_input_filter_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -152,93 +152,78 @@ module hmac_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_hmac_done_qs;
   logic intr_state_hmac_done_wd;
-  logic intr_state_hmac_done_we;
   logic intr_state_fifo_empty_qs;
   logic intr_state_fifo_empty_wd;
-  logic intr_state_fifo_empty_we;
   logic intr_state_hmac_err_qs;
   logic intr_state_hmac_err_wd;
-  logic intr_state_hmac_err_we;
+  logic intr_enable_we;
   logic intr_enable_hmac_done_qs;
   logic intr_enable_hmac_done_wd;
-  logic intr_enable_hmac_done_we;
   logic intr_enable_fifo_empty_qs;
   logic intr_enable_fifo_empty_wd;
-  logic intr_enable_fifo_empty_we;
   logic intr_enable_hmac_err_qs;
   logic intr_enable_hmac_err_wd;
-  logic intr_enable_hmac_err_we;
+  logic intr_test_we;
   logic intr_test_hmac_done_wd;
-  logic intr_test_hmac_done_we;
   logic intr_test_fifo_empty_wd;
-  logic intr_test_fifo_empty_we;
   logic intr_test_hmac_err_wd;
-  logic intr_test_hmac_err_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic cfg_re;
+  logic cfg_we;
   logic cfg_hmac_en_qs;
   logic cfg_hmac_en_wd;
-  logic cfg_hmac_en_we;
-  logic cfg_hmac_en_re;
   logic cfg_sha_en_qs;
   logic cfg_sha_en_wd;
-  logic cfg_sha_en_we;
-  logic cfg_sha_en_re;
   logic cfg_endian_swap_qs;
   logic cfg_endian_swap_wd;
-  logic cfg_endian_swap_we;
-  logic cfg_endian_swap_re;
   logic cfg_digest_swap_qs;
   logic cfg_digest_swap_wd;
-  logic cfg_digest_swap_we;
-  logic cfg_digest_swap_re;
+  logic cmd_we;
   logic cmd_hash_start_wd;
-  logic cmd_hash_start_we;
   logic cmd_hash_process_wd;
-  logic cmd_hash_process_we;
+  logic status_re;
   logic status_fifo_empty_qs;
-  logic status_fifo_empty_re;
   logic status_fifo_full_qs;
-  logic status_fifo_full_re;
   logic [4:0] status_fifo_depth_qs;
-  logic status_fifo_depth_re;
   logic [31:0] err_code_qs;
-  logic [31:0] wipe_secret_wd;
   logic wipe_secret_we;
-  logic [31:0] key_0_wd;
+  logic [31:0] wipe_secret_wd;
   logic key_0_we;
-  logic [31:0] key_1_wd;
+  logic [31:0] key_0_wd;
   logic key_1_we;
-  logic [31:0] key_2_wd;
+  logic [31:0] key_1_wd;
   logic key_2_we;
-  logic [31:0] key_3_wd;
+  logic [31:0] key_2_wd;
   logic key_3_we;
-  logic [31:0] key_4_wd;
+  logic [31:0] key_3_wd;
   logic key_4_we;
-  logic [31:0] key_5_wd;
+  logic [31:0] key_4_wd;
   logic key_5_we;
-  logic [31:0] key_6_wd;
+  logic [31:0] key_5_wd;
   logic key_6_we;
-  logic [31:0] key_7_wd;
+  logic [31:0] key_6_wd;
   logic key_7_we;
-  logic [31:0] digest_0_qs;
+  logic [31:0] key_7_wd;
   logic digest_0_re;
-  logic [31:0] digest_1_qs;
+  logic [31:0] digest_0_qs;
   logic digest_1_re;
-  logic [31:0] digest_2_qs;
+  logic [31:0] digest_1_qs;
   logic digest_2_re;
-  logic [31:0] digest_3_qs;
+  logic [31:0] digest_2_qs;
   logic digest_3_re;
-  logic [31:0] digest_4_qs;
+  logic [31:0] digest_3_qs;
   logic digest_4_re;
-  logic [31:0] digest_5_qs;
+  logic [31:0] digest_4_qs;
   logic digest_5_re;
-  logic [31:0] digest_6_qs;
+  logic [31:0] digest_5_qs;
   logic digest_6_re;
-  logic [31:0] digest_7_qs;
+  logic [31:0] digest_6_qs;
   logic digest_7_re;
+  logic [31:0] digest_7_qs;
   logic [31:0] msg_length_lower_qs;
   logic [31:0] msg_length_upper_qs;
 
@@ -255,7 +240,7 @@ module hmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_hmac_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_hmac_done_wd),
 
     // from internal hardware
@@ -281,7 +266,7 @@ module hmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_fifo_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_fifo_empty_wd),
 
     // from internal hardware
@@ -307,7 +292,7 @@ module hmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_hmac_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_hmac_err_wd),
 
     // from internal hardware
@@ -335,7 +320,7 @@ module hmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_hmac_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_hmac_done_wd),
 
     // from internal hardware
@@ -361,7 +346,7 @@ module hmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_fifo_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_fifo_empty_wd),
 
     // from internal hardware
@@ -387,7 +372,7 @@ module hmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_hmac_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_hmac_err_wd),
 
     // from internal hardware
@@ -410,7 +395,7 @@ module hmac_reg_top (
     .DW    (1)
   ) u_intr_test_hmac_done (
     .re     (1'b0),
-    .we     (intr_test_hmac_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_hmac_done_wd),
     .d      ('0),
     .qre    (),
@@ -425,7 +410,7 @@ module hmac_reg_top (
     .DW    (1)
   ) u_intr_test_fifo_empty (
     .re     (1'b0),
-    .we     (intr_test_fifo_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_fifo_empty_wd),
     .d      ('0),
     .qre    (),
@@ -440,7 +425,7 @@ module hmac_reg_top (
     .DW    (1)
   ) u_intr_test_hmac_err (
     .re     (1'b0),
-    .we     (intr_test_hmac_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_hmac_err_wd),
     .d      ('0),
     .qre    (),
@@ -472,8 +457,8 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_cfg_hmac_en (
-    .re     (cfg_hmac_en_re),
-    .we     (cfg_hmac_en_we),
+    .re     (cfg_re),
+    .we     (cfg_we),
     .wd     (cfg_hmac_en_wd),
     .d      (hw2reg.cfg.hmac_en.d),
     .qre    (),
@@ -487,8 +472,8 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_cfg_sha_en (
-    .re     (cfg_sha_en_re),
-    .we     (cfg_sha_en_we),
+    .re     (cfg_re),
+    .we     (cfg_we),
     .wd     (cfg_sha_en_wd),
     .d      (hw2reg.cfg.sha_en.d),
     .qre    (),
@@ -502,8 +487,8 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_cfg_endian_swap (
-    .re     (cfg_endian_swap_re),
-    .we     (cfg_endian_swap_we),
+    .re     (cfg_re),
+    .we     (cfg_we),
     .wd     (cfg_endian_swap_wd),
     .d      (hw2reg.cfg.endian_swap.d),
     .qre    (),
@@ -517,8 +502,8 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_cfg_digest_swap (
-    .re     (cfg_digest_swap_re),
-    .we     (cfg_digest_swap_we),
+    .re     (cfg_re),
+    .we     (cfg_we),
     .wd     (cfg_digest_swap_wd),
     .d      (hw2reg.cfg.digest_swap.d),
     .qre    (),
@@ -535,7 +520,7 @@ module hmac_reg_top (
     .DW    (1)
   ) u_cmd_hash_start (
     .re     (1'b0),
-    .we     (cmd_hash_start_we),
+    .we     (cmd_we),
     .wd     (cmd_hash_start_wd),
     .d      ('0),
     .qre    (),
@@ -550,7 +535,7 @@ module hmac_reg_top (
     .DW    (1)
   ) u_cmd_hash_process (
     .re     (1'b0),
-    .we     (cmd_hash_process_we),
+    .we     (cmd_we),
     .wd     (cmd_hash_process_wd),
     .d      ('0),
     .qre    (),
@@ -566,7 +551,7 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_fifo_empty (
-    .re     (status_fifo_empty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fifo_empty.d),
@@ -581,7 +566,7 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_fifo_full (
-    .re     (status_fifo_full_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fifo_full.d),
@@ -596,7 +581,7 @@ module hmac_reg_top (
   prim_subreg_ext #(
     .DW    (5)
   ) u_status_fifo_depth (
-    .re     (status_fifo_depth_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fifo_depth.d),
@@ -1031,106 +1016,80 @@ module hmac_reg_top (
                (addr_hit[25] & (|(HMAC_PERMIT[25] & ~reg_be))) |
                (addr_hit[26] & (|(HMAC_PERMIT[26] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_hmac_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_hmac_done_wd = reg_wdata[0];
 
-  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_state_hmac_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_hmac_err_wd = reg_wdata[2];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_hmac_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_hmac_done_wd = reg_wdata[0];
 
-  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_enable_hmac_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_hmac_err_wd = reg_wdata[2];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_hmac_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_hmac_done_wd = reg_wdata[0];
 
-  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_test_hmac_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_hmac_err_wd = reg_wdata[2];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
+  assign cfg_re = addr_hit[4] & reg_re & !reg_error;
+  assign cfg_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign cfg_hmac_en_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_hmac_en_wd = reg_wdata[0];
-  assign cfg_hmac_en_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign cfg_sha_en_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_sha_en_wd = reg_wdata[1];
-  assign cfg_sha_en_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign cfg_endian_swap_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_endian_swap_wd = reg_wdata[2];
-  assign cfg_endian_swap_re = addr_hit[4] & reg_re & !reg_error;
 
-  assign cfg_digest_swap_we = addr_hit[4] & reg_we & !reg_error;
   assign cfg_digest_swap_wd = reg_wdata[3];
-  assign cfg_digest_swap_re = addr_hit[4] & reg_re & !reg_error;
+  assign cmd_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign cmd_hash_start_we = addr_hit[5] & reg_we & !reg_error;
   assign cmd_hash_start_wd = reg_wdata[0];
 
-  assign cmd_hash_process_we = addr_hit[5] & reg_we & !reg_error;
   assign cmd_hash_process_wd = reg_wdata[1];
-
-  assign status_fifo_empty_re = addr_hit[6] & reg_re & !reg_error;
-
-  assign status_fifo_full_re = addr_hit[6] & reg_re & !reg_error;
-
-  assign status_fifo_depth_re = addr_hit[6] & reg_re & !reg_error;
-
+  assign status_re = addr_hit[6] & reg_re & !reg_error;
   assign wipe_secret_we = addr_hit[8] & reg_we & !reg_error;
+
   assign wipe_secret_wd = reg_wdata[31:0];
-
   assign key_0_we = addr_hit[9] & reg_we & !reg_error;
+
   assign key_0_wd = reg_wdata[31:0];
-
   assign key_1_we = addr_hit[10] & reg_we & !reg_error;
+
   assign key_1_wd = reg_wdata[31:0];
-
   assign key_2_we = addr_hit[11] & reg_we & !reg_error;
+
   assign key_2_wd = reg_wdata[31:0];
-
   assign key_3_we = addr_hit[12] & reg_we & !reg_error;
+
   assign key_3_wd = reg_wdata[31:0];
-
   assign key_4_we = addr_hit[13] & reg_we & !reg_error;
+
   assign key_4_wd = reg_wdata[31:0];
-
   assign key_5_we = addr_hit[14] & reg_we & !reg_error;
+
   assign key_5_wd = reg_wdata[31:0];
-
   assign key_6_we = addr_hit[15] & reg_we & !reg_error;
+
   assign key_6_wd = reg_wdata[31:0];
-
   assign key_7_we = addr_hit[16] & reg_we & !reg_error;
+
   assign key_7_wd = reg_wdata[31:0];
-
   assign digest_0_re = addr_hit[17] & reg_re & !reg_error;
-
   assign digest_1_re = addr_hit[18] & reg_re & !reg_error;
-
   assign digest_2_re = addr_hit[19] & reg_re & !reg_error;
-
   assign digest_3_re = addr_hit[20] & reg_re & !reg_error;
-
   assign digest_4_re = addr_hit[21] & reg_re & !reg_error;
-
   assign digest_5_re = addr_hit[22] & reg_re & !reg_error;
-
   assign digest_6_re = addr_hit[23] & reg_re & !reg_error;
-
   assign digest_7_re = addr_hit[24] & reg_re & !reg_error;
 
   // Read data return

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -104,283 +104,198 @@ module i2c_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_fmt_watermark_qs;
   logic intr_state_fmt_watermark_wd;
-  logic intr_state_fmt_watermark_we;
   logic intr_state_rx_watermark_qs;
   logic intr_state_rx_watermark_wd;
-  logic intr_state_rx_watermark_we;
   logic intr_state_fmt_overflow_qs;
   logic intr_state_fmt_overflow_wd;
-  logic intr_state_fmt_overflow_we;
   logic intr_state_rx_overflow_qs;
   logic intr_state_rx_overflow_wd;
-  logic intr_state_rx_overflow_we;
   logic intr_state_nak_qs;
   logic intr_state_nak_wd;
-  logic intr_state_nak_we;
   logic intr_state_scl_interference_qs;
   logic intr_state_scl_interference_wd;
-  logic intr_state_scl_interference_we;
   logic intr_state_sda_interference_qs;
   logic intr_state_sda_interference_wd;
-  logic intr_state_sda_interference_we;
   logic intr_state_stretch_timeout_qs;
   logic intr_state_stretch_timeout_wd;
-  logic intr_state_stretch_timeout_we;
   logic intr_state_sda_unstable_qs;
   logic intr_state_sda_unstable_wd;
-  logic intr_state_sda_unstable_we;
   logic intr_state_trans_complete_qs;
   logic intr_state_trans_complete_wd;
-  logic intr_state_trans_complete_we;
   logic intr_state_tx_empty_qs;
   logic intr_state_tx_empty_wd;
-  logic intr_state_tx_empty_we;
   logic intr_state_tx_nonempty_qs;
   logic intr_state_tx_nonempty_wd;
-  logic intr_state_tx_nonempty_we;
   logic intr_state_tx_overflow_qs;
   logic intr_state_tx_overflow_wd;
-  logic intr_state_tx_overflow_we;
   logic intr_state_acq_overflow_qs;
   logic intr_state_acq_overflow_wd;
-  logic intr_state_acq_overflow_we;
   logic intr_state_ack_stop_qs;
   logic intr_state_ack_stop_wd;
-  logic intr_state_ack_stop_we;
   logic intr_state_host_timeout_qs;
   logic intr_state_host_timeout_wd;
-  logic intr_state_host_timeout_we;
+  logic intr_enable_we;
   logic intr_enable_fmt_watermark_qs;
   logic intr_enable_fmt_watermark_wd;
-  logic intr_enable_fmt_watermark_we;
   logic intr_enable_rx_watermark_qs;
   logic intr_enable_rx_watermark_wd;
-  logic intr_enable_rx_watermark_we;
   logic intr_enable_fmt_overflow_qs;
   logic intr_enable_fmt_overflow_wd;
-  logic intr_enable_fmt_overflow_we;
   logic intr_enable_rx_overflow_qs;
   logic intr_enable_rx_overflow_wd;
-  logic intr_enable_rx_overflow_we;
   logic intr_enable_nak_qs;
   logic intr_enable_nak_wd;
-  logic intr_enable_nak_we;
   logic intr_enable_scl_interference_qs;
   logic intr_enable_scl_interference_wd;
-  logic intr_enable_scl_interference_we;
   logic intr_enable_sda_interference_qs;
   logic intr_enable_sda_interference_wd;
-  logic intr_enable_sda_interference_we;
   logic intr_enable_stretch_timeout_qs;
   logic intr_enable_stretch_timeout_wd;
-  logic intr_enable_stretch_timeout_we;
   logic intr_enable_sda_unstable_qs;
   logic intr_enable_sda_unstable_wd;
-  logic intr_enable_sda_unstable_we;
   logic intr_enable_trans_complete_qs;
   logic intr_enable_trans_complete_wd;
-  logic intr_enable_trans_complete_we;
   logic intr_enable_tx_empty_qs;
   logic intr_enable_tx_empty_wd;
-  logic intr_enable_tx_empty_we;
   logic intr_enable_tx_nonempty_qs;
   logic intr_enable_tx_nonempty_wd;
-  logic intr_enable_tx_nonempty_we;
   logic intr_enable_tx_overflow_qs;
   logic intr_enable_tx_overflow_wd;
-  logic intr_enable_tx_overflow_we;
   logic intr_enable_acq_overflow_qs;
   logic intr_enable_acq_overflow_wd;
-  logic intr_enable_acq_overflow_we;
   logic intr_enable_ack_stop_qs;
   logic intr_enable_ack_stop_wd;
-  logic intr_enable_ack_stop_we;
   logic intr_enable_host_timeout_qs;
   logic intr_enable_host_timeout_wd;
-  logic intr_enable_host_timeout_we;
+  logic intr_test_we;
   logic intr_test_fmt_watermark_wd;
-  logic intr_test_fmt_watermark_we;
   logic intr_test_rx_watermark_wd;
-  logic intr_test_rx_watermark_we;
   logic intr_test_fmt_overflow_wd;
-  logic intr_test_fmt_overflow_we;
   logic intr_test_rx_overflow_wd;
-  logic intr_test_rx_overflow_we;
   logic intr_test_nak_wd;
-  logic intr_test_nak_we;
   logic intr_test_scl_interference_wd;
-  logic intr_test_scl_interference_we;
   logic intr_test_sda_interference_wd;
-  logic intr_test_sda_interference_we;
   logic intr_test_stretch_timeout_wd;
-  logic intr_test_stretch_timeout_we;
   logic intr_test_sda_unstable_wd;
-  logic intr_test_sda_unstable_we;
   logic intr_test_trans_complete_wd;
-  logic intr_test_trans_complete_we;
   logic intr_test_tx_empty_wd;
-  logic intr_test_tx_empty_we;
   logic intr_test_tx_nonempty_wd;
-  logic intr_test_tx_nonempty_we;
   logic intr_test_tx_overflow_wd;
-  logic intr_test_tx_overflow_we;
   logic intr_test_acq_overflow_wd;
-  logic intr_test_acq_overflow_we;
   logic intr_test_ack_stop_wd;
-  logic intr_test_ack_stop_we;
   logic intr_test_host_timeout_wd;
-  logic intr_test_host_timeout_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic ctrl_we;
   logic ctrl_enablehost_qs;
   logic ctrl_enablehost_wd;
-  logic ctrl_enablehost_we;
   logic ctrl_enabletarget_qs;
   logic ctrl_enabletarget_wd;
-  logic ctrl_enabletarget_we;
   logic ctrl_llpbk_qs;
   logic ctrl_llpbk_wd;
-  logic ctrl_llpbk_we;
+  logic status_re;
   logic status_fmtfull_qs;
-  logic status_fmtfull_re;
   logic status_rxfull_qs;
-  logic status_rxfull_re;
   logic status_fmtempty_qs;
-  logic status_fmtempty_re;
   logic status_hostidle_qs;
-  logic status_hostidle_re;
   logic status_targetidle_qs;
-  logic status_targetidle_re;
   logic status_rxempty_qs;
-  logic status_rxempty_re;
   logic status_txfull_qs;
-  logic status_txfull_re;
   logic status_acqfull_qs;
-  logic status_acqfull_re;
   logic status_txempty_qs;
-  logic status_txempty_re;
   logic status_acqempty_qs;
-  logic status_acqempty_re;
-  logic [7:0] rdata_qs;
   logic rdata_re;
+  logic [7:0] rdata_qs;
+  logic fdata_we;
   logic [7:0] fdata_fbyte_wd;
-  logic fdata_fbyte_we;
   logic fdata_start_wd;
-  logic fdata_start_we;
   logic fdata_stop_wd;
-  logic fdata_stop_we;
   logic fdata_read_wd;
-  logic fdata_read_we;
   logic fdata_rcont_wd;
-  logic fdata_rcont_we;
   logic fdata_nakok_wd;
-  logic fdata_nakok_we;
+  logic fifo_ctrl_we;
   logic fifo_ctrl_rxrst_wd;
-  logic fifo_ctrl_rxrst_we;
   logic fifo_ctrl_fmtrst_wd;
-  logic fifo_ctrl_fmtrst_we;
   logic [2:0] fifo_ctrl_rxilvl_qs;
   logic [2:0] fifo_ctrl_rxilvl_wd;
-  logic fifo_ctrl_rxilvl_we;
   logic [1:0] fifo_ctrl_fmtilvl_qs;
   logic [1:0] fifo_ctrl_fmtilvl_wd;
-  logic fifo_ctrl_fmtilvl_we;
   logic fifo_ctrl_acqrst_wd;
-  logic fifo_ctrl_acqrst_we;
   logic fifo_ctrl_txrst_wd;
-  logic fifo_ctrl_txrst_we;
+  logic fifo_status_re;
   logic [6:0] fifo_status_fmtlvl_qs;
-  logic fifo_status_fmtlvl_re;
   logic [6:0] fifo_status_txlvl_qs;
-  logic fifo_status_txlvl_re;
   logic [6:0] fifo_status_rxlvl_qs;
-  logic fifo_status_rxlvl_re;
   logic [6:0] fifo_status_acqlvl_qs;
-  logic fifo_status_acqlvl_re;
+  logic ovrd_we;
   logic ovrd_txovrden_qs;
   logic ovrd_txovrden_wd;
-  logic ovrd_txovrden_we;
   logic ovrd_sclval_qs;
   logic ovrd_sclval_wd;
-  logic ovrd_sclval_we;
   logic ovrd_sdaval_qs;
   logic ovrd_sdaval_wd;
-  logic ovrd_sdaval_we;
+  logic val_re;
   logic [15:0] val_scl_rx_qs;
-  logic val_scl_rx_re;
   logic [15:0] val_sda_rx_qs;
-  logic val_sda_rx_re;
+  logic timing0_we;
   logic [15:0] timing0_thigh_qs;
   logic [15:0] timing0_thigh_wd;
-  logic timing0_thigh_we;
   logic [15:0] timing0_tlow_qs;
   logic [15:0] timing0_tlow_wd;
-  logic timing0_tlow_we;
+  logic timing1_we;
   logic [15:0] timing1_t_r_qs;
   logic [15:0] timing1_t_r_wd;
-  logic timing1_t_r_we;
   logic [15:0] timing1_t_f_qs;
   logic [15:0] timing1_t_f_wd;
-  logic timing1_t_f_we;
+  logic timing2_we;
   logic [15:0] timing2_tsu_sta_qs;
   logic [15:0] timing2_tsu_sta_wd;
-  logic timing2_tsu_sta_we;
   logic [15:0] timing2_thd_sta_qs;
   logic [15:0] timing2_thd_sta_wd;
-  logic timing2_thd_sta_we;
+  logic timing3_we;
   logic [15:0] timing3_tsu_dat_qs;
   logic [15:0] timing3_tsu_dat_wd;
-  logic timing3_tsu_dat_we;
   logic [15:0] timing3_thd_dat_qs;
   logic [15:0] timing3_thd_dat_wd;
-  logic timing3_thd_dat_we;
+  logic timing4_we;
   logic [15:0] timing4_tsu_sto_qs;
   logic [15:0] timing4_tsu_sto_wd;
-  logic timing4_tsu_sto_we;
   logic [15:0] timing4_t_buf_qs;
   logic [15:0] timing4_t_buf_wd;
-  logic timing4_t_buf_we;
+  logic timeout_ctrl_we;
   logic [30:0] timeout_ctrl_val_qs;
   logic [30:0] timeout_ctrl_val_wd;
-  logic timeout_ctrl_val_we;
   logic timeout_ctrl_en_qs;
   logic timeout_ctrl_en_wd;
-  logic timeout_ctrl_en_we;
+  logic target_id_we;
   logic [6:0] target_id_address0_qs;
   logic [6:0] target_id_address0_wd;
-  logic target_id_address0_we;
   logic [6:0] target_id_mask0_qs;
   logic [6:0] target_id_mask0_wd;
-  logic target_id_mask0_we;
   logic [6:0] target_id_address1_qs;
   logic [6:0] target_id_address1_wd;
-  logic target_id_address1_we;
   logic [6:0] target_id_mask1_qs;
   logic [6:0] target_id_mask1_wd;
-  logic target_id_mask1_we;
+  logic acqdata_re;
   logic [7:0] acqdata_abyte_qs;
-  logic acqdata_abyte_re;
   logic [1:0] acqdata_signal_qs;
-  logic acqdata_signal_re;
-  logic [7:0] txdata_wd;
   logic txdata_we;
+  logic [7:0] txdata_wd;
+  logic stretch_ctrl_we;
   logic stretch_ctrl_en_addr_tx_qs;
   logic stretch_ctrl_en_addr_tx_wd;
-  logic stretch_ctrl_en_addr_tx_we;
   logic stretch_ctrl_en_addr_acq_qs;
   logic stretch_ctrl_en_addr_acq_wd;
-  logic stretch_ctrl_en_addr_acq_we;
   logic stretch_ctrl_stop_tx_qs;
   logic stretch_ctrl_stop_tx_wd;
-  logic stretch_ctrl_stop_tx_we;
   logic stretch_ctrl_stop_acq_qs;
   logic stretch_ctrl_stop_acq_wd;
-  logic stretch_ctrl_stop_acq_we;
+  logic host_timeout_ctrl_we;
   logic [31:0] host_timeout_ctrl_qs;
   logic [31:0] host_timeout_ctrl_wd;
-  logic host_timeout_ctrl_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -395,7 +310,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_fmt_watermark_we),
+    .we     (intr_state_we),
     .wd     (intr_state_fmt_watermark_wd),
 
     // from internal hardware
@@ -421,7 +336,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_watermark_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_watermark_wd),
 
     // from internal hardware
@@ -447,7 +362,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_fmt_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_fmt_overflow_wd),
 
     // from internal hardware
@@ -473,7 +388,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_overflow_wd),
 
     // from internal hardware
@@ -499,7 +414,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_nak_we),
+    .we     (intr_state_we),
     .wd     (intr_state_nak_wd),
 
     // from internal hardware
@@ -525,7 +440,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_scl_interference_we),
+    .we     (intr_state_we),
     .wd     (intr_state_scl_interference_wd),
 
     // from internal hardware
@@ -551,7 +466,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_sda_interference_we),
+    .we     (intr_state_we),
     .wd     (intr_state_sda_interference_wd),
 
     // from internal hardware
@@ -577,7 +492,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_stretch_timeout_we),
+    .we     (intr_state_we),
     .wd     (intr_state_stretch_timeout_wd),
 
     // from internal hardware
@@ -603,7 +518,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_sda_unstable_we),
+    .we     (intr_state_we),
     .wd     (intr_state_sda_unstable_wd),
 
     // from internal hardware
@@ -629,7 +544,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_trans_complete_we),
+    .we     (intr_state_we),
     .wd     (intr_state_trans_complete_wd),
 
     // from internal hardware
@@ -655,7 +570,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_empty_wd),
 
     // from internal hardware
@@ -681,7 +596,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_nonempty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_nonempty_wd),
 
     // from internal hardware
@@ -707,7 +622,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_overflow_wd),
 
     // from internal hardware
@@ -733,7 +648,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_acq_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_acq_overflow_wd),
 
     // from internal hardware
@@ -759,7 +674,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_ack_stop_we),
+    .we     (intr_state_we),
     .wd     (intr_state_ack_stop_wd),
 
     // from internal hardware
@@ -785,7 +700,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_host_timeout_we),
+    .we     (intr_state_we),
     .wd     (intr_state_host_timeout_wd),
 
     // from internal hardware
@@ -813,7 +728,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_fmt_watermark_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_fmt_watermark_wd),
 
     // from internal hardware
@@ -839,7 +754,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_watermark_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_watermark_wd),
 
     // from internal hardware
@@ -865,7 +780,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_fmt_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_fmt_overflow_wd),
 
     // from internal hardware
@@ -891,7 +806,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_overflow_wd),
 
     // from internal hardware
@@ -917,7 +832,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_nak_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_nak_wd),
 
     // from internal hardware
@@ -943,7 +858,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_scl_interference_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_scl_interference_wd),
 
     // from internal hardware
@@ -969,7 +884,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_sda_interference_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_sda_interference_wd),
 
     // from internal hardware
@@ -995,7 +910,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_stretch_timeout_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_stretch_timeout_wd),
 
     // from internal hardware
@@ -1021,7 +936,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_sda_unstable_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_sda_unstable_wd),
 
     // from internal hardware
@@ -1047,7 +962,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_trans_complete_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_trans_complete_wd),
 
     // from internal hardware
@@ -1073,7 +988,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_empty_wd),
 
     // from internal hardware
@@ -1099,7 +1014,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_nonempty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_nonempty_wd),
 
     // from internal hardware
@@ -1125,7 +1040,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_overflow_wd),
 
     // from internal hardware
@@ -1151,7 +1066,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_acq_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_acq_overflow_wd),
 
     // from internal hardware
@@ -1177,7 +1092,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_ack_stop_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_ack_stop_wd),
 
     // from internal hardware
@@ -1203,7 +1118,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_host_timeout_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_host_timeout_wd),
 
     // from internal hardware
@@ -1226,7 +1141,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_fmt_watermark (
     .re     (1'b0),
-    .we     (intr_test_fmt_watermark_we),
+    .we     (intr_test_we),
     .wd     (intr_test_fmt_watermark_wd),
     .d      ('0),
     .qre    (),
@@ -1241,7 +1156,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_rx_watermark (
     .re     (1'b0),
-    .we     (intr_test_rx_watermark_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_watermark_wd),
     .d      ('0),
     .qre    (),
@@ -1256,7 +1171,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_fmt_overflow (
     .re     (1'b0),
-    .we     (intr_test_fmt_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_fmt_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -1271,7 +1186,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_rx_overflow (
     .re     (1'b0),
-    .we     (intr_test_rx_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -1286,7 +1201,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_nak (
     .re     (1'b0),
-    .we     (intr_test_nak_we),
+    .we     (intr_test_we),
     .wd     (intr_test_nak_wd),
     .d      ('0),
     .qre    (),
@@ -1301,7 +1216,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_scl_interference (
     .re     (1'b0),
-    .we     (intr_test_scl_interference_we),
+    .we     (intr_test_we),
     .wd     (intr_test_scl_interference_wd),
     .d      ('0),
     .qre    (),
@@ -1316,7 +1231,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_sda_interference (
     .re     (1'b0),
-    .we     (intr_test_sda_interference_we),
+    .we     (intr_test_we),
     .wd     (intr_test_sda_interference_wd),
     .d      ('0),
     .qre    (),
@@ -1331,7 +1246,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_stretch_timeout (
     .re     (1'b0),
-    .we     (intr_test_stretch_timeout_we),
+    .we     (intr_test_we),
     .wd     (intr_test_stretch_timeout_wd),
     .d      ('0),
     .qre    (),
@@ -1346,7 +1261,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_sda_unstable (
     .re     (1'b0),
-    .we     (intr_test_sda_unstable_we),
+    .we     (intr_test_we),
     .wd     (intr_test_sda_unstable_wd),
     .d      ('0),
     .qre    (),
@@ -1361,7 +1276,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_trans_complete (
     .re     (1'b0),
-    .we     (intr_test_trans_complete_we),
+    .we     (intr_test_we),
     .wd     (intr_test_trans_complete_wd),
     .d      ('0),
     .qre    (),
@@ -1376,7 +1291,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_tx_empty (
     .re     (1'b0),
-    .we     (intr_test_tx_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_empty_wd),
     .d      ('0),
     .qre    (),
@@ -1391,7 +1306,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_tx_nonempty (
     .re     (1'b0),
-    .we     (intr_test_tx_nonempty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_nonempty_wd),
     .d      ('0),
     .qre    (),
@@ -1406,7 +1321,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_tx_overflow (
     .re     (1'b0),
-    .we     (intr_test_tx_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -1421,7 +1336,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_acq_overflow (
     .re     (1'b0),
-    .we     (intr_test_acq_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_acq_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -1436,7 +1351,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_ack_stop (
     .re     (1'b0),
-    .we     (intr_test_ack_stop_we),
+    .we     (intr_test_we),
     .wd     (intr_test_ack_stop_wd),
     .d      ('0),
     .qre    (),
@@ -1451,7 +1366,7 @@ module i2c_reg_top (
     .DW    (1)
   ) u_intr_test_host_timeout (
     .re     (1'b0),
-    .we     (intr_test_host_timeout_we),
+    .we     (intr_test_we),
     .wd     (intr_test_host_timeout_wd),
     .d      ('0),
     .qre    (),
@@ -1489,7 +1404,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_enablehost_we),
+    .we     (ctrl_we),
     .wd     (ctrl_enablehost_wd),
 
     // from internal hardware
@@ -1515,7 +1430,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_enabletarget_we),
+    .we     (ctrl_we),
     .wd     (ctrl_enabletarget_wd),
 
     // from internal hardware
@@ -1541,7 +1456,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_llpbk_we),
+    .we     (ctrl_we),
     .wd     (ctrl_llpbk_wd),
 
     // from internal hardware
@@ -1563,7 +1478,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_fmtfull (
-    .re     (status_fmtfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fmtfull.d),
@@ -1578,7 +1493,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxfull (
-    .re     (status_rxfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxfull.d),
@@ -1593,7 +1508,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_fmtempty (
-    .re     (status_fmtempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fmtempty.d),
@@ -1608,7 +1523,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_hostidle (
-    .re     (status_hostidle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.hostidle.d),
@@ -1623,7 +1538,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_targetidle (
-    .re     (status_targetidle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.targetidle.d),
@@ -1638,7 +1553,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxempty (
-    .re     (status_rxempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxempty.d),
@@ -1653,7 +1568,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txfull (
-    .re     (status_txfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txfull.d),
@@ -1668,7 +1583,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_acqfull (
-    .re     (status_acqfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.acqfull.d),
@@ -1683,7 +1598,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txempty (
-    .re     (status_txempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txempty.d),
@@ -1698,7 +1613,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_acqempty (
-    .re     (status_acqempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.acqempty.d),
@@ -1737,7 +1652,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fdata_fbyte_we),
+    .we     (fdata_we),
     .wd     (fdata_fbyte_wd),
 
     // from internal hardware
@@ -1763,7 +1678,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fdata_start_we),
+    .we     (fdata_we),
     .wd     (fdata_start_wd),
 
     // from internal hardware
@@ -1789,7 +1704,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fdata_stop_we),
+    .we     (fdata_we),
     .wd     (fdata_stop_wd),
 
     // from internal hardware
@@ -1815,7 +1730,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fdata_read_we),
+    .we     (fdata_we),
     .wd     (fdata_read_wd),
 
     // from internal hardware
@@ -1841,7 +1756,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fdata_rcont_we),
+    .we     (fdata_we),
     .wd     (fdata_rcont_wd),
 
     // from internal hardware
@@ -1867,7 +1782,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fdata_nakok_we),
+    .we     (fdata_we),
     .wd     (fdata_nakok_wd),
 
     // from internal hardware
@@ -1895,7 +1810,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_rxrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_rxrst_wd),
 
     // from internal hardware
@@ -1921,7 +1836,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_fmtrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_fmtrst_wd),
 
     // from internal hardware
@@ -1947,7 +1862,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_rxilvl_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_rxilvl_wd),
 
     // from internal hardware
@@ -1973,7 +1888,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_fmtilvl_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_fmtilvl_wd),
 
     // from internal hardware
@@ -1999,7 +1914,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_acqrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_acqrst_wd),
 
     // from internal hardware
@@ -2025,7 +1940,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_txrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_txrst_wd),
 
     // from internal hardware
@@ -2047,7 +1962,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (7)
   ) u_fifo_status_fmtlvl (
-    .re     (fifo_status_fmtlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.fmtlvl.d),
@@ -2062,7 +1977,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (7)
   ) u_fifo_status_txlvl (
-    .re     (fifo_status_txlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.txlvl.d),
@@ -2077,7 +1992,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (7)
   ) u_fifo_status_rxlvl (
-    .re     (fifo_status_rxlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.rxlvl.d),
@@ -2092,7 +2007,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (7)
   ) u_fifo_status_acqlvl (
-    .re     (fifo_status_acqlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.acqlvl.d),
@@ -2115,7 +2030,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_txovrden_we),
+    .we     (ovrd_we),
     .wd     (ovrd_txovrden_wd),
 
     // from internal hardware
@@ -2141,7 +2056,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_sclval_we),
+    .we     (ovrd_we),
     .wd     (ovrd_sclval_wd),
 
     // from internal hardware
@@ -2167,7 +2082,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_sdaval_we),
+    .we     (ovrd_we),
     .wd     (ovrd_sdaval_wd),
 
     // from internal hardware
@@ -2189,7 +2104,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_val_scl_rx (
-    .re     (val_scl_rx_re),
+    .re     (val_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.val.scl_rx.d),
@@ -2204,7 +2119,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_val_sda_rx (
-    .re     (val_sda_rx_re),
+    .re     (val_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.val.sda_rx.d),
@@ -2227,7 +2142,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing0_thigh_we),
+    .we     (timing0_we),
     .wd     (timing0_thigh_wd),
 
     // from internal hardware
@@ -2253,7 +2168,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing0_tlow_we),
+    .we     (timing0_we),
     .wd     (timing0_tlow_wd),
 
     // from internal hardware
@@ -2281,7 +2196,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing1_t_r_we),
+    .we     (timing1_we),
     .wd     (timing1_t_r_wd),
 
     // from internal hardware
@@ -2307,7 +2222,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing1_t_f_we),
+    .we     (timing1_we),
     .wd     (timing1_t_f_wd),
 
     // from internal hardware
@@ -2335,7 +2250,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing2_tsu_sta_we),
+    .we     (timing2_we),
     .wd     (timing2_tsu_sta_wd),
 
     // from internal hardware
@@ -2361,7 +2276,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing2_thd_sta_we),
+    .we     (timing2_we),
     .wd     (timing2_thd_sta_wd),
 
     // from internal hardware
@@ -2389,7 +2304,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing3_tsu_dat_we),
+    .we     (timing3_we),
     .wd     (timing3_tsu_dat_wd),
 
     // from internal hardware
@@ -2415,7 +2330,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing3_thd_dat_we),
+    .we     (timing3_we),
     .wd     (timing3_thd_dat_wd),
 
     // from internal hardware
@@ -2443,7 +2358,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing4_tsu_sto_we),
+    .we     (timing4_we),
     .wd     (timing4_tsu_sto_wd),
 
     // from internal hardware
@@ -2469,7 +2384,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timing4_t_buf_we),
+    .we     (timing4_we),
     .wd     (timing4_t_buf_wd),
 
     // from internal hardware
@@ -2497,7 +2412,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timeout_ctrl_val_we),
+    .we     (timeout_ctrl_we),
     .wd     (timeout_ctrl_val_wd),
 
     // from internal hardware
@@ -2523,7 +2438,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timeout_ctrl_en_we),
+    .we     (timeout_ctrl_we),
     .wd     (timeout_ctrl_en_wd),
 
     // from internal hardware
@@ -2551,7 +2466,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (target_id_address0_we),
+    .we     (target_id_we),
     .wd     (target_id_address0_wd),
 
     // from internal hardware
@@ -2577,7 +2492,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (target_id_mask0_we),
+    .we     (target_id_we),
     .wd     (target_id_mask0_wd),
 
     // from internal hardware
@@ -2603,7 +2518,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (target_id_address1_we),
+    .we     (target_id_we),
     .wd     (target_id_address1_wd),
 
     // from internal hardware
@@ -2629,7 +2544,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (target_id_mask1_we),
+    .we     (target_id_we),
     .wd     (target_id_mask1_wd),
 
     // from internal hardware
@@ -2651,7 +2566,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (8)
   ) u_acqdata_abyte (
-    .re     (acqdata_abyte_re),
+    .re     (acqdata_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.acqdata.abyte.d),
@@ -2666,7 +2581,7 @@ module i2c_reg_top (
   prim_subreg_ext #(
     .DW    (2)
   ) u_acqdata_signal (
-    .re     (acqdata_signal_re),
+    .re     (acqdata_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.acqdata.signal.d),
@@ -2716,7 +2631,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stretch_ctrl_en_addr_tx_we),
+    .we     (stretch_ctrl_we),
     .wd     (stretch_ctrl_en_addr_tx_wd),
 
     // from internal hardware
@@ -2742,7 +2657,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stretch_ctrl_en_addr_acq_we),
+    .we     (stretch_ctrl_we),
     .wd     (stretch_ctrl_en_addr_acq_wd),
 
     // from internal hardware
@@ -2768,7 +2683,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stretch_ctrl_stop_tx_we),
+    .we     (stretch_ctrl_we),
     .wd     (stretch_ctrl_stop_tx_wd),
 
     // from internal hardware
@@ -2794,7 +2709,7 @@ module i2c_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stretch_ctrl_stop_acq_we),
+    .we     (stretch_ctrl_we),
     .wd     (stretch_ctrl_stop_acq_wd),
 
     // from internal hardware
@@ -2896,310 +2811,206 @@ module i2c_reg_top (
                (addr_hit[21] & (|(I2C_PERMIT[21] & ~reg_be))) |
                (addr_hit[22] & (|(I2C_PERMIT[22] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_fmt_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fmt_watermark_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_state_fmt_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fmt_overflow_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_state_nak_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_nak_wd = reg_wdata[4];
 
-  assign intr_state_scl_interference_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_scl_interference_wd = reg_wdata[5];
 
-  assign intr_state_sda_interference_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_sda_interference_wd = reg_wdata[6];
 
-  assign intr_state_stretch_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_stretch_timeout_wd = reg_wdata[7];
 
-  assign intr_state_sda_unstable_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_sda_unstable_wd = reg_wdata[8];
 
-  assign intr_state_trans_complete_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_trans_complete_wd = reg_wdata[9];
 
-  assign intr_state_tx_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_empty_wd = reg_wdata[10];
 
-  assign intr_state_tx_nonempty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_nonempty_wd = reg_wdata[11];
 
-  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_overflow_wd = reg_wdata[12];
 
-  assign intr_state_acq_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_acq_overflow_wd = reg_wdata[13];
 
-  assign intr_state_ack_stop_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_ack_stop_wd = reg_wdata[14];
 
-  assign intr_state_host_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_host_timeout_wd = reg_wdata[15];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_fmt_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fmt_watermark_wd = reg_wdata[0];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_enable_fmt_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fmt_overflow_wd = reg_wdata[2];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_enable_nak_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_nak_wd = reg_wdata[4];
 
-  assign intr_enable_scl_interference_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_scl_interference_wd = reg_wdata[5];
 
-  assign intr_enable_sda_interference_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_sda_interference_wd = reg_wdata[6];
 
-  assign intr_enable_stretch_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_stretch_timeout_wd = reg_wdata[7];
 
-  assign intr_enable_sda_unstable_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_sda_unstable_wd = reg_wdata[8];
 
-  assign intr_enable_trans_complete_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_trans_complete_wd = reg_wdata[9];
 
-  assign intr_enable_tx_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_empty_wd = reg_wdata[10];
 
-  assign intr_enable_tx_nonempty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_nonempty_wd = reg_wdata[11];
 
-  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_overflow_wd = reg_wdata[12];
 
-  assign intr_enable_acq_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_acq_overflow_wd = reg_wdata[13];
 
-  assign intr_enable_ack_stop_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_ack_stop_wd = reg_wdata[14];
 
-  assign intr_enable_host_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_host_timeout_wd = reg_wdata[15];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_fmt_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fmt_watermark_wd = reg_wdata[0];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_test_fmt_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fmt_overflow_wd = reg_wdata[2];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_test_nak_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_nak_wd = reg_wdata[4];
 
-  assign intr_test_scl_interference_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_scl_interference_wd = reg_wdata[5];
 
-  assign intr_test_sda_interference_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_sda_interference_wd = reg_wdata[6];
 
-  assign intr_test_stretch_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_stretch_timeout_wd = reg_wdata[7];
 
-  assign intr_test_sda_unstable_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_sda_unstable_wd = reg_wdata[8];
 
-  assign intr_test_trans_complete_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_trans_complete_wd = reg_wdata[9];
 
-  assign intr_test_tx_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_empty_wd = reg_wdata[10];
 
-  assign intr_test_tx_nonempty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_nonempty_wd = reg_wdata[11];
 
-  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_overflow_wd = reg_wdata[12];
 
-  assign intr_test_acq_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_acq_overflow_wd = reg_wdata[13];
 
-  assign intr_test_ack_stop_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_ack_stop_wd = reg_wdata[14];
 
-  assign intr_test_host_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_host_timeout_wd = reg_wdata[15];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
-  assign alert_test_wd = reg_wdata[0];
 
-  assign ctrl_enablehost_we = addr_hit[4] & reg_we & !reg_error;
+  assign alert_test_wd = reg_wdata[0];
+  assign ctrl_we = addr_hit[4] & reg_we & !reg_error;
+
   assign ctrl_enablehost_wd = reg_wdata[0];
 
-  assign ctrl_enabletarget_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_enabletarget_wd = reg_wdata[1];
 
-  assign ctrl_llpbk_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_llpbk_wd = reg_wdata[2];
-
-  assign status_fmtfull_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_rxfull_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_fmtempty_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_hostidle_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_targetidle_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_rxempty_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_txfull_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_acqfull_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_txempty_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_acqempty_re = addr_hit[5] & reg_re & !reg_error;
-
+  assign status_re = addr_hit[5] & reg_re & !reg_error;
   assign rdata_re = addr_hit[6] & reg_re & !reg_error;
+  assign fdata_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign fdata_fbyte_we = addr_hit[7] & reg_we & !reg_error;
   assign fdata_fbyte_wd = reg_wdata[7:0];
 
-  assign fdata_start_we = addr_hit[7] & reg_we & !reg_error;
   assign fdata_start_wd = reg_wdata[8];
 
-  assign fdata_stop_we = addr_hit[7] & reg_we & !reg_error;
   assign fdata_stop_wd = reg_wdata[9];
 
-  assign fdata_read_we = addr_hit[7] & reg_we & !reg_error;
   assign fdata_read_wd = reg_wdata[10];
 
-  assign fdata_rcont_we = addr_hit[7] & reg_we & !reg_error;
   assign fdata_rcont_wd = reg_wdata[11];
 
-  assign fdata_nakok_we = addr_hit[7] & reg_we & !reg_error;
   assign fdata_nakok_wd = reg_wdata[12];
+  assign fifo_ctrl_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign fifo_ctrl_rxrst_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_rxrst_wd = reg_wdata[0];
 
-  assign fifo_ctrl_fmtrst_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_fmtrst_wd = reg_wdata[1];
 
-  assign fifo_ctrl_rxilvl_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
-  assign fifo_ctrl_fmtilvl_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_fmtilvl_wd = reg_wdata[6:5];
 
-  assign fifo_ctrl_acqrst_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_acqrst_wd = reg_wdata[7];
 
-  assign fifo_ctrl_txrst_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_txrst_wd = reg_wdata[8];
+  assign fifo_status_re = addr_hit[9] & reg_re & !reg_error;
+  assign ovrd_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign fifo_status_fmtlvl_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign fifo_status_txlvl_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign fifo_status_rxlvl_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign fifo_status_acqlvl_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign ovrd_txovrden_we = addr_hit[10] & reg_we & !reg_error;
   assign ovrd_txovrden_wd = reg_wdata[0];
 
-  assign ovrd_sclval_we = addr_hit[10] & reg_we & !reg_error;
   assign ovrd_sclval_wd = reg_wdata[1];
 
-  assign ovrd_sdaval_we = addr_hit[10] & reg_we & !reg_error;
   assign ovrd_sdaval_wd = reg_wdata[2];
+  assign val_re = addr_hit[11] & reg_re & !reg_error;
+  assign timing0_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign val_scl_rx_re = addr_hit[11] & reg_re & !reg_error;
-
-  assign val_sda_rx_re = addr_hit[11] & reg_re & !reg_error;
-
-  assign timing0_thigh_we = addr_hit[12] & reg_we & !reg_error;
   assign timing0_thigh_wd = reg_wdata[15:0];
 
-  assign timing0_tlow_we = addr_hit[12] & reg_we & !reg_error;
   assign timing0_tlow_wd = reg_wdata[31:16];
+  assign timing1_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign timing1_t_r_we = addr_hit[13] & reg_we & !reg_error;
   assign timing1_t_r_wd = reg_wdata[15:0];
 
-  assign timing1_t_f_we = addr_hit[13] & reg_we & !reg_error;
   assign timing1_t_f_wd = reg_wdata[31:16];
+  assign timing2_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign timing2_tsu_sta_we = addr_hit[14] & reg_we & !reg_error;
   assign timing2_tsu_sta_wd = reg_wdata[15:0];
 
-  assign timing2_thd_sta_we = addr_hit[14] & reg_we & !reg_error;
   assign timing2_thd_sta_wd = reg_wdata[31:16];
+  assign timing3_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign timing3_tsu_dat_we = addr_hit[15] & reg_we & !reg_error;
   assign timing3_tsu_dat_wd = reg_wdata[15:0];
 
-  assign timing3_thd_dat_we = addr_hit[15] & reg_we & !reg_error;
   assign timing3_thd_dat_wd = reg_wdata[31:16];
+  assign timing4_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign timing4_tsu_sto_we = addr_hit[16] & reg_we & !reg_error;
   assign timing4_tsu_sto_wd = reg_wdata[15:0];
 
-  assign timing4_t_buf_we = addr_hit[16] & reg_we & !reg_error;
   assign timing4_t_buf_wd = reg_wdata[31:16];
+  assign timeout_ctrl_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign timeout_ctrl_val_we = addr_hit[17] & reg_we & !reg_error;
   assign timeout_ctrl_val_wd = reg_wdata[30:0];
 
-  assign timeout_ctrl_en_we = addr_hit[17] & reg_we & !reg_error;
   assign timeout_ctrl_en_wd = reg_wdata[31];
+  assign target_id_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign target_id_address0_we = addr_hit[18] & reg_we & !reg_error;
   assign target_id_address0_wd = reg_wdata[6:0];
 
-  assign target_id_mask0_we = addr_hit[18] & reg_we & !reg_error;
   assign target_id_mask0_wd = reg_wdata[13:7];
 
-  assign target_id_address1_we = addr_hit[18] & reg_we & !reg_error;
   assign target_id_address1_wd = reg_wdata[20:14];
 
-  assign target_id_mask1_we = addr_hit[18] & reg_we & !reg_error;
   assign target_id_mask1_wd = reg_wdata[27:21];
-
-  assign acqdata_abyte_re = addr_hit[19] & reg_re & !reg_error;
-
-  assign acqdata_signal_re = addr_hit[19] & reg_re & !reg_error;
-
+  assign acqdata_re = addr_hit[19] & reg_re & !reg_error;
   assign txdata_we = addr_hit[20] & reg_we & !reg_error;
-  assign txdata_wd = reg_wdata[7:0];
 
-  assign stretch_ctrl_en_addr_tx_we = addr_hit[21] & reg_we & !reg_error;
+  assign txdata_wd = reg_wdata[7:0];
+  assign stretch_ctrl_we = addr_hit[21] & reg_we & !reg_error;
+
   assign stretch_ctrl_en_addr_tx_wd = reg_wdata[0];
 
-  assign stretch_ctrl_en_addr_acq_we = addr_hit[21] & reg_we & !reg_error;
   assign stretch_ctrl_en_addr_acq_wd = reg_wdata[1];
 
-  assign stretch_ctrl_stop_tx_we = addr_hit[21] & reg_we & !reg_error;
   assign stretch_ctrl_stop_tx_wd = reg_wdata[2];
 
-  assign stretch_ctrl_stop_acq_we = addr_hit[21] & reg_we & !reg_error;
   assign stretch_ctrl_stop_acq_wd = reg_wdata[3];
-
   assign host_timeout_ctrl_we = addr_hit[22] & reg_we & !reg_error;
+
   assign host_timeout_ctrl_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -104,172 +104,166 @@ module keymgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_qs;
   logic intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
-  logic intr_enable_we;
-  logic intr_test_wd;
   logic intr_test_we;
+  logic intr_test_wd;
+  logic alert_test_we;
   logic alert_test_fatal_fault_err_wd;
-  logic alert_test_fatal_fault_err_we;
   logic alert_test_recov_operation_err_wd;
-  logic alert_test_recov_operation_err_we;
-  logic cfg_regwen_qs;
   logic cfg_regwen_re;
+  logic cfg_regwen_qs;
+  logic control_we;
   logic control_start_qs;
   logic control_start_wd;
-  logic control_start_we;
   logic [2:0] control_operation_qs;
   logic [2:0] control_operation_wd;
-  logic control_operation_we;
   logic [1:0] control_dest_sel_qs;
   logic [1:0] control_dest_sel_wd;
-  logic control_dest_sel_we;
+  logic sideload_clear_we;
   logic sideload_clear_qs;
   logic sideload_clear_wd;
-  logic sideload_clear_we;
+  logic reseed_interval_we;
   logic [15:0] reseed_interval_qs;
   logic [15:0] reseed_interval_wd;
-  logic reseed_interval_we;
+  logic sw_binding_regwen_re;
+  logic sw_binding_regwen_we;
   logic sw_binding_regwen_qs;
   logic sw_binding_regwen_wd;
-  logic sw_binding_regwen_we;
-  logic sw_binding_regwen_re;
+  logic sw_binding_0_we;
   logic [31:0] sw_binding_0_qs;
   logic [31:0] sw_binding_0_wd;
-  logic sw_binding_0_we;
+  logic sw_binding_1_we;
   logic [31:0] sw_binding_1_qs;
   logic [31:0] sw_binding_1_wd;
-  logic sw_binding_1_we;
+  logic sw_binding_2_we;
   logic [31:0] sw_binding_2_qs;
   logic [31:0] sw_binding_2_wd;
-  logic sw_binding_2_we;
+  logic sw_binding_3_we;
   logic [31:0] sw_binding_3_qs;
   logic [31:0] sw_binding_3_wd;
-  logic sw_binding_3_we;
+  logic sw_binding_4_we;
   logic [31:0] sw_binding_4_qs;
   logic [31:0] sw_binding_4_wd;
-  logic sw_binding_4_we;
+  logic sw_binding_5_we;
   logic [31:0] sw_binding_5_qs;
   logic [31:0] sw_binding_5_wd;
-  logic sw_binding_5_we;
+  logic sw_binding_6_we;
   logic [31:0] sw_binding_6_qs;
   logic [31:0] sw_binding_6_wd;
-  logic sw_binding_6_we;
+  logic sw_binding_7_we;
   logic [31:0] sw_binding_7_qs;
   logic [31:0] sw_binding_7_wd;
-  logic sw_binding_7_we;
+  logic salt_0_we;
   logic [31:0] salt_0_qs;
   logic [31:0] salt_0_wd;
-  logic salt_0_we;
+  logic salt_1_we;
   logic [31:0] salt_1_qs;
   logic [31:0] salt_1_wd;
-  logic salt_1_we;
+  logic salt_2_we;
   logic [31:0] salt_2_qs;
   logic [31:0] salt_2_wd;
-  logic salt_2_we;
+  logic salt_3_we;
   logic [31:0] salt_3_qs;
   logic [31:0] salt_3_wd;
-  logic salt_3_we;
+  logic salt_4_we;
   logic [31:0] salt_4_qs;
   logic [31:0] salt_4_wd;
-  logic salt_4_we;
+  logic salt_5_we;
   logic [31:0] salt_5_qs;
   logic [31:0] salt_5_wd;
-  logic salt_5_we;
+  logic salt_6_we;
   logic [31:0] salt_6_qs;
   logic [31:0] salt_6_wd;
-  logic salt_6_we;
+  logic salt_7_we;
   logic [31:0] salt_7_qs;
   logic [31:0] salt_7_wd;
-  logic salt_7_we;
+  logic key_version_we;
   logic [31:0] key_version_qs;
   logic [31:0] key_version_wd;
-  logic key_version_we;
+  logic max_creator_key_ver_regwen_we;
   logic max_creator_key_ver_regwen_qs;
   logic max_creator_key_ver_regwen_wd;
-  logic max_creator_key_ver_regwen_we;
+  logic max_creator_key_ver_we;
   logic [31:0] max_creator_key_ver_qs;
   logic [31:0] max_creator_key_ver_wd;
-  logic max_creator_key_ver_we;
+  logic max_owner_int_key_ver_regwen_we;
   logic max_owner_int_key_ver_regwen_qs;
   logic max_owner_int_key_ver_regwen_wd;
-  logic max_owner_int_key_ver_regwen_we;
+  logic max_owner_int_key_ver_we;
   logic [31:0] max_owner_int_key_ver_qs;
   logic [31:0] max_owner_int_key_ver_wd;
-  logic max_owner_int_key_ver_we;
+  logic max_owner_key_ver_regwen_we;
   logic max_owner_key_ver_regwen_qs;
   logic max_owner_key_ver_regwen_wd;
-  logic max_owner_key_ver_regwen_we;
+  logic max_owner_key_ver_we;
   logic [31:0] max_owner_key_ver_qs;
   logic [31:0] max_owner_key_ver_wd;
-  logic max_owner_key_ver_we;
+  logic sw_share0_output_0_re;
   logic [31:0] sw_share0_output_0_qs;
   logic [31:0] sw_share0_output_0_wd;
-  logic sw_share0_output_0_we;
+  logic sw_share0_output_1_re;
   logic [31:0] sw_share0_output_1_qs;
   logic [31:0] sw_share0_output_1_wd;
-  logic sw_share0_output_1_we;
+  logic sw_share0_output_2_re;
   logic [31:0] sw_share0_output_2_qs;
   logic [31:0] sw_share0_output_2_wd;
-  logic sw_share0_output_2_we;
+  logic sw_share0_output_3_re;
   logic [31:0] sw_share0_output_3_qs;
   logic [31:0] sw_share0_output_3_wd;
-  logic sw_share0_output_3_we;
+  logic sw_share0_output_4_re;
   logic [31:0] sw_share0_output_4_qs;
   logic [31:0] sw_share0_output_4_wd;
-  logic sw_share0_output_4_we;
+  logic sw_share0_output_5_re;
   logic [31:0] sw_share0_output_5_qs;
   logic [31:0] sw_share0_output_5_wd;
-  logic sw_share0_output_5_we;
+  logic sw_share0_output_6_re;
   logic [31:0] sw_share0_output_6_qs;
   logic [31:0] sw_share0_output_6_wd;
-  logic sw_share0_output_6_we;
+  logic sw_share0_output_7_re;
   logic [31:0] sw_share0_output_7_qs;
   logic [31:0] sw_share0_output_7_wd;
-  logic sw_share0_output_7_we;
+  logic sw_share1_output_0_re;
   logic [31:0] sw_share1_output_0_qs;
   logic [31:0] sw_share1_output_0_wd;
-  logic sw_share1_output_0_we;
+  logic sw_share1_output_1_re;
   logic [31:0] sw_share1_output_1_qs;
   logic [31:0] sw_share1_output_1_wd;
-  logic sw_share1_output_1_we;
+  logic sw_share1_output_2_re;
   logic [31:0] sw_share1_output_2_qs;
   logic [31:0] sw_share1_output_2_wd;
-  logic sw_share1_output_2_we;
+  logic sw_share1_output_3_re;
   logic [31:0] sw_share1_output_3_qs;
   logic [31:0] sw_share1_output_3_wd;
-  logic sw_share1_output_3_we;
+  logic sw_share1_output_4_re;
   logic [31:0] sw_share1_output_4_qs;
   logic [31:0] sw_share1_output_4_wd;
-  logic sw_share1_output_4_we;
+  logic sw_share1_output_5_re;
   logic [31:0] sw_share1_output_5_qs;
   logic [31:0] sw_share1_output_5_wd;
-  logic sw_share1_output_5_we;
+  logic sw_share1_output_6_re;
   logic [31:0] sw_share1_output_6_qs;
   logic [31:0] sw_share1_output_6_wd;
-  logic sw_share1_output_6_we;
+  logic sw_share1_output_7_re;
   logic [31:0] sw_share1_output_7_qs;
   logic [31:0] sw_share1_output_7_wd;
-  logic sw_share1_output_7_we;
   logic [2:0] working_state_qs;
+  logic op_status_we;
   logic [1:0] op_status_qs;
   logic [1:0] op_status_wd;
-  logic op_status_we;
+  logic err_code_we;
   logic err_code_invalid_op_qs;
   logic err_code_invalid_op_wd;
-  logic err_code_invalid_op_we;
   logic err_code_invalid_cmd_qs;
   logic err_code_invalid_cmd_wd;
-  logic err_code_invalid_cmd_we;
   logic err_code_invalid_kmac_input_qs;
   logic err_code_invalid_kmac_input_wd;
-  logic err_code_invalid_kmac_input_we;
   logic err_code_invalid_kmac_data_qs;
   logic err_code_invalid_kmac_data_wd;
-  logic err_code_invalid_kmac_data_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -349,7 +343,7 @@ module keymgr_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_fault_err (
     .re     (1'b0),
-    .we     (alert_test_fatal_fault_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_fault_err_wd),
     .d      ('0),
     .qre    (),
@@ -364,7 +358,7 @@ module keymgr_reg_top (
     .DW    (1)
   ) u_alert_test_recov_operation_err (
     .re     (1'b0),
-    .we     (alert_test_recov_operation_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_operation_err_wd),
     .d      ('0),
     .qre    (),
@@ -402,7 +396,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_start_we & cfg_regwen_qs),
+    .we     (control_we & cfg_regwen_qs),
     .wd     (control_start_wd),
 
     // from internal hardware
@@ -428,7 +422,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_operation_we & cfg_regwen_qs),
+    .we     (control_we & cfg_regwen_qs),
     .wd     (control_operation_wd),
 
     // from internal hardware
@@ -454,7 +448,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_dest_sel_we & cfg_regwen_qs),
+    .we     (control_we & cfg_regwen_qs),
     .wd     (control_dest_sel_wd),
 
     // from internal hardware
@@ -1180,7 +1174,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_0_we),
+    .we     (sw_share0_output_0_re),
     .wd     (sw_share0_output_0_wd),
 
     // from internal hardware
@@ -1207,7 +1201,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_1_we),
+    .we     (sw_share0_output_1_re),
     .wd     (sw_share0_output_1_wd),
 
     // from internal hardware
@@ -1234,7 +1228,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_2_we),
+    .we     (sw_share0_output_2_re),
     .wd     (sw_share0_output_2_wd),
 
     // from internal hardware
@@ -1261,7 +1255,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_3_we),
+    .we     (sw_share0_output_3_re),
     .wd     (sw_share0_output_3_wd),
 
     // from internal hardware
@@ -1288,7 +1282,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_4_we),
+    .we     (sw_share0_output_4_re),
     .wd     (sw_share0_output_4_wd),
 
     // from internal hardware
@@ -1315,7 +1309,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_5_we),
+    .we     (sw_share0_output_5_re),
     .wd     (sw_share0_output_5_wd),
 
     // from internal hardware
@@ -1342,7 +1336,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_6_we),
+    .we     (sw_share0_output_6_re),
     .wd     (sw_share0_output_6_wd),
 
     // from internal hardware
@@ -1369,7 +1363,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share0_output_7_we),
+    .we     (sw_share0_output_7_re),
     .wd     (sw_share0_output_7_wd),
 
     // from internal hardware
@@ -1398,7 +1392,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_0_we),
+    .we     (sw_share1_output_0_re),
     .wd     (sw_share1_output_0_wd),
 
     // from internal hardware
@@ -1425,7 +1419,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_1_we),
+    .we     (sw_share1_output_1_re),
     .wd     (sw_share1_output_1_wd),
 
     // from internal hardware
@@ -1452,7 +1446,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_2_we),
+    .we     (sw_share1_output_2_re),
     .wd     (sw_share1_output_2_wd),
 
     // from internal hardware
@@ -1479,7 +1473,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_3_we),
+    .we     (sw_share1_output_3_re),
     .wd     (sw_share1_output_3_wd),
 
     // from internal hardware
@@ -1506,7 +1500,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_4_we),
+    .we     (sw_share1_output_4_re),
     .wd     (sw_share1_output_4_wd),
 
     // from internal hardware
@@ -1533,7 +1527,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_5_we),
+    .we     (sw_share1_output_5_re),
     .wd     (sw_share1_output_5_wd),
 
     // from internal hardware
@@ -1560,7 +1554,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_6_we),
+    .we     (sw_share1_output_6_re),
     .wd     (sw_share1_output_6_wd),
 
     // from internal hardware
@@ -1587,7 +1581,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_share1_output_7_we),
+    .we     (sw_share1_output_7_re),
     .wd     (sw_share1_output_7_wd),
 
     // from internal hardware
@@ -1669,7 +1663,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_invalid_op_we),
+    .we     (err_code_we),
     .wd     (err_code_invalid_op_wd),
 
     // from internal hardware
@@ -1695,7 +1689,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_invalid_cmd_we),
+    .we     (err_code_we),
     .wd     (err_code_invalid_cmd_wd),
 
     // from internal hardware
@@ -1721,7 +1715,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_invalid_kmac_input_we),
+    .we     (err_code_we),
     .wd     (err_code_invalid_kmac_input_wd),
 
     // from internal hardware
@@ -1747,7 +1741,7 @@ module keymgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_invalid_kmac_data_we),
+    .we     (err_code_we),
     .wd     (err_code_invalid_kmac_data_wd),
 
     // from internal hardware
@@ -1878,173 +1872,166 @@ module keymgr_reg_top (
                (addr_hit[49] & (|(KEYMGR_PERMIT[49] & ~reg_be))) |
                (addr_hit[50] & (|(KEYMGR_PERMIT[50] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
-  assign intr_test_wd = reg_wdata[0];
 
-  assign alert_test_fatal_fault_err_we = addr_hit[3] & reg_we & !reg_error;
+  assign intr_test_wd = reg_wdata[0];
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_fatal_fault_err_wd = reg_wdata[0];
 
-  assign alert_test_recov_operation_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_operation_err_wd = reg_wdata[1];
-
   assign cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
+  assign control_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign control_start_we = addr_hit[5] & reg_we & !reg_error;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_operation_we = addr_hit[5] & reg_we & !reg_error;
   assign control_operation_wd = reg_wdata[6:4];
 
-  assign control_dest_sel_we = addr_hit[5] & reg_we & !reg_error;
   assign control_dest_sel_wd = reg_wdata[13:12];
-
   assign sideload_clear_we = addr_hit[6] & reg_we & !reg_error;
+
   assign sideload_clear_wd = reg_wdata[0];
-
   assign reseed_interval_we = addr_hit[7] & reg_we & !reg_error;
+
   assign reseed_interval_wd = reg_wdata[15:0];
-
-  assign sw_binding_regwen_we = addr_hit[8] & reg_we & !reg_error;
-  assign sw_binding_regwen_wd = reg_wdata[0];
   assign sw_binding_regwen_re = addr_hit[8] & reg_re & !reg_error;
+  assign sw_binding_regwen_we = addr_hit[8] & reg_we & !reg_error;
 
+  assign sw_binding_regwen_wd = reg_wdata[0];
   assign sw_binding_0_we = addr_hit[9] & reg_we & !reg_error;
+
   assign sw_binding_0_wd = reg_wdata[31:0];
-
   assign sw_binding_1_we = addr_hit[10] & reg_we & !reg_error;
+
   assign sw_binding_1_wd = reg_wdata[31:0];
-
   assign sw_binding_2_we = addr_hit[11] & reg_we & !reg_error;
+
   assign sw_binding_2_wd = reg_wdata[31:0];
-
   assign sw_binding_3_we = addr_hit[12] & reg_we & !reg_error;
+
   assign sw_binding_3_wd = reg_wdata[31:0];
-
   assign sw_binding_4_we = addr_hit[13] & reg_we & !reg_error;
+
   assign sw_binding_4_wd = reg_wdata[31:0];
-
   assign sw_binding_5_we = addr_hit[14] & reg_we & !reg_error;
+
   assign sw_binding_5_wd = reg_wdata[31:0];
-
   assign sw_binding_6_we = addr_hit[15] & reg_we & !reg_error;
+
   assign sw_binding_6_wd = reg_wdata[31:0];
-
   assign sw_binding_7_we = addr_hit[16] & reg_we & !reg_error;
+
   assign sw_binding_7_wd = reg_wdata[31:0];
-
   assign salt_0_we = addr_hit[17] & reg_we & !reg_error;
+
   assign salt_0_wd = reg_wdata[31:0];
-
   assign salt_1_we = addr_hit[18] & reg_we & !reg_error;
+
   assign salt_1_wd = reg_wdata[31:0];
-
   assign salt_2_we = addr_hit[19] & reg_we & !reg_error;
+
   assign salt_2_wd = reg_wdata[31:0];
-
   assign salt_3_we = addr_hit[20] & reg_we & !reg_error;
+
   assign salt_3_wd = reg_wdata[31:0];
-
   assign salt_4_we = addr_hit[21] & reg_we & !reg_error;
+
   assign salt_4_wd = reg_wdata[31:0];
-
   assign salt_5_we = addr_hit[22] & reg_we & !reg_error;
+
   assign salt_5_wd = reg_wdata[31:0];
-
   assign salt_6_we = addr_hit[23] & reg_we & !reg_error;
+
   assign salt_6_wd = reg_wdata[31:0];
-
   assign salt_7_we = addr_hit[24] & reg_we & !reg_error;
+
   assign salt_7_wd = reg_wdata[31:0];
-
   assign key_version_we = addr_hit[25] & reg_we & !reg_error;
+
   assign key_version_wd = reg_wdata[31:0];
-
   assign max_creator_key_ver_regwen_we = addr_hit[26] & reg_we & !reg_error;
+
   assign max_creator_key_ver_regwen_wd = reg_wdata[0];
-
   assign max_creator_key_ver_we = addr_hit[27] & reg_we & !reg_error;
+
   assign max_creator_key_ver_wd = reg_wdata[31:0];
-
   assign max_owner_int_key_ver_regwen_we = addr_hit[28] & reg_we & !reg_error;
+
   assign max_owner_int_key_ver_regwen_wd = reg_wdata[0];
-
   assign max_owner_int_key_ver_we = addr_hit[29] & reg_we & !reg_error;
+
   assign max_owner_int_key_ver_wd = reg_wdata[31:0];
-
   assign max_owner_key_ver_regwen_we = addr_hit[30] & reg_we & !reg_error;
+
   assign max_owner_key_ver_regwen_wd = reg_wdata[0];
-
   assign max_owner_key_ver_we = addr_hit[31] & reg_we & !reg_error;
+
   assign max_owner_key_ver_wd = reg_wdata[31:0];
+  assign sw_share0_output_0_re = addr_hit[32] & reg_re & !reg_error;
 
-  assign sw_share0_output_0_we = addr_hit[32] & reg_re & !reg_error;
   assign sw_share0_output_0_wd = '1;
+  assign sw_share0_output_1_re = addr_hit[33] & reg_re & !reg_error;
 
-  assign sw_share0_output_1_we = addr_hit[33] & reg_re & !reg_error;
   assign sw_share0_output_1_wd = '1;
+  assign sw_share0_output_2_re = addr_hit[34] & reg_re & !reg_error;
 
-  assign sw_share0_output_2_we = addr_hit[34] & reg_re & !reg_error;
   assign sw_share0_output_2_wd = '1;
+  assign sw_share0_output_3_re = addr_hit[35] & reg_re & !reg_error;
 
-  assign sw_share0_output_3_we = addr_hit[35] & reg_re & !reg_error;
   assign sw_share0_output_3_wd = '1;
+  assign sw_share0_output_4_re = addr_hit[36] & reg_re & !reg_error;
 
-  assign sw_share0_output_4_we = addr_hit[36] & reg_re & !reg_error;
   assign sw_share0_output_4_wd = '1;
+  assign sw_share0_output_5_re = addr_hit[37] & reg_re & !reg_error;
 
-  assign sw_share0_output_5_we = addr_hit[37] & reg_re & !reg_error;
   assign sw_share0_output_5_wd = '1;
+  assign sw_share0_output_6_re = addr_hit[38] & reg_re & !reg_error;
 
-  assign sw_share0_output_6_we = addr_hit[38] & reg_re & !reg_error;
   assign sw_share0_output_6_wd = '1;
+  assign sw_share0_output_7_re = addr_hit[39] & reg_re & !reg_error;
 
-  assign sw_share0_output_7_we = addr_hit[39] & reg_re & !reg_error;
   assign sw_share0_output_7_wd = '1;
+  assign sw_share1_output_0_re = addr_hit[40] & reg_re & !reg_error;
 
-  assign sw_share1_output_0_we = addr_hit[40] & reg_re & !reg_error;
   assign sw_share1_output_0_wd = '1;
+  assign sw_share1_output_1_re = addr_hit[41] & reg_re & !reg_error;
 
-  assign sw_share1_output_1_we = addr_hit[41] & reg_re & !reg_error;
   assign sw_share1_output_1_wd = '1;
+  assign sw_share1_output_2_re = addr_hit[42] & reg_re & !reg_error;
 
-  assign sw_share1_output_2_we = addr_hit[42] & reg_re & !reg_error;
   assign sw_share1_output_2_wd = '1;
+  assign sw_share1_output_3_re = addr_hit[43] & reg_re & !reg_error;
 
-  assign sw_share1_output_3_we = addr_hit[43] & reg_re & !reg_error;
   assign sw_share1_output_3_wd = '1;
+  assign sw_share1_output_4_re = addr_hit[44] & reg_re & !reg_error;
 
-  assign sw_share1_output_4_we = addr_hit[44] & reg_re & !reg_error;
   assign sw_share1_output_4_wd = '1;
+  assign sw_share1_output_5_re = addr_hit[45] & reg_re & !reg_error;
 
-  assign sw_share1_output_5_we = addr_hit[45] & reg_re & !reg_error;
   assign sw_share1_output_5_wd = '1;
+  assign sw_share1_output_6_re = addr_hit[46] & reg_re & !reg_error;
 
-  assign sw_share1_output_6_we = addr_hit[46] & reg_re & !reg_error;
   assign sw_share1_output_6_wd = '1;
+  assign sw_share1_output_7_re = addr_hit[47] & reg_re & !reg_error;
 
-  assign sw_share1_output_7_we = addr_hit[47] & reg_re & !reg_error;
   assign sw_share1_output_7_wd = '1;
-
   assign op_status_we = addr_hit[49] & reg_we & !reg_error;
-  assign op_status_wd = reg_wdata[1:0];
 
-  assign err_code_invalid_op_we = addr_hit[50] & reg_we & !reg_error;
+  assign op_status_wd = reg_wdata[1:0];
+  assign err_code_we = addr_hit[50] & reg_we & !reg_error;
+
   assign err_code_invalid_op_wd = reg_wdata[0];
 
-  assign err_code_invalid_cmd_we = addr_hit[50] & reg_we & !reg_error;
   assign err_code_invalid_cmd_wd = reg_wdata[1];
 
-  assign err_code_invalid_kmac_input_we = addr_hit[50] & reg_we & !reg_error;
   assign err_code_invalid_kmac_input_wd = reg_wdata[2];
 
-  assign err_code_invalid_kmac_data_we = addr_hit[50] & reg_we & !reg_error;
   assign err_code_invalid_kmac_data_wd = reg_wdata[3];
 
   // Read data return

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -157,189 +157,168 @@ module kmac_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_kmac_done_qs;
   logic intr_state_kmac_done_wd;
-  logic intr_state_kmac_done_we;
   logic intr_state_fifo_empty_qs;
   logic intr_state_fifo_empty_wd;
-  logic intr_state_fifo_empty_we;
   logic intr_state_kmac_err_qs;
   logic intr_state_kmac_err_wd;
-  logic intr_state_kmac_err_we;
+  logic intr_enable_we;
   logic intr_enable_kmac_done_qs;
   logic intr_enable_kmac_done_wd;
-  logic intr_enable_kmac_done_we;
   logic intr_enable_fifo_empty_qs;
   logic intr_enable_fifo_empty_wd;
-  logic intr_enable_fifo_empty_we;
   logic intr_enable_kmac_err_qs;
   logic intr_enable_kmac_err_wd;
-  logic intr_enable_kmac_err_we;
+  logic intr_test_we;
   logic intr_test_kmac_done_wd;
-  logic intr_test_kmac_done_we;
   logic intr_test_fifo_empty_wd;
-  logic intr_test_fifo_empty_we;
   logic intr_test_kmac_err_wd;
-  logic intr_test_kmac_err_we;
-  logic alert_test_wd;
   logic alert_test_we;
-  logic cfg_regwen_qs;
+  logic alert_test_wd;
   logic cfg_regwen_re;
+  logic cfg_regwen_qs;
+  logic cfg_we;
   logic cfg_kmac_en_qs;
   logic cfg_kmac_en_wd;
-  logic cfg_kmac_en_we;
   logic [2:0] cfg_kstrength_qs;
   logic [2:0] cfg_kstrength_wd;
-  logic cfg_kstrength_we;
   logic [1:0] cfg_mode_qs;
   logic [1:0] cfg_mode_wd;
-  logic cfg_mode_we;
   logic cfg_msg_endianness_qs;
   logic cfg_msg_endianness_wd;
-  logic cfg_msg_endianness_we;
   logic cfg_state_endianness_qs;
   logic cfg_state_endianness_wd;
-  logic cfg_state_endianness_we;
   logic cfg_sideload_qs;
   logic cfg_sideload_wd;
-  logic cfg_sideload_we;
   logic [1:0] cfg_entropy_mode_qs;
   logic [1:0] cfg_entropy_mode_wd;
-  logic cfg_entropy_mode_we;
   logic cfg_entropy_fast_process_qs;
   logic cfg_entropy_fast_process_wd;
-  logic cfg_entropy_fast_process_we;
   logic cfg_entropy_ready_qs;
   logic cfg_entropy_ready_wd;
-  logic cfg_entropy_ready_we;
   logic cfg_err_processed_qs;
   logic cfg_err_processed_wd;
-  logic cfg_err_processed_we;
-  logic [3:0] cmd_wd;
   logic cmd_we;
+  logic [3:0] cmd_wd;
+  logic status_re;
   logic status_sha3_idle_qs;
-  logic status_sha3_idle_re;
   logic status_sha3_absorb_qs;
-  logic status_sha3_absorb_re;
   logic status_sha3_squeeze_qs;
-  logic status_sha3_squeeze_re;
   logic [4:0] status_fifo_depth_qs;
-  logic status_fifo_depth_re;
   logic status_fifo_empty_qs;
-  logic status_fifo_empty_re;
   logic status_fifo_full_qs;
-  logic status_fifo_full_re;
+  logic entropy_period_we;
   logic [15:0] entropy_period_entropy_timer_qs;
   logic [15:0] entropy_period_entropy_timer_wd;
-  logic entropy_period_entropy_timer_we;
   logic [15:0] entropy_period_wait_timer_qs;
   logic [15:0] entropy_period_wait_timer_wd;
-  logic entropy_period_wait_timer_we;
+  logic entropy_seed_lower_we;
   logic [31:0] entropy_seed_lower_qs;
   logic [31:0] entropy_seed_lower_wd;
-  logic entropy_seed_lower_we;
+  logic entropy_seed_upper_we;
   logic [31:0] entropy_seed_upper_qs;
   logic [31:0] entropy_seed_upper_wd;
-  logic entropy_seed_upper_we;
-  logic [31:0] key_share0_0_wd;
   logic key_share0_0_we;
-  logic [31:0] key_share0_1_wd;
+  logic [31:0] key_share0_0_wd;
   logic key_share0_1_we;
-  logic [31:0] key_share0_2_wd;
+  logic [31:0] key_share0_1_wd;
   logic key_share0_2_we;
-  logic [31:0] key_share0_3_wd;
+  logic [31:0] key_share0_2_wd;
   logic key_share0_3_we;
-  logic [31:0] key_share0_4_wd;
+  logic [31:0] key_share0_3_wd;
   logic key_share0_4_we;
-  logic [31:0] key_share0_5_wd;
+  logic [31:0] key_share0_4_wd;
   logic key_share0_5_we;
-  logic [31:0] key_share0_6_wd;
+  logic [31:0] key_share0_5_wd;
   logic key_share0_6_we;
-  logic [31:0] key_share0_7_wd;
+  logic [31:0] key_share0_6_wd;
   logic key_share0_7_we;
-  logic [31:0] key_share0_8_wd;
+  logic [31:0] key_share0_7_wd;
   logic key_share0_8_we;
-  logic [31:0] key_share0_9_wd;
+  logic [31:0] key_share0_8_wd;
   logic key_share0_9_we;
-  logic [31:0] key_share0_10_wd;
+  logic [31:0] key_share0_9_wd;
   logic key_share0_10_we;
-  logic [31:0] key_share0_11_wd;
+  logic [31:0] key_share0_10_wd;
   logic key_share0_11_we;
-  logic [31:0] key_share0_12_wd;
+  logic [31:0] key_share0_11_wd;
   logic key_share0_12_we;
-  logic [31:0] key_share0_13_wd;
+  logic [31:0] key_share0_12_wd;
   logic key_share0_13_we;
-  logic [31:0] key_share0_14_wd;
+  logic [31:0] key_share0_13_wd;
   logic key_share0_14_we;
-  logic [31:0] key_share0_15_wd;
+  logic [31:0] key_share0_14_wd;
   logic key_share0_15_we;
-  logic [31:0] key_share1_0_wd;
+  logic [31:0] key_share0_15_wd;
   logic key_share1_0_we;
-  logic [31:0] key_share1_1_wd;
+  logic [31:0] key_share1_0_wd;
   logic key_share1_1_we;
-  logic [31:0] key_share1_2_wd;
+  logic [31:0] key_share1_1_wd;
   logic key_share1_2_we;
-  logic [31:0] key_share1_3_wd;
+  logic [31:0] key_share1_2_wd;
   logic key_share1_3_we;
-  logic [31:0] key_share1_4_wd;
+  logic [31:0] key_share1_3_wd;
   logic key_share1_4_we;
-  logic [31:0] key_share1_5_wd;
+  logic [31:0] key_share1_4_wd;
   logic key_share1_5_we;
-  logic [31:0] key_share1_6_wd;
+  logic [31:0] key_share1_5_wd;
   logic key_share1_6_we;
-  logic [31:0] key_share1_7_wd;
+  logic [31:0] key_share1_6_wd;
   logic key_share1_7_we;
-  logic [31:0] key_share1_8_wd;
+  logic [31:0] key_share1_7_wd;
   logic key_share1_8_we;
-  logic [31:0] key_share1_9_wd;
+  logic [31:0] key_share1_8_wd;
   logic key_share1_9_we;
-  logic [31:0] key_share1_10_wd;
+  logic [31:0] key_share1_9_wd;
   logic key_share1_10_we;
-  logic [31:0] key_share1_11_wd;
+  logic [31:0] key_share1_10_wd;
   logic key_share1_11_we;
-  logic [31:0] key_share1_12_wd;
+  logic [31:0] key_share1_11_wd;
   logic key_share1_12_we;
-  logic [31:0] key_share1_13_wd;
+  logic [31:0] key_share1_12_wd;
   logic key_share1_13_we;
-  logic [31:0] key_share1_14_wd;
+  logic [31:0] key_share1_13_wd;
   logic key_share1_14_we;
-  logic [31:0] key_share1_15_wd;
+  logic [31:0] key_share1_14_wd;
   logic key_share1_15_we;
-  logic [2:0] key_len_wd;
+  logic [31:0] key_share1_15_wd;
   logic key_len_we;
+  logic [2:0] key_len_wd;
+  logic prefix_0_we;
   logic [31:0] prefix_0_qs;
   logic [31:0] prefix_0_wd;
-  logic prefix_0_we;
+  logic prefix_1_we;
   logic [31:0] prefix_1_qs;
   logic [31:0] prefix_1_wd;
-  logic prefix_1_we;
+  logic prefix_2_we;
   logic [31:0] prefix_2_qs;
   logic [31:0] prefix_2_wd;
-  logic prefix_2_we;
+  logic prefix_3_we;
   logic [31:0] prefix_3_qs;
   logic [31:0] prefix_3_wd;
-  logic prefix_3_we;
+  logic prefix_4_we;
   logic [31:0] prefix_4_qs;
   logic [31:0] prefix_4_wd;
-  logic prefix_4_we;
+  logic prefix_5_we;
   logic [31:0] prefix_5_qs;
   logic [31:0] prefix_5_wd;
-  logic prefix_5_we;
+  logic prefix_6_we;
   logic [31:0] prefix_6_qs;
   logic [31:0] prefix_6_wd;
-  logic prefix_6_we;
+  logic prefix_7_we;
   logic [31:0] prefix_7_qs;
   logic [31:0] prefix_7_wd;
-  logic prefix_7_we;
+  logic prefix_8_we;
   logic [31:0] prefix_8_qs;
   logic [31:0] prefix_8_wd;
-  logic prefix_8_we;
+  logic prefix_9_we;
   logic [31:0] prefix_9_qs;
   logic [31:0] prefix_9_wd;
-  logic prefix_9_we;
+  logic prefix_10_we;
   logic [31:0] prefix_10_qs;
   logic [31:0] prefix_10_wd;
-  logic prefix_10_we;
   logic [31:0] err_code_qs;
 
   // Register instances
@@ -355,7 +334,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_kmac_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_kmac_done_wd),
 
     // from internal hardware
@@ -381,7 +360,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_fifo_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_fifo_empty_wd),
 
     // from internal hardware
@@ -407,7 +386,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_kmac_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_kmac_err_wd),
 
     // from internal hardware
@@ -435,7 +414,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_kmac_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_kmac_done_wd),
 
     // from internal hardware
@@ -461,7 +440,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_fifo_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_fifo_empty_wd),
 
     // from internal hardware
@@ -487,7 +466,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_kmac_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_kmac_err_wd),
 
     // from internal hardware
@@ -510,7 +489,7 @@ module kmac_reg_top (
     .DW    (1)
   ) u_intr_test_kmac_done (
     .re     (1'b0),
-    .we     (intr_test_kmac_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_kmac_done_wd),
     .d      ('0),
     .qre    (),
@@ -525,7 +504,7 @@ module kmac_reg_top (
     .DW    (1)
   ) u_intr_test_fifo_empty (
     .re     (1'b0),
-    .we     (intr_test_fifo_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_fifo_empty_wd),
     .d      ('0),
     .qre    (),
@@ -540,7 +519,7 @@ module kmac_reg_top (
     .DW    (1)
   ) u_intr_test_kmac_err (
     .re     (1'b0),
-    .we     (intr_test_kmac_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_kmac_err_wd),
     .d      ('0),
     .qre    (),
@@ -594,7 +573,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_kmac_en_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_kmac_en_wd),
 
     // from internal hardware
@@ -620,7 +599,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_kstrength_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_kstrength_wd),
 
     // from internal hardware
@@ -646,7 +625,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_mode_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_mode_wd),
 
     // from internal hardware
@@ -672,7 +651,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_msg_endianness_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_msg_endianness_wd),
 
     // from internal hardware
@@ -698,7 +677,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_state_endianness_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_state_endianness_wd),
 
     // from internal hardware
@@ -724,7 +703,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_sideload_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_sideload_wd),
 
     // from internal hardware
@@ -750,7 +729,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_entropy_mode_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_entropy_mode_wd),
 
     // from internal hardware
@@ -776,7 +755,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_entropy_fast_process_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_entropy_fast_process_wd),
 
     // from internal hardware
@@ -802,7 +781,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_entropy_ready_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_entropy_ready_wd),
 
     // from internal hardware
@@ -828,7 +807,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_err_processed_we & cfg_regwen_qs),
+    .we     (cfg_we & cfg_regwen_qs),
     .wd     (cfg_err_processed_wd),
 
     // from internal hardware
@@ -866,7 +845,7 @@ module kmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_sha3_idle (
-    .re     (status_sha3_idle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.sha3_idle.d),
@@ -881,7 +860,7 @@ module kmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_sha3_absorb (
-    .re     (status_sha3_absorb_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.sha3_absorb.d),
@@ -896,7 +875,7 @@ module kmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_sha3_squeeze (
-    .re     (status_sha3_squeeze_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.sha3_squeeze.d),
@@ -911,7 +890,7 @@ module kmac_reg_top (
   prim_subreg_ext #(
     .DW    (5)
   ) u_status_fifo_depth (
-    .re     (status_fifo_depth_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fifo_depth.d),
@@ -926,7 +905,7 @@ module kmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_fifo_empty (
-    .re     (status_fifo_empty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fifo_empty.d),
@@ -941,7 +920,7 @@ module kmac_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_fifo_full (
-    .re     (status_fifo_full_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.fifo_full.d),
@@ -964,7 +943,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (entropy_period_entropy_timer_we & cfg_regwen_qs),
+    .we     (entropy_period_we & cfg_regwen_qs),
     .wd     (entropy_period_entropy_timer_wd),
 
     // from internal hardware
@@ -990,7 +969,7 @@ module kmac_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (entropy_period_wait_timer_we & cfg_regwen_qs),
+    .we     (entropy_period_we & cfg_regwen_qs),
     .wd     (entropy_period_wait_timer_wd),
 
     // from internal hardware
@@ -2054,226 +2033,198 @@ module kmac_reg_top (
                (addr_hit[54] & (|(KMAC_PERMIT[54] & ~reg_be))) |
                (addr_hit[55] & (|(KMAC_PERMIT[55] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_kmac_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_kmac_done_wd = reg_wdata[0];
 
-  assign intr_state_fifo_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_state_kmac_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_kmac_err_wd = reg_wdata[2];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_kmac_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_kmac_done_wd = reg_wdata[0];
 
-  assign intr_enable_fifo_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_enable_kmac_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_kmac_err_wd = reg_wdata[2];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_kmac_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_kmac_done_wd = reg_wdata[0];
 
-  assign intr_test_fifo_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_fifo_empty_wd = reg_wdata[1];
 
-  assign intr_test_kmac_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_kmac_err_wd = reg_wdata[2];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
   assign cfg_regwen_re = addr_hit[4] & reg_re & !reg_error;
+  assign cfg_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign cfg_kmac_en_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_kmac_en_wd = reg_wdata[0];
 
-  assign cfg_kstrength_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_kstrength_wd = reg_wdata[3:1];
 
-  assign cfg_mode_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_mode_wd = reg_wdata[5:4];
 
-  assign cfg_msg_endianness_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_msg_endianness_wd = reg_wdata[8];
 
-  assign cfg_state_endianness_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_state_endianness_wd = reg_wdata[9];
 
-  assign cfg_sideload_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_sideload_wd = reg_wdata[12];
 
-  assign cfg_entropy_mode_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_entropy_mode_wd = reg_wdata[17:16];
 
-  assign cfg_entropy_fast_process_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_entropy_fast_process_wd = reg_wdata[19];
 
-  assign cfg_entropy_ready_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_entropy_ready_wd = reg_wdata[24];
 
-  assign cfg_err_processed_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_err_processed_wd = reg_wdata[25];
-
   assign cmd_we = addr_hit[6] & reg_we & !reg_error;
+
   assign cmd_wd = reg_wdata[3:0];
+  assign status_re = addr_hit[7] & reg_re & !reg_error;
+  assign entropy_period_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign status_sha3_idle_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign status_sha3_absorb_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign status_sha3_squeeze_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign status_fifo_depth_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign status_fifo_empty_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign status_fifo_full_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign entropy_period_entropy_timer_we = addr_hit[8] & reg_we & !reg_error;
   assign entropy_period_entropy_timer_wd = reg_wdata[15:0];
 
-  assign entropy_period_wait_timer_we = addr_hit[8] & reg_we & !reg_error;
   assign entropy_period_wait_timer_wd = reg_wdata[31:16];
-
   assign entropy_seed_lower_we = addr_hit[9] & reg_we & !reg_error;
+
   assign entropy_seed_lower_wd = reg_wdata[31:0];
-
   assign entropy_seed_upper_we = addr_hit[10] & reg_we & !reg_error;
+
   assign entropy_seed_upper_wd = reg_wdata[31:0];
-
   assign key_share0_0_we = addr_hit[11] & reg_we & !reg_error;
+
   assign key_share0_0_wd = reg_wdata[31:0];
-
   assign key_share0_1_we = addr_hit[12] & reg_we & !reg_error;
+
   assign key_share0_1_wd = reg_wdata[31:0];
-
   assign key_share0_2_we = addr_hit[13] & reg_we & !reg_error;
+
   assign key_share0_2_wd = reg_wdata[31:0];
-
   assign key_share0_3_we = addr_hit[14] & reg_we & !reg_error;
+
   assign key_share0_3_wd = reg_wdata[31:0];
-
   assign key_share0_4_we = addr_hit[15] & reg_we & !reg_error;
+
   assign key_share0_4_wd = reg_wdata[31:0];
-
   assign key_share0_5_we = addr_hit[16] & reg_we & !reg_error;
+
   assign key_share0_5_wd = reg_wdata[31:0];
-
   assign key_share0_6_we = addr_hit[17] & reg_we & !reg_error;
+
   assign key_share0_6_wd = reg_wdata[31:0];
-
   assign key_share0_7_we = addr_hit[18] & reg_we & !reg_error;
+
   assign key_share0_7_wd = reg_wdata[31:0];
-
   assign key_share0_8_we = addr_hit[19] & reg_we & !reg_error;
+
   assign key_share0_8_wd = reg_wdata[31:0];
-
   assign key_share0_9_we = addr_hit[20] & reg_we & !reg_error;
+
   assign key_share0_9_wd = reg_wdata[31:0];
-
   assign key_share0_10_we = addr_hit[21] & reg_we & !reg_error;
+
   assign key_share0_10_wd = reg_wdata[31:0];
-
   assign key_share0_11_we = addr_hit[22] & reg_we & !reg_error;
+
   assign key_share0_11_wd = reg_wdata[31:0];
-
   assign key_share0_12_we = addr_hit[23] & reg_we & !reg_error;
+
   assign key_share0_12_wd = reg_wdata[31:0];
-
   assign key_share0_13_we = addr_hit[24] & reg_we & !reg_error;
+
   assign key_share0_13_wd = reg_wdata[31:0];
-
   assign key_share0_14_we = addr_hit[25] & reg_we & !reg_error;
+
   assign key_share0_14_wd = reg_wdata[31:0];
-
   assign key_share0_15_we = addr_hit[26] & reg_we & !reg_error;
+
   assign key_share0_15_wd = reg_wdata[31:0];
-
   assign key_share1_0_we = addr_hit[27] & reg_we & !reg_error;
+
   assign key_share1_0_wd = reg_wdata[31:0];
-
   assign key_share1_1_we = addr_hit[28] & reg_we & !reg_error;
+
   assign key_share1_1_wd = reg_wdata[31:0];
-
   assign key_share1_2_we = addr_hit[29] & reg_we & !reg_error;
+
   assign key_share1_2_wd = reg_wdata[31:0];
-
   assign key_share1_3_we = addr_hit[30] & reg_we & !reg_error;
+
   assign key_share1_3_wd = reg_wdata[31:0];
-
   assign key_share1_4_we = addr_hit[31] & reg_we & !reg_error;
+
   assign key_share1_4_wd = reg_wdata[31:0];
-
   assign key_share1_5_we = addr_hit[32] & reg_we & !reg_error;
+
   assign key_share1_5_wd = reg_wdata[31:0];
-
   assign key_share1_6_we = addr_hit[33] & reg_we & !reg_error;
+
   assign key_share1_6_wd = reg_wdata[31:0];
-
   assign key_share1_7_we = addr_hit[34] & reg_we & !reg_error;
+
   assign key_share1_7_wd = reg_wdata[31:0];
-
   assign key_share1_8_we = addr_hit[35] & reg_we & !reg_error;
+
   assign key_share1_8_wd = reg_wdata[31:0];
-
   assign key_share1_9_we = addr_hit[36] & reg_we & !reg_error;
+
   assign key_share1_9_wd = reg_wdata[31:0];
-
   assign key_share1_10_we = addr_hit[37] & reg_we & !reg_error;
+
   assign key_share1_10_wd = reg_wdata[31:0];
-
   assign key_share1_11_we = addr_hit[38] & reg_we & !reg_error;
+
   assign key_share1_11_wd = reg_wdata[31:0];
-
   assign key_share1_12_we = addr_hit[39] & reg_we & !reg_error;
+
   assign key_share1_12_wd = reg_wdata[31:0];
-
   assign key_share1_13_we = addr_hit[40] & reg_we & !reg_error;
+
   assign key_share1_13_wd = reg_wdata[31:0];
-
   assign key_share1_14_we = addr_hit[41] & reg_we & !reg_error;
+
   assign key_share1_14_wd = reg_wdata[31:0];
-
   assign key_share1_15_we = addr_hit[42] & reg_we & !reg_error;
+
   assign key_share1_15_wd = reg_wdata[31:0];
-
   assign key_len_we = addr_hit[43] & reg_we & !reg_error;
+
   assign key_len_wd = reg_wdata[2:0];
-
   assign prefix_0_we = addr_hit[44] & reg_we & !reg_error;
+
   assign prefix_0_wd = reg_wdata[31:0];
-
   assign prefix_1_we = addr_hit[45] & reg_we & !reg_error;
+
   assign prefix_1_wd = reg_wdata[31:0];
-
   assign prefix_2_we = addr_hit[46] & reg_we & !reg_error;
+
   assign prefix_2_wd = reg_wdata[31:0];
-
   assign prefix_3_we = addr_hit[47] & reg_we & !reg_error;
+
   assign prefix_3_wd = reg_wdata[31:0];
-
   assign prefix_4_we = addr_hit[48] & reg_we & !reg_error;
+
   assign prefix_4_wd = reg_wdata[31:0];
-
   assign prefix_5_we = addr_hit[49] & reg_we & !reg_error;
+
   assign prefix_5_wd = reg_wdata[31:0];
-
   assign prefix_6_we = addr_hit[50] & reg_we & !reg_error;
+
   assign prefix_6_wd = reg_wdata[31:0];
-
   assign prefix_7_we = addr_hit[51] & reg_we & !reg_error;
+
   assign prefix_7_wd = reg_wdata[31:0];
-
   assign prefix_8_we = addr_hit[52] & reg_we & !reg_error;
+
   assign prefix_8_wd = reg_wdata[31:0];
-
   assign prefix_9_we = addr_hit[53] & reg_we & !reg_error;
-  assign prefix_9_wd = reg_wdata[31:0];
 
+  assign prefix_9_wd = reg_wdata[31:0];
   assign prefix_10_we = addr_hit[54] & reg_we & !reg_error;
+
   assign prefix_10_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -104,86 +104,75 @@ module lc_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic alert_test_we;
   logic alert_test_fatal_prog_error_wd;
-  logic alert_test_fatal_prog_error_we;
   logic alert_test_fatal_state_error_wd;
-  logic alert_test_fatal_state_error_we;
   logic alert_test_fatal_bus_integ_error_wd;
-  logic alert_test_fatal_bus_integ_error_we;
+  logic status_re;
   logic status_ready_qs;
-  logic status_ready_re;
   logic status_transition_successful_qs;
-  logic status_transition_successful_re;
   logic status_transition_count_error_qs;
-  logic status_transition_count_error_re;
   logic status_transition_error_qs;
-  logic status_transition_error_re;
   logic status_token_error_qs;
-  logic status_token_error_re;
   logic status_flash_rma_error_qs;
-  logic status_flash_rma_error_re;
   logic status_otp_error_qs;
-  logic status_otp_error_re;
   logic status_state_error_qs;
-  logic status_state_error_re;
   logic status_bus_integ_error_qs;
-  logic status_bus_integ_error_re;
   logic status_otp_partition_error_qs;
-  logic status_otp_partition_error_re;
+  logic claim_transition_if_re;
+  logic claim_transition_if_we;
   logic [7:0] claim_transition_if_qs;
   logic [7:0] claim_transition_if_wd;
-  logic claim_transition_if_we;
-  logic claim_transition_if_re;
-  logic transition_regwen_qs;
   logic transition_regwen_re;
-  logic transition_cmd_wd;
+  logic transition_regwen_qs;
   logic transition_cmd_we;
+  logic transition_cmd_wd;
+  logic transition_token_0_re;
+  logic transition_token_0_we;
   logic [31:0] transition_token_0_qs;
   logic [31:0] transition_token_0_wd;
-  logic transition_token_0_we;
-  logic transition_token_0_re;
+  logic transition_token_1_re;
+  logic transition_token_1_we;
   logic [31:0] transition_token_1_qs;
   logic [31:0] transition_token_1_wd;
-  logic transition_token_1_we;
-  logic transition_token_1_re;
+  logic transition_token_2_re;
+  logic transition_token_2_we;
   logic [31:0] transition_token_2_qs;
   logic [31:0] transition_token_2_wd;
-  logic transition_token_2_we;
-  logic transition_token_2_re;
+  logic transition_token_3_re;
+  logic transition_token_3_we;
   logic [31:0] transition_token_3_qs;
   logic [31:0] transition_token_3_wd;
-  logic transition_token_3_we;
-  logic transition_token_3_re;
+  logic transition_target_re;
+  logic transition_target_we;
   logic [3:0] transition_target_qs;
   logic [3:0] transition_target_wd;
-  logic transition_target_we;
-  logic transition_target_re;
+  logic otp_test_ctrl_re;
+  logic otp_test_ctrl_we;
   logic [7:0] otp_test_ctrl_qs;
   logic [7:0] otp_test_ctrl_wd;
-  logic otp_test_ctrl_we;
-  logic otp_test_ctrl_re;
-  logic [3:0] lc_state_qs;
   logic lc_state_re;
-  logic [4:0] lc_transition_cnt_qs;
+  logic [3:0] lc_state_qs;
   logic lc_transition_cnt_re;
-  logic [1:0] lc_id_state_qs;
+  logic [4:0] lc_transition_cnt_qs;
   logic lc_id_state_re;
-  logic [31:0] device_id_0_qs;
+  logic [1:0] lc_id_state_qs;
   logic device_id_0_re;
-  logic [31:0] device_id_1_qs;
+  logic [31:0] device_id_0_qs;
   logic device_id_1_re;
-  logic [31:0] device_id_2_qs;
+  logic [31:0] device_id_1_qs;
   logic device_id_2_re;
-  logic [31:0] device_id_3_qs;
+  logic [31:0] device_id_2_qs;
   logic device_id_3_re;
-  logic [31:0] device_id_4_qs;
+  logic [31:0] device_id_3_qs;
   logic device_id_4_re;
-  logic [31:0] device_id_5_qs;
+  logic [31:0] device_id_4_qs;
   logic device_id_5_re;
-  logic [31:0] device_id_6_qs;
+  logic [31:0] device_id_5_qs;
   logic device_id_6_re;
-  logic [31:0] device_id_7_qs;
+  logic [31:0] device_id_6_qs;
   logic device_id_7_re;
+  logic [31:0] device_id_7_qs;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -193,7 +182,7 @@ module lc_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_prog_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_prog_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_prog_error_wd),
     .d      ('0),
     .qre    (),
@@ -208,7 +197,7 @@ module lc_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_state_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_state_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_state_error_wd),
     .d      ('0),
     .qre    (),
@@ -223,7 +212,7 @@ module lc_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_bus_integ_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_bus_integ_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_bus_integ_error_wd),
     .d      ('0),
     .qre    (),
@@ -239,7 +228,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_ready (
-    .re     (status_ready_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.ready.d),
@@ -254,7 +243,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_transition_successful (
-    .re     (status_transition_successful_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.transition_successful.d),
@@ -269,7 +258,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_transition_count_error (
-    .re     (status_transition_count_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.transition_count_error.d),
@@ -284,7 +273,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_transition_error (
-    .re     (status_transition_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.transition_error.d),
@@ -299,7 +288,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_token_error (
-    .re     (status_token_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.token_error.d),
@@ -314,7 +303,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_flash_rma_error (
-    .re     (status_flash_rma_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.flash_rma_error.d),
@@ -329,7 +318,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_otp_error (
-    .re     (status_otp_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.otp_error.d),
@@ -344,7 +333,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_state_error (
-    .re     (status_state_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.state_error.d),
@@ -359,7 +348,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_bus_integ_error (
-    .re     (status_bus_integ_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.bus_integ_error.d),
@@ -374,7 +363,7 @@ module lc_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_otp_partition_error (
-    .re     (status_otp_partition_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.otp_partition_error.d),
@@ -766,89 +755,56 @@ module lc_ctrl_reg_top (
                (addr_hit[20] & (|(LC_CTRL_PERMIT[20] & ~reg_be))) |
                (addr_hit[21] & (|(LC_CTRL_PERMIT[21] & ~reg_be)))));
   end
+  assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_fatal_prog_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_prog_error_wd = reg_wdata[0];
 
-  assign alert_test_fatal_state_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_state_error_wd = reg_wdata[1];
 
-  assign alert_test_fatal_bus_integ_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_bus_integ_error_wd = reg_wdata[2];
-
-  assign status_ready_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_transition_successful_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_transition_count_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_transition_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_token_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_flash_rma_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_otp_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_state_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_bus_integ_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_otp_partition_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign claim_transition_if_we = addr_hit[2] & reg_we & !reg_error;
-  assign claim_transition_if_wd = reg_wdata[7:0];
+  assign status_re = addr_hit[1] & reg_re & !reg_error;
   assign claim_transition_if_re = addr_hit[2] & reg_re & !reg_error;
+  assign claim_transition_if_we = addr_hit[2] & reg_we & !reg_error;
 
+  assign claim_transition_if_wd = reg_wdata[7:0];
   assign transition_regwen_re = addr_hit[3] & reg_re & !reg_error;
-
   assign transition_cmd_we = addr_hit[4] & reg_we & !reg_error;
+
   assign transition_cmd_wd = reg_wdata[0];
-
-  assign transition_token_0_we = addr_hit[5] & reg_we & !reg_error;
-  assign transition_token_0_wd = reg_wdata[31:0];
   assign transition_token_0_re = addr_hit[5] & reg_re & !reg_error;
+  assign transition_token_0_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign transition_token_1_we = addr_hit[6] & reg_we & !reg_error;
-  assign transition_token_1_wd = reg_wdata[31:0];
+  assign transition_token_0_wd = reg_wdata[31:0];
   assign transition_token_1_re = addr_hit[6] & reg_re & !reg_error;
+  assign transition_token_1_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign transition_token_2_we = addr_hit[7] & reg_we & !reg_error;
-  assign transition_token_2_wd = reg_wdata[31:0];
+  assign transition_token_1_wd = reg_wdata[31:0];
   assign transition_token_2_re = addr_hit[7] & reg_re & !reg_error;
+  assign transition_token_2_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign transition_token_3_we = addr_hit[8] & reg_we & !reg_error;
-  assign transition_token_3_wd = reg_wdata[31:0];
+  assign transition_token_2_wd = reg_wdata[31:0];
   assign transition_token_3_re = addr_hit[8] & reg_re & !reg_error;
+  assign transition_token_3_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign transition_target_we = addr_hit[9] & reg_we & !reg_error;
-  assign transition_target_wd = reg_wdata[3:0];
+  assign transition_token_3_wd = reg_wdata[31:0];
   assign transition_target_re = addr_hit[9] & reg_re & !reg_error;
+  assign transition_target_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign otp_test_ctrl_we = addr_hit[10] & reg_we & !reg_error;
-  assign otp_test_ctrl_wd = reg_wdata[7:0];
+  assign transition_target_wd = reg_wdata[3:0];
   assign otp_test_ctrl_re = addr_hit[10] & reg_re & !reg_error;
+  assign otp_test_ctrl_we = addr_hit[10] & reg_we & !reg_error;
 
+  assign otp_test_ctrl_wd = reg_wdata[7:0];
   assign lc_state_re = addr_hit[11] & reg_re & !reg_error;
-
   assign lc_transition_cnt_re = addr_hit[12] & reg_re & !reg_error;
-
   assign lc_id_state_re = addr_hit[13] & reg_re & !reg_error;
-
   assign device_id_0_re = addr_hit[14] & reg_re & !reg_error;
-
   assign device_id_1_re = addr_hit[15] & reg_re & !reg_error;
-
   assign device_id_2_re = addr_hit[16] & reg_re & !reg_error;
-
   assign device_id_3_re = addr_hit[17] & reg_re & !reg_error;
-
   assign device_id_4_re = addr_hit[18] & reg_re & !reg_error;
-
   assign device_id_5_re = addr_hit[19] & reg_re & !reg_error;
-
   assign device_id_6_re = addr_hit[20] & reg_re & !reg_error;
-
   assign device_id_7_re = addr_hit[21] & reg_re & !reg_error;
 
   // Read data return

--- a/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen_reg_top.sv
@@ -104,30 +104,24 @@ module nmi_gen_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_esc0_qs;
   logic intr_state_esc0_wd;
-  logic intr_state_esc0_we;
   logic intr_state_esc1_qs;
   logic intr_state_esc1_wd;
-  logic intr_state_esc1_we;
   logic intr_state_esc2_qs;
   logic intr_state_esc2_wd;
-  logic intr_state_esc2_we;
+  logic intr_enable_we;
   logic intr_enable_esc0_qs;
   logic intr_enable_esc0_wd;
-  logic intr_enable_esc0_we;
   logic intr_enable_esc1_qs;
   logic intr_enable_esc1_wd;
-  logic intr_enable_esc1_we;
   logic intr_enable_esc2_qs;
   logic intr_enable_esc2_wd;
-  logic intr_enable_esc2_we;
+  logic intr_test_we;
   logic intr_test_esc0_wd;
-  logic intr_test_esc0_we;
   logic intr_test_esc1_wd;
-  logic intr_test_esc1_we;
   logic intr_test_esc2_wd;
-  logic intr_test_esc2_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -142,7 +136,7 @@ module nmi_gen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_esc0_we),
+    .we     (intr_state_we),
     .wd     (intr_state_esc0_wd),
 
     // from internal hardware
@@ -168,7 +162,7 @@ module nmi_gen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_esc1_we),
+    .we     (intr_state_we),
     .wd     (intr_state_esc1_wd),
 
     // from internal hardware
@@ -194,7 +188,7 @@ module nmi_gen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_esc2_we),
+    .we     (intr_state_we),
     .wd     (intr_state_esc2_wd),
 
     // from internal hardware
@@ -222,7 +216,7 @@ module nmi_gen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_esc0_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_esc0_wd),
 
     // from internal hardware
@@ -248,7 +242,7 @@ module nmi_gen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_esc1_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_esc1_wd),
 
     // from internal hardware
@@ -274,7 +268,7 @@ module nmi_gen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_esc2_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_esc2_wd),
 
     // from internal hardware
@@ -297,7 +291,7 @@ module nmi_gen_reg_top (
     .DW    (1)
   ) u_intr_test_esc0 (
     .re     (1'b0),
-    .we     (intr_test_esc0_we),
+    .we     (intr_test_we),
     .wd     (intr_test_esc0_wd),
     .d      ('0),
     .qre    (),
@@ -312,7 +306,7 @@ module nmi_gen_reg_top (
     .DW    (1)
   ) u_intr_test_esc1 (
     .re     (1'b0),
-    .we     (intr_test_esc1_we),
+    .we     (intr_test_we),
     .wd     (intr_test_esc1_wd),
     .d      ('0),
     .qre    (),
@@ -327,7 +321,7 @@ module nmi_gen_reg_top (
     .DW    (1)
   ) u_intr_test_esc2 (
     .re     (1'b0),
-    .we     (intr_test_esc2_we),
+    .we     (intr_test_we),
     .wd     (intr_test_esc2_wd),
     .d      ('0),
     .qre    (),
@@ -356,32 +350,26 @@ module nmi_gen_reg_top (
                (addr_hit[1] & (|(NMI_GEN_PERMIT[1] & ~reg_be))) |
                (addr_hit[2] & (|(NMI_GEN_PERMIT[2] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_esc0_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_esc0_wd = reg_wdata[0];
 
-  assign intr_state_esc1_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_esc1_wd = reg_wdata[1];
 
-  assign intr_state_esc2_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_esc2_wd = reg_wdata[2];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_esc0_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_esc0_wd = reg_wdata[0];
 
-  assign intr_enable_esc1_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_esc1_wd = reg_wdata[1];
 
-  assign intr_enable_esc2_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_esc2_wd = reg_wdata[2];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_esc0_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_esc0_wd = reg_wdata[0];
 
-  assign intr_test_esc1_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_esc1_wd = reg_wdata[1];
 
-  assign intr_test_esc2_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_esc2_wd = reg_wdata[2];
 
   // Read data return

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -157,22 +157,21 @@ module otbn_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_qs;
   logic intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
-  logic intr_enable_we;
-  logic intr_test_wd;
   logic intr_test_we;
+  logic intr_test_wd;
+  logic alert_test_we;
   logic alert_test_fatal_wd;
-  logic alert_test_fatal_we;
   logic alert_test_recov_wd;
-  logic alert_test_recov_we;
-  logic cmd_wd;
   logic cmd_we;
-  logic status_qs;
+  logic cmd_wd;
   logic status_re;
+  logic status_qs;
   logic err_bits_bad_data_addr_qs;
   logic err_bits_bad_insn_addr_qs;
   logic err_bits_call_stack_qs;
@@ -181,14 +180,14 @@ module otbn_reg_top (
   logic err_bits_fatal_imem_qs;
   logic err_bits_fatal_dmem_qs;
   logic err_bits_fatal_reg_qs;
-  logic [31:0] start_addr_wd;
   logic start_addr_we;
+  logic [31:0] start_addr_wd;
   logic fatal_alert_cause_bus_integrity_error_qs;
   logic fatal_alert_cause_imem_error_qs;
   logic fatal_alert_cause_dmem_error_qs;
   logic fatal_alert_cause_reg_error_qs;
-  logic [31:0] insn_cnt_qs;
   logic insn_cnt_re;
+  logic [31:0] insn_cnt_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -268,7 +267,7 @@ module otbn_reg_top (
     .DW    (1)
   ) u_alert_test_fatal (
     .re     (1'b0),
-    .we     (alert_test_fatal_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_wd),
     .d      ('0),
     .qre    (),
@@ -283,7 +282,7 @@ module otbn_reg_top (
     .DW    (1)
   ) u_alert_test_recov (
     .re     (1'b0),
-    .we     (alert_test_recov_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_wd),
     .d      ('0),
     .qre    (),
@@ -717,30 +716,27 @@ module otbn_reg_top (
                (addr_hit[8] & (|(OTBN_PERMIT[8] & ~reg_be))) |
                (addr_hit[9] & (|(OTBN_PERMIT[9] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
-  assign intr_test_wd = reg_wdata[0];
 
-  assign alert_test_fatal_we = addr_hit[3] & reg_we & !reg_error;
+  assign intr_test_wd = reg_wdata[0];
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_fatal_wd = reg_wdata[0];
 
-  assign alert_test_recov_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_wd = reg_wdata[1];
-
   assign cmd_we = addr_hit[4] & reg_we & !reg_error;
+
   assign cmd_wd = reg_wdata[0];
-
   assign status_re = addr_hit[5] & reg_re & !reg_error;
-
   assign start_addr_we = addr_hit[7] & reg_we & !reg_error;
-  assign start_addr_wd = reg_wdata[31:0];
 
+  assign start_addr_wd = reg_wdata[31:0];
   assign insn_cnt_re = addr_hit[9] & reg_re & !reg_error;
 
   // Read data return

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_top.sv
@@ -157,144 +157,115 @@ module otp_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_otp_operation_done_qs;
   logic intr_state_otp_operation_done_wd;
-  logic intr_state_otp_operation_done_we;
   logic intr_state_otp_error_qs;
   logic intr_state_otp_error_wd;
-  logic intr_state_otp_error_we;
+  logic intr_enable_we;
   logic intr_enable_otp_operation_done_qs;
   logic intr_enable_otp_operation_done_wd;
-  logic intr_enable_otp_operation_done_we;
   logic intr_enable_otp_error_qs;
   logic intr_enable_otp_error_wd;
-  logic intr_enable_otp_error_we;
+  logic intr_test_we;
   logic intr_test_otp_operation_done_wd;
-  logic intr_test_otp_operation_done_we;
   logic intr_test_otp_error_wd;
-  logic intr_test_otp_error_we;
+  logic alert_test_we;
   logic alert_test_fatal_macro_error_wd;
-  logic alert_test_fatal_macro_error_we;
   logic alert_test_fatal_check_error_wd;
-  logic alert_test_fatal_check_error_we;
+  logic status_re;
   logic status_creator_sw_cfg_error_qs;
-  logic status_creator_sw_cfg_error_re;
   logic status_owner_sw_cfg_error_qs;
-  logic status_owner_sw_cfg_error_re;
   logic status_hw_cfg_error_qs;
-  logic status_hw_cfg_error_re;
   logic status_secret0_error_qs;
-  logic status_secret0_error_re;
   logic status_secret1_error_qs;
-  logic status_secret1_error_re;
   logic status_secret2_error_qs;
-  logic status_secret2_error_re;
   logic status_life_cycle_error_qs;
-  logic status_life_cycle_error_re;
   logic status_dai_error_qs;
-  logic status_dai_error_re;
   logic status_lci_error_qs;
-  logic status_lci_error_re;
   logic status_timeout_error_qs;
-  logic status_timeout_error_re;
   logic status_lfsr_fsm_error_qs;
-  logic status_lfsr_fsm_error_re;
   logic status_scrambling_fsm_error_qs;
-  logic status_scrambling_fsm_error_re;
   logic status_key_deriv_fsm_error_qs;
-  logic status_key_deriv_fsm_error_re;
   logic status_dai_idle_qs;
-  logic status_dai_idle_re;
   logic status_check_pending_qs;
-  logic status_check_pending_re;
+  logic err_code_re;
   logic [2:0] err_code_err_code_0_qs;
-  logic err_code_err_code_0_re;
   logic [2:0] err_code_err_code_1_qs;
-  logic err_code_err_code_1_re;
   logic [2:0] err_code_err_code_2_qs;
-  logic err_code_err_code_2_re;
   logic [2:0] err_code_err_code_3_qs;
-  logic err_code_err_code_3_re;
   logic [2:0] err_code_err_code_4_qs;
-  logic err_code_err_code_4_re;
   logic [2:0] err_code_err_code_5_qs;
-  logic err_code_err_code_5_re;
   logic [2:0] err_code_err_code_6_qs;
-  logic err_code_err_code_6_re;
   logic [2:0] err_code_err_code_7_qs;
-  logic err_code_err_code_7_re;
   logic [2:0] err_code_err_code_8_qs;
-  logic err_code_err_code_8_re;
-  logic direct_access_regwen_qs;
   logic direct_access_regwen_re;
+  logic direct_access_regwen_qs;
+  logic direct_access_cmd_we;
   logic direct_access_cmd_rd_wd;
-  logic direct_access_cmd_rd_we;
   logic direct_access_cmd_wr_wd;
-  logic direct_access_cmd_wr_we;
   logic direct_access_cmd_digest_wd;
-  logic direct_access_cmd_digest_we;
+  logic direct_access_address_we;
   logic [10:0] direct_access_address_qs;
   logic [10:0] direct_access_address_wd;
-  logic direct_access_address_we;
+  logic direct_access_wdata_0_we;
   logic [31:0] direct_access_wdata_0_qs;
   logic [31:0] direct_access_wdata_0_wd;
-  logic direct_access_wdata_0_we;
+  logic direct_access_wdata_1_we;
   logic [31:0] direct_access_wdata_1_qs;
   logic [31:0] direct_access_wdata_1_wd;
-  logic direct_access_wdata_1_we;
-  logic [31:0] direct_access_rdata_0_qs;
   logic direct_access_rdata_0_re;
-  logic [31:0] direct_access_rdata_1_qs;
+  logic [31:0] direct_access_rdata_0_qs;
   logic direct_access_rdata_1_re;
+  logic [31:0] direct_access_rdata_1_qs;
+  logic check_trigger_regwen_we;
   logic check_trigger_regwen_qs;
   logic check_trigger_regwen_wd;
-  logic check_trigger_regwen_we;
+  logic check_trigger_we;
   logic check_trigger_integrity_wd;
-  logic check_trigger_integrity_we;
   logic check_trigger_consistency_wd;
-  logic check_trigger_consistency_we;
+  logic check_regwen_we;
   logic check_regwen_qs;
   logic check_regwen_wd;
-  logic check_regwen_we;
+  logic check_timeout_we;
   logic [31:0] check_timeout_qs;
   logic [31:0] check_timeout_wd;
-  logic check_timeout_we;
+  logic integrity_check_period_we;
   logic [31:0] integrity_check_period_qs;
   logic [31:0] integrity_check_period_wd;
-  logic integrity_check_period_we;
+  logic consistency_check_period_we;
   logic [31:0] consistency_check_period_qs;
   logic [31:0] consistency_check_period_wd;
-  logic consistency_check_period_we;
+  logic creator_sw_cfg_read_lock_we;
   logic creator_sw_cfg_read_lock_qs;
   logic creator_sw_cfg_read_lock_wd;
-  logic creator_sw_cfg_read_lock_we;
+  logic owner_sw_cfg_read_lock_we;
   logic owner_sw_cfg_read_lock_qs;
   logic owner_sw_cfg_read_lock_wd;
-  logic owner_sw_cfg_read_lock_we;
-  logic [31:0] creator_sw_cfg_digest_0_qs;
   logic creator_sw_cfg_digest_0_re;
-  logic [31:0] creator_sw_cfg_digest_1_qs;
+  logic [31:0] creator_sw_cfg_digest_0_qs;
   logic creator_sw_cfg_digest_1_re;
-  logic [31:0] owner_sw_cfg_digest_0_qs;
+  logic [31:0] creator_sw_cfg_digest_1_qs;
   logic owner_sw_cfg_digest_0_re;
-  logic [31:0] owner_sw_cfg_digest_1_qs;
+  logic [31:0] owner_sw_cfg_digest_0_qs;
   logic owner_sw_cfg_digest_1_re;
-  logic [31:0] hw_cfg_digest_0_qs;
+  logic [31:0] owner_sw_cfg_digest_1_qs;
   logic hw_cfg_digest_0_re;
-  logic [31:0] hw_cfg_digest_1_qs;
+  logic [31:0] hw_cfg_digest_0_qs;
   logic hw_cfg_digest_1_re;
-  logic [31:0] secret0_digest_0_qs;
+  logic [31:0] hw_cfg_digest_1_qs;
   logic secret0_digest_0_re;
-  logic [31:0] secret0_digest_1_qs;
+  logic [31:0] secret0_digest_0_qs;
   logic secret0_digest_1_re;
-  logic [31:0] secret1_digest_0_qs;
+  logic [31:0] secret0_digest_1_qs;
   logic secret1_digest_0_re;
-  logic [31:0] secret1_digest_1_qs;
+  logic [31:0] secret1_digest_0_qs;
   logic secret1_digest_1_re;
-  logic [31:0] secret2_digest_0_qs;
+  logic [31:0] secret1_digest_1_qs;
   logic secret2_digest_0_re;
-  logic [31:0] secret2_digest_1_qs;
+  logic [31:0] secret2_digest_0_qs;
   logic secret2_digest_1_re;
+  logic [31:0] secret2_digest_1_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -309,7 +280,7 @@ module otp_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_otp_operation_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_otp_operation_done_wd),
 
     // from internal hardware
@@ -335,7 +306,7 @@ module otp_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_otp_error_we),
+    .we     (intr_state_we),
     .wd     (intr_state_otp_error_wd),
 
     // from internal hardware
@@ -363,7 +334,7 @@ module otp_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_otp_operation_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_otp_operation_done_wd),
 
     // from internal hardware
@@ -389,7 +360,7 @@ module otp_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_otp_error_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_otp_error_wd),
 
     // from internal hardware
@@ -412,7 +383,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_intr_test_otp_operation_done (
     .re     (1'b0),
-    .we     (intr_test_otp_operation_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_otp_operation_done_wd),
     .d      ('0),
     .qre    (),
@@ -427,7 +398,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_intr_test_otp_error (
     .re     (1'b0),
-    .we     (intr_test_otp_error_we),
+    .we     (intr_test_we),
     .wd     (intr_test_otp_error_wd),
     .d      ('0),
     .qre    (),
@@ -444,7 +415,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_macro_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_macro_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_macro_error_wd),
     .d      ('0),
     .qre    (),
@@ -459,7 +430,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_check_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_check_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_check_error_wd),
     .d      ('0),
     .qre    (),
@@ -475,7 +446,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_creator_sw_cfg_error (
-    .re     (status_creator_sw_cfg_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.creator_sw_cfg_error.d),
@@ -490,7 +461,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_owner_sw_cfg_error (
-    .re     (status_owner_sw_cfg_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.owner_sw_cfg_error.d),
@@ -505,7 +476,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_hw_cfg_error (
-    .re     (status_hw_cfg_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.hw_cfg_error.d),
@@ -520,7 +491,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_secret0_error (
-    .re     (status_secret0_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.secret0_error.d),
@@ -535,7 +506,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_secret1_error (
-    .re     (status_secret1_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.secret1_error.d),
@@ -550,7 +521,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_secret2_error (
-    .re     (status_secret2_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.secret2_error.d),
@@ -565,7 +536,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_life_cycle_error (
-    .re     (status_life_cycle_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.life_cycle_error.d),
@@ -580,7 +551,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_dai_error (
-    .re     (status_dai_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.dai_error.d),
@@ -595,7 +566,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_lci_error (
-    .re     (status_lci_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.lci_error.d),
@@ -610,7 +581,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_timeout_error (
-    .re     (status_timeout_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.timeout_error.d),
@@ -625,7 +596,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_lfsr_fsm_error (
-    .re     (status_lfsr_fsm_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.lfsr_fsm_error.d),
@@ -640,7 +611,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_scrambling_fsm_error (
-    .re     (status_scrambling_fsm_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.scrambling_fsm_error.d),
@@ -655,7 +626,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_key_deriv_fsm_error (
-    .re     (status_key_deriv_fsm_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.key_deriv_fsm_error.d),
@@ -670,7 +641,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_dai_idle (
-    .re     (status_dai_idle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.dai_idle.d),
@@ -685,7 +656,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_check_pending (
-    .re     (status_check_pending_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.check_pending.d),
@@ -704,7 +675,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_0 (
-    .re     (err_code_err_code_0_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[0].d),
@@ -719,7 +690,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_1 (
-    .re     (err_code_err_code_1_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[1].d),
@@ -734,7 +705,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_2 (
-    .re     (err_code_err_code_2_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[2].d),
@@ -749,7 +720,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_3 (
-    .re     (err_code_err_code_3_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[3].d),
@@ -764,7 +735,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_4 (
-    .re     (err_code_err_code_4_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[4].d),
@@ -779,7 +750,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_5 (
-    .re     (err_code_err_code_5_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[5].d),
@@ -794,7 +765,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_6 (
-    .re     (err_code_err_code_6_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[6].d),
@@ -809,7 +780,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_7 (
-    .re     (err_code_err_code_7_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[7].d),
@@ -824,7 +795,7 @@ module otp_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_8 (
-    .re     (err_code_err_code_8_re),
+    .re     (err_code_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.err_code[8].d),
@@ -859,7 +830,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_direct_access_cmd_rd (
     .re     (1'b0),
-    .we     (direct_access_cmd_rd_we & direct_access_regwen_qs),
+    .we     (direct_access_cmd_we & direct_access_regwen_qs),
     .wd     (direct_access_cmd_rd_wd),
     .d      ('0),
     .qre    (),
@@ -874,7 +845,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_direct_access_cmd_wr (
     .re     (1'b0),
-    .we     (direct_access_cmd_wr_we & direct_access_regwen_qs),
+    .we     (direct_access_cmd_we & direct_access_regwen_qs),
     .wd     (direct_access_cmd_wr_wd),
     .d      ('0),
     .qre    (),
@@ -889,7 +860,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_direct_access_cmd_digest (
     .re     (1'b0),
-    .we     (direct_access_cmd_digest_we & direct_access_regwen_qs),
+    .we     (direct_access_cmd_we & direct_access_regwen_qs),
     .wd     (direct_access_cmd_digest_wd),
     .d      ('0),
     .qre    (),
@@ -1050,7 +1021,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_check_trigger_integrity (
     .re     (1'b0),
-    .we     (check_trigger_integrity_we & check_trigger_regwen_qs),
+    .we     (check_trigger_we & check_trigger_regwen_qs),
     .wd     (check_trigger_integrity_wd),
     .d      ('0),
     .qre    (),
@@ -1065,7 +1036,7 @@ module otp_ctrl_reg_top (
     .DW    (1)
   ) u_check_trigger_consistency (
     .re     (1'b0),
-    .we     (check_trigger_consistency_we & check_trigger_regwen_qs),
+    .we     (check_trigger_we & check_trigger_regwen_qs),
     .wd     (check_trigger_consistency_wd),
     .d      ('0),
     .qre    (),
@@ -1520,152 +1491,84 @@ module otp_ctrl_reg_top (
                (addr_hit[31] & (|(OTP_CTRL_PERMIT[31] & ~reg_be))) |
                (addr_hit[32] & (|(OTP_CTRL_PERMIT[32] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_otp_operation_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_otp_operation_done_wd = reg_wdata[0];
 
-  assign intr_state_otp_error_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_otp_error_wd = reg_wdata[1];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_otp_operation_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_otp_operation_done_wd = reg_wdata[0];
 
-  assign intr_enable_otp_error_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_otp_error_wd = reg_wdata[1];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_otp_operation_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_otp_operation_done_wd = reg_wdata[0];
 
-  assign intr_test_otp_error_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_otp_error_wd = reg_wdata[1];
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_fatal_macro_error_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_macro_error_wd = reg_wdata[0];
 
-  assign alert_test_fatal_check_error_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_check_error_wd = reg_wdata[1];
-
-  assign status_creator_sw_cfg_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_owner_sw_cfg_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_hw_cfg_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_secret0_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_secret1_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_secret2_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_life_cycle_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_dai_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_lci_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_timeout_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_lfsr_fsm_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_scrambling_fsm_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_key_deriv_fsm_error_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_dai_idle_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_check_pending_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign err_code_err_code_0_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_1_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_2_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_3_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_4_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_5_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_6_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_7_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign err_code_err_code_8_re = addr_hit[5] & reg_re & !reg_error;
-
+  assign status_re = addr_hit[4] & reg_re & !reg_error;
+  assign err_code_re = addr_hit[5] & reg_re & !reg_error;
   assign direct_access_regwen_re = addr_hit[6] & reg_re & !reg_error;
+  assign direct_access_cmd_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign direct_access_cmd_rd_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_access_cmd_rd_wd = reg_wdata[0];
 
-  assign direct_access_cmd_wr_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_access_cmd_wr_wd = reg_wdata[1];
 
-  assign direct_access_cmd_digest_we = addr_hit[7] & reg_we & !reg_error;
   assign direct_access_cmd_digest_wd = reg_wdata[2];
-
   assign direct_access_address_we = addr_hit[8] & reg_we & !reg_error;
+
   assign direct_access_address_wd = reg_wdata[10:0];
-
   assign direct_access_wdata_0_we = addr_hit[9] & reg_we & !reg_error;
+
   assign direct_access_wdata_0_wd = reg_wdata[31:0];
-
   assign direct_access_wdata_1_we = addr_hit[10] & reg_we & !reg_error;
+
   assign direct_access_wdata_1_wd = reg_wdata[31:0];
-
   assign direct_access_rdata_0_re = addr_hit[11] & reg_re & !reg_error;
-
   assign direct_access_rdata_1_re = addr_hit[12] & reg_re & !reg_error;
-
   assign check_trigger_regwen_we = addr_hit[13] & reg_we & !reg_error;
-  assign check_trigger_regwen_wd = reg_wdata[0];
 
-  assign check_trigger_integrity_we = addr_hit[14] & reg_we & !reg_error;
+  assign check_trigger_regwen_wd = reg_wdata[0];
+  assign check_trigger_we = addr_hit[14] & reg_we & !reg_error;
+
   assign check_trigger_integrity_wd = reg_wdata[0];
 
-  assign check_trigger_consistency_we = addr_hit[14] & reg_we & !reg_error;
   assign check_trigger_consistency_wd = reg_wdata[1];
-
   assign check_regwen_we = addr_hit[15] & reg_we & !reg_error;
+
   assign check_regwen_wd = reg_wdata[0];
-
   assign check_timeout_we = addr_hit[16] & reg_we & !reg_error;
+
   assign check_timeout_wd = reg_wdata[31:0];
-
   assign integrity_check_period_we = addr_hit[17] & reg_we & !reg_error;
+
   assign integrity_check_period_wd = reg_wdata[31:0];
-
   assign consistency_check_period_we = addr_hit[18] & reg_we & !reg_error;
+
   assign consistency_check_period_wd = reg_wdata[31:0];
-
   assign creator_sw_cfg_read_lock_we = addr_hit[19] & reg_we & !reg_error;
+
   assign creator_sw_cfg_read_lock_wd = reg_wdata[0];
-
   assign owner_sw_cfg_read_lock_we = addr_hit[20] & reg_we & !reg_error;
+
   assign owner_sw_cfg_read_lock_wd = reg_wdata[0];
-
   assign creator_sw_cfg_digest_0_re = addr_hit[21] & reg_re & !reg_error;
-
   assign creator_sw_cfg_digest_1_re = addr_hit[22] & reg_re & !reg_error;
-
   assign owner_sw_cfg_digest_0_re = addr_hit[23] & reg_re & !reg_error;
-
   assign owner_sw_cfg_digest_1_re = addr_hit[24] & reg_re & !reg_error;
-
   assign hw_cfg_digest_0_re = addr_hit[25] & reg_re & !reg_error;
-
   assign hw_cfg_digest_1_re = addr_hit[26] & reg_re & !reg_error;
-
   assign secret0_digest_0_re = addr_hit[27] & reg_re & !reg_error;
-
   assign secret0_digest_1_re = addr_hit[28] & reg_re & !reg_error;
-
   assign secret1_digest_0_re = addr_hit[29] & reg_re & !reg_error;
-
   assign secret1_digest_1_re = addr_hit[30] & reg_re & !reg_error;
-
   assign secret2_digest_0_re = addr_hit[31] & reg_re & !reg_error;
-
   assign secret2_digest_1_re = addr_hit[32] & reg_re & !reg_error;
 
   // Read data return

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -104,66 +104,57 @@ module pattgen_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_done_ch0_qs;
   logic intr_state_done_ch0_wd;
-  logic intr_state_done_ch0_we;
   logic intr_state_done_ch1_qs;
   logic intr_state_done_ch1_wd;
-  logic intr_state_done_ch1_we;
+  logic intr_enable_we;
   logic intr_enable_done_ch0_qs;
   logic intr_enable_done_ch0_wd;
-  logic intr_enable_done_ch0_we;
   logic intr_enable_done_ch1_qs;
   logic intr_enable_done_ch1_wd;
-  logic intr_enable_done_ch1_we;
+  logic intr_test_we;
   logic intr_test_done_ch0_wd;
-  logic intr_test_done_ch0_we;
   logic intr_test_done_ch1_wd;
-  logic intr_test_done_ch1_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic ctrl_we;
   logic ctrl_enable_ch0_qs;
   logic ctrl_enable_ch0_wd;
-  logic ctrl_enable_ch0_we;
   logic ctrl_enable_ch1_qs;
   logic ctrl_enable_ch1_wd;
-  logic ctrl_enable_ch1_we;
   logic ctrl_polarity_ch0_qs;
   logic ctrl_polarity_ch0_wd;
-  logic ctrl_polarity_ch0_we;
   logic ctrl_polarity_ch1_qs;
   logic ctrl_polarity_ch1_wd;
-  logic ctrl_polarity_ch1_we;
+  logic prediv_ch0_we;
   logic [31:0] prediv_ch0_qs;
   logic [31:0] prediv_ch0_wd;
-  logic prediv_ch0_we;
+  logic prediv_ch1_we;
   logic [31:0] prediv_ch1_qs;
   logic [31:0] prediv_ch1_wd;
-  logic prediv_ch1_we;
+  logic data_ch0_0_we;
   logic [31:0] data_ch0_0_qs;
   logic [31:0] data_ch0_0_wd;
-  logic data_ch0_0_we;
+  logic data_ch0_1_we;
   logic [31:0] data_ch0_1_qs;
   logic [31:0] data_ch0_1_wd;
-  logic data_ch0_1_we;
+  logic data_ch1_0_we;
   logic [31:0] data_ch1_0_qs;
   logic [31:0] data_ch1_0_wd;
-  logic data_ch1_0_we;
+  logic data_ch1_1_we;
   logic [31:0] data_ch1_1_qs;
   logic [31:0] data_ch1_1_wd;
-  logic data_ch1_1_we;
+  logic size_we;
   logic [5:0] size_len_ch0_qs;
   logic [5:0] size_len_ch0_wd;
-  logic size_len_ch0_we;
   logic [9:0] size_reps_ch0_qs;
   logic [9:0] size_reps_ch0_wd;
-  logic size_reps_ch0_we;
   logic [5:0] size_len_ch1_qs;
   logic [5:0] size_len_ch1_wd;
-  logic size_len_ch1_we;
   logic [9:0] size_reps_ch1_qs;
   logic [9:0] size_reps_ch1_wd;
-  logic size_reps_ch1_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -178,7 +169,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_done_ch0_we),
+    .we     (intr_state_we),
     .wd     (intr_state_done_ch0_wd),
 
     // from internal hardware
@@ -204,7 +195,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_done_ch1_we),
+    .we     (intr_state_we),
     .wd     (intr_state_done_ch1_wd),
 
     // from internal hardware
@@ -232,7 +223,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_done_ch0_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_done_ch0_wd),
 
     // from internal hardware
@@ -258,7 +249,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_done_ch1_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_done_ch1_wd),
 
     // from internal hardware
@@ -281,7 +272,7 @@ module pattgen_reg_top (
     .DW    (1)
   ) u_intr_test_done_ch0 (
     .re     (1'b0),
-    .we     (intr_test_done_ch0_we),
+    .we     (intr_test_we),
     .wd     (intr_test_done_ch0_wd),
     .d      ('0),
     .qre    (),
@@ -296,7 +287,7 @@ module pattgen_reg_top (
     .DW    (1)
   ) u_intr_test_done_ch1 (
     .re     (1'b0),
-    .we     (intr_test_done_ch1_we),
+    .we     (intr_test_we),
     .wd     (intr_test_done_ch1_wd),
     .d      ('0),
     .qre    (),
@@ -334,7 +325,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_enable_ch0_we),
+    .we     (ctrl_we),
     .wd     (ctrl_enable_ch0_wd),
 
     // from internal hardware
@@ -360,7 +351,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_enable_ch1_we),
+    .we     (ctrl_we),
     .wd     (ctrl_enable_ch1_wd),
 
     // from internal hardware
@@ -386,7 +377,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_polarity_ch0_we),
+    .we     (ctrl_we),
     .wd     (ctrl_polarity_ch0_wd),
 
     // from internal hardware
@@ -412,7 +403,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_polarity_ch1_we),
+    .we     (ctrl_we),
     .wd     (ctrl_polarity_ch1_wd),
 
     // from internal hardware
@@ -606,7 +597,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (size_len_ch0_we),
+    .we     (size_we),
     .wd     (size_len_ch0_wd),
 
     // from internal hardware
@@ -632,7 +623,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (size_reps_ch0_we),
+    .we     (size_we),
     .wd     (size_reps_ch0_wd),
 
     // from internal hardware
@@ -658,7 +649,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (size_len_ch1_we),
+    .we     (size_we),
     .wd     (size_len_ch1_wd),
 
     // from internal hardware
@@ -684,7 +675,7 @@ module pattgen_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (size_reps_ch1_we),
+    .we     (size_we),
     .wd     (size_reps_ch1_wd),
 
     // from internal hardware
@@ -737,68 +728,59 @@ module pattgen_reg_top (
                (addr_hit[10] & (|(PATTGEN_PERMIT[10] & ~reg_be))) |
                (addr_hit[11] & (|(PATTGEN_PERMIT[11] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_done_ch0_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_done_ch0_wd = reg_wdata[0];
 
-  assign intr_state_done_ch1_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_done_ch1_wd = reg_wdata[1];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_done_ch0_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_done_ch0_wd = reg_wdata[0];
 
-  assign intr_enable_done_ch1_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_done_ch1_wd = reg_wdata[1];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_done_ch0_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_done_ch0_wd = reg_wdata[0];
 
-  assign intr_test_done_ch1_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_done_ch1_wd = reg_wdata[1];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
-  assign alert_test_wd = reg_wdata[0];
 
-  assign ctrl_enable_ch0_we = addr_hit[4] & reg_we & !reg_error;
+  assign alert_test_wd = reg_wdata[0];
+  assign ctrl_we = addr_hit[4] & reg_we & !reg_error;
+
   assign ctrl_enable_ch0_wd = reg_wdata[0];
 
-  assign ctrl_enable_ch1_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_enable_ch1_wd = reg_wdata[1];
 
-  assign ctrl_polarity_ch0_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_polarity_ch0_wd = reg_wdata[2];
 
-  assign ctrl_polarity_ch1_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_polarity_ch1_wd = reg_wdata[3];
-
   assign prediv_ch0_we = addr_hit[5] & reg_we & !reg_error;
+
   assign prediv_ch0_wd = reg_wdata[31:0];
-
   assign prediv_ch1_we = addr_hit[6] & reg_we & !reg_error;
+
   assign prediv_ch1_wd = reg_wdata[31:0];
-
   assign data_ch0_0_we = addr_hit[7] & reg_we & !reg_error;
+
   assign data_ch0_0_wd = reg_wdata[31:0];
-
   assign data_ch0_1_we = addr_hit[8] & reg_we & !reg_error;
+
   assign data_ch0_1_wd = reg_wdata[31:0];
-
   assign data_ch1_0_we = addr_hit[9] & reg_we & !reg_error;
+
   assign data_ch1_0_wd = reg_wdata[31:0];
-
   assign data_ch1_1_we = addr_hit[10] & reg_we & !reg_error;
-  assign data_ch1_1_wd = reg_wdata[31:0];
 
-  assign size_len_ch0_we = addr_hit[11] & reg_we & !reg_error;
+  assign data_ch1_1_wd = reg_wdata[31:0];
+  assign size_we = addr_hit[11] & reg_we & !reg_error;
+
   assign size_len_ch0_wd = reg_wdata[5:0];
 
-  assign size_reps_ch0_we = addr_hit[11] & reg_we & !reg_error;
   assign size_reps_ch0_wd = reg_wdata[15:6];
 
-  assign size_len_ch1_we = addr_hit[11] & reg_we & !reg_error;
   assign size_len_ch1_wd = reg_wdata[21:16];
 
-  assign size_reps_ch1_we = addr_hit[11] & reg_we & !reg_error;
   assign size_reps_ch1_wd = reg_wdata[31:22];
 
   // Read data return

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -104,1510 +104,1434 @@ module pinmux_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic mio_periph_insel_regwen_0_we;
   logic mio_periph_insel_regwen_0_qs;
   logic mio_periph_insel_regwen_0_wd;
-  logic mio_periph_insel_regwen_0_we;
+  logic mio_periph_insel_regwen_1_we;
   logic mio_periph_insel_regwen_1_qs;
   logic mio_periph_insel_regwen_1_wd;
-  logic mio_periph_insel_regwen_1_we;
+  logic mio_periph_insel_regwen_2_we;
   logic mio_periph_insel_regwen_2_qs;
   logic mio_periph_insel_regwen_2_wd;
-  logic mio_periph_insel_regwen_2_we;
+  logic mio_periph_insel_regwen_3_we;
   logic mio_periph_insel_regwen_3_qs;
   logic mio_periph_insel_regwen_3_wd;
-  logic mio_periph_insel_regwen_3_we;
+  logic mio_periph_insel_regwen_4_we;
   logic mio_periph_insel_regwen_4_qs;
   logic mio_periph_insel_regwen_4_wd;
-  logic mio_periph_insel_regwen_4_we;
+  logic mio_periph_insel_regwen_5_we;
   logic mio_periph_insel_regwen_5_qs;
   logic mio_periph_insel_regwen_5_wd;
-  logic mio_periph_insel_regwen_5_we;
+  logic mio_periph_insel_regwen_6_we;
   logic mio_periph_insel_regwen_6_qs;
   logic mio_periph_insel_regwen_6_wd;
-  logic mio_periph_insel_regwen_6_we;
+  logic mio_periph_insel_regwen_7_we;
   logic mio_periph_insel_regwen_7_qs;
   logic mio_periph_insel_regwen_7_wd;
-  logic mio_periph_insel_regwen_7_we;
+  logic mio_periph_insel_regwen_8_we;
   logic mio_periph_insel_regwen_8_qs;
   logic mio_periph_insel_regwen_8_wd;
-  logic mio_periph_insel_regwen_8_we;
+  logic mio_periph_insel_regwen_9_we;
   logic mio_periph_insel_regwen_9_qs;
   logic mio_periph_insel_regwen_9_wd;
-  logic mio_periph_insel_regwen_9_we;
+  logic mio_periph_insel_regwen_10_we;
   logic mio_periph_insel_regwen_10_qs;
   logic mio_periph_insel_regwen_10_wd;
-  logic mio_periph_insel_regwen_10_we;
+  logic mio_periph_insel_regwen_11_we;
   logic mio_periph_insel_regwen_11_qs;
   logic mio_periph_insel_regwen_11_wd;
-  logic mio_periph_insel_regwen_11_we;
+  logic mio_periph_insel_regwen_12_we;
   logic mio_periph_insel_regwen_12_qs;
   logic mio_periph_insel_regwen_12_wd;
-  logic mio_periph_insel_regwen_12_we;
+  logic mio_periph_insel_regwen_13_we;
   logic mio_periph_insel_regwen_13_qs;
   logic mio_periph_insel_regwen_13_wd;
-  logic mio_periph_insel_regwen_13_we;
+  logic mio_periph_insel_regwen_14_we;
   logic mio_periph_insel_regwen_14_qs;
   logic mio_periph_insel_regwen_14_wd;
-  logic mio_periph_insel_regwen_14_we;
+  logic mio_periph_insel_regwen_15_we;
   logic mio_periph_insel_regwen_15_qs;
   logic mio_periph_insel_regwen_15_wd;
-  logic mio_periph_insel_regwen_15_we;
+  logic mio_periph_insel_regwen_16_we;
   logic mio_periph_insel_regwen_16_qs;
   logic mio_periph_insel_regwen_16_wd;
-  logic mio_periph_insel_regwen_16_we;
+  logic mio_periph_insel_regwen_17_we;
   logic mio_periph_insel_regwen_17_qs;
   logic mio_periph_insel_regwen_17_wd;
-  logic mio_periph_insel_regwen_17_we;
+  logic mio_periph_insel_regwen_18_we;
   logic mio_periph_insel_regwen_18_qs;
   logic mio_periph_insel_regwen_18_wd;
-  logic mio_periph_insel_regwen_18_we;
+  logic mio_periph_insel_regwen_19_we;
   logic mio_periph_insel_regwen_19_qs;
   logic mio_periph_insel_regwen_19_wd;
-  logic mio_periph_insel_regwen_19_we;
+  logic mio_periph_insel_regwen_20_we;
   logic mio_periph_insel_regwen_20_qs;
   logic mio_periph_insel_regwen_20_wd;
-  logic mio_periph_insel_regwen_20_we;
+  logic mio_periph_insel_regwen_21_we;
   logic mio_periph_insel_regwen_21_qs;
   logic mio_periph_insel_regwen_21_wd;
-  logic mio_periph_insel_regwen_21_we;
+  logic mio_periph_insel_regwen_22_we;
   logic mio_periph_insel_regwen_22_qs;
   logic mio_periph_insel_regwen_22_wd;
-  logic mio_periph_insel_regwen_22_we;
+  logic mio_periph_insel_regwen_23_we;
   logic mio_periph_insel_regwen_23_qs;
   logic mio_periph_insel_regwen_23_wd;
-  logic mio_periph_insel_regwen_23_we;
+  logic mio_periph_insel_regwen_24_we;
   logic mio_periph_insel_regwen_24_qs;
   logic mio_periph_insel_regwen_24_wd;
-  logic mio_periph_insel_regwen_24_we;
+  logic mio_periph_insel_regwen_25_we;
   logic mio_periph_insel_regwen_25_qs;
   logic mio_periph_insel_regwen_25_wd;
-  logic mio_periph_insel_regwen_25_we;
+  logic mio_periph_insel_regwen_26_we;
   logic mio_periph_insel_regwen_26_qs;
   logic mio_periph_insel_regwen_26_wd;
-  logic mio_periph_insel_regwen_26_we;
+  logic mio_periph_insel_regwen_27_we;
   logic mio_periph_insel_regwen_27_qs;
   logic mio_periph_insel_regwen_27_wd;
-  logic mio_periph_insel_regwen_27_we;
+  logic mio_periph_insel_regwen_28_we;
   logic mio_periph_insel_regwen_28_qs;
   logic mio_periph_insel_regwen_28_wd;
-  logic mio_periph_insel_regwen_28_we;
+  logic mio_periph_insel_regwen_29_we;
   logic mio_periph_insel_regwen_29_qs;
   logic mio_periph_insel_regwen_29_wd;
-  logic mio_periph_insel_regwen_29_we;
+  logic mio_periph_insel_regwen_30_we;
   logic mio_periph_insel_regwen_30_qs;
   logic mio_periph_insel_regwen_30_wd;
-  logic mio_periph_insel_regwen_30_we;
+  logic mio_periph_insel_regwen_31_we;
   logic mio_periph_insel_regwen_31_qs;
   logic mio_periph_insel_regwen_31_wd;
-  logic mio_periph_insel_regwen_31_we;
+  logic mio_periph_insel_regwen_32_we;
   logic mio_periph_insel_regwen_32_qs;
   logic mio_periph_insel_regwen_32_wd;
-  logic mio_periph_insel_regwen_32_we;
+  logic mio_periph_insel_0_we;
   logic [5:0] mio_periph_insel_0_qs;
   logic [5:0] mio_periph_insel_0_wd;
-  logic mio_periph_insel_0_we;
+  logic mio_periph_insel_1_we;
   logic [5:0] mio_periph_insel_1_qs;
   logic [5:0] mio_periph_insel_1_wd;
-  logic mio_periph_insel_1_we;
+  logic mio_periph_insel_2_we;
   logic [5:0] mio_periph_insel_2_qs;
   logic [5:0] mio_periph_insel_2_wd;
-  logic mio_periph_insel_2_we;
+  logic mio_periph_insel_3_we;
   logic [5:0] mio_periph_insel_3_qs;
   logic [5:0] mio_periph_insel_3_wd;
-  logic mio_periph_insel_3_we;
+  logic mio_periph_insel_4_we;
   logic [5:0] mio_periph_insel_4_qs;
   logic [5:0] mio_periph_insel_4_wd;
-  logic mio_periph_insel_4_we;
+  logic mio_periph_insel_5_we;
   logic [5:0] mio_periph_insel_5_qs;
   logic [5:0] mio_periph_insel_5_wd;
-  logic mio_periph_insel_5_we;
+  logic mio_periph_insel_6_we;
   logic [5:0] mio_periph_insel_6_qs;
   logic [5:0] mio_periph_insel_6_wd;
-  logic mio_periph_insel_6_we;
+  logic mio_periph_insel_7_we;
   logic [5:0] mio_periph_insel_7_qs;
   logic [5:0] mio_periph_insel_7_wd;
-  logic mio_periph_insel_7_we;
+  logic mio_periph_insel_8_we;
   logic [5:0] mio_periph_insel_8_qs;
   logic [5:0] mio_periph_insel_8_wd;
-  logic mio_periph_insel_8_we;
+  logic mio_periph_insel_9_we;
   logic [5:0] mio_periph_insel_9_qs;
   logic [5:0] mio_periph_insel_9_wd;
-  logic mio_periph_insel_9_we;
+  logic mio_periph_insel_10_we;
   logic [5:0] mio_periph_insel_10_qs;
   logic [5:0] mio_periph_insel_10_wd;
-  logic mio_periph_insel_10_we;
+  logic mio_periph_insel_11_we;
   logic [5:0] mio_periph_insel_11_qs;
   logic [5:0] mio_periph_insel_11_wd;
-  logic mio_periph_insel_11_we;
+  logic mio_periph_insel_12_we;
   logic [5:0] mio_periph_insel_12_qs;
   logic [5:0] mio_periph_insel_12_wd;
-  logic mio_periph_insel_12_we;
+  logic mio_periph_insel_13_we;
   logic [5:0] mio_periph_insel_13_qs;
   logic [5:0] mio_periph_insel_13_wd;
-  logic mio_periph_insel_13_we;
+  logic mio_periph_insel_14_we;
   logic [5:0] mio_periph_insel_14_qs;
   logic [5:0] mio_periph_insel_14_wd;
-  logic mio_periph_insel_14_we;
+  logic mio_periph_insel_15_we;
   logic [5:0] mio_periph_insel_15_qs;
   logic [5:0] mio_periph_insel_15_wd;
-  logic mio_periph_insel_15_we;
+  logic mio_periph_insel_16_we;
   logic [5:0] mio_periph_insel_16_qs;
   logic [5:0] mio_periph_insel_16_wd;
-  logic mio_periph_insel_16_we;
+  logic mio_periph_insel_17_we;
   logic [5:0] mio_periph_insel_17_qs;
   logic [5:0] mio_periph_insel_17_wd;
-  logic mio_periph_insel_17_we;
+  logic mio_periph_insel_18_we;
   logic [5:0] mio_periph_insel_18_qs;
   logic [5:0] mio_periph_insel_18_wd;
-  logic mio_periph_insel_18_we;
+  logic mio_periph_insel_19_we;
   logic [5:0] mio_periph_insel_19_qs;
   logic [5:0] mio_periph_insel_19_wd;
-  logic mio_periph_insel_19_we;
+  logic mio_periph_insel_20_we;
   logic [5:0] mio_periph_insel_20_qs;
   logic [5:0] mio_periph_insel_20_wd;
-  logic mio_periph_insel_20_we;
+  logic mio_periph_insel_21_we;
   logic [5:0] mio_periph_insel_21_qs;
   logic [5:0] mio_periph_insel_21_wd;
-  logic mio_periph_insel_21_we;
+  logic mio_periph_insel_22_we;
   logic [5:0] mio_periph_insel_22_qs;
   logic [5:0] mio_periph_insel_22_wd;
-  logic mio_periph_insel_22_we;
+  logic mio_periph_insel_23_we;
   logic [5:0] mio_periph_insel_23_qs;
   logic [5:0] mio_periph_insel_23_wd;
-  logic mio_periph_insel_23_we;
+  logic mio_periph_insel_24_we;
   logic [5:0] mio_periph_insel_24_qs;
   logic [5:0] mio_periph_insel_24_wd;
-  logic mio_periph_insel_24_we;
+  logic mio_periph_insel_25_we;
   logic [5:0] mio_periph_insel_25_qs;
   logic [5:0] mio_periph_insel_25_wd;
-  logic mio_periph_insel_25_we;
+  logic mio_periph_insel_26_we;
   logic [5:0] mio_periph_insel_26_qs;
   logic [5:0] mio_periph_insel_26_wd;
-  logic mio_periph_insel_26_we;
+  logic mio_periph_insel_27_we;
   logic [5:0] mio_periph_insel_27_qs;
   logic [5:0] mio_periph_insel_27_wd;
-  logic mio_periph_insel_27_we;
+  logic mio_periph_insel_28_we;
   logic [5:0] mio_periph_insel_28_qs;
   logic [5:0] mio_periph_insel_28_wd;
-  logic mio_periph_insel_28_we;
+  logic mio_periph_insel_29_we;
   logic [5:0] mio_periph_insel_29_qs;
   logic [5:0] mio_periph_insel_29_wd;
-  logic mio_periph_insel_29_we;
+  logic mio_periph_insel_30_we;
   logic [5:0] mio_periph_insel_30_qs;
   logic [5:0] mio_periph_insel_30_wd;
-  logic mio_periph_insel_30_we;
+  logic mio_periph_insel_31_we;
   logic [5:0] mio_periph_insel_31_qs;
   logic [5:0] mio_periph_insel_31_wd;
-  logic mio_periph_insel_31_we;
+  logic mio_periph_insel_32_we;
   logic [5:0] mio_periph_insel_32_qs;
   logic [5:0] mio_periph_insel_32_wd;
-  logic mio_periph_insel_32_we;
+  logic mio_outsel_regwen_0_we;
   logic mio_outsel_regwen_0_qs;
   logic mio_outsel_regwen_0_wd;
-  logic mio_outsel_regwen_0_we;
+  logic mio_outsel_regwen_1_we;
   logic mio_outsel_regwen_1_qs;
   logic mio_outsel_regwen_1_wd;
-  logic mio_outsel_regwen_1_we;
+  logic mio_outsel_regwen_2_we;
   logic mio_outsel_regwen_2_qs;
   logic mio_outsel_regwen_2_wd;
-  logic mio_outsel_regwen_2_we;
+  logic mio_outsel_regwen_3_we;
   logic mio_outsel_regwen_3_qs;
   logic mio_outsel_regwen_3_wd;
-  logic mio_outsel_regwen_3_we;
+  logic mio_outsel_regwen_4_we;
   logic mio_outsel_regwen_4_qs;
   logic mio_outsel_regwen_4_wd;
-  logic mio_outsel_regwen_4_we;
+  logic mio_outsel_regwen_5_we;
   logic mio_outsel_regwen_5_qs;
   logic mio_outsel_regwen_5_wd;
-  logic mio_outsel_regwen_5_we;
+  logic mio_outsel_regwen_6_we;
   logic mio_outsel_regwen_6_qs;
   logic mio_outsel_regwen_6_wd;
-  logic mio_outsel_regwen_6_we;
+  logic mio_outsel_regwen_7_we;
   logic mio_outsel_regwen_7_qs;
   logic mio_outsel_regwen_7_wd;
-  logic mio_outsel_regwen_7_we;
+  logic mio_outsel_regwen_8_we;
   logic mio_outsel_regwen_8_qs;
   logic mio_outsel_regwen_8_wd;
-  logic mio_outsel_regwen_8_we;
+  logic mio_outsel_regwen_9_we;
   logic mio_outsel_regwen_9_qs;
   logic mio_outsel_regwen_9_wd;
-  logic mio_outsel_regwen_9_we;
+  logic mio_outsel_regwen_10_we;
   logic mio_outsel_regwen_10_qs;
   logic mio_outsel_regwen_10_wd;
-  logic mio_outsel_regwen_10_we;
+  logic mio_outsel_regwen_11_we;
   logic mio_outsel_regwen_11_qs;
   logic mio_outsel_regwen_11_wd;
-  logic mio_outsel_regwen_11_we;
+  logic mio_outsel_regwen_12_we;
   logic mio_outsel_regwen_12_qs;
   logic mio_outsel_regwen_12_wd;
-  logic mio_outsel_regwen_12_we;
+  logic mio_outsel_regwen_13_we;
   logic mio_outsel_regwen_13_qs;
   logic mio_outsel_regwen_13_wd;
-  logic mio_outsel_regwen_13_we;
+  logic mio_outsel_regwen_14_we;
   logic mio_outsel_regwen_14_qs;
   logic mio_outsel_regwen_14_wd;
-  logic mio_outsel_regwen_14_we;
+  logic mio_outsel_regwen_15_we;
   logic mio_outsel_regwen_15_qs;
   logic mio_outsel_regwen_15_wd;
-  logic mio_outsel_regwen_15_we;
+  logic mio_outsel_regwen_16_we;
   logic mio_outsel_regwen_16_qs;
   logic mio_outsel_regwen_16_wd;
-  logic mio_outsel_regwen_16_we;
+  logic mio_outsel_regwen_17_we;
   logic mio_outsel_regwen_17_qs;
   logic mio_outsel_regwen_17_wd;
-  logic mio_outsel_regwen_17_we;
+  logic mio_outsel_regwen_18_we;
   logic mio_outsel_regwen_18_qs;
   logic mio_outsel_regwen_18_wd;
-  logic mio_outsel_regwen_18_we;
+  logic mio_outsel_regwen_19_we;
   logic mio_outsel_regwen_19_qs;
   logic mio_outsel_regwen_19_wd;
-  logic mio_outsel_regwen_19_we;
+  logic mio_outsel_regwen_20_we;
   logic mio_outsel_regwen_20_qs;
   logic mio_outsel_regwen_20_wd;
-  logic mio_outsel_regwen_20_we;
+  logic mio_outsel_regwen_21_we;
   logic mio_outsel_regwen_21_qs;
   logic mio_outsel_regwen_21_wd;
-  logic mio_outsel_regwen_21_we;
+  logic mio_outsel_regwen_22_we;
   logic mio_outsel_regwen_22_qs;
   logic mio_outsel_regwen_22_wd;
-  logic mio_outsel_regwen_22_we;
+  logic mio_outsel_regwen_23_we;
   logic mio_outsel_regwen_23_qs;
   logic mio_outsel_regwen_23_wd;
-  logic mio_outsel_regwen_23_we;
+  logic mio_outsel_regwen_24_we;
   logic mio_outsel_regwen_24_qs;
   logic mio_outsel_regwen_24_wd;
-  logic mio_outsel_regwen_24_we;
+  logic mio_outsel_regwen_25_we;
   logic mio_outsel_regwen_25_qs;
   logic mio_outsel_regwen_25_wd;
-  logic mio_outsel_regwen_25_we;
+  logic mio_outsel_regwen_26_we;
   logic mio_outsel_regwen_26_qs;
   logic mio_outsel_regwen_26_wd;
-  logic mio_outsel_regwen_26_we;
+  logic mio_outsel_regwen_27_we;
   logic mio_outsel_regwen_27_qs;
   logic mio_outsel_regwen_27_wd;
-  logic mio_outsel_regwen_27_we;
+  logic mio_outsel_regwen_28_we;
   logic mio_outsel_regwen_28_qs;
   logic mio_outsel_regwen_28_wd;
-  logic mio_outsel_regwen_28_we;
+  logic mio_outsel_regwen_29_we;
   logic mio_outsel_regwen_29_qs;
   logic mio_outsel_regwen_29_wd;
-  logic mio_outsel_regwen_29_we;
+  logic mio_outsel_regwen_30_we;
   logic mio_outsel_regwen_30_qs;
   logic mio_outsel_regwen_30_wd;
-  logic mio_outsel_regwen_30_we;
+  logic mio_outsel_regwen_31_we;
   logic mio_outsel_regwen_31_qs;
   logic mio_outsel_regwen_31_wd;
-  logic mio_outsel_regwen_31_we;
+  logic mio_outsel_0_we;
   logic [5:0] mio_outsel_0_qs;
   logic [5:0] mio_outsel_0_wd;
-  logic mio_outsel_0_we;
+  logic mio_outsel_1_we;
   logic [5:0] mio_outsel_1_qs;
   logic [5:0] mio_outsel_1_wd;
-  logic mio_outsel_1_we;
+  logic mio_outsel_2_we;
   logic [5:0] mio_outsel_2_qs;
   logic [5:0] mio_outsel_2_wd;
-  logic mio_outsel_2_we;
+  logic mio_outsel_3_we;
   logic [5:0] mio_outsel_3_qs;
   logic [5:0] mio_outsel_3_wd;
-  logic mio_outsel_3_we;
+  logic mio_outsel_4_we;
   logic [5:0] mio_outsel_4_qs;
   logic [5:0] mio_outsel_4_wd;
-  logic mio_outsel_4_we;
+  logic mio_outsel_5_we;
   logic [5:0] mio_outsel_5_qs;
   logic [5:0] mio_outsel_5_wd;
-  logic mio_outsel_5_we;
+  logic mio_outsel_6_we;
   logic [5:0] mio_outsel_6_qs;
   logic [5:0] mio_outsel_6_wd;
-  logic mio_outsel_6_we;
+  logic mio_outsel_7_we;
   logic [5:0] mio_outsel_7_qs;
   logic [5:0] mio_outsel_7_wd;
-  logic mio_outsel_7_we;
+  logic mio_outsel_8_we;
   logic [5:0] mio_outsel_8_qs;
   logic [5:0] mio_outsel_8_wd;
-  logic mio_outsel_8_we;
+  logic mio_outsel_9_we;
   logic [5:0] mio_outsel_9_qs;
   logic [5:0] mio_outsel_9_wd;
-  logic mio_outsel_9_we;
+  logic mio_outsel_10_we;
   logic [5:0] mio_outsel_10_qs;
   logic [5:0] mio_outsel_10_wd;
-  logic mio_outsel_10_we;
+  logic mio_outsel_11_we;
   logic [5:0] mio_outsel_11_qs;
   logic [5:0] mio_outsel_11_wd;
-  logic mio_outsel_11_we;
+  logic mio_outsel_12_we;
   logic [5:0] mio_outsel_12_qs;
   logic [5:0] mio_outsel_12_wd;
-  logic mio_outsel_12_we;
+  logic mio_outsel_13_we;
   logic [5:0] mio_outsel_13_qs;
   logic [5:0] mio_outsel_13_wd;
-  logic mio_outsel_13_we;
+  logic mio_outsel_14_we;
   logic [5:0] mio_outsel_14_qs;
   logic [5:0] mio_outsel_14_wd;
-  logic mio_outsel_14_we;
+  logic mio_outsel_15_we;
   logic [5:0] mio_outsel_15_qs;
   logic [5:0] mio_outsel_15_wd;
-  logic mio_outsel_15_we;
+  logic mio_outsel_16_we;
   logic [5:0] mio_outsel_16_qs;
   logic [5:0] mio_outsel_16_wd;
-  logic mio_outsel_16_we;
+  logic mio_outsel_17_we;
   logic [5:0] mio_outsel_17_qs;
   logic [5:0] mio_outsel_17_wd;
-  logic mio_outsel_17_we;
+  logic mio_outsel_18_we;
   logic [5:0] mio_outsel_18_qs;
   logic [5:0] mio_outsel_18_wd;
-  logic mio_outsel_18_we;
+  logic mio_outsel_19_we;
   logic [5:0] mio_outsel_19_qs;
   logic [5:0] mio_outsel_19_wd;
-  logic mio_outsel_19_we;
+  logic mio_outsel_20_we;
   logic [5:0] mio_outsel_20_qs;
   logic [5:0] mio_outsel_20_wd;
-  logic mio_outsel_20_we;
+  logic mio_outsel_21_we;
   logic [5:0] mio_outsel_21_qs;
   logic [5:0] mio_outsel_21_wd;
-  logic mio_outsel_21_we;
+  logic mio_outsel_22_we;
   logic [5:0] mio_outsel_22_qs;
   logic [5:0] mio_outsel_22_wd;
-  logic mio_outsel_22_we;
+  logic mio_outsel_23_we;
   logic [5:0] mio_outsel_23_qs;
   logic [5:0] mio_outsel_23_wd;
-  logic mio_outsel_23_we;
+  logic mio_outsel_24_we;
   logic [5:0] mio_outsel_24_qs;
   logic [5:0] mio_outsel_24_wd;
-  logic mio_outsel_24_we;
+  logic mio_outsel_25_we;
   logic [5:0] mio_outsel_25_qs;
   logic [5:0] mio_outsel_25_wd;
-  logic mio_outsel_25_we;
+  logic mio_outsel_26_we;
   logic [5:0] mio_outsel_26_qs;
   logic [5:0] mio_outsel_26_wd;
-  logic mio_outsel_26_we;
+  logic mio_outsel_27_we;
   logic [5:0] mio_outsel_27_qs;
   logic [5:0] mio_outsel_27_wd;
-  logic mio_outsel_27_we;
+  logic mio_outsel_28_we;
   logic [5:0] mio_outsel_28_qs;
   logic [5:0] mio_outsel_28_wd;
-  logic mio_outsel_28_we;
+  logic mio_outsel_29_we;
   logic [5:0] mio_outsel_29_qs;
   logic [5:0] mio_outsel_29_wd;
-  logic mio_outsel_29_we;
+  logic mio_outsel_30_we;
   logic [5:0] mio_outsel_30_qs;
   logic [5:0] mio_outsel_30_wd;
-  logic mio_outsel_30_we;
+  logic mio_outsel_31_we;
   logic [5:0] mio_outsel_31_qs;
   logic [5:0] mio_outsel_31_wd;
-  logic mio_outsel_31_we;
+  logic mio_pad_attr_regwen_0_we;
   logic mio_pad_attr_regwen_0_qs;
   logic mio_pad_attr_regwen_0_wd;
-  logic mio_pad_attr_regwen_0_we;
+  logic mio_pad_attr_regwen_1_we;
   logic mio_pad_attr_regwen_1_qs;
   logic mio_pad_attr_regwen_1_wd;
-  logic mio_pad_attr_regwen_1_we;
+  logic mio_pad_attr_regwen_2_we;
   logic mio_pad_attr_regwen_2_qs;
   logic mio_pad_attr_regwen_2_wd;
-  logic mio_pad_attr_regwen_2_we;
+  logic mio_pad_attr_regwen_3_we;
   logic mio_pad_attr_regwen_3_qs;
   logic mio_pad_attr_regwen_3_wd;
-  logic mio_pad_attr_regwen_3_we;
+  logic mio_pad_attr_regwen_4_we;
   logic mio_pad_attr_regwen_4_qs;
   logic mio_pad_attr_regwen_4_wd;
-  logic mio_pad_attr_regwen_4_we;
+  logic mio_pad_attr_regwen_5_we;
   logic mio_pad_attr_regwen_5_qs;
   logic mio_pad_attr_regwen_5_wd;
-  logic mio_pad_attr_regwen_5_we;
+  logic mio_pad_attr_regwen_6_we;
   logic mio_pad_attr_regwen_6_qs;
   logic mio_pad_attr_regwen_6_wd;
-  logic mio_pad_attr_regwen_6_we;
+  logic mio_pad_attr_regwen_7_we;
   logic mio_pad_attr_regwen_7_qs;
   logic mio_pad_attr_regwen_7_wd;
-  logic mio_pad_attr_regwen_7_we;
+  logic mio_pad_attr_regwen_8_we;
   logic mio_pad_attr_regwen_8_qs;
   logic mio_pad_attr_regwen_8_wd;
-  logic mio_pad_attr_regwen_8_we;
+  logic mio_pad_attr_regwen_9_we;
   logic mio_pad_attr_regwen_9_qs;
   logic mio_pad_attr_regwen_9_wd;
-  logic mio_pad_attr_regwen_9_we;
+  logic mio_pad_attr_regwen_10_we;
   logic mio_pad_attr_regwen_10_qs;
   logic mio_pad_attr_regwen_10_wd;
-  logic mio_pad_attr_regwen_10_we;
+  logic mio_pad_attr_regwen_11_we;
   logic mio_pad_attr_regwen_11_qs;
   logic mio_pad_attr_regwen_11_wd;
-  logic mio_pad_attr_regwen_11_we;
+  logic mio_pad_attr_regwen_12_we;
   logic mio_pad_attr_regwen_12_qs;
   logic mio_pad_attr_regwen_12_wd;
-  logic mio_pad_attr_regwen_12_we;
+  logic mio_pad_attr_regwen_13_we;
   logic mio_pad_attr_regwen_13_qs;
   logic mio_pad_attr_regwen_13_wd;
-  logic mio_pad_attr_regwen_13_we;
+  logic mio_pad_attr_regwen_14_we;
   logic mio_pad_attr_regwen_14_qs;
   logic mio_pad_attr_regwen_14_wd;
-  logic mio_pad_attr_regwen_14_we;
+  logic mio_pad_attr_regwen_15_we;
   logic mio_pad_attr_regwen_15_qs;
   logic mio_pad_attr_regwen_15_wd;
-  logic mio_pad_attr_regwen_15_we;
+  logic mio_pad_attr_regwen_16_we;
   logic mio_pad_attr_regwen_16_qs;
   logic mio_pad_attr_regwen_16_wd;
-  logic mio_pad_attr_regwen_16_we;
+  logic mio_pad_attr_regwen_17_we;
   logic mio_pad_attr_regwen_17_qs;
   logic mio_pad_attr_regwen_17_wd;
-  logic mio_pad_attr_regwen_17_we;
+  logic mio_pad_attr_regwen_18_we;
   logic mio_pad_attr_regwen_18_qs;
   logic mio_pad_attr_regwen_18_wd;
-  logic mio_pad_attr_regwen_18_we;
+  logic mio_pad_attr_regwen_19_we;
   logic mio_pad_attr_regwen_19_qs;
   logic mio_pad_attr_regwen_19_wd;
-  logic mio_pad_attr_regwen_19_we;
+  logic mio_pad_attr_regwen_20_we;
   logic mio_pad_attr_regwen_20_qs;
   logic mio_pad_attr_regwen_20_wd;
-  logic mio_pad_attr_regwen_20_we;
+  logic mio_pad_attr_regwen_21_we;
   logic mio_pad_attr_regwen_21_qs;
   logic mio_pad_attr_regwen_21_wd;
-  logic mio_pad_attr_regwen_21_we;
+  logic mio_pad_attr_regwen_22_we;
   logic mio_pad_attr_regwen_22_qs;
   logic mio_pad_attr_regwen_22_wd;
-  logic mio_pad_attr_regwen_22_we;
+  logic mio_pad_attr_regwen_23_we;
   logic mio_pad_attr_regwen_23_qs;
   logic mio_pad_attr_regwen_23_wd;
-  logic mio_pad_attr_regwen_23_we;
+  logic mio_pad_attr_regwen_24_we;
   logic mio_pad_attr_regwen_24_qs;
   logic mio_pad_attr_regwen_24_wd;
-  logic mio_pad_attr_regwen_24_we;
+  logic mio_pad_attr_regwen_25_we;
   logic mio_pad_attr_regwen_25_qs;
   logic mio_pad_attr_regwen_25_wd;
-  logic mio_pad_attr_regwen_25_we;
+  logic mio_pad_attr_regwen_26_we;
   logic mio_pad_attr_regwen_26_qs;
   logic mio_pad_attr_regwen_26_wd;
-  logic mio_pad_attr_regwen_26_we;
+  logic mio_pad_attr_regwen_27_we;
   logic mio_pad_attr_regwen_27_qs;
   logic mio_pad_attr_regwen_27_wd;
-  logic mio_pad_attr_regwen_27_we;
+  logic mio_pad_attr_regwen_28_we;
   logic mio_pad_attr_regwen_28_qs;
   logic mio_pad_attr_regwen_28_wd;
-  logic mio_pad_attr_regwen_28_we;
+  logic mio_pad_attr_regwen_29_we;
   logic mio_pad_attr_regwen_29_qs;
   logic mio_pad_attr_regwen_29_wd;
-  logic mio_pad_attr_regwen_29_we;
+  logic mio_pad_attr_regwen_30_we;
   logic mio_pad_attr_regwen_30_qs;
   logic mio_pad_attr_regwen_30_wd;
-  logic mio_pad_attr_regwen_30_we;
+  logic mio_pad_attr_regwen_31_we;
   logic mio_pad_attr_regwen_31_qs;
   logic mio_pad_attr_regwen_31_wd;
-  logic mio_pad_attr_regwen_31_we;
+  logic mio_pad_attr_0_re;
+  logic mio_pad_attr_0_we;
   logic [12:0] mio_pad_attr_0_qs;
   logic [12:0] mio_pad_attr_0_wd;
-  logic mio_pad_attr_0_we;
-  logic mio_pad_attr_0_re;
+  logic mio_pad_attr_1_re;
+  logic mio_pad_attr_1_we;
   logic [12:0] mio_pad_attr_1_qs;
   logic [12:0] mio_pad_attr_1_wd;
-  logic mio_pad_attr_1_we;
-  logic mio_pad_attr_1_re;
+  logic mio_pad_attr_2_re;
+  logic mio_pad_attr_2_we;
   logic [12:0] mio_pad_attr_2_qs;
   logic [12:0] mio_pad_attr_2_wd;
-  logic mio_pad_attr_2_we;
-  logic mio_pad_attr_2_re;
+  logic mio_pad_attr_3_re;
+  logic mio_pad_attr_3_we;
   logic [12:0] mio_pad_attr_3_qs;
   logic [12:0] mio_pad_attr_3_wd;
-  logic mio_pad_attr_3_we;
-  logic mio_pad_attr_3_re;
+  logic mio_pad_attr_4_re;
+  logic mio_pad_attr_4_we;
   logic [12:0] mio_pad_attr_4_qs;
   logic [12:0] mio_pad_attr_4_wd;
-  logic mio_pad_attr_4_we;
-  logic mio_pad_attr_4_re;
+  logic mio_pad_attr_5_re;
+  logic mio_pad_attr_5_we;
   logic [12:0] mio_pad_attr_5_qs;
   logic [12:0] mio_pad_attr_5_wd;
-  logic mio_pad_attr_5_we;
-  logic mio_pad_attr_5_re;
+  logic mio_pad_attr_6_re;
+  logic mio_pad_attr_6_we;
   logic [12:0] mio_pad_attr_6_qs;
   logic [12:0] mio_pad_attr_6_wd;
-  logic mio_pad_attr_6_we;
-  logic mio_pad_attr_6_re;
+  logic mio_pad_attr_7_re;
+  logic mio_pad_attr_7_we;
   logic [12:0] mio_pad_attr_7_qs;
   logic [12:0] mio_pad_attr_7_wd;
-  logic mio_pad_attr_7_we;
-  logic mio_pad_attr_7_re;
+  logic mio_pad_attr_8_re;
+  logic mio_pad_attr_8_we;
   logic [12:0] mio_pad_attr_8_qs;
   logic [12:0] mio_pad_attr_8_wd;
-  logic mio_pad_attr_8_we;
-  logic mio_pad_attr_8_re;
+  logic mio_pad_attr_9_re;
+  logic mio_pad_attr_9_we;
   logic [12:0] mio_pad_attr_9_qs;
   logic [12:0] mio_pad_attr_9_wd;
-  logic mio_pad_attr_9_we;
-  logic mio_pad_attr_9_re;
+  logic mio_pad_attr_10_re;
+  logic mio_pad_attr_10_we;
   logic [12:0] mio_pad_attr_10_qs;
   logic [12:0] mio_pad_attr_10_wd;
-  logic mio_pad_attr_10_we;
-  logic mio_pad_attr_10_re;
+  logic mio_pad_attr_11_re;
+  logic mio_pad_attr_11_we;
   logic [12:0] mio_pad_attr_11_qs;
   logic [12:0] mio_pad_attr_11_wd;
-  logic mio_pad_attr_11_we;
-  logic mio_pad_attr_11_re;
+  logic mio_pad_attr_12_re;
+  logic mio_pad_attr_12_we;
   logic [12:0] mio_pad_attr_12_qs;
   logic [12:0] mio_pad_attr_12_wd;
-  logic mio_pad_attr_12_we;
-  logic mio_pad_attr_12_re;
+  logic mio_pad_attr_13_re;
+  logic mio_pad_attr_13_we;
   logic [12:0] mio_pad_attr_13_qs;
   logic [12:0] mio_pad_attr_13_wd;
-  logic mio_pad_attr_13_we;
-  logic mio_pad_attr_13_re;
+  logic mio_pad_attr_14_re;
+  logic mio_pad_attr_14_we;
   logic [12:0] mio_pad_attr_14_qs;
   logic [12:0] mio_pad_attr_14_wd;
-  logic mio_pad_attr_14_we;
-  logic mio_pad_attr_14_re;
+  logic mio_pad_attr_15_re;
+  logic mio_pad_attr_15_we;
   logic [12:0] mio_pad_attr_15_qs;
   logic [12:0] mio_pad_attr_15_wd;
-  logic mio_pad_attr_15_we;
-  logic mio_pad_attr_15_re;
+  logic mio_pad_attr_16_re;
+  logic mio_pad_attr_16_we;
   logic [12:0] mio_pad_attr_16_qs;
   logic [12:0] mio_pad_attr_16_wd;
-  logic mio_pad_attr_16_we;
-  logic mio_pad_attr_16_re;
+  logic mio_pad_attr_17_re;
+  logic mio_pad_attr_17_we;
   logic [12:0] mio_pad_attr_17_qs;
   logic [12:0] mio_pad_attr_17_wd;
-  logic mio_pad_attr_17_we;
-  logic mio_pad_attr_17_re;
+  logic mio_pad_attr_18_re;
+  logic mio_pad_attr_18_we;
   logic [12:0] mio_pad_attr_18_qs;
   logic [12:0] mio_pad_attr_18_wd;
-  logic mio_pad_attr_18_we;
-  logic mio_pad_attr_18_re;
+  logic mio_pad_attr_19_re;
+  logic mio_pad_attr_19_we;
   logic [12:0] mio_pad_attr_19_qs;
   logic [12:0] mio_pad_attr_19_wd;
-  logic mio_pad_attr_19_we;
-  logic mio_pad_attr_19_re;
+  logic mio_pad_attr_20_re;
+  logic mio_pad_attr_20_we;
   logic [12:0] mio_pad_attr_20_qs;
   logic [12:0] mio_pad_attr_20_wd;
-  logic mio_pad_attr_20_we;
-  logic mio_pad_attr_20_re;
+  logic mio_pad_attr_21_re;
+  logic mio_pad_attr_21_we;
   logic [12:0] mio_pad_attr_21_qs;
   logic [12:0] mio_pad_attr_21_wd;
-  logic mio_pad_attr_21_we;
-  logic mio_pad_attr_21_re;
+  logic mio_pad_attr_22_re;
+  logic mio_pad_attr_22_we;
   logic [12:0] mio_pad_attr_22_qs;
   logic [12:0] mio_pad_attr_22_wd;
-  logic mio_pad_attr_22_we;
-  logic mio_pad_attr_22_re;
+  logic mio_pad_attr_23_re;
+  logic mio_pad_attr_23_we;
   logic [12:0] mio_pad_attr_23_qs;
   logic [12:0] mio_pad_attr_23_wd;
-  logic mio_pad_attr_23_we;
-  logic mio_pad_attr_23_re;
+  logic mio_pad_attr_24_re;
+  logic mio_pad_attr_24_we;
   logic [12:0] mio_pad_attr_24_qs;
   logic [12:0] mio_pad_attr_24_wd;
-  logic mio_pad_attr_24_we;
-  logic mio_pad_attr_24_re;
+  logic mio_pad_attr_25_re;
+  logic mio_pad_attr_25_we;
   logic [12:0] mio_pad_attr_25_qs;
   logic [12:0] mio_pad_attr_25_wd;
-  logic mio_pad_attr_25_we;
-  logic mio_pad_attr_25_re;
+  logic mio_pad_attr_26_re;
+  logic mio_pad_attr_26_we;
   logic [12:0] mio_pad_attr_26_qs;
   logic [12:0] mio_pad_attr_26_wd;
-  logic mio_pad_attr_26_we;
-  logic mio_pad_attr_26_re;
+  logic mio_pad_attr_27_re;
+  logic mio_pad_attr_27_we;
   logic [12:0] mio_pad_attr_27_qs;
   logic [12:0] mio_pad_attr_27_wd;
-  logic mio_pad_attr_27_we;
-  logic mio_pad_attr_27_re;
+  logic mio_pad_attr_28_re;
+  logic mio_pad_attr_28_we;
   logic [12:0] mio_pad_attr_28_qs;
   logic [12:0] mio_pad_attr_28_wd;
-  logic mio_pad_attr_28_we;
-  logic mio_pad_attr_28_re;
+  logic mio_pad_attr_29_re;
+  logic mio_pad_attr_29_we;
   logic [12:0] mio_pad_attr_29_qs;
   logic [12:0] mio_pad_attr_29_wd;
-  logic mio_pad_attr_29_we;
-  logic mio_pad_attr_29_re;
+  logic mio_pad_attr_30_re;
+  logic mio_pad_attr_30_we;
   logic [12:0] mio_pad_attr_30_qs;
   logic [12:0] mio_pad_attr_30_wd;
-  logic mio_pad_attr_30_we;
-  logic mio_pad_attr_30_re;
+  logic mio_pad_attr_31_re;
+  logic mio_pad_attr_31_we;
   logic [12:0] mio_pad_attr_31_qs;
   logic [12:0] mio_pad_attr_31_wd;
-  logic mio_pad_attr_31_we;
-  logic mio_pad_attr_31_re;
+  logic dio_pad_attr_regwen_0_we;
   logic dio_pad_attr_regwen_0_qs;
   logic dio_pad_attr_regwen_0_wd;
-  logic dio_pad_attr_regwen_0_we;
+  logic dio_pad_attr_regwen_1_we;
   logic dio_pad_attr_regwen_1_qs;
   logic dio_pad_attr_regwen_1_wd;
-  logic dio_pad_attr_regwen_1_we;
+  logic dio_pad_attr_regwen_2_we;
   logic dio_pad_attr_regwen_2_qs;
   logic dio_pad_attr_regwen_2_wd;
-  logic dio_pad_attr_regwen_2_we;
+  logic dio_pad_attr_regwen_3_we;
   logic dio_pad_attr_regwen_3_qs;
   logic dio_pad_attr_regwen_3_wd;
-  logic dio_pad_attr_regwen_3_we;
+  logic dio_pad_attr_regwen_4_we;
   logic dio_pad_attr_regwen_4_qs;
   logic dio_pad_attr_regwen_4_wd;
-  logic dio_pad_attr_regwen_4_we;
+  logic dio_pad_attr_regwen_5_we;
   logic dio_pad_attr_regwen_5_qs;
   logic dio_pad_attr_regwen_5_wd;
-  logic dio_pad_attr_regwen_5_we;
+  logic dio_pad_attr_regwen_6_we;
   logic dio_pad_attr_regwen_6_qs;
   logic dio_pad_attr_regwen_6_wd;
-  logic dio_pad_attr_regwen_6_we;
+  logic dio_pad_attr_regwen_7_we;
   logic dio_pad_attr_regwen_7_qs;
   logic dio_pad_attr_regwen_7_wd;
-  logic dio_pad_attr_regwen_7_we;
+  logic dio_pad_attr_regwen_8_we;
   logic dio_pad_attr_regwen_8_qs;
   logic dio_pad_attr_regwen_8_wd;
-  logic dio_pad_attr_regwen_8_we;
+  logic dio_pad_attr_regwen_9_we;
   logic dio_pad_attr_regwen_9_qs;
   logic dio_pad_attr_regwen_9_wd;
-  logic dio_pad_attr_regwen_9_we;
+  logic dio_pad_attr_regwen_10_we;
   logic dio_pad_attr_regwen_10_qs;
   logic dio_pad_attr_regwen_10_wd;
-  logic dio_pad_attr_regwen_10_we;
+  logic dio_pad_attr_regwen_11_we;
   logic dio_pad_attr_regwen_11_qs;
   logic dio_pad_attr_regwen_11_wd;
-  logic dio_pad_attr_regwen_11_we;
+  logic dio_pad_attr_regwen_12_we;
   logic dio_pad_attr_regwen_12_qs;
   logic dio_pad_attr_regwen_12_wd;
-  logic dio_pad_attr_regwen_12_we;
+  logic dio_pad_attr_regwen_13_we;
   logic dio_pad_attr_regwen_13_qs;
   logic dio_pad_attr_regwen_13_wd;
-  logic dio_pad_attr_regwen_13_we;
+  logic dio_pad_attr_regwen_14_we;
   logic dio_pad_attr_regwen_14_qs;
   logic dio_pad_attr_regwen_14_wd;
-  logic dio_pad_attr_regwen_14_we;
+  logic dio_pad_attr_regwen_15_we;
   logic dio_pad_attr_regwen_15_qs;
   logic dio_pad_attr_regwen_15_wd;
-  logic dio_pad_attr_regwen_15_we;
+  logic dio_pad_attr_0_re;
+  logic dio_pad_attr_0_we;
   logic [12:0] dio_pad_attr_0_qs;
   logic [12:0] dio_pad_attr_0_wd;
-  logic dio_pad_attr_0_we;
-  logic dio_pad_attr_0_re;
+  logic dio_pad_attr_1_re;
+  logic dio_pad_attr_1_we;
   logic [12:0] dio_pad_attr_1_qs;
   logic [12:0] dio_pad_attr_1_wd;
-  logic dio_pad_attr_1_we;
-  logic dio_pad_attr_1_re;
+  logic dio_pad_attr_2_re;
+  logic dio_pad_attr_2_we;
   logic [12:0] dio_pad_attr_2_qs;
   logic [12:0] dio_pad_attr_2_wd;
-  logic dio_pad_attr_2_we;
-  logic dio_pad_attr_2_re;
+  logic dio_pad_attr_3_re;
+  logic dio_pad_attr_3_we;
   logic [12:0] dio_pad_attr_3_qs;
   logic [12:0] dio_pad_attr_3_wd;
-  logic dio_pad_attr_3_we;
-  logic dio_pad_attr_3_re;
+  logic dio_pad_attr_4_re;
+  logic dio_pad_attr_4_we;
   logic [12:0] dio_pad_attr_4_qs;
   logic [12:0] dio_pad_attr_4_wd;
-  logic dio_pad_attr_4_we;
-  logic dio_pad_attr_4_re;
+  logic dio_pad_attr_5_re;
+  logic dio_pad_attr_5_we;
   logic [12:0] dio_pad_attr_5_qs;
   logic [12:0] dio_pad_attr_5_wd;
-  logic dio_pad_attr_5_we;
-  logic dio_pad_attr_5_re;
+  logic dio_pad_attr_6_re;
+  logic dio_pad_attr_6_we;
   logic [12:0] dio_pad_attr_6_qs;
   logic [12:0] dio_pad_attr_6_wd;
-  logic dio_pad_attr_6_we;
-  logic dio_pad_attr_6_re;
+  logic dio_pad_attr_7_re;
+  logic dio_pad_attr_7_we;
   logic [12:0] dio_pad_attr_7_qs;
   logic [12:0] dio_pad_attr_7_wd;
-  logic dio_pad_attr_7_we;
-  logic dio_pad_attr_7_re;
+  logic dio_pad_attr_8_re;
+  logic dio_pad_attr_8_we;
   logic [12:0] dio_pad_attr_8_qs;
   logic [12:0] dio_pad_attr_8_wd;
-  logic dio_pad_attr_8_we;
-  logic dio_pad_attr_8_re;
+  logic dio_pad_attr_9_re;
+  logic dio_pad_attr_9_we;
   logic [12:0] dio_pad_attr_9_qs;
   logic [12:0] dio_pad_attr_9_wd;
-  logic dio_pad_attr_9_we;
-  logic dio_pad_attr_9_re;
+  logic dio_pad_attr_10_re;
+  logic dio_pad_attr_10_we;
   logic [12:0] dio_pad_attr_10_qs;
   logic [12:0] dio_pad_attr_10_wd;
-  logic dio_pad_attr_10_we;
-  logic dio_pad_attr_10_re;
+  logic dio_pad_attr_11_re;
+  logic dio_pad_attr_11_we;
   logic [12:0] dio_pad_attr_11_qs;
   logic [12:0] dio_pad_attr_11_wd;
-  logic dio_pad_attr_11_we;
-  logic dio_pad_attr_11_re;
+  logic dio_pad_attr_12_re;
+  logic dio_pad_attr_12_we;
   logic [12:0] dio_pad_attr_12_qs;
   logic [12:0] dio_pad_attr_12_wd;
-  logic dio_pad_attr_12_we;
-  logic dio_pad_attr_12_re;
+  logic dio_pad_attr_13_re;
+  logic dio_pad_attr_13_we;
   logic [12:0] dio_pad_attr_13_qs;
   logic [12:0] dio_pad_attr_13_wd;
-  logic dio_pad_attr_13_we;
-  logic dio_pad_attr_13_re;
+  logic dio_pad_attr_14_re;
+  logic dio_pad_attr_14_we;
   logic [12:0] dio_pad_attr_14_qs;
   logic [12:0] dio_pad_attr_14_wd;
-  logic dio_pad_attr_14_we;
-  logic dio_pad_attr_14_re;
+  logic dio_pad_attr_15_re;
+  logic dio_pad_attr_15_we;
   logic [12:0] dio_pad_attr_15_qs;
   logic [12:0] dio_pad_attr_15_wd;
-  logic dio_pad_attr_15_we;
-  logic dio_pad_attr_15_re;
+  logic mio_pad_sleep_status_we;
   logic mio_pad_sleep_status_en_0_qs;
   logic mio_pad_sleep_status_en_0_wd;
-  logic mio_pad_sleep_status_en_0_we;
   logic mio_pad_sleep_status_en_1_qs;
   logic mio_pad_sleep_status_en_1_wd;
-  logic mio_pad_sleep_status_en_1_we;
   logic mio_pad_sleep_status_en_2_qs;
   logic mio_pad_sleep_status_en_2_wd;
-  logic mio_pad_sleep_status_en_2_we;
   logic mio_pad_sleep_status_en_3_qs;
   logic mio_pad_sleep_status_en_3_wd;
-  logic mio_pad_sleep_status_en_3_we;
   logic mio_pad_sleep_status_en_4_qs;
   logic mio_pad_sleep_status_en_4_wd;
-  logic mio_pad_sleep_status_en_4_we;
   logic mio_pad_sleep_status_en_5_qs;
   logic mio_pad_sleep_status_en_5_wd;
-  logic mio_pad_sleep_status_en_5_we;
   logic mio_pad_sleep_status_en_6_qs;
   logic mio_pad_sleep_status_en_6_wd;
-  logic mio_pad_sleep_status_en_6_we;
   logic mio_pad_sleep_status_en_7_qs;
   logic mio_pad_sleep_status_en_7_wd;
-  logic mio_pad_sleep_status_en_7_we;
   logic mio_pad_sleep_status_en_8_qs;
   logic mio_pad_sleep_status_en_8_wd;
-  logic mio_pad_sleep_status_en_8_we;
   logic mio_pad_sleep_status_en_9_qs;
   logic mio_pad_sleep_status_en_9_wd;
-  logic mio_pad_sleep_status_en_9_we;
   logic mio_pad_sleep_status_en_10_qs;
   logic mio_pad_sleep_status_en_10_wd;
-  logic mio_pad_sleep_status_en_10_we;
   logic mio_pad_sleep_status_en_11_qs;
   logic mio_pad_sleep_status_en_11_wd;
-  logic mio_pad_sleep_status_en_11_we;
   logic mio_pad_sleep_status_en_12_qs;
   logic mio_pad_sleep_status_en_12_wd;
-  logic mio_pad_sleep_status_en_12_we;
   logic mio_pad_sleep_status_en_13_qs;
   logic mio_pad_sleep_status_en_13_wd;
-  logic mio_pad_sleep_status_en_13_we;
   logic mio_pad_sleep_status_en_14_qs;
   logic mio_pad_sleep_status_en_14_wd;
-  logic mio_pad_sleep_status_en_14_we;
   logic mio_pad_sleep_status_en_15_qs;
   logic mio_pad_sleep_status_en_15_wd;
-  logic mio_pad_sleep_status_en_15_we;
   logic mio_pad_sleep_status_en_16_qs;
   logic mio_pad_sleep_status_en_16_wd;
-  logic mio_pad_sleep_status_en_16_we;
   logic mio_pad_sleep_status_en_17_qs;
   logic mio_pad_sleep_status_en_17_wd;
-  logic mio_pad_sleep_status_en_17_we;
   logic mio_pad_sleep_status_en_18_qs;
   logic mio_pad_sleep_status_en_18_wd;
-  logic mio_pad_sleep_status_en_18_we;
   logic mio_pad_sleep_status_en_19_qs;
   logic mio_pad_sleep_status_en_19_wd;
-  logic mio_pad_sleep_status_en_19_we;
   logic mio_pad_sleep_status_en_20_qs;
   logic mio_pad_sleep_status_en_20_wd;
-  logic mio_pad_sleep_status_en_20_we;
   logic mio_pad_sleep_status_en_21_qs;
   logic mio_pad_sleep_status_en_21_wd;
-  logic mio_pad_sleep_status_en_21_we;
   logic mio_pad_sleep_status_en_22_qs;
   logic mio_pad_sleep_status_en_22_wd;
-  logic mio_pad_sleep_status_en_22_we;
   logic mio_pad_sleep_status_en_23_qs;
   logic mio_pad_sleep_status_en_23_wd;
-  logic mio_pad_sleep_status_en_23_we;
   logic mio_pad_sleep_status_en_24_qs;
   logic mio_pad_sleep_status_en_24_wd;
-  logic mio_pad_sleep_status_en_24_we;
   logic mio_pad_sleep_status_en_25_qs;
   logic mio_pad_sleep_status_en_25_wd;
-  logic mio_pad_sleep_status_en_25_we;
   logic mio_pad_sleep_status_en_26_qs;
   logic mio_pad_sleep_status_en_26_wd;
-  logic mio_pad_sleep_status_en_26_we;
   logic mio_pad_sleep_status_en_27_qs;
   logic mio_pad_sleep_status_en_27_wd;
-  logic mio_pad_sleep_status_en_27_we;
   logic mio_pad_sleep_status_en_28_qs;
   logic mio_pad_sleep_status_en_28_wd;
-  logic mio_pad_sleep_status_en_28_we;
   logic mio_pad_sleep_status_en_29_qs;
   logic mio_pad_sleep_status_en_29_wd;
-  logic mio_pad_sleep_status_en_29_we;
   logic mio_pad_sleep_status_en_30_qs;
   logic mio_pad_sleep_status_en_30_wd;
-  logic mio_pad_sleep_status_en_30_we;
   logic mio_pad_sleep_status_en_31_qs;
   logic mio_pad_sleep_status_en_31_wd;
-  logic mio_pad_sleep_status_en_31_we;
+  logic mio_pad_sleep_regwen_0_we;
   logic mio_pad_sleep_regwen_0_qs;
   logic mio_pad_sleep_regwen_0_wd;
-  logic mio_pad_sleep_regwen_0_we;
+  logic mio_pad_sleep_regwen_1_we;
   logic mio_pad_sleep_regwen_1_qs;
   logic mio_pad_sleep_regwen_1_wd;
-  logic mio_pad_sleep_regwen_1_we;
+  logic mio_pad_sleep_regwen_2_we;
   logic mio_pad_sleep_regwen_2_qs;
   logic mio_pad_sleep_regwen_2_wd;
-  logic mio_pad_sleep_regwen_2_we;
+  logic mio_pad_sleep_regwen_3_we;
   logic mio_pad_sleep_regwen_3_qs;
   logic mio_pad_sleep_regwen_3_wd;
-  logic mio_pad_sleep_regwen_3_we;
+  logic mio_pad_sleep_regwen_4_we;
   logic mio_pad_sleep_regwen_4_qs;
   logic mio_pad_sleep_regwen_4_wd;
-  logic mio_pad_sleep_regwen_4_we;
+  logic mio_pad_sleep_regwen_5_we;
   logic mio_pad_sleep_regwen_5_qs;
   logic mio_pad_sleep_regwen_5_wd;
-  logic mio_pad_sleep_regwen_5_we;
+  logic mio_pad_sleep_regwen_6_we;
   logic mio_pad_sleep_regwen_6_qs;
   logic mio_pad_sleep_regwen_6_wd;
-  logic mio_pad_sleep_regwen_6_we;
+  logic mio_pad_sleep_regwen_7_we;
   logic mio_pad_sleep_regwen_7_qs;
   logic mio_pad_sleep_regwen_7_wd;
-  logic mio_pad_sleep_regwen_7_we;
+  logic mio_pad_sleep_regwen_8_we;
   logic mio_pad_sleep_regwen_8_qs;
   logic mio_pad_sleep_regwen_8_wd;
-  logic mio_pad_sleep_regwen_8_we;
+  logic mio_pad_sleep_regwen_9_we;
   logic mio_pad_sleep_regwen_9_qs;
   logic mio_pad_sleep_regwen_9_wd;
-  logic mio_pad_sleep_regwen_9_we;
+  logic mio_pad_sleep_regwen_10_we;
   logic mio_pad_sleep_regwen_10_qs;
   logic mio_pad_sleep_regwen_10_wd;
-  logic mio_pad_sleep_regwen_10_we;
+  logic mio_pad_sleep_regwen_11_we;
   logic mio_pad_sleep_regwen_11_qs;
   logic mio_pad_sleep_regwen_11_wd;
-  logic mio_pad_sleep_regwen_11_we;
+  logic mio_pad_sleep_regwen_12_we;
   logic mio_pad_sleep_regwen_12_qs;
   logic mio_pad_sleep_regwen_12_wd;
-  logic mio_pad_sleep_regwen_12_we;
+  logic mio_pad_sleep_regwen_13_we;
   logic mio_pad_sleep_regwen_13_qs;
   logic mio_pad_sleep_regwen_13_wd;
-  logic mio_pad_sleep_regwen_13_we;
+  logic mio_pad_sleep_regwen_14_we;
   logic mio_pad_sleep_regwen_14_qs;
   logic mio_pad_sleep_regwen_14_wd;
-  logic mio_pad_sleep_regwen_14_we;
+  logic mio_pad_sleep_regwen_15_we;
   logic mio_pad_sleep_regwen_15_qs;
   logic mio_pad_sleep_regwen_15_wd;
-  logic mio_pad_sleep_regwen_15_we;
+  logic mio_pad_sleep_regwen_16_we;
   logic mio_pad_sleep_regwen_16_qs;
   logic mio_pad_sleep_regwen_16_wd;
-  logic mio_pad_sleep_regwen_16_we;
+  logic mio_pad_sleep_regwen_17_we;
   logic mio_pad_sleep_regwen_17_qs;
   logic mio_pad_sleep_regwen_17_wd;
-  logic mio_pad_sleep_regwen_17_we;
+  logic mio_pad_sleep_regwen_18_we;
   logic mio_pad_sleep_regwen_18_qs;
   logic mio_pad_sleep_regwen_18_wd;
-  logic mio_pad_sleep_regwen_18_we;
+  logic mio_pad_sleep_regwen_19_we;
   logic mio_pad_sleep_regwen_19_qs;
   logic mio_pad_sleep_regwen_19_wd;
-  logic mio_pad_sleep_regwen_19_we;
+  logic mio_pad_sleep_regwen_20_we;
   logic mio_pad_sleep_regwen_20_qs;
   logic mio_pad_sleep_regwen_20_wd;
-  logic mio_pad_sleep_regwen_20_we;
+  logic mio_pad_sleep_regwen_21_we;
   logic mio_pad_sleep_regwen_21_qs;
   logic mio_pad_sleep_regwen_21_wd;
-  logic mio_pad_sleep_regwen_21_we;
+  logic mio_pad_sleep_regwen_22_we;
   logic mio_pad_sleep_regwen_22_qs;
   logic mio_pad_sleep_regwen_22_wd;
-  logic mio_pad_sleep_regwen_22_we;
+  logic mio_pad_sleep_regwen_23_we;
   logic mio_pad_sleep_regwen_23_qs;
   logic mio_pad_sleep_regwen_23_wd;
-  logic mio_pad_sleep_regwen_23_we;
+  logic mio_pad_sleep_regwen_24_we;
   logic mio_pad_sleep_regwen_24_qs;
   logic mio_pad_sleep_regwen_24_wd;
-  logic mio_pad_sleep_regwen_24_we;
+  logic mio_pad_sleep_regwen_25_we;
   logic mio_pad_sleep_regwen_25_qs;
   logic mio_pad_sleep_regwen_25_wd;
-  logic mio_pad_sleep_regwen_25_we;
+  logic mio_pad_sleep_regwen_26_we;
   logic mio_pad_sleep_regwen_26_qs;
   logic mio_pad_sleep_regwen_26_wd;
-  logic mio_pad_sleep_regwen_26_we;
+  logic mio_pad_sleep_regwen_27_we;
   logic mio_pad_sleep_regwen_27_qs;
   logic mio_pad_sleep_regwen_27_wd;
-  logic mio_pad_sleep_regwen_27_we;
+  logic mio_pad_sleep_regwen_28_we;
   logic mio_pad_sleep_regwen_28_qs;
   logic mio_pad_sleep_regwen_28_wd;
-  logic mio_pad_sleep_regwen_28_we;
+  logic mio_pad_sleep_regwen_29_we;
   logic mio_pad_sleep_regwen_29_qs;
   logic mio_pad_sleep_regwen_29_wd;
-  logic mio_pad_sleep_regwen_29_we;
+  logic mio_pad_sleep_regwen_30_we;
   logic mio_pad_sleep_regwen_30_qs;
   logic mio_pad_sleep_regwen_30_wd;
-  logic mio_pad_sleep_regwen_30_we;
+  logic mio_pad_sleep_regwen_31_we;
   logic mio_pad_sleep_regwen_31_qs;
   logic mio_pad_sleep_regwen_31_wd;
-  logic mio_pad_sleep_regwen_31_we;
+  logic mio_pad_sleep_en_0_we;
   logic mio_pad_sleep_en_0_qs;
   logic mio_pad_sleep_en_0_wd;
-  logic mio_pad_sleep_en_0_we;
+  logic mio_pad_sleep_en_1_we;
   logic mio_pad_sleep_en_1_qs;
   logic mio_pad_sleep_en_1_wd;
-  logic mio_pad_sleep_en_1_we;
+  logic mio_pad_sleep_en_2_we;
   logic mio_pad_sleep_en_2_qs;
   logic mio_pad_sleep_en_2_wd;
-  logic mio_pad_sleep_en_2_we;
+  logic mio_pad_sleep_en_3_we;
   logic mio_pad_sleep_en_3_qs;
   logic mio_pad_sleep_en_3_wd;
-  logic mio_pad_sleep_en_3_we;
+  logic mio_pad_sleep_en_4_we;
   logic mio_pad_sleep_en_4_qs;
   logic mio_pad_sleep_en_4_wd;
-  logic mio_pad_sleep_en_4_we;
+  logic mio_pad_sleep_en_5_we;
   logic mio_pad_sleep_en_5_qs;
   logic mio_pad_sleep_en_5_wd;
-  logic mio_pad_sleep_en_5_we;
+  logic mio_pad_sleep_en_6_we;
   logic mio_pad_sleep_en_6_qs;
   logic mio_pad_sleep_en_6_wd;
-  logic mio_pad_sleep_en_6_we;
+  logic mio_pad_sleep_en_7_we;
   logic mio_pad_sleep_en_7_qs;
   logic mio_pad_sleep_en_7_wd;
-  logic mio_pad_sleep_en_7_we;
+  logic mio_pad_sleep_en_8_we;
   logic mio_pad_sleep_en_8_qs;
   logic mio_pad_sleep_en_8_wd;
-  logic mio_pad_sleep_en_8_we;
+  logic mio_pad_sleep_en_9_we;
   logic mio_pad_sleep_en_9_qs;
   logic mio_pad_sleep_en_9_wd;
-  logic mio_pad_sleep_en_9_we;
+  logic mio_pad_sleep_en_10_we;
   logic mio_pad_sleep_en_10_qs;
   logic mio_pad_sleep_en_10_wd;
-  logic mio_pad_sleep_en_10_we;
+  logic mio_pad_sleep_en_11_we;
   logic mio_pad_sleep_en_11_qs;
   logic mio_pad_sleep_en_11_wd;
-  logic mio_pad_sleep_en_11_we;
+  logic mio_pad_sleep_en_12_we;
   logic mio_pad_sleep_en_12_qs;
   logic mio_pad_sleep_en_12_wd;
-  logic mio_pad_sleep_en_12_we;
+  logic mio_pad_sleep_en_13_we;
   logic mio_pad_sleep_en_13_qs;
   logic mio_pad_sleep_en_13_wd;
-  logic mio_pad_sleep_en_13_we;
+  logic mio_pad_sleep_en_14_we;
   logic mio_pad_sleep_en_14_qs;
   logic mio_pad_sleep_en_14_wd;
-  logic mio_pad_sleep_en_14_we;
+  logic mio_pad_sleep_en_15_we;
   logic mio_pad_sleep_en_15_qs;
   logic mio_pad_sleep_en_15_wd;
-  logic mio_pad_sleep_en_15_we;
+  logic mio_pad_sleep_en_16_we;
   logic mio_pad_sleep_en_16_qs;
   logic mio_pad_sleep_en_16_wd;
-  logic mio_pad_sleep_en_16_we;
+  logic mio_pad_sleep_en_17_we;
   logic mio_pad_sleep_en_17_qs;
   logic mio_pad_sleep_en_17_wd;
-  logic mio_pad_sleep_en_17_we;
+  logic mio_pad_sleep_en_18_we;
   logic mio_pad_sleep_en_18_qs;
   logic mio_pad_sleep_en_18_wd;
-  logic mio_pad_sleep_en_18_we;
+  logic mio_pad_sleep_en_19_we;
   logic mio_pad_sleep_en_19_qs;
   logic mio_pad_sleep_en_19_wd;
-  logic mio_pad_sleep_en_19_we;
+  logic mio_pad_sleep_en_20_we;
   logic mio_pad_sleep_en_20_qs;
   logic mio_pad_sleep_en_20_wd;
-  logic mio_pad_sleep_en_20_we;
+  logic mio_pad_sleep_en_21_we;
   logic mio_pad_sleep_en_21_qs;
   logic mio_pad_sleep_en_21_wd;
-  logic mio_pad_sleep_en_21_we;
+  logic mio_pad_sleep_en_22_we;
   logic mio_pad_sleep_en_22_qs;
   logic mio_pad_sleep_en_22_wd;
-  logic mio_pad_sleep_en_22_we;
+  logic mio_pad_sleep_en_23_we;
   logic mio_pad_sleep_en_23_qs;
   logic mio_pad_sleep_en_23_wd;
-  logic mio_pad_sleep_en_23_we;
+  logic mio_pad_sleep_en_24_we;
   logic mio_pad_sleep_en_24_qs;
   logic mio_pad_sleep_en_24_wd;
-  logic mio_pad_sleep_en_24_we;
+  logic mio_pad_sleep_en_25_we;
   logic mio_pad_sleep_en_25_qs;
   logic mio_pad_sleep_en_25_wd;
-  logic mio_pad_sleep_en_25_we;
+  logic mio_pad_sleep_en_26_we;
   logic mio_pad_sleep_en_26_qs;
   logic mio_pad_sleep_en_26_wd;
-  logic mio_pad_sleep_en_26_we;
+  logic mio_pad_sleep_en_27_we;
   logic mio_pad_sleep_en_27_qs;
   logic mio_pad_sleep_en_27_wd;
-  logic mio_pad_sleep_en_27_we;
+  logic mio_pad_sleep_en_28_we;
   logic mio_pad_sleep_en_28_qs;
   logic mio_pad_sleep_en_28_wd;
-  logic mio_pad_sleep_en_28_we;
+  logic mio_pad_sleep_en_29_we;
   logic mio_pad_sleep_en_29_qs;
   logic mio_pad_sleep_en_29_wd;
-  logic mio_pad_sleep_en_29_we;
+  logic mio_pad_sleep_en_30_we;
   logic mio_pad_sleep_en_30_qs;
   logic mio_pad_sleep_en_30_wd;
-  logic mio_pad_sleep_en_30_we;
+  logic mio_pad_sleep_en_31_we;
   logic mio_pad_sleep_en_31_qs;
   logic mio_pad_sleep_en_31_wd;
-  logic mio_pad_sleep_en_31_we;
+  logic mio_pad_sleep_mode_0_we;
   logic [1:0] mio_pad_sleep_mode_0_qs;
   logic [1:0] mio_pad_sleep_mode_0_wd;
-  logic mio_pad_sleep_mode_0_we;
+  logic mio_pad_sleep_mode_1_we;
   logic [1:0] mio_pad_sleep_mode_1_qs;
   logic [1:0] mio_pad_sleep_mode_1_wd;
-  logic mio_pad_sleep_mode_1_we;
+  logic mio_pad_sleep_mode_2_we;
   logic [1:0] mio_pad_sleep_mode_2_qs;
   logic [1:0] mio_pad_sleep_mode_2_wd;
-  logic mio_pad_sleep_mode_2_we;
+  logic mio_pad_sleep_mode_3_we;
   logic [1:0] mio_pad_sleep_mode_3_qs;
   logic [1:0] mio_pad_sleep_mode_3_wd;
-  logic mio_pad_sleep_mode_3_we;
+  logic mio_pad_sleep_mode_4_we;
   logic [1:0] mio_pad_sleep_mode_4_qs;
   logic [1:0] mio_pad_sleep_mode_4_wd;
-  logic mio_pad_sleep_mode_4_we;
+  logic mio_pad_sleep_mode_5_we;
   logic [1:0] mio_pad_sleep_mode_5_qs;
   logic [1:0] mio_pad_sleep_mode_5_wd;
-  logic mio_pad_sleep_mode_5_we;
+  logic mio_pad_sleep_mode_6_we;
   logic [1:0] mio_pad_sleep_mode_6_qs;
   logic [1:0] mio_pad_sleep_mode_6_wd;
-  logic mio_pad_sleep_mode_6_we;
+  logic mio_pad_sleep_mode_7_we;
   logic [1:0] mio_pad_sleep_mode_7_qs;
   logic [1:0] mio_pad_sleep_mode_7_wd;
-  logic mio_pad_sleep_mode_7_we;
+  logic mio_pad_sleep_mode_8_we;
   logic [1:0] mio_pad_sleep_mode_8_qs;
   logic [1:0] mio_pad_sleep_mode_8_wd;
-  logic mio_pad_sleep_mode_8_we;
+  logic mio_pad_sleep_mode_9_we;
   logic [1:0] mio_pad_sleep_mode_9_qs;
   logic [1:0] mio_pad_sleep_mode_9_wd;
-  logic mio_pad_sleep_mode_9_we;
+  logic mio_pad_sleep_mode_10_we;
   logic [1:0] mio_pad_sleep_mode_10_qs;
   logic [1:0] mio_pad_sleep_mode_10_wd;
-  logic mio_pad_sleep_mode_10_we;
+  logic mio_pad_sleep_mode_11_we;
   logic [1:0] mio_pad_sleep_mode_11_qs;
   logic [1:0] mio_pad_sleep_mode_11_wd;
-  logic mio_pad_sleep_mode_11_we;
+  logic mio_pad_sleep_mode_12_we;
   logic [1:0] mio_pad_sleep_mode_12_qs;
   logic [1:0] mio_pad_sleep_mode_12_wd;
-  logic mio_pad_sleep_mode_12_we;
+  logic mio_pad_sleep_mode_13_we;
   logic [1:0] mio_pad_sleep_mode_13_qs;
   logic [1:0] mio_pad_sleep_mode_13_wd;
-  logic mio_pad_sleep_mode_13_we;
+  logic mio_pad_sleep_mode_14_we;
   logic [1:0] mio_pad_sleep_mode_14_qs;
   logic [1:0] mio_pad_sleep_mode_14_wd;
-  logic mio_pad_sleep_mode_14_we;
+  logic mio_pad_sleep_mode_15_we;
   logic [1:0] mio_pad_sleep_mode_15_qs;
   logic [1:0] mio_pad_sleep_mode_15_wd;
-  logic mio_pad_sleep_mode_15_we;
+  logic mio_pad_sleep_mode_16_we;
   logic [1:0] mio_pad_sleep_mode_16_qs;
   logic [1:0] mio_pad_sleep_mode_16_wd;
-  logic mio_pad_sleep_mode_16_we;
+  logic mio_pad_sleep_mode_17_we;
   logic [1:0] mio_pad_sleep_mode_17_qs;
   logic [1:0] mio_pad_sleep_mode_17_wd;
-  logic mio_pad_sleep_mode_17_we;
+  logic mio_pad_sleep_mode_18_we;
   logic [1:0] mio_pad_sleep_mode_18_qs;
   logic [1:0] mio_pad_sleep_mode_18_wd;
-  logic mio_pad_sleep_mode_18_we;
+  logic mio_pad_sleep_mode_19_we;
   logic [1:0] mio_pad_sleep_mode_19_qs;
   logic [1:0] mio_pad_sleep_mode_19_wd;
-  logic mio_pad_sleep_mode_19_we;
+  logic mio_pad_sleep_mode_20_we;
   logic [1:0] mio_pad_sleep_mode_20_qs;
   logic [1:0] mio_pad_sleep_mode_20_wd;
-  logic mio_pad_sleep_mode_20_we;
+  logic mio_pad_sleep_mode_21_we;
   logic [1:0] mio_pad_sleep_mode_21_qs;
   logic [1:0] mio_pad_sleep_mode_21_wd;
-  logic mio_pad_sleep_mode_21_we;
+  logic mio_pad_sleep_mode_22_we;
   logic [1:0] mio_pad_sleep_mode_22_qs;
   logic [1:0] mio_pad_sleep_mode_22_wd;
-  logic mio_pad_sleep_mode_22_we;
+  logic mio_pad_sleep_mode_23_we;
   logic [1:0] mio_pad_sleep_mode_23_qs;
   logic [1:0] mio_pad_sleep_mode_23_wd;
-  logic mio_pad_sleep_mode_23_we;
+  logic mio_pad_sleep_mode_24_we;
   logic [1:0] mio_pad_sleep_mode_24_qs;
   logic [1:0] mio_pad_sleep_mode_24_wd;
-  logic mio_pad_sleep_mode_24_we;
+  logic mio_pad_sleep_mode_25_we;
   logic [1:0] mio_pad_sleep_mode_25_qs;
   logic [1:0] mio_pad_sleep_mode_25_wd;
-  logic mio_pad_sleep_mode_25_we;
+  logic mio_pad_sleep_mode_26_we;
   logic [1:0] mio_pad_sleep_mode_26_qs;
   logic [1:0] mio_pad_sleep_mode_26_wd;
-  logic mio_pad_sleep_mode_26_we;
+  logic mio_pad_sleep_mode_27_we;
   logic [1:0] mio_pad_sleep_mode_27_qs;
   logic [1:0] mio_pad_sleep_mode_27_wd;
-  logic mio_pad_sleep_mode_27_we;
+  logic mio_pad_sleep_mode_28_we;
   logic [1:0] mio_pad_sleep_mode_28_qs;
   logic [1:0] mio_pad_sleep_mode_28_wd;
-  logic mio_pad_sleep_mode_28_we;
+  logic mio_pad_sleep_mode_29_we;
   logic [1:0] mio_pad_sleep_mode_29_qs;
   logic [1:0] mio_pad_sleep_mode_29_wd;
-  logic mio_pad_sleep_mode_29_we;
+  logic mio_pad_sleep_mode_30_we;
   logic [1:0] mio_pad_sleep_mode_30_qs;
   logic [1:0] mio_pad_sleep_mode_30_wd;
-  logic mio_pad_sleep_mode_30_we;
+  logic mio_pad_sleep_mode_31_we;
   logic [1:0] mio_pad_sleep_mode_31_qs;
   logic [1:0] mio_pad_sleep_mode_31_wd;
-  logic mio_pad_sleep_mode_31_we;
+  logic dio_pad_sleep_status_we;
   logic dio_pad_sleep_status_en_0_qs;
   logic dio_pad_sleep_status_en_0_wd;
-  logic dio_pad_sleep_status_en_0_we;
   logic dio_pad_sleep_status_en_1_qs;
   logic dio_pad_sleep_status_en_1_wd;
-  logic dio_pad_sleep_status_en_1_we;
   logic dio_pad_sleep_status_en_2_qs;
   logic dio_pad_sleep_status_en_2_wd;
-  logic dio_pad_sleep_status_en_2_we;
   logic dio_pad_sleep_status_en_3_qs;
   logic dio_pad_sleep_status_en_3_wd;
-  logic dio_pad_sleep_status_en_3_we;
   logic dio_pad_sleep_status_en_4_qs;
   logic dio_pad_sleep_status_en_4_wd;
-  logic dio_pad_sleep_status_en_4_we;
   logic dio_pad_sleep_status_en_5_qs;
   logic dio_pad_sleep_status_en_5_wd;
-  logic dio_pad_sleep_status_en_5_we;
   logic dio_pad_sleep_status_en_6_qs;
   logic dio_pad_sleep_status_en_6_wd;
-  logic dio_pad_sleep_status_en_6_we;
   logic dio_pad_sleep_status_en_7_qs;
   logic dio_pad_sleep_status_en_7_wd;
-  logic dio_pad_sleep_status_en_7_we;
   logic dio_pad_sleep_status_en_8_qs;
   logic dio_pad_sleep_status_en_8_wd;
-  logic dio_pad_sleep_status_en_8_we;
   logic dio_pad_sleep_status_en_9_qs;
   logic dio_pad_sleep_status_en_9_wd;
-  logic dio_pad_sleep_status_en_9_we;
   logic dio_pad_sleep_status_en_10_qs;
   logic dio_pad_sleep_status_en_10_wd;
-  logic dio_pad_sleep_status_en_10_we;
   logic dio_pad_sleep_status_en_11_qs;
   logic dio_pad_sleep_status_en_11_wd;
-  logic dio_pad_sleep_status_en_11_we;
   logic dio_pad_sleep_status_en_12_qs;
   logic dio_pad_sleep_status_en_12_wd;
-  logic dio_pad_sleep_status_en_12_we;
   logic dio_pad_sleep_status_en_13_qs;
   logic dio_pad_sleep_status_en_13_wd;
-  logic dio_pad_sleep_status_en_13_we;
   logic dio_pad_sleep_status_en_14_qs;
   logic dio_pad_sleep_status_en_14_wd;
-  logic dio_pad_sleep_status_en_14_we;
   logic dio_pad_sleep_status_en_15_qs;
   logic dio_pad_sleep_status_en_15_wd;
-  logic dio_pad_sleep_status_en_15_we;
+  logic dio_pad_sleep_regwen_0_we;
   logic dio_pad_sleep_regwen_0_qs;
   logic dio_pad_sleep_regwen_0_wd;
-  logic dio_pad_sleep_regwen_0_we;
+  logic dio_pad_sleep_regwen_1_we;
   logic dio_pad_sleep_regwen_1_qs;
   logic dio_pad_sleep_regwen_1_wd;
-  logic dio_pad_sleep_regwen_1_we;
+  logic dio_pad_sleep_regwen_2_we;
   logic dio_pad_sleep_regwen_2_qs;
   logic dio_pad_sleep_regwen_2_wd;
-  logic dio_pad_sleep_regwen_2_we;
+  logic dio_pad_sleep_regwen_3_we;
   logic dio_pad_sleep_regwen_3_qs;
   logic dio_pad_sleep_regwen_3_wd;
-  logic dio_pad_sleep_regwen_3_we;
+  logic dio_pad_sleep_regwen_4_we;
   logic dio_pad_sleep_regwen_4_qs;
   logic dio_pad_sleep_regwen_4_wd;
-  logic dio_pad_sleep_regwen_4_we;
+  logic dio_pad_sleep_regwen_5_we;
   logic dio_pad_sleep_regwen_5_qs;
   logic dio_pad_sleep_regwen_5_wd;
-  logic dio_pad_sleep_regwen_5_we;
+  logic dio_pad_sleep_regwen_6_we;
   logic dio_pad_sleep_regwen_6_qs;
   logic dio_pad_sleep_regwen_6_wd;
-  logic dio_pad_sleep_regwen_6_we;
+  logic dio_pad_sleep_regwen_7_we;
   logic dio_pad_sleep_regwen_7_qs;
   logic dio_pad_sleep_regwen_7_wd;
-  logic dio_pad_sleep_regwen_7_we;
+  logic dio_pad_sleep_regwen_8_we;
   logic dio_pad_sleep_regwen_8_qs;
   logic dio_pad_sleep_regwen_8_wd;
-  logic dio_pad_sleep_regwen_8_we;
+  logic dio_pad_sleep_regwen_9_we;
   logic dio_pad_sleep_regwen_9_qs;
   logic dio_pad_sleep_regwen_9_wd;
-  logic dio_pad_sleep_regwen_9_we;
+  logic dio_pad_sleep_regwen_10_we;
   logic dio_pad_sleep_regwen_10_qs;
   logic dio_pad_sleep_regwen_10_wd;
-  logic dio_pad_sleep_regwen_10_we;
+  logic dio_pad_sleep_regwen_11_we;
   logic dio_pad_sleep_regwen_11_qs;
   logic dio_pad_sleep_regwen_11_wd;
-  logic dio_pad_sleep_regwen_11_we;
+  logic dio_pad_sleep_regwen_12_we;
   logic dio_pad_sleep_regwen_12_qs;
   logic dio_pad_sleep_regwen_12_wd;
-  logic dio_pad_sleep_regwen_12_we;
+  logic dio_pad_sleep_regwen_13_we;
   logic dio_pad_sleep_regwen_13_qs;
   logic dio_pad_sleep_regwen_13_wd;
-  logic dio_pad_sleep_regwen_13_we;
+  logic dio_pad_sleep_regwen_14_we;
   logic dio_pad_sleep_regwen_14_qs;
   logic dio_pad_sleep_regwen_14_wd;
-  logic dio_pad_sleep_regwen_14_we;
+  logic dio_pad_sleep_regwen_15_we;
   logic dio_pad_sleep_regwen_15_qs;
   logic dio_pad_sleep_regwen_15_wd;
-  logic dio_pad_sleep_regwen_15_we;
+  logic dio_pad_sleep_en_0_we;
   logic dio_pad_sleep_en_0_qs;
   logic dio_pad_sleep_en_0_wd;
-  logic dio_pad_sleep_en_0_we;
+  logic dio_pad_sleep_en_1_we;
   logic dio_pad_sleep_en_1_qs;
   logic dio_pad_sleep_en_1_wd;
-  logic dio_pad_sleep_en_1_we;
+  logic dio_pad_sleep_en_2_we;
   logic dio_pad_sleep_en_2_qs;
   logic dio_pad_sleep_en_2_wd;
-  logic dio_pad_sleep_en_2_we;
+  logic dio_pad_sleep_en_3_we;
   logic dio_pad_sleep_en_3_qs;
   logic dio_pad_sleep_en_3_wd;
-  logic dio_pad_sleep_en_3_we;
+  logic dio_pad_sleep_en_4_we;
   logic dio_pad_sleep_en_4_qs;
   logic dio_pad_sleep_en_4_wd;
-  logic dio_pad_sleep_en_4_we;
+  logic dio_pad_sleep_en_5_we;
   logic dio_pad_sleep_en_5_qs;
   logic dio_pad_sleep_en_5_wd;
-  logic dio_pad_sleep_en_5_we;
+  logic dio_pad_sleep_en_6_we;
   logic dio_pad_sleep_en_6_qs;
   logic dio_pad_sleep_en_6_wd;
-  logic dio_pad_sleep_en_6_we;
+  logic dio_pad_sleep_en_7_we;
   logic dio_pad_sleep_en_7_qs;
   logic dio_pad_sleep_en_7_wd;
-  logic dio_pad_sleep_en_7_we;
+  logic dio_pad_sleep_en_8_we;
   logic dio_pad_sleep_en_8_qs;
   logic dio_pad_sleep_en_8_wd;
-  logic dio_pad_sleep_en_8_we;
+  logic dio_pad_sleep_en_9_we;
   logic dio_pad_sleep_en_9_qs;
   logic dio_pad_sleep_en_9_wd;
-  logic dio_pad_sleep_en_9_we;
+  logic dio_pad_sleep_en_10_we;
   logic dio_pad_sleep_en_10_qs;
   logic dio_pad_sleep_en_10_wd;
-  logic dio_pad_sleep_en_10_we;
+  logic dio_pad_sleep_en_11_we;
   logic dio_pad_sleep_en_11_qs;
   logic dio_pad_sleep_en_11_wd;
-  logic dio_pad_sleep_en_11_we;
+  logic dio_pad_sleep_en_12_we;
   logic dio_pad_sleep_en_12_qs;
   logic dio_pad_sleep_en_12_wd;
-  logic dio_pad_sleep_en_12_we;
+  logic dio_pad_sleep_en_13_we;
   logic dio_pad_sleep_en_13_qs;
   logic dio_pad_sleep_en_13_wd;
-  logic dio_pad_sleep_en_13_we;
+  logic dio_pad_sleep_en_14_we;
   logic dio_pad_sleep_en_14_qs;
   logic dio_pad_sleep_en_14_wd;
-  logic dio_pad_sleep_en_14_we;
+  logic dio_pad_sleep_en_15_we;
   logic dio_pad_sleep_en_15_qs;
   logic dio_pad_sleep_en_15_wd;
-  logic dio_pad_sleep_en_15_we;
+  logic dio_pad_sleep_mode_0_we;
   logic [1:0] dio_pad_sleep_mode_0_qs;
   logic [1:0] dio_pad_sleep_mode_0_wd;
-  logic dio_pad_sleep_mode_0_we;
+  logic dio_pad_sleep_mode_1_we;
   logic [1:0] dio_pad_sleep_mode_1_qs;
   logic [1:0] dio_pad_sleep_mode_1_wd;
-  logic dio_pad_sleep_mode_1_we;
+  logic dio_pad_sleep_mode_2_we;
   logic [1:0] dio_pad_sleep_mode_2_qs;
   logic [1:0] dio_pad_sleep_mode_2_wd;
-  logic dio_pad_sleep_mode_2_we;
+  logic dio_pad_sleep_mode_3_we;
   logic [1:0] dio_pad_sleep_mode_3_qs;
   logic [1:0] dio_pad_sleep_mode_3_wd;
-  logic dio_pad_sleep_mode_3_we;
+  logic dio_pad_sleep_mode_4_we;
   logic [1:0] dio_pad_sleep_mode_4_qs;
   logic [1:0] dio_pad_sleep_mode_4_wd;
-  logic dio_pad_sleep_mode_4_we;
+  logic dio_pad_sleep_mode_5_we;
   logic [1:0] dio_pad_sleep_mode_5_qs;
   logic [1:0] dio_pad_sleep_mode_5_wd;
-  logic dio_pad_sleep_mode_5_we;
+  logic dio_pad_sleep_mode_6_we;
   logic [1:0] dio_pad_sleep_mode_6_qs;
   logic [1:0] dio_pad_sleep_mode_6_wd;
-  logic dio_pad_sleep_mode_6_we;
+  logic dio_pad_sleep_mode_7_we;
   logic [1:0] dio_pad_sleep_mode_7_qs;
   logic [1:0] dio_pad_sleep_mode_7_wd;
-  logic dio_pad_sleep_mode_7_we;
+  logic dio_pad_sleep_mode_8_we;
   logic [1:0] dio_pad_sleep_mode_8_qs;
   logic [1:0] dio_pad_sleep_mode_8_wd;
-  logic dio_pad_sleep_mode_8_we;
+  logic dio_pad_sleep_mode_9_we;
   logic [1:0] dio_pad_sleep_mode_9_qs;
   logic [1:0] dio_pad_sleep_mode_9_wd;
-  logic dio_pad_sleep_mode_9_we;
+  logic dio_pad_sleep_mode_10_we;
   logic [1:0] dio_pad_sleep_mode_10_qs;
   logic [1:0] dio_pad_sleep_mode_10_wd;
-  logic dio_pad_sleep_mode_10_we;
+  logic dio_pad_sleep_mode_11_we;
   logic [1:0] dio_pad_sleep_mode_11_qs;
   logic [1:0] dio_pad_sleep_mode_11_wd;
-  logic dio_pad_sleep_mode_11_we;
+  logic dio_pad_sleep_mode_12_we;
   logic [1:0] dio_pad_sleep_mode_12_qs;
   logic [1:0] dio_pad_sleep_mode_12_wd;
-  logic dio_pad_sleep_mode_12_we;
+  logic dio_pad_sleep_mode_13_we;
   logic [1:0] dio_pad_sleep_mode_13_qs;
   logic [1:0] dio_pad_sleep_mode_13_wd;
-  logic dio_pad_sleep_mode_13_we;
+  logic dio_pad_sleep_mode_14_we;
   logic [1:0] dio_pad_sleep_mode_14_qs;
   logic [1:0] dio_pad_sleep_mode_14_wd;
-  logic dio_pad_sleep_mode_14_we;
+  logic dio_pad_sleep_mode_15_we;
   logic [1:0] dio_pad_sleep_mode_15_qs;
   logic [1:0] dio_pad_sleep_mode_15_wd;
-  logic dio_pad_sleep_mode_15_we;
+  logic wkup_detector_regwen_0_we;
   logic wkup_detector_regwen_0_qs;
   logic wkup_detector_regwen_0_wd;
-  logic wkup_detector_regwen_0_we;
+  logic wkup_detector_regwen_1_we;
   logic wkup_detector_regwen_1_qs;
   logic wkup_detector_regwen_1_wd;
-  logic wkup_detector_regwen_1_we;
+  logic wkup_detector_regwen_2_we;
   logic wkup_detector_regwen_2_qs;
   logic wkup_detector_regwen_2_wd;
-  logic wkup_detector_regwen_2_we;
+  logic wkup_detector_regwen_3_we;
   logic wkup_detector_regwen_3_qs;
   logic wkup_detector_regwen_3_wd;
-  logic wkup_detector_regwen_3_we;
+  logic wkup_detector_regwen_4_we;
   logic wkup_detector_regwen_4_qs;
   logic wkup_detector_regwen_4_wd;
-  logic wkup_detector_regwen_4_we;
+  logic wkup_detector_regwen_5_we;
   logic wkup_detector_regwen_5_qs;
   logic wkup_detector_regwen_5_wd;
-  logic wkup_detector_regwen_5_we;
+  logic wkup_detector_regwen_6_we;
   logic wkup_detector_regwen_6_qs;
   logic wkup_detector_regwen_6_wd;
-  logic wkup_detector_regwen_6_we;
+  logic wkup_detector_regwen_7_we;
   logic wkup_detector_regwen_7_qs;
   logic wkup_detector_regwen_7_wd;
-  logic wkup_detector_regwen_7_we;
+  logic wkup_detector_en_0_we;
   logic wkup_detector_en_0_qs;
   logic wkup_detector_en_0_wd;
-  logic wkup_detector_en_0_we;
+  logic wkup_detector_en_1_we;
   logic wkup_detector_en_1_qs;
   logic wkup_detector_en_1_wd;
-  logic wkup_detector_en_1_we;
+  logic wkup_detector_en_2_we;
   logic wkup_detector_en_2_qs;
   logic wkup_detector_en_2_wd;
-  logic wkup_detector_en_2_we;
+  logic wkup_detector_en_3_we;
   logic wkup_detector_en_3_qs;
   logic wkup_detector_en_3_wd;
-  logic wkup_detector_en_3_we;
+  logic wkup_detector_en_4_we;
   logic wkup_detector_en_4_qs;
   logic wkup_detector_en_4_wd;
-  logic wkup_detector_en_4_we;
+  logic wkup_detector_en_5_we;
   logic wkup_detector_en_5_qs;
   logic wkup_detector_en_5_wd;
-  logic wkup_detector_en_5_we;
+  logic wkup_detector_en_6_we;
   logic wkup_detector_en_6_qs;
   logic wkup_detector_en_6_wd;
-  logic wkup_detector_en_6_we;
+  logic wkup_detector_en_7_we;
   logic wkup_detector_en_7_qs;
   logic wkup_detector_en_7_wd;
-  logic wkup_detector_en_7_we;
+  logic wkup_detector_0_we;
   logic [2:0] wkup_detector_0_mode_0_qs;
   logic [2:0] wkup_detector_0_mode_0_wd;
-  logic wkup_detector_0_mode_0_we;
   logic wkup_detector_0_filter_0_qs;
   logic wkup_detector_0_filter_0_wd;
-  logic wkup_detector_0_filter_0_we;
   logic wkup_detector_0_miodio_0_qs;
   logic wkup_detector_0_miodio_0_wd;
-  logic wkup_detector_0_miodio_0_we;
+  logic wkup_detector_1_we;
   logic [2:0] wkup_detector_1_mode_1_qs;
   logic [2:0] wkup_detector_1_mode_1_wd;
-  logic wkup_detector_1_mode_1_we;
   logic wkup_detector_1_filter_1_qs;
   logic wkup_detector_1_filter_1_wd;
-  logic wkup_detector_1_filter_1_we;
   logic wkup_detector_1_miodio_1_qs;
   logic wkup_detector_1_miodio_1_wd;
-  logic wkup_detector_1_miodio_1_we;
+  logic wkup_detector_2_we;
   logic [2:0] wkup_detector_2_mode_2_qs;
   logic [2:0] wkup_detector_2_mode_2_wd;
-  logic wkup_detector_2_mode_2_we;
   logic wkup_detector_2_filter_2_qs;
   logic wkup_detector_2_filter_2_wd;
-  logic wkup_detector_2_filter_2_we;
   logic wkup_detector_2_miodio_2_qs;
   logic wkup_detector_2_miodio_2_wd;
-  logic wkup_detector_2_miodio_2_we;
+  logic wkup_detector_3_we;
   logic [2:0] wkup_detector_3_mode_3_qs;
   logic [2:0] wkup_detector_3_mode_3_wd;
-  logic wkup_detector_3_mode_3_we;
   logic wkup_detector_3_filter_3_qs;
   logic wkup_detector_3_filter_3_wd;
-  logic wkup_detector_3_filter_3_we;
   logic wkup_detector_3_miodio_3_qs;
   logic wkup_detector_3_miodio_3_wd;
-  logic wkup_detector_3_miodio_3_we;
+  logic wkup_detector_4_we;
   logic [2:0] wkup_detector_4_mode_4_qs;
   logic [2:0] wkup_detector_4_mode_4_wd;
-  logic wkup_detector_4_mode_4_we;
   logic wkup_detector_4_filter_4_qs;
   logic wkup_detector_4_filter_4_wd;
-  logic wkup_detector_4_filter_4_we;
   logic wkup_detector_4_miodio_4_qs;
   logic wkup_detector_4_miodio_4_wd;
-  logic wkup_detector_4_miodio_4_we;
+  logic wkup_detector_5_we;
   logic [2:0] wkup_detector_5_mode_5_qs;
   logic [2:0] wkup_detector_5_mode_5_wd;
-  logic wkup_detector_5_mode_5_we;
   logic wkup_detector_5_filter_5_qs;
   logic wkup_detector_5_filter_5_wd;
-  logic wkup_detector_5_filter_5_we;
   logic wkup_detector_5_miodio_5_qs;
   logic wkup_detector_5_miodio_5_wd;
-  logic wkup_detector_5_miodio_5_we;
+  logic wkup_detector_6_we;
   logic [2:0] wkup_detector_6_mode_6_qs;
   logic [2:0] wkup_detector_6_mode_6_wd;
-  logic wkup_detector_6_mode_6_we;
   logic wkup_detector_6_filter_6_qs;
   logic wkup_detector_6_filter_6_wd;
-  logic wkup_detector_6_filter_6_we;
   logic wkup_detector_6_miodio_6_qs;
   logic wkup_detector_6_miodio_6_wd;
-  logic wkup_detector_6_miodio_6_we;
+  logic wkup_detector_7_we;
   logic [2:0] wkup_detector_7_mode_7_qs;
   logic [2:0] wkup_detector_7_mode_7_wd;
-  logic wkup_detector_7_mode_7_we;
   logic wkup_detector_7_filter_7_qs;
   logic wkup_detector_7_filter_7_wd;
-  logic wkup_detector_7_filter_7_we;
   logic wkup_detector_7_miodio_7_qs;
   logic wkup_detector_7_miodio_7_wd;
-  logic wkup_detector_7_miodio_7_we;
+  logic wkup_detector_cnt_th_0_we;
   logic [7:0] wkup_detector_cnt_th_0_qs;
   logic [7:0] wkup_detector_cnt_th_0_wd;
-  logic wkup_detector_cnt_th_0_we;
+  logic wkup_detector_cnt_th_1_we;
   logic [7:0] wkup_detector_cnt_th_1_qs;
   logic [7:0] wkup_detector_cnt_th_1_wd;
-  logic wkup_detector_cnt_th_1_we;
+  logic wkup_detector_cnt_th_2_we;
   logic [7:0] wkup_detector_cnt_th_2_qs;
   logic [7:0] wkup_detector_cnt_th_2_wd;
-  logic wkup_detector_cnt_th_2_we;
+  logic wkup_detector_cnt_th_3_we;
   logic [7:0] wkup_detector_cnt_th_3_qs;
   logic [7:0] wkup_detector_cnt_th_3_wd;
-  logic wkup_detector_cnt_th_3_we;
+  logic wkup_detector_cnt_th_4_we;
   logic [7:0] wkup_detector_cnt_th_4_qs;
   logic [7:0] wkup_detector_cnt_th_4_wd;
-  logic wkup_detector_cnt_th_4_we;
+  logic wkup_detector_cnt_th_5_we;
   logic [7:0] wkup_detector_cnt_th_5_qs;
   logic [7:0] wkup_detector_cnt_th_5_wd;
-  logic wkup_detector_cnt_th_5_we;
+  logic wkup_detector_cnt_th_6_we;
   logic [7:0] wkup_detector_cnt_th_6_qs;
   logic [7:0] wkup_detector_cnt_th_6_wd;
-  logic wkup_detector_cnt_th_6_we;
+  logic wkup_detector_cnt_th_7_we;
   logic [7:0] wkup_detector_cnt_th_7_qs;
   logic [7:0] wkup_detector_cnt_th_7_wd;
-  logic wkup_detector_cnt_th_7_we;
+  logic wkup_detector_padsel_0_we;
   logic [5:0] wkup_detector_padsel_0_qs;
   logic [5:0] wkup_detector_padsel_0_wd;
-  logic wkup_detector_padsel_0_we;
+  logic wkup_detector_padsel_1_we;
   logic [5:0] wkup_detector_padsel_1_qs;
   logic [5:0] wkup_detector_padsel_1_wd;
-  logic wkup_detector_padsel_1_we;
+  logic wkup_detector_padsel_2_we;
   logic [5:0] wkup_detector_padsel_2_qs;
   logic [5:0] wkup_detector_padsel_2_wd;
-  logic wkup_detector_padsel_2_we;
+  logic wkup_detector_padsel_3_we;
   logic [5:0] wkup_detector_padsel_3_qs;
   logic [5:0] wkup_detector_padsel_3_wd;
-  logic wkup_detector_padsel_3_we;
+  logic wkup_detector_padsel_4_we;
   logic [5:0] wkup_detector_padsel_4_qs;
   logic [5:0] wkup_detector_padsel_4_wd;
-  logic wkup_detector_padsel_4_we;
+  logic wkup_detector_padsel_5_we;
   logic [5:0] wkup_detector_padsel_5_qs;
   logic [5:0] wkup_detector_padsel_5_wd;
-  logic wkup_detector_padsel_5_we;
+  logic wkup_detector_padsel_6_we;
   logic [5:0] wkup_detector_padsel_6_qs;
   logic [5:0] wkup_detector_padsel_6_wd;
-  logic wkup_detector_padsel_6_we;
+  logic wkup_detector_padsel_7_we;
   logic [5:0] wkup_detector_padsel_7_qs;
   logic [5:0] wkup_detector_padsel_7_wd;
-  logic wkup_detector_padsel_7_we;
+  logic wkup_cause_re;
+  logic wkup_cause_we;
   logic wkup_cause_cause_0_qs;
   logic wkup_cause_cause_0_wd;
-  logic wkup_cause_cause_0_we;
-  logic wkup_cause_cause_0_re;
   logic wkup_cause_cause_1_qs;
   logic wkup_cause_cause_1_wd;
-  logic wkup_cause_cause_1_we;
-  logic wkup_cause_cause_1_re;
   logic wkup_cause_cause_2_qs;
   logic wkup_cause_cause_2_wd;
-  logic wkup_cause_cause_2_we;
-  logic wkup_cause_cause_2_re;
   logic wkup_cause_cause_3_qs;
   logic wkup_cause_cause_3_wd;
-  logic wkup_cause_cause_3_we;
-  logic wkup_cause_cause_3_re;
   logic wkup_cause_cause_4_qs;
   logic wkup_cause_cause_4_wd;
-  logic wkup_cause_cause_4_we;
-  logic wkup_cause_cause_4_re;
   logic wkup_cause_cause_5_qs;
   logic wkup_cause_cause_5_wd;
-  logic wkup_cause_cause_5_we;
-  logic wkup_cause_cause_5_re;
   logic wkup_cause_cause_6_qs;
   logic wkup_cause_cause_6_wd;
-  logic wkup_cause_cause_6_we;
-  logic wkup_cause_cause_6_re;
   logic wkup_cause_cause_7_qs;
   logic wkup_cause_cause_7_wd;
-  logic wkup_cause_cause_7_we;
-  logic wkup_cause_cause_7_re;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -7230,7 +7154,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_0_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_0_wd),
 
     // from internal hardware
@@ -7256,7 +7180,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_1_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_1_wd),
 
     // from internal hardware
@@ -7282,7 +7206,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_2_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_2_wd),
 
     // from internal hardware
@@ -7308,7 +7232,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_3_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_3_wd),
 
     // from internal hardware
@@ -7334,7 +7258,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_4_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_4_wd),
 
     // from internal hardware
@@ -7360,7 +7284,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_5_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_5_wd),
 
     // from internal hardware
@@ -7386,7 +7310,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_6_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_6_wd),
 
     // from internal hardware
@@ -7412,7 +7336,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_7_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_7_wd),
 
     // from internal hardware
@@ -7438,7 +7362,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_8_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_8_wd),
 
     // from internal hardware
@@ -7464,7 +7388,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_9_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_9_wd),
 
     // from internal hardware
@@ -7490,7 +7414,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_10_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_10_wd),
 
     // from internal hardware
@@ -7516,7 +7440,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_11_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_11_wd),
 
     // from internal hardware
@@ -7542,7 +7466,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_12_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_12_wd),
 
     // from internal hardware
@@ -7568,7 +7492,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_13_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_13_wd),
 
     // from internal hardware
@@ -7594,7 +7518,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_14_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_14_wd),
 
     // from internal hardware
@@ -7620,7 +7544,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_15_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_15_wd),
 
     // from internal hardware
@@ -7646,7 +7570,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_16_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_16_wd),
 
     // from internal hardware
@@ -7672,7 +7596,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_17_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_17_wd),
 
     // from internal hardware
@@ -7698,7 +7622,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_18_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_18_wd),
 
     // from internal hardware
@@ -7724,7 +7648,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_19_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_19_wd),
 
     // from internal hardware
@@ -7750,7 +7674,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_20_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_20_wd),
 
     // from internal hardware
@@ -7776,7 +7700,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_21_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_21_wd),
 
     // from internal hardware
@@ -7802,7 +7726,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_22_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_22_wd),
 
     // from internal hardware
@@ -7828,7 +7752,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_23_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_23_wd),
 
     // from internal hardware
@@ -7854,7 +7778,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_24_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_24_wd),
 
     // from internal hardware
@@ -7880,7 +7804,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_25_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_25_wd),
 
     // from internal hardware
@@ -7906,7 +7830,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_26_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_26_wd),
 
     // from internal hardware
@@ -7932,7 +7856,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_27_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_27_wd),
 
     // from internal hardware
@@ -7958,7 +7882,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_28_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_28_wd),
 
     // from internal hardware
@@ -7984,7 +7908,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_29_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_29_wd),
 
     // from internal hardware
@@ -8010,7 +7934,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_30_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_30_wd),
 
     // from internal hardware
@@ -8036,7 +7960,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_en_31_we),
+    .we     (mio_pad_sleep_status_we),
     .wd     (mio_pad_sleep_status_en_31_wd),
 
     // from internal hardware
@@ -10665,7 +10589,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_0_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_0_wd),
 
     // from internal hardware
@@ -10691,7 +10615,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_1_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_1_wd),
 
     // from internal hardware
@@ -10717,7 +10641,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_2_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_2_wd),
 
     // from internal hardware
@@ -10743,7 +10667,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_3_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_3_wd),
 
     // from internal hardware
@@ -10769,7 +10693,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_4_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_4_wd),
 
     // from internal hardware
@@ -10795,7 +10719,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_5_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_5_wd),
 
     // from internal hardware
@@ -10821,7 +10745,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_6_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_6_wd),
 
     // from internal hardware
@@ -10847,7 +10771,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_7_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_7_wd),
 
     // from internal hardware
@@ -10873,7 +10797,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_8_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_8_wd),
 
     // from internal hardware
@@ -10899,7 +10823,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_9_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_9_wd),
 
     // from internal hardware
@@ -10925,7 +10849,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_10_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_10_wd),
 
     // from internal hardware
@@ -10951,7 +10875,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_11_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_11_wd),
 
     // from internal hardware
@@ -10977,7 +10901,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_12_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_12_wd),
 
     // from internal hardware
@@ -11003,7 +10927,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_13_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_13_wd),
 
     // from internal hardware
@@ -11029,7 +10953,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_14_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_14_wd),
 
     // from internal hardware
@@ -11055,7 +10979,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_15_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_15_wd),
 
     // from internal hardware
@@ -12824,7 +12748,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_0_mode_0_we & wkup_detector_regwen_0_qs),
+    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
     .wd     (wkup_detector_0_mode_0_wd),
 
     // from internal hardware
@@ -12850,7 +12774,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_0_filter_0_we & wkup_detector_regwen_0_qs),
+    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
     .wd     (wkup_detector_0_filter_0_wd),
 
     // from internal hardware
@@ -12876,7 +12800,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_0_miodio_0_we & wkup_detector_regwen_0_qs),
+    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
     .wd     (wkup_detector_0_miodio_0_wd),
 
     // from internal hardware
@@ -12905,7 +12829,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_1_mode_1_we & wkup_detector_regwen_1_qs),
+    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
     .wd     (wkup_detector_1_mode_1_wd),
 
     // from internal hardware
@@ -12931,7 +12855,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_1_filter_1_we & wkup_detector_regwen_1_qs),
+    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
     .wd     (wkup_detector_1_filter_1_wd),
 
     // from internal hardware
@@ -12957,7 +12881,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_1_miodio_1_we & wkup_detector_regwen_1_qs),
+    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
     .wd     (wkup_detector_1_miodio_1_wd),
 
     // from internal hardware
@@ -12986,7 +12910,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_2_mode_2_we & wkup_detector_regwen_2_qs),
+    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
     .wd     (wkup_detector_2_mode_2_wd),
 
     // from internal hardware
@@ -13012,7 +12936,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_2_filter_2_we & wkup_detector_regwen_2_qs),
+    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
     .wd     (wkup_detector_2_filter_2_wd),
 
     // from internal hardware
@@ -13038,7 +12962,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_2_miodio_2_we & wkup_detector_regwen_2_qs),
+    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
     .wd     (wkup_detector_2_miodio_2_wd),
 
     // from internal hardware
@@ -13067,7 +12991,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_3_mode_3_we & wkup_detector_regwen_3_qs),
+    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
     .wd     (wkup_detector_3_mode_3_wd),
 
     // from internal hardware
@@ -13093,7 +13017,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_3_filter_3_we & wkup_detector_regwen_3_qs),
+    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
     .wd     (wkup_detector_3_filter_3_wd),
 
     // from internal hardware
@@ -13119,7 +13043,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_3_miodio_3_we & wkup_detector_regwen_3_qs),
+    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
     .wd     (wkup_detector_3_miodio_3_wd),
 
     // from internal hardware
@@ -13148,7 +13072,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_4_mode_4_we & wkup_detector_regwen_4_qs),
+    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
     .wd     (wkup_detector_4_mode_4_wd),
 
     // from internal hardware
@@ -13174,7 +13098,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_4_filter_4_we & wkup_detector_regwen_4_qs),
+    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
     .wd     (wkup_detector_4_filter_4_wd),
 
     // from internal hardware
@@ -13200,7 +13124,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_4_miodio_4_we & wkup_detector_regwen_4_qs),
+    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
     .wd     (wkup_detector_4_miodio_4_wd),
 
     // from internal hardware
@@ -13229,7 +13153,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_5_mode_5_we & wkup_detector_regwen_5_qs),
+    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
     .wd     (wkup_detector_5_mode_5_wd),
 
     // from internal hardware
@@ -13255,7 +13179,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_5_filter_5_we & wkup_detector_regwen_5_qs),
+    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
     .wd     (wkup_detector_5_filter_5_wd),
 
     // from internal hardware
@@ -13281,7 +13205,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_5_miodio_5_we & wkup_detector_regwen_5_qs),
+    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
     .wd     (wkup_detector_5_miodio_5_wd),
 
     // from internal hardware
@@ -13310,7 +13234,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_6_mode_6_we & wkup_detector_regwen_6_qs),
+    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
     .wd     (wkup_detector_6_mode_6_wd),
 
     // from internal hardware
@@ -13336,7 +13260,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_6_filter_6_we & wkup_detector_regwen_6_qs),
+    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
     .wd     (wkup_detector_6_filter_6_wd),
 
     // from internal hardware
@@ -13362,7 +13286,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_6_miodio_6_we & wkup_detector_regwen_6_qs),
+    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
     .wd     (wkup_detector_6_miodio_6_wd),
 
     // from internal hardware
@@ -13391,7 +13315,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_7_mode_7_we & wkup_detector_regwen_7_qs),
+    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
     .wd     (wkup_detector_7_mode_7_wd),
 
     // from internal hardware
@@ -13417,7 +13341,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_7_filter_7_we & wkup_detector_regwen_7_qs),
+    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
     .wd     (wkup_detector_7_filter_7_wd),
 
     // from internal hardware
@@ -13443,7 +13367,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_7_miodio_7_we & wkup_detector_regwen_7_qs),
+    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
     .wd     (wkup_detector_7_miodio_7_wd),
 
     // from internal hardware
@@ -13904,8 +13828,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_0 (
-    .re     (wkup_cause_cause_0_re),
-    .we     (wkup_cause_cause_0_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_0_wd),
     .d      (hw2reg.wkup_cause[0].d),
     .qre    (),
@@ -13919,8 +13843,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_1 (
-    .re     (wkup_cause_cause_1_re),
-    .we     (wkup_cause_cause_1_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_1_wd),
     .d      (hw2reg.wkup_cause[1].d),
     .qre    (),
@@ -13934,8 +13858,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_2 (
-    .re     (wkup_cause_cause_2_re),
-    .we     (wkup_cause_cause_2_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_2_wd),
     .d      (hw2reg.wkup_cause[2].d),
     .qre    (),
@@ -13949,8 +13873,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_3 (
-    .re     (wkup_cause_cause_3_re),
-    .we     (wkup_cause_cause_3_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_3_wd),
     .d      (hw2reg.wkup_cause[3].d),
     .qre    (),
@@ -13964,8 +13888,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_4 (
-    .re     (wkup_cause_cause_4_re),
-    .we     (wkup_cause_cause_4_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_4_wd),
     .d      (hw2reg.wkup_cause[4].d),
     .qre    (),
@@ -13979,8 +13903,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_5 (
-    .re     (wkup_cause_cause_5_re),
-    .we     (wkup_cause_cause_5_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_5_wd),
     .d      (hw2reg.wkup_cause[5].d),
     .qre    (),
@@ -13994,8 +13918,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_6 (
-    .re     (wkup_cause_cause_6_re),
-    .we     (wkup_cause_cause_6_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_6_wd),
     .d      (hw2reg.wkup_cause[6].d),
     .qre    (),
@@ -14009,8 +13933,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_7 (
-    .re     (wkup_cause_cause_7_re),
-    .we     (wkup_cause_cause_7_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_7_wd),
     .d      (hw2reg.wkup_cause[7].d),
     .qre    (),
@@ -14862,1511 +14786,1435 @@ module pinmux_reg_top (
                (addr_hit[412] & (|(PINMUX_PERMIT[412] & ~reg_be))) |
                (addr_hit[413] & (|(PINMUX_PERMIT[413] & ~reg_be)))));
   end
-
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_0_we = addr_hit[1] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_1_we = addr_hit[2] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_1_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_2_we = addr_hit[3] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_2_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_3_we = addr_hit[4] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_3_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_4_we = addr_hit[5] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_4_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_5_we = addr_hit[6] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_5_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_6_we = addr_hit[7] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_6_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_7_we = addr_hit[8] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_7_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_8_we = addr_hit[9] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_8_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_9_we = addr_hit[10] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_9_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_10_we = addr_hit[11] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_10_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_11_we = addr_hit[12] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_11_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_12_we = addr_hit[13] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_12_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_13_we = addr_hit[14] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_13_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_14_we = addr_hit[15] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_14_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_15_we = addr_hit[16] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_15_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_16_we = addr_hit[17] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_16_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_17_we = addr_hit[18] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_17_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_18_we = addr_hit[19] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_18_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_19_we = addr_hit[20] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_19_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_20_we = addr_hit[21] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_20_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_21_we = addr_hit[22] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_21_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_22_we = addr_hit[23] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_22_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_23_we = addr_hit[24] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_23_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_24_we = addr_hit[25] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_24_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_25_we = addr_hit[26] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_25_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_26_we = addr_hit[27] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_26_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_27_we = addr_hit[28] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_27_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_28_we = addr_hit[29] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_28_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_29_we = addr_hit[30] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_29_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_30_we = addr_hit[31] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_30_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_31_we = addr_hit[32] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_31_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_32_we = addr_hit[33] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_32_wd = reg_wdata[0];
-
   assign mio_periph_insel_0_we = addr_hit[34] & reg_we & !reg_error;
+
   assign mio_periph_insel_0_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_1_we = addr_hit[35] & reg_we & !reg_error;
+
   assign mio_periph_insel_1_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_2_we = addr_hit[36] & reg_we & !reg_error;
+
   assign mio_periph_insel_2_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_3_we = addr_hit[37] & reg_we & !reg_error;
+
   assign mio_periph_insel_3_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_4_we = addr_hit[38] & reg_we & !reg_error;
+
   assign mio_periph_insel_4_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_5_we = addr_hit[39] & reg_we & !reg_error;
+
   assign mio_periph_insel_5_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_6_we = addr_hit[40] & reg_we & !reg_error;
+
   assign mio_periph_insel_6_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_7_we = addr_hit[41] & reg_we & !reg_error;
+
   assign mio_periph_insel_7_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_8_we = addr_hit[42] & reg_we & !reg_error;
+
   assign mio_periph_insel_8_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_9_we = addr_hit[43] & reg_we & !reg_error;
+
   assign mio_periph_insel_9_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_10_we = addr_hit[44] & reg_we & !reg_error;
+
   assign mio_periph_insel_10_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_11_we = addr_hit[45] & reg_we & !reg_error;
+
   assign mio_periph_insel_11_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_12_we = addr_hit[46] & reg_we & !reg_error;
+
   assign mio_periph_insel_12_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_13_we = addr_hit[47] & reg_we & !reg_error;
+
   assign mio_periph_insel_13_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_14_we = addr_hit[48] & reg_we & !reg_error;
+
   assign mio_periph_insel_14_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_15_we = addr_hit[49] & reg_we & !reg_error;
+
   assign mio_periph_insel_15_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_16_we = addr_hit[50] & reg_we & !reg_error;
+
   assign mio_periph_insel_16_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_17_we = addr_hit[51] & reg_we & !reg_error;
+
   assign mio_periph_insel_17_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_18_we = addr_hit[52] & reg_we & !reg_error;
+
   assign mio_periph_insel_18_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_19_we = addr_hit[53] & reg_we & !reg_error;
+
   assign mio_periph_insel_19_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_20_we = addr_hit[54] & reg_we & !reg_error;
+
   assign mio_periph_insel_20_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_21_we = addr_hit[55] & reg_we & !reg_error;
+
   assign mio_periph_insel_21_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_22_we = addr_hit[56] & reg_we & !reg_error;
+
   assign mio_periph_insel_22_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_23_we = addr_hit[57] & reg_we & !reg_error;
+
   assign mio_periph_insel_23_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_24_we = addr_hit[58] & reg_we & !reg_error;
+
   assign mio_periph_insel_24_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_25_we = addr_hit[59] & reg_we & !reg_error;
+
   assign mio_periph_insel_25_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_26_we = addr_hit[60] & reg_we & !reg_error;
+
   assign mio_periph_insel_26_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_27_we = addr_hit[61] & reg_we & !reg_error;
+
   assign mio_periph_insel_27_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_28_we = addr_hit[62] & reg_we & !reg_error;
+
   assign mio_periph_insel_28_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_29_we = addr_hit[63] & reg_we & !reg_error;
+
   assign mio_periph_insel_29_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_30_we = addr_hit[64] & reg_we & !reg_error;
+
   assign mio_periph_insel_30_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_31_we = addr_hit[65] & reg_we & !reg_error;
+
   assign mio_periph_insel_31_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_32_we = addr_hit[66] & reg_we & !reg_error;
+
   assign mio_periph_insel_32_wd = reg_wdata[5:0];
-
   assign mio_outsel_regwen_0_we = addr_hit[67] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_0_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_1_we = addr_hit[68] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_1_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_2_we = addr_hit[69] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_2_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_3_we = addr_hit[70] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_3_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_4_we = addr_hit[71] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_4_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_5_we = addr_hit[72] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_5_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_6_we = addr_hit[73] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_6_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_7_we = addr_hit[74] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_7_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_8_we = addr_hit[75] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_8_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_9_we = addr_hit[76] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_9_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_10_we = addr_hit[77] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_10_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_11_we = addr_hit[78] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_11_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_12_we = addr_hit[79] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_12_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_13_we = addr_hit[80] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_13_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_14_we = addr_hit[81] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_14_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_15_we = addr_hit[82] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_15_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_16_we = addr_hit[83] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_16_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_17_we = addr_hit[84] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_17_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_18_we = addr_hit[85] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_18_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_19_we = addr_hit[86] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_19_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_20_we = addr_hit[87] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_20_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_21_we = addr_hit[88] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_21_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_22_we = addr_hit[89] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_22_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_23_we = addr_hit[90] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_23_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_24_we = addr_hit[91] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_24_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_25_we = addr_hit[92] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_25_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_26_we = addr_hit[93] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_26_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_27_we = addr_hit[94] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_27_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_28_we = addr_hit[95] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_28_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_29_we = addr_hit[96] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_29_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_30_we = addr_hit[97] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_30_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_31_we = addr_hit[98] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_31_wd = reg_wdata[0];
-
   assign mio_outsel_0_we = addr_hit[99] & reg_we & !reg_error;
+
   assign mio_outsel_0_wd = reg_wdata[5:0];
-
   assign mio_outsel_1_we = addr_hit[100] & reg_we & !reg_error;
+
   assign mio_outsel_1_wd = reg_wdata[5:0];
-
   assign mio_outsel_2_we = addr_hit[101] & reg_we & !reg_error;
+
   assign mio_outsel_2_wd = reg_wdata[5:0];
-
   assign mio_outsel_3_we = addr_hit[102] & reg_we & !reg_error;
+
   assign mio_outsel_3_wd = reg_wdata[5:0];
-
   assign mio_outsel_4_we = addr_hit[103] & reg_we & !reg_error;
+
   assign mio_outsel_4_wd = reg_wdata[5:0];
-
   assign mio_outsel_5_we = addr_hit[104] & reg_we & !reg_error;
+
   assign mio_outsel_5_wd = reg_wdata[5:0];
-
   assign mio_outsel_6_we = addr_hit[105] & reg_we & !reg_error;
+
   assign mio_outsel_6_wd = reg_wdata[5:0];
-
   assign mio_outsel_7_we = addr_hit[106] & reg_we & !reg_error;
+
   assign mio_outsel_7_wd = reg_wdata[5:0];
-
   assign mio_outsel_8_we = addr_hit[107] & reg_we & !reg_error;
+
   assign mio_outsel_8_wd = reg_wdata[5:0];
-
   assign mio_outsel_9_we = addr_hit[108] & reg_we & !reg_error;
+
   assign mio_outsel_9_wd = reg_wdata[5:0];
-
   assign mio_outsel_10_we = addr_hit[109] & reg_we & !reg_error;
+
   assign mio_outsel_10_wd = reg_wdata[5:0];
-
   assign mio_outsel_11_we = addr_hit[110] & reg_we & !reg_error;
+
   assign mio_outsel_11_wd = reg_wdata[5:0];
-
   assign mio_outsel_12_we = addr_hit[111] & reg_we & !reg_error;
+
   assign mio_outsel_12_wd = reg_wdata[5:0];
-
   assign mio_outsel_13_we = addr_hit[112] & reg_we & !reg_error;
+
   assign mio_outsel_13_wd = reg_wdata[5:0];
-
   assign mio_outsel_14_we = addr_hit[113] & reg_we & !reg_error;
+
   assign mio_outsel_14_wd = reg_wdata[5:0];
-
   assign mio_outsel_15_we = addr_hit[114] & reg_we & !reg_error;
+
   assign mio_outsel_15_wd = reg_wdata[5:0];
-
   assign mio_outsel_16_we = addr_hit[115] & reg_we & !reg_error;
+
   assign mio_outsel_16_wd = reg_wdata[5:0];
-
   assign mio_outsel_17_we = addr_hit[116] & reg_we & !reg_error;
+
   assign mio_outsel_17_wd = reg_wdata[5:0];
-
   assign mio_outsel_18_we = addr_hit[117] & reg_we & !reg_error;
+
   assign mio_outsel_18_wd = reg_wdata[5:0];
-
   assign mio_outsel_19_we = addr_hit[118] & reg_we & !reg_error;
+
   assign mio_outsel_19_wd = reg_wdata[5:0];
-
   assign mio_outsel_20_we = addr_hit[119] & reg_we & !reg_error;
+
   assign mio_outsel_20_wd = reg_wdata[5:0];
-
   assign mio_outsel_21_we = addr_hit[120] & reg_we & !reg_error;
+
   assign mio_outsel_21_wd = reg_wdata[5:0];
-
   assign mio_outsel_22_we = addr_hit[121] & reg_we & !reg_error;
+
   assign mio_outsel_22_wd = reg_wdata[5:0];
-
   assign mio_outsel_23_we = addr_hit[122] & reg_we & !reg_error;
+
   assign mio_outsel_23_wd = reg_wdata[5:0];
-
   assign mio_outsel_24_we = addr_hit[123] & reg_we & !reg_error;
+
   assign mio_outsel_24_wd = reg_wdata[5:0];
-
   assign mio_outsel_25_we = addr_hit[124] & reg_we & !reg_error;
+
   assign mio_outsel_25_wd = reg_wdata[5:0];
-
   assign mio_outsel_26_we = addr_hit[125] & reg_we & !reg_error;
+
   assign mio_outsel_26_wd = reg_wdata[5:0];
-
   assign mio_outsel_27_we = addr_hit[126] & reg_we & !reg_error;
+
   assign mio_outsel_27_wd = reg_wdata[5:0];
-
   assign mio_outsel_28_we = addr_hit[127] & reg_we & !reg_error;
+
   assign mio_outsel_28_wd = reg_wdata[5:0];
-
   assign mio_outsel_29_we = addr_hit[128] & reg_we & !reg_error;
+
   assign mio_outsel_29_wd = reg_wdata[5:0];
-
   assign mio_outsel_30_we = addr_hit[129] & reg_we & !reg_error;
+
   assign mio_outsel_30_wd = reg_wdata[5:0];
-
   assign mio_outsel_31_we = addr_hit[130] & reg_we & !reg_error;
+
   assign mio_outsel_31_wd = reg_wdata[5:0];
-
   assign mio_pad_attr_regwen_0_we = addr_hit[131] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_0_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_1_we = addr_hit[132] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_1_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_2_we = addr_hit[133] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_2_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_3_we = addr_hit[134] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_3_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_4_we = addr_hit[135] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_4_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_5_we = addr_hit[136] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_5_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_6_we = addr_hit[137] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_6_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_7_we = addr_hit[138] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_7_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_8_we = addr_hit[139] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_8_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_9_we = addr_hit[140] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_9_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_10_we = addr_hit[141] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_10_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_11_we = addr_hit[142] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_11_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_12_we = addr_hit[143] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_12_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_13_we = addr_hit[144] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_13_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_14_we = addr_hit[145] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_14_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_15_we = addr_hit[146] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_15_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_16_we = addr_hit[147] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_16_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_17_we = addr_hit[148] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_17_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_18_we = addr_hit[149] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_18_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_19_we = addr_hit[150] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_19_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_20_we = addr_hit[151] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_20_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_21_we = addr_hit[152] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_21_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_22_we = addr_hit[153] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_22_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_23_we = addr_hit[154] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_23_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_24_we = addr_hit[155] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_24_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_25_we = addr_hit[156] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_25_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_26_we = addr_hit[157] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_26_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_27_we = addr_hit[158] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_27_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_28_we = addr_hit[159] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_28_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_29_we = addr_hit[160] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_29_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_30_we = addr_hit[161] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_30_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_31_we = addr_hit[162] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_31_wd = reg_wdata[0];
-
-  assign mio_pad_attr_0_we = addr_hit[163] & reg_we & !reg_error;
-  assign mio_pad_attr_0_wd = reg_wdata[12:0];
   assign mio_pad_attr_0_re = addr_hit[163] & reg_re & !reg_error;
+  assign mio_pad_attr_0_we = addr_hit[163] & reg_we & !reg_error;
 
-  assign mio_pad_attr_1_we = addr_hit[164] & reg_we & !reg_error;
-  assign mio_pad_attr_1_wd = reg_wdata[12:0];
+  assign mio_pad_attr_0_wd = reg_wdata[12:0];
   assign mio_pad_attr_1_re = addr_hit[164] & reg_re & !reg_error;
+  assign mio_pad_attr_1_we = addr_hit[164] & reg_we & !reg_error;
 
-  assign mio_pad_attr_2_we = addr_hit[165] & reg_we & !reg_error;
-  assign mio_pad_attr_2_wd = reg_wdata[12:0];
+  assign mio_pad_attr_1_wd = reg_wdata[12:0];
   assign mio_pad_attr_2_re = addr_hit[165] & reg_re & !reg_error;
+  assign mio_pad_attr_2_we = addr_hit[165] & reg_we & !reg_error;
 
-  assign mio_pad_attr_3_we = addr_hit[166] & reg_we & !reg_error;
-  assign mio_pad_attr_3_wd = reg_wdata[12:0];
+  assign mio_pad_attr_2_wd = reg_wdata[12:0];
   assign mio_pad_attr_3_re = addr_hit[166] & reg_re & !reg_error;
+  assign mio_pad_attr_3_we = addr_hit[166] & reg_we & !reg_error;
 
-  assign mio_pad_attr_4_we = addr_hit[167] & reg_we & !reg_error;
-  assign mio_pad_attr_4_wd = reg_wdata[12:0];
+  assign mio_pad_attr_3_wd = reg_wdata[12:0];
   assign mio_pad_attr_4_re = addr_hit[167] & reg_re & !reg_error;
+  assign mio_pad_attr_4_we = addr_hit[167] & reg_we & !reg_error;
 
-  assign mio_pad_attr_5_we = addr_hit[168] & reg_we & !reg_error;
-  assign mio_pad_attr_5_wd = reg_wdata[12:0];
+  assign mio_pad_attr_4_wd = reg_wdata[12:0];
   assign mio_pad_attr_5_re = addr_hit[168] & reg_re & !reg_error;
+  assign mio_pad_attr_5_we = addr_hit[168] & reg_we & !reg_error;
 
-  assign mio_pad_attr_6_we = addr_hit[169] & reg_we & !reg_error;
-  assign mio_pad_attr_6_wd = reg_wdata[12:0];
+  assign mio_pad_attr_5_wd = reg_wdata[12:0];
   assign mio_pad_attr_6_re = addr_hit[169] & reg_re & !reg_error;
+  assign mio_pad_attr_6_we = addr_hit[169] & reg_we & !reg_error;
 
-  assign mio_pad_attr_7_we = addr_hit[170] & reg_we & !reg_error;
-  assign mio_pad_attr_7_wd = reg_wdata[12:0];
+  assign mio_pad_attr_6_wd = reg_wdata[12:0];
   assign mio_pad_attr_7_re = addr_hit[170] & reg_re & !reg_error;
+  assign mio_pad_attr_7_we = addr_hit[170] & reg_we & !reg_error;
 
-  assign mio_pad_attr_8_we = addr_hit[171] & reg_we & !reg_error;
-  assign mio_pad_attr_8_wd = reg_wdata[12:0];
+  assign mio_pad_attr_7_wd = reg_wdata[12:0];
   assign mio_pad_attr_8_re = addr_hit[171] & reg_re & !reg_error;
+  assign mio_pad_attr_8_we = addr_hit[171] & reg_we & !reg_error;
 
-  assign mio_pad_attr_9_we = addr_hit[172] & reg_we & !reg_error;
-  assign mio_pad_attr_9_wd = reg_wdata[12:0];
+  assign mio_pad_attr_8_wd = reg_wdata[12:0];
   assign mio_pad_attr_9_re = addr_hit[172] & reg_re & !reg_error;
+  assign mio_pad_attr_9_we = addr_hit[172] & reg_we & !reg_error;
 
-  assign mio_pad_attr_10_we = addr_hit[173] & reg_we & !reg_error;
-  assign mio_pad_attr_10_wd = reg_wdata[12:0];
+  assign mio_pad_attr_9_wd = reg_wdata[12:0];
   assign mio_pad_attr_10_re = addr_hit[173] & reg_re & !reg_error;
+  assign mio_pad_attr_10_we = addr_hit[173] & reg_we & !reg_error;
 
-  assign mio_pad_attr_11_we = addr_hit[174] & reg_we & !reg_error;
-  assign mio_pad_attr_11_wd = reg_wdata[12:0];
+  assign mio_pad_attr_10_wd = reg_wdata[12:0];
   assign mio_pad_attr_11_re = addr_hit[174] & reg_re & !reg_error;
+  assign mio_pad_attr_11_we = addr_hit[174] & reg_we & !reg_error;
 
-  assign mio_pad_attr_12_we = addr_hit[175] & reg_we & !reg_error;
-  assign mio_pad_attr_12_wd = reg_wdata[12:0];
+  assign mio_pad_attr_11_wd = reg_wdata[12:0];
   assign mio_pad_attr_12_re = addr_hit[175] & reg_re & !reg_error;
+  assign mio_pad_attr_12_we = addr_hit[175] & reg_we & !reg_error;
 
-  assign mio_pad_attr_13_we = addr_hit[176] & reg_we & !reg_error;
-  assign mio_pad_attr_13_wd = reg_wdata[12:0];
+  assign mio_pad_attr_12_wd = reg_wdata[12:0];
   assign mio_pad_attr_13_re = addr_hit[176] & reg_re & !reg_error;
+  assign mio_pad_attr_13_we = addr_hit[176] & reg_we & !reg_error;
 
-  assign mio_pad_attr_14_we = addr_hit[177] & reg_we & !reg_error;
-  assign mio_pad_attr_14_wd = reg_wdata[12:0];
+  assign mio_pad_attr_13_wd = reg_wdata[12:0];
   assign mio_pad_attr_14_re = addr_hit[177] & reg_re & !reg_error;
+  assign mio_pad_attr_14_we = addr_hit[177] & reg_we & !reg_error;
 
-  assign mio_pad_attr_15_we = addr_hit[178] & reg_we & !reg_error;
-  assign mio_pad_attr_15_wd = reg_wdata[12:0];
+  assign mio_pad_attr_14_wd = reg_wdata[12:0];
   assign mio_pad_attr_15_re = addr_hit[178] & reg_re & !reg_error;
+  assign mio_pad_attr_15_we = addr_hit[178] & reg_we & !reg_error;
 
-  assign mio_pad_attr_16_we = addr_hit[179] & reg_we & !reg_error;
-  assign mio_pad_attr_16_wd = reg_wdata[12:0];
+  assign mio_pad_attr_15_wd = reg_wdata[12:0];
   assign mio_pad_attr_16_re = addr_hit[179] & reg_re & !reg_error;
+  assign mio_pad_attr_16_we = addr_hit[179] & reg_we & !reg_error;
 
-  assign mio_pad_attr_17_we = addr_hit[180] & reg_we & !reg_error;
-  assign mio_pad_attr_17_wd = reg_wdata[12:0];
+  assign mio_pad_attr_16_wd = reg_wdata[12:0];
   assign mio_pad_attr_17_re = addr_hit[180] & reg_re & !reg_error;
+  assign mio_pad_attr_17_we = addr_hit[180] & reg_we & !reg_error;
 
-  assign mio_pad_attr_18_we = addr_hit[181] & reg_we & !reg_error;
-  assign mio_pad_attr_18_wd = reg_wdata[12:0];
+  assign mio_pad_attr_17_wd = reg_wdata[12:0];
   assign mio_pad_attr_18_re = addr_hit[181] & reg_re & !reg_error;
+  assign mio_pad_attr_18_we = addr_hit[181] & reg_we & !reg_error;
 
-  assign mio_pad_attr_19_we = addr_hit[182] & reg_we & !reg_error;
-  assign mio_pad_attr_19_wd = reg_wdata[12:0];
+  assign mio_pad_attr_18_wd = reg_wdata[12:0];
   assign mio_pad_attr_19_re = addr_hit[182] & reg_re & !reg_error;
+  assign mio_pad_attr_19_we = addr_hit[182] & reg_we & !reg_error;
 
-  assign mio_pad_attr_20_we = addr_hit[183] & reg_we & !reg_error;
-  assign mio_pad_attr_20_wd = reg_wdata[12:0];
+  assign mio_pad_attr_19_wd = reg_wdata[12:0];
   assign mio_pad_attr_20_re = addr_hit[183] & reg_re & !reg_error;
+  assign mio_pad_attr_20_we = addr_hit[183] & reg_we & !reg_error;
 
-  assign mio_pad_attr_21_we = addr_hit[184] & reg_we & !reg_error;
-  assign mio_pad_attr_21_wd = reg_wdata[12:0];
+  assign mio_pad_attr_20_wd = reg_wdata[12:0];
   assign mio_pad_attr_21_re = addr_hit[184] & reg_re & !reg_error;
+  assign mio_pad_attr_21_we = addr_hit[184] & reg_we & !reg_error;
 
-  assign mio_pad_attr_22_we = addr_hit[185] & reg_we & !reg_error;
-  assign mio_pad_attr_22_wd = reg_wdata[12:0];
+  assign mio_pad_attr_21_wd = reg_wdata[12:0];
   assign mio_pad_attr_22_re = addr_hit[185] & reg_re & !reg_error;
+  assign mio_pad_attr_22_we = addr_hit[185] & reg_we & !reg_error;
 
-  assign mio_pad_attr_23_we = addr_hit[186] & reg_we & !reg_error;
-  assign mio_pad_attr_23_wd = reg_wdata[12:0];
+  assign mio_pad_attr_22_wd = reg_wdata[12:0];
   assign mio_pad_attr_23_re = addr_hit[186] & reg_re & !reg_error;
+  assign mio_pad_attr_23_we = addr_hit[186] & reg_we & !reg_error;
 
-  assign mio_pad_attr_24_we = addr_hit[187] & reg_we & !reg_error;
-  assign mio_pad_attr_24_wd = reg_wdata[12:0];
+  assign mio_pad_attr_23_wd = reg_wdata[12:0];
   assign mio_pad_attr_24_re = addr_hit[187] & reg_re & !reg_error;
+  assign mio_pad_attr_24_we = addr_hit[187] & reg_we & !reg_error;
 
-  assign mio_pad_attr_25_we = addr_hit[188] & reg_we & !reg_error;
-  assign mio_pad_attr_25_wd = reg_wdata[12:0];
+  assign mio_pad_attr_24_wd = reg_wdata[12:0];
   assign mio_pad_attr_25_re = addr_hit[188] & reg_re & !reg_error;
+  assign mio_pad_attr_25_we = addr_hit[188] & reg_we & !reg_error;
 
-  assign mio_pad_attr_26_we = addr_hit[189] & reg_we & !reg_error;
-  assign mio_pad_attr_26_wd = reg_wdata[12:0];
+  assign mio_pad_attr_25_wd = reg_wdata[12:0];
   assign mio_pad_attr_26_re = addr_hit[189] & reg_re & !reg_error;
+  assign mio_pad_attr_26_we = addr_hit[189] & reg_we & !reg_error;
 
-  assign mio_pad_attr_27_we = addr_hit[190] & reg_we & !reg_error;
-  assign mio_pad_attr_27_wd = reg_wdata[12:0];
+  assign mio_pad_attr_26_wd = reg_wdata[12:0];
   assign mio_pad_attr_27_re = addr_hit[190] & reg_re & !reg_error;
+  assign mio_pad_attr_27_we = addr_hit[190] & reg_we & !reg_error;
 
-  assign mio_pad_attr_28_we = addr_hit[191] & reg_we & !reg_error;
-  assign mio_pad_attr_28_wd = reg_wdata[12:0];
+  assign mio_pad_attr_27_wd = reg_wdata[12:0];
   assign mio_pad_attr_28_re = addr_hit[191] & reg_re & !reg_error;
+  assign mio_pad_attr_28_we = addr_hit[191] & reg_we & !reg_error;
 
-  assign mio_pad_attr_29_we = addr_hit[192] & reg_we & !reg_error;
-  assign mio_pad_attr_29_wd = reg_wdata[12:0];
+  assign mio_pad_attr_28_wd = reg_wdata[12:0];
   assign mio_pad_attr_29_re = addr_hit[192] & reg_re & !reg_error;
+  assign mio_pad_attr_29_we = addr_hit[192] & reg_we & !reg_error;
 
-  assign mio_pad_attr_30_we = addr_hit[193] & reg_we & !reg_error;
-  assign mio_pad_attr_30_wd = reg_wdata[12:0];
+  assign mio_pad_attr_29_wd = reg_wdata[12:0];
   assign mio_pad_attr_30_re = addr_hit[193] & reg_re & !reg_error;
+  assign mio_pad_attr_30_we = addr_hit[193] & reg_we & !reg_error;
 
-  assign mio_pad_attr_31_we = addr_hit[194] & reg_we & !reg_error;
-  assign mio_pad_attr_31_wd = reg_wdata[12:0];
+  assign mio_pad_attr_30_wd = reg_wdata[12:0];
   assign mio_pad_attr_31_re = addr_hit[194] & reg_re & !reg_error;
+  assign mio_pad_attr_31_we = addr_hit[194] & reg_we & !reg_error;
 
+  assign mio_pad_attr_31_wd = reg_wdata[12:0];
   assign dio_pad_attr_regwen_0_we = addr_hit[195] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_0_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_1_we = addr_hit[196] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_1_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_2_we = addr_hit[197] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_2_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_3_we = addr_hit[198] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_3_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_4_we = addr_hit[199] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_4_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_5_we = addr_hit[200] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_5_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_6_we = addr_hit[201] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_6_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_7_we = addr_hit[202] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_7_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_8_we = addr_hit[203] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_8_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_9_we = addr_hit[204] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_9_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_10_we = addr_hit[205] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_10_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_11_we = addr_hit[206] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_11_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_12_we = addr_hit[207] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_12_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_13_we = addr_hit[208] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_13_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_14_we = addr_hit[209] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_14_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_15_we = addr_hit[210] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_15_wd = reg_wdata[0];
-
-  assign dio_pad_attr_0_we = addr_hit[211] & reg_we & !reg_error;
-  assign dio_pad_attr_0_wd = reg_wdata[12:0];
   assign dio_pad_attr_0_re = addr_hit[211] & reg_re & !reg_error;
+  assign dio_pad_attr_0_we = addr_hit[211] & reg_we & !reg_error;
 
-  assign dio_pad_attr_1_we = addr_hit[212] & reg_we & !reg_error;
-  assign dio_pad_attr_1_wd = reg_wdata[12:0];
+  assign dio_pad_attr_0_wd = reg_wdata[12:0];
   assign dio_pad_attr_1_re = addr_hit[212] & reg_re & !reg_error;
+  assign dio_pad_attr_1_we = addr_hit[212] & reg_we & !reg_error;
 
-  assign dio_pad_attr_2_we = addr_hit[213] & reg_we & !reg_error;
-  assign dio_pad_attr_2_wd = reg_wdata[12:0];
+  assign dio_pad_attr_1_wd = reg_wdata[12:0];
   assign dio_pad_attr_2_re = addr_hit[213] & reg_re & !reg_error;
+  assign dio_pad_attr_2_we = addr_hit[213] & reg_we & !reg_error;
 
-  assign dio_pad_attr_3_we = addr_hit[214] & reg_we & !reg_error;
-  assign dio_pad_attr_3_wd = reg_wdata[12:0];
+  assign dio_pad_attr_2_wd = reg_wdata[12:0];
   assign dio_pad_attr_3_re = addr_hit[214] & reg_re & !reg_error;
+  assign dio_pad_attr_3_we = addr_hit[214] & reg_we & !reg_error;
 
-  assign dio_pad_attr_4_we = addr_hit[215] & reg_we & !reg_error;
-  assign dio_pad_attr_4_wd = reg_wdata[12:0];
+  assign dio_pad_attr_3_wd = reg_wdata[12:0];
   assign dio_pad_attr_4_re = addr_hit[215] & reg_re & !reg_error;
+  assign dio_pad_attr_4_we = addr_hit[215] & reg_we & !reg_error;
 
-  assign dio_pad_attr_5_we = addr_hit[216] & reg_we & !reg_error;
-  assign dio_pad_attr_5_wd = reg_wdata[12:0];
+  assign dio_pad_attr_4_wd = reg_wdata[12:0];
   assign dio_pad_attr_5_re = addr_hit[216] & reg_re & !reg_error;
+  assign dio_pad_attr_5_we = addr_hit[216] & reg_we & !reg_error;
 
-  assign dio_pad_attr_6_we = addr_hit[217] & reg_we & !reg_error;
-  assign dio_pad_attr_6_wd = reg_wdata[12:0];
+  assign dio_pad_attr_5_wd = reg_wdata[12:0];
   assign dio_pad_attr_6_re = addr_hit[217] & reg_re & !reg_error;
+  assign dio_pad_attr_6_we = addr_hit[217] & reg_we & !reg_error;
 
-  assign dio_pad_attr_7_we = addr_hit[218] & reg_we & !reg_error;
-  assign dio_pad_attr_7_wd = reg_wdata[12:0];
+  assign dio_pad_attr_6_wd = reg_wdata[12:0];
   assign dio_pad_attr_7_re = addr_hit[218] & reg_re & !reg_error;
+  assign dio_pad_attr_7_we = addr_hit[218] & reg_we & !reg_error;
 
-  assign dio_pad_attr_8_we = addr_hit[219] & reg_we & !reg_error;
-  assign dio_pad_attr_8_wd = reg_wdata[12:0];
+  assign dio_pad_attr_7_wd = reg_wdata[12:0];
   assign dio_pad_attr_8_re = addr_hit[219] & reg_re & !reg_error;
+  assign dio_pad_attr_8_we = addr_hit[219] & reg_we & !reg_error;
 
-  assign dio_pad_attr_9_we = addr_hit[220] & reg_we & !reg_error;
-  assign dio_pad_attr_9_wd = reg_wdata[12:0];
+  assign dio_pad_attr_8_wd = reg_wdata[12:0];
   assign dio_pad_attr_9_re = addr_hit[220] & reg_re & !reg_error;
+  assign dio_pad_attr_9_we = addr_hit[220] & reg_we & !reg_error;
 
-  assign dio_pad_attr_10_we = addr_hit[221] & reg_we & !reg_error;
-  assign dio_pad_attr_10_wd = reg_wdata[12:0];
+  assign dio_pad_attr_9_wd = reg_wdata[12:0];
   assign dio_pad_attr_10_re = addr_hit[221] & reg_re & !reg_error;
+  assign dio_pad_attr_10_we = addr_hit[221] & reg_we & !reg_error;
 
-  assign dio_pad_attr_11_we = addr_hit[222] & reg_we & !reg_error;
-  assign dio_pad_attr_11_wd = reg_wdata[12:0];
+  assign dio_pad_attr_10_wd = reg_wdata[12:0];
   assign dio_pad_attr_11_re = addr_hit[222] & reg_re & !reg_error;
+  assign dio_pad_attr_11_we = addr_hit[222] & reg_we & !reg_error;
 
-  assign dio_pad_attr_12_we = addr_hit[223] & reg_we & !reg_error;
-  assign dio_pad_attr_12_wd = reg_wdata[12:0];
+  assign dio_pad_attr_11_wd = reg_wdata[12:0];
   assign dio_pad_attr_12_re = addr_hit[223] & reg_re & !reg_error;
+  assign dio_pad_attr_12_we = addr_hit[223] & reg_we & !reg_error;
 
-  assign dio_pad_attr_13_we = addr_hit[224] & reg_we & !reg_error;
-  assign dio_pad_attr_13_wd = reg_wdata[12:0];
+  assign dio_pad_attr_12_wd = reg_wdata[12:0];
   assign dio_pad_attr_13_re = addr_hit[224] & reg_re & !reg_error;
+  assign dio_pad_attr_13_we = addr_hit[224] & reg_we & !reg_error;
 
-  assign dio_pad_attr_14_we = addr_hit[225] & reg_we & !reg_error;
-  assign dio_pad_attr_14_wd = reg_wdata[12:0];
+  assign dio_pad_attr_13_wd = reg_wdata[12:0];
   assign dio_pad_attr_14_re = addr_hit[225] & reg_re & !reg_error;
+  assign dio_pad_attr_14_we = addr_hit[225] & reg_we & !reg_error;
 
-  assign dio_pad_attr_15_we = addr_hit[226] & reg_we & !reg_error;
-  assign dio_pad_attr_15_wd = reg_wdata[12:0];
+  assign dio_pad_attr_14_wd = reg_wdata[12:0];
   assign dio_pad_attr_15_re = addr_hit[226] & reg_re & !reg_error;
+  assign dio_pad_attr_15_we = addr_hit[226] & reg_we & !reg_error;
 
-  assign mio_pad_sleep_status_en_0_we = addr_hit[227] & reg_we & !reg_error;
+  assign dio_pad_attr_15_wd = reg_wdata[12:0];
+  assign mio_pad_sleep_status_we = addr_hit[227] & reg_we & !reg_error;
+
   assign mio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_en_1_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_en_2_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_en_3_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_en_4_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_en_5_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_en_6_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_en_7_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_en_8_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_en_9_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_en_10_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_en_11_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_en_12_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_en_13_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_en_14_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_status_en_15_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign mio_pad_sleep_status_en_16_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_16_wd = reg_wdata[16];
 
-  assign mio_pad_sleep_status_en_17_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_17_wd = reg_wdata[17];
 
-  assign mio_pad_sleep_status_en_18_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_18_wd = reg_wdata[18];
 
-  assign mio_pad_sleep_status_en_19_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_19_wd = reg_wdata[19];
 
-  assign mio_pad_sleep_status_en_20_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_20_wd = reg_wdata[20];
 
-  assign mio_pad_sleep_status_en_21_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_21_wd = reg_wdata[21];
 
-  assign mio_pad_sleep_status_en_22_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_22_wd = reg_wdata[22];
 
-  assign mio_pad_sleep_status_en_23_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_23_wd = reg_wdata[23];
 
-  assign mio_pad_sleep_status_en_24_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_24_wd = reg_wdata[24];
 
-  assign mio_pad_sleep_status_en_25_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_25_wd = reg_wdata[25];
 
-  assign mio_pad_sleep_status_en_26_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_26_wd = reg_wdata[26];
 
-  assign mio_pad_sleep_status_en_27_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_27_wd = reg_wdata[27];
 
-  assign mio_pad_sleep_status_en_28_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_28_wd = reg_wdata[28];
 
-  assign mio_pad_sleep_status_en_29_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_29_wd = reg_wdata[29];
 
-  assign mio_pad_sleep_status_en_30_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_30_wd = reg_wdata[30];
 
-  assign mio_pad_sleep_status_en_31_we = addr_hit[227] & reg_we & !reg_error;
   assign mio_pad_sleep_status_en_31_wd = reg_wdata[31];
-
   assign mio_pad_sleep_regwen_0_we = addr_hit[228] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_0_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_1_we = addr_hit[229] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_1_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_2_we = addr_hit[230] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_2_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_3_we = addr_hit[231] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_3_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_4_we = addr_hit[232] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_4_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_5_we = addr_hit[233] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_5_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_6_we = addr_hit[234] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_6_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_7_we = addr_hit[235] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_7_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_8_we = addr_hit[236] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_8_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_9_we = addr_hit[237] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_9_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_10_we = addr_hit[238] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_10_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_11_we = addr_hit[239] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_11_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_12_we = addr_hit[240] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_12_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_13_we = addr_hit[241] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_13_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_14_we = addr_hit[242] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_14_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_15_we = addr_hit[243] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_15_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_16_we = addr_hit[244] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_16_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_17_we = addr_hit[245] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_17_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_18_we = addr_hit[246] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_18_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_19_we = addr_hit[247] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_19_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_20_we = addr_hit[248] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_20_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_21_we = addr_hit[249] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_21_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_22_we = addr_hit[250] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_22_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_23_we = addr_hit[251] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_23_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_24_we = addr_hit[252] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_24_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_25_we = addr_hit[253] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_25_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_26_we = addr_hit[254] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_26_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_27_we = addr_hit[255] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_27_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_28_we = addr_hit[256] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_28_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_29_we = addr_hit[257] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_29_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_30_we = addr_hit[258] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_30_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_31_we = addr_hit[259] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_31_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_0_we = addr_hit[260] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_0_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_1_we = addr_hit[261] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_1_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_2_we = addr_hit[262] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_2_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_3_we = addr_hit[263] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_3_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_4_we = addr_hit[264] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_4_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_5_we = addr_hit[265] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_5_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_6_we = addr_hit[266] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_6_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_7_we = addr_hit[267] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_7_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_8_we = addr_hit[268] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_8_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_9_we = addr_hit[269] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_9_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_10_we = addr_hit[270] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_10_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_11_we = addr_hit[271] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_11_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_12_we = addr_hit[272] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_12_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_13_we = addr_hit[273] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_13_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_14_we = addr_hit[274] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_14_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_15_we = addr_hit[275] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_15_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_16_we = addr_hit[276] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_16_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_17_we = addr_hit[277] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_17_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_18_we = addr_hit[278] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_18_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_19_we = addr_hit[279] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_19_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_20_we = addr_hit[280] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_20_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_21_we = addr_hit[281] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_21_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_22_we = addr_hit[282] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_22_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_23_we = addr_hit[283] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_23_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_24_we = addr_hit[284] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_24_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_25_we = addr_hit[285] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_25_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_26_we = addr_hit[286] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_26_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_27_we = addr_hit[287] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_27_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_28_we = addr_hit[288] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_28_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_29_we = addr_hit[289] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_29_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_30_we = addr_hit[290] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_30_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_31_we = addr_hit[291] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_31_wd = reg_wdata[0];
-
   assign mio_pad_sleep_mode_0_we = addr_hit[292] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_0_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_1_we = addr_hit[293] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_1_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_2_we = addr_hit[294] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_2_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_3_we = addr_hit[295] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_3_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_4_we = addr_hit[296] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_4_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_5_we = addr_hit[297] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_5_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_6_we = addr_hit[298] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_6_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_7_we = addr_hit[299] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_7_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_8_we = addr_hit[300] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_8_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_9_we = addr_hit[301] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_9_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_10_we = addr_hit[302] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_10_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_11_we = addr_hit[303] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_11_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_12_we = addr_hit[304] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_12_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_13_we = addr_hit[305] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_13_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_14_we = addr_hit[306] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_14_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_15_we = addr_hit[307] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_15_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_16_we = addr_hit[308] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_16_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_17_we = addr_hit[309] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_17_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_18_we = addr_hit[310] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_18_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_19_we = addr_hit[311] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_19_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_20_we = addr_hit[312] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_20_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_21_we = addr_hit[313] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_21_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_22_we = addr_hit[314] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_22_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_23_we = addr_hit[315] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_23_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_24_we = addr_hit[316] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_24_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_25_we = addr_hit[317] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_25_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_26_we = addr_hit[318] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_26_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_27_we = addr_hit[319] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_27_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_28_we = addr_hit[320] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_28_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_29_we = addr_hit[321] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_29_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_30_we = addr_hit[322] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_30_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_31_we = addr_hit[323] & reg_we & !reg_error;
-  assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_status_en_0_we = addr_hit[324] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
+  assign dio_pad_sleep_status_we = addr_hit[324] & reg_we & !reg_error;
+
   assign dio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_status_en_1_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign dio_pad_sleep_status_en_2_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign dio_pad_sleep_status_en_3_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign dio_pad_sleep_status_en_4_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign dio_pad_sleep_status_en_5_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign dio_pad_sleep_status_en_6_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign dio_pad_sleep_status_en_7_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign dio_pad_sleep_status_en_8_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign dio_pad_sleep_status_en_9_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign dio_pad_sleep_status_en_10_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign dio_pad_sleep_status_en_11_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign dio_pad_sleep_status_en_12_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign dio_pad_sleep_status_en_13_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign dio_pad_sleep_status_en_14_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign dio_pad_sleep_status_en_15_we = addr_hit[324] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_15_wd = reg_wdata[15];
-
   assign dio_pad_sleep_regwen_0_we = addr_hit[325] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_0_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_1_we = addr_hit[326] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_1_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_2_we = addr_hit[327] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_2_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_3_we = addr_hit[328] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_3_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_4_we = addr_hit[329] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_4_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_5_we = addr_hit[330] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_5_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_6_we = addr_hit[331] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_6_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_7_we = addr_hit[332] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_7_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_8_we = addr_hit[333] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_8_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_9_we = addr_hit[334] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_9_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_10_we = addr_hit[335] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_10_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_11_we = addr_hit[336] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_11_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_12_we = addr_hit[337] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_12_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_13_we = addr_hit[338] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_13_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_14_we = addr_hit[339] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_14_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_15_we = addr_hit[340] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_15_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_0_we = addr_hit[341] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_0_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_1_we = addr_hit[342] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_1_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_2_we = addr_hit[343] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_2_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_3_we = addr_hit[344] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_3_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_4_we = addr_hit[345] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_4_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_5_we = addr_hit[346] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_5_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_6_we = addr_hit[347] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_6_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_7_we = addr_hit[348] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_7_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_8_we = addr_hit[349] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_8_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_9_we = addr_hit[350] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_9_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_10_we = addr_hit[351] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_10_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_11_we = addr_hit[352] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_11_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_12_we = addr_hit[353] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_12_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_13_we = addr_hit[354] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_13_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_14_we = addr_hit[355] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_14_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_15_we = addr_hit[356] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_15_wd = reg_wdata[0];
-
   assign dio_pad_sleep_mode_0_we = addr_hit[357] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_0_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_1_we = addr_hit[358] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_1_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_2_we = addr_hit[359] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_2_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_3_we = addr_hit[360] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_3_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_4_we = addr_hit[361] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_4_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_5_we = addr_hit[362] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_5_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_6_we = addr_hit[363] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_6_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_7_we = addr_hit[364] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_7_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_8_we = addr_hit[365] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_8_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_9_we = addr_hit[366] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_9_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_10_we = addr_hit[367] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_10_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_11_we = addr_hit[368] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_11_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_12_we = addr_hit[369] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_12_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_13_we = addr_hit[370] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_13_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_14_we = addr_hit[371] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_14_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_15_we = addr_hit[372] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_15_wd = reg_wdata[1:0];
-
   assign wkup_detector_regwen_0_we = addr_hit[373] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_0_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_1_we = addr_hit[374] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_1_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_2_we = addr_hit[375] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_2_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_3_we = addr_hit[376] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_3_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_4_we = addr_hit[377] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_4_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_5_we = addr_hit[378] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_5_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_6_we = addr_hit[379] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_6_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_7_we = addr_hit[380] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
-
   assign wkup_detector_en_0_we = addr_hit[381] & reg_we & !reg_error;
+
   assign wkup_detector_en_0_wd = reg_wdata[0];
-
   assign wkup_detector_en_1_we = addr_hit[382] & reg_we & !reg_error;
+
   assign wkup_detector_en_1_wd = reg_wdata[0];
-
   assign wkup_detector_en_2_we = addr_hit[383] & reg_we & !reg_error;
+
   assign wkup_detector_en_2_wd = reg_wdata[0];
-
   assign wkup_detector_en_3_we = addr_hit[384] & reg_we & !reg_error;
+
   assign wkup_detector_en_3_wd = reg_wdata[0];
-
   assign wkup_detector_en_4_we = addr_hit[385] & reg_we & !reg_error;
+
   assign wkup_detector_en_4_wd = reg_wdata[0];
-
   assign wkup_detector_en_5_we = addr_hit[386] & reg_we & !reg_error;
+
   assign wkup_detector_en_5_wd = reg_wdata[0];
-
   assign wkup_detector_en_6_we = addr_hit[387] & reg_we & !reg_error;
+
   assign wkup_detector_en_6_wd = reg_wdata[0];
-
   assign wkup_detector_en_7_we = addr_hit[388] & reg_we & !reg_error;
-  assign wkup_detector_en_7_wd = reg_wdata[0];
 
-  assign wkup_detector_0_mode_0_we = addr_hit[389] & reg_we & !reg_error;
+  assign wkup_detector_en_7_wd = reg_wdata[0];
+  assign wkup_detector_0_we = addr_hit[389] & reg_we & !reg_error;
+
   assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_we = addr_hit[389] & reg_we & !reg_error;
   assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_we = addr_hit[389] & reg_we & !reg_error;
   assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
+  assign wkup_detector_1_we = addr_hit[390] & reg_we & !reg_error;
 
-  assign wkup_detector_1_mode_1_we = addr_hit[390] & reg_we & !reg_error;
   assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_we = addr_hit[390] & reg_we & !reg_error;
   assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_we = addr_hit[390] & reg_we & !reg_error;
   assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
+  assign wkup_detector_2_we = addr_hit[391] & reg_we & !reg_error;
 
-  assign wkup_detector_2_mode_2_we = addr_hit[391] & reg_we & !reg_error;
   assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_we = addr_hit[391] & reg_we & !reg_error;
   assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_we = addr_hit[391] & reg_we & !reg_error;
   assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
+  assign wkup_detector_3_we = addr_hit[392] & reg_we & !reg_error;
 
-  assign wkup_detector_3_mode_3_we = addr_hit[392] & reg_we & !reg_error;
   assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_we = addr_hit[392] & reg_we & !reg_error;
   assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_we = addr_hit[392] & reg_we & !reg_error;
   assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
+  assign wkup_detector_4_we = addr_hit[393] & reg_we & !reg_error;
 
-  assign wkup_detector_4_mode_4_we = addr_hit[393] & reg_we & !reg_error;
   assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_we = addr_hit[393] & reg_we & !reg_error;
   assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_we = addr_hit[393] & reg_we & !reg_error;
   assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
+  assign wkup_detector_5_we = addr_hit[394] & reg_we & !reg_error;
 
-  assign wkup_detector_5_mode_5_we = addr_hit[394] & reg_we & !reg_error;
   assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_we = addr_hit[394] & reg_we & !reg_error;
   assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_we = addr_hit[394] & reg_we & !reg_error;
   assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
+  assign wkup_detector_6_we = addr_hit[395] & reg_we & !reg_error;
 
-  assign wkup_detector_6_mode_6_we = addr_hit[395] & reg_we & !reg_error;
   assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_we = addr_hit[395] & reg_we & !reg_error;
   assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_we = addr_hit[395] & reg_we & !reg_error;
   assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
+  assign wkup_detector_7_we = addr_hit[396] & reg_we & !reg_error;
 
-  assign wkup_detector_7_mode_7_we = addr_hit[396] & reg_we & !reg_error;
   assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_we = addr_hit[396] & reg_we & !reg_error;
   assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_we = addr_hit[396] & reg_we & !reg_error;
   assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
-
   assign wkup_detector_cnt_th_0_we = addr_hit[397] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_1_we = addr_hit[398] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_2_we = addr_hit[399] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_3_we = addr_hit[400] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_4_we = addr_hit[401] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_5_we = addr_hit[402] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_6_we = addr_hit[403] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_7_we = addr_hit[404] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
-
   assign wkup_detector_padsel_0_we = addr_hit[405] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_1_we = addr_hit[406] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_2_we = addr_hit[407] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_3_we = addr_hit[408] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_4_we = addr_hit[409] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_5_we = addr_hit[410] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_6_we = addr_hit[411] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_7_we = addr_hit[412] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
+  assign wkup_cause_re = addr_hit[413] & reg_re & !reg_error;
+  assign wkup_cause_we = addr_hit[413] & reg_we & !reg_error;
 
-  assign wkup_cause_cause_0_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_0_wd = reg_wdata[0];
-  assign wkup_cause_cause_0_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_1_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_1_wd = reg_wdata[1];
-  assign wkup_cause_cause_1_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_2_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_2_wd = reg_wdata[2];
-  assign wkup_cause_cause_2_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_3_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_3_wd = reg_wdata[3];
-  assign wkup_cause_cause_3_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_4_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_4_wd = reg_wdata[4];
-  assign wkup_cause_cause_4_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_5_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_5_wd = reg_wdata[5];
-  assign wkup_cause_cause_5_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_6_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_6_wd = reg_wdata[6];
-  assign wkup_cause_cause_6_re = addr_hit[413] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_7_we = addr_hit[413] & reg_we & !reg_error;
   assign wkup_cause_cause_7_wd = reg_wdata[7];
-  assign wkup_cause_cause_7_re = addr_hit[413] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -104,66 +104,57 @@ module pwrmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_qs;
   logic intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
-  logic intr_enable_we;
-  logic intr_test_wd;
   logic intr_test_we;
-  logic ctrl_cfg_regwen_qs;
+  logic intr_test_wd;
   logic ctrl_cfg_regwen_re;
+  logic ctrl_cfg_regwen_qs;
+  logic control_we;
   logic control_low_power_hint_qs;
   logic control_low_power_hint_wd;
-  logic control_low_power_hint_we;
   logic control_core_clk_en_qs;
   logic control_core_clk_en_wd;
-  logic control_core_clk_en_we;
   logic control_io_clk_en_qs;
   logic control_io_clk_en_wd;
-  logic control_io_clk_en_we;
   logic control_usb_clk_en_lp_qs;
   logic control_usb_clk_en_lp_wd;
-  logic control_usb_clk_en_lp_we;
   logic control_usb_clk_en_active_qs;
   logic control_usb_clk_en_active_wd;
-  logic control_usb_clk_en_active_we;
   logic control_main_pd_n_qs;
   logic control_main_pd_n_wd;
-  logic control_main_pd_n_we;
+  logic cfg_cdc_sync_we;
   logic cfg_cdc_sync_qs;
   logic cfg_cdc_sync_wd;
-  logic cfg_cdc_sync_we;
+  logic wakeup_en_regwen_we;
   logic wakeup_en_regwen_qs;
   logic wakeup_en_regwen_wd;
-  logic wakeup_en_regwen_we;
+  logic wakeup_en_we;
   logic wakeup_en_qs;
   logic wakeup_en_wd;
-  logic wakeup_en_we;
   logic wake_status_qs;
+  logic reset_en_regwen_we;
   logic reset_en_regwen_qs;
   logic reset_en_regwen_wd;
-  logic reset_en_regwen_we;
+  logic reset_en_we;
   logic reset_en_qs;
   logic reset_en_wd;
-  logic reset_en_we;
   logic reset_status_qs;
+  logic wake_info_capture_dis_we;
   logic wake_info_capture_dis_qs;
   logic wake_info_capture_dis_wd;
-  logic wake_info_capture_dis_we;
+  logic wake_info_re;
+  logic wake_info_we;
   logic wake_info_reasons_qs;
   logic wake_info_reasons_wd;
-  logic wake_info_reasons_we;
-  logic wake_info_reasons_re;
   logic wake_info_fall_through_qs;
   logic wake_info_fall_through_wd;
-  logic wake_info_fall_through_we;
-  logic wake_info_fall_through_re;
   logic wake_info_abort_qs;
   logic wake_info_abort_wd;
-  logic wake_info_abort_we;
-  logic wake_info_abort_re;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -264,7 +255,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_low_power_hint_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_low_power_hint_wd),
 
     // from internal hardware
@@ -290,7 +281,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_core_clk_en_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_core_clk_en_wd),
 
     // from internal hardware
@@ -316,7 +307,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_io_clk_en_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_io_clk_en_wd),
 
     // from internal hardware
@@ -342,7 +333,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_usb_clk_en_lp_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_usb_clk_en_lp_wd),
 
     // from internal hardware
@@ -368,7 +359,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_usb_clk_en_active_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_usb_clk_en_active_wd),
 
     // from internal hardware
@@ -394,7 +385,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_main_pd_n_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_main_pd_n_wd),
 
     // from internal hardware
@@ -640,8 +631,8 @@ module pwrmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_reasons (
-    .re     (wake_info_reasons_re),
-    .we     (wake_info_reasons_we),
+    .re     (wake_info_re),
+    .we     (wake_info_we),
     .wd     (wake_info_reasons_wd),
     .d      (hw2reg.wake_info.reasons.d),
     .qre    (),
@@ -655,8 +646,8 @@ module pwrmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_fall_through (
-    .re     (wake_info_fall_through_re),
-    .we     (wake_info_fall_through_we),
+    .re     (wake_info_re),
+    .we     (wake_info_we),
     .wd     (wake_info_fall_through_wd),
     .d      (hw2reg.wake_info.fall_through.d),
     .qre    (),
@@ -670,8 +661,8 @@ module pwrmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_abort (
-    .re     (wake_info_abort_re),
-    .we     (wake_info_abort_we),
+    .re     (wake_info_re),
+    .we     (wake_info_we),
     .wd     (wake_info_abort_wd),
     .d      (hw2reg.wake_info.abort.d),
     .qre    (),
@@ -722,65 +713,55 @@ module pwrmgr_reg_top (
                (addr_hit[12] & (|(PWRMGR_PERMIT[12] & ~reg_be))) |
                (addr_hit[13] & (|(PWRMGR_PERMIT[13] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
+
   assign intr_test_wd = reg_wdata[0];
-
   assign ctrl_cfg_regwen_re = addr_hit[3] & reg_re & !reg_error;
+  assign control_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign control_low_power_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign control_low_power_hint_wd = reg_wdata[0];
 
-  assign control_core_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_core_clk_en_wd = reg_wdata[4];
 
-  assign control_io_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_io_clk_en_wd = reg_wdata[5];
 
-  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_lp_wd = reg_wdata[6];
 
-  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_active_wd = reg_wdata[7];
 
-  assign control_main_pd_n_we = addr_hit[4] & reg_we & !reg_error;
   assign control_main_pd_n_wd = reg_wdata[8];
-
   assign cfg_cdc_sync_we = addr_hit[5] & reg_we & !reg_error;
+
   assign cfg_cdc_sync_wd = reg_wdata[0];
-
   assign wakeup_en_regwen_we = addr_hit[6] & reg_we & !reg_error;
+
   assign wakeup_en_regwen_wd = reg_wdata[0];
-
   assign wakeup_en_we = addr_hit[7] & reg_we & !reg_error;
+
   assign wakeup_en_wd = reg_wdata[0];
-
   assign reset_en_regwen_we = addr_hit[9] & reg_we & !reg_error;
+
   assign reset_en_regwen_wd = reg_wdata[0];
-
   assign reset_en_we = addr_hit[10] & reg_we & !reg_error;
+
   assign reset_en_wd = reg_wdata[0];
-
   assign wake_info_capture_dis_we = addr_hit[12] & reg_we & !reg_error;
+
   assign wake_info_capture_dis_wd = reg_wdata[0];
+  assign wake_info_re = addr_hit[13] & reg_re & !reg_error;
+  assign wake_info_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign wake_info_reasons_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_reasons_wd = reg_wdata[0];
-  assign wake_info_reasons_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign wake_info_fall_through_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_fall_through_wd = reg_wdata[1];
-  assign wake_info_fall_through_re = addr_hit[13] & reg_re & !reg_error;
 
-  assign wake_info_abort_we = addr_hit[13] & reg_we & !reg_error;
   assign wake_info_abort_wd = reg_wdata[2];
-  assign wake_info_abort_re = addr_hit[13] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -104,8 +104,8 @@ module rom_ctrl_regs_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
   logic fatal_alert_cause_checker_error_qs;
   logic fatal_alert_cause_integrity_error_qs;
   logic [31:0] digest_0_qs;
@@ -681,8 +681,8 @@ module rom_ctrl_regs_reg_top (
                (addr_hit[16] & (|(ROM_CTRL_REGS_PERMIT[16] & ~reg_be))) |
                (addr_hit[17] & (|(ROM_CTRL_REGS_PERMIT[17] & ~reg_be)))));
   end
-
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -104,42 +104,35 @@ module rstmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic reset_info_we;
   logic reset_info_por_qs;
   logic reset_info_por_wd;
-  logic reset_info_por_we;
   logic reset_info_low_power_exit_qs;
   logic reset_info_low_power_exit_wd;
-  logic reset_info_low_power_exit_we;
   logic reset_info_ndm_reset_qs;
   logic reset_info_ndm_reset_wd;
-  logic reset_info_ndm_reset_we;
   logic reset_info_hw_req_qs;
   logic reset_info_hw_req_wd;
-  logic reset_info_hw_req_we;
+  logic alert_info_ctrl_we;
   logic alert_info_ctrl_en_qs;
   logic alert_info_ctrl_en_wd;
-  logic alert_info_ctrl_en_we;
   logic [3:0] alert_info_ctrl_index_qs;
   logic [3:0] alert_info_ctrl_index_wd;
-  logic alert_info_ctrl_index_we;
-  logic [3:0] alert_info_attr_qs;
   logic alert_info_attr_re;
-  logic [31:0] alert_info_qs;
+  logic [3:0] alert_info_attr_qs;
   logic alert_info_re;
+  logic [31:0] alert_info_qs;
+  logic sw_rst_regen_we;
   logic sw_rst_regen_en_0_qs;
   logic sw_rst_regen_en_0_wd;
-  logic sw_rst_regen_en_0_we;
   logic sw_rst_regen_en_1_qs;
   logic sw_rst_regen_en_1_wd;
-  logic sw_rst_regen_en_1_we;
+  logic sw_rst_ctrl_n_re;
+  logic sw_rst_ctrl_n_we;
   logic sw_rst_ctrl_n_val_0_qs;
   logic sw_rst_ctrl_n_val_0_wd;
-  logic sw_rst_ctrl_n_val_0_we;
-  logic sw_rst_ctrl_n_val_0_re;
   logic sw_rst_ctrl_n_val_1_qs;
   logic sw_rst_ctrl_n_val_1_wd;
-  logic sw_rst_ctrl_n_val_1_we;
-  logic sw_rst_ctrl_n_val_1_re;
 
   // Register instances
   // R[reset_info]: V(False)
@@ -154,7 +147,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_por_we),
+    .we     (reset_info_we),
     .wd     (reset_info_por_wd),
 
     // from internal hardware
@@ -180,7 +173,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_low_power_exit_we),
+    .we     (reset_info_we),
     .wd     (reset_info_low_power_exit_wd),
 
     // from internal hardware
@@ -206,7 +199,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_ndm_reset_we),
+    .we     (reset_info_we),
     .wd     (reset_info_ndm_reset_wd),
 
     // from internal hardware
@@ -232,7 +225,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_hw_req_we),
+    .we     (reset_info_we),
     .wd     (reset_info_hw_req_wd),
 
     // from internal hardware
@@ -260,7 +253,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_info_ctrl_en_we),
+    .we     (alert_info_ctrl_we),
     .wd     (alert_info_ctrl_en_wd),
 
     // from internal hardware
@@ -286,7 +279,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_info_ctrl_index_we),
+    .we     (alert_info_ctrl_we),
     .wd     (alert_info_ctrl_index_wd),
 
     // from internal hardware
@@ -348,7 +341,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_0_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_0_wd),
 
     // from internal hardware
@@ -374,7 +367,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_1_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_1_wd),
 
     // from internal hardware
@@ -399,8 +392,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_0 (
-    .re     (sw_rst_ctrl_n_val_0_re),
-    .we     (sw_rst_ctrl_n_val_0_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_0_wd),
     .d      (hw2reg.sw_rst_ctrl_n[0].d),
     .qre    (),
@@ -414,8 +407,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_1 (
-    .re     (sw_rst_ctrl_n_val_1_re),
-    .we     (sw_rst_ctrl_n_val_1_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_1_wd),
     .d      (hw2reg.sw_rst_ctrl_n[1].d),
     .qre    (),
@@ -451,42 +444,33 @@ module rstmgr_reg_top (
                (addr_hit[4] & (|(RSTMGR_PERMIT[4] & ~reg_be))) |
                (addr_hit[5] & (|(RSTMGR_PERMIT[5] & ~reg_be)))));
   end
+  assign reset_info_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign reset_info_por_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_por_wd = reg_wdata[0];
 
-  assign reset_info_low_power_exit_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_low_power_exit_wd = reg_wdata[1];
 
-  assign reset_info_ndm_reset_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_ndm_reset_wd = reg_wdata[2];
 
-  assign reset_info_hw_req_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_hw_req_wd = reg_wdata[3];
+  assign alert_info_ctrl_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign alert_info_ctrl_en_we = addr_hit[1] & reg_we & !reg_error;
   assign alert_info_ctrl_en_wd = reg_wdata[0];
 
-  assign alert_info_ctrl_index_we = addr_hit[1] & reg_we & !reg_error;
   assign alert_info_ctrl_index_wd = reg_wdata[7:4];
-
   assign alert_info_attr_re = addr_hit[2] & reg_re & !reg_error;
-
   assign alert_info_re = addr_hit[3] & reg_re & !reg_error;
+  assign sw_rst_regen_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_0_we = addr_hit[4] & reg_we & !reg_error;
   assign sw_rst_regen_en_0_wd = reg_wdata[0];
 
-  assign sw_rst_regen_en_1_we = addr_hit[4] & reg_we & !reg_error;
   assign sw_rst_regen_en_1_wd = reg_wdata[1];
+  assign sw_rst_ctrl_n_re = addr_hit[5] & reg_re & !reg_error;
+  assign sw_rst_ctrl_n_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_0_we = addr_hit[5] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_0_wd = reg_wdata[0];
-  assign sw_rst_ctrl_n_val_0_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_1_we = addr_hit[5] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_1_wd = reg_wdata[1];
-  assign sw_rst_ctrl_n_val_1_re = addr_hit[5] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -136,304 +136,242 @@ module rv_plic_reg_top (
   logic ip_p_29_qs;
   logic ip_p_30_qs;
   logic ip_p_31_qs;
+  logic le_we;
   logic le_le_0_qs;
   logic le_le_0_wd;
-  logic le_le_0_we;
   logic le_le_1_qs;
   logic le_le_1_wd;
-  logic le_le_1_we;
   logic le_le_2_qs;
   logic le_le_2_wd;
-  logic le_le_2_we;
   logic le_le_3_qs;
   logic le_le_3_wd;
-  logic le_le_3_we;
   logic le_le_4_qs;
   logic le_le_4_wd;
-  logic le_le_4_we;
   logic le_le_5_qs;
   logic le_le_5_wd;
-  logic le_le_5_we;
   logic le_le_6_qs;
   logic le_le_6_wd;
-  logic le_le_6_we;
   logic le_le_7_qs;
   logic le_le_7_wd;
-  logic le_le_7_we;
   logic le_le_8_qs;
   logic le_le_8_wd;
-  logic le_le_8_we;
   logic le_le_9_qs;
   logic le_le_9_wd;
-  logic le_le_9_we;
   logic le_le_10_qs;
   logic le_le_10_wd;
-  logic le_le_10_we;
   logic le_le_11_qs;
   logic le_le_11_wd;
-  logic le_le_11_we;
   logic le_le_12_qs;
   logic le_le_12_wd;
-  logic le_le_12_we;
   logic le_le_13_qs;
   logic le_le_13_wd;
-  logic le_le_13_we;
   logic le_le_14_qs;
   logic le_le_14_wd;
-  logic le_le_14_we;
   logic le_le_15_qs;
   logic le_le_15_wd;
-  logic le_le_15_we;
   logic le_le_16_qs;
   logic le_le_16_wd;
-  logic le_le_16_we;
   logic le_le_17_qs;
   logic le_le_17_wd;
-  logic le_le_17_we;
   logic le_le_18_qs;
   logic le_le_18_wd;
-  logic le_le_18_we;
   logic le_le_19_qs;
   logic le_le_19_wd;
-  logic le_le_19_we;
   logic le_le_20_qs;
   logic le_le_20_wd;
-  logic le_le_20_we;
   logic le_le_21_qs;
   logic le_le_21_wd;
-  logic le_le_21_we;
   logic le_le_22_qs;
   logic le_le_22_wd;
-  logic le_le_22_we;
   logic le_le_23_qs;
   logic le_le_23_wd;
-  logic le_le_23_we;
   logic le_le_24_qs;
   logic le_le_24_wd;
-  logic le_le_24_we;
   logic le_le_25_qs;
   logic le_le_25_wd;
-  logic le_le_25_we;
   logic le_le_26_qs;
   logic le_le_26_wd;
-  logic le_le_26_we;
   logic le_le_27_qs;
   logic le_le_27_wd;
-  logic le_le_27_we;
   logic le_le_28_qs;
   logic le_le_28_wd;
-  logic le_le_28_we;
   logic le_le_29_qs;
   logic le_le_29_wd;
-  logic le_le_29_we;
   logic le_le_30_qs;
   logic le_le_30_wd;
-  logic le_le_30_we;
   logic le_le_31_qs;
   logic le_le_31_wd;
-  logic le_le_31_we;
+  logic prio0_we;
   logic [2:0] prio0_qs;
   logic [2:0] prio0_wd;
-  logic prio0_we;
+  logic prio1_we;
   logic [2:0] prio1_qs;
   logic [2:0] prio1_wd;
-  logic prio1_we;
+  logic prio2_we;
   logic [2:0] prio2_qs;
   logic [2:0] prio2_wd;
-  logic prio2_we;
+  logic prio3_we;
   logic [2:0] prio3_qs;
   logic [2:0] prio3_wd;
-  logic prio3_we;
+  logic prio4_we;
   logic [2:0] prio4_qs;
   logic [2:0] prio4_wd;
-  logic prio4_we;
+  logic prio5_we;
   logic [2:0] prio5_qs;
   logic [2:0] prio5_wd;
-  logic prio5_we;
+  logic prio6_we;
   logic [2:0] prio6_qs;
   logic [2:0] prio6_wd;
-  logic prio6_we;
+  logic prio7_we;
   logic [2:0] prio7_qs;
   logic [2:0] prio7_wd;
-  logic prio7_we;
+  logic prio8_we;
   logic [2:0] prio8_qs;
   logic [2:0] prio8_wd;
-  logic prio8_we;
+  logic prio9_we;
   logic [2:0] prio9_qs;
   logic [2:0] prio9_wd;
-  logic prio9_we;
+  logic prio10_we;
   logic [2:0] prio10_qs;
   logic [2:0] prio10_wd;
-  logic prio10_we;
+  logic prio11_we;
   logic [2:0] prio11_qs;
   logic [2:0] prio11_wd;
-  logic prio11_we;
+  logic prio12_we;
   logic [2:0] prio12_qs;
   logic [2:0] prio12_wd;
-  logic prio12_we;
+  logic prio13_we;
   logic [2:0] prio13_qs;
   logic [2:0] prio13_wd;
-  logic prio13_we;
+  logic prio14_we;
   logic [2:0] prio14_qs;
   logic [2:0] prio14_wd;
-  logic prio14_we;
+  logic prio15_we;
   logic [2:0] prio15_qs;
   logic [2:0] prio15_wd;
-  logic prio15_we;
+  logic prio16_we;
   logic [2:0] prio16_qs;
   logic [2:0] prio16_wd;
-  logic prio16_we;
+  logic prio17_we;
   logic [2:0] prio17_qs;
   logic [2:0] prio17_wd;
-  logic prio17_we;
+  logic prio18_we;
   logic [2:0] prio18_qs;
   logic [2:0] prio18_wd;
-  logic prio18_we;
+  logic prio19_we;
   logic [2:0] prio19_qs;
   logic [2:0] prio19_wd;
-  logic prio19_we;
+  logic prio20_we;
   logic [2:0] prio20_qs;
   logic [2:0] prio20_wd;
-  logic prio20_we;
+  logic prio21_we;
   logic [2:0] prio21_qs;
   logic [2:0] prio21_wd;
-  logic prio21_we;
+  logic prio22_we;
   logic [2:0] prio22_qs;
   logic [2:0] prio22_wd;
-  logic prio22_we;
+  logic prio23_we;
   logic [2:0] prio23_qs;
   logic [2:0] prio23_wd;
-  logic prio23_we;
+  logic prio24_we;
   logic [2:0] prio24_qs;
   logic [2:0] prio24_wd;
-  logic prio24_we;
+  logic prio25_we;
   logic [2:0] prio25_qs;
   logic [2:0] prio25_wd;
-  logic prio25_we;
+  logic prio26_we;
   logic [2:0] prio26_qs;
   logic [2:0] prio26_wd;
-  logic prio26_we;
+  logic prio27_we;
   logic [2:0] prio27_qs;
   logic [2:0] prio27_wd;
-  logic prio27_we;
+  logic prio28_we;
   logic [2:0] prio28_qs;
   logic [2:0] prio28_wd;
-  logic prio28_we;
+  logic prio29_we;
   logic [2:0] prio29_qs;
   logic [2:0] prio29_wd;
-  logic prio29_we;
+  logic prio30_we;
   logic [2:0] prio30_qs;
   logic [2:0] prio30_wd;
-  logic prio30_we;
+  logic prio31_we;
   logic [2:0] prio31_qs;
   logic [2:0] prio31_wd;
-  logic prio31_we;
+  logic ie0_we;
   logic ie0_e_0_qs;
   logic ie0_e_0_wd;
-  logic ie0_e_0_we;
   logic ie0_e_1_qs;
   logic ie0_e_1_wd;
-  logic ie0_e_1_we;
   logic ie0_e_2_qs;
   logic ie0_e_2_wd;
-  logic ie0_e_2_we;
   logic ie0_e_3_qs;
   logic ie0_e_3_wd;
-  logic ie0_e_3_we;
   logic ie0_e_4_qs;
   logic ie0_e_4_wd;
-  logic ie0_e_4_we;
   logic ie0_e_5_qs;
   logic ie0_e_5_wd;
-  logic ie0_e_5_we;
   logic ie0_e_6_qs;
   logic ie0_e_6_wd;
-  logic ie0_e_6_we;
   logic ie0_e_7_qs;
   logic ie0_e_7_wd;
-  logic ie0_e_7_we;
   logic ie0_e_8_qs;
   logic ie0_e_8_wd;
-  logic ie0_e_8_we;
   logic ie0_e_9_qs;
   logic ie0_e_9_wd;
-  logic ie0_e_9_we;
   logic ie0_e_10_qs;
   logic ie0_e_10_wd;
-  logic ie0_e_10_we;
   logic ie0_e_11_qs;
   logic ie0_e_11_wd;
-  logic ie0_e_11_we;
   logic ie0_e_12_qs;
   logic ie0_e_12_wd;
-  logic ie0_e_12_we;
   logic ie0_e_13_qs;
   logic ie0_e_13_wd;
-  logic ie0_e_13_we;
   logic ie0_e_14_qs;
   logic ie0_e_14_wd;
-  logic ie0_e_14_we;
   logic ie0_e_15_qs;
   logic ie0_e_15_wd;
-  logic ie0_e_15_we;
   logic ie0_e_16_qs;
   logic ie0_e_16_wd;
-  logic ie0_e_16_we;
   logic ie0_e_17_qs;
   logic ie0_e_17_wd;
-  logic ie0_e_17_we;
   logic ie0_e_18_qs;
   logic ie0_e_18_wd;
-  logic ie0_e_18_we;
   logic ie0_e_19_qs;
   logic ie0_e_19_wd;
-  logic ie0_e_19_we;
   logic ie0_e_20_qs;
   logic ie0_e_20_wd;
-  logic ie0_e_20_we;
   logic ie0_e_21_qs;
   logic ie0_e_21_wd;
-  logic ie0_e_21_we;
   logic ie0_e_22_qs;
   logic ie0_e_22_wd;
-  logic ie0_e_22_we;
   logic ie0_e_23_qs;
   logic ie0_e_23_wd;
-  logic ie0_e_23_we;
   logic ie0_e_24_qs;
   logic ie0_e_24_wd;
-  logic ie0_e_24_we;
   logic ie0_e_25_qs;
   logic ie0_e_25_wd;
-  logic ie0_e_25_we;
   logic ie0_e_26_qs;
   logic ie0_e_26_wd;
-  logic ie0_e_26_we;
   logic ie0_e_27_qs;
   logic ie0_e_27_wd;
-  logic ie0_e_27_we;
   logic ie0_e_28_qs;
   logic ie0_e_28_wd;
-  logic ie0_e_28_we;
   logic ie0_e_29_qs;
   logic ie0_e_29_wd;
-  logic ie0_e_29_we;
   logic ie0_e_30_qs;
   logic ie0_e_30_wd;
-  logic ie0_e_30_we;
   logic ie0_e_31_qs;
   logic ie0_e_31_wd;
-  logic ie0_e_31_we;
+  logic threshold0_we;
   logic [2:0] threshold0_qs;
   logic [2:0] threshold0_wd;
-  logic threshold0_we;
+  logic cc0_re;
+  logic cc0_we;
   logic [5:0] cc0_qs;
   logic [5:0] cc0_wd;
-  logic cc0_we;
-  logic cc0_re;
+  logic msip0_we;
   logic msip0_qs;
   logic msip0_wd;
-  logic msip0_we;
 
   // Register instances
 
@@ -1287,7 +1225,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_0_we),
+    .we     (le_we),
     .wd     (le_le_0_wd),
 
     // from internal hardware
@@ -1313,7 +1251,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_1_we),
+    .we     (le_we),
     .wd     (le_le_1_wd),
 
     // from internal hardware
@@ -1339,7 +1277,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_2_we),
+    .we     (le_we),
     .wd     (le_le_2_wd),
 
     // from internal hardware
@@ -1365,7 +1303,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_3_we),
+    .we     (le_we),
     .wd     (le_le_3_wd),
 
     // from internal hardware
@@ -1391,7 +1329,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_4_we),
+    .we     (le_we),
     .wd     (le_le_4_wd),
 
     // from internal hardware
@@ -1417,7 +1355,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_5_we),
+    .we     (le_we),
     .wd     (le_le_5_wd),
 
     // from internal hardware
@@ -1443,7 +1381,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_6_we),
+    .we     (le_we),
     .wd     (le_le_6_wd),
 
     // from internal hardware
@@ -1469,7 +1407,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_7_we),
+    .we     (le_we),
     .wd     (le_le_7_wd),
 
     // from internal hardware
@@ -1495,7 +1433,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_8_we),
+    .we     (le_we),
     .wd     (le_le_8_wd),
 
     // from internal hardware
@@ -1521,7 +1459,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_9_we),
+    .we     (le_we),
     .wd     (le_le_9_wd),
 
     // from internal hardware
@@ -1547,7 +1485,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_10_we),
+    .we     (le_we),
     .wd     (le_le_10_wd),
 
     // from internal hardware
@@ -1573,7 +1511,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_11_we),
+    .we     (le_we),
     .wd     (le_le_11_wd),
 
     // from internal hardware
@@ -1599,7 +1537,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_12_we),
+    .we     (le_we),
     .wd     (le_le_12_wd),
 
     // from internal hardware
@@ -1625,7 +1563,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_13_we),
+    .we     (le_we),
     .wd     (le_le_13_wd),
 
     // from internal hardware
@@ -1651,7 +1589,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_14_we),
+    .we     (le_we),
     .wd     (le_le_14_wd),
 
     // from internal hardware
@@ -1677,7 +1615,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_15_we),
+    .we     (le_we),
     .wd     (le_le_15_wd),
 
     // from internal hardware
@@ -1703,7 +1641,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_16_we),
+    .we     (le_we),
     .wd     (le_le_16_wd),
 
     // from internal hardware
@@ -1729,7 +1667,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_17_we),
+    .we     (le_we),
     .wd     (le_le_17_wd),
 
     // from internal hardware
@@ -1755,7 +1693,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_18_we),
+    .we     (le_we),
     .wd     (le_le_18_wd),
 
     // from internal hardware
@@ -1781,7 +1719,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_19_we),
+    .we     (le_we),
     .wd     (le_le_19_wd),
 
     // from internal hardware
@@ -1807,7 +1745,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_20_we),
+    .we     (le_we),
     .wd     (le_le_20_wd),
 
     // from internal hardware
@@ -1833,7 +1771,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_21_we),
+    .we     (le_we),
     .wd     (le_le_21_wd),
 
     // from internal hardware
@@ -1859,7 +1797,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_22_we),
+    .we     (le_we),
     .wd     (le_le_22_wd),
 
     // from internal hardware
@@ -1885,7 +1823,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_23_we),
+    .we     (le_we),
     .wd     (le_le_23_wd),
 
     // from internal hardware
@@ -1911,7 +1849,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_24_we),
+    .we     (le_we),
     .wd     (le_le_24_wd),
 
     // from internal hardware
@@ -1937,7 +1875,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_25_we),
+    .we     (le_we),
     .wd     (le_le_25_wd),
 
     // from internal hardware
@@ -1963,7 +1901,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_26_we),
+    .we     (le_we),
     .wd     (le_le_26_wd),
 
     // from internal hardware
@@ -1989,7 +1927,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_27_we),
+    .we     (le_we),
     .wd     (le_le_27_wd),
 
     // from internal hardware
@@ -2015,7 +1953,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_28_we),
+    .we     (le_we),
     .wd     (le_le_28_wd),
 
     // from internal hardware
@@ -2041,7 +1979,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_29_we),
+    .we     (le_we),
     .wd     (le_le_29_wd),
 
     // from internal hardware
@@ -2067,7 +2005,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_30_we),
+    .we     (le_we),
     .wd     (le_le_30_wd),
 
     // from internal hardware
@@ -2093,7 +2031,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_le_31_we),
+    .we     (le_we),
     .wd     (le_le_31_wd),
 
     // from internal hardware
@@ -2988,7 +2926,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_0_we),
+    .we     (ie0_we),
     .wd     (ie0_e_0_wd),
 
     // from internal hardware
@@ -3014,7 +2952,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_1_we),
+    .we     (ie0_we),
     .wd     (ie0_e_1_wd),
 
     // from internal hardware
@@ -3040,7 +2978,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_2_we),
+    .we     (ie0_we),
     .wd     (ie0_e_2_wd),
 
     // from internal hardware
@@ -3066,7 +3004,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_3_we),
+    .we     (ie0_we),
     .wd     (ie0_e_3_wd),
 
     // from internal hardware
@@ -3092,7 +3030,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_4_we),
+    .we     (ie0_we),
     .wd     (ie0_e_4_wd),
 
     // from internal hardware
@@ -3118,7 +3056,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_5_we),
+    .we     (ie0_we),
     .wd     (ie0_e_5_wd),
 
     // from internal hardware
@@ -3144,7 +3082,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_6_we),
+    .we     (ie0_we),
     .wd     (ie0_e_6_wd),
 
     // from internal hardware
@@ -3170,7 +3108,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_7_we),
+    .we     (ie0_we),
     .wd     (ie0_e_7_wd),
 
     // from internal hardware
@@ -3196,7 +3134,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_8_we),
+    .we     (ie0_we),
     .wd     (ie0_e_8_wd),
 
     // from internal hardware
@@ -3222,7 +3160,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_9_we),
+    .we     (ie0_we),
     .wd     (ie0_e_9_wd),
 
     // from internal hardware
@@ -3248,7 +3186,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_10_we),
+    .we     (ie0_we),
     .wd     (ie0_e_10_wd),
 
     // from internal hardware
@@ -3274,7 +3212,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_11_we),
+    .we     (ie0_we),
     .wd     (ie0_e_11_wd),
 
     // from internal hardware
@@ -3300,7 +3238,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_12_we),
+    .we     (ie0_we),
     .wd     (ie0_e_12_wd),
 
     // from internal hardware
@@ -3326,7 +3264,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_13_we),
+    .we     (ie0_we),
     .wd     (ie0_e_13_wd),
 
     // from internal hardware
@@ -3352,7 +3290,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_14_we),
+    .we     (ie0_we),
     .wd     (ie0_e_14_wd),
 
     // from internal hardware
@@ -3378,7 +3316,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_15_we),
+    .we     (ie0_we),
     .wd     (ie0_e_15_wd),
 
     // from internal hardware
@@ -3404,7 +3342,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_16_we),
+    .we     (ie0_we),
     .wd     (ie0_e_16_wd),
 
     // from internal hardware
@@ -3430,7 +3368,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_17_we),
+    .we     (ie0_we),
     .wd     (ie0_e_17_wd),
 
     // from internal hardware
@@ -3456,7 +3394,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_18_we),
+    .we     (ie0_we),
     .wd     (ie0_e_18_wd),
 
     // from internal hardware
@@ -3482,7 +3420,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_19_we),
+    .we     (ie0_we),
     .wd     (ie0_e_19_wd),
 
     // from internal hardware
@@ -3508,7 +3446,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_20_we),
+    .we     (ie0_we),
     .wd     (ie0_e_20_wd),
 
     // from internal hardware
@@ -3534,7 +3472,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_21_we),
+    .we     (ie0_we),
     .wd     (ie0_e_21_wd),
 
     // from internal hardware
@@ -3560,7 +3498,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_22_we),
+    .we     (ie0_we),
     .wd     (ie0_e_22_wd),
 
     // from internal hardware
@@ -3586,7 +3524,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_23_we),
+    .we     (ie0_we),
     .wd     (ie0_e_23_wd),
 
     // from internal hardware
@@ -3612,7 +3550,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_24_we),
+    .we     (ie0_we),
     .wd     (ie0_e_24_wd),
 
     // from internal hardware
@@ -3638,7 +3576,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_25_we),
+    .we     (ie0_we),
     .wd     (ie0_e_25_wd),
 
     // from internal hardware
@@ -3664,7 +3602,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_26_we),
+    .we     (ie0_we),
     .wd     (ie0_e_26_wd),
 
     // from internal hardware
@@ -3690,7 +3628,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_27_we),
+    .we     (ie0_we),
     .wd     (ie0_e_27_wd),
 
     // from internal hardware
@@ -3716,7 +3654,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_28_we),
+    .we     (ie0_we),
     .wd     (ie0_e_28_wd),
 
     // from internal hardware
@@ -3742,7 +3680,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_29_we),
+    .we     (ie0_we),
     .wd     (ie0_e_29_wd),
 
     // from internal hardware
@@ -3768,7 +3706,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_30_we),
+    .we     (ie0_we),
     .wd     (ie0_e_30_wd),
 
     // from internal hardware
@@ -3794,7 +3732,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_e_31_we),
+    .we     (ie0_we),
     .wd     (ie0_e_31_wd),
 
     // from internal hardware
@@ -3970,303 +3908,241 @@ module rv_plic_reg_top (
                (addr_hit[36] & (|(RV_PLIC_PERMIT[36] & ~reg_be))) |
                (addr_hit[37] & (|(RV_PLIC_PERMIT[37] & ~reg_be)))));
   end
+  assign le_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign le_le_0_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_0_wd = reg_wdata[0];
 
-  assign le_le_1_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_1_wd = reg_wdata[1];
 
-  assign le_le_2_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_2_wd = reg_wdata[2];
 
-  assign le_le_3_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_3_wd = reg_wdata[3];
 
-  assign le_le_4_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_4_wd = reg_wdata[4];
 
-  assign le_le_5_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_5_wd = reg_wdata[5];
 
-  assign le_le_6_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_6_wd = reg_wdata[6];
 
-  assign le_le_7_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_7_wd = reg_wdata[7];
 
-  assign le_le_8_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_8_wd = reg_wdata[8];
 
-  assign le_le_9_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_9_wd = reg_wdata[9];
 
-  assign le_le_10_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_10_wd = reg_wdata[10];
 
-  assign le_le_11_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_11_wd = reg_wdata[11];
 
-  assign le_le_12_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_12_wd = reg_wdata[12];
 
-  assign le_le_13_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_13_wd = reg_wdata[13];
 
-  assign le_le_14_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_14_wd = reg_wdata[14];
 
-  assign le_le_15_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_15_wd = reg_wdata[15];
 
-  assign le_le_16_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_16_wd = reg_wdata[16];
 
-  assign le_le_17_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_17_wd = reg_wdata[17];
 
-  assign le_le_18_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_18_wd = reg_wdata[18];
 
-  assign le_le_19_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_19_wd = reg_wdata[19];
 
-  assign le_le_20_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_20_wd = reg_wdata[20];
 
-  assign le_le_21_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_21_wd = reg_wdata[21];
 
-  assign le_le_22_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_22_wd = reg_wdata[22];
 
-  assign le_le_23_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_23_wd = reg_wdata[23];
 
-  assign le_le_24_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_24_wd = reg_wdata[24];
 
-  assign le_le_25_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_25_wd = reg_wdata[25];
 
-  assign le_le_26_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_26_wd = reg_wdata[26];
 
-  assign le_le_27_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_27_wd = reg_wdata[27];
 
-  assign le_le_28_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_28_wd = reg_wdata[28];
 
-  assign le_le_29_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_29_wd = reg_wdata[29];
 
-  assign le_le_30_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_30_wd = reg_wdata[30];
 
-  assign le_le_31_we = addr_hit[1] & reg_we & !reg_error;
   assign le_le_31_wd = reg_wdata[31];
-
   assign prio0_we = addr_hit[2] & reg_we & !reg_error;
+
   assign prio0_wd = reg_wdata[2:0];
-
   assign prio1_we = addr_hit[3] & reg_we & !reg_error;
+
   assign prio1_wd = reg_wdata[2:0];
-
   assign prio2_we = addr_hit[4] & reg_we & !reg_error;
+
   assign prio2_wd = reg_wdata[2:0];
-
   assign prio3_we = addr_hit[5] & reg_we & !reg_error;
+
   assign prio3_wd = reg_wdata[2:0];
-
   assign prio4_we = addr_hit[6] & reg_we & !reg_error;
+
   assign prio4_wd = reg_wdata[2:0];
-
   assign prio5_we = addr_hit[7] & reg_we & !reg_error;
+
   assign prio5_wd = reg_wdata[2:0];
-
   assign prio6_we = addr_hit[8] & reg_we & !reg_error;
+
   assign prio6_wd = reg_wdata[2:0];
-
   assign prio7_we = addr_hit[9] & reg_we & !reg_error;
+
   assign prio7_wd = reg_wdata[2:0];
-
   assign prio8_we = addr_hit[10] & reg_we & !reg_error;
+
   assign prio8_wd = reg_wdata[2:0];
-
   assign prio9_we = addr_hit[11] & reg_we & !reg_error;
+
   assign prio9_wd = reg_wdata[2:0];
-
   assign prio10_we = addr_hit[12] & reg_we & !reg_error;
+
   assign prio10_wd = reg_wdata[2:0];
-
   assign prio11_we = addr_hit[13] & reg_we & !reg_error;
+
   assign prio11_wd = reg_wdata[2:0];
-
   assign prio12_we = addr_hit[14] & reg_we & !reg_error;
+
   assign prio12_wd = reg_wdata[2:0];
-
   assign prio13_we = addr_hit[15] & reg_we & !reg_error;
+
   assign prio13_wd = reg_wdata[2:0];
-
   assign prio14_we = addr_hit[16] & reg_we & !reg_error;
+
   assign prio14_wd = reg_wdata[2:0];
-
   assign prio15_we = addr_hit[17] & reg_we & !reg_error;
+
   assign prio15_wd = reg_wdata[2:0];
-
   assign prio16_we = addr_hit[18] & reg_we & !reg_error;
+
   assign prio16_wd = reg_wdata[2:0];
-
   assign prio17_we = addr_hit[19] & reg_we & !reg_error;
+
   assign prio17_wd = reg_wdata[2:0];
-
   assign prio18_we = addr_hit[20] & reg_we & !reg_error;
+
   assign prio18_wd = reg_wdata[2:0];
-
   assign prio19_we = addr_hit[21] & reg_we & !reg_error;
+
   assign prio19_wd = reg_wdata[2:0];
-
   assign prio20_we = addr_hit[22] & reg_we & !reg_error;
+
   assign prio20_wd = reg_wdata[2:0];
-
   assign prio21_we = addr_hit[23] & reg_we & !reg_error;
+
   assign prio21_wd = reg_wdata[2:0];
-
   assign prio22_we = addr_hit[24] & reg_we & !reg_error;
+
   assign prio22_wd = reg_wdata[2:0];
-
   assign prio23_we = addr_hit[25] & reg_we & !reg_error;
+
   assign prio23_wd = reg_wdata[2:0];
-
   assign prio24_we = addr_hit[26] & reg_we & !reg_error;
+
   assign prio24_wd = reg_wdata[2:0];
-
   assign prio25_we = addr_hit[27] & reg_we & !reg_error;
+
   assign prio25_wd = reg_wdata[2:0];
-
   assign prio26_we = addr_hit[28] & reg_we & !reg_error;
+
   assign prio26_wd = reg_wdata[2:0];
-
   assign prio27_we = addr_hit[29] & reg_we & !reg_error;
+
   assign prio27_wd = reg_wdata[2:0];
-
   assign prio28_we = addr_hit[30] & reg_we & !reg_error;
+
   assign prio28_wd = reg_wdata[2:0];
-
   assign prio29_we = addr_hit[31] & reg_we & !reg_error;
+
   assign prio29_wd = reg_wdata[2:0];
-
   assign prio30_we = addr_hit[32] & reg_we & !reg_error;
+
   assign prio30_wd = reg_wdata[2:0];
-
   assign prio31_we = addr_hit[33] & reg_we & !reg_error;
-  assign prio31_wd = reg_wdata[2:0];
 
-  assign ie0_e_0_we = addr_hit[34] & reg_we & !reg_error;
+  assign prio31_wd = reg_wdata[2:0];
+  assign ie0_we = addr_hit[34] & reg_we & !reg_error;
+
   assign ie0_e_0_wd = reg_wdata[0];
 
-  assign ie0_e_1_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_1_wd = reg_wdata[1];
 
-  assign ie0_e_2_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_2_wd = reg_wdata[2];
 
-  assign ie0_e_3_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_3_wd = reg_wdata[3];
 
-  assign ie0_e_4_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_4_wd = reg_wdata[4];
 
-  assign ie0_e_5_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_5_wd = reg_wdata[5];
 
-  assign ie0_e_6_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_6_wd = reg_wdata[6];
 
-  assign ie0_e_7_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_7_wd = reg_wdata[7];
 
-  assign ie0_e_8_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_8_wd = reg_wdata[8];
 
-  assign ie0_e_9_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_9_wd = reg_wdata[9];
 
-  assign ie0_e_10_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_10_wd = reg_wdata[10];
 
-  assign ie0_e_11_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_11_wd = reg_wdata[11];
 
-  assign ie0_e_12_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_12_wd = reg_wdata[12];
 
-  assign ie0_e_13_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_13_wd = reg_wdata[13];
 
-  assign ie0_e_14_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_14_wd = reg_wdata[14];
 
-  assign ie0_e_15_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_15_wd = reg_wdata[15];
 
-  assign ie0_e_16_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_16_wd = reg_wdata[16];
 
-  assign ie0_e_17_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_17_wd = reg_wdata[17];
 
-  assign ie0_e_18_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_18_wd = reg_wdata[18];
 
-  assign ie0_e_19_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_19_wd = reg_wdata[19];
 
-  assign ie0_e_20_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_20_wd = reg_wdata[20];
 
-  assign ie0_e_21_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_21_wd = reg_wdata[21];
 
-  assign ie0_e_22_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_22_wd = reg_wdata[22];
 
-  assign ie0_e_23_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_23_wd = reg_wdata[23];
 
-  assign ie0_e_24_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_24_wd = reg_wdata[24];
 
-  assign ie0_e_25_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_25_wd = reg_wdata[25];
 
-  assign ie0_e_26_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_26_wd = reg_wdata[26];
 
-  assign ie0_e_27_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_27_wd = reg_wdata[27];
 
-  assign ie0_e_28_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_28_wd = reg_wdata[28];
 
-  assign ie0_e_29_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_29_wd = reg_wdata[29];
 
-  assign ie0_e_30_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_30_wd = reg_wdata[30];
 
-  assign ie0_e_31_we = addr_hit[34] & reg_we & !reg_error;
   assign ie0_e_31_wd = reg_wdata[31];
-
   assign threshold0_we = addr_hit[35] & reg_we & !reg_error;
+
   assign threshold0_wd = reg_wdata[2:0];
-
-  assign cc0_we = addr_hit[36] & reg_we & !reg_error;
-  assign cc0_wd = reg_wdata[5:0];
   assign cc0_re = addr_hit[36] & reg_re & !reg_error;
+  assign cc0_we = addr_hit[36] & reg_we & !reg_error;
 
+  assign cc0_wd = reg_wdata[5:0];
   assign msip0_we = addr_hit[37] & reg_we & !reg_error;
+
   assign msip0_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -104,35 +104,34 @@ module rv_timer_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic ctrl_we;
   logic ctrl_qs;
   logic ctrl_wd;
-  logic ctrl_we;
+  logic cfg0_we;
   logic [11:0] cfg0_prescale_qs;
   logic [11:0] cfg0_prescale_wd;
-  logic cfg0_prescale_we;
   logic [7:0] cfg0_step_qs;
   logic [7:0] cfg0_step_wd;
-  logic cfg0_step_we;
+  logic timer_v_lower0_we;
   logic [31:0] timer_v_lower0_qs;
   logic [31:0] timer_v_lower0_wd;
-  logic timer_v_lower0_we;
+  logic timer_v_upper0_we;
   logic [31:0] timer_v_upper0_qs;
   logic [31:0] timer_v_upper0_wd;
-  logic timer_v_upper0_we;
+  logic compare_lower0_0_we;
   logic [31:0] compare_lower0_0_qs;
   logic [31:0] compare_lower0_0_wd;
-  logic compare_lower0_0_we;
+  logic compare_upper0_0_we;
   logic [31:0] compare_upper0_0_qs;
   logic [31:0] compare_upper0_0_wd;
-  logic compare_upper0_0_we;
+  logic intr_enable0_we;
   logic intr_enable0_qs;
   logic intr_enable0_wd;
-  logic intr_enable0_we;
+  logic intr_state0_we;
   logic intr_state0_qs;
   logic intr_state0_wd;
-  logic intr_state0_we;
-  logic intr_test0_wd;
   logic intr_test0_we;
+  logic intr_test0_wd;
 
   // Register instances
 
@@ -176,7 +175,7 @@ module rv_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg0_prescale_we),
+    .we     (cfg0_we),
     .wd     (cfg0_prescale_wd),
 
     // from internal hardware
@@ -202,7 +201,7 @@ module rv_timer_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg0_step_we),
+    .we     (cfg0_we),
     .wd     (cfg0_step_wd),
 
     // from internal hardware
@@ -433,35 +432,34 @@ module rv_timer_reg_top (
                (addr_hit[7] & (|(RV_TIMER_PERMIT[7] & ~reg_be))) |
                (addr_hit[8] & (|(RV_TIMER_PERMIT[8] & ~reg_be)))));
   end
-
   assign ctrl_we = addr_hit[0] & reg_we & !reg_error;
-  assign ctrl_wd = reg_wdata[0];
 
-  assign cfg0_prescale_we = addr_hit[1] & reg_we & !reg_error;
+  assign ctrl_wd = reg_wdata[0];
+  assign cfg0_we = addr_hit[1] & reg_we & !reg_error;
+
   assign cfg0_prescale_wd = reg_wdata[11:0];
 
-  assign cfg0_step_we = addr_hit[1] & reg_we & !reg_error;
   assign cfg0_step_wd = reg_wdata[23:16];
-
   assign timer_v_lower0_we = addr_hit[2] & reg_we & !reg_error;
+
   assign timer_v_lower0_wd = reg_wdata[31:0];
-
   assign timer_v_upper0_we = addr_hit[3] & reg_we & !reg_error;
+
   assign timer_v_upper0_wd = reg_wdata[31:0];
-
   assign compare_lower0_0_we = addr_hit[4] & reg_we & !reg_error;
+
   assign compare_lower0_0_wd = reg_wdata[31:0];
-
   assign compare_upper0_0_we = addr_hit[5] & reg_we & !reg_error;
+
   assign compare_upper0_0_wd = reg_wdata[31:0];
-
   assign intr_enable0_we = addr_hit[6] & reg_we & !reg_error;
+
   assign intr_enable0_wd = reg_wdata[0];
-
   assign intr_state0_we = addr_hit[7] & reg_we & !reg_error;
-  assign intr_state0_wd = reg_wdata[0];
 
+  assign intr_state0_wd = reg_wdata[0];
   assign intr_test0_we = addr_hit[8] & reg_we & !reg_error;
+
   assign intr_test0_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -152,1289 +152,896 @@ module spi_device_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_rxf_qs;
   logic intr_state_rxf_wd;
-  logic intr_state_rxf_we;
   logic intr_state_rxlvl_qs;
   logic intr_state_rxlvl_wd;
-  logic intr_state_rxlvl_we;
   logic intr_state_txlvl_qs;
   logic intr_state_txlvl_wd;
-  logic intr_state_txlvl_we;
   logic intr_state_rxerr_qs;
   logic intr_state_rxerr_wd;
-  logic intr_state_rxerr_we;
   logic intr_state_rxoverflow_qs;
   logic intr_state_rxoverflow_wd;
-  logic intr_state_rxoverflow_we;
   logic intr_state_txunderflow_qs;
   logic intr_state_txunderflow_wd;
-  logic intr_state_txunderflow_we;
+  logic intr_enable_we;
   logic intr_enable_rxf_qs;
   logic intr_enable_rxf_wd;
-  logic intr_enable_rxf_we;
   logic intr_enable_rxlvl_qs;
   logic intr_enable_rxlvl_wd;
-  logic intr_enable_rxlvl_we;
   logic intr_enable_txlvl_qs;
   logic intr_enable_txlvl_wd;
-  logic intr_enable_txlvl_we;
   logic intr_enable_rxerr_qs;
   logic intr_enable_rxerr_wd;
-  logic intr_enable_rxerr_we;
   logic intr_enable_rxoverflow_qs;
   logic intr_enable_rxoverflow_wd;
-  logic intr_enable_rxoverflow_we;
   logic intr_enable_txunderflow_qs;
   logic intr_enable_txunderflow_wd;
-  logic intr_enable_txunderflow_we;
+  logic intr_test_we;
   logic intr_test_rxf_wd;
-  logic intr_test_rxf_we;
   logic intr_test_rxlvl_wd;
-  logic intr_test_rxlvl_we;
   logic intr_test_txlvl_wd;
-  logic intr_test_txlvl_we;
   logic intr_test_rxerr_wd;
-  logic intr_test_rxerr_we;
   logic intr_test_rxoverflow_wd;
-  logic intr_test_rxoverflow_we;
   logic intr_test_txunderflow_wd;
-  logic intr_test_txunderflow_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic control_we;
   logic control_abort_qs;
   logic control_abort_wd;
-  logic control_abort_we;
   logic [1:0] control_mode_qs;
   logic [1:0] control_mode_wd;
-  logic control_mode_we;
   logic control_rst_txfifo_qs;
   logic control_rst_txfifo_wd;
-  logic control_rst_txfifo_we;
   logic control_rst_rxfifo_qs;
   logic control_rst_rxfifo_wd;
-  logic control_rst_rxfifo_we;
   logic control_sram_clk_en_qs;
   logic control_sram_clk_en_wd;
-  logic control_sram_clk_en_we;
+  logic cfg_we;
   logic cfg_cpol_qs;
   logic cfg_cpol_wd;
-  logic cfg_cpol_we;
   logic cfg_cpha_qs;
   logic cfg_cpha_wd;
-  logic cfg_cpha_we;
   logic cfg_tx_order_qs;
   logic cfg_tx_order_wd;
-  logic cfg_tx_order_we;
   logic cfg_rx_order_qs;
   logic cfg_rx_order_wd;
-  logic cfg_rx_order_we;
   logic [7:0] cfg_timer_v_qs;
   logic [7:0] cfg_timer_v_wd;
-  logic cfg_timer_v_we;
   logic cfg_addr_4b_en_qs;
   logic cfg_addr_4b_en_wd;
-  logic cfg_addr_4b_en_we;
+  logic fifo_level_we;
   logic [15:0] fifo_level_rxlvl_qs;
   logic [15:0] fifo_level_rxlvl_wd;
-  logic fifo_level_rxlvl_we;
   logic [15:0] fifo_level_txlvl_qs;
   logic [15:0] fifo_level_txlvl_wd;
-  logic fifo_level_txlvl_we;
+  logic async_fifo_level_re;
   logic [7:0] async_fifo_level_rxlvl_qs;
-  logic async_fifo_level_rxlvl_re;
   logic [7:0] async_fifo_level_txlvl_qs;
-  logic async_fifo_level_txlvl_re;
+  logic status_re;
   logic status_rxf_full_qs;
-  logic status_rxf_full_re;
   logic status_rxf_empty_qs;
-  logic status_rxf_empty_re;
   logic status_txf_full_qs;
-  logic status_txf_full_re;
   logic status_txf_empty_qs;
-  logic status_txf_empty_re;
   logic status_abort_done_qs;
-  logic status_abort_done_re;
   logic status_csb_qs;
-  logic status_csb_re;
+  logic rxf_ptr_we;
   logic [15:0] rxf_ptr_rptr_qs;
   logic [15:0] rxf_ptr_rptr_wd;
-  logic rxf_ptr_rptr_we;
   logic [15:0] rxf_ptr_wptr_qs;
+  logic txf_ptr_we;
   logic [15:0] txf_ptr_rptr_qs;
   logic [15:0] txf_ptr_wptr_qs;
   logic [15:0] txf_ptr_wptr_wd;
-  logic txf_ptr_wptr_we;
+  logic rxf_addr_we;
   logic [15:0] rxf_addr_base_qs;
   logic [15:0] rxf_addr_base_wd;
-  logic rxf_addr_base_we;
   logic [15:0] rxf_addr_limit_qs;
   logic [15:0] rxf_addr_limit_wd;
-  logic rxf_addr_limit_we;
+  logic txf_addr_we;
   logic [15:0] txf_addr_base_qs;
   logic [15:0] txf_addr_base_wd;
-  logic txf_addr_base_we;
   logic [15:0] txf_addr_limit_qs;
   logic [15:0] txf_addr_limit_wd;
-  logic txf_addr_limit_we;
+  logic cmd_filter_0_we;
   logic cmd_filter_0_filter_0_qs;
   logic cmd_filter_0_filter_0_wd;
-  logic cmd_filter_0_filter_0_we;
   logic cmd_filter_0_filter_1_qs;
   logic cmd_filter_0_filter_1_wd;
-  logic cmd_filter_0_filter_1_we;
   logic cmd_filter_0_filter_2_qs;
   logic cmd_filter_0_filter_2_wd;
-  logic cmd_filter_0_filter_2_we;
   logic cmd_filter_0_filter_3_qs;
   logic cmd_filter_0_filter_3_wd;
-  logic cmd_filter_0_filter_3_we;
   logic cmd_filter_0_filter_4_qs;
   logic cmd_filter_0_filter_4_wd;
-  logic cmd_filter_0_filter_4_we;
   logic cmd_filter_0_filter_5_qs;
   logic cmd_filter_0_filter_5_wd;
-  logic cmd_filter_0_filter_5_we;
   logic cmd_filter_0_filter_6_qs;
   logic cmd_filter_0_filter_6_wd;
-  logic cmd_filter_0_filter_6_we;
   logic cmd_filter_0_filter_7_qs;
   logic cmd_filter_0_filter_7_wd;
-  logic cmd_filter_0_filter_7_we;
   logic cmd_filter_0_filter_8_qs;
   logic cmd_filter_0_filter_8_wd;
-  logic cmd_filter_0_filter_8_we;
   logic cmd_filter_0_filter_9_qs;
   logic cmd_filter_0_filter_9_wd;
-  logic cmd_filter_0_filter_9_we;
   logic cmd_filter_0_filter_10_qs;
   logic cmd_filter_0_filter_10_wd;
-  logic cmd_filter_0_filter_10_we;
   logic cmd_filter_0_filter_11_qs;
   logic cmd_filter_0_filter_11_wd;
-  logic cmd_filter_0_filter_11_we;
   logic cmd_filter_0_filter_12_qs;
   logic cmd_filter_0_filter_12_wd;
-  logic cmd_filter_0_filter_12_we;
   logic cmd_filter_0_filter_13_qs;
   logic cmd_filter_0_filter_13_wd;
-  logic cmd_filter_0_filter_13_we;
   logic cmd_filter_0_filter_14_qs;
   logic cmd_filter_0_filter_14_wd;
-  logic cmd_filter_0_filter_14_we;
   logic cmd_filter_0_filter_15_qs;
   logic cmd_filter_0_filter_15_wd;
-  logic cmd_filter_0_filter_15_we;
   logic cmd_filter_0_filter_16_qs;
   logic cmd_filter_0_filter_16_wd;
-  logic cmd_filter_0_filter_16_we;
   logic cmd_filter_0_filter_17_qs;
   logic cmd_filter_0_filter_17_wd;
-  logic cmd_filter_0_filter_17_we;
   logic cmd_filter_0_filter_18_qs;
   logic cmd_filter_0_filter_18_wd;
-  logic cmd_filter_0_filter_18_we;
   logic cmd_filter_0_filter_19_qs;
   logic cmd_filter_0_filter_19_wd;
-  logic cmd_filter_0_filter_19_we;
   logic cmd_filter_0_filter_20_qs;
   logic cmd_filter_0_filter_20_wd;
-  logic cmd_filter_0_filter_20_we;
   logic cmd_filter_0_filter_21_qs;
   logic cmd_filter_0_filter_21_wd;
-  logic cmd_filter_0_filter_21_we;
   logic cmd_filter_0_filter_22_qs;
   logic cmd_filter_0_filter_22_wd;
-  logic cmd_filter_0_filter_22_we;
   logic cmd_filter_0_filter_23_qs;
   logic cmd_filter_0_filter_23_wd;
-  logic cmd_filter_0_filter_23_we;
   logic cmd_filter_0_filter_24_qs;
   logic cmd_filter_0_filter_24_wd;
-  logic cmd_filter_0_filter_24_we;
   logic cmd_filter_0_filter_25_qs;
   logic cmd_filter_0_filter_25_wd;
-  logic cmd_filter_0_filter_25_we;
   logic cmd_filter_0_filter_26_qs;
   logic cmd_filter_0_filter_26_wd;
-  logic cmd_filter_0_filter_26_we;
   logic cmd_filter_0_filter_27_qs;
   logic cmd_filter_0_filter_27_wd;
-  logic cmd_filter_0_filter_27_we;
   logic cmd_filter_0_filter_28_qs;
   logic cmd_filter_0_filter_28_wd;
-  logic cmd_filter_0_filter_28_we;
   logic cmd_filter_0_filter_29_qs;
   logic cmd_filter_0_filter_29_wd;
-  logic cmd_filter_0_filter_29_we;
   logic cmd_filter_0_filter_30_qs;
   logic cmd_filter_0_filter_30_wd;
-  logic cmd_filter_0_filter_30_we;
   logic cmd_filter_0_filter_31_qs;
   logic cmd_filter_0_filter_31_wd;
-  logic cmd_filter_0_filter_31_we;
+  logic cmd_filter_1_we;
   logic cmd_filter_1_filter_32_qs;
   logic cmd_filter_1_filter_32_wd;
-  logic cmd_filter_1_filter_32_we;
   logic cmd_filter_1_filter_33_qs;
   logic cmd_filter_1_filter_33_wd;
-  logic cmd_filter_1_filter_33_we;
   logic cmd_filter_1_filter_34_qs;
   logic cmd_filter_1_filter_34_wd;
-  logic cmd_filter_1_filter_34_we;
   logic cmd_filter_1_filter_35_qs;
   logic cmd_filter_1_filter_35_wd;
-  logic cmd_filter_1_filter_35_we;
   logic cmd_filter_1_filter_36_qs;
   logic cmd_filter_1_filter_36_wd;
-  logic cmd_filter_1_filter_36_we;
   logic cmd_filter_1_filter_37_qs;
   logic cmd_filter_1_filter_37_wd;
-  logic cmd_filter_1_filter_37_we;
   logic cmd_filter_1_filter_38_qs;
   logic cmd_filter_1_filter_38_wd;
-  logic cmd_filter_1_filter_38_we;
   logic cmd_filter_1_filter_39_qs;
   logic cmd_filter_1_filter_39_wd;
-  logic cmd_filter_1_filter_39_we;
   logic cmd_filter_1_filter_40_qs;
   logic cmd_filter_1_filter_40_wd;
-  logic cmd_filter_1_filter_40_we;
   logic cmd_filter_1_filter_41_qs;
   logic cmd_filter_1_filter_41_wd;
-  logic cmd_filter_1_filter_41_we;
   logic cmd_filter_1_filter_42_qs;
   logic cmd_filter_1_filter_42_wd;
-  logic cmd_filter_1_filter_42_we;
   logic cmd_filter_1_filter_43_qs;
   logic cmd_filter_1_filter_43_wd;
-  logic cmd_filter_1_filter_43_we;
   logic cmd_filter_1_filter_44_qs;
   logic cmd_filter_1_filter_44_wd;
-  logic cmd_filter_1_filter_44_we;
   logic cmd_filter_1_filter_45_qs;
   logic cmd_filter_1_filter_45_wd;
-  logic cmd_filter_1_filter_45_we;
   logic cmd_filter_1_filter_46_qs;
   logic cmd_filter_1_filter_46_wd;
-  logic cmd_filter_1_filter_46_we;
   logic cmd_filter_1_filter_47_qs;
   logic cmd_filter_1_filter_47_wd;
-  logic cmd_filter_1_filter_47_we;
   logic cmd_filter_1_filter_48_qs;
   logic cmd_filter_1_filter_48_wd;
-  logic cmd_filter_1_filter_48_we;
   logic cmd_filter_1_filter_49_qs;
   logic cmd_filter_1_filter_49_wd;
-  logic cmd_filter_1_filter_49_we;
   logic cmd_filter_1_filter_50_qs;
   logic cmd_filter_1_filter_50_wd;
-  logic cmd_filter_1_filter_50_we;
   logic cmd_filter_1_filter_51_qs;
   logic cmd_filter_1_filter_51_wd;
-  logic cmd_filter_1_filter_51_we;
   logic cmd_filter_1_filter_52_qs;
   logic cmd_filter_1_filter_52_wd;
-  logic cmd_filter_1_filter_52_we;
   logic cmd_filter_1_filter_53_qs;
   logic cmd_filter_1_filter_53_wd;
-  logic cmd_filter_1_filter_53_we;
   logic cmd_filter_1_filter_54_qs;
   logic cmd_filter_1_filter_54_wd;
-  logic cmd_filter_1_filter_54_we;
   logic cmd_filter_1_filter_55_qs;
   logic cmd_filter_1_filter_55_wd;
-  logic cmd_filter_1_filter_55_we;
   logic cmd_filter_1_filter_56_qs;
   logic cmd_filter_1_filter_56_wd;
-  logic cmd_filter_1_filter_56_we;
   logic cmd_filter_1_filter_57_qs;
   logic cmd_filter_1_filter_57_wd;
-  logic cmd_filter_1_filter_57_we;
   logic cmd_filter_1_filter_58_qs;
   logic cmd_filter_1_filter_58_wd;
-  logic cmd_filter_1_filter_58_we;
   logic cmd_filter_1_filter_59_qs;
   logic cmd_filter_1_filter_59_wd;
-  logic cmd_filter_1_filter_59_we;
   logic cmd_filter_1_filter_60_qs;
   logic cmd_filter_1_filter_60_wd;
-  logic cmd_filter_1_filter_60_we;
   logic cmd_filter_1_filter_61_qs;
   logic cmd_filter_1_filter_61_wd;
-  logic cmd_filter_1_filter_61_we;
   logic cmd_filter_1_filter_62_qs;
   logic cmd_filter_1_filter_62_wd;
-  logic cmd_filter_1_filter_62_we;
   logic cmd_filter_1_filter_63_qs;
   logic cmd_filter_1_filter_63_wd;
-  logic cmd_filter_1_filter_63_we;
+  logic cmd_filter_2_we;
   logic cmd_filter_2_filter_64_qs;
   logic cmd_filter_2_filter_64_wd;
-  logic cmd_filter_2_filter_64_we;
   logic cmd_filter_2_filter_65_qs;
   logic cmd_filter_2_filter_65_wd;
-  logic cmd_filter_2_filter_65_we;
   logic cmd_filter_2_filter_66_qs;
   logic cmd_filter_2_filter_66_wd;
-  logic cmd_filter_2_filter_66_we;
   logic cmd_filter_2_filter_67_qs;
   logic cmd_filter_2_filter_67_wd;
-  logic cmd_filter_2_filter_67_we;
   logic cmd_filter_2_filter_68_qs;
   logic cmd_filter_2_filter_68_wd;
-  logic cmd_filter_2_filter_68_we;
   logic cmd_filter_2_filter_69_qs;
   logic cmd_filter_2_filter_69_wd;
-  logic cmd_filter_2_filter_69_we;
   logic cmd_filter_2_filter_70_qs;
   logic cmd_filter_2_filter_70_wd;
-  logic cmd_filter_2_filter_70_we;
   logic cmd_filter_2_filter_71_qs;
   logic cmd_filter_2_filter_71_wd;
-  logic cmd_filter_2_filter_71_we;
   logic cmd_filter_2_filter_72_qs;
   logic cmd_filter_2_filter_72_wd;
-  logic cmd_filter_2_filter_72_we;
   logic cmd_filter_2_filter_73_qs;
   logic cmd_filter_2_filter_73_wd;
-  logic cmd_filter_2_filter_73_we;
   logic cmd_filter_2_filter_74_qs;
   logic cmd_filter_2_filter_74_wd;
-  logic cmd_filter_2_filter_74_we;
   logic cmd_filter_2_filter_75_qs;
   logic cmd_filter_2_filter_75_wd;
-  logic cmd_filter_2_filter_75_we;
   logic cmd_filter_2_filter_76_qs;
   logic cmd_filter_2_filter_76_wd;
-  logic cmd_filter_2_filter_76_we;
   logic cmd_filter_2_filter_77_qs;
   logic cmd_filter_2_filter_77_wd;
-  logic cmd_filter_2_filter_77_we;
   logic cmd_filter_2_filter_78_qs;
   logic cmd_filter_2_filter_78_wd;
-  logic cmd_filter_2_filter_78_we;
   logic cmd_filter_2_filter_79_qs;
   logic cmd_filter_2_filter_79_wd;
-  logic cmd_filter_2_filter_79_we;
   logic cmd_filter_2_filter_80_qs;
   logic cmd_filter_2_filter_80_wd;
-  logic cmd_filter_2_filter_80_we;
   logic cmd_filter_2_filter_81_qs;
   logic cmd_filter_2_filter_81_wd;
-  logic cmd_filter_2_filter_81_we;
   logic cmd_filter_2_filter_82_qs;
   logic cmd_filter_2_filter_82_wd;
-  logic cmd_filter_2_filter_82_we;
   logic cmd_filter_2_filter_83_qs;
   logic cmd_filter_2_filter_83_wd;
-  logic cmd_filter_2_filter_83_we;
   logic cmd_filter_2_filter_84_qs;
   logic cmd_filter_2_filter_84_wd;
-  logic cmd_filter_2_filter_84_we;
   logic cmd_filter_2_filter_85_qs;
   logic cmd_filter_2_filter_85_wd;
-  logic cmd_filter_2_filter_85_we;
   logic cmd_filter_2_filter_86_qs;
   logic cmd_filter_2_filter_86_wd;
-  logic cmd_filter_2_filter_86_we;
   logic cmd_filter_2_filter_87_qs;
   logic cmd_filter_2_filter_87_wd;
-  logic cmd_filter_2_filter_87_we;
   logic cmd_filter_2_filter_88_qs;
   logic cmd_filter_2_filter_88_wd;
-  logic cmd_filter_2_filter_88_we;
   logic cmd_filter_2_filter_89_qs;
   logic cmd_filter_2_filter_89_wd;
-  logic cmd_filter_2_filter_89_we;
   logic cmd_filter_2_filter_90_qs;
   logic cmd_filter_2_filter_90_wd;
-  logic cmd_filter_2_filter_90_we;
   logic cmd_filter_2_filter_91_qs;
   logic cmd_filter_2_filter_91_wd;
-  logic cmd_filter_2_filter_91_we;
   logic cmd_filter_2_filter_92_qs;
   logic cmd_filter_2_filter_92_wd;
-  logic cmd_filter_2_filter_92_we;
   logic cmd_filter_2_filter_93_qs;
   logic cmd_filter_2_filter_93_wd;
-  logic cmd_filter_2_filter_93_we;
   logic cmd_filter_2_filter_94_qs;
   logic cmd_filter_2_filter_94_wd;
-  logic cmd_filter_2_filter_94_we;
   logic cmd_filter_2_filter_95_qs;
   logic cmd_filter_2_filter_95_wd;
-  logic cmd_filter_2_filter_95_we;
+  logic cmd_filter_3_we;
   logic cmd_filter_3_filter_96_qs;
   logic cmd_filter_3_filter_96_wd;
-  logic cmd_filter_3_filter_96_we;
   logic cmd_filter_3_filter_97_qs;
   logic cmd_filter_3_filter_97_wd;
-  logic cmd_filter_3_filter_97_we;
   logic cmd_filter_3_filter_98_qs;
   logic cmd_filter_3_filter_98_wd;
-  logic cmd_filter_3_filter_98_we;
   logic cmd_filter_3_filter_99_qs;
   logic cmd_filter_3_filter_99_wd;
-  logic cmd_filter_3_filter_99_we;
   logic cmd_filter_3_filter_100_qs;
   logic cmd_filter_3_filter_100_wd;
-  logic cmd_filter_3_filter_100_we;
   logic cmd_filter_3_filter_101_qs;
   logic cmd_filter_3_filter_101_wd;
-  logic cmd_filter_3_filter_101_we;
   logic cmd_filter_3_filter_102_qs;
   logic cmd_filter_3_filter_102_wd;
-  logic cmd_filter_3_filter_102_we;
   logic cmd_filter_3_filter_103_qs;
   logic cmd_filter_3_filter_103_wd;
-  logic cmd_filter_3_filter_103_we;
   logic cmd_filter_3_filter_104_qs;
   logic cmd_filter_3_filter_104_wd;
-  logic cmd_filter_3_filter_104_we;
   logic cmd_filter_3_filter_105_qs;
   logic cmd_filter_3_filter_105_wd;
-  logic cmd_filter_3_filter_105_we;
   logic cmd_filter_3_filter_106_qs;
   logic cmd_filter_3_filter_106_wd;
-  logic cmd_filter_3_filter_106_we;
   logic cmd_filter_3_filter_107_qs;
   logic cmd_filter_3_filter_107_wd;
-  logic cmd_filter_3_filter_107_we;
   logic cmd_filter_3_filter_108_qs;
   logic cmd_filter_3_filter_108_wd;
-  logic cmd_filter_3_filter_108_we;
   logic cmd_filter_3_filter_109_qs;
   logic cmd_filter_3_filter_109_wd;
-  logic cmd_filter_3_filter_109_we;
   logic cmd_filter_3_filter_110_qs;
   logic cmd_filter_3_filter_110_wd;
-  logic cmd_filter_3_filter_110_we;
   logic cmd_filter_3_filter_111_qs;
   logic cmd_filter_3_filter_111_wd;
-  logic cmd_filter_3_filter_111_we;
   logic cmd_filter_3_filter_112_qs;
   logic cmd_filter_3_filter_112_wd;
-  logic cmd_filter_3_filter_112_we;
   logic cmd_filter_3_filter_113_qs;
   logic cmd_filter_3_filter_113_wd;
-  logic cmd_filter_3_filter_113_we;
   logic cmd_filter_3_filter_114_qs;
   logic cmd_filter_3_filter_114_wd;
-  logic cmd_filter_3_filter_114_we;
   logic cmd_filter_3_filter_115_qs;
   logic cmd_filter_3_filter_115_wd;
-  logic cmd_filter_3_filter_115_we;
   logic cmd_filter_3_filter_116_qs;
   logic cmd_filter_3_filter_116_wd;
-  logic cmd_filter_3_filter_116_we;
   logic cmd_filter_3_filter_117_qs;
   logic cmd_filter_3_filter_117_wd;
-  logic cmd_filter_3_filter_117_we;
   logic cmd_filter_3_filter_118_qs;
   logic cmd_filter_3_filter_118_wd;
-  logic cmd_filter_3_filter_118_we;
   logic cmd_filter_3_filter_119_qs;
   logic cmd_filter_3_filter_119_wd;
-  logic cmd_filter_3_filter_119_we;
   logic cmd_filter_3_filter_120_qs;
   logic cmd_filter_3_filter_120_wd;
-  logic cmd_filter_3_filter_120_we;
   logic cmd_filter_3_filter_121_qs;
   logic cmd_filter_3_filter_121_wd;
-  logic cmd_filter_3_filter_121_we;
   logic cmd_filter_3_filter_122_qs;
   logic cmd_filter_3_filter_122_wd;
-  logic cmd_filter_3_filter_122_we;
   logic cmd_filter_3_filter_123_qs;
   logic cmd_filter_3_filter_123_wd;
-  logic cmd_filter_3_filter_123_we;
   logic cmd_filter_3_filter_124_qs;
   logic cmd_filter_3_filter_124_wd;
-  logic cmd_filter_3_filter_124_we;
   logic cmd_filter_3_filter_125_qs;
   logic cmd_filter_3_filter_125_wd;
-  logic cmd_filter_3_filter_125_we;
   logic cmd_filter_3_filter_126_qs;
   logic cmd_filter_3_filter_126_wd;
-  logic cmd_filter_3_filter_126_we;
   logic cmd_filter_3_filter_127_qs;
   logic cmd_filter_3_filter_127_wd;
-  logic cmd_filter_3_filter_127_we;
+  logic cmd_filter_4_we;
   logic cmd_filter_4_filter_128_qs;
   logic cmd_filter_4_filter_128_wd;
-  logic cmd_filter_4_filter_128_we;
   logic cmd_filter_4_filter_129_qs;
   logic cmd_filter_4_filter_129_wd;
-  logic cmd_filter_4_filter_129_we;
   logic cmd_filter_4_filter_130_qs;
   logic cmd_filter_4_filter_130_wd;
-  logic cmd_filter_4_filter_130_we;
   logic cmd_filter_4_filter_131_qs;
   logic cmd_filter_4_filter_131_wd;
-  logic cmd_filter_4_filter_131_we;
   logic cmd_filter_4_filter_132_qs;
   logic cmd_filter_4_filter_132_wd;
-  logic cmd_filter_4_filter_132_we;
   logic cmd_filter_4_filter_133_qs;
   logic cmd_filter_4_filter_133_wd;
-  logic cmd_filter_4_filter_133_we;
   logic cmd_filter_4_filter_134_qs;
   logic cmd_filter_4_filter_134_wd;
-  logic cmd_filter_4_filter_134_we;
   logic cmd_filter_4_filter_135_qs;
   logic cmd_filter_4_filter_135_wd;
-  logic cmd_filter_4_filter_135_we;
   logic cmd_filter_4_filter_136_qs;
   logic cmd_filter_4_filter_136_wd;
-  logic cmd_filter_4_filter_136_we;
   logic cmd_filter_4_filter_137_qs;
   logic cmd_filter_4_filter_137_wd;
-  logic cmd_filter_4_filter_137_we;
   logic cmd_filter_4_filter_138_qs;
   logic cmd_filter_4_filter_138_wd;
-  logic cmd_filter_4_filter_138_we;
   logic cmd_filter_4_filter_139_qs;
   logic cmd_filter_4_filter_139_wd;
-  logic cmd_filter_4_filter_139_we;
   logic cmd_filter_4_filter_140_qs;
   logic cmd_filter_4_filter_140_wd;
-  logic cmd_filter_4_filter_140_we;
   logic cmd_filter_4_filter_141_qs;
   logic cmd_filter_4_filter_141_wd;
-  logic cmd_filter_4_filter_141_we;
   logic cmd_filter_4_filter_142_qs;
   logic cmd_filter_4_filter_142_wd;
-  logic cmd_filter_4_filter_142_we;
   logic cmd_filter_4_filter_143_qs;
   logic cmd_filter_4_filter_143_wd;
-  logic cmd_filter_4_filter_143_we;
   logic cmd_filter_4_filter_144_qs;
   logic cmd_filter_4_filter_144_wd;
-  logic cmd_filter_4_filter_144_we;
   logic cmd_filter_4_filter_145_qs;
   logic cmd_filter_4_filter_145_wd;
-  logic cmd_filter_4_filter_145_we;
   logic cmd_filter_4_filter_146_qs;
   logic cmd_filter_4_filter_146_wd;
-  logic cmd_filter_4_filter_146_we;
   logic cmd_filter_4_filter_147_qs;
   logic cmd_filter_4_filter_147_wd;
-  logic cmd_filter_4_filter_147_we;
   logic cmd_filter_4_filter_148_qs;
   logic cmd_filter_4_filter_148_wd;
-  logic cmd_filter_4_filter_148_we;
   logic cmd_filter_4_filter_149_qs;
   logic cmd_filter_4_filter_149_wd;
-  logic cmd_filter_4_filter_149_we;
   logic cmd_filter_4_filter_150_qs;
   logic cmd_filter_4_filter_150_wd;
-  logic cmd_filter_4_filter_150_we;
   logic cmd_filter_4_filter_151_qs;
   logic cmd_filter_4_filter_151_wd;
-  logic cmd_filter_4_filter_151_we;
   logic cmd_filter_4_filter_152_qs;
   logic cmd_filter_4_filter_152_wd;
-  logic cmd_filter_4_filter_152_we;
   logic cmd_filter_4_filter_153_qs;
   logic cmd_filter_4_filter_153_wd;
-  logic cmd_filter_4_filter_153_we;
   logic cmd_filter_4_filter_154_qs;
   logic cmd_filter_4_filter_154_wd;
-  logic cmd_filter_4_filter_154_we;
   logic cmd_filter_4_filter_155_qs;
   logic cmd_filter_4_filter_155_wd;
-  logic cmd_filter_4_filter_155_we;
   logic cmd_filter_4_filter_156_qs;
   logic cmd_filter_4_filter_156_wd;
-  logic cmd_filter_4_filter_156_we;
   logic cmd_filter_4_filter_157_qs;
   logic cmd_filter_4_filter_157_wd;
-  logic cmd_filter_4_filter_157_we;
   logic cmd_filter_4_filter_158_qs;
   logic cmd_filter_4_filter_158_wd;
-  logic cmd_filter_4_filter_158_we;
   logic cmd_filter_4_filter_159_qs;
   logic cmd_filter_4_filter_159_wd;
-  logic cmd_filter_4_filter_159_we;
+  logic cmd_filter_5_we;
   logic cmd_filter_5_filter_160_qs;
   logic cmd_filter_5_filter_160_wd;
-  logic cmd_filter_5_filter_160_we;
   logic cmd_filter_5_filter_161_qs;
   logic cmd_filter_5_filter_161_wd;
-  logic cmd_filter_5_filter_161_we;
   logic cmd_filter_5_filter_162_qs;
   logic cmd_filter_5_filter_162_wd;
-  logic cmd_filter_5_filter_162_we;
   logic cmd_filter_5_filter_163_qs;
   logic cmd_filter_5_filter_163_wd;
-  logic cmd_filter_5_filter_163_we;
   logic cmd_filter_5_filter_164_qs;
   logic cmd_filter_5_filter_164_wd;
-  logic cmd_filter_5_filter_164_we;
   logic cmd_filter_5_filter_165_qs;
   logic cmd_filter_5_filter_165_wd;
-  logic cmd_filter_5_filter_165_we;
   logic cmd_filter_5_filter_166_qs;
   logic cmd_filter_5_filter_166_wd;
-  logic cmd_filter_5_filter_166_we;
   logic cmd_filter_5_filter_167_qs;
   logic cmd_filter_5_filter_167_wd;
-  logic cmd_filter_5_filter_167_we;
   logic cmd_filter_5_filter_168_qs;
   logic cmd_filter_5_filter_168_wd;
-  logic cmd_filter_5_filter_168_we;
   logic cmd_filter_5_filter_169_qs;
   logic cmd_filter_5_filter_169_wd;
-  logic cmd_filter_5_filter_169_we;
   logic cmd_filter_5_filter_170_qs;
   logic cmd_filter_5_filter_170_wd;
-  logic cmd_filter_5_filter_170_we;
   logic cmd_filter_5_filter_171_qs;
   logic cmd_filter_5_filter_171_wd;
-  logic cmd_filter_5_filter_171_we;
   logic cmd_filter_5_filter_172_qs;
   logic cmd_filter_5_filter_172_wd;
-  logic cmd_filter_5_filter_172_we;
   logic cmd_filter_5_filter_173_qs;
   logic cmd_filter_5_filter_173_wd;
-  logic cmd_filter_5_filter_173_we;
   logic cmd_filter_5_filter_174_qs;
   logic cmd_filter_5_filter_174_wd;
-  logic cmd_filter_5_filter_174_we;
   logic cmd_filter_5_filter_175_qs;
   logic cmd_filter_5_filter_175_wd;
-  logic cmd_filter_5_filter_175_we;
   logic cmd_filter_5_filter_176_qs;
   logic cmd_filter_5_filter_176_wd;
-  logic cmd_filter_5_filter_176_we;
   logic cmd_filter_5_filter_177_qs;
   logic cmd_filter_5_filter_177_wd;
-  logic cmd_filter_5_filter_177_we;
   logic cmd_filter_5_filter_178_qs;
   logic cmd_filter_5_filter_178_wd;
-  logic cmd_filter_5_filter_178_we;
   logic cmd_filter_5_filter_179_qs;
   logic cmd_filter_5_filter_179_wd;
-  logic cmd_filter_5_filter_179_we;
   logic cmd_filter_5_filter_180_qs;
   logic cmd_filter_5_filter_180_wd;
-  logic cmd_filter_5_filter_180_we;
   logic cmd_filter_5_filter_181_qs;
   logic cmd_filter_5_filter_181_wd;
-  logic cmd_filter_5_filter_181_we;
   logic cmd_filter_5_filter_182_qs;
   logic cmd_filter_5_filter_182_wd;
-  logic cmd_filter_5_filter_182_we;
   logic cmd_filter_5_filter_183_qs;
   logic cmd_filter_5_filter_183_wd;
-  logic cmd_filter_5_filter_183_we;
   logic cmd_filter_5_filter_184_qs;
   logic cmd_filter_5_filter_184_wd;
-  logic cmd_filter_5_filter_184_we;
   logic cmd_filter_5_filter_185_qs;
   logic cmd_filter_5_filter_185_wd;
-  logic cmd_filter_5_filter_185_we;
   logic cmd_filter_5_filter_186_qs;
   logic cmd_filter_5_filter_186_wd;
-  logic cmd_filter_5_filter_186_we;
   logic cmd_filter_5_filter_187_qs;
   logic cmd_filter_5_filter_187_wd;
-  logic cmd_filter_5_filter_187_we;
   logic cmd_filter_5_filter_188_qs;
   logic cmd_filter_5_filter_188_wd;
-  logic cmd_filter_5_filter_188_we;
   logic cmd_filter_5_filter_189_qs;
   logic cmd_filter_5_filter_189_wd;
-  logic cmd_filter_5_filter_189_we;
   logic cmd_filter_5_filter_190_qs;
   logic cmd_filter_5_filter_190_wd;
-  logic cmd_filter_5_filter_190_we;
   logic cmd_filter_5_filter_191_qs;
   logic cmd_filter_5_filter_191_wd;
-  logic cmd_filter_5_filter_191_we;
+  logic cmd_filter_6_we;
   logic cmd_filter_6_filter_192_qs;
   logic cmd_filter_6_filter_192_wd;
-  logic cmd_filter_6_filter_192_we;
   logic cmd_filter_6_filter_193_qs;
   logic cmd_filter_6_filter_193_wd;
-  logic cmd_filter_6_filter_193_we;
   logic cmd_filter_6_filter_194_qs;
   logic cmd_filter_6_filter_194_wd;
-  logic cmd_filter_6_filter_194_we;
   logic cmd_filter_6_filter_195_qs;
   logic cmd_filter_6_filter_195_wd;
-  logic cmd_filter_6_filter_195_we;
   logic cmd_filter_6_filter_196_qs;
   logic cmd_filter_6_filter_196_wd;
-  logic cmd_filter_6_filter_196_we;
   logic cmd_filter_6_filter_197_qs;
   logic cmd_filter_6_filter_197_wd;
-  logic cmd_filter_6_filter_197_we;
   logic cmd_filter_6_filter_198_qs;
   logic cmd_filter_6_filter_198_wd;
-  logic cmd_filter_6_filter_198_we;
   logic cmd_filter_6_filter_199_qs;
   logic cmd_filter_6_filter_199_wd;
-  logic cmd_filter_6_filter_199_we;
   logic cmd_filter_6_filter_200_qs;
   logic cmd_filter_6_filter_200_wd;
-  logic cmd_filter_6_filter_200_we;
   logic cmd_filter_6_filter_201_qs;
   logic cmd_filter_6_filter_201_wd;
-  logic cmd_filter_6_filter_201_we;
   logic cmd_filter_6_filter_202_qs;
   logic cmd_filter_6_filter_202_wd;
-  logic cmd_filter_6_filter_202_we;
   logic cmd_filter_6_filter_203_qs;
   logic cmd_filter_6_filter_203_wd;
-  logic cmd_filter_6_filter_203_we;
   logic cmd_filter_6_filter_204_qs;
   logic cmd_filter_6_filter_204_wd;
-  logic cmd_filter_6_filter_204_we;
   logic cmd_filter_6_filter_205_qs;
   logic cmd_filter_6_filter_205_wd;
-  logic cmd_filter_6_filter_205_we;
   logic cmd_filter_6_filter_206_qs;
   logic cmd_filter_6_filter_206_wd;
-  logic cmd_filter_6_filter_206_we;
   logic cmd_filter_6_filter_207_qs;
   logic cmd_filter_6_filter_207_wd;
-  logic cmd_filter_6_filter_207_we;
   logic cmd_filter_6_filter_208_qs;
   logic cmd_filter_6_filter_208_wd;
-  logic cmd_filter_6_filter_208_we;
   logic cmd_filter_6_filter_209_qs;
   logic cmd_filter_6_filter_209_wd;
-  logic cmd_filter_6_filter_209_we;
   logic cmd_filter_6_filter_210_qs;
   logic cmd_filter_6_filter_210_wd;
-  logic cmd_filter_6_filter_210_we;
   logic cmd_filter_6_filter_211_qs;
   logic cmd_filter_6_filter_211_wd;
-  logic cmd_filter_6_filter_211_we;
   logic cmd_filter_6_filter_212_qs;
   logic cmd_filter_6_filter_212_wd;
-  logic cmd_filter_6_filter_212_we;
   logic cmd_filter_6_filter_213_qs;
   logic cmd_filter_6_filter_213_wd;
-  logic cmd_filter_6_filter_213_we;
   logic cmd_filter_6_filter_214_qs;
   logic cmd_filter_6_filter_214_wd;
-  logic cmd_filter_6_filter_214_we;
   logic cmd_filter_6_filter_215_qs;
   logic cmd_filter_6_filter_215_wd;
-  logic cmd_filter_6_filter_215_we;
   logic cmd_filter_6_filter_216_qs;
   logic cmd_filter_6_filter_216_wd;
-  logic cmd_filter_6_filter_216_we;
   logic cmd_filter_6_filter_217_qs;
   logic cmd_filter_6_filter_217_wd;
-  logic cmd_filter_6_filter_217_we;
   logic cmd_filter_6_filter_218_qs;
   logic cmd_filter_6_filter_218_wd;
-  logic cmd_filter_6_filter_218_we;
   logic cmd_filter_6_filter_219_qs;
   logic cmd_filter_6_filter_219_wd;
-  logic cmd_filter_6_filter_219_we;
   logic cmd_filter_6_filter_220_qs;
   logic cmd_filter_6_filter_220_wd;
-  logic cmd_filter_6_filter_220_we;
   logic cmd_filter_6_filter_221_qs;
   logic cmd_filter_6_filter_221_wd;
-  logic cmd_filter_6_filter_221_we;
   logic cmd_filter_6_filter_222_qs;
   logic cmd_filter_6_filter_222_wd;
-  logic cmd_filter_6_filter_222_we;
   logic cmd_filter_6_filter_223_qs;
   logic cmd_filter_6_filter_223_wd;
-  logic cmd_filter_6_filter_223_we;
+  logic cmd_filter_7_we;
   logic cmd_filter_7_filter_224_qs;
   logic cmd_filter_7_filter_224_wd;
-  logic cmd_filter_7_filter_224_we;
   logic cmd_filter_7_filter_225_qs;
   logic cmd_filter_7_filter_225_wd;
-  logic cmd_filter_7_filter_225_we;
   logic cmd_filter_7_filter_226_qs;
   logic cmd_filter_7_filter_226_wd;
-  logic cmd_filter_7_filter_226_we;
   logic cmd_filter_7_filter_227_qs;
   logic cmd_filter_7_filter_227_wd;
-  logic cmd_filter_7_filter_227_we;
   logic cmd_filter_7_filter_228_qs;
   logic cmd_filter_7_filter_228_wd;
-  logic cmd_filter_7_filter_228_we;
   logic cmd_filter_7_filter_229_qs;
   logic cmd_filter_7_filter_229_wd;
-  logic cmd_filter_7_filter_229_we;
   logic cmd_filter_7_filter_230_qs;
   logic cmd_filter_7_filter_230_wd;
-  logic cmd_filter_7_filter_230_we;
   logic cmd_filter_7_filter_231_qs;
   logic cmd_filter_7_filter_231_wd;
-  logic cmd_filter_7_filter_231_we;
   logic cmd_filter_7_filter_232_qs;
   logic cmd_filter_7_filter_232_wd;
-  logic cmd_filter_7_filter_232_we;
   logic cmd_filter_7_filter_233_qs;
   logic cmd_filter_7_filter_233_wd;
-  logic cmd_filter_7_filter_233_we;
   logic cmd_filter_7_filter_234_qs;
   logic cmd_filter_7_filter_234_wd;
-  logic cmd_filter_7_filter_234_we;
   logic cmd_filter_7_filter_235_qs;
   logic cmd_filter_7_filter_235_wd;
-  logic cmd_filter_7_filter_235_we;
   logic cmd_filter_7_filter_236_qs;
   logic cmd_filter_7_filter_236_wd;
-  logic cmd_filter_7_filter_236_we;
   logic cmd_filter_7_filter_237_qs;
   logic cmd_filter_7_filter_237_wd;
-  logic cmd_filter_7_filter_237_we;
   logic cmd_filter_7_filter_238_qs;
   logic cmd_filter_7_filter_238_wd;
-  logic cmd_filter_7_filter_238_we;
   logic cmd_filter_7_filter_239_qs;
   logic cmd_filter_7_filter_239_wd;
-  logic cmd_filter_7_filter_239_we;
   logic cmd_filter_7_filter_240_qs;
   logic cmd_filter_7_filter_240_wd;
-  logic cmd_filter_7_filter_240_we;
   logic cmd_filter_7_filter_241_qs;
   logic cmd_filter_7_filter_241_wd;
-  logic cmd_filter_7_filter_241_we;
   logic cmd_filter_7_filter_242_qs;
   logic cmd_filter_7_filter_242_wd;
-  logic cmd_filter_7_filter_242_we;
   logic cmd_filter_7_filter_243_qs;
   logic cmd_filter_7_filter_243_wd;
-  logic cmd_filter_7_filter_243_we;
   logic cmd_filter_7_filter_244_qs;
   logic cmd_filter_7_filter_244_wd;
-  logic cmd_filter_7_filter_244_we;
   logic cmd_filter_7_filter_245_qs;
   logic cmd_filter_7_filter_245_wd;
-  logic cmd_filter_7_filter_245_we;
   logic cmd_filter_7_filter_246_qs;
   logic cmd_filter_7_filter_246_wd;
-  logic cmd_filter_7_filter_246_we;
   logic cmd_filter_7_filter_247_qs;
   logic cmd_filter_7_filter_247_wd;
-  logic cmd_filter_7_filter_247_we;
   logic cmd_filter_7_filter_248_qs;
   logic cmd_filter_7_filter_248_wd;
-  logic cmd_filter_7_filter_248_we;
   logic cmd_filter_7_filter_249_qs;
   logic cmd_filter_7_filter_249_wd;
-  logic cmd_filter_7_filter_249_we;
   logic cmd_filter_7_filter_250_qs;
   logic cmd_filter_7_filter_250_wd;
-  logic cmd_filter_7_filter_250_we;
   logic cmd_filter_7_filter_251_qs;
   logic cmd_filter_7_filter_251_wd;
-  logic cmd_filter_7_filter_251_we;
   logic cmd_filter_7_filter_252_qs;
   logic cmd_filter_7_filter_252_wd;
-  logic cmd_filter_7_filter_252_we;
   logic cmd_filter_7_filter_253_qs;
   logic cmd_filter_7_filter_253_wd;
-  logic cmd_filter_7_filter_253_we;
   logic cmd_filter_7_filter_254_qs;
   logic cmd_filter_7_filter_254_wd;
-  logic cmd_filter_7_filter_254_we;
   logic cmd_filter_7_filter_255_qs;
   logic cmd_filter_7_filter_255_wd;
-  logic cmd_filter_7_filter_255_we;
+  logic addr_swap_mask_we;
   logic [31:0] addr_swap_mask_qs;
   logic [31:0] addr_swap_mask_wd;
-  logic addr_swap_mask_we;
+  logic addr_swap_data_we;
   logic [31:0] addr_swap_data_qs;
   logic [31:0] addr_swap_data_wd;
-  logic addr_swap_data_we;
+  logic cmd_info_0_we;
   logic [7:0] cmd_info_0_opcode_0_qs;
   logic [7:0] cmd_info_0_opcode_0_wd;
-  logic cmd_info_0_opcode_0_we;
   logic cmd_info_0_addr_en_0_qs;
   logic cmd_info_0_addr_en_0_wd;
-  logic cmd_info_0_addr_en_0_we;
   logic cmd_info_0_addr_swap_en_0_qs;
   logic cmd_info_0_addr_swap_en_0_wd;
-  logic cmd_info_0_addr_swap_en_0_we;
   logic cmd_info_0_addr_4b_affected_0_qs;
   logic cmd_info_0_addr_4b_affected_0_wd;
-  logic cmd_info_0_addr_4b_affected_0_we;
   logic [2:0] cmd_info_0_dummy_size_0_qs;
   logic [2:0] cmd_info_0_dummy_size_0_wd;
-  logic cmd_info_0_dummy_size_0_we;
   logic cmd_info_0_dummy_en_0_qs;
   logic cmd_info_0_dummy_en_0_wd;
-  logic cmd_info_0_dummy_en_0_we;
   logic [3:0] cmd_info_0_payload_en_0_qs;
   logic [3:0] cmd_info_0_payload_en_0_wd;
-  logic cmd_info_0_payload_en_0_we;
   logic cmd_info_0_payload_dir_0_qs;
   logic cmd_info_0_payload_dir_0_wd;
-  logic cmd_info_0_payload_dir_0_we;
+  logic cmd_info_1_we;
   logic [7:0] cmd_info_1_opcode_1_qs;
   logic [7:0] cmd_info_1_opcode_1_wd;
-  logic cmd_info_1_opcode_1_we;
   logic cmd_info_1_addr_en_1_qs;
   logic cmd_info_1_addr_en_1_wd;
-  logic cmd_info_1_addr_en_1_we;
   logic cmd_info_1_addr_swap_en_1_qs;
   logic cmd_info_1_addr_swap_en_1_wd;
-  logic cmd_info_1_addr_swap_en_1_we;
   logic cmd_info_1_addr_4b_affected_1_qs;
   logic cmd_info_1_addr_4b_affected_1_wd;
-  logic cmd_info_1_addr_4b_affected_1_we;
   logic [2:0] cmd_info_1_dummy_size_1_qs;
   logic [2:0] cmd_info_1_dummy_size_1_wd;
-  logic cmd_info_1_dummy_size_1_we;
   logic cmd_info_1_dummy_en_1_qs;
   logic cmd_info_1_dummy_en_1_wd;
-  logic cmd_info_1_dummy_en_1_we;
   logic [3:0] cmd_info_1_payload_en_1_qs;
   logic [3:0] cmd_info_1_payload_en_1_wd;
-  logic cmd_info_1_payload_en_1_we;
   logic cmd_info_1_payload_dir_1_qs;
   logic cmd_info_1_payload_dir_1_wd;
-  logic cmd_info_1_payload_dir_1_we;
+  logic cmd_info_2_we;
   logic [7:0] cmd_info_2_opcode_2_qs;
   logic [7:0] cmd_info_2_opcode_2_wd;
-  logic cmd_info_2_opcode_2_we;
   logic cmd_info_2_addr_en_2_qs;
   logic cmd_info_2_addr_en_2_wd;
-  logic cmd_info_2_addr_en_2_we;
   logic cmd_info_2_addr_swap_en_2_qs;
   logic cmd_info_2_addr_swap_en_2_wd;
-  logic cmd_info_2_addr_swap_en_2_we;
   logic cmd_info_2_addr_4b_affected_2_qs;
   logic cmd_info_2_addr_4b_affected_2_wd;
-  logic cmd_info_2_addr_4b_affected_2_we;
   logic [2:0] cmd_info_2_dummy_size_2_qs;
   logic [2:0] cmd_info_2_dummy_size_2_wd;
-  logic cmd_info_2_dummy_size_2_we;
   logic cmd_info_2_dummy_en_2_qs;
   logic cmd_info_2_dummy_en_2_wd;
-  logic cmd_info_2_dummy_en_2_we;
   logic [3:0] cmd_info_2_payload_en_2_qs;
   logic [3:0] cmd_info_2_payload_en_2_wd;
-  logic cmd_info_2_payload_en_2_we;
   logic cmd_info_2_payload_dir_2_qs;
   logic cmd_info_2_payload_dir_2_wd;
-  logic cmd_info_2_payload_dir_2_we;
+  logic cmd_info_3_we;
   logic [7:0] cmd_info_3_opcode_3_qs;
   logic [7:0] cmd_info_3_opcode_3_wd;
-  logic cmd_info_3_opcode_3_we;
   logic cmd_info_3_addr_en_3_qs;
   logic cmd_info_3_addr_en_3_wd;
-  logic cmd_info_3_addr_en_3_we;
   logic cmd_info_3_addr_swap_en_3_qs;
   logic cmd_info_3_addr_swap_en_3_wd;
-  logic cmd_info_3_addr_swap_en_3_we;
   logic cmd_info_3_addr_4b_affected_3_qs;
   logic cmd_info_3_addr_4b_affected_3_wd;
-  logic cmd_info_3_addr_4b_affected_3_we;
   logic [2:0] cmd_info_3_dummy_size_3_qs;
   logic [2:0] cmd_info_3_dummy_size_3_wd;
-  logic cmd_info_3_dummy_size_3_we;
   logic cmd_info_3_dummy_en_3_qs;
   logic cmd_info_3_dummy_en_3_wd;
-  logic cmd_info_3_dummy_en_3_we;
   logic [3:0] cmd_info_3_payload_en_3_qs;
   logic [3:0] cmd_info_3_payload_en_3_wd;
-  logic cmd_info_3_payload_en_3_we;
   logic cmd_info_3_payload_dir_3_qs;
   logic cmd_info_3_payload_dir_3_wd;
-  logic cmd_info_3_payload_dir_3_we;
+  logic cmd_info_4_we;
   logic [7:0] cmd_info_4_opcode_4_qs;
   logic [7:0] cmd_info_4_opcode_4_wd;
-  logic cmd_info_4_opcode_4_we;
   logic cmd_info_4_addr_en_4_qs;
   logic cmd_info_4_addr_en_4_wd;
-  logic cmd_info_4_addr_en_4_we;
   logic cmd_info_4_addr_swap_en_4_qs;
   logic cmd_info_4_addr_swap_en_4_wd;
-  logic cmd_info_4_addr_swap_en_4_we;
   logic cmd_info_4_addr_4b_affected_4_qs;
   logic cmd_info_4_addr_4b_affected_4_wd;
-  logic cmd_info_4_addr_4b_affected_4_we;
   logic [2:0] cmd_info_4_dummy_size_4_qs;
   logic [2:0] cmd_info_4_dummy_size_4_wd;
-  logic cmd_info_4_dummy_size_4_we;
   logic cmd_info_4_dummy_en_4_qs;
   logic cmd_info_4_dummy_en_4_wd;
-  logic cmd_info_4_dummy_en_4_we;
   logic [3:0] cmd_info_4_payload_en_4_qs;
   logic [3:0] cmd_info_4_payload_en_4_wd;
-  logic cmd_info_4_payload_en_4_we;
   logic cmd_info_4_payload_dir_4_qs;
   logic cmd_info_4_payload_dir_4_wd;
-  logic cmd_info_4_payload_dir_4_we;
+  logic cmd_info_5_we;
   logic [7:0] cmd_info_5_opcode_5_qs;
   logic [7:0] cmd_info_5_opcode_5_wd;
-  logic cmd_info_5_opcode_5_we;
   logic cmd_info_5_addr_en_5_qs;
   logic cmd_info_5_addr_en_5_wd;
-  logic cmd_info_5_addr_en_5_we;
   logic cmd_info_5_addr_swap_en_5_qs;
   logic cmd_info_5_addr_swap_en_5_wd;
-  logic cmd_info_5_addr_swap_en_5_we;
   logic cmd_info_5_addr_4b_affected_5_qs;
   logic cmd_info_5_addr_4b_affected_5_wd;
-  logic cmd_info_5_addr_4b_affected_5_we;
   logic [2:0] cmd_info_5_dummy_size_5_qs;
   logic [2:0] cmd_info_5_dummy_size_5_wd;
-  logic cmd_info_5_dummy_size_5_we;
   logic cmd_info_5_dummy_en_5_qs;
   logic cmd_info_5_dummy_en_5_wd;
-  logic cmd_info_5_dummy_en_5_we;
   logic [3:0] cmd_info_5_payload_en_5_qs;
   logic [3:0] cmd_info_5_payload_en_5_wd;
-  logic cmd_info_5_payload_en_5_we;
   logic cmd_info_5_payload_dir_5_qs;
   logic cmd_info_5_payload_dir_5_wd;
-  logic cmd_info_5_payload_dir_5_we;
+  logic cmd_info_6_we;
   logic [7:0] cmd_info_6_opcode_6_qs;
   logic [7:0] cmd_info_6_opcode_6_wd;
-  logic cmd_info_6_opcode_6_we;
   logic cmd_info_6_addr_en_6_qs;
   logic cmd_info_6_addr_en_6_wd;
-  logic cmd_info_6_addr_en_6_we;
   logic cmd_info_6_addr_swap_en_6_qs;
   logic cmd_info_6_addr_swap_en_6_wd;
-  logic cmd_info_6_addr_swap_en_6_we;
   logic cmd_info_6_addr_4b_affected_6_qs;
   logic cmd_info_6_addr_4b_affected_6_wd;
-  logic cmd_info_6_addr_4b_affected_6_we;
   logic [2:0] cmd_info_6_dummy_size_6_qs;
   logic [2:0] cmd_info_6_dummy_size_6_wd;
-  logic cmd_info_6_dummy_size_6_we;
   logic cmd_info_6_dummy_en_6_qs;
   logic cmd_info_6_dummy_en_6_wd;
-  logic cmd_info_6_dummy_en_6_we;
   logic [3:0] cmd_info_6_payload_en_6_qs;
   logic [3:0] cmd_info_6_payload_en_6_wd;
-  logic cmd_info_6_payload_en_6_we;
   logic cmd_info_6_payload_dir_6_qs;
   logic cmd_info_6_payload_dir_6_wd;
-  logic cmd_info_6_payload_dir_6_we;
+  logic cmd_info_7_we;
   logic [7:0] cmd_info_7_opcode_7_qs;
   logic [7:0] cmd_info_7_opcode_7_wd;
-  logic cmd_info_7_opcode_7_we;
   logic cmd_info_7_addr_en_7_qs;
   logic cmd_info_7_addr_en_7_wd;
-  logic cmd_info_7_addr_en_7_we;
   logic cmd_info_7_addr_swap_en_7_qs;
   logic cmd_info_7_addr_swap_en_7_wd;
-  logic cmd_info_7_addr_swap_en_7_we;
   logic cmd_info_7_addr_4b_affected_7_qs;
   logic cmd_info_7_addr_4b_affected_7_wd;
-  logic cmd_info_7_addr_4b_affected_7_we;
   logic [2:0] cmd_info_7_dummy_size_7_qs;
   logic [2:0] cmd_info_7_dummy_size_7_wd;
-  logic cmd_info_7_dummy_size_7_we;
   logic cmd_info_7_dummy_en_7_qs;
   logic cmd_info_7_dummy_en_7_wd;
-  logic cmd_info_7_dummy_en_7_we;
   logic [3:0] cmd_info_7_payload_en_7_qs;
   logic [3:0] cmd_info_7_payload_en_7_wd;
-  logic cmd_info_7_payload_en_7_we;
   logic cmd_info_7_payload_dir_7_qs;
   logic cmd_info_7_payload_dir_7_wd;
-  logic cmd_info_7_payload_dir_7_we;
+  logic cmd_info_8_we;
   logic [7:0] cmd_info_8_opcode_8_qs;
   logic [7:0] cmd_info_8_opcode_8_wd;
-  logic cmd_info_8_opcode_8_we;
   logic cmd_info_8_addr_en_8_qs;
   logic cmd_info_8_addr_en_8_wd;
-  logic cmd_info_8_addr_en_8_we;
   logic cmd_info_8_addr_swap_en_8_qs;
   logic cmd_info_8_addr_swap_en_8_wd;
-  logic cmd_info_8_addr_swap_en_8_we;
   logic cmd_info_8_addr_4b_affected_8_qs;
   logic cmd_info_8_addr_4b_affected_8_wd;
-  logic cmd_info_8_addr_4b_affected_8_we;
   logic [2:0] cmd_info_8_dummy_size_8_qs;
   logic [2:0] cmd_info_8_dummy_size_8_wd;
-  logic cmd_info_8_dummy_size_8_we;
   logic cmd_info_8_dummy_en_8_qs;
   logic cmd_info_8_dummy_en_8_wd;
-  logic cmd_info_8_dummy_en_8_we;
   logic [3:0] cmd_info_8_payload_en_8_qs;
   logic [3:0] cmd_info_8_payload_en_8_wd;
-  logic cmd_info_8_payload_en_8_we;
   logic cmd_info_8_payload_dir_8_qs;
   logic cmd_info_8_payload_dir_8_wd;
-  logic cmd_info_8_payload_dir_8_we;
+  logic cmd_info_9_we;
   logic [7:0] cmd_info_9_opcode_9_qs;
   logic [7:0] cmd_info_9_opcode_9_wd;
-  logic cmd_info_9_opcode_9_we;
   logic cmd_info_9_addr_en_9_qs;
   logic cmd_info_9_addr_en_9_wd;
-  logic cmd_info_9_addr_en_9_we;
   logic cmd_info_9_addr_swap_en_9_qs;
   logic cmd_info_9_addr_swap_en_9_wd;
-  logic cmd_info_9_addr_swap_en_9_we;
   logic cmd_info_9_addr_4b_affected_9_qs;
   logic cmd_info_9_addr_4b_affected_9_wd;
-  logic cmd_info_9_addr_4b_affected_9_we;
   logic [2:0] cmd_info_9_dummy_size_9_qs;
   logic [2:0] cmd_info_9_dummy_size_9_wd;
-  logic cmd_info_9_dummy_size_9_we;
   logic cmd_info_9_dummy_en_9_qs;
   logic cmd_info_9_dummy_en_9_wd;
-  logic cmd_info_9_dummy_en_9_we;
   logic [3:0] cmd_info_9_payload_en_9_qs;
   logic [3:0] cmd_info_9_payload_en_9_wd;
-  logic cmd_info_9_payload_en_9_we;
   logic cmd_info_9_payload_dir_9_qs;
   logic cmd_info_9_payload_dir_9_wd;
-  logic cmd_info_9_payload_dir_9_we;
+  logic cmd_info_10_we;
   logic [7:0] cmd_info_10_opcode_10_qs;
   logic [7:0] cmd_info_10_opcode_10_wd;
-  logic cmd_info_10_opcode_10_we;
   logic cmd_info_10_addr_en_10_qs;
   logic cmd_info_10_addr_en_10_wd;
-  logic cmd_info_10_addr_en_10_we;
   logic cmd_info_10_addr_swap_en_10_qs;
   logic cmd_info_10_addr_swap_en_10_wd;
-  logic cmd_info_10_addr_swap_en_10_we;
   logic cmd_info_10_addr_4b_affected_10_qs;
   logic cmd_info_10_addr_4b_affected_10_wd;
-  logic cmd_info_10_addr_4b_affected_10_we;
   logic [2:0] cmd_info_10_dummy_size_10_qs;
   logic [2:0] cmd_info_10_dummy_size_10_wd;
-  logic cmd_info_10_dummy_size_10_we;
   logic cmd_info_10_dummy_en_10_qs;
   logic cmd_info_10_dummy_en_10_wd;
-  logic cmd_info_10_dummy_en_10_we;
   logic [3:0] cmd_info_10_payload_en_10_qs;
   logic [3:0] cmd_info_10_payload_en_10_wd;
-  logic cmd_info_10_payload_en_10_we;
   logic cmd_info_10_payload_dir_10_qs;
   logic cmd_info_10_payload_dir_10_wd;
-  logic cmd_info_10_payload_dir_10_we;
+  logic cmd_info_11_we;
   logic [7:0] cmd_info_11_opcode_11_qs;
   logic [7:0] cmd_info_11_opcode_11_wd;
-  logic cmd_info_11_opcode_11_we;
   logic cmd_info_11_addr_en_11_qs;
   logic cmd_info_11_addr_en_11_wd;
-  logic cmd_info_11_addr_en_11_we;
   logic cmd_info_11_addr_swap_en_11_qs;
   logic cmd_info_11_addr_swap_en_11_wd;
-  logic cmd_info_11_addr_swap_en_11_we;
   logic cmd_info_11_addr_4b_affected_11_qs;
   logic cmd_info_11_addr_4b_affected_11_wd;
-  logic cmd_info_11_addr_4b_affected_11_we;
   logic [2:0] cmd_info_11_dummy_size_11_qs;
   logic [2:0] cmd_info_11_dummy_size_11_wd;
-  logic cmd_info_11_dummy_size_11_we;
   logic cmd_info_11_dummy_en_11_qs;
   logic cmd_info_11_dummy_en_11_wd;
-  logic cmd_info_11_dummy_en_11_we;
   logic [3:0] cmd_info_11_payload_en_11_qs;
   logic [3:0] cmd_info_11_payload_en_11_wd;
-  logic cmd_info_11_payload_en_11_we;
   logic cmd_info_11_payload_dir_11_qs;
   logic cmd_info_11_payload_dir_11_wd;
-  logic cmd_info_11_payload_dir_11_we;
+  logic cmd_info_12_we;
   logic [7:0] cmd_info_12_opcode_12_qs;
   logic [7:0] cmd_info_12_opcode_12_wd;
-  logic cmd_info_12_opcode_12_we;
   logic cmd_info_12_addr_en_12_qs;
   logic cmd_info_12_addr_en_12_wd;
-  logic cmd_info_12_addr_en_12_we;
   logic cmd_info_12_addr_swap_en_12_qs;
   logic cmd_info_12_addr_swap_en_12_wd;
-  logic cmd_info_12_addr_swap_en_12_we;
   logic cmd_info_12_addr_4b_affected_12_qs;
   logic cmd_info_12_addr_4b_affected_12_wd;
-  logic cmd_info_12_addr_4b_affected_12_we;
   logic [2:0] cmd_info_12_dummy_size_12_qs;
   logic [2:0] cmd_info_12_dummy_size_12_wd;
-  logic cmd_info_12_dummy_size_12_we;
   logic cmd_info_12_dummy_en_12_qs;
   logic cmd_info_12_dummy_en_12_wd;
-  logic cmd_info_12_dummy_en_12_we;
   logic [3:0] cmd_info_12_payload_en_12_qs;
   logic [3:0] cmd_info_12_payload_en_12_wd;
-  logic cmd_info_12_payload_en_12_we;
   logic cmd_info_12_payload_dir_12_qs;
   logic cmd_info_12_payload_dir_12_wd;
-  logic cmd_info_12_payload_dir_12_we;
+  logic cmd_info_13_we;
   logic [7:0] cmd_info_13_opcode_13_qs;
   logic [7:0] cmd_info_13_opcode_13_wd;
-  logic cmd_info_13_opcode_13_we;
   logic cmd_info_13_addr_en_13_qs;
   logic cmd_info_13_addr_en_13_wd;
-  logic cmd_info_13_addr_en_13_we;
   logic cmd_info_13_addr_swap_en_13_qs;
   logic cmd_info_13_addr_swap_en_13_wd;
-  logic cmd_info_13_addr_swap_en_13_we;
   logic cmd_info_13_addr_4b_affected_13_qs;
   logic cmd_info_13_addr_4b_affected_13_wd;
-  logic cmd_info_13_addr_4b_affected_13_we;
   logic [2:0] cmd_info_13_dummy_size_13_qs;
   logic [2:0] cmd_info_13_dummy_size_13_wd;
-  logic cmd_info_13_dummy_size_13_we;
   logic cmd_info_13_dummy_en_13_qs;
   logic cmd_info_13_dummy_en_13_wd;
-  logic cmd_info_13_dummy_en_13_we;
   logic [3:0] cmd_info_13_payload_en_13_qs;
   logic [3:0] cmd_info_13_payload_en_13_wd;
-  logic cmd_info_13_payload_en_13_we;
   logic cmd_info_13_payload_dir_13_qs;
   logic cmd_info_13_payload_dir_13_wd;
-  logic cmd_info_13_payload_dir_13_we;
+  logic cmd_info_14_we;
   logic [7:0] cmd_info_14_opcode_14_qs;
   logic [7:0] cmd_info_14_opcode_14_wd;
-  logic cmd_info_14_opcode_14_we;
   logic cmd_info_14_addr_en_14_qs;
   logic cmd_info_14_addr_en_14_wd;
-  logic cmd_info_14_addr_en_14_we;
   logic cmd_info_14_addr_swap_en_14_qs;
   logic cmd_info_14_addr_swap_en_14_wd;
-  logic cmd_info_14_addr_swap_en_14_we;
   logic cmd_info_14_addr_4b_affected_14_qs;
   logic cmd_info_14_addr_4b_affected_14_wd;
-  logic cmd_info_14_addr_4b_affected_14_we;
   logic [2:0] cmd_info_14_dummy_size_14_qs;
   logic [2:0] cmd_info_14_dummy_size_14_wd;
-  logic cmd_info_14_dummy_size_14_we;
   logic cmd_info_14_dummy_en_14_qs;
   logic cmd_info_14_dummy_en_14_wd;
-  logic cmd_info_14_dummy_en_14_we;
   logic [3:0] cmd_info_14_payload_en_14_qs;
   logic [3:0] cmd_info_14_payload_en_14_wd;
-  logic cmd_info_14_payload_en_14_we;
   logic cmd_info_14_payload_dir_14_qs;
   logic cmd_info_14_payload_dir_14_wd;
-  logic cmd_info_14_payload_dir_14_we;
+  logic cmd_info_15_we;
   logic [7:0] cmd_info_15_opcode_15_qs;
   logic [7:0] cmd_info_15_opcode_15_wd;
-  logic cmd_info_15_opcode_15_we;
   logic cmd_info_15_addr_en_15_qs;
   logic cmd_info_15_addr_en_15_wd;
-  logic cmd_info_15_addr_en_15_we;
   logic cmd_info_15_addr_swap_en_15_qs;
   logic cmd_info_15_addr_swap_en_15_wd;
-  logic cmd_info_15_addr_swap_en_15_we;
   logic cmd_info_15_addr_4b_affected_15_qs;
   logic cmd_info_15_addr_4b_affected_15_wd;
-  logic cmd_info_15_addr_4b_affected_15_we;
   logic [2:0] cmd_info_15_dummy_size_15_qs;
   logic [2:0] cmd_info_15_dummy_size_15_wd;
-  logic cmd_info_15_dummy_size_15_we;
   logic cmd_info_15_dummy_en_15_qs;
   logic cmd_info_15_dummy_en_15_wd;
-  logic cmd_info_15_dummy_en_15_we;
   logic [3:0] cmd_info_15_payload_en_15_qs;
   logic [3:0] cmd_info_15_payload_en_15_wd;
-  logic cmd_info_15_payload_en_15_we;
   logic cmd_info_15_payload_dir_15_qs;
   logic cmd_info_15_payload_dir_15_wd;
-  logic cmd_info_15_payload_dir_15_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1449,7 +1056,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rxf_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rxf_wd),
 
     // from internal hardware
@@ -1475,7 +1082,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rxlvl_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rxlvl_wd),
 
     // from internal hardware
@@ -1501,7 +1108,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_txlvl_we),
+    .we     (intr_state_we),
     .wd     (intr_state_txlvl_wd),
 
     // from internal hardware
@@ -1527,7 +1134,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rxerr_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rxerr_wd),
 
     // from internal hardware
@@ -1553,7 +1160,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rxoverflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rxoverflow_wd),
 
     // from internal hardware
@@ -1579,7 +1186,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_txunderflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_txunderflow_wd),
 
     // from internal hardware
@@ -1607,7 +1214,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rxf_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rxf_wd),
 
     // from internal hardware
@@ -1633,7 +1240,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rxlvl_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rxlvl_wd),
 
     // from internal hardware
@@ -1659,7 +1266,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_txlvl_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_txlvl_wd),
 
     // from internal hardware
@@ -1685,7 +1292,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rxerr_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rxerr_wd),
 
     // from internal hardware
@@ -1711,7 +1318,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rxoverflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rxoverflow_wd),
 
     // from internal hardware
@@ -1737,7 +1344,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_txunderflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_txunderflow_wd),
 
     // from internal hardware
@@ -1760,7 +1367,7 @@ module spi_device_reg_top (
     .DW    (1)
   ) u_intr_test_rxf (
     .re     (1'b0),
-    .we     (intr_test_rxf_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rxf_wd),
     .d      ('0),
     .qre    (),
@@ -1775,7 +1382,7 @@ module spi_device_reg_top (
     .DW    (1)
   ) u_intr_test_rxlvl (
     .re     (1'b0),
-    .we     (intr_test_rxlvl_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rxlvl_wd),
     .d      ('0),
     .qre    (),
@@ -1790,7 +1397,7 @@ module spi_device_reg_top (
     .DW    (1)
   ) u_intr_test_txlvl (
     .re     (1'b0),
-    .we     (intr_test_txlvl_we),
+    .we     (intr_test_we),
     .wd     (intr_test_txlvl_wd),
     .d      ('0),
     .qre    (),
@@ -1805,7 +1412,7 @@ module spi_device_reg_top (
     .DW    (1)
   ) u_intr_test_rxerr (
     .re     (1'b0),
-    .we     (intr_test_rxerr_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rxerr_wd),
     .d      ('0),
     .qre    (),
@@ -1820,7 +1427,7 @@ module spi_device_reg_top (
     .DW    (1)
   ) u_intr_test_rxoverflow (
     .re     (1'b0),
-    .we     (intr_test_rxoverflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rxoverflow_wd),
     .d      ('0),
     .qre    (),
@@ -1835,7 +1442,7 @@ module spi_device_reg_top (
     .DW    (1)
   ) u_intr_test_txunderflow (
     .re     (1'b0),
-    .we     (intr_test_txunderflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_txunderflow_wd),
     .d      ('0),
     .qre    (),
@@ -1873,7 +1480,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_abort_we),
+    .we     (control_we),
     .wd     (control_abort_wd),
 
     // from internal hardware
@@ -1899,7 +1506,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_mode_we),
+    .we     (control_we),
     .wd     (control_mode_wd),
 
     // from internal hardware
@@ -1925,7 +1532,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_rst_txfifo_we),
+    .we     (control_we),
     .wd     (control_rst_txfifo_wd),
 
     // from internal hardware
@@ -1951,7 +1558,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_rst_rxfifo_we),
+    .we     (control_we),
     .wd     (control_rst_rxfifo_wd),
 
     // from internal hardware
@@ -1977,7 +1584,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_sram_clk_en_we),
+    .we     (control_we),
     .wd     (control_sram_clk_en_wd),
 
     // from internal hardware
@@ -2005,7 +1612,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_cpol_we),
+    .we     (cfg_we),
     .wd     (cfg_cpol_wd),
 
     // from internal hardware
@@ -2031,7 +1638,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_cpha_we),
+    .we     (cfg_we),
     .wd     (cfg_cpha_wd),
 
     // from internal hardware
@@ -2057,7 +1664,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_tx_order_we),
+    .we     (cfg_we),
     .wd     (cfg_tx_order_wd),
 
     // from internal hardware
@@ -2083,7 +1690,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_rx_order_we),
+    .we     (cfg_we),
     .wd     (cfg_rx_order_wd),
 
     // from internal hardware
@@ -2109,7 +1716,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_timer_v_we),
+    .we     (cfg_we),
     .wd     (cfg_timer_v_wd),
 
     // from internal hardware
@@ -2135,7 +1742,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cfg_addr_4b_en_we),
+    .we     (cfg_we),
     .wd     (cfg_addr_4b_en_wd),
 
     // from internal hardware
@@ -2163,7 +1770,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_level_rxlvl_we),
+    .we     (fifo_level_we),
     .wd     (fifo_level_rxlvl_wd),
 
     // from internal hardware
@@ -2189,7 +1796,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_level_txlvl_we),
+    .we     (fifo_level_we),
     .wd     (fifo_level_txlvl_wd),
 
     // from internal hardware
@@ -2211,7 +1818,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (8)
   ) u_async_fifo_level_rxlvl (
-    .re     (async_fifo_level_rxlvl_re),
+    .re     (async_fifo_level_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.async_fifo_level.rxlvl.d),
@@ -2226,7 +1833,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (8)
   ) u_async_fifo_level_txlvl (
-    .re     (async_fifo_level_txlvl_re),
+    .re     (async_fifo_level_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.async_fifo_level.txlvl.d),
@@ -2243,7 +1850,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxf_full (
-    .re     (status_rxf_full_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxf_full.d),
@@ -2258,7 +1865,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxf_empty (
-    .re     (status_rxf_empty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxf_empty.d),
@@ -2273,7 +1880,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txf_full (
-    .re     (status_txf_full_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txf_full.d),
@@ -2288,7 +1895,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txf_empty (
-    .re     (status_txf_empty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txf_empty.d),
@@ -2303,7 +1910,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_abort_done (
-    .re     (status_abort_done_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.abort_done.d),
@@ -2318,7 +1925,7 @@ module spi_device_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_csb (
-    .re     (status_csb_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.csb.d),
@@ -2341,7 +1948,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxf_ptr_rptr_we),
+    .we     (rxf_ptr_we),
     .wd     (rxf_ptr_rptr_wd),
 
     // from internal hardware
@@ -2421,7 +2028,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (txf_ptr_wptr_we),
+    .we     (txf_ptr_we),
     .wd     (txf_ptr_wptr_wd),
 
     // from internal hardware
@@ -2449,7 +2056,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxf_addr_base_we),
+    .we     (rxf_addr_we),
     .wd     (rxf_addr_base_wd),
 
     // from internal hardware
@@ -2475,7 +2082,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxf_addr_limit_we),
+    .we     (rxf_addr_we),
     .wd     (rxf_addr_limit_wd),
 
     // from internal hardware
@@ -2503,7 +2110,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (txf_addr_base_we),
+    .we     (txf_addr_we),
     .wd     (txf_addr_base_wd),
 
     // from internal hardware
@@ -2529,7 +2136,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (txf_addr_limit_we),
+    .we     (txf_addr_we),
     .wd     (txf_addr_limit_wd),
 
     // from internal hardware
@@ -2559,7 +2166,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_0_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_0_wd),
 
     // from internal hardware
@@ -2585,7 +2192,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_1_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_1_wd),
 
     // from internal hardware
@@ -2611,7 +2218,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_2_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_2_wd),
 
     // from internal hardware
@@ -2637,7 +2244,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_3_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_3_wd),
 
     // from internal hardware
@@ -2663,7 +2270,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_4_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_4_wd),
 
     // from internal hardware
@@ -2689,7 +2296,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_5_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_5_wd),
 
     // from internal hardware
@@ -2715,7 +2322,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_6_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_6_wd),
 
     // from internal hardware
@@ -2741,7 +2348,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_7_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_7_wd),
 
     // from internal hardware
@@ -2767,7 +2374,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_8_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_8_wd),
 
     // from internal hardware
@@ -2793,7 +2400,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_9_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_9_wd),
 
     // from internal hardware
@@ -2819,7 +2426,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_10_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_10_wd),
 
     // from internal hardware
@@ -2845,7 +2452,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_11_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_11_wd),
 
     // from internal hardware
@@ -2871,7 +2478,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_12_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_12_wd),
 
     // from internal hardware
@@ -2897,7 +2504,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_13_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_13_wd),
 
     // from internal hardware
@@ -2923,7 +2530,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_14_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_14_wd),
 
     // from internal hardware
@@ -2949,7 +2556,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_15_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_15_wd),
 
     // from internal hardware
@@ -2975,7 +2582,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_16_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_16_wd),
 
     // from internal hardware
@@ -3001,7 +2608,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_17_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_17_wd),
 
     // from internal hardware
@@ -3027,7 +2634,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_18_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_18_wd),
 
     // from internal hardware
@@ -3053,7 +2660,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_19_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_19_wd),
 
     // from internal hardware
@@ -3079,7 +2686,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_20_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_20_wd),
 
     // from internal hardware
@@ -3105,7 +2712,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_21_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_21_wd),
 
     // from internal hardware
@@ -3131,7 +2738,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_22_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_22_wd),
 
     // from internal hardware
@@ -3157,7 +2764,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_23_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_23_wd),
 
     // from internal hardware
@@ -3183,7 +2790,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_24_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_24_wd),
 
     // from internal hardware
@@ -3209,7 +2816,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_25_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_25_wd),
 
     // from internal hardware
@@ -3235,7 +2842,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_26_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_26_wd),
 
     // from internal hardware
@@ -3261,7 +2868,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_27_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_27_wd),
 
     // from internal hardware
@@ -3287,7 +2894,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_28_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_28_wd),
 
     // from internal hardware
@@ -3313,7 +2920,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_29_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_29_wd),
 
     // from internal hardware
@@ -3339,7 +2946,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_30_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_30_wd),
 
     // from internal hardware
@@ -3365,7 +2972,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_0_filter_31_we),
+    .we     (cmd_filter_0_we),
     .wd     (cmd_filter_0_filter_31_wd),
 
     // from internal hardware
@@ -3394,7 +3001,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_32_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_32_wd),
 
     // from internal hardware
@@ -3420,7 +3027,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_33_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_33_wd),
 
     // from internal hardware
@@ -3446,7 +3053,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_34_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_34_wd),
 
     // from internal hardware
@@ -3472,7 +3079,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_35_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_35_wd),
 
     // from internal hardware
@@ -3498,7 +3105,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_36_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_36_wd),
 
     // from internal hardware
@@ -3524,7 +3131,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_37_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_37_wd),
 
     // from internal hardware
@@ -3550,7 +3157,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_38_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_38_wd),
 
     // from internal hardware
@@ -3576,7 +3183,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_39_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_39_wd),
 
     // from internal hardware
@@ -3602,7 +3209,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_40_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_40_wd),
 
     // from internal hardware
@@ -3628,7 +3235,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_41_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_41_wd),
 
     // from internal hardware
@@ -3654,7 +3261,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_42_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_42_wd),
 
     // from internal hardware
@@ -3680,7 +3287,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_43_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_43_wd),
 
     // from internal hardware
@@ -3706,7 +3313,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_44_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_44_wd),
 
     // from internal hardware
@@ -3732,7 +3339,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_45_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_45_wd),
 
     // from internal hardware
@@ -3758,7 +3365,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_46_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_46_wd),
 
     // from internal hardware
@@ -3784,7 +3391,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_47_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_47_wd),
 
     // from internal hardware
@@ -3810,7 +3417,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_48_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_48_wd),
 
     // from internal hardware
@@ -3836,7 +3443,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_49_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_49_wd),
 
     // from internal hardware
@@ -3862,7 +3469,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_50_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_50_wd),
 
     // from internal hardware
@@ -3888,7 +3495,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_51_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_51_wd),
 
     // from internal hardware
@@ -3914,7 +3521,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_52_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_52_wd),
 
     // from internal hardware
@@ -3940,7 +3547,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_53_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_53_wd),
 
     // from internal hardware
@@ -3966,7 +3573,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_54_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_54_wd),
 
     // from internal hardware
@@ -3992,7 +3599,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_55_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_55_wd),
 
     // from internal hardware
@@ -4018,7 +3625,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_56_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_56_wd),
 
     // from internal hardware
@@ -4044,7 +3651,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_57_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_57_wd),
 
     // from internal hardware
@@ -4070,7 +3677,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_58_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_58_wd),
 
     // from internal hardware
@@ -4096,7 +3703,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_59_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_59_wd),
 
     // from internal hardware
@@ -4122,7 +3729,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_60_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_60_wd),
 
     // from internal hardware
@@ -4148,7 +3755,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_61_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_61_wd),
 
     // from internal hardware
@@ -4174,7 +3781,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_62_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_62_wd),
 
     // from internal hardware
@@ -4200,7 +3807,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_1_filter_63_we),
+    .we     (cmd_filter_1_we),
     .wd     (cmd_filter_1_filter_63_wd),
 
     // from internal hardware
@@ -4229,7 +3836,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_64_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_64_wd),
 
     // from internal hardware
@@ -4255,7 +3862,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_65_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_65_wd),
 
     // from internal hardware
@@ -4281,7 +3888,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_66_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_66_wd),
 
     // from internal hardware
@@ -4307,7 +3914,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_67_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_67_wd),
 
     // from internal hardware
@@ -4333,7 +3940,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_68_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_68_wd),
 
     // from internal hardware
@@ -4359,7 +3966,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_69_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_69_wd),
 
     // from internal hardware
@@ -4385,7 +3992,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_70_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_70_wd),
 
     // from internal hardware
@@ -4411,7 +4018,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_71_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_71_wd),
 
     // from internal hardware
@@ -4437,7 +4044,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_72_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_72_wd),
 
     // from internal hardware
@@ -4463,7 +4070,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_73_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_73_wd),
 
     // from internal hardware
@@ -4489,7 +4096,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_74_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_74_wd),
 
     // from internal hardware
@@ -4515,7 +4122,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_75_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_75_wd),
 
     // from internal hardware
@@ -4541,7 +4148,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_76_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_76_wd),
 
     // from internal hardware
@@ -4567,7 +4174,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_77_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_77_wd),
 
     // from internal hardware
@@ -4593,7 +4200,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_78_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_78_wd),
 
     // from internal hardware
@@ -4619,7 +4226,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_79_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_79_wd),
 
     // from internal hardware
@@ -4645,7 +4252,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_80_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_80_wd),
 
     // from internal hardware
@@ -4671,7 +4278,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_81_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_81_wd),
 
     // from internal hardware
@@ -4697,7 +4304,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_82_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_82_wd),
 
     // from internal hardware
@@ -4723,7 +4330,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_83_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_83_wd),
 
     // from internal hardware
@@ -4749,7 +4356,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_84_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_84_wd),
 
     // from internal hardware
@@ -4775,7 +4382,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_85_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_85_wd),
 
     // from internal hardware
@@ -4801,7 +4408,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_86_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_86_wd),
 
     // from internal hardware
@@ -4827,7 +4434,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_87_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_87_wd),
 
     // from internal hardware
@@ -4853,7 +4460,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_88_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_88_wd),
 
     // from internal hardware
@@ -4879,7 +4486,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_89_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_89_wd),
 
     // from internal hardware
@@ -4905,7 +4512,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_90_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_90_wd),
 
     // from internal hardware
@@ -4931,7 +4538,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_91_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_91_wd),
 
     // from internal hardware
@@ -4957,7 +4564,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_92_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_92_wd),
 
     // from internal hardware
@@ -4983,7 +4590,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_93_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_93_wd),
 
     // from internal hardware
@@ -5009,7 +4616,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_94_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_94_wd),
 
     // from internal hardware
@@ -5035,7 +4642,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_2_filter_95_we),
+    .we     (cmd_filter_2_we),
     .wd     (cmd_filter_2_filter_95_wd),
 
     // from internal hardware
@@ -5064,7 +4671,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_96_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_96_wd),
 
     // from internal hardware
@@ -5090,7 +4697,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_97_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_97_wd),
 
     // from internal hardware
@@ -5116,7 +4723,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_98_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_98_wd),
 
     // from internal hardware
@@ -5142,7 +4749,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_99_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_99_wd),
 
     // from internal hardware
@@ -5168,7 +4775,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_100_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_100_wd),
 
     // from internal hardware
@@ -5194,7 +4801,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_101_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_101_wd),
 
     // from internal hardware
@@ -5220,7 +4827,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_102_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_102_wd),
 
     // from internal hardware
@@ -5246,7 +4853,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_103_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_103_wd),
 
     // from internal hardware
@@ -5272,7 +4879,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_104_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_104_wd),
 
     // from internal hardware
@@ -5298,7 +4905,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_105_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_105_wd),
 
     // from internal hardware
@@ -5324,7 +4931,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_106_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_106_wd),
 
     // from internal hardware
@@ -5350,7 +4957,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_107_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_107_wd),
 
     // from internal hardware
@@ -5376,7 +4983,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_108_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_108_wd),
 
     // from internal hardware
@@ -5402,7 +5009,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_109_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_109_wd),
 
     // from internal hardware
@@ -5428,7 +5035,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_110_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_110_wd),
 
     // from internal hardware
@@ -5454,7 +5061,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_111_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_111_wd),
 
     // from internal hardware
@@ -5480,7 +5087,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_112_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_112_wd),
 
     // from internal hardware
@@ -5506,7 +5113,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_113_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_113_wd),
 
     // from internal hardware
@@ -5532,7 +5139,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_114_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_114_wd),
 
     // from internal hardware
@@ -5558,7 +5165,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_115_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_115_wd),
 
     // from internal hardware
@@ -5584,7 +5191,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_116_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_116_wd),
 
     // from internal hardware
@@ -5610,7 +5217,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_117_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_117_wd),
 
     // from internal hardware
@@ -5636,7 +5243,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_118_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_118_wd),
 
     // from internal hardware
@@ -5662,7 +5269,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_119_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_119_wd),
 
     // from internal hardware
@@ -5688,7 +5295,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_120_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_120_wd),
 
     // from internal hardware
@@ -5714,7 +5321,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_121_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_121_wd),
 
     // from internal hardware
@@ -5740,7 +5347,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_122_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_122_wd),
 
     // from internal hardware
@@ -5766,7 +5373,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_123_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_123_wd),
 
     // from internal hardware
@@ -5792,7 +5399,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_124_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_124_wd),
 
     // from internal hardware
@@ -5818,7 +5425,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_125_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_125_wd),
 
     // from internal hardware
@@ -5844,7 +5451,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_126_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_126_wd),
 
     // from internal hardware
@@ -5870,7 +5477,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_3_filter_127_we),
+    .we     (cmd_filter_3_we),
     .wd     (cmd_filter_3_filter_127_wd),
 
     // from internal hardware
@@ -5899,7 +5506,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_128_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_128_wd),
 
     // from internal hardware
@@ -5925,7 +5532,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_129_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_129_wd),
 
     // from internal hardware
@@ -5951,7 +5558,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_130_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_130_wd),
 
     // from internal hardware
@@ -5977,7 +5584,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_131_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_131_wd),
 
     // from internal hardware
@@ -6003,7 +5610,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_132_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_132_wd),
 
     // from internal hardware
@@ -6029,7 +5636,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_133_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_133_wd),
 
     // from internal hardware
@@ -6055,7 +5662,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_134_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_134_wd),
 
     // from internal hardware
@@ -6081,7 +5688,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_135_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_135_wd),
 
     // from internal hardware
@@ -6107,7 +5714,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_136_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_136_wd),
 
     // from internal hardware
@@ -6133,7 +5740,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_137_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_137_wd),
 
     // from internal hardware
@@ -6159,7 +5766,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_138_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_138_wd),
 
     // from internal hardware
@@ -6185,7 +5792,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_139_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_139_wd),
 
     // from internal hardware
@@ -6211,7 +5818,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_140_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_140_wd),
 
     // from internal hardware
@@ -6237,7 +5844,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_141_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_141_wd),
 
     // from internal hardware
@@ -6263,7 +5870,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_142_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_142_wd),
 
     // from internal hardware
@@ -6289,7 +5896,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_143_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_143_wd),
 
     // from internal hardware
@@ -6315,7 +5922,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_144_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_144_wd),
 
     // from internal hardware
@@ -6341,7 +5948,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_145_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_145_wd),
 
     // from internal hardware
@@ -6367,7 +5974,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_146_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_146_wd),
 
     // from internal hardware
@@ -6393,7 +6000,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_147_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_147_wd),
 
     // from internal hardware
@@ -6419,7 +6026,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_148_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_148_wd),
 
     // from internal hardware
@@ -6445,7 +6052,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_149_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_149_wd),
 
     // from internal hardware
@@ -6471,7 +6078,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_150_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_150_wd),
 
     // from internal hardware
@@ -6497,7 +6104,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_151_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_151_wd),
 
     // from internal hardware
@@ -6523,7 +6130,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_152_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_152_wd),
 
     // from internal hardware
@@ -6549,7 +6156,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_153_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_153_wd),
 
     // from internal hardware
@@ -6575,7 +6182,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_154_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_154_wd),
 
     // from internal hardware
@@ -6601,7 +6208,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_155_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_155_wd),
 
     // from internal hardware
@@ -6627,7 +6234,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_156_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_156_wd),
 
     // from internal hardware
@@ -6653,7 +6260,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_157_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_157_wd),
 
     // from internal hardware
@@ -6679,7 +6286,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_158_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_158_wd),
 
     // from internal hardware
@@ -6705,7 +6312,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_4_filter_159_we),
+    .we     (cmd_filter_4_we),
     .wd     (cmd_filter_4_filter_159_wd),
 
     // from internal hardware
@@ -6734,7 +6341,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_160_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_160_wd),
 
     // from internal hardware
@@ -6760,7 +6367,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_161_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_161_wd),
 
     // from internal hardware
@@ -6786,7 +6393,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_162_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_162_wd),
 
     // from internal hardware
@@ -6812,7 +6419,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_163_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_163_wd),
 
     // from internal hardware
@@ -6838,7 +6445,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_164_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_164_wd),
 
     // from internal hardware
@@ -6864,7 +6471,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_165_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_165_wd),
 
     // from internal hardware
@@ -6890,7 +6497,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_166_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_166_wd),
 
     // from internal hardware
@@ -6916,7 +6523,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_167_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_167_wd),
 
     // from internal hardware
@@ -6942,7 +6549,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_168_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_168_wd),
 
     // from internal hardware
@@ -6968,7 +6575,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_169_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_169_wd),
 
     // from internal hardware
@@ -6994,7 +6601,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_170_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_170_wd),
 
     // from internal hardware
@@ -7020,7 +6627,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_171_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_171_wd),
 
     // from internal hardware
@@ -7046,7 +6653,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_172_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_172_wd),
 
     // from internal hardware
@@ -7072,7 +6679,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_173_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_173_wd),
 
     // from internal hardware
@@ -7098,7 +6705,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_174_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_174_wd),
 
     // from internal hardware
@@ -7124,7 +6731,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_175_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_175_wd),
 
     // from internal hardware
@@ -7150,7 +6757,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_176_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_176_wd),
 
     // from internal hardware
@@ -7176,7 +6783,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_177_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_177_wd),
 
     // from internal hardware
@@ -7202,7 +6809,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_178_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_178_wd),
 
     // from internal hardware
@@ -7228,7 +6835,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_179_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_179_wd),
 
     // from internal hardware
@@ -7254,7 +6861,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_180_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_180_wd),
 
     // from internal hardware
@@ -7280,7 +6887,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_181_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_181_wd),
 
     // from internal hardware
@@ -7306,7 +6913,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_182_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_182_wd),
 
     // from internal hardware
@@ -7332,7 +6939,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_183_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_183_wd),
 
     // from internal hardware
@@ -7358,7 +6965,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_184_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_184_wd),
 
     // from internal hardware
@@ -7384,7 +6991,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_185_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_185_wd),
 
     // from internal hardware
@@ -7410,7 +7017,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_186_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_186_wd),
 
     // from internal hardware
@@ -7436,7 +7043,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_187_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_187_wd),
 
     // from internal hardware
@@ -7462,7 +7069,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_188_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_188_wd),
 
     // from internal hardware
@@ -7488,7 +7095,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_189_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_189_wd),
 
     // from internal hardware
@@ -7514,7 +7121,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_190_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_190_wd),
 
     // from internal hardware
@@ -7540,7 +7147,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_5_filter_191_we),
+    .we     (cmd_filter_5_we),
     .wd     (cmd_filter_5_filter_191_wd),
 
     // from internal hardware
@@ -7569,7 +7176,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_192_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_192_wd),
 
     // from internal hardware
@@ -7595,7 +7202,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_193_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_193_wd),
 
     // from internal hardware
@@ -7621,7 +7228,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_194_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_194_wd),
 
     // from internal hardware
@@ -7647,7 +7254,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_195_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_195_wd),
 
     // from internal hardware
@@ -7673,7 +7280,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_196_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_196_wd),
 
     // from internal hardware
@@ -7699,7 +7306,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_197_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_197_wd),
 
     // from internal hardware
@@ -7725,7 +7332,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_198_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_198_wd),
 
     // from internal hardware
@@ -7751,7 +7358,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_199_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_199_wd),
 
     // from internal hardware
@@ -7777,7 +7384,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_200_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_200_wd),
 
     // from internal hardware
@@ -7803,7 +7410,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_201_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_201_wd),
 
     // from internal hardware
@@ -7829,7 +7436,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_202_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_202_wd),
 
     // from internal hardware
@@ -7855,7 +7462,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_203_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_203_wd),
 
     // from internal hardware
@@ -7881,7 +7488,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_204_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_204_wd),
 
     // from internal hardware
@@ -7907,7 +7514,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_205_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_205_wd),
 
     // from internal hardware
@@ -7933,7 +7540,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_206_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_206_wd),
 
     // from internal hardware
@@ -7959,7 +7566,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_207_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_207_wd),
 
     // from internal hardware
@@ -7985,7 +7592,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_208_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_208_wd),
 
     // from internal hardware
@@ -8011,7 +7618,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_209_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_209_wd),
 
     // from internal hardware
@@ -8037,7 +7644,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_210_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_210_wd),
 
     // from internal hardware
@@ -8063,7 +7670,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_211_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_211_wd),
 
     // from internal hardware
@@ -8089,7 +7696,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_212_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_212_wd),
 
     // from internal hardware
@@ -8115,7 +7722,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_213_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_213_wd),
 
     // from internal hardware
@@ -8141,7 +7748,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_214_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_214_wd),
 
     // from internal hardware
@@ -8167,7 +7774,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_215_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_215_wd),
 
     // from internal hardware
@@ -8193,7 +7800,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_216_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_216_wd),
 
     // from internal hardware
@@ -8219,7 +7826,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_217_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_217_wd),
 
     // from internal hardware
@@ -8245,7 +7852,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_218_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_218_wd),
 
     // from internal hardware
@@ -8271,7 +7878,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_219_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_219_wd),
 
     // from internal hardware
@@ -8297,7 +7904,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_220_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_220_wd),
 
     // from internal hardware
@@ -8323,7 +7930,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_221_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_221_wd),
 
     // from internal hardware
@@ -8349,7 +7956,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_222_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_222_wd),
 
     // from internal hardware
@@ -8375,7 +7982,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_6_filter_223_we),
+    .we     (cmd_filter_6_we),
     .wd     (cmd_filter_6_filter_223_wd),
 
     // from internal hardware
@@ -8404,7 +8011,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_224_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_224_wd),
 
     // from internal hardware
@@ -8430,7 +8037,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_225_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_225_wd),
 
     // from internal hardware
@@ -8456,7 +8063,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_226_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_226_wd),
 
     // from internal hardware
@@ -8482,7 +8089,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_227_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_227_wd),
 
     // from internal hardware
@@ -8508,7 +8115,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_228_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_228_wd),
 
     // from internal hardware
@@ -8534,7 +8141,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_229_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_229_wd),
 
     // from internal hardware
@@ -8560,7 +8167,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_230_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_230_wd),
 
     // from internal hardware
@@ -8586,7 +8193,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_231_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_231_wd),
 
     // from internal hardware
@@ -8612,7 +8219,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_232_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_232_wd),
 
     // from internal hardware
@@ -8638,7 +8245,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_233_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_233_wd),
 
     // from internal hardware
@@ -8664,7 +8271,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_234_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_234_wd),
 
     // from internal hardware
@@ -8690,7 +8297,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_235_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_235_wd),
 
     // from internal hardware
@@ -8716,7 +8323,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_236_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_236_wd),
 
     // from internal hardware
@@ -8742,7 +8349,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_237_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_237_wd),
 
     // from internal hardware
@@ -8768,7 +8375,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_238_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_238_wd),
 
     // from internal hardware
@@ -8794,7 +8401,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_239_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_239_wd),
 
     // from internal hardware
@@ -8820,7 +8427,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_240_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_240_wd),
 
     // from internal hardware
@@ -8846,7 +8453,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_241_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_241_wd),
 
     // from internal hardware
@@ -8872,7 +8479,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_242_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_242_wd),
 
     // from internal hardware
@@ -8898,7 +8505,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_243_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_243_wd),
 
     // from internal hardware
@@ -8924,7 +8531,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_244_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_244_wd),
 
     // from internal hardware
@@ -8950,7 +8557,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_245_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_245_wd),
 
     // from internal hardware
@@ -8976,7 +8583,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_246_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_246_wd),
 
     // from internal hardware
@@ -9002,7 +8609,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_247_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_247_wd),
 
     // from internal hardware
@@ -9028,7 +8635,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_248_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_248_wd),
 
     // from internal hardware
@@ -9054,7 +8661,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_249_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_249_wd),
 
     // from internal hardware
@@ -9080,7 +8687,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_250_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_250_wd),
 
     // from internal hardware
@@ -9106,7 +8713,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_251_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_251_wd),
 
     // from internal hardware
@@ -9132,7 +8739,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_252_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_252_wd),
 
     // from internal hardware
@@ -9158,7 +8765,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_253_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_253_wd),
 
     // from internal hardware
@@ -9184,7 +8791,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_254_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_254_wd),
 
     // from internal hardware
@@ -9210,7 +8817,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_filter_7_filter_255_we),
+    .we     (cmd_filter_7_we),
     .wd     (cmd_filter_7_filter_255_wd),
 
     // from internal hardware
@@ -9295,7 +8902,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_opcode_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_opcode_0_wd),
 
     // from internal hardware
@@ -9321,7 +8928,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_addr_en_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_addr_en_0_wd),
 
     // from internal hardware
@@ -9347,7 +8954,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_addr_swap_en_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_addr_swap_en_0_wd),
 
     // from internal hardware
@@ -9373,7 +8980,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_addr_4b_affected_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_addr_4b_affected_0_wd),
 
     // from internal hardware
@@ -9399,7 +9006,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_dummy_size_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_dummy_size_0_wd),
 
     // from internal hardware
@@ -9425,7 +9032,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_dummy_en_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_dummy_en_0_wd),
 
     // from internal hardware
@@ -9451,7 +9058,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_payload_en_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_payload_en_0_wd),
 
     // from internal hardware
@@ -9477,7 +9084,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_0_payload_dir_0_we),
+    .we     (cmd_info_0_we),
     .wd     (cmd_info_0_payload_dir_0_wd),
 
     // from internal hardware
@@ -9506,7 +9113,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_opcode_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_opcode_1_wd),
 
     // from internal hardware
@@ -9532,7 +9139,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_addr_en_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_addr_en_1_wd),
 
     // from internal hardware
@@ -9558,7 +9165,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_addr_swap_en_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_addr_swap_en_1_wd),
 
     // from internal hardware
@@ -9584,7 +9191,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_addr_4b_affected_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_addr_4b_affected_1_wd),
 
     // from internal hardware
@@ -9610,7 +9217,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_dummy_size_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_dummy_size_1_wd),
 
     // from internal hardware
@@ -9636,7 +9243,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_dummy_en_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_dummy_en_1_wd),
 
     // from internal hardware
@@ -9662,7 +9269,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_payload_en_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_payload_en_1_wd),
 
     // from internal hardware
@@ -9688,7 +9295,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_1_payload_dir_1_we),
+    .we     (cmd_info_1_we),
     .wd     (cmd_info_1_payload_dir_1_wd),
 
     // from internal hardware
@@ -9717,7 +9324,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_opcode_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_opcode_2_wd),
 
     // from internal hardware
@@ -9743,7 +9350,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_addr_en_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_addr_en_2_wd),
 
     // from internal hardware
@@ -9769,7 +9376,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_addr_swap_en_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_addr_swap_en_2_wd),
 
     // from internal hardware
@@ -9795,7 +9402,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_addr_4b_affected_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_addr_4b_affected_2_wd),
 
     // from internal hardware
@@ -9821,7 +9428,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_dummy_size_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_dummy_size_2_wd),
 
     // from internal hardware
@@ -9847,7 +9454,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_dummy_en_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_dummy_en_2_wd),
 
     // from internal hardware
@@ -9873,7 +9480,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_payload_en_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_payload_en_2_wd),
 
     // from internal hardware
@@ -9899,7 +9506,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_2_payload_dir_2_we),
+    .we     (cmd_info_2_we),
     .wd     (cmd_info_2_payload_dir_2_wd),
 
     // from internal hardware
@@ -9928,7 +9535,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_opcode_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_opcode_3_wd),
 
     // from internal hardware
@@ -9954,7 +9561,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_addr_en_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_addr_en_3_wd),
 
     // from internal hardware
@@ -9980,7 +9587,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_addr_swap_en_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_addr_swap_en_3_wd),
 
     // from internal hardware
@@ -10006,7 +9613,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_addr_4b_affected_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_addr_4b_affected_3_wd),
 
     // from internal hardware
@@ -10032,7 +9639,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_dummy_size_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_dummy_size_3_wd),
 
     // from internal hardware
@@ -10058,7 +9665,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_dummy_en_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_dummy_en_3_wd),
 
     // from internal hardware
@@ -10084,7 +9691,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_payload_en_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_payload_en_3_wd),
 
     // from internal hardware
@@ -10110,7 +9717,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_3_payload_dir_3_we),
+    .we     (cmd_info_3_we),
     .wd     (cmd_info_3_payload_dir_3_wd),
 
     // from internal hardware
@@ -10139,7 +9746,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_opcode_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_opcode_4_wd),
 
     // from internal hardware
@@ -10165,7 +9772,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_addr_en_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_addr_en_4_wd),
 
     // from internal hardware
@@ -10191,7 +9798,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_addr_swap_en_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_addr_swap_en_4_wd),
 
     // from internal hardware
@@ -10217,7 +9824,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_addr_4b_affected_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_addr_4b_affected_4_wd),
 
     // from internal hardware
@@ -10243,7 +9850,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_dummy_size_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_dummy_size_4_wd),
 
     // from internal hardware
@@ -10269,7 +9876,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_dummy_en_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_dummy_en_4_wd),
 
     // from internal hardware
@@ -10295,7 +9902,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_payload_en_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_payload_en_4_wd),
 
     // from internal hardware
@@ -10321,7 +9928,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_4_payload_dir_4_we),
+    .we     (cmd_info_4_we),
     .wd     (cmd_info_4_payload_dir_4_wd),
 
     // from internal hardware
@@ -10350,7 +9957,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_opcode_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_opcode_5_wd),
 
     // from internal hardware
@@ -10376,7 +9983,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_addr_en_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_addr_en_5_wd),
 
     // from internal hardware
@@ -10402,7 +10009,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_addr_swap_en_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_addr_swap_en_5_wd),
 
     // from internal hardware
@@ -10428,7 +10035,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_addr_4b_affected_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_addr_4b_affected_5_wd),
 
     // from internal hardware
@@ -10454,7 +10061,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_dummy_size_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_dummy_size_5_wd),
 
     // from internal hardware
@@ -10480,7 +10087,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_dummy_en_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_dummy_en_5_wd),
 
     // from internal hardware
@@ -10506,7 +10113,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_payload_en_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_payload_en_5_wd),
 
     // from internal hardware
@@ -10532,7 +10139,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_5_payload_dir_5_we),
+    .we     (cmd_info_5_we),
     .wd     (cmd_info_5_payload_dir_5_wd),
 
     // from internal hardware
@@ -10561,7 +10168,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_opcode_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_opcode_6_wd),
 
     // from internal hardware
@@ -10587,7 +10194,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_addr_en_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_addr_en_6_wd),
 
     // from internal hardware
@@ -10613,7 +10220,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_addr_swap_en_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_addr_swap_en_6_wd),
 
     // from internal hardware
@@ -10639,7 +10246,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_addr_4b_affected_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_addr_4b_affected_6_wd),
 
     // from internal hardware
@@ -10665,7 +10272,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_dummy_size_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_dummy_size_6_wd),
 
     // from internal hardware
@@ -10691,7 +10298,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_dummy_en_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_dummy_en_6_wd),
 
     // from internal hardware
@@ -10717,7 +10324,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_payload_en_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_payload_en_6_wd),
 
     // from internal hardware
@@ -10743,7 +10350,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_6_payload_dir_6_we),
+    .we     (cmd_info_6_we),
     .wd     (cmd_info_6_payload_dir_6_wd),
 
     // from internal hardware
@@ -10772,7 +10379,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_opcode_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_opcode_7_wd),
 
     // from internal hardware
@@ -10798,7 +10405,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_addr_en_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_addr_en_7_wd),
 
     // from internal hardware
@@ -10824,7 +10431,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_addr_swap_en_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_addr_swap_en_7_wd),
 
     // from internal hardware
@@ -10850,7 +10457,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_addr_4b_affected_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_addr_4b_affected_7_wd),
 
     // from internal hardware
@@ -10876,7 +10483,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_dummy_size_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_dummy_size_7_wd),
 
     // from internal hardware
@@ -10902,7 +10509,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_dummy_en_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_dummy_en_7_wd),
 
     // from internal hardware
@@ -10928,7 +10535,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_payload_en_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_payload_en_7_wd),
 
     // from internal hardware
@@ -10954,7 +10561,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_7_payload_dir_7_we),
+    .we     (cmd_info_7_we),
     .wd     (cmd_info_7_payload_dir_7_wd),
 
     // from internal hardware
@@ -10983,7 +10590,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_opcode_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_opcode_8_wd),
 
     // from internal hardware
@@ -11009,7 +10616,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_addr_en_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_addr_en_8_wd),
 
     // from internal hardware
@@ -11035,7 +10642,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_addr_swap_en_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_addr_swap_en_8_wd),
 
     // from internal hardware
@@ -11061,7 +10668,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_addr_4b_affected_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_addr_4b_affected_8_wd),
 
     // from internal hardware
@@ -11087,7 +10694,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_dummy_size_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_dummy_size_8_wd),
 
     // from internal hardware
@@ -11113,7 +10720,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_dummy_en_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_dummy_en_8_wd),
 
     // from internal hardware
@@ -11139,7 +10746,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_payload_en_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_payload_en_8_wd),
 
     // from internal hardware
@@ -11165,7 +10772,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_8_payload_dir_8_we),
+    .we     (cmd_info_8_we),
     .wd     (cmd_info_8_payload_dir_8_wd),
 
     // from internal hardware
@@ -11194,7 +10801,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_opcode_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_opcode_9_wd),
 
     // from internal hardware
@@ -11220,7 +10827,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_addr_en_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_addr_en_9_wd),
 
     // from internal hardware
@@ -11246,7 +10853,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_addr_swap_en_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_addr_swap_en_9_wd),
 
     // from internal hardware
@@ -11272,7 +10879,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_addr_4b_affected_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_addr_4b_affected_9_wd),
 
     // from internal hardware
@@ -11298,7 +10905,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_dummy_size_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_dummy_size_9_wd),
 
     // from internal hardware
@@ -11324,7 +10931,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_dummy_en_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_dummy_en_9_wd),
 
     // from internal hardware
@@ -11350,7 +10957,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_payload_en_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_payload_en_9_wd),
 
     // from internal hardware
@@ -11376,7 +10983,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_9_payload_dir_9_we),
+    .we     (cmd_info_9_we),
     .wd     (cmd_info_9_payload_dir_9_wd),
 
     // from internal hardware
@@ -11405,7 +11012,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_opcode_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_opcode_10_wd),
 
     // from internal hardware
@@ -11431,7 +11038,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_addr_en_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_addr_en_10_wd),
 
     // from internal hardware
@@ -11457,7 +11064,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_addr_swap_en_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_addr_swap_en_10_wd),
 
     // from internal hardware
@@ -11483,7 +11090,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_addr_4b_affected_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_addr_4b_affected_10_wd),
 
     // from internal hardware
@@ -11509,7 +11116,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_dummy_size_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_dummy_size_10_wd),
 
     // from internal hardware
@@ -11535,7 +11142,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_dummy_en_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_dummy_en_10_wd),
 
     // from internal hardware
@@ -11561,7 +11168,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_payload_en_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_payload_en_10_wd),
 
     // from internal hardware
@@ -11587,7 +11194,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_10_payload_dir_10_we),
+    .we     (cmd_info_10_we),
     .wd     (cmd_info_10_payload_dir_10_wd),
 
     // from internal hardware
@@ -11616,7 +11223,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_opcode_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_opcode_11_wd),
 
     // from internal hardware
@@ -11642,7 +11249,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_addr_en_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_addr_en_11_wd),
 
     // from internal hardware
@@ -11668,7 +11275,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_addr_swap_en_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_addr_swap_en_11_wd),
 
     // from internal hardware
@@ -11694,7 +11301,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_addr_4b_affected_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_addr_4b_affected_11_wd),
 
     // from internal hardware
@@ -11720,7 +11327,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_dummy_size_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_dummy_size_11_wd),
 
     // from internal hardware
@@ -11746,7 +11353,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_dummy_en_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_dummy_en_11_wd),
 
     // from internal hardware
@@ -11772,7 +11379,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_payload_en_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_payload_en_11_wd),
 
     // from internal hardware
@@ -11798,7 +11405,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_11_payload_dir_11_we),
+    .we     (cmd_info_11_we),
     .wd     (cmd_info_11_payload_dir_11_wd),
 
     // from internal hardware
@@ -11827,7 +11434,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_opcode_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_opcode_12_wd),
 
     // from internal hardware
@@ -11853,7 +11460,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_addr_en_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_addr_en_12_wd),
 
     // from internal hardware
@@ -11879,7 +11486,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_addr_swap_en_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_addr_swap_en_12_wd),
 
     // from internal hardware
@@ -11905,7 +11512,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_addr_4b_affected_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_addr_4b_affected_12_wd),
 
     // from internal hardware
@@ -11931,7 +11538,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_dummy_size_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_dummy_size_12_wd),
 
     // from internal hardware
@@ -11957,7 +11564,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_dummy_en_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_dummy_en_12_wd),
 
     // from internal hardware
@@ -11983,7 +11590,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_payload_en_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_payload_en_12_wd),
 
     // from internal hardware
@@ -12009,7 +11616,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_12_payload_dir_12_we),
+    .we     (cmd_info_12_we),
     .wd     (cmd_info_12_payload_dir_12_wd),
 
     // from internal hardware
@@ -12038,7 +11645,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_opcode_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_opcode_13_wd),
 
     // from internal hardware
@@ -12064,7 +11671,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_addr_en_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_addr_en_13_wd),
 
     // from internal hardware
@@ -12090,7 +11697,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_addr_swap_en_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_addr_swap_en_13_wd),
 
     // from internal hardware
@@ -12116,7 +11723,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_addr_4b_affected_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_addr_4b_affected_13_wd),
 
     // from internal hardware
@@ -12142,7 +11749,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_dummy_size_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_dummy_size_13_wd),
 
     // from internal hardware
@@ -12168,7 +11775,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_dummy_en_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_dummy_en_13_wd),
 
     // from internal hardware
@@ -12194,7 +11801,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_payload_en_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_payload_en_13_wd),
 
     // from internal hardware
@@ -12220,7 +11827,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_13_payload_dir_13_we),
+    .we     (cmd_info_13_we),
     .wd     (cmd_info_13_payload_dir_13_wd),
 
     // from internal hardware
@@ -12249,7 +11856,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_opcode_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_opcode_14_wd),
 
     // from internal hardware
@@ -12275,7 +11882,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_addr_en_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_addr_en_14_wd),
 
     // from internal hardware
@@ -12301,7 +11908,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_addr_swap_en_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_addr_swap_en_14_wd),
 
     // from internal hardware
@@ -12327,7 +11934,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_addr_4b_affected_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_addr_4b_affected_14_wd),
 
     // from internal hardware
@@ -12353,7 +11960,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_dummy_size_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_dummy_size_14_wd),
 
     // from internal hardware
@@ -12379,7 +11986,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_dummy_en_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_dummy_en_14_wd),
 
     // from internal hardware
@@ -12405,7 +12012,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_payload_en_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_payload_en_14_wd),
 
     // from internal hardware
@@ -12431,7 +12038,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_14_payload_dir_14_we),
+    .we     (cmd_info_14_we),
     .wd     (cmd_info_14_payload_dir_14_wd),
 
     // from internal hardware
@@ -12460,7 +12067,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_opcode_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_opcode_15_wd),
 
     // from internal hardware
@@ -12486,7 +12093,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_addr_en_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_addr_en_15_wd),
 
     // from internal hardware
@@ -12512,7 +12119,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_addr_swap_en_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_addr_swap_en_15_wd),
 
     // from internal hardware
@@ -12538,7 +12145,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_addr_4b_affected_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_addr_4b_affected_15_wd),
 
     // from internal hardware
@@ -12564,7 +12171,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_dummy_size_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_dummy_size_15_wd),
 
     // from internal hardware
@@ -12590,7 +12197,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_dummy_en_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_dummy_en_15_wd),
 
     // from internal hardware
@@ -12616,7 +12223,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_payload_en_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_payload_en_15_wd),
 
     // from internal hardware
@@ -12642,7 +12249,7 @@ module spi_device_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cmd_info_15_payload_dir_15_we),
+    .we     (cmd_info_15_we),
     .wd     (cmd_info_15_payload_dir_15_wd),
 
     // from internal hardware
@@ -12750,1293 +12357,892 @@ module spi_device_reg_top (
                (addr_hit[37] & (|(SPI_DEVICE_PERMIT[37] & ~reg_be))) |
                (addr_hit[38] & (|(SPI_DEVICE_PERMIT[38] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_rxf_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxf_wd = reg_wdata[0];
 
-  assign intr_state_rxlvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxlvl_wd = reg_wdata[1];
 
-  assign intr_state_txlvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_txlvl_wd = reg_wdata[2];
 
-  assign intr_state_rxerr_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxerr_wd = reg_wdata[3];
 
-  assign intr_state_rxoverflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rxoverflow_wd = reg_wdata[4];
 
-  assign intr_state_txunderflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_txunderflow_wd = reg_wdata[5];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_rxf_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxf_wd = reg_wdata[0];
 
-  assign intr_enable_rxlvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxlvl_wd = reg_wdata[1];
 
-  assign intr_enable_txlvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_txlvl_wd = reg_wdata[2];
 
-  assign intr_enable_rxerr_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxerr_wd = reg_wdata[3];
 
-  assign intr_enable_rxoverflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rxoverflow_wd = reg_wdata[4];
 
-  assign intr_enable_txunderflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_txunderflow_wd = reg_wdata[5];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_rxf_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxf_wd = reg_wdata[0];
 
-  assign intr_test_rxlvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxlvl_wd = reg_wdata[1];
 
-  assign intr_test_txlvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_txlvl_wd = reg_wdata[2];
 
-  assign intr_test_rxerr_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxerr_wd = reg_wdata[3];
 
-  assign intr_test_rxoverflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rxoverflow_wd = reg_wdata[4];
 
-  assign intr_test_txunderflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_txunderflow_wd = reg_wdata[5];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
-  assign alert_test_wd = reg_wdata[0];
 
-  assign control_abort_we = addr_hit[4] & reg_we & !reg_error;
+  assign alert_test_wd = reg_wdata[0];
+  assign control_we = addr_hit[4] & reg_we & !reg_error;
+
   assign control_abort_wd = reg_wdata[0];
 
-  assign control_mode_we = addr_hit[4] & reg_we & !reg_error;
   assign control_mode_wd = reg_wdata[5:4];
 
-  assign control_rst_txfifo_we = addr_hit[4] & reg_we & !reg_error;
   assign control_rst_txfifo_wd = reg_wdata[16];
 
-  assign control_rst_rxfifo_we = addr_hit[4] & reg_we & !reg_error;
   assign control_rst_rxfifo_wd = reg_wdata[17];
 
-  assign control_sram_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_sram_clk_en_wd = reg_wdata[31];
+  assign cfg_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign cfg_cpol_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_cpol_wd = reg_wdata[0];
 
-  assign cfg_cpha_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_cpha_wd = reg_wdata[1];
 
-  assign cfg_tx_order_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_tx_order_wd = reg_wdata[2];
 
-  assign cfg_rx_order_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_rx_order_wd = reg_wdata[3];
 
-  assign cfg_timer_v_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_timer_v_wd = reg_wdata[15:8];
 
-  assign cfg_addr_4b_en_we = addr_hit[5] & reg_we & !reg_error;
   assign cfg_addr_4b_en_wd = reg_wdata[16];
+  assign fifo_level_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign fifo_level_rxlvl_we = addr_hit[6] & reg_we & !reg_error;
   assign fifo_level_rxlvl_wd = reg_wdata[15:0];
 
-  assign fifo_level_txlvl_we = addr_hit[6] & reg_we & !reg_error;
   assign fifo_level_txlvl_wd = reg_wdata[31:16];
+  assign async_fifo_level_re = addr_hit[7] & reg_re & !reg_error;
+  assign status_re = addr_hit[8] & reg_re & !reg_error;
+  assign rxf_ptr_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign async_fifo_level_rxlvl_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign async_fifo_level_txlvl_re = addr_hit[7] & reg_re & !reg_error;
-
-  assign status_rxf_full_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign status_rxf_empty_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign status_txf_full_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign status_txf_empty_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign status_abort_done_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign status_csb_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign rxf_ptr_rptr_we = addr_hit[9] & reg_we & !reg_error;
   assign rxf_ptr_rptr_wd = reg_wdata[15:0];
+  assign txf_ptr_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign txf_ptr_wptr_we = addr_hit[10] & reg_we & !reg_error;
   assign txf_ptr_wptr_wd = reg_wdata[31:16];
+  assign rxf_addr_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign rxf_addr_base_we = addr_hit[11] & reg_we & !reg_error;
   assign rxf_addr_base_wd = reg_wdata[15:0];
 
-  assign rxf_addr_limit_we = addr_hit[11] & reg_we & !reg_error;
   assign rxf_addr_limit_wd = reg_wdata[31:16];
+  assign txf_addr_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign txf_addr_base_we = addr_hit[12] & reg_we & !reg_error;
   assign txf_addr_base_wd = reg_wdata[15:0];
 
-  assign txf_addr_limit_we = addr_hit[12] & reg_we & !reg_error;
   assign txf_addr_limit_wd = reg_wdata[31:16];
+  assign cmd_filter_0_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign cmd_filter_0_filter_0_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
-  assign cmd_filter_0_filter_1_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_1_wd = reg_wdata[1];
 
-  assign cmd_filter_0_filter_2_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_2_wd = reg_wdata[2];
 
-  assign cmd_filter_0_filter_3_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_3_wd = reg_wdata[3];
 
-  assign cmd_filter_0_filter_4_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_4_wd = reg_wdata[4];
 
-  assign cmd_filter_0_filter_5_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_5_wd = reg_wdata[5];
 
-  assign cmd_filter_0_filter_6_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_6_wd = reg_wdata[6];
 
-  assign cmd_filter_0_filter_7_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_7_wd = reg_wdata[7];
 
-  assign cmd_filter_0_filter_8_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_8_wd = reg_wdata[8];
 
-  assign cmd_filter_0_filter_9_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_9_wd = reg_wdata[9];
 
-  assign cmd_filter_0_filter_10_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_10_wd = reg_wdata[10];
 
-  assign cmd_filter_0_filter_11_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_11_wd = reg_wdata[11];
 
-  assign cmd_filter_0_filter_12_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_12_wd = reg_wdata[12];
 
-  assign cmd_filter_0_filter_13_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_13_wd = reg_wdata[13];
 
-  assign cmd_filter_0_filter_14_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_14_wd = reg_wdata[14];
 
-  assign cmd_filter_0_filter_15_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_15_wd = reg_wdata[15];
 
-  assign cmd_filter_0_filter_16_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_16_wd = reg_wdata[16];
 
-  assign cmd_filter_0_filter_17_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_17_wd = reg_wdata[17];
 
-  assign cmd_filter_0_filter_18_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_18_wd = reg_wdata[18];
 
-  assign cmd_filter_0_filter_19_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_19_wd = reg_wdata[19];
 
-  assign cmd_filter_0_filter_20_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_20_wd = reg_wdata[20];
 
-  assign cmd_filter_0_filter_21_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_21_wd = reg_wdata[21];
 
-  assign cmd_filter_0_filter_22_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_22_wd = reg_wdata[22];
 
-  assign cmd_filter_0_filter_23_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_23_wd = reg_wdata[23];
 
-  assign cmd_filter_0_filter_24_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_24_wd = reg_wdata[24];
 
-  assign cmd_filter_0_filter_25_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_25_wd = reg_wdata[25];
 
-  assign cmd_filter_0_filter_26_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_26_wd = reg_wdata[26];
 
-  assign cmd_filter_0_filter_27_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_27_wd = reg_wdata[27];
 
-  assign cmd_filter_0_filter_28_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_28_wd = reg_wdata[28];
 
-  assign cmd_filter_0_filter_29_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_29_wd = reg_wdata[29];
 
-  assign cmd_filter_0_filter_30_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
-  assign cmd_filter_0_filter_31_we = addr_hit[13] & reg_we & !reg_error;
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
+  assign cmd_filter_1_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign cmd_filter_1_filter_32_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
-  assign cmd_filter_1_filter_33_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_33_wd = reg_wdata[1];
 
-  assign cmd_filter_1_filter_34_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_34_wd = reg_wdata[2];
 
-  assign cmd_filter_1_filter_35_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_35_wd = reg_wdata[3];
 
-  assign cmd_filter_1_filter_36_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_36_wd = reg_wdata[4];
 
-  assign cmd_filter_1_filter_37_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_37_wd = reg_wdata[5];
 
-  assign cmd_filter_1_filter_38_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_38_wd = reg_wdata[6];
 
-  assign cmd_filter_1_filter_39_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_39_wd = reg_wdata[7];
 
-  assign cmd_filter_1_filter_40_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_40_wd = reg_wdata[8];
 
-  assign cmd_filter_1_filter_41_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_41_wd = reg_wdata[9];
 
-  assign cmd_filter_1_filter_42_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_42_wd = reg_wdata[10];
 
-  assign cmd_filter_1_filter_43_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_43_wd = reg_wdata[11];
 
-  assign cmd_filter_1_filter_44_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_44_wd = reg_wdata[12];
 
-  assign cmd_filter_1_filter_45_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_45_wd = reg_wdata[13];
 
-  assign cmd_filter_1_filter_46_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_46_wd = reg_wdata[14];
 
-  assign cmd_filter_1_filter_47_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_47_wd = reg_wdata[15];
 
-  assign cmd_filter_1_filter_48_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_48_wd = reg_wdata[16];
 
-  assign cmd_filter_1_filter_49_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_49_wd = reg_wdata[17];
 
-  assign cmd_filter_1_filter_50_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_50_wd = reg_wdata[18];
 
-  assign cmd_filter_1_filter_51_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_51_wd = reg_wdata[19];
 
-  assign cmd_filter_1_filter_52_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_52_wd = reg_wdata[20];
 
-  assign cmd_filter_1_filter_53_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_53_wd = reg_wdata[21];
 
-  assign cmd_filter_1_filter_54_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_54_wd = reg_wdata[22];
 
-  assign cmd_filter_1_filter_55_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_55_wd = reg_wdata[23];
 
-  assign cmd_filter_1_filter_56_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_56_wd = reg_wdata[24];
 
-  assign cmd_filter_1_filter_57_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_57_wd = reg_wdata[25];
 
-  assign cmd_filter_1_filter_58_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_58_wd = reg_wdata[26];
 
-  assign cmd_filter_1_filter_59_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_59_wd = reg_wdata[27];
 
-  assign cmd_filter_1_filter_60_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_60_wd = reg_wdata[28];
 
-  assign cmd_filter_1_filter_61_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_61_wd = reg_wdata[29];
 
-  assign cmd_filter_1_filter_62_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
-  assign cmd_filter_1_filter_63_we = addr_hit[14] & reg_we & !reg_error;
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
+  assign cmd_filter_2_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign cmd_filter_2_filter_64_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
-  assign cmd_filter_2_filter_65_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_65_wd = reg_wdata[1];
 
-  assign cmd_filter_2_filter_66_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_66_wd = reg_wdata[2];
 
-  assign cmd_filter_2_filter_67_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_67_wd = reg_wdata[3];
 
-  assign cmd_filter_2_filter_68_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_68_wd = reg_wdata[4];
 
-  assign cmd_filter_2_filter_69_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_69_wd = reg_wdata[5];
 
-  assign cmd_filter_2_filter_70_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_70_wd = reg_wdata[6];
 
-  assign cmd_filter_2_filter_71_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_71_wd = reg_wdata[7];
 
-  assign cmd_filter_2_filter_72_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_72_wd = reg_wdata[8];
 
-  assign cmd_filter_2_filter_73_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_73_wd = reg_wdata[9];
 
-  assign cmd_filter_2_filter_74_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_74_wd = reg_wdata[10];
 
-  assign cmd_filter_2_filter_75_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_75_wd = reg_wdata[11];
 
-  assign cmd_filter_2_filter_76_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_76_wd = reg_wdata[12];
 
-  assign cmd_filter_2_filter_77_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_77_wd = reg_wdata[13];
 
-  assign cmd_filter_2_filter_78_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_78_wd = reg_wdata[14];
 
-  assign cmd_filter_2_filter_79_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_79_wd = reg_wdata[15];
 
-  assign cmd_filter_2_filter_80_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_80_wd = reg_wdata[16];
 
-  assign cmd_filter_2_filter_81_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_81_wd = reg_wdata[17];
 
-  assign cmd_filter_2_filter_82_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_82_wd = reg_wdata[18];
 
-  assign cmd_filter_2_filter_83_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_83_wd = reg_wdata[19];
 
-  assign cmd_filter_2_filter_84_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_84_wd = reg_wdata[20];
 
-  assign cmd_filter_2_filter_85_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_85_wd = reg_wdata[21];
 
-  assign cmd_filter_2_filter_86_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_86_wd = reg_wdata[22];
 
-  assign cmd_filter_2_filter_87_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_87_wd = reg_wdata[23];
 
-  assign cmd_filter_2_filter_88_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_88_wd = reg_wdata[24];
 
-  assign cmd_filter_2_filter_89_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_89_wd = reg_wdata[25];
 
-  assign cmd_filter_2_filter_90_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_90_wd = reg_wdata[26];
 
-  assign cmd_filter_2_filter_91_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_91_wd = reg_wdata[27];
 
-  assign cmd_filter_2_filter_92_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_92_wd = reg_wdata[28];
 
-  assign cmd_filter_2_filter_93_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_93_wd = reg_wdata[29];
 
-  assign cmd_filter_2_filter_94_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
-  assign cmd_filter_2_filter_95_we = addr_hit[15] & reg_we & !reg_error;
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
+  assign cmd_filter_3_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign cmd_filter_3_filter_96_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
-  assign cmd_filter_3_filter_97_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_97_wd = reg_wdata[1];
 
-  assign cmd_filter_3_filter_98_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_98_wd = reg_wdata[2];
 
-  assign cmd_filter_3_filter_99_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_99_wd = reg_wdata[3];
 
-  assign cmd_filter_3_filter_100_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_100_wd = reg_wdata[4];
 
-  assign cmd_filter_3_filter_101_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_101_wd = reg_wdata[5];
 
-  assign cmd_filter_3_filter_102_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_102_wd = reg_wdata[6];
 
-  assign cmd_filter_3_filter_103_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_103_wd = reg_wdata[7];
 
-  assign cmd_filter_3_filter_104_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_104_wd = reg_wdata[8];
 
-  assign cmd_filter_3_filter_105_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_105_wd = reg_wdata[9];
 
-  assign cmd_filter_3_filter_106_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_106_wd = reg_wdata[10];
 
-  assign cmd_filter_3_filter_107_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_107_wd = reg_wdata[11];
 
-  assign cmd_filter_3_filter_108_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_108_wd = reg_wdata[12];
 
-  assign cmd_filter_3_filter_109_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_109_wd = reg_wdata[13];
 
-  assign cmd_filter_3_filter_110_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_110_wd = reg_wdata[14];
 
-  assign cmd_filter_3_filter_111_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_111_wd = reg_wdata[15];
 
-  assign cmd_filter_3_filter_112_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_112_wd = reg_wdata[16];
 
-  assign cmd_filter_3_filter_113_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_113_wd = reg_wdata[17];
 
-  assign cmd_filter_3_filter_114_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_114_wd = reg_wdata[18];
 
-  assign cmd_filter_3_filter_115_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_115_wd = reg_wdata[19];
 
-  assign cmd_filter_3_filter_116_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_116_wd = reg_wdata[20];
 
-  assign cmd_filter_3_filter_117_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_117_wd = reg_wdata[21];
 
-  assign cmd_filter_3_filter_118_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_118_wd = reg_wdata[22];
 
-  assign cmd_filter_3_filter_119_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_119_wd = reg_wdata[23];
 
-  assign cmd_filter_3_filter_120_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_120_wd = reg_wdata[24];
 
-  assign cmd_filter_3_filter_121_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_121_wd = reg_wdata[25];
 
-  assign cmd_filter_3_filter_122_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_122_wd = reg_wdata[26];
 
-  assign cmd_filter_3_filter_123_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_123_wd = reg_wdata[27];
 
-  assign cmd_filter_3_filter_124_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_124_wd = reg_wdata[28];
 
-  assign cmd_filter_3_filter_125_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_125_wd = reg_wdata[29];
 
-  assign cmd_filter_3_filter_126_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
-  assign cmd_filter_3_filter_127_we = addr_hit[16] & reg_we & !reg_error;
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
+  assign cmd_filter_4_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign cmd_filter_4_filter_128_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
-  assign cmd_filter_4_filter_129_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_129_wd = reg_wdata[1];
 
-  assign cmd_filter_4_filter_130_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_130_wd = reg_wdata[2];
 
-  assign cmd_filter_4_filter_131_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_131_wd = reg_wdata[3];
 
-  assign cmd_filter_4_filter_132_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_132_wd = reg_wdata[4];
 
-  assign cmd_filter_4_filter_133_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_133_wd = reg_wdata[5];
 
-  assign cmd_filter_4_filter_134_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_134_wd = reg_wdata[6];
 
-  assign cmd_filter_4_filter_135_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_135_wd = reg_wdata[7];
 
-  assign cmd_filter_4_filter_136_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_136_wd = reg_wdata[8];
 
-  assign cmd_filter_4_filter_137_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_137_wd = reg_wdata[9];
 
-  assign cmd_filter_4_filter_138_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_138_wd = reg_wdata[10];
 
-  assign cmd_filter_4_filter_139_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_139_wd = reg_wdata[11];
 
-  assign cmd_filter_4_filter_140_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_140_wd = reg_wdata[12];
 
-  assign cmd_filter_4_filter_141_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_141_wd = reg_wdata[13];
 
-  assign cmd_filter_4_filter_142_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_142_wd = reg_wdata[14];
 
-  assign cmd_filter_4_filter_143_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_143_wd = reg_wdata[15];
 
-  assign cmd_filter_4_filter_144_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_144_wd = reg_wdata[16];
 
-  assign cmd_filter_4_filter_145_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_145_wd = reg_wdata[17];
 
-  assign cmd_filter_4_filter_146_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_146_wd = reg_wdata[18];
 
-  assign cmd_filter_4_filter_147_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_147_wd = reg_wdata[19];
 
-  assign cmd_filter_4_filter_148_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_148_wd = reg_wdata[20];
 
-  assign cmd_filter_4_filter_149_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_149_wd = reg_wdata[21];
 
-  assign cmd_filter_4_filter_150_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_150_wd = reg_wdata[22];
 
-  assign cmd_filter_4_filter_151_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_151_wd = reg_wdata[23];
 
-  assign cmd_filter_4_filter_152_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_152_wd = reg_wdata[24];
 
-  assign cmd_filter_4_filter_153_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_153_wd = reg_wdata[25];
 
-  assign cmd_filter_4_filter_154_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_154_wd = reg_wdata[26];
 
-  assign cmd_filter_4_filter_155_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_155_wd = reg_wdata[27];
 
-  assign cmd_filter_4_filter_156_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_156_wd = reg_wdata[28];
 
-  assign cmd_filter_4_filter_157_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_157_wd = reg_wdata[29];
 
-  assign cmd_filter_4_filter_158_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
-  assign cmd_filter_4_filter_159_we = addr_hit[17] & reg_we & !reg_error;
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
+  assign cmd_filter_5_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign cmd_filter_5_filter_160_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
-  assign cmd_filter_5_filter_161_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_161_wd = reg_wdata[1];
 
-  assign cmd_filter_5_filter_162_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_162_wd = reg_wdata[2];
 
-  assign cmd_filter_5_filter_163_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_163_wd = reg_wdata[3];
 
-  assign cmd_filter_5_filter_164_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_164_wd = reg_wdata[4];
 
-  assign cmd_filter_5_filter_165_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_165_wd = reg_wdata[5];
 
-  assign cmd_filter_5_filter_166_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_166_wd = reg_wdata[6];
 
-  assign cmd_filter_5_filter_167_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_167_wd = reg_wdata[7];
 
-  assign cmd_filter_5_filter_168_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_168_wd = reg_wdata[8];
 
-  assign cmd_filter_5_filter_169_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_169_wd = reg_wdata[9];
 
-  assign cmd_filter_5_filter_170_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_170_wd = reg_wdata[10];
 
-  assign cmd_filter_5_filter_171_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_171_wd = reg_wdata[11];
 
-  assign cmd_filter_5_filter_172_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_172_wd = reg_wdata[12];
 
-  assign cmd_filter_5_filter_173_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_173_wd = reg_wdata[13];
 
-  assign cmd_filter_5_filter_174_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_174_wd = reg_wdata[14];
 
-  assign cmd_filter_5_filter_175_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_175_wd = reg_wdata[15];
 
-  assign cmd_filter_5_filter_176_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_176_wd = reg_wdata[16];
 
-  assign cmd_filter_5_filter_177_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_177_wd = reg_wdata[17];
 
-  assign cmd_filter_5_filter_178_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_178_wd = reg_wdata[18];
 
-  assign cmd_filter_5_filter_179_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_179_wd = reg_wdata[19];
 
-  assign cmd_filter_5_filter_180_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_180_wd = reg_wdata[20];
 
-  assign cmd_filter_5_filter_181_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_181_wd = reg_wdata[21];
 
-  assign cmd_filter_5_filter_182_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_182_wd = reg_wdata[22];
 
-  assign cmd_filter_5_filter_183_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_183_wd = reg_wdata[23];
 
-  assign cmd_filter_5_filter_184_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_184_wd = reg_wdata[24];
 
-  assign cmd_filter_5_filter_185_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_185_wd = reg_wdata[25];
 
-  assign cmd_filter_5_filter_186_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_186_wd = reg_wdata[26];
 
-  assign cmd_filter_5_filter_187_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_187_wd = reg_wdata[27];
 
-  assign cmd_filter_5_filter_188_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_188_wd = reg_wdata[28];
 
-  assign cmd_filter_5_filter_189_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_189_wd = reg_wdata[29];
 
-  assign cmd_filter_5_filter_190_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
-  assign cmd_filter_5_filter_191_we = addr_hit[18] & reg_we & !reg_error;
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
+  assign cmd_filter_6_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign cmd_filter_6_filter_192_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
-  assign cmd_filter_6_filter_193_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_193_wd = reg_wdata[1];
 
-  assign cmd_filter_6_filter_194_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_194_wd = reg_wdata[2];
 
-  assign cmd_filter_6_filter_195_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_195_wd = reg_wdata[3];
 
-  assign cmd_filter_6_filter_196_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_196_wd = reg_wdata[4];
 
-  assign cmd_filter_6_filter_197_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_197_wd = reg_wdata[5];
 
-  assign cmd_filter_6_filter_198_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_198_wd = reg_wdata[6];
 
-  assign cmd_filter_6_filter_199_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_199_wd = reg_wdata[7];
 
-  assign cmd_filter_6_filter_200_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_200_wd = reg_wdata[8];
 
-  assign cmd_filter_6_filter_201_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_201_wd = reg_wdata[9];
 
-  assign cmd_filter_6_filter_202_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_202_wd = reg_wdata[10];
 
-  assign cmd_filter_6_filter_203_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_203_wd = reg_wdata[11];
 
-  assign cmd_filter_6_filter_204_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_204_wd = reg_wdata[12];
 
-  assign cmd_filter_6_filter_205_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_205_wd = reg_wdata[13];
 
-  assign cmd_filter_6_filter_206_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_206_wd = reg_wdata[14];
 
-  assign cmd_filter_6_filter_207_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_207_wd = reg_wdata[15];
 
-  assign cmd_filter_6_filter_208_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_208_wd = reg_wdata[16];
 
-  assign cmd_filter_6_filter_209_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_209_wd = reg_wdata[17];
 
-  assign cmd_filter_6_filter_210_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_210_wd = reg_wdata[18];
 
-  assign cmd_filter_6_filter_211_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_211_wd = reg_wdata[19];
 
-  assign cmd_filter_6_filter_212_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_212_wd = reg_wdata[20];
 
-  assign cmd_filter_6_filter_213_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_213_wd = reg_wdata[21];
 
-  assign cmd_filter_6_filter_214_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_214_wd = reg_wdata[22];
 
-  assign cmd_filter_6_filter_215_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_215_wd = reg_wdata[23];
 
-  assign cmd_filter_6_filter_216_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_216_wd = reg_wdata[24];
 
-  assign cmd_filter_6_filter_217_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_217_wd = reg_wdata[25];
 
-  assign cmd_filter_6_filter_218_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_218_wd = reg_wdata[26];
 
-  assign cmd_filter_6_filter_219_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_219_wd = reg_wdata[27];
 
-  assign cmd_filter_6_filter_220_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_220_wd = reg_wdata[28];
 
-  assign cmd_filter_6_filter_221_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_221_wd = reg_wdata[29];
 
-  assign cmd_filter_6_filter_222_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
-  assign cmd_filter_6_filter_223_we = addr_hit[19] & reg_we & !reg_error;
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
+  assign cmd_filter_7_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign cmd_filter_7_filter_224_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
-  assign cmd_filter_7_filter_225_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_225_wd = reg_wdata[1];
 
-  assign cmd_filter_7_filter_226_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_226_wd = reg_wdata[2];
 
-  assign cmd_filter_7_filter_227_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_227_wd = reg_wdata[3];
 
-  assign cmd_filter_7_filter_228_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_228_wd = reg_wdata[4];
 
-  assign cmd_filter_7_filter_229_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_229_wd = reg_wdata[5];
 
-  assign cmd_filter_7_filter_230_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_230_wd = reg_wdata[6];
 
-  assign cmd_filter_7_filter_231_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_231_wd = reg_wdata[7];
 
-  assign cmd_filter_7_filter_232_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_232_wd = reg_wdata[8];
 
-  assign cmd_filter_7_filter_233_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_233_wd = reg_wdata[9];
 
-  assign cmd_filter_7_filter_234_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_234_wd = reg_wdata[10];
 
-  assign cmd_filter_7_filter_235_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_235_wd = reg_wdata[11];
 
-  assign cmd_filter_7_filter_236_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_236_wd = reg_wdata[12];
 
-  assign cmd_filter_7_filter_237_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_237_wd = reg_wdata[13];
 
-  assign cmd_filter_7_filter_238_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_238_wd = reg_wdata[14];
 
-  assign cmd_filter_7_filter_239_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_239_wd = reg_wdata[15];
 
-  assign cmd_filter_7_filter_240_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_240_wd = reg_wdata[16];
 
-  assign cmd_filter_7_filter_241_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_241_wd = reg_wdata[17];
 
-  assign cmd_filter_7_filter_242_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_242_wd = reg_wdata[18];
 
-  assign cmd_filter_7_filter_243_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_243_wd = reg_wdata[19];
 
-  assign cmd_filter_7_filter_244_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_244_wd = reg_wdata[20];
 
-  assign cmd_filter_7_filter_245_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_245_wd = reg_wdata[21];
 
-  assign cmd_filter_7_filter_246_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_246_wd = reg_wdata[22];
 
-  assign cmd_filter_7_filter_247_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_247_wd = reg_wdata[23];
 
-  assign cmd_filter_7_filter_248_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_248_wd = reg_wdata[24];
 
-  assign cmd_filter_7_filter_249_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_249_wd = reg_wdata[25];
 
-  assign cmd_filter_7_filter_250_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_250_wd = reg_wdata[26];
 
-  assign cmd_filter_7_filter_251_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_251_wd = reg_wdata[27];
 
-  assign cmd_filter_7_filter_252_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_252_wd = reg_wdata[28];
 
-  assign cmd_filter_7_filter_253_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_253_wd = reg_wdata[29];
 
-  assign cmd_filter_7_filter_254_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
-  assign cmd_filter_7_filter_255_we = addr_hit[20] & reg_we & !reg_error;
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-
   assign addr_swap_mask_we = addr_hit[21] & reg_we & !reg_error;
+
   assign addr_swap_mask_wd = reg_wdata[31:0];
-
   assign addr_swap_data_we = addr_hit[22] & reg_we & !reg_error;
-  assign addr_swap_data_wd = reg_wdata[31:0];
 
-  assign cmd_info_0_opcode_0_we = addr_hit[23] & reg_we & !reg_error;
+  assign addr_swap_data_wd = reg_wdata[31:0];
+  assign cmd_info_0_we = addr_hit[23] & reg_we & !reg_error;
+
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
-  assign cmd_info_0_addr_en_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_addr_en_0_wd = reg_wdata[8];
 
-  assign cmd_info_0_addr_swap_en_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_addr_swap_en_0_wd = reg_wdata[9];
 
-  assign cmd_info_0_addr_4b_affected_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_addr_4b_affected_0_wd = reg_wdata[10];
 
-  assign cmd_info_0_dummy_size_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_dummy_size_0_wd = reg_wdata[14:12];
 
-  assign cmd_info_0_dummy_en_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_dummy_en_0_wd = reg_wdata[15];
 
-  assign cmd_info_0_payload_en_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_payload_en_0_wd = reg_wdata[19:16];
 
-  assign cmd_info_0_payload_dir_0_we = addr_hit[23] & reg_we & !reg_error;
   assign cmd_info_0_payload_dir_0_wd = reg_wdata[20];
+  assign cmd_info_1_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign cmd_info_1_opcode_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
-  assign cmd_info_1_addr_en_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_addr_en_1_wd = reg_wdata[8];
 
-  assign cmd_info_1_addr_swap_en_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_addr_swap_en_1_wd = reg_wdata[9];
 
-  assign cmd_info_1_addr_4b_affected_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_addr_4b_affected_1_wd = reg_wdata[10];
 
-  assign cmd_info_1_dummy_size_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_dummy_size_1_wd = reg_wdata[14:12];
 
-  assign cmd_info_1_dummy_en_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_dummy_en_1_wd = reg_wdata[15];
 
-  assign cmd_info_1_payload_en_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_payload_en_1_wd = reg_wdata[19:16];
 
-  assign cmd_info_1_payload_dir_1_we = addr_hit[24] & reg_we & !reg_error;
   assign cmd_info_1_payload_dir_1_wd = reg_wdata[20];
+  assign cmd_info_2_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign cmd_info_2_opcode_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
-  assign cmd_info_2_addr_en_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_addr_en_2_wd = reg_wdata[8];
 
-  assign cmd_info_2_addr_swap_en_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_addr_swap_en_2_wd = reg_wdata[9];
 
-  assign cmd_info_2_addr_4b_affected_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_addr_4b_affected_2_wd = reg_wdata[10];
 
-  assign cmd_info_2_dummy_size_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_dummy_size_2_wd = reg_wdata[14:12];
 
-  assign cmd_info_2_dummy_en_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_dummy_en_2_wd = reg_wdata[15];
 
-  assign cmd_info_2_payload_en_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_payload_en_2_wd = reg_wdata[19:16];
 
-  assign cmd_info_2_payload_dir_2_we = addr_hit[25] & reg_we & !reg_error;
   assign cmd_info_2_payload_dir_2_wd = reg_wdata[20];
+  assign cmd_info_3_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign cmd_info_3_opcode_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
-  assign cmd_info_3_addr_en_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_addr_en_3_wd = reg_wdata[8];
 
-  assign cmd_info_3_addr_swap_en_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_addr_swap_en_3_wd = reg_wdata[9];
 
-  assign cmd_info_3_addr_4b_affected_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_addr_4b_affected_3_wd = reg_wdata[10];
 
-  assign cmd_info_3_dummy_size_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_dummy_size_3_wd = reg_wdata[14:12];
 
-  assign cmd_info_3_dummy_en_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_dummy_en_3_wd = reg_wdata[15];
 
-  assign cmd_info_3_payload_en_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_payload_en_3_wd = reg_wdata[19:16];
 
-  assign cmd_info_3_payload_dir_3_we = addr_hit[26] & reg_we & !reg_error;
   assign cmd_info_3_payload_dir_3_wd = reg_wdata[20];
+  assign cmd_info_4_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign cmd_info_4_opcode_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
-  assign cmd_info_4_addr_en_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_addr_en_4_wd = reg_wdata[8];
 
-  assign cmd_info_4_addr_swap_en_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_addr_swap_en_4_wd = reg_wdata[9];
 
-  assign cmd_info_4_addr_4b_affected_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_addr_4b_affected_4_wd = reg_wdata[10];
 
-  assign cmd_info_4_dummy_size_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_dummy_size_4_wd = reg_wdata[14:12];
 
-  assign cmd_info_4_dummy_en_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_dummy_en_4_wd = reg_wdata[15];
 
-  assign cmd_info_4_payload_en_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_payload_en_4_wd = reg_wdata[19:16];
 
-  assign cmd_info_4_payload_dir_4_we = addr_hit[27] & reg_we & !reg_error;
   assign cmd_info_4_payload_dir_4_wd = reg_wdata[20];
+  assign cmd_info_5_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign cmd_info_5_opcode_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
-  assign cmd_info_5_addr_en_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_addr_en_5_wd = reg_wdata[8];
 
-  assign cmd_info_5_addr_swap_en_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_addr_swap_en_5_wd = reg_wdata[9];
 
-  assign cmd_info_5_addr_4b_affected_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_addr_4b_affected_5_wd = reg_wdata[10];
 
-  assign cmd_info_5_dummy_size_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_dummy_size_5_wd = reg_wdata[14:12];
 
-  assign cmd_info_5_dummy_en_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_dummy_en_5_wd = reg_wdata[15];
 
-  assign cmd_info_5_payload_en_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_payload_en_5_wd = reg_wdata[19:16];
 
-  assign cmd_info_5_payload_dir_5_we = addr_hit[28] & reg_we & !reg_error;
   assign cmd_info_5_payload_dir_5_wd = reg_wdata[20];
+  assign cmd_info_6_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign cmd_info_6_opcode_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
-  assign cmd_info_6_addr_en_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_addr_en_6_wd = reg_wdata[8];
 
-  assign cmd_info_6_addr_swap_en_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_addr_swap_en_6_wd = reg_wdata[9];
 
-  assign cmd_info_6_addr_4b_affected_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_addr_4b_affected_6_wd = reg_wdata[10];
 
-  assign cmd_info_6_dummy_size_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_dummy_size_6_wd = reg_wdata[14:12];
 
-  assign cmd_info_6_dummy_en_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_dummy_en_6_wd = reg_wdata[15];
 
-  assign cmd_info_6_payload_en_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_payload_en_6_wd = reg_wdata[19:16];
 
-  assign cmd_info_6_payload_dir_6_we = addr_hit[29] & reg_we & !reg_error;
   assign cmd_info_6_payload_dir_6_wd = reg_wdata[20];
+  assign cmd_info_7_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign cmd_info_7_opcode_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
-  assign cmd_info_7_addr_en_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_addr_en_7_wd = reg_wdata[8];
 
-  assign cmd_info_7_addr_swap_en_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_addr_swap_en_7_wd = reg_wdata[9];
 
-  assign cmd_info_7_addr_4b_affected_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_addr_4b_affected_7_wd = reg_wdata[10];
 
-  assign cmd_info_7_dummy_size_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_dummy_size_7_wd = reg_wdata[14:12];
 
-  assign cmd_info_7_dummy_en_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_dummy_en_7_wd = reg_wdata[15];
 
-  assign cmd_info_7_payload_en_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_payload_en_7_wd = reg_wdata[19:16];
 
-  assign cmd_info_7_payload_dir_7_we = addr_hit[30] & reg_we & !reg_error;
   assign cmd_info_7_payload_dir_7_wd = reg_wdata[20];
+  assign cmd_info_8_we = addr_hit[31] & reg_we & !reg_error;
 
-  assign cmd_info_8_opcode_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
-  assign cmd_info_8_addr_en_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_addr_en_8_wd = reg_wdata[8];
 
-  assign cmd_info_8_addr_swap_en_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_addr_swap_en_8_wd = reg_wdata[9];
 
-  assign cmd_info_8_addr_4b_affected_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_addr_4b_affected_8_wd = reg_wdata[10];
 
-  assign cmd_info_8_dummy_size_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_dummy_size_8_wd = reg_wdata[14:12];
 
-  assign cmd_info_8_dummy_en_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_dummy_en_8_wd = reg_wdata[15];
 
-  assign cmd_info_8_payload_en_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_payload_en_8_wd = reg_wdata[19:16];
 
-  assign cmd_info_8_payload_dir_8_we = addr_hit[31] & reg_we & !reg_error;
   assign cmd_info_8_payload_dir_8_wd = reg_wdata[20];
+  assign cmd_info_9_we = addr_hit[32] & reg_we & !reg_error;
 
-  assign cmd_info_9_opcode_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
-  assign cmd_info_9_addr_en_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_addr_en_9_wd = reg_wdata[8];
 
-  assign cmd_info_9_addr_swap_en_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_addr_swap_en_9_wd = reg_wdata[9];
 
-  assign cmd_info_9_addr_4b_affected_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_addr_4b_affected_9_wd = reg_wdata[10];
 
-  assign cmd_info_9_dummy_size_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_dummy_size_9_wd = reg_wdata[14:12];
 
-  assign cmd_info_9_dummy_en_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_dummy_en_9_wd = reg_wdata[15];
 
-  assign cmd_info_9_payload_en_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_payload_en_9_wd = reg_wdata[19:16];
 
-  assign cmd_info_9_payload_dir_9_we = addr_hit[32] & reg_we & !reg_error;
   assign cmd_info_9_payload_dir_9_wd = reg_wdata[20];
+  assign cmd_info_10_we = addr_hit[33] & reg_we & !reg_error;
 
-  assign cmd_info_10_opcode_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
-  assign cmd_info_10_addr_en_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_addr_en_10_wd = reg_wdata[8];
 
-  assign cmd_info_10_addr_swap_en_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_addr_swap_en_10_wd = reg_wdata[9];
 
-  assign cmd_info_10_addr_4b_affected_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_addr_4b_affected_10_wd = reg_wdata[10];
 
-  assign cmd_info_10_dummy_size_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_dummy_size_10_wd = reg_wdata[14:12];
 
-  assign cmd_info_10_dummy_en_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_dummy_en_10_wd = reg_wdata[15];
 
-  assign cmd_info_10_payload_en_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_payload_en_10_wd = reg_wdata[19:16];
 
-  assign cmd_info_10_payload_dir_10_we = addr_hit[33] & reg_we & !reg_error;
   assign cmd_info_10_payload_dir_10_wd = reg_wdata[20];
+  assign cmd_info_11_we = addr_hit[34] & reg_we & !reg_error;
 
-  assign cmd_info_11_opcode_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
-  assign cmd_info_11_addr_en_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_addr_en_11_wd = reg_wdata[8];
 
-  assign cmd_info_11_addr_swap_en_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_addr_swap_en_11_wd = reg_wdata[9];
 
-  assign cmd_info_11_addr_4b_affected_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_addr_4b_affected_11_wd = reg_wdata[10];
 
-  assign cmd_info_11_dummy_size_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_dummy_size_11_wd = reg_wdata[14:12];
 
-  assign cmd_info_11_dummy_en_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_dummy_en_11_wd = reg_wdata[15];
 
-  assign cmd_info_11_payload_en_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_payload_en_11_wd = reg_wdata[19:16];
 
-  assign cmd_info_11_payload_dir_11_we = addr_hit[34] & reg_we & !reg_error;
   assign cmd_info_11_payload_dir_11_wd = reg_wdata[20];
+  assign cmd_info_12_we = addr_hit[35] & reg_we & !reg_error;
 
-  assign cmd_info_12_opcode_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
-  assign cmd_info_12_addr_en_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_addr_en_12_wd = reg_wdata[8];
 
-  assign cmd_info_12_addr_swap_en_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_addr_swap_en_12_wd = reg_wdata[9];
 
-  assign cmd_info_12_addr_4b_affected_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_addr_4b_affected_12_wd = reg_wdata[10];
 
-  assign cmd_info_12_dummy_size_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_dummy_size_12_wd = reg_wdata[14:12];
 
-  assign cmd_info_12_dummy_en_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_dummy_en_12_wd = reg_wdata[15];
 
-  assign cmd_info_12_payload_en_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_payload_en_12_wd = reg_wdata[19:16];
 
-  assign cmd_info_12_payload_dir_12_we = addr_hit[35] & reg_we & !reg_error;
   assign cmd_info_12_payload_dir_12_wd = reg_wdata[20];
+  assign cmd_info_13_we = addr_hit[36] & reg_we & !reg_error;
 
-  assign cmd_info_13_opcode_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
-  assign cmd_info_13_addr_en_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_addr_en_13_wd = reg_wdata[8];
 
-  assign cmd_info_13_addr_swap_en_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_addr_swap_en_13_wd = reg_wdata[9];
 
-  assign cmd_info_13_addr_4b_affected_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_addr_4b_affected_13_wd = reg_wdata[10];
 
-  assign cmd_info_13_dummy_size_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_dummy_size_13_wd = reg_wdata[14:12];
 
-  assign cmd_info_13_dummy_en_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_dummy_en_13_wd = reg_wdata[15];
 
-  assign cmd_info_13_payload_en_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_payload_en_13_wd = reg_wdata[19:16];
 
-  assign cmd_info_13_payload_dir_13_we = addr_hit[36] & reg_we & !reg_error;
   assign cmd_info_13_payload_dir_13_wd = reg_wdata[20];
+  assign cmd_info_14_we = addr_hit[37] & reg_we & !reg_error;
 
-  assign cmd_info_14_opcode_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
-  assign cmd_info_14_addr_en_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_addr_en_14_wd = reg_wdata[8];
 
-  assign cmd_info_14_addr_swap_en_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_addr_swap_en_14_wd = reg_wdata[9];
 
-  assign cmd_info_14_addr_4b_affected_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_addr_4b_affected_14_wd = reg_wdata[10];
 
-  assign cmd_info_14_dummy_size_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_dummy_size_14_wd = reg_wdata[14:12];
 
-  assign cmd_info_14_dummy_en_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_dummy_en_14_wd = reg_wdata[15];
 
-  assign cmd_info_14_payload_en_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_payload_en_14_wd = reg_wdata[19:16];
 
-  assign cmd_info_14_payload_dir_14_we = addr_hit[37] & reg_we & !reg_error;
   assign cmd_info_14_payload_dir_14_wd = reg_wdata[20];
+  assign cmd_info_15_we = addr_hit[38] & reg_we & !reg_error;
 
-  assign cmd_info_15_opcode_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
-  assign cmd_info_15_addr_en_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_addr_en_15_wd = reg_wdata[8];
 
-  assign cmd_info_15_addr_swap_en_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_addr_swap_en_15_wd = reg_wdata[9];
 
-  assign cmd_info_15_addr_4b_affected_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_addr_4b_affected_15_wd = reg_wdata[10];
 
-  assign cmd_info_15_dummy_size_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_dummy_size_15_wd = reg_wdata[14:12];
 
-  assign cmd_info_15_dummy_en_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_dummy_en_15_wd = reg_wdata[15];
 
-  assign cmd_info_15_payload_en_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_payload_en_15_wd = reg_wdata[19:16];
 
-  assign cmd_info_15_payload_dir_15_we = addr_hit[38] & reg_we & !reg_error;
   assign cmd_info_15_payload_dir_15_wd = reg_wdata[20];
 
   // Read data return

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -152,39 +152,32 @@ module spi_host_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_error_qs;
   logic intr_state_error_wd;
-  logic intr_state_error_we;
   logic intr_state_spi_event_qs;
   logic intr_state_spi_event_wd;
-  logic intr_state_spi_event_we;
+  logic intr_enable_we;
   logic intr_enable_error_qs;
   logic intr_enable_error_wd;
-  logic intr_enable_error_we;
   logic intr_enable_spi_event_qs;
   logic intr_enable_spi_event_wd;
-  logic intr_enable_spi_event_we;
+  logic intr_test_we;
   logic intr_test_error_wd;
-  logic intr_test_error_we;
   logic intr_test_spi_event_wd;
-  logic intr_test_spi_event_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic control_we;
   logic [7:0] control_rx_watermark_qs;
   logic [7:0] control_rx_watermark_wd;
-  logic control_rx_watermark_we;
   logic [7:0] control_tx_watermark_qs;
   logic [7:0] control_tx_watermark_wd;
-  logic control_tx_watermark_we;
   logic control_passthru_qs;
   logic control_passthru_wd;
-  logic control_passthru_we;
   logic control_sw_rst_qs;
   logic control_sw_rst_wd;
-  logic control_sw_rst_we;
   logic control_spien_qs;
   logic control_spien_wd;
-  logic control_spien_we;
   logic [7:0] status_txqd_qs;
   logic [7:0] status_rxqd_qs;
   logic status_rxwm_qs;
@@ -198,90 +191,68 @@ module spi_host_reg_top (
   logic status_txfull_qs;
   logic status_active_qs;
   logic status_ready_qs;
+  logic configopts_we;
   logic [15:0] configopts_clkdiv_0_qs;
   logic [15:0] configopts_clkdiv_0_wd;
-  logic configopts_clkdiv_0_we;
   logic [3:0] configopts_csnidle_0_qs;
   logic [3:0] configopts_csnidle_0_wd;
-  logic configopts_csnidle_0_we;
   logic [3:0] configopts_csntrail_0_qs;
   logic [3:0] configopts_csntrail_0_wd;
-  logic configopts_csntrail_0_we;
   logic [3:0] configopts_csnlead_0_qs;
   logic [3:0] configopts_csnlead_0_wd;
-  logic configopts_csnlead_0_we;
   logic configopts_fullcyc_0_qs;
   logic configopts_fullcyc_0_wd;
-  logic configopts_fullcyc_0_we;
   logic configopts_cpha_0_qs;
   logic configopts_cpha_0_wd;
-  logic configopts_cpha_0_we;
   logic configopts_cpol_0_qs;
   logic configopts_cpol_0_wd;
-  logic configopts_cpol_0_we;
+  logic csid_we;
   logic [31:0] csid_qs;
   logic [31:0] csid_wd;
-  logic csid_we;
+  logic command_we;
   logic [8:0] command_len_qs;
   logic [8:0] command_len_wd;
-  logic command_len_we;
   logic command_csaat_qs;
   logic command_csaat_wd;
-  logic command_csaat_we;
   logic [1:0] command_speed_qs;
   logic [1:0] command_speed_wd;
-  logic command_speed_we;
   logic [1:0] command_direction_qs;
   logic [1:0] command_direction_wd;
-  logic command_direction_we;
+  logic error_enable_we;
   logic error_enable_cmdbusy_qs;
   logic error_enable_cmdbusy_wd;
-  logic error_enable_cmdbusy_we;
   logic error_enable_overflow_qs;
   logic error_enable_overflow_wd;
-  logic error_enable_overflow_we;
   logic error_enable_underflow_qs;
   logic error_enable_underflow_wd;
-  logic error_enable_underflow_we;
   logic error_enable_cmdinval_qs;
   logic error_enable_cmdinval_wd;
-  logic error_enable_cmdinval_we;
   logic error_enable_csidinval_qs;
   logic error_enable_csidinval_wd;
-  logic error_enable_csidinval_we;
+  logic error_status_we;
   logic error_status_cmdbusy_qs;
   logic error_status_cmdbusy_wd;
-  logic error_status_cmdbusy_we;
   logic error_status_overflow_qs;
   logic error_status_overflow_wd;
-  logic error_status_overflow_we;
   logic error_status_underflow_qs;
   logic error_status_underflow_wd;
-  logic error_status_underflow_we;
   logic error_status_cmdinval_qs;
   logic error_status_cmdinval_wd;
-  logic error_status_cmdinval_we;
   logic error_status_csidinval_qs;
   logic error_status_csidinval_wd;
-  logic error_status_csidinval_we;
+  logic event_enable_we;
   logic event_enable_rxfull_qs;
   logic event_enable_rxfull_wd;
-  logic event_enable_rxfull_we;
   logic event_enable_txempty_qs;
   logic event_enable_txempty_wd;
-  logic event_enable_txempty_we;
   logic event_enable_rxwm_qs;
   logic event_enable_rxwm_wd;
-  logic event_enable_rxwm_we;
   logic event_enable_txwm_qs;
   logic event_enable_txwm_wd;
-  logic event_enable_txwm_we;
   logic event_enable_ready_qs;
   logic event_enable_ready_wd;
-  logic event_enable_ready_we;
   logic event_enable_idle_qs;
   logic event_enable_idle_wd;
-  logic event_enable_idle_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -296,7 +267,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_error_we),
+    .we     (intr_state_we),
     .wd     (intr_state_error_wd),
 
     // from internal hardware
@@ -322,7 +293,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_spi_event_we),
+    .we     (intr_state_we),
     .wd     (intr_state_spi_event_wd),
 
     // from internal hardware
@@ -350,7 +321,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_error_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_error_wd),
 
     // from internal hardware
@@ -376,7 +347,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_spi_event_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_spi_event_wd),
 
     // from internal hardware
@@ -399,7 +370,7 @@ module spi_host_reg_top (
     .DW    (1)
   ) u_intr_test_error (
     .re     (1'b0),
-    .we     (intr_test_error_we),
+    .we     (intr_test_we),
     .wd     (intr_test_error_wd),
     .d      ('0),
     .qre    (),
@@ -414,7 +385,7 @@ module spi_host_reg_top (
     .DW    (1)
   ) u_intr_test_spi_event (
     .re     (1'b0),
-    .we     (intr_test_spi_event_we),
+    .we     (intr_test_we),
     .wd     (intr_test_spi_event_wd),
     .d      ('0),
     .qre    (),
@@ -452,7 +423,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_rx_watermark_we),
+    .we     (control_we),
     .wd     (control_rx_watermark_wd),
 
     // from internal hardware
@@ -478,7 +449,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_tx_watermark_we),
+    .we     (control_we),
     .wd     (control_tx_watermark_wd),
 
     // from internal hardware
@@ -504,7 +475,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_passthru_we),
+    .we     (control_we),
     .wd     (control_passthru_wd),
 
     // from internal hardware
@@ -530,7 +501,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_sw_rst_we),
+    .we     (control_we),
     .wd     (control_sw_rst_wd),
 
     // from internal hardware
@@ -556,7 +527,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_spien_we),
+    .we     (control_we),
     .wd     (control_spien_wd),
 
     // from internal hardware
@@ -926,7 +897,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_clkdiv_0_we),
+    .we     (configopts_we),
     .wd     (configopts_clkdiv_0_wd),
 
     // from internal hardware
@@ -952,7 +923,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_csnidle_0_we),
+    .we     (configopts_we),
     .wd     (configopts_csnidle_0_wd),
 
     // from internal hardware
@@ -978,7 +949,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_csntrail_0_we),
+    .we     (configopts_we),
     .wd     (configopts_csntrail_0_wd),
 
     // from internal hardware
@@ -1004,7 +975,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_csnlead_0_we),
+    .we     (configopts_we),
     .wd     (configopts_csnlead_0_wd),
 
     // from internal hardware
@@ -1030,7 +1001,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_fullcyc_0_we),
+    .we     (configopts_we),
     .wd     (configopts_fullcyc_0_wd),
 
     // from internal hardware
@@ -1056,7 +1027,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_cpha_0_we),
+    .we     (configopts_we),
     .wd     (configopts_cpha_0_wd),
 
     // from internal hardware
@@ -1082,7 +1053,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configopts_cpol_0_we),
+    .we     (configopts_we),
     .wd     (configopts_cpol_0_wd),
 
     // from internal hardware
@@ -1138,7 +1109,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (command_len_we),
+    .we     (command_we),
     .wd     (command_len_wd),
 
     // from internal hardware
@@ -1164,7 +1135,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (command_csaat_we),
+    .we     (command_we),
     .wd     (command_csaat_wd),
 
     // from internal hardware
@@ -1190,7 +1161,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (command_speed_we),
+    .we     (command_we),
     .wd     (command_speed_wd),
 
     // from internal hardware
@@ -1216,7 +1187,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (command_direction_we),
+    .we     (command_we),
     .wd     (command_direction_wd),
 
     // from internal hardware
@@ -1244,7 +1215,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_enable_cmdbusy_we),
+    .we     (error_enable_we),
     .wd     (error_enable_cmdbusy_wd),
 
     // from internal hardware
@@ -1270,7 +1241,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_enable_overflow_we),
+    .we     (error_enable_we),
     .wd     (error_enable_overflow_wd),
 
     // from internal hardware
@@ -1296,7 +1267,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_enable_underflow_we),
+    .we     (error_enable_we),
     .wd     (error_enable_underflow_wd),
 
     // from internal hardware
@@ -1322,7 +1293,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_enable_cmdinval_we),
+    .we     (error_enable_we),
     .wd     (error_enable_cmdinval_wd),
 
     // from internal hardware
@@ -1348,7 +1319,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_enable_csidinval_we),
+    .we     (error_enable_we),
     .wd     (error_enable_csidinval_wd),
 
     // from internal hardware
@@ -1376,7 +1347,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_status_cmdbusy_we),
+    .we     (error_status_we),
     .wd     (error_status_cmdbusy_wd),
 
     // from internal hardware
@@ -1402,7 +1373,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_status_overflow_we),
+    .we     (error_status_we),
     .wd     (error_status_overflow_wd),
 
     // from internal hardware
@@ -1428,7 +1399,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_status_underflow_we),
+    .we     (error_status_we),
     .wd     (error_status_underflow_wd),
 
     // from internal hardware
@@ -1454,7 +1425,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_status_cmdinval_we),
+    .we     (error_status_we),
     .wd     (error_status_cmdinval_wd),
 
     // from internal hardware
@@ -1480,7 +1451,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (error_status_csidinval_we),
+    .we     (error_status_we),
     .wd     (error_status_csidinval_wd),
 
     // from internal hardware
@@ -1508,7 +1479,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (event_enable_rxfull_we),
+    .we     (event_enable_we),
     .wd     (event_enable_rxfull_wd),
 
     // from internal hardware
@@ -1534,7 +1505,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (event_enable_txempty_we),
+    .we     (event_enable_we),
     .wd     (event_enable_txempty_wd),
 
     // from internal hardware
@@ -1560,7 +1531,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (event_enable_rxwm_we),
+    .we     (event_enable_we),
     .wd     (event_enable_rxwm_wd),
 
     // from internal hardware
@@ -1586,7 +1557,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (event_enable_txwm_we),
+    .we     (event_enable_we),
     .wd     (event_enable_txwm_wd),
 
     // from internal hardware
@@ -1612,7 +1583,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (event_enable_ready_we),
+    .we     (event_enable_we),
     .wd     (event_enable_ready_wd),
 
     // from internal hardware
@@ -1638,7 +1609,7 @@ module spi_host_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (event_enable_idle_we),
+    .we     (event_enable_we),
     .wd     (event_enable_idle_wd),
 
     // from internal hardware
@@ -1691,125 +1662,96 @@ module spi_host_reg_top (
                (addr_hit[10] & (|(SPI_HOST_PERMIT[10] & ~reg_be))) |
                (addr_hit[11] & (|(SPI_HOST_PERMIT[11] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_error_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_error_wd = reg_wdata[0];
 
-  assign intr_state_spi_event_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_spi_event_wd = reg_wdata[1];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_error_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_error_wd = reg_wdata[0];
 
-  assign intr_enable_spi_event_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_spi_event_wd = reg_wdata[1];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_error_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_error_wd = reg_wdata[0];
 
-  assign intr_test_spi_event_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_spi_event_wd = reg_wdata[1];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
-  assign alert_test_wd = reg_wdata[0];
 
-  assign control_rx_watermark_we = addr_hit[4] & reg_we & !reg_error;
+  assign alert_test_wd = reg_wdata[0];
+  assign control_we = addr_hit[4] & reg_we & !reg_error;
+
   assign control_rx_watermark_wd = reg_wdata[7:0];
 
-  assign control_tx_watermark_we = addr_hit[4] & reg_we & !reg_error;
   assign control_tx_watermark_wd = reg_wdata[15:8];
 
-  assign control_passthru_we = addr_hit[4] & reg_we & !reg_error;
   assign control_passthru_wd = reg_wdata[29];
 
-  assign control_sw_rst_we = addr_hit[4] & reg_we & !reg_error;
   assign control_sw_rst_wd = reg_wdata[30];
 
-  assign control_spien_we = addr_hit[4] & reg_we & !reg_error;
   assign control_spien_wd = reg_wdata[31];
+  assign configopts_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign configopts_clkdiv_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_clkdiv_0_wd = reg_wdata[15:0];
 
-  assign configopts_csnidle_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_csnidle_0_wd = reg_wdata[19:16];
 
-  assign configopts_csntrail_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_csntrail_0_wd = reg_wdata[23:20];
 
-  assign configopts_csnlead_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_csnlead_0_wd = reg_wdata[27:24];
 
-  assign configopts_fullcyc_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_fullcyc_0_wd = reg_wdata[29];
 
-  assign configopts_cpha_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_cpha_0_wd = reg_wdata[30];
 
-  assign configopts_cpol_0_we = addr_hit[6] & reg_we & !reg_error;
   assign configopts_cpol_0_wd = reg_wdata[31];
-
   assign csid_we = addr_hit[7] & reg_we & !reg_error;
-  assign csid_wd = reg_wdata[31:0];
 
-  assign command_len_we = addr_hit[8] & reg_we & !reg_error;
+  assign csid_wd = reg_wdata[31:0];
+  assign command_we = addr_hit[8] & reg_we & !reg_error;
+
   assign command_len_wd = reg_wdata[8:0];
 
-  assign command_csaat_we = addr_hit[8] & reg_we & !reg_error;
   assign command_csaat_wd = reg_wdata[9];
 
-  assign command_speed_we = addr_hit[8] & reg_we & !reg_error;
   assign command_speed_wd = reg_wdata[11:10];
 
-  assign command_direction_we = addr_hit[8] & reg_we & !reg_error;
   assign command_direction_wd = reg_wdata[13:12];
+  assign error_enable_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign error_enable_cmdbusy_we = addr_hit[9] & reg_we & !reg_error;
   assign error_enable_cmdbusy_wd = reg_wdata[0];
 
-  assign error_enable_overflow_we = addr_hit[9] & reg_we & !reg_error;
   assign error_enable_overflow_wd = reg_wdata[1];
 
-  assign error_enable_underflow_we = addr_hit[9] & reg_we & !reg_error;
   assign error_enable_underflow_wd = reg_wdata[2];
 
-  assign error_enable_cmdinval_we = addr_hit[9] & reg_we & !reg_error;
   assign error_enable_cmdinval_wd = reg_wdata[3];
 
-  assign error_enable_csidinval_we = addr_hit[9] & reg_we & !reg_error;
   assign error_enable_csidinval_wd = reg_wdata[4];
+  assign error_status_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign error_status_cmdbusy_we = addr_hit[10] & reg_we & !reg_error;
   assign error_status_cmdbusy_wd = reg_wdata[0];
 
-  assign error_status_overflow_we = addr_hit[10] & reg_we & !reg_error;
   assign error_status_overflow_wd = reg_wdata[1];
 
-  assign error_status_underflow_we = addr_hit[10] & reg_we & !reg_error;
   assign error_status_underflow_wd = reg_wdata[2];
 
-  assign error_status_cmdinval_we = addr_hit[10] & reg_we & !reg_error;
   assign error_status_cmdinval_wd = reg_wdata[3];
 
-  assign error_status_csidinval_we = addr_hit[10] & reg_we & !reg_error;
   assign error_status_csidinval_wd = reg_wdata[4];
+  assign event_enable_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign event_enable_rxfull_we = addr_hit[11] & reg_we & !reg_error;
   assign event_enable_rxfull_wd = reg_wdata[0];
 
-  assign event_enable_txempty_we = addr_hit[11] & reg_we & !reg_error;
   assign event_enable_txempty_wd = reg_wdata[1];
 
-  assign event_enable_rxwm_we = addr_hit[11] & reg_we & !reg_error;
   assign event_enable_rxwm_wd = reg_wdata[2];
 
-  assign event_enable_txwm_we = addr_hit[11] & reg_we & !reg_error;
   assign event_enable_txwm_wd = reg_wdata[3];
 
-  assign event_enable_ready_we = addr_hit[11] & reg_we & !reg_error;
   assign event_enable_ready_wd = reg_wdata[4];
 
-  assign event_enable_idle_we = addr_hit[11] & reg_we & !reg_error;
   assign event_enable_idle_wd = reg_wdata[5];
 
   // Read data return

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_reg_top.sv
@@ -104,35 +104,29 @@ module sram_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic alert_test_we;
   logic alert_test_fatal_intg_error_wd;
-  logic alert_test_fatal_intg_error_we;
   logic alert_test_fatal_parity_error_wd;
-  logic alert_test_fatal_parity_error_we;
+  logic status_re;
   logic status_error_qs;
-  logic status_error_re;
   logic status_escalated_qs;
-  logic status_escalated_re;
   logic status_scr_key_valid_qs;
-  logic status_scr_key_valid_re;
   logic status_scr_key_seed_valid_qs;
-  logic status_scr_key_seed_valid_re;
+  logic exec_regwen_we;
   logic exec_regwen_qs;
   logic exec_regwen_wd;
-  logic exec_regwen_we;
+  logic exec_we;
   logic [2:0] exec_qs;
   logic [2:0] exec_wd;
-  logic exec_we;
+  logic ctrl_regwen_we;
   logic ctrl_regwen_qs;
   logic ctrl_regwen_wd;
-  logic ctrl_regwen_we;
+  logic ctrl_re;
+  logic ctrl_we;
   logic ctrl_renew_scr_key_qs;
   logic ctrl_renew_scr_key_wd;
-  logic ctrl_renew_scr_key_we;
-  logic ctrl_renew_scr_key_re;
   logic ctrl_init_qs;
   logic ctrl_init_wd;
-  logic ctrl_init_we;
-  logic ctrl_init_re;
   logic [31:0] error_address_qs;
 
   // Register instances
@@ -143,7 +137,7 @@ module sram_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_intg_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_intg_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_intg_error_wd),
     .d      ('0),
     .qre    (),
@@ -158,7 +152,7 @@ module sram_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_parity_error (
     .re     (1'b0),
-    .we     (alert_test_fatal_parity_error_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_parity_error_wd),
     .d      ('0),
     .qre    (),
@@ -174,7 +168,7 @@ module sram_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_error (
-    .re     (status_error_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.error.d),
@@ -189,7 +183,7 @@ module sram_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_escalated (
-    .re     (status_escalated_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.escalated.d),
@@ -204,7 +198,7 @@ module sram_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_scr_key_valid (
-    .re     (status_scr_key_valid_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.scr_key_valid.d),
@@ -219,7 +213,7 @@ module sram_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_scr_key_seed_valid (
-    .re     (status_scr_key_seed_valid_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.scr_key_seed_valid.d),
@@ -317,8 +311,8 @@ module sram_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_renew_scr_key (
-    .re     (ctrl_renew_scr_key_re),
-    .we     (ctrl_renew_scr_key_we & ctrl_regwen_qs),
+    .re     (ctrl_re),
+    .we     (ctrl_we & ctrl_regwen_qs),
     .wd     (ctrl_renew_scr_key_wd),
     .d      (hw2reg.ctrl.renew_scr_key.d),
     .qre    (),
@@ -332,8 +326,8 @@ module sram_ctrl_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_init (
-    .re     (ctrl_init_re),
-    .we     (ctrl_init_we & ctrl_regwen_qs),
+    .re     (ctrl_re),
+    .we     (ctrl_we & ctrl_regwen_qs),
     .wd     (ctrl_init_wd),
     .d      (hw2reg.ctrl.init.d),
     .qre    (),
@@ -397,37 +391,27 @@ module sram_ctrl_reg_top (
                (addr_hit[5] & (|(SRAM_CTRL_PERMIT[5] & ~reg_be))) |
                (addr_hit[6] & (|(SRAM_CTRL_PERMIT[6] & ~reg_be)))));
   end
+  assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_fatal_intg_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_intg_error_wd = reg_wdata[0];
 
-  assign alert_test_fatal_parity_error_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_fatal_parity_error_wd = reg_wdata[1];
-
-  assign status_error_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_escalated_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_scr_key_valid_re = addr_hit[1] & reg_re & !reg_error;
-
-  assign status_scr_key_seed_valid_re = addr_hit[1] & reg_re & !reg_error;
-
+  assign status_re = addr_hit[1] & reg_re & !reg_error;
   assign exec_regwen_we = addr_hit[2] & reg_we & !reg_error;
+
   assign exec_regwen_wd = reg_wdata[0];
-
   assign exec_we = addr_hit[3] & reg_we & !reg_error;
+
   assign exec_wd = reg_wdata[2:0];
-
   assign ctrl_regwen_we = addr_hit[4] & reg_we & !reg_error;
+
   assign ctrl_regwen_wd = reg_wdata[0];
+  assign ctrl_re = addr_hit[5] & reg_re & !reg_error;
+  assign ctrl_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign ctrl_renew_scr_key_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_renew_scr_key_wd = reg_wdata[0];
-  assign ctrl_renew_scr_key_re = addr_hit[5] & reg_re & !reg_error;
 
-  assign ctrl_init_we = addr_hit[5] & reg_we & !reg_error;
   assign ctrl_init_wd = reg_wdata[1];
-  assign ctrl_init_re = addr_hit[5] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -104,160 +104,124 @@ module sysrst_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_qs;
   logic intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
-  logic intr_enable_we;
-  logic intr_test_wd;
   logic intr_test_we;
-  logic alert_test_wd;
+  logic intr_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic regwen_we;
   logic regwen_qs;
   logic regwen_wd;
-  logic regwen_we;
+  logic ec_rst_ctl_we;
   logic [15:0] ec_rst_ctl_qs;
   logic [15:0] ec_rst_ctl_wd;
-  logic ec_rst_ctl_we;
+  logic ulp_ac_debounce_ctl_we;
   logic [15:0] ulp_ac_debounce_ctl_qs;
   logic [15:0] ulp_ac_debounce_ctl_wd;
-  logic ulp_ac_debounce_ctl_we;
+  logic ulp_lid_debounce_ctl_we;
   logic [15:0] ulp_lid_debounce_ctl_qs;
   logic [15:0] ulp_lid_debounce_ctl_wd;
-  logic ulp_lid_debounce_ctl_we;
+  logic ulp_pwrb_debounce_ctl_we;
   logic [15:0] ulp_pwrb_debounce_ctl_qs;
   logic [15:0] ulp_pwrb_debounce_ctl_wd;
-  logic ulp_pwrb_debounce_ctl_we;
+  logic ulp_ctl_we;
   logic ulp_ctl_qs;
   logic ulp_ctl_wd;
-  logic ulp_ctl_we;
+  logic ulp_status_we;
   logic ulp_status_qs;
   logic ulp_status_wd;
-  logic ulp_status_we;
+  logic wk_status_we;
   logic wk_status_qs;
   logic wk_status_wd;
-  logic wk_status_we;
+  logic key_invert_ctl_we;
   logic key_invert_ctl_key0_in_qs;
   logic key_invert_ctl_key0_in_wd;
-  logic key_invert_ctl_key0_in_we;
   logic key_invert_ctl_key0_out_qs;
   logic key_invert_ctl_key0_out_wd;
-  logic key_invert_ctl_key0_out_we;
   logic key_invert_ctl_key1_in_qs;
   logic key_invert_ctl_key1_in_wd;
-  logic key_invert_ctl_key1_in_we;
   logic key_invert_ctl_key1_out_qs;
   logic key_invert_ctl_key1_out_wd;
-  logic key_invert_ctl_key1_out_we;
   logic key_invert_ctl_key2_in_qs;
   logic key_invert_ctl_key2_in_wd;
-  logic key_invert_ctl_key2_in_we;
   logic key_invert_ctl_key2_out_qs;
   logic key_invert_ctl_key2_out_wd;
-  logic key_invert_ctl_key2_out_we;
   logic key_invert_ctl_pwrb_in_qs;
   logic key_invert_ctl_pwrb_in_wd;
-  logic key_invert_ctl_pwrb_in_we;
   logic key_invert_ctl_pwrb_out_qs;
   logic key_invert_ctl_pwrb_out_wd;
-  logic key_invert_ctl_pwrb_out_we;
   logic key_invert_ctl_ac_present_qs;
   logic key_invert_ctl_ac_present_wd;
-  logic key_invert_ctl_ac_present_we;
   logic key_invert_ctl_bat_disable_qs;
   logic key_invert_ctl_bat_disable_wd;
-  logic key_invert_ctl_bat_disable_we;
   logic key_invert_ctl_lid_open_qs;
   logic key_invert_ctl_lid_open_wd;
-  logic key_invert_ctl_lid_open_we;
   logic key_invert_ctl_z3_wakeup_qs;
   logic key_invert_ctl_z3_wakeup_wd;
-  logic key_invert_ctl_z3_wakeup_we;
+  logic pin_allowed_ctl_we;
   logic pin_allowed_ctl_bat_disable_0_qs;
   logic pin_allowed_ctl_bat_disable_0_wd;
-  logic pin_allowed_ctl_bat_disable_0_we;
   logic pin_allowed_ctl_ec_rst_l_0_qs;
   logic pin_allowed_ctl_ec_rst_l_0_wd;
-  logic pin_allowed_ctl_ec_rst_l_0_we;
   logic pin_allowed_ctl_pwrb_out_0_qs;
   logic pin_allowed_ctl_pwrb_out_0_wd;
-  logic pin_allowed_ctl_pwrb_out_0_we;
   logic pin_allowed_ctl_key0_out_0_qs;
   logic pin_allowed_ctl_key0_out_0_wd;
-  logic pin_allowed_ctl_key0_out_0_we;
   logic pin_allowed_ctl_key1_out_0_qs;
   logic pin_allowed_ctl_key1_out_0_wd;
-  logic pin_allowed_ctl_key1_out_0_we;
   logic pin_allowed_ctl_key2_out_0_qs;
   logic pin_allowed_ctl_key2_out_0_wd;
-  logic pin_allowed_ctl_key2_out_0_we;
   logic pin_allowed_ctl_z3_wakeup_0_qs;
   logic pin_allowed_ctl_z3_wakeup_0_wd;
-  logic pin_allowed_ctl_z3_wakeup_0_we;
   logic pin_allowed_ctl_bat_disable_1_qs;
   logic pin_allowed_ctl_bat_disable_1_wd;
-  logic pin_allowed_ctl_bat_disable_1_we;
   logic pin_allowed_ctl_ec_rst_l_1_qs;
   logic pin_allowed_ctl_ec_rst_l_1_wd;
-  logic pin_allowed_ctl_ec_rst_l_1_we;
   logic pin_allowed_ctl_pwrb_out_1_qs;
   logic pin_allowed_ctl_pwrb_out_1_wd;
-  logic pin_allowed_ctl_pwrb_out_1_we;
   logic pin_allowed_ctl_key0_out_1_qs;
   logic pin_allowed_ctl_key0_out_1_wd;
-  logic pin_allowed_ctl_key0_out_1_we;
   logic pin_allowed_ctl_key1_out_1_qs;
   logic pin_allowed_ctl_key1_out_1_wd;
-  logic pin_allowed_ctl_key1_out_1_we;
   logic pin_allowed_ctl_key2_out_1_qs;
   logic pin_allowed_ctl_key2_out_1_wd;
-  logic pin_allowed_ctl_key2_out_1_we;
   logic pin_allowed_ctl_z3_wakeup_1_qs;
   logic pin_allowed_ctl_z3_wakeup_1_wd;
-  logic pin_allowed_ctl_z3_wakeup_1_we;
+  logic pin_out_ctl_we;
   logic pin_out_ctl_bat_disable_qs;
   logic pin_out_ctl_bat_disable_wd;
-  logic pin_out_ctl_bat_disable_we;
   logic pin_out_ctl_ec_rst_l_qs;
   logic pin_out_ctl_ec_rst_l_wd;
-  logic pin_out_ctl_ec_rst_l_we;
   logic pin_out_ctl_pwrb_out_qs;
   logic pin_out_ctl_pwrb_out_wd;
-  logic pin_out_ctl_pwrb_out_we;
   logic pin_out_ctl_key0_out_qs;
   logic pin_out_ctl_key0_out_wd;
-  logic pin_out_ctl_key0_out_we;
   logic pin_out_ctl_key1_out_qs;
   logic pin_out_ctl_key1_out_wd;
-  logic pin_out_ctl_key1_out_we;
   logic pin_out_ctl_key2_out_qs;
   logic pin_out_ctl_key2_out_wd;
-  logic pin_out_ctl_key2_out_we;
   logic pin_out_ctl_z3_wakeup_qs;
   logic pin_out_ctl_z3_wakeup_wd;
-  logic pin_out_ctl_z3_wakeup_we;
+  logic pin_out_value_we;
   logic pin_out_value_bat_disable_qs;
   logic pin_out_value_bat_disable_wd;
-  logic pin_out_value_bat_disable_we;
   logic pin_out_value_ec_rst_l_qs;
   logic pin_out_value_ec_rst_l_wd;
-  logic pin_out_value_ec_rst_l_we;
   logic pin_out_value_pwrb_out_qs;
   logic pin_out_value_pwrb_out_wd;
-  logic pin_out_value_pwrb_out_we;
   logic pin_out_value_key0_out_qs;
   logic pin_out_value_key0_out_wd;
-  logic pin_out_value_key0_out_we;
   logic pin_out_value_key1_out_qs;
   logic pin_out_value_key1_out_wd;
-  logic pin_out_value_key1_out_we;
   logic pin_out_value_key2_out_qs;
   logic pin_out_value_key2_out_wd;
-  logic pin_out_value_key2_out_we;
   logic pin_out_value_z3_wakeup_qs;
   logic pin_out_value_z3_wakeup_wd;
-  logic pin_out_value_z3_wakeup_we;
   logic pin_in_value_ac_present_qs;
   logic pin_in_value_ec_rst_l_qs;
   logic pin_in_value_pwrb_in_qs;
@@ -265,237 +229,178 @@ module sysrst_ctrl_reg_top (
   logic pin_in_value_key1_in_qs;
   logic pin_in_value_key2_in_qs;
   logic pin_in_value_lid_open_qs;
+  logic key_intr_ctl_we;
   logic key_intr_ctl_pwrb_in_h2l_qs;
   logic key_intr_ctl_pwrb_in_h2l_wd;
-  logic key_intr_ctl_pwrb_in_h2l_we;
   logic key_intr_ctl_key0_in_h2l_qs;
   logic key_intr_ctl_key0_in_h2l_wd;
-  logic key_intr_ctl_key0_in_h2l_we;
   logic key_intr_ctl_key1_in_h2l_qs;
   logic key_intr_ctl_key1_in_h2l_wd;
-  logic key_intr_ctl_key1_in_h2l_we;
   logic key_intr_ctl_key2_in_h2l_qs;
   logic key_intr_ctl_key2_in_h2l_wd;
-  logic key_intr_ctl_key2_in_h2l_we;
   logic key_intr_ctl_ac_present_h2l_qs;
   logic key_intr_ctl_ac_present_h2l_wd;
-  logic key_intr_ctl_ac_present_h2l_we;
   logic key_intr_ctl_ec_rst_l_h2l_qs;
   logic key_intr_ctl_ec_rst_l_h2l_wd;
-  logic key_intr_ctl_ec_rst_l_h2l_we;
   logic key_intr_ctl_pwrb_in_l2h_qs;
   logic key_intr_ctl_pwrb_in_l2h_wd;
-  logic key_intr_ctl_pwrb_in_l2h_we;
   logic key_intr_ctl_key0_in_l2h_qs;
   logic key_intr_ctl_key0_in_l2h_wd;
-  logic key_intr_ctl_key0_in_l2h_we;
   logic key_intr_ctl_key1_in_l2h_qs;
   logic key_intr_ctl_key1_in_l2h_wd;
-  logic key_intr_ctl_key1_in_l2h_we;
   logic key_intr_ctl_key2_in_l2h_qs;
   logic key_intr_ctl_key2_in_l2h_wd;
-  logic key_intr_ctl_key2_in_l2h_we;
   logic key_intr_ctl_ac_present_l2h_qs;
   logic key_intr_ctl_ac_present_l2h_wd;
-  logic key_intr_ctl_ac_present_l2h_we;
   logic key_intr_ctl_ec_rst_l_l2h_qs;
   logic key_intr_ctl_ec_rst_l_l2h_wd;
-  logic key_intr_ctl_ec_rst_l_l2h_we;
+  logic key_intr_debounce_ctl_we;
   logic [15:0] key_intr_debounce_ctl_qs;
   logic [15:0] key_intr_debounce_ctl_wd;
-  logic key_intr_debounce_ctl_we;
+  logic auto_block_debounce_ctl_we;
   logic [15:0] auto_block_debounce_ctl_debounce_timer_qs;
   logic [15:0] auto_block_debounce_ctl_debounce_timer_wd;
-  logic auto_block_debounce_ctl_debounce_timer_we;
   logic auto_block_debounce_ctl_auto_block_enable_qs;
   logic auto_block_debounce_ctl_auto_block_enable_wd;
-  logic auto_block_debounce_ctl_auto_block_enable_we;
+  logic auto_block_out_ctl_we;
   logic auto_block_out_ctl_key0_out_sel_qs;
   logic auto_block_out_ctl_key0_out_sel_wd;
-  logic auto_block_out_ctl_key0_out_sel_we;
   logic auto_block_out_ctl_key1_out_sel_qs;
   logic auto_block_out_ctl_key1_out_sel_wd;
-  logic auto_block_out_ctl_key1_out_sel_we;
   logic auto_block_out_ctl_key2_out_sel_qs;
   logic auto_block_out_ctl_key2_out_sel_wd;
-  logic auto_block_out_ctl_key2_out_sel_we;
   logic auto_block_out_ctl_key0_out_value_qs;
   logic auto_block_out_ctl_key0_out_value_wd;
-  logic auto_block_out_ctl_key0_out_value_we;
   logic auto_block_out_ctl_key1_out_value_qs;
   logic auto_block_out_ctl_key1_out_value_wd;
-  logic auto_block_out_ctl_key1_out_value_we;
   logic auto_block_out_ctl_key2_out_value_qs;
   logic auto_block_out_ctl_key2_out_value_wd;
-  logic auto_block_out_ctl_key2_out_value_we;
+  logic com_sel_ctl_0_we;
   logic com_sel_ctl_0_key0_in_sel_0_qs;
   logic com_sel_ctl_0_key0_in_sel_0_wd;
-  logic com_sel_ctl_0_key0_in_sel_0_we;
   logic com_sel_ctl_0_key1_in_sel_0_qs;
   logic com_sel_ctl_0_key1_in_sel_0_wd;
-  logic com_sel_ctl_0_key1_in_sel_0_we;
   logic com_sel_ctl_0_key2_in_sel_0_qs;
   logic com_sel_ctl_0_key2_in_sel_0_wd;
-  logic com_sel_ctl_0_key2_in_sel_0_we;
   logic com_sel_ctl_0_pwrb_in_sel_0_qs;
   logic com_sel_ctl_0_pwrb_in_sel_0_wd;
-  logic com_sel_ctl_0_pwrb_in_sel_0_we;
   logic com_sel_ctl_0_ac_present_sel_0_qs;
   logic com_sel_ctl_0_ac_present_sel_0_wd;
-  logic com_sel_ctl_0_ac_present_sel_0_we;
+  logic com_sel_ctl_1_we;
   logic com_sel_ctl_1_key0_in_sel_1_qs;
   logic com_sel_ctl_1_key0_in_sel_1_wd;
-  logic com_sel_ctl_1_key0_in_sel_1_we;
   logic com_sel_ctl_1_key1_in_sel_1_qs;
   logic com_sel_ctl_1_key1_in_sel_1_wd;
-  logic com_sel_ctl_1_key1_in_sel_1_we;
   logic com_sel_ctl_1_key2_in_sel_1_qs;
   logic com_sel_ctl_1_key2_in_sel_1_wd;
-  logic com_sel_ctl_1_key2_in_sel_1_we;
   logic com_sel_ctl_1_pwrb_in_sel_1_qs;
   logic com_sel_ctl_1_pwrb_in_sel_1_wd;
-  logic com_sel_ctl_1_pwrb_in_sel_1_we;
   logic com_sel_ctl_1_ac_present_sel_1_qs;
   logic com_sel_ctl_1_ac_present_sel_1_wd;
-  logic com_sel_ctl_1_ac_present_sel_1_we;
+  logic com_sel_ctl_2_we;
   logic com_sel_ctl_2_key0_in_sel_2_qs;
   logic com_sel_ctl_2_key0_in_sel_2_wd;
-  logic com_sel_ctl_2_key0_in_sel_2_we;
   logic com_sel_ctl_2_key1_in_sel_2_qs;
   logic com_sel_ctl_2_key1_in_sel_2_wd;
-  logic com_sel_ctl_2_key1_in_sel_2_we;
   logic com_sel_ctl_2_key2_in_sel_2_qs;
   logic com_sel_ctl_2_key2_in_sel_2_wd;
-  logic com_sel_ctl_2_key2_in_sel_2_we;
   logic com_sel_ctl_2_pwrb_in_sel_2_qs;
   logic com_sel_ctl_2_pwrb_in_sel_2_wd;
-  logic com_sel_ctl_2_pwrb_in_sel_2_we;
   logic com_sel_ctl_2_ac_present_sel_2_qs;
   logic com_sel_ctl_2_ac_present_sel_2_wd;
-  logic com_sel_ctl_2_ac_present_sel_2_we;
+  logic com_sel_ctl_3_we;
   logic com_sel_ctl_3_key0_in_sel_3_qs;
   logic com_sel_ctl_3_key0_in_sel_3_wd;
-  logic com_sel_ctl_3_key0_in_sel_3_we;
   logic com_sel_ctl_3_key1_in_sel_3_qs;
   logic com_sel_ctl_3_key1_in_sel_3_wd;
-  logic com_sel_ctl_3_key1_in_sel_3_we;
   logic com_sel_ctl_3_key2_in_sel_3_qs;
   logic com_sel_ctl_3_key2_in_sel_3_wd;
-  logic com_sel_ctl_3_key2_in_sel_3_we;
   logic com_sel_ctl_3_pwrb_in_sel_3_qs;
   logic com_sel_ctl_3_pwrb_in_sel_3_wd;
-  logic com_sel_ctl_3_pwrb_in_sel_3_we;
   logic com_sel_ctl_3_ac_present_sel_3_qs;
   logic com_sel_ctl_3_ac_present_sel_3_wd;
-  logic com_sel_ctl_3_ac_present_sel_3_we;
+  logic com_det_ctl_0_we;
   logic [31:0] com_det_ctl_0_qs;
   logic [31:0] com_det_ctl_0_wd;
-  logic com_det_ctl_0_we;
+  logic com_det_ctl_1_we;
   logic [31:0] com_det_ctl_1_qs;
   logic [31:0] com_det_ctl_1_wd;
-  logic com_det_ctl_1_we;
+  logic com_det_ctl_2_we;
   logic [31:0] com_det_ctl_2_qs;
   logic [31:0] com_det_ctl_2_wd;
-  logic com_det_ctl_2_we;
+  logic com_det_ctl_3_we;
   logic [31:0] com_det_ctl_3_qs;
   logic [31:0] com_det_ctl_3_wd;
-  logic com_det_ctl_3_we;
+  logic com_out_ctl_0_we;
   logic com_out_ctl_0_bat_disable_0_qs;
   logic com_out_ctl_0_bat_disable_0_wd;
-  logic com_out_ctl_0_bat_disable_0_we;
   logic com_out_ctl_0_interrupt_0_qs;
   logic com_out_ctl_0_interrupt_0_wd;
-  logic com_out_ctl_0_interrupt_0_we;
   logic com_out_ctl_0_ec_rst_0_qs;
   logic com_out_ctl_0_ec_rst_0_wd;
-  logic com_out_ctl_0_ec_rst_0_we;
   logic com_out_ctl_0_gsc_rst_0_qs;
   logic com_out_ctl_0_gsc_rst_0_wd;
-  logic com_out_ctl_0_gsc_rst_0_we;
+  logic com_out_ctl_1_we;
   logic com_out_ctl_1_bat_disable_1_qs;
   logic com_out_ctl_1_bat_disable_1_wd;
-  logic com_out_ctl_1_bat_disable_1_we;
   logic com_out_ctl_1_interrupt_1_qs;
   logic com_out_ctl_1_interrupt_1_wd;
-  logic com_out_ctl_1_interrupt_1_we;
   logic com_out_ctl_1_ec_rst_1_qs;
   logic com_out_ctl_1_ec_rst_1_wd;
-  logic com_out_ctl_1_ec_rst_1_we;
   logic com_out_ctl_1_gsc_rst_1_qs;
   logic com_out_ctl_1_gsc_rst_1_wd;
-  logic com_out_ctl_1_gsc_rst_1_we;
+  logic com_out_ctl_2_we;
   logic com_out_ctl_2_bat_disable_2_qs;
   logic com_out_ctl_2_bat_disable_2_wd;
-  logic com_out_ctl_2_bat_disable_2_we;
   logic com_out_ctl_2_interrupt_2_qs;
   logic com_out_ctl_2_interrupt_2_wd;
-  logic com_out_ctl_2_interrupt_2_we;
   logic com_out_ctl_2_ec_rst_2_qs;
   logic com_out_ctl_2_ec_rst_2_wd;
-  logic com_out_ctl_2_ec_rst_2_we;
   logic com_out_ctl_2_gsc_rst_2_qs;
   logic com_out_ctl_2_gsc_rst_2_wd;
-  logic com_out_ctl_2_gsc_rst_2_we;
+  logic com_out_ctl_3_we;
   logic com_out_ctl_3_bat_disable_3_qs;
   logic com_out_ctl_3_bat_disable_3_wd;
-  logic com_out_ctl_3_bat_disable_3_we;
   logic com_out_ctl_3_interrupt_3_qs;
   logic com_out_ctl_3_interrupt_3_wd;
-  logic com_out_ctl_3_interrupt_3_we;
   logic com_out_ctl_3_ec_rst_3_qs;
   logic com_out_ctl_3_ec_rst_3_wd;
-  logic com_out_ctl_3_ec_rst_3_we;
   logic com_out_ctl_3_gsc_rst_3_qs;
   logic com_out_ctl_3_gsc_rst_3_wd;
-  logic com_out_ctl_3_gsc_rst_3_we;
+  logic combo_intr_status_we;
   logic combo_intr_status_combo0_h2l_qs;
   logic combo_intr_status_combo0_h2l_wd;
-  logic combo_intr_status_combo0_h2l_we;
   logic combo_intr_status_combo1_h2l_qs;
   logic combo_intr_status_combo1_h2l_wd;
-  logic combo_intr_status_combo1_h2l_we;
   logic combo_intr_status_combo2_h2l_qs;
   logic combo_intr_status_combo2_h2l_wd;
-  logic combo_intr_status_combo2_h2l_we;
   logic combo_intr_status_combo3_h2l_qs;
   logic combo_intr_status_combo3_h2l_wd;
-  logic combo_intr_status_combo3_h2l_we;
+  logic key_intr_status_we;
   logic key_intr_status_pwrb_h2l_qs;
   logic key_intr_status_pwrb_h2l_wd;
-  logic key_intr_status_pwrb_h2l_we;
   logic key_intr_status_key0_in_h2l_qs;
   logic key_intr_status_key0_in_h2l_wd;
-  logic key_intr_status_key0_in_h2l_we;
   logic key_intr_status_key1_in_h2l_qs;
   logic key_intr_status_key1_in_h2l_wd;
-  logic key_intr_status_key1_in_h2l_we;
   logic key_intr_status_key2_in_h2l_qs;
   logic key_intr_status_key2_in_h2l_wd;
-  logic key_intr_status_key2_in_h2l_we;
   logic key_intr_status_ac_present_h2l_qs;
   logic key_intr_status_ac_present_h2l_wd;
-  logic key_intr_status_ac_present_h2l_we;
   logic key_intr_status_ec_rst_l_h2l_qs;
   logic key_intr_status_ec_rst_l_h2l_wd;
-  logic key_intr_status_ec_rst_l_h2l_we;
   logic key_intr_status_pwrb_l2h_qs;
   logic key_intr_status_pwrb_l2h_wd;
-  logic key_intr_status_pwrb_l2h_we;
   logic key_intr_status_key0_in_l2h_qs;
   logic key_intr_status_key0_in_l2h_wd;
-  logic key_intr_status_key0_in_l2h_we;
   logic key_intr_status_key1_in_l2h_qs;
   logic key_intr_status_key1_in_l2h_wd;
-  logic key_intr_status_key1_in_l2h_we;
   logic key_intr_status_key2_in_l2h_qs;
   logic key_intr_status_key2_in_l2h_wd;
-  logic key_intr_status_key2_in_l2h_we;
   logic key_intr_status_ac_present_l2h_qs;
   logic key_intr_status_ac_present_l2h_wd;
-  logic key_intr_status_ac_present_l2h_we;
   logic key_intr_status_ec_rst_l_l2h_qs;
   logic key_intr_status_ec_rst_l_l2h_wd;
-  logic key_intr_status_ec_rst_l_l2h_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -812,7 +717,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_key0_in_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_key0_in_wd),
 
     // from internal hardware
@@ -838,7 +743,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_key0_out_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_key0_out_wd),
 
     // from internal hardware
@@ -864,7 +769,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_key1_in_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_key1_in_wd),
 
     // from internal hardware
@@ -890,7 +795,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_key1_out_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_key1_out_wd),
 
     // from internal hardware
@@ -916,7 +821,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_key2_in_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_key2_in_wd),
 
     // from internal hardware
@@ -942,7 +847,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_key2_out_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_key2_out_wd),
 
     // from internal hardware
@@ -968,7 +873,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_pwrb_in_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_pwrb_in_wd),
 
     // from internal hardware
@@ -994,7 +899,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_pwrb_out_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_pwrb_out_wd),
 
     // from internal hardware
@@ -1020,7 +925,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_ac_present_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_ac_present_wd),
 
     // from internal hardware
@@ -1046,7 +951,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_bat_disable_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_bat_disable_wd),
 
     // from internal hardware
@@ -1072,7 +977,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_lid_open_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_lid_open_wd),
 
     // from internal hardware
@@ -1098,7 +1003,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_invert_ctl_z3_wakeup_we & regwen_qs),
+    .we     (key_invert_ctl_we & regwen_qs),
     .wd     (key_invert_ctl_z3_wakeup_wd),
 
     // from internal hardware
@@ -1126,7 +1031,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_bat_disable_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_bat_disable_0_wd),
 
     // from internal hardware
@@ -1152,7 +1057,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_ec_rst_l_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_ec_rst_l_0_wd),
 
     // from internal hardware
@@ -1178,7 +1083,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_pwrb_out_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_pwrb_out_0_wd),
 
     // from internal hardware
@@ -1204,7 +1109,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_key0_out_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_key0_out_0_wd),
 
     // from internal hardware
@@ -1230,7 +1135,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_key1_out_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_key1_out_0_wd),
 
     // from internal hardware
@@ -1256,7 +1161,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_key2_out_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_key2_out_0_wd),
 
     // from internal hardware
@@ -1282,7 +1187,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_z3_wakeup_0_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_z3_wakeup_0_wd),
 
     // from internal hardware
@@ -1308,7 +1213,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_bat_disable_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_bat_disable_1_wd),
 
     // from internal hardware
@@ -1334,7 +1239,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_ec_rst_l_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_ec_rst_l_1_wd),
 
     // from internal hardware
@@ -1360,7 +1265,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_pwrb_out_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_pwrb_out_1_wd),
 
     // from internal hardware
@@ -1386,7 +1291,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_key0_out_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_key0_out_1_wd),
 
     // from internal hardware
@@ -1412,7 +1317,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_key1_out_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_key1_out_1_wd),
 
     // from internal hardware
@@ -1438,7 +1343,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_key2_out_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_key2_out_1_wd),
 
     // from internal hardware
@@ -1464,7 +1369,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_allowed_ctl_z3_wakeup_1_we & regwen_qs),
+    .we     (pin_allowed_ctl_we & regwen_qs),
     .wd     (pin_allowed_ctl_z3_wakeup_1_wd),
 
     // from internal hardware
@@ -1492,7 +1397,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_bat_disable_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_bat_disable_wd),
 
     // from internal hardware
@@ -1518,7 +1423,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_ec_rst_l_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_ec_rst_l_wd),
 
     // from internal hardware
@@ -1544,7 +1449,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_pwrb_out_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_pwrb_out_wd),
 
     // from internal hardware
@@ -1570,7 +1475,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_key0_out_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_key0_out_wd),
 
     // from internal hardware
@@ -1596,7 +1501,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_key1_out_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_key1_out_wd),
 
     // from internal hardware
@@ -1622,7 +1527,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_key2_out_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_key2_out_wd),
 
     // from internal hardware
@@ -1648,7 +1553,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_ctl_z3_wakeup_we),
+    .we     (pin_out_ctl_we),
     .wd     (pin_out_ctl_z3_wakeup_wd),
 
     // from internal hardware
@@ -1676,7 +1581,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_bat_disable_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_bat_disable_wd),
 
     // from internal hardware
@@ -1702,7 +1607,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_ec_rst_l_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_ec_rst_l_wd),
 
     // from internal hardware
@@ -1728,7 +1633,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_pwrb_out_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_pwrb_out_wd),
 
     // from internal hardware
@@ -1754,7 +1659,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_key0_out_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_key0_out_wd),
 
     // from internal hardware
@@ -1780,7 +1685,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_key1_out_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_key1_out_wd),
 
     // from internal hardware
@@ -1806,7 +1711,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_key2_out_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_key2_out_wd),
 
     // from internal hardware
@@ -1832,7 +1737,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (pin_out_value_z3_wakeup_we),
+    .we     (pin_out_value_we),
     .wd     (pin_out_value_z3_wakeup_wd),
 
     // from internal hardware
@@ -2044,7 +1949,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_pwrb_in_h2l_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_pwrb_in_h2l_wd),
 
     // from internal hardware
@@ -2070,7 +1975,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_key0_in_h2l_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_key0_in_h2l_wd),
 
     // from internal hardware
@@ -2096,7 +2001,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_key1_in_h2l_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_key1_in_h2l_wd),
 
     // from internal hardware
@@ -2122,7 +2027,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_key2_in_h2l_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_key2_in_h2l_wd),
 
     // from internal hardware
@@ -2148,7 +2053,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_ac_present_h2l_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_ac_present_h2l_wd),
 
     // from internal hardware
@@ -2174,7 +2079,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_ec_rst_l_h2l_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_ec_rst_l_h2l_wd),
 
     // from internal hardware
@@ -2200,7 +2105,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_pwrb_in_l2h_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_pwrb_in_l2h_wd),
 
     // from internal hardware
@@ -2226,7 +2131,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_key0_in_l2h_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_key0_in_l2h_wd),
 
     // from internal hardware
@@ -2252,7 +2157,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_key1_in_l2h_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_key1_in_l2h_wd),
 
     // from internal hardware
@@ -2278,7 +2183,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_key2_in_l2h_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_key2_in_l2h_wd),
 
     // from internal hardware
@@ -2304,7 +2209,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_ac_present_l2h_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_ac_present_l2h_wd),
 
     // from internal hardware
@@ -2330,7 +2235,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_ctl_ec_rst_l_l2h_we & regwen_qs),
+    .we     (key_intr_ctl_we & regwen_qs),
     .wd     (key_intr_ctl_ec_rst_l_l2h_wd),
 
     // from internal hardware
@@ -2385,7 +2290,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_debounce_ctl_debounce_timer_we & regwen_qs),
+    .we     (auto_block_debounce_ctl_we & regwen_qs),
     .wd     (auto_block_debounce_ctl_debounce_timer_wd),
 
     // from internal hardware
@@ -2411,7 +2316,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_debounce_ctl_auto_block_enable_we & regwen_qs),
+    .we     (auto_block_debounce_ctl_we & regwen_qs),
     .wd     (auto_block_debounce_ctl_auto_block_enable_wd),
 
     // from internal hardware
@@ -2439,7 +2344,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_out_ctl_key0_out_sel_we & regwen_qs),
+    .we     (auto_block_out_ctl_we & regwen_qs),
     .wd     (auto_block_out_ctl_key0_out_sel_wd),
 
     // from internal hardware
@@ -2465,7 +2370,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_out_ctl_key1_out_sel_we & regwen_qs),
+    .we     (auto_block_out_ctl_we & regwen_qs),
     .wd     (auto_block_out_ctl_key1_out_sel_wd),
 
     // from internal hardware
@@ -2491,7 +2396,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_out_ctl_key2_out_sel_we & regwen_qs),
+    .we     (auto_block_out_ctl_we & regwen_qs),
     .wd     (auto_block_out_ctl_key2_out_sel_wd),
 
     // from internal hardware
@@ -2517,7 +2422,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_out_ctl_key0_out_value_we & regwen_qs),
+    .we     (auto_block_out_ctl_we & regwen_qs),
     .wd     (auto_block_out_ctl_key0_out_value_wd),
 
     // from internal hardware
@@ -2543,7 +2448,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_out_ctl_key1_out_value_we & regwen_qs),
+    .we     (auto_block_out_ctl_we & regwen_qs),
     .wd     (auto_block_out_ctl_key1_out_value_wd),
 
     // from internal hardware
@@ -2569,7 +2474,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (auto_block_out_ctl_key2_out_value_we & regwen_qs),
+    .we     (auto_block_out_ctl_we & regwen_qs),
     .wd     (auto_block_out_ctl_key2_out_value_wd),
 
     // from internal hardware
@@ -2599,7 +2504,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_0_key0_in_sel_0_we & regwen_qs),
+    .we     (com_sel_ctl_0_we & regwen_qs),
     .wd     (com_sel_ctl_0_key0_in_sel_0_wd),
 
     // from internal hardware
@@ -2625,7 +2530,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_0_key1_in_sel_0_we & regwen_qs),
+    .we     (com_sel_ctl_0_we & regwen_qs),
     .wd     (com_sel_ctl_0_key1_in_sel_0_wd),
 
     // from internal hardware
@@ -2651,7 +2556,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_0_key2_in_sel_0_we & regwen_qs),
+    .we     (com_sel_ctl_0_we & regwen_qs),
     .wd     (com_sel_ctl_0_key2_in_sel_0_wd),
 
     // from internal hardware
@@ -2677,7 +2582,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_0_pwrb_in_sel_0_we & regwen_qs),
+    .we     (com_sel_ctl_0_we & regwen_qs),
     .wd     (com_sel_ctl_0_pwrb_in_sel_0_wd),
 
     // from internal hardware
@@ -2703,7 +2608,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_0_ac_present_sel_0_we & regwen_qs),
+    .we     (com_sel_ctl_0_we & regwen_qs),
     .wd     (com_sel_ctl_0_ac_present_sel_0_wd),
 
     // from internal hardware
@@ -2732,7 +2637,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_1_key0_in_sel_1_we & regwen_qs),
+    .we     (com_sel_ctl_1_we & regwen_qs),
     .wd     (com_sel_ctl_1_key0_in_sel_1_wd),
 
     // from internal hardware
@@ -2758,7 +2663,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_1_key1_in_sel_1_we & regwen_qs),
+    .we     (com_sel_ctl_1_we & regwen_qs),
     .wd     (com_sel_ctl_1_key1_in_sel_1_wd),
 
     // from internal hardware
@@ -2784,7 +2689,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_1_key2_in_sel_1_we & regwen_qs),
+    .we     (com_sel_ctl_1_we & regwen_qs),
     .wd     (com_sel_ctl_1_key2_in_sel_1_wd),
 
     // from internal hardware
@@ -2810,7 +2715,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_1_pwrb_in_sel_1_we & regwen_qs),
+    .we     (com_sel_ctl_1_we & regwen_qs),
     .wd     (com_sel_ctl_1_pwrb_in_sel_1_wd),
 
     // from internal hardware
@@ -2836,7 +2741,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_1_ac_present_sel_1_we & regwen_qs),
+    .we     (com_sel_ctl_1_we & regwen_qs),
     .wd     (com_sel_ctl_1_ac_present_sel_1_wd),
 
     // from internal hardware
@@ -2865,7 +2770,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_2_key0_in_sel_2_we & regwen_qs),
+    .we     (com_sel_ctl_2_we & regwen_qs),
     .wd     (com_sel_ctl_2_key0_in_sel_2_wd),
 
     // from internal hardware
@@ -2891,7 +2796,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_2_key1_in_sel_2_we & regwen_qs),
+    .we     (com_sel_ctl_2_we & regwen_qs),
     .wd     (com_sel_ctl_2_key1_in_sel_2_wd),
 
     // from internal hardware
@@ -2917,7 +2822,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_2_key2_in_sel_2_we & regwen_qs),
+    .we     (com_sel_ctl_2_we & regwen_qs),
     .wd     (com_sel_ctl_2_key2_in_sel_2_wd),
 
     // from internal hardware
@@ -2943,7 +2848,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_2_pwrb_in_sel_2_we & regwen_qs),
+    .we     (com_sel_ctl_2_we & regwen_qs),
     .wd     (com_sel_ctl_2_pwrb_in_sel_2_wd),
 
     // from internal hardware
@@ -2969,7 +2874,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_2_ac_present_sel_2_we & regwen_qs),
+    .we     (com_sel_ctl_2_we & regwen_qs),
     .wd     (com_sel_ctl_2_ac_present_sel_2_wd),
 
     // from internal hardware
@@ -2998,7 +2903,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_3_key0_in_sel_3_we & regwen_qs),
+    .we     (com_sel_ctl_3_we & regwen_qs),
     .wd     (com_sel_ctl_3_key0_in_sel_3_wd),
 
     // from internal hardware
@@ -3024,7 +2929,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_3_key1_in_sel_3_we & regwen_qs),
+    .we     (com_sel_ctl_3_we & regwen_qs),
     .wd     (com_sel_ctl_3_key1_in_sel_3_wd),
 
     // from internal hardware
@@ -3050,7 +2955,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_3_key2_in_sel_3_we & regwen_qs),
+    .we     (com_sel_ctl_3_we & regwen_qs),
     .wd     (com_sel_ctl_3_key2_in_sel_3_wd),
 
     // from internal hardware
@@ -3076,7 +2981,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_3_pwrb_in_sel_3_we & regwen_qs),
+    .we     (com_sel_ctl_3_we & regwen_qs),
     .wd     (com_sel_ctl_3_pwrb_in_sel_3_wd),
 
     // from internal hardware
@@ -3102,7 +3007,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_sel_ctl_3_ac_present_sel_3_we & regwen_qs),
+    .we     (com_sel_ctl_3_we & regwen_qs),
     .wd     (com_sel_ctl_3_ac_present_sel_3_wd),
 
     // from internal hardware
@@ -3243,7 +3148,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_0_bat_disable_0_we & regwen_qs),
+    .we     (com_out_ctl_0_we & regwen_qs),
     .wd     (com_out_ctl_0_bat_disable_0_wd),
 
     // from internal hardware
@@ -3269,7 +3174,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_0_interrupt_0_we & regwen_qs),
+    .we     (com_out_ctl_0_we & regwen_qs),
     .wd     (com_out_ctl_0_interrupt_0_wd),
 
     // from internal hardware
@@ -3295,7 +3200,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_0_ec_rst_0_we & regwen_qs),
+    .we     (com_out_ctl_0_we & regwen_qs),
     .wd     (com_out_ctl_0_ec_rst_0_wd),
 
     // from internal hardware
@@ -3321,7 +3226,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_0_gsc_rst_0_we & regwen_qs),
+    .we     (com_out_ctl_0_we & regwen_qs),
     .wd     (com_out_ctl_0_gsc_rst_0_wd),
 
     // from internal hardware
@@ -3350,7 +3255,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_1_bat_disable_1_we & regwen_qs),
+    .we     (com_out_ctl_1_we & regwen_qs),
     .wd     (com_out_ctl_1_bat_disable_1_wd),
 
     // from internal hardware
@@ -3376,7 +3281,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_1_interrupt_1_we & regwen_qs),
+    .we     (com_out_ctl_1_we & regwen_qs),
     .wd     (com_out_ctl_1_interrupt_1_wd),
 
     // from internal hardware
@@ -3402,7 +3307,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_1_ec_rst_1_we & regwen_qs),
+    .we     (com_out_ctl_1_we & regwen_qs),
     .wd     (com_out_ctl_1_ec_rst_1_wd),
 
     // from internal hardware
@@ -3428,7 +3333,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_1_gsc_rst_1_we & regwen_qs),
+    .we     (com_out_ctl_1_we & regwen_qs),
     .wd     (com_out_ctl_1_gsc_rst_1_wd),
 
     // from internal hardware
@@ -3457,7 +3362,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_2_bat_disable_2_we & regwen_qs),
+    .we     (com_out_ctl_2_we & regwen_qs),
     .wd     (com_out_ctl_2_bat_disable_2_wd),
 
     // from internal hardware
@@ -3483,7 +3388,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_2_interrupt_2_we & regwen_qs),
+    .we     (com_out_ctl_2_we & regwen_qs),
     .wd     (com_out_ctl_2_interrupt_2_wd),
 
     // from internal hardware
@@ -3509,7 +3414,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_2_ec_rst_2_we & regwen_qs),
+    .we     (com_out_ctl_2_we & regwen_qs),
     .wd     (com_out_ctl_2_ec_rst_2_wd),
 
     // from internal hardware
@@ -3535,7 +3440,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_2_gsc_rst_2_we & regwen_qs),
+    .we     (com_out_ctl_2_we & regwen_qs),
     .wd     (com_out_ctl_2_gsc_rst_2_wd),
 
     // from internal hardware
@@ -3564,7 +3469,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_3_bat_disable_3_we & regwen_qs),
+    .we     (com_out_ctl_3_we & regwen_qs),
     .wd     (com_out_ctl_3_bat_disable_3_wd),
 
     // from internal hardware
@@ -3590,7 +3495,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_3_interrupt_3_we & regwen_qs),
+    .we     (com_out_ctl_3_we & regwen_qs),
     .wd     (com_out_ctl_3_interrupt_3_wd),
 
     // from internal hardware
@@ -3616,7 +3521,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_3_ec_rst_3_we & regwen_qs),
+    .we     (com_out_ctl_3_we & regwen_qs),
     .wd     (com_out_ctl_3_ec_rst_3_wd),
 
     // from internal hardware
@@ -3642,7 +3547,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (com_out_ctl_3_gsc_rst_3_we & regwen_qs),
+    .we     (com_out_ctl_3_we & regwen_qs),
     .wd     (com_out_ctl_3_gsc_rst_3_wd),
 
     // from internal hardware
@@ -3671,7 +3576,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (combo_intr_status_combo0_h2l_we),
+    .we     (combo_intr_status_we),
     .wd     (combo_intr_status_combo0_h2l_wd),
 
     // from internal hardware
@@ -3697,7 +3602,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (combo_intr_status_combo1_h2l_we),
+    .we     (combo_intr_status_we),
     .wd     (combo_intr_status_combo1_h2l_wd),
 
     // from internal hardware
@@ -3723,7 +3628,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (combo_intr_status_combo2_h2l_we),
+    .we     (combo_intr_status_we),
     .wd     (combo_intr_status_combo2_h2l_wd),
 
     // from internal hardware
@@ -3749,7 +3654,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (combo_intr_status_combo3_h2l_we),
+    .we     (combo_intr_status_we),
     .wd     (combo_intr_status_combo3_h2l_wd),
 
     // from internal hardware
@@ -3777,7 +3682,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_pwrb_h2l_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_pwrb_h2l_wd),
 
     // from internal hardware
@@ -3803,7 +3708,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_key0_in_h2l_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_key0_in_h2l_wd),
 
     // from internal hardware
@@ -3829,7 +3734,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_key1_in_h2l_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_key1_in_h2l_wd),
 
     // from internal hardware
@@ -3855,7 +3760,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_key2_in_h2l_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_key2_in_h2l_wd),
 
     // from internal hardware
@@ -3881,7 +3786,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_ac_present_h2l_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_ac_present_h2l_wd),
 
     // from internal hardware
@@ -3907,7 +3812,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_ec_rst_l_h2l_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_ec_rst_l_h2l_wd),
 
     // from internal hardware
@@ -3933,7 +3838,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_pwrb_l2h_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_pwrb_l2h_wd),
 
     // from internal hardware
@@ -3959,7 +3864,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_key0_in_l2h_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_key0_in_l2h_wd),
 
     // from internal hardware
@@ -3985,7 +3890,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_key1_in_l2h_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_key1_in_l2h_wd),
 
     // from internal hardware
@@ -4011,7 +3916,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_key2_in_l2h_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_key2_in_l2h_wd),
 
     // from internal hardware
@@ -4037,7 +3942,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_ac_present_l2h_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_ac_present_l2h_wd),
 
     // from internal hardware
@@ -4063,7 +3968,7 @@ module sysrst_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (key_intr_status_ec_rst_l_l2h_we),
+    .we     (key_intr_status_we),
     .wd     (key_intr_status_ec_rst_l_l2h_wd),
 
     // from internal hardware
@@ -4162,392 +4067,297 @@ module sysrst_ctrl_reg_top (
                (addr_hit[33] & (|(SYSRST_CTRL_PERMIT[33] & ~reg_be))) |
                (addr_hit[34] & (|(SYSRST_CTRL_PERMIT[34] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
+
   assign intr_test_wd = reg_wdata[0];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
   assign regwen_we = addr_hit[4] & reg_we & !reg_error;
+
   assign regwen_wd = reg_wdata[0];
-
   assign ec_rst_ctl_we = addr_hit[5] & reg_we & !reg_error;
+
   assign ec_rst_ctl_wd = reg_wdata[15:0];
-
   assign ulp_ac_debounce_ctl_we = addr_hit[6] & reg_we & !reg_error;
+
   assign ulp_ac_debounce_ctl_wd = reg_wdata[15:0];
-
   assign ulp_lid_debounce_ctl_we = addr_hit[7] & reg_we & !reg_error;
+
   assign ulp_lid_debounce_ctl_wd = reg_wdata[15:0];
-
   assign ulp_pwrb_debounce_ctl_we = addr_hit[8] & reg_we & !reg_error;
+
   assign ulp_pwrb_debounce_ctl_wd = reg_wdata[15:0];
-
   assign ulp_ctl_we = addr_hit[9] & reg_we & !reg_error;
+
   assign ulp_ctl_wd = reg_wdata[0];
-
   assign ulp_status_we = addr_hit[10] & reg_we & !reg_error;
+
   assign ulp_status_wd = reg_wdata[0];
-
   assign wk_status_we = addr_hit[11] & reg_we & !reg_error;
-  assign wk_status_wd = reg_wdata[0];
 
-  assign key_invert_ctl_key0_in_we = addr_hit[12] & reg_we & !reg_error;
+  assign wk_status_wd = reg_wdata[0];
+  assign key_invert_ctl_we = addr_hit[12] & reg_we & !reg_error;
+
   assign key_invert_ctl_key0_in_wd = reg_wdata[0];
 
-  assign key_invert_ctl_key0_out_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_key0_out_wd = reg_wdata[1];
 
-  assign key_invert_ctl_key1_in_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_key1_in_wd = reg_wdata[2];
 
-  assign key_invert_ctl_key1_out_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_key1_out_wd = reg_wdata[3];
 
-  assign key_invert_ctl_key2_in_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_key2_in_wd = reg_wdata[4];
 
-  assign key_invert_ctl_key2_out_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_key2_out_wd = reg_wdata[5];
 
-  assign key_invert_ctl_pwrb_in_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_pwrb_in_wd = reg_wdata[6];
 
-  assign key_invert_ctl_pwrb_out_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_pwrb_out_wd = reg_wdata[7];
 
-  assign key_invert_ctl_ac_present_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_ac_present_wd = reg_wdata[8];
 
-  assign key_invert_ctl_bat_disable_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_bat_disable_wd = reg_wdata[9];
 
-  assign key_invert_ctl_lid_open_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_lid_open_wd = reg_wdata[10];
 
-  assign key_invert_ctl_z3_wakeup_we = addr_hit[12] & reg_we & !reg_error;
   assign key_invert_ctl_z3_wakeup_wd = reg_wdata[11];
+  assign pin_allowed_ctl_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign pin_allowed_ctl_bat_disable_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_bat_disable_0_wd = reg_wdata[0];
 
-  assign pin_allowed_ctl_ec_rst_l_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_ec_rst_l_0_wd = reg_wdata[1];
 
-  assign pin_allowed_ctl_pwrb_out_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_pwrb_out_0_wd = reg_wdata[2];
 
-  assign pin_allowed_ctl_key0_out_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_key0_out_0_wd = reg_wdata[3];
 
-  assign pin_allowed_ctl_key1_out_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_key1_out_0_wd = reg_wdata[4];
 
-  assign pin_allowed_ctl_key2_out_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_key2_out_0_wd = reg_wdata[5];
 
-  assign pin_allowed_ctl_z3_wakeup_0_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_z3_wakeup_0_wd = reg_wdata[6];
 
-  assign pin_allowed_ctl_bat_disable_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_bat_disable_1_wd = reg_wdata[7];
 
-  assign pin_allowed_ctl_ec_rst_l_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_ec_rst_l_1_wd = reg_wdata[8];
 
-  assign pin_allowed_ctl_pwrb_out_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_pwrb_out_1_wd = reg_wdata[9];
 
-  assign pin_allowed_ctl_key0_out_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_key0_out_1_wd = reg_wdata[10];
 
-  assign pin_allowed_ctl_key1_out_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_key1_out_1_wd = reg_wdata[11];
 
-  assign pin_allowed_ctl_key2_out_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_key2_out_1_wd = reg_wdata[12];
 
-  assign pin_allowed_ctl_z3_wakeup_1_we = addr_hit[13] & reg_we & !reg_error;
   assign pin_allowed_ctl_z3_wakeup_1_wd = reg_wdata[13];
+  assign pin_out_ctl_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign pin_out_ctl_bat_disable_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_bat_disable_wd = reg_wdata[0];
 
-  assign pin_out_ctl_ec_rst_l_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_ec_rst_l_wd = reg_wdata[1];
 
-  assign pin_out_ctl_pwrb_out_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_pwrb_out_wd = reg_wdata[2];
 
-  assign pin_out_ctl_key0_out_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_key0_out_wd = reg_wdata[3];
 
-  assign pin_out_ctl_key1_out_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_key1_out_wd = reg_wdata[4];
 
-  assign pin_out_ctl_key2_out_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_key2_out_wd = reg_wdata[5];
 
-  assign pin_out_ctl_z3_wakeup_we = addr_hit[14] & reg_we & !reg_error;
   assign pin_out_ctl_z3_wakeup_wd = reg_wdata[6];
+  assign pin_out_value_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign pin_out_value_bat_disable_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_bat_disable_wd = reg_wdata[0];
 
-  assign pin_out_value_ec_rst_l_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_ec_rst_l_wd = reg_wdata[1];
 
-  assign pin_out_value_pwrb_out_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_pwrb_out_wd = reg_wdata[2];
 
-  assign pin_out_value_key0_out_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_key0_out_wd = reg_wdata[3];
 
-  assign pin_out_value_key1_out_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_key1_out_wd = reg_wdata[4];
 
-  assign pin_out_value_key2_out_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_key2_out_wd = reg_wdata[5];
 
-  assign pin_out_value_z3_wakeup_we = addr_hit[15] & reg_we & !reg_error;
   assign pin_out_value_z3_wakeup_wd = reg_wdata[6];
+  assign key_intr_ctl_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign key_intr_ctl_pwrb_in_h2l_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_pwrb_in_h2l_wd = reg_wdata[0];
 
-  assign key_intr_ctl_key0_in_h2l_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_key0_in_h2l_wd = reg_wdata[1];
 
-  assign key_intr_ctl_key1_in_h2l_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_key1_in_h2l_wd = reg_wdata[2];
 
-  assign key_intr_ctl_key2_in_h2l_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_key2_in_h2l_wd = reg_wdata[3];
 
-  assign key_intr_ctl_ac_present_h2l_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_ac_present_h2l_wd = reg_wdata[4];
 
-  assign key_intr_ctl_ec_rst_l_h2l_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_ec_rst_l_h2l_wd = reg_wdata[5];
 
-  assign key_intr_ctl_pwrb_in_l2h_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_pwrb_in_l2h_wd = reg_wdata[8];
 
-  assign key_intr_ctl_key0_in_l2h_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_key0_in_l2h_wd = reg_wdata[9];
 
-  assign key_intr_ctl_key1_in_l2h_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_key1_in_l2h_wd = reg_wdata[10];
 
-  assign key_intr_ctl_key2_in_l2h_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_key2_in_l2h_wd = reg_wdata[11];
 
-  assign key_intr_ctl_ac_present_l2h_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_ac_present_l2h_wd = reg_wdata[12];
 
-  assign key_intr_ctl_ec_rst_l_l2h_we = addr_hit[17] & reg_we & !reg_error;
   assign key_intr_ctl_ec_rst_l_l2h_wd = reg_wdata[13];
-
   assign key_intr_debounce_ctl_we = addr_hit[18] & reg_we & !reg_error;
-  assign key_intr_debounce_ctl_wd = reg_wdata[15:0];
 
-  assign auto_block_debounce_ctl_debounce_timer_we = addr_hit[19] & reg_we & !reg_error;
+  assign key_intr_debounce_ctl_wd = reg_wdata[15:0];
+  assign auto_block_debounce_ctl_we = addr_hit[19] & reg_we & !reg_error;
+
   assign auto_block_debounce_ctl_debounce_timer_wd = reg_wdata[15:0];
 
-  assign auto_block_debounce_ctl_auto_block_enable_we = addr_hit[19] & reg_we & !reg_error;
   assign auto_block_debounce_ctl_auto_block_enable_wd = reg_wdata[16];
+  assign auto_block_out_ctl_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign auto_block_out_ctl_key0_out_sel_we = addr_hit[20] & reg_we & !reg_error;
   assign auto_block_out_ctl_key0_out_sel_wd = reg_wdata[0];
 
-  assign auto_block_out_ctl_key1_out_sel_we = addr_hit[20] & reg_we & !reg_error;
   assign auto_block_out_ctl_key1_out_sel_wd = reg_wdata[1];
 
-  assign auto_block_out_ctl_key2_out_sel_we = addr_hit[20] & reg_we & !reg_error;
   assign auto_block_out_ctl_key2_out_sel_wd = reg_wdata[2];
 
-  assign auto_block_out_ctl_key0_out_value_we = addr_hit[20] & reg_we & !reg_error;
   assign auto_block_out_ctl_key0_out_value_wd = reg_wdata[4];
 
-  assign auto_block_out_ctl_key1_out_value_we = addr_hit[20] & reg_we & !reg_error;
   assign auto_block_out_ctl_key1_out_value_wd = reg_wdata[5];
 
-  assign auto_block_out_ctl_key2_out_value_we = addr_hit[20] & reg_we & !reg_error;
   assign auto_block_out_ctl_key2_out_value_wd = reg_wdata[6];
+  assign com_sel_ctl_0_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign com_sel_ctl_0_key0_in_sel_0_we = addr_hit[21] & reg_we & !reg_error;
   assign com_sel_ctl_0_key0_in_sel_0_wd = reg_wdata[0];
 
-  assign com_sel_ctl_0_key1_in_sel_0_we = addr_hit[21] & reg_we & !reg_error;
   assign com_sel_ctl_0_key1_in_sel_0_wd = reg_wdata[1];
 
-  assign com_sel_ctl_0_key2_in_sel_0_we = addr_hit[21] & reg_we & !reg_error;
   assign com_sel_ctl_0_key2_in_sel_0_wd = reg_wdata[2];
 
-  assign com_sel_ctl_0_pwrb_in_sel_0_we = addr_hit[21] & reg_we & !reg_error;
   assign com_sel_ctl_0_pwrb_in_sel_0_wd = reg_wdata[3];
 
-  assign com_sel_ctl_0_ac_present_sel_0_we = addr_hit[21] & reg_we & !reg_error;
   assign com_sel_ctl_0_ac_present_sel_0_wd = reg_wdata[4];
+  assign com_sel_ctl_1_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign com_sel_ctl_1_key0_in_sel_1_we = addr_hit[22] & reg_we & !reg_error;
   assign com_sel_ctl_1_key0_in_sel_1_wd = reg_wdata[0];
 
-  assign com_sel_ctl_1_key1_in_sel_1_we = addr_hit[22] & reg_we & !reg_error;
   assign com_sel_ctl_1_key1_in_sel_1_wd = reg_wdata[1];
 
-  assign com_sel_ctl_1_key2_in_sel_1_we = addr_hit[22] & reg_we & !reg_error;
   assign com_sel_ctl_1_key2_in_sel_1_wd = reg_wdata[2];
 
-  assign com_sel_ctl_1_pwrb_in_sel_1_we = addr_hit[22] & reg_we & !reg_error;
   assign com_sel_ctl_1_pwrb_in_sel_1_wd = reg_wdata[3];
 
-  assign com_sel_ctl_1_ac_present_sel_1_we = addr_hit[22] & reg_we & !reg_error;
   assign com_sel_ctl_1_ac_present_sel_1_wd = reg_wdata[4];
+  assign com_sel_ctl_2_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign com_sel_ctl_2_key0_in_sel_2_we = addr_hit[23] & reg_we & !reg_error;
   assign com_sel_ctl_2_key0_in_sel_2_wd = reg_wdata[0];
 
-  assign com_sel_ctl_2_key1_in_sel_2_we = addr_hit[23] & reg_we & !reg_error;
   assign com_sel_ctl_2_key1_in_sel_2_wd = reg_wdata[1];
 
-  assign com_sel_ctl_2_key2_in_sel_2_we = addr_hit[23] & reg_we & !reg_error;
   assign com_sel_ctl_2_key2_in_sel_2_wd = reg_wdata[2];
 
-  assign com_sel_ctl_2_pwrb_in_sel_2_we = addr_hit[23] & reg_we & !reg_error;
   assign com_sel_ctl_2_pwrb_in_sel_2_wd = reg_wdata[3];
 
-  assign com_sel_ctl_2_ac_present_sel_2_we = addr_hit[23] & reg_we & !reg_error;
   assign com_sel_ctl_2_ac_present_sel_2_wd = reg_wdata[4];
+  assign com_sel_ctl_3_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign com_sel_ctl_3_key0_in_sel_3_we = addr_hit[24] & reg_we & !reg_error;
   assign com_sel_ctl_3_key0_in_sel_3_wd = reg_wdata[0];
 
-  assign com_sel_ctl_3_key1_in_sel_3_we = addr_hit[24] & reg_we & !reg_error;
   assign com_sel_ctl_3_key1_in_sel_3_wd = reg_wdata[1];
 
-  assign com_sel_ctl_3_key2_in_sel_3_we = addr_hit[24] & reg_we & !reg_error;
   assign com_sel_ctl_3_key2_in_sel_3_wd = reg_wdata[2];
 
-  assign com_sel_ctl_3_pwrb_in_sel_3_we = addr_hit[24] & reg_we & !reg_error;
   assign com_sel_ctl_3_pwrb_in_sel_3_wd = reg_wdata[3];
 
-  assign com_sel_ctl_3_ac_present_sel_3_we = addr_hit[24] & reg_we & !reg_error;
   assign com_sel_ctl_3_ac_present_sel_3_wd = reg_wdata[4];
-
   assign com_det_ctl_0_we = addr_hit[25] & reg_we & !reg_error;
+
   assign com_det_ctl_0_wd = reg_wdata[31:0];
-
   assign com_det_ctl_1_we = addr_hit[26] & reg_we & !reg_error;
+
   assign com_det_ctl_1_wd = reg_wdata[31:0];
-
   assign com_det_ctl_2_we = addr_hit[27] & reg_we & !reg_error;
+
   assign com_det_ctl_2_wd = reg_wdata[31:0];
-
   assign com_det_ctl_3_we = addr_hit[28] & reg_we & !reg_error;
-  assign com_det_ctl_3_wd = reg_wdata[31:0];
 
-  assign com_out_ctl_0_bat_disable_0_we = addr_hit[29] & reg_we & !reg_error;
+  assign com_det_ctl_3_wd = reg_wdata[31:0];
+  assign com_out_ctl_0_we = addr_hit[29] & reg_we & !reg_error;
+
   assign com_out_ctl_0_bat_disable_0_wd = reg_wdata[0];
 
-  assign com_out_ctl_0_interrupt_0_we = addr_hit[29] & reg_we & !reg_error;
   assign com_out_ctl_0_interrupt_0_wd = reg_wdata[1];
 
-  assign com_out_ctl_0_ec_rst_0_we = addr_hit[29] & reg_we & !reg_error;
   assign com_out_ctl_0_ec_rst_0_wd = reg_wdata[2];
 
-  assign com_out_ctl_0_gsc_rst_0_we = addr_hit[29] & reg_we & !reg_error;
   assign com_out_ctl_0_gsc_rst_0_wd = reg_wdata[3];
+  assign com_out_ctl_1_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign com_out_ctl_1_bat_disable_1_we = addr_hit[30] & reg_we & !reg_error;
   assign com_out_ctl_1_bat_disable_1_wd = reg_wdata[0];
 
-  assign com_out_ctl_1_interrupt_1_we = addr_hit[30] & reg_we & !reg_error;
   assign com_out_ctl_1_interrupt_1_wd = reg_wdata[1];
 
-  assign com_out_ctl_1_ec_rst_1_we = addr_hit[30] & reg_we & !reg_error;
   assign com_out_ctl_1_ec_rst_1_wd = reg_wdata[2];
 
-  assign com_out_ctl_1_gsc_rst_1_we = addr_hit[30] & reg_we & !reg_error;
   assign com_out_ctl_1_gsc_rst_1_wd = reg_wdata[3];
+  assign com_out_ctl_2_we = addr_hit[31] & reg_we & !reg_error;
 
-  assign com_out_ctl_2_bat_disable_2_we = addr_hit[31] & reg_we & !reg_error;
   assign com_out_ctl_2_bat_disable_2_wd = reg_wdata[0];
 
-  assign com_out_ctl_2_interrupt_2_we = addr_hit[31] & reg_we & !reg_error;
   assign com_out_ctl_2_interrupt_2_wd = reg_wdata[1];
 
-  assign com_out_ctl_2_ec_rst_2_we = addr_hit[31] & reg_we & !reg_error;
   assign com_out_ctl_2_ec_rst_2_wd = reg_wdata[2];
 
-  assign com_out_ctl_2_gsc_rst_2_we = addr_hit[31] & reg_we & !reg_error;
   assign com_out_ctl_2_gsc_rst_2_wd = reg_wdata[3];
+  assign com_out_ctl_3_we = addr_hit[32] & reg_we & !reg_error;
 
-  assign com_out_ctl_3_bat_disable_3_we = addr_hit[32] & reg_we & !reg_error;
   assign com_out_ctl_3_bat_disable_3_wd = reg_wdata[0];
 
-  assign com_out_ctl_3_interrupt_3_we = addr_hit[32] & reg_we & !reg_error;
   assign com_out_ctl_3_interrupt_3_wd = reg_wdata[1];
 
-  assign com_out_ctl_3_ec_rst_3_we = addr_hit[32] & reg_we & !reg_error;
   assign com_out_ctl_3_ec_rst_3_wd = reg_wdata[2];
 
-  assign com_out_ctl_3_gsc_rst_3_we = addr_hit[32] & reg_we & !reg_error;
   assign com_out_ctl_3_gsc_rst_3_wd = reg_wdata[3];
+  assign combo_intr_status_we = addr_hit[33] & reg_we & !reg_error;
 
-  assign combo_intr_status_combo0_h2l_we = addr_hit[33] & reg_we & !reg_error;
   assign combo_intr_status_combo0_h2l_wd = reg_wdata[0];
 
-  assign combo_intr_status_combo1_h2l_we = addr_hit[33] & reg_we & !reg_error;
   assign combo_intr_status_combo1_h2l_wd = reg_wdata[1];
 
-  assign combo_intr_status_combo2_h2l_we = addr_hit[33] & reg_we & !reg_error;
   assign combo_intr_status_combo2_h2l_wd = reg_wdata[2];
 
-  assign combo_intr_status_combo3_h2l_we = addr_hit[33] & reg_we & !reg_error;
   assign combo_intr_status_combo3_h2l_wd = reg_wdata[3];
+  assign key_intr_status_we = addr_hit[34] & reg_we & !reg_error;
 
-  assign key_intr_status_pwrb_h2l_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_pwrb_h2l_wd = reg_wdata[0];
 
-  assign key_intr_status_key0_in_h2l_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_key0_in_h2l_wd = reg_wdata[1];
 
-  assign key_intr_status_key1_in_h2l_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_key1_in_h2l_wd = reg_wdata[2];
 
-  assign key_intr_status_key2_in_h2l_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_key2_in_h2l_wd = reg_wdata[3];
 
-  assign key_intr_status_ac_present_h2l_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_ac_present_h2l_wd = reg_wdata[4];
 
-  assign key_intr_status_ec_rst_l_h2l_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_ec_rst_l_h2l_wd = reg_wdata[5];
 
-  assign key_intr_status_pwrb_l2h_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_pwrb_l2h_wd = reg_wdata[6];
 
-  assign key_intr_status_key0_in_l2h_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_key0_in_l2h_wd = reg_wdata[7];
 
-  assign key_intr_status_key1_in_l2h_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_key1_in_l2h_wd = reg_wdata[8];
 
-  assign key_intr_status_key2_in_l2h_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_key2_in_l2h_wd = reg_wdata[9];
 
-  assign key_intr_status_ac_present_l2h_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_ac_present_l2h_wd = reg_wdata[10];
 
-  assign key_intr_status_ec_rst_l_l2h_we = addr_hit[34] & reg_we & !reg_error;
   assign key_intr_status_ec_rst_l_l2h_wd = reg_wdata[11];
 
   // Read data return

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -104,96 +104,86 @@ module trial1_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic rwtype0_we;
   logic [31:0] rwtype0_qs;
   logic [31:0] rwtype0_wd;
-  logic rwtype0_we;
+  logic rwtype1_we;
   logic rwtype1_field0_qs;
   logic rwtype1_field0_wd;
-  logic rwtype1_field0_we;
   logic rwtype1_field1_qs;
   logic rwtype1_field1_wd;
-  logic rwtype1_field1_we;
   logic rwtype1_field4_qs;
   logic rwtype1_field4_wd;
-  logic rwtype1_field4_we;
   logic [7:0] rwtype1_field15_8_qs;
   logic [7:0] rwtype1_field15_8_wd;
-  logic rwtype1_field15_8_we;
+  logic rwtype2_we;
   logic [31:0] rwtype2_qs;
   logic [31:0] rwtype2_wd;
-  logic rwtype2_we;
+  logic rwtype3_we;
   logic [15:0] rwtype3_field0_qs;
   logic [15:0] rwtype3_field0_wd;
-  logic rwtype3_field0_we;
   logic [15:0] rwtype3_field1_qs;
   logic [15:0] rwtype3_field1_wd;
-  logic rwtype3_field1_we;
+  logic rwtype4_we;
   logic [15:0] rwtype4_field0_qs;
   logic [15:0] rwtype4_field0_wd;
-  logic rwtype4_field0_we;
   logic [15:0] rwtype4_field1_qs;
   logic [15:0] rwtype4_field1_wd;
-  logic rwtype4_field1_we;
   logic [31:0] rotype0_qs;
+  logic w1ctype0_we;
   logic [31:0] w1ctype0_qs;
   logic [31:0] w1ctype0_wd;
-  logic w1ctype0_we;
+  logic w1ctype1_we;
   logic [15:0] w1ctype1_field0_qs;
   logic [15:0] w1ctype1_field0_wd;
-  logic w1ctype1_field0_we;
   logic [15:0] w1ctype1_field1_qs;
   logic [15:0] w1ctype1_field1_wd;
-  logic w1ctype1_field1_we;
+  logic w1ctype2_we;
   logic [31:0] w1ctype2_qs;
   logic [31:0] w1ctype2_wd;
-  logic w1ctype2_we;
+  logic w1stype2_we;
   logic [31:0] w1stype2_qs;
   logic [31:0] w1stype2_wd;
-  logic w1stype2_we;
+  logic w0ctype2_we;
   logic [31:0] w0ctype2_qs;
   logic [31:0] w0ctype2_wd;
-  logic w0ctype2_we;
-  logic [31:0] r0w1ctype2_wd;
   logic r0w1ctype2_we;
+  logic [31:0] r0w1ctype2_wd;
+  logic rctype0_re;
   logic [31:0] rctype0_qs;
   logic [31:0] rctype0_wd;
-  logic rctype0_we;
-  logic [31:0] wotype0_wd;
   logic wotype0_we;
+  logic [31:0] wotype0_wd;
+  logic mixtype0_re;
+  logic mixtype0_we;
   logic [3:0] mixtype0_field0_qs;
   logic [3:0] mixtype0_field0_wd;
-  logic mixtype0_field0_we;
   logic [3:0] mixtype0_field1_qs;
   logic [3:0] mixtype0_field1_wd;
-  logic mixtype0_field1_we;
   logic [3:0] mixtype0_field2_qs;
   logic [3:0] mixtype0_field3_qs;
   logic [3:0] mixtype0_field4_qs;
   logic [3:0] mixtype0_field4_wd;
-  logic mixtype0_field4_we;
   logic [3:0] mixtype0_field5_qs;
   logic [3:0] mixtype0_field5_wd;
-  logic mixtype0_field5_we;
   logic [3:0] mixtype0_field6_qs;
   logic [3:0] mixtype0_field6_wd;
-  logic mixtype0_field6_we;
   logic [3:0] mixtype0_field7_wd;
-  logic mixtype0_field7_we;
+  logic rwtype5_we;
   logic [31:0] rwtype5_qs;
   logic [31:0] rwtype5_wd;
-  logic rwtype5_we;
+  logic rwtype6_re;
+  logic rwtype6_we;
   logic [31:0] rwtype6_qs;
   logic [31:0] rwtype6_wd;
-  logic rwtype6_we;
-  logic rwtype6_re;
-  logic [31:0] rotype1_qs;
   logic rotype1_re;
+  logic [31:0] rotype1_qs;
   logic [7:0] rotype2_field0_qs;
   logic [7:0] rotype2_field1_qs;
   logic [11:0] rotype2_field2_qs;
+  logic rwtype7_we;
   logic [31:0] rwtype7_qs;
   logic [31:0] rwtype7_wd;
-  logic rwtype7_we;
 
   // Register instances
   // R[rwtype0]: V(False)
@@ -235,7 +225,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype1_field0_we),
+    .we     (rwtype1_we),
     .wd     (rwtype1_field0_wd),
 
     // from internal hardware
@@ -261,7 +251,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype1_field1_we),
+    .we     (rwtype1_we),
     .wd     (rwtype1_field1_wd),
 
     // from internal hardware
@@ -287,7 +277,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype1_field4_we),
+    .we     (rwtype1_we),
     .wd     (rwtype1_field4_wd),
 
     // from internal hardware
@@ -313,7 +303,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype1_field15_8_we),
+    .we     (rwtype1_we),
     .wd     (rwtype1_field15_8_wd),
 
     // from internal hardware
@@ -368,7 +358,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype3_field0_we),
+    .we     (rwtype3_we),
     .wd     (rwtype3_field0_wd),
 
     // from internal hardware
@@ -394,7 +384,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype3_field1_we),
+    .we     (rwtype3_we),
     .wd     (rwtype3_field1_wd),
 
     // from internal hardware
@@ -422,7 +412,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype4_field0_we),
+    .we     (rwtype4_we),
     .wd     (rwtype4_field0_wd),
 
     // from internal hardware
@@ -448,7 +438,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rwtype4_field1_we),
+    .we     (rwtype4_we),
     .wd     (rwtype4_field1_wd),
 
     // from internal hardware
@@ -530,7 +520,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (w1ctype1_field0_we),
+    .we     (w1ctype1_we),
     .wd     (w1ctype1_field0_wd),
 
     // from internal hardware
@@ -556,7 +546,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (w1ctype1_field1_we),
+    .we     (w1ctype1_we),
     .wd     (w1ctype1_field1_wd),
 
     // from internal hardware
@@ -691,7 +681,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rctype0_we),
+    .we     (rctype0_re),
     .wd     (rctype0_wd),
 
     // from internal hardware
@@ -746,7 +736,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_field0_we),
+    .we     (mixtype0_we),
     .wd     (mixtype0_field0_wd),
 
     // from internal hardware
@@ -772,7 +762,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_field1_we),
+    .we     (mixtype0_we),
     .wd     (mixtype0_field1_wd),
 
     // from internal hardware
@@ -850,7 +840,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_field4_we),
+    .we     (mixtype0_we),
     .wd     (mixtype0_field4_wd),
 
     // from internal hardware
@@ -876,7 +866,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_field5_we),
+    .we     (mixtype0_we),
     .wd     (mixtype0_field5_wd),
 
     // from internal hardware
@@ -902,7 +892,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_field6_we),
+    .we     (mixtype0_re),
     .wd     (mixtype0_field6_wd),
 
     // from internal hardware
@@ -928,7 +918,7 @@ module trial1_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_field7_we),
+    .we     (mixtype0_we),
     .wd     (mixtype0_field7_wd),
 
     // from internal hardware
@@ -1100,92 +1090,81 @@ module trial1_reg_top (
                (addr_hit[18] & (|(TRIAL1_PERMIT[18] & ~reg_be))) |
                (addr_hit[19] & (|(TRIAL1_PERMIT[19] & ~reg_be)))));
   end
-
   assign rwtype0_we = addr_hit[0] & reg_we & !reg_error;
-  assign rwtype0_wd = reg_wdata[31:0];
 
-  assign rwtype1_field0_we = addr_hit[1] & reg_we & !reg_error;
+  assign rwtype0_wd = reg_wdata[31:0];
+  assign rwtype1_we = addr_hit[1] & reg_we & !reg_error;
+
   assign rwtype1_field0_wd = reg_wdata[0];
 
-  assign rwtype1_field1_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field1_wd = reg_wdata[1];
 
-  assign rwtype1_field4_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field4_wd = reg_wdata[4];
 
-  assign rwtype1_field15_8_we = addr_hit[1] & reg_we & !reg_error;
   assign rwtype1_field15_8_wd = reg_wdata[15:8];
-
   assign rwtype2_we = addr_hit[2] & reg_we & !reg_error;
-  assign rwtype2_wd = reg_wdata[31:0];
 
-  assign rwtype3_field0_we = addr_hit[3] & reg_we & !reg_error;
+  assign rwtype2_wd = reg_wdata[31:0];
+  assign rwtype3_we = addr_hit[3] & reg_we & !reg_error;
+
   assign rwtype3_field0_wd = reg_wdata[15:0];
 
-  assign rwtype3_field1_we = addr_hit[3] & reg_we & !reg_error;
   assign rwtype3_field1_wd = reg_wdata[31:16];
+  assign rwtype4_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign rwtype4_field0_we = addr_hit[4] & reg_we & !reg_error;
   assign rwtype4_field0_wd = reg_wdata[15:0];
 
-  assign rwtype4_field1_we = addr_hit[4] & reg_we & !reg_error;
   assign rwtype4_field1_wd = reg_wdata[31:16];
-
   assign w1ctype0_we = addr_hit[6] & reg_we & !reg_error;
-  assign w1ctype0_wd = reg_wdata[31:0];
 
-  assign w1ctype1_field0_we = addr_hit[7] & reg_we & !reg_error;
+  assign w1ctype0_wd = reg_wdata[31:0];
+  assign w1ctype1_we = addr_hit[7] & reg_we & !reg_error;
+
   assign w1ctype1_field0_wd = reg_wdata[15:0];
 
-  assign w1ctype1_field1_we = addr_hit[7] & reg_we & !reg_error;
   assign w1ctype1_field1_wd = reg_wdata[31:16];
-
   assign w1ctype2_we = addr_hit[8] & reg_we & !reg_error;
+
   assign w1ctype2_wd = reg_wdata[31:0];
-
   assign w1stype2_we = addr_hit[9] & reg_we & !reg_error;
+
   assign w1stype2_wd = reg_wdata[31:0];
-
   assign w0ctype2_we = addr_hit[10] & reg_we & !reg_error;
+
   assign w0ctype2_wd = reg_wdata[31:0];
-
   assign r0w1ctype2_we = addr_hit[11] & reg_we & !reg_error;
+
   assign r0w1ctype2_wd = reg_wdata[31:0];
+  assign rctype0_re = addr_hit[12] & reg_re & !reg_error;
 
-  assign rctype0_we = addr_hit[12] & reg_re & !reg_error;
   assign rctype0_wd = '1;
-
   assign wotype0_we = addr_hit[13] & reg_we & !reg_error;
-  assign wotype0_wd = reg_wdata[31:0];
 
-  assign mixtype0_field0_we = addr_hit[14] & reg_we & !reg_error;
+  assign wotype0_wd = reg_wdata[31:0];
+  assign mixtype0_re = addr_hit[14] & reg_re & !reg_error;
+  assign mixtype0_we = addr_hit[14] & reg_we & !reg_error;
+
   assign mixtype0_field0_wd = reg_wdata[3:0];
 
-  assign mixtype0_field1_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field1_wd = reg_wdata[7:4];
 
-  assign mixtype0_field4_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field4_wd = reg_wdata[19:16];
 
-  assign mixtype0_field5_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field5_wd = reg_wdata[23:20];
 
-  assign mixtype0_field6_we = addr_hit[14] & reg_re & !reg_error;
   assign mixtype0_field6_wd = '1;
 
-  assign mixtype0_field7_we = addr_hit[14] & reg_we & !reg_error;
   assign mixtype0_field7_wd = reg_wdata[31:28];
-
   assign rwtype5_we = addr_hit[15] & reg_we & !reg_error;
+
   assign rwtype5_wd = reg_wdata[31:0];
-
-  assign rwtype6_we = addr_hit[16] & reg_we & !reg_error;
-  assign rwtype6_wd = reg_wdata[31:0];
   assign rwtype6_re = addr_hit[16] & reg_re & !reg_error;
+  assign rwtype6_we = addr_hit[16] & reg_we & !reg_error;
 
+  assign rwtype6_wd = reg_wdata[31:0];
   assign rotype1_re = addr_hit[17] & reg_re & !reg_error;
-
   assign rwtype7_we = addr_hit[19] & reg_we & !reg_error;
+
   assign rwtype7_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -104,143 +104,103 @@ module uart_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_tx_watermark_qs;
   logic intr_state_tx_watermark_wd;
-  logic intr_state_tx_watermark_we;
   logic intr_state_rx_watermark_qs;
   logic intr_state_rx_watermark_wd;
-  logic intr_state_rx_watermark_we;
   logic intr_state_tx_empty_qs;
   logic intr_state_tx_empty_wd;
-  logic intr_state_tx_empty_we;
   logic intr_state_rx_overflow_qs;
   logic intr_state_rx_overflow_wd;
-  logic intr_state_rx_overflow_we;
   logic intr_state_rx_frame_err_qs;
   logic intr_state_rx_frame_err_wd;
-  logic intr_state_rx_frame_err_we;
   logic intr_state_rx_break_err_qs;
   logic intr_state_rx_break_err_wd;
-  logic intr_state_rx_break_err_we;
   logic intr_state_rx_timeout_qs;
   logic intr_state_rx_timeout_wd;
-  logic intr_state_rx_timeout_we;
   logic intr_state_rx_parity_err_qs;
   logic intr_state_rx_parity_err_wd;
-  logic intr_state_rx_parity_err_we;
+  logic intr_enable_we;
   logic intr_enable_tx_watermark_qs;
   logic intr_enable_tx_watermark_wd;
-  logic intr_enable_tx_watermark_we;
   logic intr_enable_rx_watermark_qs;
   logic intr_enable_rx_watermark_wd;
-  logic intr_enable_rx_watermark_we;
   logic intr_enable_tx_empty_qs;
   logic intr_enable_tx_empty_wd;
-  logic intr_enable_tx_empty_we;
   logic intr_enable_rx_overflow_qs;
   logic intr_enable_rx_overflow_wd;
-  logic intr_enable_rx_overflow_we;
   logic intr_enable_rx_frame_err_qs;
   logic intr_enable_rx_frame_err_wd;
-  logic intr_enable_rx_frame_err_we;
   logic intr_enable_rx_break_err_qs;
   logic intr_enable_rx_break_err_wd;
-  logic intr_enable_rx_break_err_we;
   logic intr_enable_rx_timeout_qs;
   logic intr_enable_rx_timeout_wd;
-  logic intr_enable_rx_timeout_we;
   logic intr_enable_rx_parity_err_qs;
   logic intr_enable_rx_parity_err_wd;
-  logic intr_enable_rx_parity_err_we;
+  logic intr_test_we;
   logic intr_test_tx_watermark_wd;
-  logic intr_test_tx_watermark_we;
   logic intr_test_rx_watermark_wd;
-  logic intr_test_rx_watermark_we;
   logic intr_test_tx_empty_wd;
-  logic intr_test_tx_empty_we;
   logic intr_test_rx_overflow_wd;
-  logic intr_test_rx_overflow_we;
   logic intr_test_rx_frame_err_wd;
-  logic intr_test_rx_frame_err_we;
   logic intr_test_rx_break_err_wd;
-  logic intr_test_rx_break_err_we;
   logic intr_test_rx_timeout_wd;
-  logic intr_test_rx_timeout_we;
   logic intr_test_rx_parity_err_wd;
-  logic intr_test_rx_parity_err_we;
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic ctrl_we;
   logic ctrl_tx_qs;
   logic ctrl_tx_wd;
-  logic ctrl_tx_we;
   logic ctrl_rx_qs;
   logic ctrl_rx_wd;
-  logic ctrl_rx_we;
   logic ctrl_nf_qs;
   logic ctrl_nf_wd;
-  logic ctrl_nf_we;
   logic ctrl_slpbk_qs;
   logic ctrl_slpbk_wd;
-  logic ctrl_slpbk_we;
   logic ctrl_llpbk_qs;
   logic ctrl_llpbk_wd;
-  logic ctrl_llpbk_we;
   logic ctrl_parity_en_qs;
   logic ctrl_parity_en_wd;
-  logic ctrl_parity_en_we;
   logic ctrl_parity_odd_qs;
   logic ctrl_parity_odd_wd;
-  logic ctrl_parity_odd_we;
   logic [1:0] ctrl_rxblvl_qs;
   logic [1:0] ctrl_rxblvl_wd;
-  logic ctrl_rxblvl_we;
   logic [15:0] ctrl_nco_qs;
   logic [15:0] ctrl_nco_wd;
-  logic ctrl_nco_we;
+  logic status_re;
   logic status_txfull_qs;
-  logic status_txfull_re;
   logic status_rxfull_qs;
-  logic status_rxfull_re;
   logic status_txempty_qs;
-  logic status_txempty_re;
   logic status_txidle_qs;
-  logic status_txidle_re;
   logic status_rxidle_qs;
-  logic status_rxidle_re;
   logic status_rxempty_qs;
-  logic status_rxempty_re;
-  logic [7:0] rdata_qs;
   logic rdata_re;
-  logic [7:0] wdata_wd;
+  logic [7:0] rdata_qs;
   logic wdata_we;
+  logic [7:0] wdata_wd;
+  logic fifo_ctrl_we;
   logic fifo_ctrl_rxrst_wd;
-  logic fifo_ctrl_rxrst_we;
   logic fifo_ctrl_txrst_wd;
-  logic fifo_ctrl_txrst_we;
   logic [2:0] fifo_ctrl_rxilvl_qs;
   logic [2:0] fifo_ctrl_rxilvl_wd;
-  logic fifo_ctrl_rxilvl_we;
   logic [1:0] fifo_ctrl_txilvl_qs;
   logic [1:0] fifo_ctrl_txilvl_wd;
-  logic fifo_ctrl_txilvl_we;
+  logic fifo_status_re;
   logic [5:0] fifo_status_txlvl_qs;
-  logic fifo_status_txlvl_re;
   logic [5:0] fifo_status_rxlvl_qs;
-  logic fifo_status_rxlvl_re;
+  logic ovrd_we;
   logic ovrd_txen_qs;
   logic ovrd_txen_wd;
-  logic ovrd_txen_we;
   logic ovrd_txval_qs;
   logic ovrd_txval_wd;
-  logic ovrd_txval_we;
-  logic [15:0] val_qs;
   logic val_re;
+  logic [15:0] val_qs;
+  logic timeout_ctrl_we;
   logic [23:0] timeout_ctrl_val_qs;
   logic [23:0] timeout_ctrl_val_wd;
-  logic timeout_ctrl_val_we;
   logic timeout_ctrl_en_qs;
   logic timeout_ctrl_en_wd;
-  logic timeout_ctrl_en_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -255,7 +215,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_watermark_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_watermark_wd),
 
     // from internal hardware
@@ -281,7 +241,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_watermark_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_watermark_wd),
 
     // from internal hardware
@@ -307,7 +267,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_empty_wd),
 
     // from internal hardware
@@ -333,7 +293,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_overflow_wd),
 
     // from internal hardware
@@ -359,7 +319,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_frame_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_frame_err_wd),
 
     // from internal hardware
@@ -385,7 +345,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_break_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_break_err_wd),
 
     // from internal hardware
@@ -411,7 +371,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_timeout_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_timeout_wd),
 
     // from internal hardware
@@ -437,7 +397,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_parity_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_parity_err_wd),
 
     // from internal hardware
@@ -465,7 +425,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_watermark_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_watermark_wd),
 
     // from internal hardware
@@ -491,7 +451,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_watermark_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_watermark_wd),
 
     // from internal hardware
@@ -517,7 +477,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_empty_wd),
 
     // from internal hardware
@@ -543,7 +503,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_overflow_wd),
 
     // from internal hardware
@@ -569,7 +529,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_frame_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_frame_err_wd),
 
     // from internal hardware
@@ -595,7 +555,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_break_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_break_err_wd),
 
     // from internal hardware
@@ -621,7 +581,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_timeout_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_timeout_wd),
 
     // from internal hardware
@@ -647,7 +607,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_parity_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_parity_err_wd),
 
     // from internal hardware
@@ -670,7 +630,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_tx_watermark (
     .re     (1'b0),
-    .we     (intr_test_tx_watermark_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_watermark_wd),
     .d      ('0),
     .qre    (),
@@ -685,7 +645,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_watermark (
     .re     (1'b0),
-    .we     (intr_test_rx_watermark_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_watermark_wd),
     .d      ('0),
     .qre    (),
@@ -700,7 +660,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_tx_empty (
     .re     (1'b0),
-    .we     (intr_test_tx_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_empty_wd),
     .d      ('0),
     .qre    (),
@@ -715,7 +675,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_overflow (
     .re     (1'b0),
-    .we     (intr_test_rx_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -730,7 +690,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_frame_err (
     .re     (1'b0),
-    .we     (intr_test_rx_frame_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_frame_err_wd),
     .d      ('0),
     .qre    (),
@@ -745,7 +705,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_break_err (
     .re     (1'b0),
-    .we     (intr_test_rx_break_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_break_err_wd),
     .d      ('0),
     .qre    (),
@@ -760,7 +720,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_timeout (
     .re     (1'b0),
-    .we     (intr_test_rx_timeout_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_timeout_wd),
     .d      ('0),
     .qre    (),
@@ -775,7 +735,7 @@ module uart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_parity_err (
     .re     (1'b0),
-    .we     (intr_test_rx_parity_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_parity_err_wd),
     .d      ('0),
     .qre    (),
@@ -813,7 +773,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_tx_we),
+    .we     (ctrl_we),
     .wd     (ctrl_tx_wd),
 
     // from internal hardware
@@ -839,7 +799,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_rx_we),
+    .we     (ctrl_we),
     .wd     (ctrl_rx_wd),
 
     // from internal hardware
@@ -865,7 +825,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_nf_we),
+    .we     (ctrl_we),
     .wd     (ctrl_nf_wd),
 
     // from internal hardware
@@ -891,7 +851,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_slpbk_we),
+    .we     (ctrl_we),
     .wd     (ctrl_slpbk_wd),
 
     // from internal hardware
@@ -917,7 +877,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_llpbk_we),
+    .we     (ctrl_we),
     .wd     (ctrl_llpbk_wd),
 
     // from internal hardware
@@ -943,7 +903,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_parity_en_we),
+    .we     (ctrl_we),
     .wd     (ctrl_parity_en_wd),
 
     // from internal hardware
@@ -969,7 +929,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_parity_odd_we),
+    .we     (ctrl_we),
     .wd     (ctrl_parity_odd_wd),
 
     // from internal hardware
@@ -995,7 +955,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_rxblvl_we),
+    .we     (ctrl_we),
     .wd     (ctrl_rxblvl_wd),
 
     // from internal hardware
@@ -1021,7 +981,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_nco_we),
+    .we     (ctrl_we),
     .wd     (ctrl_nco_wd),
 
     // from internal hardware
@@ -1043,7 +1003,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txfull (
-    .re     (status_txfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txfull.d),
@@ -1058,7 +1018,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxfull (
-    .re     (status_rxfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxfull.d),
@@ -1073,7 +1033,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txempty (
-    .re     (status_txempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txempty.d),
@@ -1088,7 +1048,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txidle (
-    .re     (status_txidle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txidle.d),
@@ -1103,7 +1063,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxidle (
-    .re     (status_rxidle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxidle.d),
@@ -1118,7 +1078,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxempty (
-    .re     (status_rxempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxempty.d),
@@ -1184,7 +1144,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_rxrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_rxrst_wd),
 
     // from internal hardware
@@ -1210,7 +1170,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_txrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_txrst_wd),
 
     // from internal hardware
@@ -1236,7 +1196,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_rxilvl_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_rxilvl_wd),
 
     // from internal hardware
@@ -1262,7 +1222,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_txilvl_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_txilvl_wd),
 
     // from internal hardware
@@ -1284,7 +1244,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (6)
   ) u_fifo_status_txlvl (
-    .re     (fifo_status_txlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.txlvl.d),
@@ -1299,7 +1259,7 @@ module uart_reg_top (
   prim_subreg_ext #(
     .DW    (6)
   ) u_fifo_status_rxlvl (
-    .re     (fifo_status_rxlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.rxlvl.d),
@@ -1322,7 +1282,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_txen_we),
+    .we     (ovrd_we),
     .wd     (ovrd_txen_wd),
 
     // from internal hardware
@@ -1348,7 +1308,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_txval_we),
+    .we     (ovrd_we),
     .wd     (ovrd_txval_wd),
 
     // from internal hardware
@@ -1392,7 +1352,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timeout_ctrl_val_we),
+    .we     (timeout_ctrl_we),
     .wd     (timeout_ctrl_val_wd),
 
     // from internal hardware
@@ -1418,7 +1378,7 @@ module uart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timeout_ctrl_en_we),
+    .we     (timeout_ctrl_we),
     .wd     (timeout_ctrl_en_wd),
 
     // from internal hardware
@@ -1473,154 +1433,104 @@ module uart_reg_top (
                (addr_hit[11] & (|(UART_PERMIT[11] & ~reg_be))) |
                (addr_hit[12] & (|(UART_PERMIT[12] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_state_tx_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_empty_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_parity_err_wd = reg_wdata[7];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_enable_tx_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_empty_wd = reg_wdata[2];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_parity_err_wd = reg_wdata[7];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_test_tx_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_empty_wd = reg_wdata[2];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_parity_err_wd = reg_wdata[7];
-
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
-  assign alert_test_wd = reg_wdata[0];
 
-  assign ctrl_tx_we = addr_hit[4] & reg_we & !reg_error;
+  assign alert_test_wd = reg_wdata[0];
+  assign ctrl_we = addr_hit[4] & reg_we & !reg_error;
+
   assign ctrl_tx_wd = reg_wdata[0];
 
-  assign ctrl_rx_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_rx_wd = reg_wdata[1];
 
-  assign ctrl_nf_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_nf_wd = reg_wdata[2];
 
-  assign ctrl_slpbk_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_slpbk_wd = reg_wdata[4];
 
-  assign ctrl_llpbk_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_llpbk_wd = reg_wdata[5];
 
-  assign ctrl_parity_en_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_parity_en_wd = reg_wdata[6];
 
-  assign ctrl_parity_odd_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_parity_odd_wd = reg_wdata[7];
 
-  assign ctrl_rxblvl_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_rxblvl_wd = reg_wdata[9:8];
 
-  assign ctrl_nco_we = addr_hit[4] & reg_we & !reg_error;
   assign ctrl_nco_wd = reg_wdata[31:16];
-
-  assign status_txfull_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_rxfull_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_txempty_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_txidle_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_rxidle_re = addr_hit[5] & reg_re & !reg_error;
-
-  assign status_rxempty_re = addr_hit[5] & reg_re & !reg_error;
-
+  assign status_re = addr_hit[5] & reg_re & !reg_error;
   assign rdata_re = addr_hit[6] & reg_re & !reg_error;
-
   assign wdata_we = addr_hit[7] & reg_we & !reg_error;
-  assign wdata_wd = reg_wdata[7:0];
 
-  assign fifo_ctrl_rxrst_we = addr_hit[8] & reg_we & !reg_error;
+  assign wdata_wd = reg_wdata[7:0];
+  assign fifo_ctrl_we = addr_hit[8] & reg_we & !reg_error;
+
   assign fifo_ctrl_rxrst_wd = reg_wdata[0];
 
-  assign fifo_ctrl_txrst_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_txrst_wd = reg_wdata[1];
 
-  assign fifo_ctrl_rxilvl_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
-  assign fifo_ctrl_txilvl_we = addr_hit[8] & reg_we & !reg_error;
   assign fifo_ctrl_txilvl_wd = reg_wdata[6:5];
+  assign fifo_status_re = addr_hit[9] & reg_re & !reg_error;
+  assign ovrd_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign fifo_status_txlvl_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign fifo_status_rxlvl_re = addr_hit[9] & reg_re & !reg_error;
-
-  assign ovrd_txen_we = addr_hit[10] & reg_we & !reg_error;
   assign ovrd_txen_wd = reg_wdata[0];
 
-  assign ovrd_txval_we = addr_hit[10] & reg_we & !reg_error;
   assign ovrd_txval_wd = reg_wdata[1];
-
   assign val_re = addr_hit[11] & reg_re & !reg_error;
+  assign timeout_ctrl_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign timeout_ctrl_val_we = addr_hit[12] & reg_we & !reg_error;
   assign timeout_ctrl_val_wd = reg_wdata[23:0];
 
-  assign timeout_ctrl_en_we = addr_hit[12] & reg_we & !reg_error;
   assign timeout_ctrl_en_wd = reg_wdata[31];
 
   // Read data return

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -152,602 +152,415 @@ module usbdev_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_pkt_received_qs;
   logic intr_state_pkt_received_wd;
-  logic intr_state_pkt_received_we;
   logic intr_state_pkt_sent_qs;
   logic intr_state_pkt_sent_wd;
-  logic intr_state_pkt_sent_we;
   logic intr_state_disconnected_qs;
   logic intr_state_disconnected_wd;
-  logic intr_state_disconnected_we;
   logic intr_state_host_lost_qs;
   logic intr_state_host_lost_wd;
-  logic intr_state_host_lost_we;
   logic intr_state_link_reset_qs;
   logic intr_state_link_reset_wd;
-  logic intr_state_link_reset_we;
   logic intr_state_link_suspend_qs;
   logic intr_state_link_suspend_wd;
-  logic intr_state_link_suspend_we;
   logic intr_state_link_resume_qs;
   logic intr_state_link_resume_wd;
-  logic intr_state_link_resume_we;
   logic intr_state_av_empty_qs;
   logic intr_state_av_empty_wd;
-  logic intr_state_av_empty_we;
   logic intr_state_rx_full_qs;
   logic intr_state_rx_full_wd;
-  logic intr_state_rx_full_we;
   logic intr_state_av_overflow_qs;
   logic intr_state_av_overflow_wd;
-  logic intr_state_av_overflow_we;
   logic intr_state_link_in_err_qs;
   logic intr_state_link_in_err_wd;
-  logic intr_state_link_in_err_we;
   logic intr_state_rx_crc_err_qs;
   logic intr_state_rx_crc_err_wd;
-  logic intr_state_rx_crc_err_we;
   logic intr_state_rx_pid_err_qs;
   logic intr_state_rx_pid_err_wd;
-  logic intr_state_rx_pid_err_we;
   logic intr_state_rx_bitstuff_err_qs;
   logic intr_state_rx_bitstuff_err_wd;
-  logic intr_state_rx_bitstuff_err_we;
   logic intr_state_frame_qs;
   logic intr_state_frame_wd;
-  logic intr_state_frame_we;
   logic intr_state_connected_qs;
   logic intr_state_connected_wd;
-  logic intr_state_connected_we;
   logic intr_state_link_out_err_qs;
   logic intr_state_link_out_err_wd;
-  logic intr_state_link_out_err_we;
+  logic intr_enable_we;
   logic intr_enable_pkt_received_qs;
   logic intr_enable_pkt_received_wd;
-  logic intr_enable_pkt_received_we;
   logic intr_enable_pkt_sent_qs;
   logic intr_enable_pkt_sent_wd;
-  logic intr_enable_pkt_sent_we;
   logic intr_enable_disconnected_qs;
   logic intr_enable_disconnected_wd;
-  logic intr_enable_disconnected_we;
   logic intr_enable_host_lost_qs;
   logic intr_enable_host_lost_wd;
-  logic intr_enable_host_lost_we;
   logic intr_enable_link_reset_qs;
   logic intr_enable_link_reset_wd;
-  logic intr_enable_link_reset_we;
   logic intr_enable_link_suspend_qs;
   logic intr_enable_link_suspend_wd;
-  logic intr_enable_link_suspend_we;
   logic intr_enable_link_resume_qs;
   logic intr_enable_link_resume_wd;
-  logic intr_enable_link_resume_we;
   logic intr_enable_av_empty_qs;
   logic intr_enable_av_empty_wd;
-  logic intr_enable_av_empty_we;
   logic intr_enable_rx_full_qs;
   logic intr_enable_rx_full_wd;
-  logic intr_enable_rx_full_we;
   logic intr_enable_av_overflow_qs;
   logic intr_enable_av_overflow_wd;
-  logic intr_enable_av_overflow_we;
   logic intr_enable_link_in_err_qs;
   logic intr_enable_link_in_err_wd;
-  logic intr_enable_link_in_err_we;
   logic intr_enable_rx_crc_err_qs;
   logic intr_enable_rx_crc_err_wd;
-  logic intr_enable_rx_crc_err_we;
   logic intr_enable_rx_pid_err_qs;
   logic intr_enable_rx_pid_err_wd;
-  logic intr_enable_rx_pid_err_we;
   logic intr_enable_rx_bitstuff_err_qs;
   logic intr_enable_rx_bitstuff_err_wd;
-  logic intr_enable_rx_bitstuff_err_we;
   logic intr_enable_frame_qs;
   logic intr_enable_frame_wd;
-  logic intr_enable_frame_we;
   logic intr_enable_connected_qs;
   logic intr_enable_connected_wd;
-  logic intr_enable_connected_we;
   logic intr_enable_link_out_err_qs;
   logic intr_enable_link_out_err_wd;
-  logic intr_enable_link_out_err_we;
+  logic intr_test_we;
   logic intr_test_pkt_received_wd;
-  logic intr_test_pkt_received_we;
   logic intr_test_pkt_sent_wd;
-  logic intr_test_pkt_sent_we;
   logic intr_test_disconnected_wd;
-  logic intr_test_disconnected_we;
   logic intr_test_host_lost_wd;
-  logic intr_test_host_lost_we;
   logic intr_test_link_reset_wd;
-  logic intr_test_link_reset_we;
   logic intr_test_link_suspend_wd;
-  logic intr_test_link_suspend_we;
   logic intr_test_link_resume_wd;
-  logic intr_test_link_resume_we;
   logic intr_test_av_empty_wd;
-  logic intr_test_av_empty_we;
   logic intr_test_rx_full_wd;
-  logic intr_test_rx_full_we;
   logic intr_test_av_overflow_wd;
-  logic intr_test_av_overflow_we;
   logic intr_test_link_in_err_wd;
-  logic intr_test_link_in_err_we;
   logic intr_test_rx_crc_err_wd;
-  logic intr_test_rx_crc_err_we;
   logic intr_test_rx_pid_err_wd;
-  logic intr_test_rx_pid_err_we;
   logic intr_test_rx_bitstuff_err_wd;
-  logic intr_test_rx_bitstuff_err_we;
   logic intr_test_frame_wd;
-  logic intr_test_frame_we;
   logic intr_test_connected_wd;
-  logic intr_test_connected_we;
   logic intr_test_link_out_err_wd;
-  logic intr_test_link_out_err_we;
+  logic usbctrl_we;
   logic usbctrl_enable_qs;
   logic usbctrl_enable_wd;
-  logic usbctrl_enable_we;
   logic [6:0] usbctrl_device_address_qs;
   logic [6:0] usbctrl_device_address_wd;
-  logic usbctrl_device_address_we;
+  logic usbstat_re;
   logic [10:0] usbstat_frame_qs;
-  logic usbstat_frame_re;
   logic usbstat_host_lost_qs;
-  logic usbstat_host_lost_re;
   logic [2:0] usbstat_link_state_qs;
-  logic usbstat_link_state_re;
   logic usbstat_sense_qs;
-  logic usbstat_sense_re;
   logic [2:0] usbstat_av_depth_qs;
-  logic usbstat_av_depth_re;
   logic usbstat_av_full_qs;
-  logic usbstat_av_full_re;
   logic [2:0] usbstat_rx_depth_qs;
-  logic usbstat_rx_depth_re;
   logic usbstat_rx_empty_qs;
-  logic usbstat_rx_empty_re;
-  logic [4:0] avbuffer_wd;
   logic avbuffer_we;
+  logic [4:0] avbuffer_wd;
+  logic rxfifo_re;
   logic [4:0] rxfifo_buffer_qs;
-  logic rxfifo_buffer_re;
   logic [6:0] rxfifo_size_qs;
-  logic rxfifo_size_re;
   logic rxfifo_setup_qs;
-  logic rxfifo_setup_re;
   logic [3:0] rxfifo_ep_qs;
-  logic rxfifo_ep_re;
+  logic rxenable_setup_we;
   logic rxenable_setup_setup_0_qs;
   logic rxenable_setup_setup_0_wd;
-  logic rxenable_setup_setup_0_we;
   logic rxenable_setup_setup_1_qs;
   logic rxenable_setup_setup_1_wd;
-  logic rxenable_setup_setup_1_we;
   logic rxenable_setup_setup_2_qs;
   logic rxenable_setup_setup_2_wd;
-  logic rxenable_setup_setup_2_we;
   logic rxenable_setup_setup_3_qs;
   logic rxenable_setup_setup_3_wd;
-  logic rxenable_setup_setup_3_we;
   logic rxenable_setup_setup_4_qs;
   logic rxenable_setup_setup_4_wd;
-  logic rxenable_setup_setup_4_we;
   logic rxenable_setup_setup_5_qs;
   logic rxenable_setup_setup_5_wd;
-  logic rxenable_setup_setup_5_we;
   logic rxenable_setup_setup_6_qs;
   logic rxenable_setup_setup_6_wd;
-  logic rxenable_setup_setup_6_we;
   logic rxenable_setup_setup_7_qs;
   logic rxenable_setup_setup_7_wd;
-  logic rxenable_setup_setup_7_we;
   logic rxenable_setup_setup_8_qs;
   logic rxenable_setup_setup_8_wd;
-  logic rxenable_setup_setup_8_we;
   logic rxenable_setup_setup_9_qs;
   logic rxenable_setup_setup_9_wd;
-  logic rxenable_setup_setup_9_we;
   logic rxenable_setup_setup_10_qs;
   logic rxenable_setup_setup_10_wd;
-  logic rxenable_setup_setup_10_we;
   logic rxenable_setup_setup_11_qs;
   logic rxenable_setup_setup_11_wd;
-  logic rxenable_setup_setup_11_we;
+  logic rxenable_out_we;
   logic rxenable_out_out_0_qs;
   logic rxenable_out_out_0_wd;
-  logic rxenable_out_out_0_we;
   logic rxenable_out_out_1_qs;
   logic rxenable_out_out_1_wd;
-  logic rxenable_out_out_1_we;
   logic rxenable_out_out_2_qs;
   logic rxenable_out_out_2_wd;
-  logic rxenable_out_out_2_we;
   logic rxenable_out_out_3_qs;
   logic rxenable_out_out_3_wd;
-  logic rxenable_out_out_3_we;
   logic rxenable_out_out_4_qs;
   logic rxenable_out_out_4_wd;
-  logic rxenable_out_out_4_we;
   logic rxenable_out_out_5_qs;
   logic rxenable_out_out_5_wd;
-  logic rxenable_out_out_5_we;
   logic rxenable_out_out_6_qs;
   logic rxenable_out_out_6_wd;
-  logic rxenable_out_out_6_we;
   logic rxenable_out_out_7_qs;
   logic rxenable_out_out_7_wd;
-  logic rxenable_out_out_7_we;
   logic rxenable_out_out_8_qs;
   logic rxenable_out_out_8_wd;
-  logic rxenable_out_out_8_we;
   logic rxenable_out_out_9_qs;
   logic rxenable_out_out_9_wd;
-  logic rxenable_out_out_9_we;
   logic rxenable_out_out_10_qs;
   logic rxenable_out_out_10_wd;
-  logic rxenable_out_out_10_we;
   logic rxenable_out_out_11_qs;
   logic rxenable_out_out_11_wd;
-  logic rxenable_out_out_11_we;
+  logic in_sent_we;
   logic in_sent_sent_0_qs;
   logic in_sent_sent_0_wd;
-  logic in_sent_sent_0_we;
   logic in_sent_sent_1_qs;
   logic in_sent_sent_1_wd;
-  logic in_sent_sent_1_we;
   logic in_sent_sent_2_qs;
   logic in_sent_sent_2_wd;
-  logic in_sent_sent_2_we;
   logic in_sent_sent_3_qs;
   logic in_sent_sent_3_wd;
-  logic in_sent_sent_3_we;
   logic in_sent_sent_4_qs;
   logic in_sent_sent_4_wd;
-  logic in_sent_sent_4_we;
   logic in_sent_sent_5_qs;
   logic in_sent_sent_5_wd;
-  logic in_sent_sent_5_we;
   logic in_sent_sent_6_qs;
   logic in_sent_sent_6_wd;
-  logic in_sent_sent_6_we;
   logic in_sent_sent_7_qs;
   logic in_sent_sent_7_wd;
-  logic in_sent_sent_7_we;
   logic in_sent_sent_8_qs;
   logic in_sent_sent_8_wd;
-  logic in_sent_sent_8_we;
   logic in_sent_sent_9_qs;
   logic in_sent_sent_9_wd;
-  logic in_sent_sent_9_we;
   logic in_sent_sent_10_qs;
   logic in_sent_sent_10_wd;
-  logic in_sent_sent_10_we;
   logic in_sent_sent_11_qs;
   logic in_sent_sent_11_wd;
-  logic in_sent_sent_11_we;
+  logic stall_we;
   logic stall_stall_0_qs;
   logic stall_stall_0_wd;
-  logic stall_stall_0_we;
   logic stall_stall_1_qs;
   logic stall_stall_1_wd;
-  logic stall_stall_1_we;
   logic stall_stall_2_qs;
   logic stall_stall_2_wd;
-  logic stall_stall_2_we;
   logic stall_stall_3_qs;
   logic stall_stall_3_wd;
-  logic stall_stall_3_we;
   logic stall_stall_4_qs;
   logic stall_stall_4_wd;
-  logic stall_stall_4_we;
   logic stall_stall_5_qs;
   logic stall_stall_5_wd;
-  logic stall_stall_5_we;
   logic stall_stall_6_qs;
   logic stall_stall_6_wd;
-  logic stall_stall_6_we;
   logic stall_stall_7_qs;
   logic stall_stall_7_wd;
-  logic stall_stall_7_we;
   logic stall_stall_8_qs;
   logic stall_stall_8_wd;
-  logic stall_stall_8_we;
   logic stall_stall_9_qs;
   logic stall_stall_9_wd;
-  logic stall_stall_9_we;
   logic stall_stall_10_qs;
   logic stall_stall_10_wd;
-  logic stall_stall_10_we;
   logic stall_stall_11_qs;
   logic stall_stall_11_wd;
-  logic stall_stall_11_we;
+  logic configin_0_we;
   logic [4:0] configin_0_buffer_0_qs;
   logic [4:0] configin_0_buffer_0_wd;
-  logic configin_0_buffer_0_we;
   logic [6:0] configin_0_size_0_qs;
   logic [6:0] configin_0_size_0_wd;
-  logic configin_0_size_0_we;
   logic configin_0_pend_0_qs;
   logic configin_0_pend_0_wd;
-  logic configin_0_pend_0_we;
   logic configin_0_rdy_0_qs;
   logic configin_0_rdy_0_wd;
-  logic configin_0_rdy_0_we;
+  logic configin_1_we;
   logic [4:0] configin_1_buffer_1_qs;
   logic [4:0] configin_1_buffer_1_wd;
-  logic configin_1_buffer_1_we;
   logic [6:0] configin_1_size_1_qs;
   logic [6:0] configin_1_size_1_wd;
-  logic configin_1_size_1_we;
   logic configin_1_pend_1_qs;
   logic configin_1_pend_1_wd;
-  logic configin_1_pend_1_we;
   logic configin_1_rdy_1_qs;
   logic configin_1_rdy_1_wd;
-  logic configin_1_rdy_1_we;
+  logic configin_2_we;
   logic [4:0] configin_2_buffer_2_qs;
   logic [4:0] configin_2_buffer_2_wd;
-  logic configin_2_buffer_2_we;
   logic [6:0] configin_2_size_2_qs;
   logic [6:0] configin_2_size_2_wd;
-  logic configin_2_size_2_we;
   logic configin_2_pend_2_qs;
   logic configin_2_pend_2_wd;
-  logic configin_2_pend_2_we;
   logic configin_2_rdy_2_qs;
   logic configin_2_rdy_2_wd;
-  logic configin_2_rdy_2_we;
+  logic configin_3_we;
   logic [4:0] configin_3_buffer_3_qs;
   logic [4:0] configin_3_buffer_3_wd;
-  logic configin_3_buffer_3_we;
   logic [6:0] configin_3_size_3_qs;
   logic [6:0] configin_3_size_3_wd;
-  logic configin_3_size_3_we;
   logic configin_3_pend_3_qs;
   logic configin_3_pend_3_wd;
-  logic configin_3_pend_3_we;
   logic configin_3_rdy_3_qs;
   logic configin_3_rdy_3_wd;
-  logic configin_3_rdy_3_we;
+  logic configin_4_we;
   logic [4:0] configin_4_buffer_4_qs;
   logic [4:0] configin_4_buffer_4_wd;
-  logic configin_4_buffer_4_we;
   logic [6:0] configin_4_size_4_qs;
   logic [6:0] configin_4_size_4_wd;
-  logic configin_4_size_4_we;
   logic configin_4_pend_4_qs;
   logic configin_4_pend_4_wd;
-  logic configin_4_pend_4_we;
   logic configin_4_rdy_4_qs;
   logic configin_4_rdy_4_wd;
-  logic configin_4_rdy_4_we;
+  logic configin_5_we;
   logic [4:0] configin_5_buffer_5_qs;
   logic [4:0] configin_5_buffer_5_wd;
-  logic configin_5_buffer_5_we;
   logic [6:0] configin_5_size_5_qs;
   logic [6:0] configin_5_size_5_wd;
-  logic configin_5_size_5_we;
   logic configin_5_pend_5_qs;
   logic configin_5_pend_5_wd;
-  logic configin_5_pend_5_we;
   logic configin_5_rdy_5_qs;
   logic configin_5_rdy_5_wd;
-  logic configin_5_rdy_5_we;
+  logic configin_6_we;
   logic [4:0] configin_6_buffer_6_qs;
   logic [4:0] configin_6_buffer_6_wd;
-  logic configin_6_buffer_6_we;
   logic [6:0] configin_6_size_6_qs;
   logic [6:0] configin_6_size_6_wd;
-  logic configin_6_size_6_we;
   logic configin_6_pend_6_qs;
   logic configin_6_pend_6_wd;
-  logic configin_6_pend_6_we;
   logic configin_6_rdy_6_qs;
   logic configin_6_rdy_6_wd;
-  logic configin_6_rdy_6_we;
+  logic configin_7_we;
   logic [4:0] configin_7_buffer_7_qs;
   logic [4:0] configin_7_buffer_7_wd;
-  logic configin_7_buffer_7_we;
   logic [6:0] configin_7_size_7_qs;
   logic [6:0] configin_7_size_7_wd;
-  logic configin_7_size_7_we;
   logic configin_7_pend_7_qs;
   logic configin_7_pend_7_wd;
-  logic configin_7_pend_7_we;
   logic configin_7_rdy_7_qs;
   logic configin_7_rdy_7_wd;
-  logic configin_7_rdy_7_we;
+  logic configin_8_we;
   logic [4:0] configin_8_buffer_8_qs;
   logic [4:0] configin_8_buffer_8_wd;
-  logic configin_8_buffer_8_we;
   logic [6:0] configin_8_size_8_qs;
   logic [6:0] configin_8_size_8_wd;
-  logic configin_8_size_8_we;
   logic configin_8_pend_8_qs;
   logic configin_8_pend_8_wd;
-  logic configin_8_pend_8_we;
   logic configin_8_rdy_8_qs;
   logic configin_8_rdy_8_wd;
-  logic configin_8_rdy_8_we;
+  logic configin_9_we;
   logic [4:0] configin_9_buffer_9_qs;
   logic [4:0] configin_9_buffer_9_wd;
-  logic configin_9_buffer_9_we;
   logic [6:0] configin_9_size_9_qs;
   logic [6:0] configin_9_size_9_wd;
-  logic configin_9_size_9_we;
   logic configin_9_pend_9_qs;
   logic configin_9_pend_9_wd;
-  logic configin_9_pend_9_we;
   logic configin_9_rdy_9_qs;
   logic configin_9_rdy_9_wd;
-  logic configin_9_rdy_9_we;
+  logic configin_10_we;
   logic [4:0] configin_10_buffer_10_qs;
   logic [4:0] configin_10_buffer_10_wd;
-  logic configin_10_buffer_10_we;
   logic [6:0] configin_10_size_10_qs;
   logic [6:0] configin_10_size_10_wd;
-  logic configin_10_size_10_we;
   logic configin_10_pend_10_qs;
   logic configin_10_pend_10_wd;
-  logic configin_10_pend_10_we;
   logic configin_10_rdy_10_qs;
   logic configin_10_rdy_10_wd;
-  logic configin_10_rdy_10_we;
+  logic configin_11_we;
   logic [4:0] configin_11_buffer_11_qs;
   logic [4:0] configin_11_buffer_11_wd;
-  logic configin_11_buffer_11_we;
   logic [6:0] configin_11_size_11_qs;
   logic [6:0] configin_11_size_11_wd;
-  logic configin_11_size_11_we;
   logic configin_11_pend_11_qs;
   logic configin_11_pend_11_wd;
-  logic configin_11_pend_11_we;
   logic configin_11_rdy_11_qs;
   logic configin_11_rdy_11_wd;
-  logic configin_11_rdy_11_we;
+  logic iso_we;
   logic iso_iso_0_qs;
   logic iso_iso_0_wd;
-  logic iso_iso_0_we;
   logic iso_iso_1_qs;
   logic iso_iso_1_wd;
-  logic iso_iso_1_we;
   logic iso_iso_2_qs;
   logic iso_iso_2_wd;
-  logic iso_iso_2_we;
   logic iso_iso_3_qs;
   logic iso_iso_3_wd;
-  logic iso_iso_3_we;
   logic iso_iso_4_qs;
   logic iso_iso_4_wd;
-  logic iso_iso_4_we;
   logic iso_iso_5_qs;
   logic iso_iso_5_wd;
-  logic iso_iso_5_we;
   logic iso_iso_6_qs;
   logic iso_iso_6_wd;
-  logic iso_iso_6_we;
   logic iso_iso_7_qs;
   logic iso_iso_7_wd;
-  logic iso_iso_7_we;
   logic iso_iso_8_qs;
   logic iso_iso_8_wd;
-  logic iso_iso_8_we;
   logic iso_iso_9_qs;
   logic iso_iso_9_wd;
-  logic iso_iso_9_we;
   logic iso_iso_10_qs;
   logic iso_iso_10_wd;
-  logic iso_iso_10_we;
   logic iso_iso_11_qs;
   logic iso_iso_11_wd;
-  logic iso_iso_11_we;
+  logic data_toggle_clear_we;
   logic data_toggle_clear_clear_0_wd;
-  logic data_toggle_clear_clear_0_we;
   logic data_toggle_clear_clear_1_wd;
-  logic data_toggle_clear_clear_1_we;
   logic data_toggle_clear_clear_2_wd;
-  logic data_toggle_clear_clear_2_we;
   logic data_toggle_clear_clear_3_wd;
-  logic data_toggle_clear_clear_3_we;
   logic data_toggle_clear_clear_4_wd;
-  logic data_toggle_clear_clear_4_we;
   logic data_toggle_clear_clear_5_wd;
-  logic data_toggle_clear_clear_5_we;
   logic data_toggle_clear_clear_6_wd;
-  logic data_toggle_clear_clear_6_we;
   logic data_toggle_clear_clear_7_wd;
-  logic data_toggle_clear_clear_7_we;
   logic data_toggle_clear_clear_8_wd;
-  logic data_toggle_clear_clear_8_we;
   logic data_toggle_clear_clear_9_wd;
-  logic data_toggle_clear_clear_9_we;
   logic data_toggle_clear_clear_10_wd;
-  logic data_toggle_clear_clear_10_we;
   logic data_toggle_clear_clear_11_wd;
-  logic data_toggle_clear_clear_11_we;
+  logic phy_pins_sense_re;
   logic phy_pins_sense_rx_dp_i_qs;
-  logic phy_pins_sense_rx_dp_i_re;
   logic phy_pins_sense_rx_dn_i_qs;
-  logic phy_pins_sense_rx_dn_i_re;
   logic phy_pins_sense_rx_d_i_qs;
-  logic phy_pins_sense_rx_d_i_re;
   logic phy_pins_sense_tx_dp_o_qs;
-  logic phy_pins_sense_tx_dp_o_re;
   logic phy_pins_sense_tx_dn_o_qs;
-  logic phy_pins_sense_tx_dn_o_re;
   logic phy_pins_sense_tx_d_o_qs;
-  logic phy_pins_sense_tx_d_o_re;
   logic phy_pins_sense_tx_se0_o_qs;
-  logic phy_pins_sense_tx_se0_o_re;
   logic phy_pins_sense_tx_oe_o_qs;
-  logic phy_pins_sense_tx_oe_o_re;
   logic phy_pins_sense_suspend_o_qs;
-  logic phy_pins_sense_suspend_o_re;
   logic phy_pins_sense_pwr_sense_qs;
-  logic phy_pins_sense_pwr_sense_re;
+  logic phy_pins_drive_we;
   logic phy_pins_drive_dp_o_qs;
   logic phy_pins_drive_dp_o_wd;
-  logic phy_pins_drive_dp_o_we;
   logic phy_pins_drive_dn_o_qs;
   logic phy_pins_drive_dn_o_wd;
-  logic phy_pins_drive_dn_o_we;
   logic phy_pins_drive_d_o_qs;
   logic phy_pins_drive_d_o_wd;
-  logic phy_pins_drive_d_o_we;
   logic phy_pins_drive_se0_o_qs;
   logic phy_pins_drive_se0_o_wd;
-  logic phy_pins_drive_se0_o_we;
   logic phy_pins_drive_oe_o_qs;
   logic phy_pins_drive_oe_o_wd;
-  logic phy_pins_drive_oe_o_we;
   logic phy_pins_drive_tx_mode_se_o_qs;
   logic phy_pins_drive_tx_mode_se_o_wd;
-  logic phy_pins_drive_tx_mode_se_o_we;
   logic phy_pins_drive_dp_pullup_en_o_qs;
   logic phy_pins_drive_dp_pullup_en_o_wd;
-  logic phy_pins_drive_dp_pullup_en_o_we;
   logic phy_pins_drive_dn_pullup_en_o_qs;
   logic phy_pins_drive_dn_pullup_en_o_wd;
-  logic phy_pins_drive_dn_pullup_en_o_we;
   logic phy_pins_drive_suspend_o_qs;
   logic phy_pins_drive_suspend_o_wd;
-  logic phy_pins_drive_suspend_o_we;
   logic phy_pins_drive_en_qs;
   logic phy_pins_drive_en_wd;
-  logic phy_pins_drive_en_we;
+  logic phy_config_we;
   logic phy_config_rx_differential_mode_qs;
   logic phy_config_rx_differential_mode_wd;
-  logic phy_config_rx_differential_mode_we;
   logic phy_config_tx_differential_mode_qs;
   logic phy_config_tx_differential_mode_wd;
-  logic phy_config_tx_differential_mode_we;
   logic phy_config_eop_single_bit_qs;
   logic phy_config_eop_single_bit_wd;
-  logic phy_config_eop_single_bit_we;
   logic phy_config_override_pwr_sense_en_qs;
   logic phy_config_override_pwr_sense_en_wd;
-  logic phy_config_override_pwr_sense_en_we;
   logic phy_config_override_pwr_sense_val_qs;
   logic phy_config_override_pwr_sense_val_wd;
-  logic phy_config_override_pwr_sense_val_we;
   logic phy_config_pinflip_qs;
   logic phy_config_pinflip_wd;
-  logic phy_config_pinflip_we;
   logic phy_config_usb_ref_disable_qs;
   logic phy_config_usb_ref_disable_wd;
-  logic phy_config_usb_ref_disable_we;
   logic phy_config_tx_osc_test_mode_qs;
   logic phy_config_tx_osc_test_mode_wd;
-  logic phy_config_tx_osc_test_mode_we;
+  logic wake_config_we;
   logic wake_config_wake_en_qs;
   logic wake_config_wake_en_wd;
-  logic wake_config_wake_en_we;
   logic wake_config_wake_ack_qs;
   logic wake_config_wake_ack_wd;
-  logic wake_config_wake_ack_we;
   logic [2:0] wake_debug_qs;
 
   // Register instances
@@ -763,7 +576,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_pkt_received_we),
+    .we     (intr_state_we),
     .wd     (intr_state_pkt_received_wd),
 
     // from internal hardware
@@ -789,7 +602,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_pkt_sent_we),
+    .we     (intr_state_we),
     .wd     (intr_state_pkt_sent_wd),
 
     // from internal hardware
@@ -815,7 +628,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_disconnected_we),
+    .we     (intr_state_we),
     .wd     (intr_state_disconnected_wd),
 
     // from internal hardware
@@ -841,7 +654,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_host_lost_we),
+    .we     (intr_state_we),
     .wd     (intr_state_host_lost_wd),
 
     // from internal hardware
@@ -867,7 +680,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_link_reset_we),
+    .we     (intr_state_we),
     .wd     (intr_state_link_reset_wd),
 
     // from internal hardware
@@ -893,7 +706,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_link_suspend_we),
+    .we     (intr_state_we),
     .wd     (intr_state_link_suspend_wd),
 
     // from internal hardware
@@ -919,7 +732,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_link_resume_we),
+    .we     (intr_state_we),
     .wd     (intr_state_link_resume_wd),
 
     // from internal hardware
@@ -945,7 +758,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_av_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_av_empty_wd),
 
     // from internal hardware
@@ -971,7 +784,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_full_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_full_wd),
 
     // from internal hardware
@@ -997,7 +810,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_av_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_av_overflow_wd),
 
     // from internal hardware
@@ -1023,7 +836,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_link_in_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_link_in_err_wd),
 
     // from internal hardware
@@ -1049,7 +862,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_crc_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_crc_err_wd),
 
     // from internal hardware
@@ -1075,7 +888,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_pid_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_pid_err_wd),
 
     // from internal hardware
@@ -1101,7 +914,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_bitstuff_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_bitstuff_err_wd),
 
     // from internal hardware
@@ -1127,7 +940,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_frame_we),
+    .we     (intr_state_we),
     .wd     (intr_state_frame_wd),
 
     // from internal hardware
@@ -1153,7 +966,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_connected_we),
+    .we     (intr_state_we),
     .wd     (intr_state_connected_wd),
 
     // from internal hardware
@@ -1179,7 +992,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_link_out_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_link_out_err_wd),
 
     // from internal hardware
@@ -1207,7 +1020,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_pkt_received_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_pkt_received_wd),
 
     // from internal hardware
@@ -1233,7 +1046,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_pkt_sent_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_pkt_sent_wd),
 
     // from internal hardware
@@ -1259,7 +1072,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_disconnected_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_disconnected_wd),
 
     // from internal hardware
@@ -1285,7 +1098,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_host_lost_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_host_lost_wd),
 
     // from internal hardware
@@ -1311,7 +1124,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_link_reset_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_link_reset_wd),
 
     // from internal hardware
@@ -1337,7 +1150,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_link_suspend_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_link_suspend_wd),
 
     // from internal hardware
@@ -1363,7 +1176,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_link_resume_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_link_resume_wd),
 
     // from internal hardware
@@ -1389,7 +1202,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_av_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_av_empty_wd),
 
     // from internal hardware
@@ -1415,7 +1228,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_full_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_full_wd),
 
     // from internal hardware
@@ -1441,7 +1254,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_av_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_av_overflow_wd),
 
     // from internal hardware
@@ -1467,7 +1280,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_link_in_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_link_in_err_wd),
 
     // from internal hardware
@@ -1493,7 +1306,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_crc_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_crc_err_wd),
 
     // from internal hardware
@@ -1519,7 +1332,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_pid_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_pid_err_wd),
 
     // from internal hardware
@@ -1545,7 +1358,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_bitstuff_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_bitstuff_err_wd),
 
     // from internal hardware
@@ -1571,7 +1384,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_frame_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_frame_wd),
 
     // from internal hardware
@@ -1597,7 +1410,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_connected_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_connected_wd),
 
     // from internal hardware
@@ -1623,7 +1436,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_link_out_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_link_out_err_wd),
 
     // from internal hardware
@@ -1646,7 +1459,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_pkt_received (
     .re     (1'b0),
-    .we     (intr_test_pkt_received_we),
+    .we     (intr_test_we),
     .wd     (intr_test_pkt_received_wd),
     .d      ('0),
     .qre    (),
@@ -1661,7 +1474,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_pkt_sent (
     .re     (1'b0),
-    .we     (intr_test_pkt_sent_we),
+    .we     (intr_test_we),
     .wd     (intr_test_pkt_sent_wd),
     .d      ('0),
     .qre    (),
@@ -1676,7 +1489,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_disconnected (
     .re     (1'b0),
-    .we     (intr_test_disconnected_we),
+    .we     (intr_test_we),
     .wd     (intr_test_disconnected_wd),
     .d      ('0),
     .qre    (),
@@ -1691,7 +1504,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_host_lost (
     .re     (1'b0),
-    .we     (intr_test_host_lost_we),
+    .we     (intr_test_we),
     .wd     (intr_test_host_lost_wd),
     .d      ('0),
     .qre    (),
@@ -1706,7 +1519,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_link_reset (
     .re     (1'b0),
-    .we     (intr_test_link_reset_we),
+    .we     (intr_test_we),
     .wd     (intr_test_link_reset_wd),
     .d      ('0),
     .qre    (),
@@ -1721,7 +1534,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_link_suspend (
     .re     (1'b0),
-    .we     (intr_test_link_suspend_we),
+    .we     (intr_test_we),
     .wd     (intr_test_link_suspend_wd),
     .d      ('0),
     .qre    (),
@@ -1736,7 +1549,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_link_resume (
     .re     (1'b0),
-    .we     (intr_test_link_resume_we),
+    .we     (intr_test_we),
     .wd     (intr_test_link_resume_wd),
     .d      ('0),
     .qre    (),
@@ -1751,7 +1564,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_av_empty (
     .re     (1'b0),
-    .we     (intr_test_av_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_av_empty_wd),
     .d      ('0),
     .qre    (),
@@ -1766,7 +1579,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_rx_full (
     .re     (1'b0),
-    .we     (intr_test_rx_full_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_full_wd),
     .d      ('0),
     .qre    (),
@@ -1781,7 +1594,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_av_overflow (
     .re     (1'b0),
-    .we     (intr_test_av_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_av_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -1796,7 +1609,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_link_in_err (
     .re     (1'b0),
-    .we     (intr_test_link_in_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_link_in_err_wd),
     .d      ('0),
     .qre    (),
@@ -1811,7 +1624,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_rx_crc_err (
     .re     (1'b0),
-    .we     (intr_test_rx_crc_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_crc_err_wd),
     .d      ('0),
     .qre    (),
@@ -1826,7 +1639,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_rx_pid_err (
     .re     (1'b0),
-    .we     (intr_test_rx_pid_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_pid_err_wd),
     .d      ('0),
     .qre    (),
@@ -1841,7 +1654,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_rx_bitstuff_err (
     .re     (1'b0),
-    .we     (intr_test_rx_bitstuff_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_bitstuff_err_wd),
     .d      ('0),
     .qre    (),
@@ -1856,7 +1669,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_frame (
     .re     (1'b0),
-    .we     (intr_test_frame_we),
+    .we     (intr_test_we),
     .wd     (intr_test_frame_wd),
     .d      ('0),
     .qre    (),
@@ -1871,7 +1684,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_connected (
     .re     (1'b0),
-    .we     (intr_test_connected_we),
+    .we     (intr_test_we),
     .wd     (intr_test_connected_wd),
     .d      ('0),
     .qre    (),
@@ -1886,7 +1699,7 @@ module usbdev_reg_top (
     .DW    (1)
   ) u_intr_test_link_out_err (
     .re     (1'b0),
-    .we     (intr_test_link_out_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_link_out_err_wd),
     .d      ('0),
     .qre    (),
@@ -1908,7 +1721,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (usbctrl_enable_we),
+    .we     (usbctrl_we),
     .wd     (usbctrl_enable_wd),
 
     // from internal hardware
@@ -1934,7 +1747,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (usbctrl_device_address_we),
+    .we     (usbctrl_we),
     .wd     (usbctrl_device_address_wd),
 
     // from internal hardware
@@ -1956,7 +1769,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (11)
   ) u_usbstat_frame (
-    .re     (usbstat_frame_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.frame.d),
@@ -1971,7 +1784,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_host_lost (
-    .re     (usbstat_host_lost_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.host_lost.d),
@@ -1986,7 +1799,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_usbstat_link_state (
-    .re     (usbstat_link_state_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.link_state.d),
@@ -2001,7 +1814,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_sense (
-    .re     (usbstat_sense_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.sense.d),
@@ -2016,7 +1829,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_usbstat_av_depth (
-    .re     (usbstat_av_depth_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.av_depth.d),
@@ -2031,7 +1844,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_av_full (
-    .re     (usbstat_av_full_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.av_full.d),
@@ -2046,7 +1859,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (3)
   ) u_usbstat_rx_depth (
-    .re     (usbstat_rx_depth_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.rx_depth.d),
@@ -2061,7 +1874,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_rx_empty (
-    .re     (usbstat_rx_empty_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.rx_empty.d),
@@ -2105,7 +1918,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (5)
   ) u_rxfifo_buffer (
-    .re     (rxfifo_buffer_re),
+    .re     (rxfifo_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.rxfifo.buffer.d),
@@ -2120,7 +1933,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (7)
   ) u_rxfifo_size (
-    .re     (rxfifo_size_re),
+    .re     (rxfifo_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.rxfifo.size.d),
@@ -2135,7 +1948,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_rxfifo_setup (
-    .re     (rxfifo_setup_re),
+    .re     (rxfifo_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.rxfifo.setup.d),
@@ -2150,7 +1963,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (4)
   ) u_rxfifo_ep (
-    .re     (rxfifo_ep_re),
+    .re     (rxfifo_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.rxfifo.ep.d),
@@ -2175,7 +1988,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_0_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_0_wd),
 
     // from internal hardware
@@ -2201,7 +2014,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_1_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_1_wd),
 
     // from internal hardware
@@ -2227,7 +2040,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_2_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_2_wd),
 
     // from internal hardware
@@ -2253,7 +2066,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_3_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_3_wd),
 
     // from internal hardware
@@ -2279,7 +2092,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_4_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_4_wd),
 
     // from internal hardware
@@ -2305,7 +2118,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_5_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_5_wd),
 
     // from internal hardware
@@ -2331,7 +2144,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_6_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_6_wd),
 
     // from internal hardware
@@ -2357,7 +2170,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_7_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_7_wd),
 
     // from internal hardware
@@ -2383,7 +2196,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_8_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_8_wd),
 
     // from internal hardware
@@ -2409,7 +2222,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_9_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_9_wd),
 
     // from internal hardware
@@ -2435,7 +2248,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_10_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_10_wd),
 
     // from internal hardware
@@ -2461,7 +2274,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_setup_setup_11_we),
+    .we     (rxenable_setup_we),
     .wd     (rxenable_setup_setup_11_wd),
 
     // from internal hardware
@@ -2492,7 +2305,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_0_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_0_wd),
 
     // from internal hardware
@@ -2518,7 +2331,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_1_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_1_wd),
 
     // from internal hardware
@@ -2544,7 +2357,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_2_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_2_wd),
 
     // from internal hardware
@@ -2570,7 +2383,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_3_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_3_wd),
 
     // from internal hardware
@@ -2596,7 +2409,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_4_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_4_wd),
 
     // from internal hardware
@@ -2622,7 +2435,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_5_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_5_wd),
 
     // from internal hardware
@@ -2648,7 +2461,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_6_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_6_wd),
 
     // from internal hardware
@@ -2674,7 +2487,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_7_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_7_wd),
 
     // from internal hardware
@@ -2700,7 +2513,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_8_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_8_wd),
 
     // from internal hardware
@@ -2726,7 +2539,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_9_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_9_wd),
 
     // from internal hardware
@@ -2752,7 +2565,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_10_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_10_wd),
 
     // from internal hardware
@@ -2778,7 +2591,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rxenable_out_out_11_we),
+    .we     (rxenable_out_we),
     .wd     (rxenable_out_out_11_wd),
 
     // from internal hardware
@@ -2809,7 +2622,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_0_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_0_wd),
 
     // from internal hardware
@@ -2835,7 +2648,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_1_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_1_wd),
 
     // from internal hardware
@@ -2861,7 +2674,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_2_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_2_wd),
 
     // from internal hardware
@@ -2887,7 +2700,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_3_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_3_wd),
 
     // from internal hardware
@@ -2913,7 +2726,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_4_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_4_wd),
 
     // from internal hardware
@@ -2939,7 +2752,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_5_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_5_wd),
 
     // from internal hardware
@@ -2965,7 +2778,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_6_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_6_wd),
 
     // from internal hardware
@@ -2991,7 +2804,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_7_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_7_wd),
 
     // from internal hardware
@@ -3017,7 +2830,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_8_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_8_wd),
 
     // from internal hardware
@@ -3043,7 +2856,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_9_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_9_wd),
 
     // from internal hardware
@@ -3069,7 +2882,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_10_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_10_wd),
 
     // from internal hardware
@@ -3095,7 +2908,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (in_sent_sent_11_we),
+    .we     (in_sent_we),
     .wd     (in_sent_sent_11_wd),
 
     // from internal hardware
@@ -3126,7 +2939,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_0_we),
+    .we     (stall_we),
     .wd     (stall_stall_0_wd),
 
     // from internal hardware
@@ -3152,7 +2965,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_1_we),
+    .we     (stall_we),
     .wd     (stall_stall_1_wd),
 
     // from internal hardware
@@ -3178,7 +2991,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_2_we),
+    .we     (stall_we),
     .wd     (stall_stall_2_wd),
 
     // from internal hardware
@@ -3204,7 +3017,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_3_we),
+    .we     (stall_we),
     .wd     (stall_stall_3_wd),
 
     // from internal hardware
@@ -3230,7 +3043,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_4_we),
+    .we     (stall_we),
     .wd     (stall_stall_4_wd),
 
     // from internal hardware
@@ -3256,7 +3069,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_5_we),
+    .we     (stall_we),
     .wd     (stall_stall_5_wd),
 
     // from internal hardware
@@ -3282,7 +3095,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_6_we),
+    .we     (stall_we),
     .wd     (stall_stall_6_wd),
 
     // from internal hardware
@@ -3308,7 +3121,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_7_we),
+    .we     (stall_we),
     .wd     (stall_stall_7_wd),
 
     // from internal hardware
@@ -3334,7 +3147,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_8_we),
+    .we     (stall_we),
     .wd     (stall_stall_8_wd),
 
     // from internal hardware
@@ -3360,7 +3173,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_9_we),
+    .we     (stall_we),
     .wd     (stall_stall_9_wd),
 
     // from internal hardware
@@ -3386,7 +3199,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_10_we),
+    .we     (stall_we),
     .wd     (stall_stall_10_wd),
 
     // from internal hardware
@@ -3412,7 +3225,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_stall_11_we),
+    .we     (stall_we),
     .wd     (stall_stall_11_wd),
 
     // from internal hardware
@@ -3443,7 +3256,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_0_buffer_0_we),
+    .we     (configin_0_we),
     .wd     (configin_0_buffer_0_wd),
 
     // from internal hardware
@@ -3469,7 +3282,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_0_size_0_we),
+    .we     (configin_0_we),
     .wd     (configin_0_size_0_wd),
 
     // from internal hardware
@@ -3495,7 +3308,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_0_pend_0_we),
+    .we     (configin_0_we),
     .wd     (configin_0_pend_0_wd),
 
     // from internal hardware
@@ -3521,7 +3334,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_0_rdy_0_we),
+    .we     (configin_0_we),
     .wd     (configin_0_rdy_0_wd),
 
     // from internal hardware
@@ -3550,7 +3363,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_1_buffer_1_we),
+    .we     (configin_1_we),
     .wd     (configin_1_buffer_1_wd),
 
     // from internal hardware
@@ -3576,7 +3389,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_1_size_1_we),
+    .we     (configin_1_we),
     .wd     (configin_1_size_1_wd),
 
     // from internal hardware
@@ -3602,7 +3415,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_1_pend_1_we),
+    .we     (configin_1_we),
     .wd     (configin_1_pend_1_wd),
 
     // from internal hardware
@@ -3628,7 +3441,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_1_rdy_1_we),
+    .we     (configin_1_we),
     .wd     (configin_1_rdy_1_wd),
 
     // from internal hardware
@@ -3657,7 +3470,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_2_buffer_2_we),
+    .we     (configin_2_we),
     .wd     (configin_2_buffer_2_wd),
 
     // from internal hardware
@@ -3683,7 +3496,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_2_size_2_we),
+    .we     (configin_2_we),
     .wd     (configin_2_size_2_wd),
 
     // from internal hardware
@@ -3709,7 +3522,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_2_pend_2_we),
+    .we     (configin_2_we),
     .wd     (configin_2_pend_2_wd),
 
     // from internal hardware
@@ -3735,7 +3548,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_2_rdy_2_we),
+    .we     (configin_2_we),
     .wd     (configin_2_rdy_2_wd),
 
     // from internal hardware
@@ -3764,7 +3577,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_3_buffer_3_we),
+    .we     (configin_3_we),
     .wd     (configin_3_buffer_3_wd),
 
     // from internal hardware
@@ -3790,7 +3603,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_3_size_3_we),
+    .we     (configin_3_we),
     .wd     (configin_3_size_3_wd),
 
     // from internal hardware
@@ -3816,7 +3629,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_3_pend_3_we),
+    .we     (configin_3_we),
     .wd     (configin_3_pend_3_wd),
 
     // from internal hardware
@@ -3842,7 +3655,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_3_rdy_3_we),
+    .we     (configin_3_we),
     .wd     (configin_3_rdy_3_wd),
 
     // from internal hardware
@@ -3871,7 +3684,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_4_buffer_4_we),
+    .we     (configin_4_we),
     .wd     (configin_4_buffer_4_wd),
 
     // from internal hardware
@@ -3897,7 +3710,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_4_size_4_we),
+    .we     (configin_4_we),
     .wd     (configin_4_size_4_wd),
 
     // from internal hardware
@@ -3923,7 +3736,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_4_pend_4_we),
+    .we     (configin_4_we),
     .wd     (configin_4_pend_4_wd),
 
     // from internal hardware
@@ -3949,7 +3762,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_4_rdy_4_we),
+    .we     (configin_4_we),
     .wd     (configin_4_rdy_4_wd),
 
     // from internal hardware
@@ -3978,7 +3791,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_5_buffer_5_we),
+    .we     (configin_5_we),
     .wd     (configin_5_buffer_5_wd),
 
     // from internal hardware
@@ -4004,7 +3817,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_5_size_5_we),
+    .we     (configin_5_we),
     .wd     (configin_5_size_5_wd),
 
     // from internal hardware
@@ -4030,7 +3843,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_5_pend_5_we),
+    .we     (configin_5_we),
     .wd     (configin_5_pend_5_wd),
 
     // from internal hardware
@@ -4056,7 +3869,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_5_rdy_5_we),
+    .we     (configin_5_we),
     .wd     (configin_5_rdy_5_wd),
 
     // from internal hardware
@@ -4085,7 +3898,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_6_buffer_6_we),
+    .we     (configin_6_we),
     .wd     (configin_6_buffer_6_wd),
 
     // from internal hardware
@@ -4111,7 +3924,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_6_size_6_we),
+    .we     (configin_6_we),
     .wd     (configin_6_size_6_wd),
 
     // from internal hardware
@@ -4137,7 +3950,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_6_pend_6_we),
+    .we     (configin_6_we),
     .wd     (configin_6_pend_6_wd),
 
     // from internal hardware
@@ -4163,7 +3976,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_6_rdy_6_we),
+    .we     (configin_6_we),
     .wd     (configin_6_rdy_6_wd),
 
     // from internal hardware
@@ -4192,7 +4005,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_7_buffer_7_we),
+    .we     (configin_7_we),
     .wd     (configin_7_buffer_7_wd),
 
     // from internal hardware
@@ -4218,7 +4031,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_7_size_7_we),
+    .we     (configin_7_we),
     .wd     (configin_7_size_7_wd),
 
     // from internal hardware
@@ -4244,7 +4057,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_7_pend_7_we),
+    .we     (configin_7_we),
     .wd     (configin_7_pend_7_wd),
 
     // from internal hardware
@@ -4270,7 +4083,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_7_rdy_7_we),
+    .we     (configin_7_we),
     .wd     (configin_7_rdy_7_wd),
 
     // from internal hardware
@@ -4299,7 +4112,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_8_buffer_8_we),
+    .we     (configin_8_we),
     .wd     (configin_8_buffer_8_wd),
 
     // from internal hardware
@@ -4325,7 +4138,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_8_size_8_we),
+    .we     (configin_8_we),
     .wd     (configin_8_size_8_wd),
 
     // from internal hardware
@@ -4351,7 +4164,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_8_pend_8_we),
+    .we     (configin_8_we),
     .wd     (configin_8_pend_8_wd),
 
     // from internal hardware
@@ -4377,7 +4190,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_8_rdy_8_we),
+    .we     (configin_8_we),
     .wd     (configin_8_rdy_8_wd),
 
     // from internal hardware
@@ -4406,7 +4219,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_9_buffer_9_we),
+    .we     (configin_9_we),
     .wd     (configin_9_buffer_9_wd),
 
     // from internal hardware
@@ -4432,7 +4245,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_9_size_9_we),
+    .we     (configin_9_we),
     .wd     (configin_9_size_9_wd),
 
     // from internal hardware
@@ -4458,7 +4271,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_9_pend_9_we),
+    .we     (configin_9_we),
     .wd     (configin_9_pend_9_wd),
 
     // from internal hardware
@@ -4484,7 +4297,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_9_rdy_9_we),
+    .we     (configin_9_we),
     .wd     (configin_9_rdy_9_wd),
 
     // from internal hardware
@@ -4513,7 +4326,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_10_buffer_10_we),
+    .we     (configin_10_we),
     .wd     (configin_10_buffer_10_wd),
 
     // from internal hardware
@@ -4539,7 +4352,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_10_size_10_we),
+    .we     (configin_10_we),
     .wd     (configin_10_size_10_wd),
 
     // from internal hardware
@@ -4565,7 +4378,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_10_pend_10_we),
+    .we     (configin_10_we),
     .wd     (configin_10_pend_10_wd),
 
     // from internal hardware
@@ -4591,7 +4404,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_10_rdy_10_we),
+    .we     (configin_10_we),
     .wd     (configin_10_rdy_10_wd),
 
     // from internal hardware
@@ -4620,7 +4433,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_11_buffer_11_we),
+    .we     (configin_11_we),
     .wd     (configin_11_buffer_11_wd),
 
     // from internal hardware
@@ -4646,7 +4459,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_11_size_11_we),
+    .we     (configin_11_we),
     .wd     (configin_11_size_11_wd),
 
     // from internal hardware
@@ -4672,7 +4485,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_11_pend_11_we),
+    .we     (configin_11_we),
     .wd     (configin_11_pend_11_wd),
 
     // from internal hardware
@@ -4698,7 +4511,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (configin_11_rdy_11_we),
+    .we     (configin_11_we),
     .wd     (configin_11_rdy_11_wd),
 
     // from internal hardware
@@ -4729,7 +4542,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_0_we),
+    .we     (iso_we),
     .wd     (iso_iso_0_wd),
 
     // from internal hardware
@@ -4755,7 +4568,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_1_we),
+    .we     (iso_we),
     .wd     (iso_iso_1_wd),
 
     // from internal hardware
@@ -4781,7 +4594,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_2_we),
+    .we     (iso_we),
     .wd     (iso_iso_2_wd),
 
     // from internal hardware
@@ -4807,7 +4620,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_3_we),
+    .we     (iso_we),
     .wd     (iso_iso_3_wd),
 
     // from internal hardware
@@ -4833,7 +4646,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_4_we),
+    .we     (iso_we),
     .wd     (iso_iso_4_wd),
 
     // from internal hardware
@@ -4859,7 +4672,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_5_we),
+    .we     (iso_we),
     .wd     (iso_iso_5_wd),
 
     // from internal hardware
@@ -4885,7 +4698,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_6_we),
+    .we     (iso_we),
     .wd     (iso_iso_6_wd),
 
     // from internal hardware
@@ -4911,7 +4724,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_7_we),
+    .we     (iso_we),
     .wd     (iso_iso_7_wd),
 
     // from internal hardware
@@ -4937,7 +4750,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_8_we),
+    .we     (iso_we),
     .wd     (iso_iso_8_wd),
 
     // from internal hardware
@@ -4963,7 +4776,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_9_we),
+    .we     (iso_we),
     .wd     (iso_iso_9_wd),
 
     // from internal hardware
@@ -4989,7 +4802,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_10_we),
+    .we     (iso_we),
     .wd     (iso_iso_10_wd),
 
     // from internal hardware
@@ -5015,7 +4828,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (iso_iso_11_we),
+    .we     (iso_we),
     .wd     (iso_iso_11_wd),
 
     // from internal hardware
@@ -5046,7 +4859,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_0_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_0_wd),
 
     // from internal hardware
@@ -5072,7 +4885,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_1_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_1_wd),
 
     // from internal hardware
@@ -5098,7 +4911,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_2_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_2_wd),
 
     // from internal hardware
@@ -5124,7 +4937,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_3_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_3_wd),
 
     // from internal hardware
@@ -5150,7 +4963,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_4_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_4_wd),
 
     // from internal hardware
@@ -5176,7 +4989,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_5_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_5_wd),
 
     // from internal hardware
@@ -5202,7 +5015,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_6_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_6_wd),
 
     // from internal hardware
@@ -5228,7 +5041,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_7_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_7_wd),
 
     // from internal hardware
@@ -5254,7 +5067,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_8_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_8_wd),
 
     // from internal hardware
@@ -5280,7 +5093,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_9_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_9_wd),
 
     // from internal hardware
@@ -5306,7 +5119,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_10_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_10_wd),
 
     // from internal hardware
@@ -5332,7 +5145,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (data_toggle_clear_clear_11_we),
+    .we     (data_toggle_clear_we),
     .wd     (data_toggle_clear_clear_11_wd),
 
     // from internal hardware
@@ -5355,7 +5168,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_rx_dp_i (
-    .re     (phy_pins_sense_rx_dp_i_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.rx_dp_i.d),
@@ -5370,7 +5183,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_rx_dn_i (
-    .re     (phy_pins_sense_rx_dn_i_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.rx_dn_i.d),
@@ -5385,7 +5198,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_rx_d_i (
-    .re     (phy_pins_sense_rx_d_i_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.rx_d_i.d),
@@ -5400,7 +5213,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_tx_dp_o (
-    .re     (phy_pins_sense_tx_dp_o_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.tx_dp_o.d),
@@ -5415,7 +5228,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_tx_dn_o (
-    .re     (phy_pins_sense_tx_dn_o_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.tx_dn_o.d),
@@ -5430,7 +5243,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_tx_d_o (
-    .re     (phy_pins_sense_tx_d_o_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.tx_d_o.d),
@@ -5445,7 +5258,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_tx_se0_o (
-    .re     (phy_pins_sense_tx_se0_o_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.tx_se0_o.d),
@@ -5460,7 +5273,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_tx_oe_o (
-    .re     (phy_pins_sense_tx_oe_o_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.tx_oe_o.d),
@@ -5475,7 +5288,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_suspend_o (
-    .re     (phy_pins_sense_suspend_o_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.suspend_o.d),
@@ -5490,7 +5303,7 @@ module usbdev_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_phy_pins_sense_pwr_sense (
-    .re     (phy_pins_sense_pwr_sense_re),
+    .re     (phy_pins_sense_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.phy_pins_sense.pwr_sense.d),
@@ -5513,7 +5326,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_dp_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_dp_o_wd),
 
     // from internal hardware
@@ -5539,7 +5352,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_dn_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_dn_o_wd),
 
     // from internal hardware
@@ -5565,7 +5378,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_d_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_d_o_wd),
 
     // from internal hardware
@@ -5591,7 +5404,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_se0_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_se0_o_wd),
 
     // from internal hardware
@@ -5617,7 +5430,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_oe_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_oe_o_wd),
 
     // from internal hardware
@@ -5643,7 +5456,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_tx_mode_se_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_tx_mode_se_o_wd),
 
     // from internal hardware
@@ -5669,7 +5482,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_dp_pullup_en_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_dp_pullup_en_o_wd),
 
     // from internal hardware
@@ -5695,7 +5508,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_dn_pullup_en_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_dn_pullup_en_o_wd),
 
     // from internal hardware
@@ -5721,7 +5534,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_suspend_o_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_suspend_o_wd),
 
     // from internal hardware
@@ -5747,7 +5560,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_pins_drive_en_we),
+    .we     (phy_pins_drive_we),
     .wd     (phy_pins_drive_en_wd),
 
     // from internal hardware
@@ -5775,7 +5588,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_rx_differential_mode_we),
+    .we     (phy_config_we),
     .wd     (phy_config_rx_differential_mode_wd),
 
     // from internal hardware
@@ -5801,7 +5614,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_tx_differential_mode_we),
+    .we     (phy_config_we),
     .wd     (phy_config_tx_differential_mode_wd),
 
     // from internal hardware
@@ -5827,7 +5640,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_eop_single_bit_we),
+    .we     (phy_config_we),
     .wd     (phy_config_eop_single_bit_wd),
 
     // from internal hardware
@@ -5853,7 +5666,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_override_pwr_sense_en_we),
+    .we     (phy_config_we),
     .wd     (phy_config_override_pwr_sense_en_wd),
 
     // from internal hardware
@@ -5879,7 +5692,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_override_pwr_sense_val_we),
+    .we     (phy_config_we),
     .wd     (phy_config_override_pwr_sense_val_wd),
 
     // from internal hardware
@@ -5905,7 +5718,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_pinflip_we),
+    .we     (phy_config_we),
     .wd     (phy_config_pinflip_wd),
 
     // from internal hardware
@@ -5931,7 +5744,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_usb_ref_disable_we),
+    .we     (phy_config_we),
     .wd     (phy_config_usb_ref_disable_wd),
 
     // from internal hardware
@@ -5957,7 +5770,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_config_tx_osc_test_mode_we),
+    .we     (phy_config_we),
     .wd     (phy_config_tx_osc_test_mode_wd),
 
     // from internal hardware
@@ -5985,7 +5798,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wake_config_wake_en_we),
+    .we     (wake_config_we),
     .wd     (wake_config_wake_en_wd),
 
     // from internal hardware
@@ -6011,7 +5824,7 @@ module usbdev_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wake_config_wake_ack_we),
+    .we     (wake_config_we),
     .wd     (wake_config_wake_ack_wd),
 
     // from internal hardware
@@ -6127,631 +5940,422 @@ module usbdev_reg_top (
                (addr_hit[28] & (|(USBDEV_PERMIT[28] & ~reg_be))) |
                (addr_hit[29] & (|(USBDEV_PERMIT[29] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_pkt_received_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_pkt_received_wd = reg_wdata[0];
 
-  assign intr_state_pkt_sent_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_state_disconnected_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_disconnected_wd = reg_wdata[2];
 
-  assign intr_state_host_lost_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_host_lost_wd = reg_wdata[3];
 
-  assign intr_state_link_reset_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_reset_wd = reg_wdata[4];
 
-  assign intr_state_link_suspend_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_suspend_wd = reg_wdata[5];
 
-  assign intr_state_link_resume_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_resume_wd = reg_wdata[6];
 
-  assign intr_state_av_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_av_empty_wd = reg_wdata[7];
 
-  assign intr_state_rx_full_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_full_wd = reg_wdata[8];
 
-  assign intr_state_av_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_av_overflow_wd = reg_wdata[9];
 
-  assign intr_state_link_in_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_in_err_wd = reg_wdata[10];
 
-  assign intr_state_rx_crc_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_state_rx_pid_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_state_rx_bitstuff_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_state_frame_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_frame_wd = reg_wdata[14];
 
-  assign intr_state_connected_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_connected_wd = reg_wdata[15];
 
-  assign intr_state_link_out_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_link_out_err_wd = reg_wdata[16];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_pkt_received_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_pkt_received_wd = reg_wdata[0];
 
-  assign intr_enable_pkt_sent_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_enable_disconnected_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_disconnected_wd = reg_wdata[2];
 
-  assign intr_enable_host_lost_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_host_lost_wd = reg_wdata[3];
 
-  assign intr_enable_link_reset_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_reset_wd = reg_wdata[4];
 
-  assign intr_enable_link_suspend_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_suspend_wd = reg_wdata[5];
 
-  assign intr_enable_link_resume_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_resume_wd = reg_wdata[6];
 
-  assign intr_enable_av_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_av_empty_wd = reg_wdata[7];
 
-  assign intr_enable_rx_full_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_full_wd = reg_wdata[8];
 
-  assign intr_enable_av_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_av_overflow_wd = reg_wdata[9];
 
-  assign intr_enable_link_in_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_in_err_wd = reg_wdata[10];
 
-  assign intr_enable_rx_crc_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_enable_rx_pid_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_enable_rx_bitstuff_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_enable_frame_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_frame_wd = reg_wdata[14];
 
-  assign intr_enable_connected_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_connected_wd = reg_wdata[15];
 
-  assign intr_enable_link_out_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_link_out_err_wd = reg_wdata[16];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_pkt_received_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_pkt_received_wd = reg_wdata[0];
 
-  assign intr_test_pkt_sent_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_pkt_sent_wd = reg_wdata[1];
 
-  assign intr_test_disconnected_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_disconnected_wd = reg_wdata[2];
 
-  assign intr_test_host_lost_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_host_lost_wd = reg_wdata[3];
 
-  assign intr_test_link_reset_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_reset_wd = reg_wdata[4];
 
-  assign intr_test_link_suspend_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_suspend_wd = reg_wdata[5];
 
-  assign intr_test_link_resume_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_resume_wd = reg_wdata[6];
 
-  assign intr_test_av_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_av_empty_wd = reg_wdata[7];
 
-  assign intr_test_rx_full_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_full_wd = reg_wdata[8];
 
-  assign intr_test_av_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_av_overflow_wd = reg_wdata[9];
 
-  assign intr_test_link_in_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_in_err_wd = reg_wdata[10];
 
-  assign intr_test_rx_crc_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_crc_err_wd = reg_wdata[11];
 
-  assign intr_test_rx_pid_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_pid_err_wd = reg_wdata[12];
 
-  assign intr_test_rx_bitstuff_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_bitstuff_err_wd = reg_wdata[13];
 
-  assign intr_test_frame_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_frame_wd = reg_wdata[14];
 
-  assign intr_test_connected_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_connected_wd = reg_wdata[15];
 
-  assign intr_test_link_out_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_link_out_err_wd = reg_wdata[16];
+  assign usbctrl_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign usbctrl_enable_we = addr_hit[3] & reg_we & !reg_error;
   assign usbctrl_enable_wd = reg_wdata[0];
 
-  assign usbctrl_device_address_we = addr_hit[3] & reg_we & !reg_error;
   assign usbctrl_device_address_wd = reg_wdata[22:16];
-
-  assign usbstat_frame_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_host_lost_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_link_state_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_sense_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_av_depth_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_av_full_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_rx_depth_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign usbstat_rx_empty_re = addr_hit[4] & reg_re & !reg_error;
-
+  assign usbstat_re = addr_hit[4] & reg_re & !reg_error;
   assign avbuffer_we = addr_hit[5] & reg_we & !reg_error;
+
   assign avbuffer_wd = reg_wdata[4:0];
+  assign rxfifo_re = addr_hit[6] & reg_re & !reg_error;
+  assign rxenable_setup_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign rxfifo_buffer_re = addr_hit[6] & reg_re & !reg_error;
-
-  assign rxfifo_size_re = addr_hit[6] & reg_re & !reg_error;
-
-  assign rxfifo_setup_re = addr_hit[6] & reg_re & !reg_error;
-
-  assign rxfifo_ep_re = addr_hit[6] & reg_re & !reg_error;
-
-  assign rxenable_setup_setup_0_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_0_wd = reg_wdata[0];
 
-  assign rxenable_setup_setup_1_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_1_wd = reg_wdata[1];
 
-  assign rxenable_setup_setup_2_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_2_wd = reg_wdata[2];
 
-  assign rxenable_setup_setup_3_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_3_wd = reg_wdata[3];
 
-  assign rxenable_setup_setup_4_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_4_wd = reg_wdata[4];
 
-  assign rxenable_setup_setup_5_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_5_wd = reg_wdata[5];
 
-  assign rxenable_setup_setup_6_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_6_wd = reg_wdata[6];
 
-  assign rxenable_setup_setup_7_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_7_wd = reg_wdata[7];
 
-  assign rxenable_setup_setup_8_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_8_wd = reg_wdata[8];
 
-  assign rxenable_setup_setup_9_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_9_wd = reg_wdata[9];
 
-  assign rxenable_setup_setup_10_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_10_wd = reg_wdata[10];
 
-  assign rxenable_setup_setup_11_we = addr_hit[7] & reg_we & !reg_error;
   assign rxenable_setup_setup_11_wd = reg_wdata[11];
+  assign rxenable_out_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign rxenable_out_out_0_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_0_wd = reg_wdata[0];
 
-  assign rxenable_out_out_1_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_1_wd = reg_wdata[1];
 
-  assign rxenable_out_out_2_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_2_wd = reg_wdata[2];
 
-  assign rxenable_out_out_3_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_3_wd = reg_wdata[3];
 
-  assign rxenable_out_out_4_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_4_wd = reg_wdata[4];
 
-  assign rxenable_out_out_5_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_5_wd = reg_wdata[5];
 
-  assign rxenable_out_out_6_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_6_wd = reg_wdata[6];
 
-  assign rxenable_out_out_7_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_7_wd = reg_wdata[7];
 
-  assign rxenable_out_out_8_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_8_wd = reg_wdata[8];
 
-  assign rxenable_out_out_9_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_9_wd = reg_wdata[9];
 
-  assign rxenable_out_out_10_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_10_wd = reg_wdata[10];
 
-  assign rxenable_out_out_11_we = addr_hit[8] & reg_we & !reg_error;
   assign rxenable_out_out_11_wd = reg_wdata[11];
+  assign in_sent_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign in_sent_sent_0_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_0_wd = reg_wdata[0];
 
-  assign in_sent_sent_1_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_1_wd = reg_wdata[1];
 
-  assign in_sent_sent_2_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_2_wd = reg_wdata[2];
 
-  assign in_sent_sent_3_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_3_wd = reg_wdata[3];
 
-  assign in_sent_sent_4_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_4_wd = reg_wdata[4];
 
-  assign in_sent_sent_5_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_5_wd = reg_wdata[5];
 
-  assign in_sent_sent_6_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_6_wd = reg_wdata[6];
 
-  assign in_sent_sent_7_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_7_wd = reg_wdata[7];
 
-  assign in_sent_sent_8_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_8_wd = reg_wdata[8];
 
-  assign in_sent_sent_9_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_9_wd = reg_wdata[9];
 
-  assign in_sent_sent_10_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_10_wd = reg_wdata[10];
 
-  assign in_sent_sent_11_we = addr_hit[9] & reg_we & !reg_error;
   assign in_sent_sent_11_wd = reg_wdata[11];
+  assign stall_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign stall_stall_0_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_0_wd = reg_wdata[0];
 
-  assign stall_stall_1_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_1_wd = reg_wdata[1];
 
-  assign stall_stall_2_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_2_wd = reg_wdata[2];
 
-  assign stall_stall_3_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_3_wd = reg_wdata[3];
 
-  assign stall_stall_4_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_4_wd = reg_wdata[4];
 
-  assign stall_stall_5_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_5_wd = reg_wdata[5];
 
-  assign stall_stall_6_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_6_wd = reg_wdata[6];
 
-  assign stall_stall_7_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_7_wd = reg_wdata[7];
 
-  assign stall_stall_8_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_8_wd = reg_wdata[8];
 
-  assign stall_stall_9_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_9_wd = reg_wdata[9];
 
-  assign stall_stall_10_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_10_wd = reg_wdata[10];
 
-  assign stall_stall_11_we = addr_hit[10] & reg_we & !reg_error;
   assign stall_stall_11_wd = reg_wdata[11];
+  assign configin_0_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign configin_0_buffer_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_buffer_0_wd = reg_wdata[4:0];
 
-  assign configin_0_size_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_size_0_wd = reg_wdata[14:8];
 
-  assign configin_0_pend_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_pend_0_wd = reg_wdata[30];
 
-  assign configin_0_rdy_0_we = addr_hit[11] & reg_we & !reg_error;
   assign configin_0_rdy_0_wd = reg_wdata[31];
+  assign configin_1_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign configin_1_buffer_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_buffer_1_wd = reg_wdata[4:0];
 
-  assign configin_1_size_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_size_1_wd = reg_wdata[14:8];
 
-  assign configin_1_pend_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_pend_1_wd = reg_wdata[30];
 
-  assign configin_1_rdy_1_we = addr_hit[12] & reg_we & !reg_error;
   assign configin_1_rdy_1_wd = reg_wdata[31];
+  assign configin_2_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign configin_2_buffer_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_buffer_2_wd = reg_wdata[4:0];
 
-  assign configin_2_size_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_size_2_wd = reg_wdata[14:8];
 
-  assign configin_2_pend_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_pend_2_wd = reg_wdata[30];
 
-  assign configin_2_rdy_2_we = addr_hit[13] & reg_we & !reg_error;
   assign configin_2_rdy_2_wd = reg_wdata[31];
+  assign configin_3_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign configin_3_buffer_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_buffer_3_wd = reg_wdata[4:0];
 
-  assign configin_3_size_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_size_3_wd = reg_wdata[14:8];
 
-  assign configin_3_pend_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_pend_3_wd = reg_wdata[30];
 
-  assign configin_3_rdy_3_we = addr_hit[14] & reg_we & !reg_error;
   assign configin_3_rdy_3_wd = reg_wdata[31];
+  assign configin_4_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign configin_4_buffer_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_buffer_4_wd = reg_wdata[4:0];
 
-  assign configin_4_size_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_size_4_wd = reg_wdata[14:8];
 
-  assign configin_4_pend_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_pend_4_wd = reg_wdata[30];
 
-  assign configin_4_rdy_4_we = addr_hit[15] & reg_we & !reg_error;
   assign configin_4_rdy_4_wd = reg_wdata[31];
+  assign configin_5_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign configin_5_buffer_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_buffer_5_wd = reg_wdata[4:0];
 
-  assign configin_5_size_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_size_5_wd = reg_wdata[14:8];
 
-  assign configin_5_pend_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_pend_5_wd = reg_wdata[30];
 
-  assign configin_5_rdy_5_we = addr_hit[16] & reg_we & !reg_error;
   assign configin_5_rdy_5_wd = reg_wdata[31];
+  assign configin_6_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign configin_6_buffer_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_buffer_6_wd = reg_wdata[4:0];
 
-  assign configin_6_size_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_size_6_wd = reg_wdata[14:8];
 
-  assign configin_6_pend_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_pend_6_wd = reg_wdata[30];
 
-  assign configin_6_rdy_6_we = addr_hit[17] & reg_we & !reg_error;
   assign configin_6_rdy_6_wd = reg_wdata[31];
+  assign configin_7_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign configin_7_buffer_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_buffer_7_wd = reg_wdata[4:0];
 
-  assign configin_7_size_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_size_7_wd = reg_wdata[14:8];
 
-  assign configin_7_pend_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_pend_7_wd = reg_wdata[30];
 
-  assign configin_7_rdy_7_we = addr_hit[18] & reg_we & !reg_error;
   assign configin_7_rdy_7_wd = reg_wdata[31];
+  assign configin_8_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign configin_8_buffer_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_buffer_8_wd = reg_wdata[4:0];
 
-  assign configin_8_size_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_size_8_wd = reg_wdata[14:8];
 
-  assign configin_8_pend_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_pend_8_wd = reg_wdata[30];
 
-  assign configin_8_rdy_8_we = addr_hit[19] & reg_we & !reg_error;
   assign configin_8_rdy_8_wd = reg_wdata[31];
+  assign configin_9_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign configin_9_buffer_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_buffer_9_wd = reg_wdata[4:0];
 
-  assign configin_9_size_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_size_9_wd = reg_wdata[14:8];
 
-  assign configin_9_pend_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_pend_9_wd = reg_wdata[30];
 
-  assign configin_9_rdy_9_we = addr_hit[20] & reg_we & !reg_error;
   assign configin_9_rdy_9_wd = reg_wdata[31];
+  assign configin_10_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign configin_10_buffer_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_buffer_10_wd = reg_wdata[4:0];
 
-  assign configin_10_size_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_size_10_wd = reg_wdata[14:8];
 
-  assign configin_10_pend_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_pend_10_wd = reg_wdata[30];
 
-  assign configin_10_rdy_10_we = addr_hit[21] & reg_we & !reg_error;
   assign configin_10_rdy_10_wd = reg_wdata[31];
+  assign configin_11_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign configin_11_buffer_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_buffer_11_wd = reg_wdata[4:0];
 
-  assign configin_11_size_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_size_11_wd = reg_wdata[14:8];
 
-  assign configin_11_pend_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_pend_11_wd = reg_wdata[30];
 
-  assign configin_11_rdy_11_we = addr_hit[22] & reg_we & !reg_error;
   assign configin_11_rdy_11_wd = reg_wdata[31];
+  assign iso_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign iso_iso_0_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_0_wd = reg_wdata[0];
 
-  assign iso_iso_1_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_1_wd = reg_wdata[1];
 
-  assign iso_iso_2_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_2_wd = reg_wdata[2];
 
-  assign iso_iso_3_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_3_wd = reg_wdata[3];
 
-  assign iso_iso_4_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_4_wd = reg_wdata[4];
 
-  assign iso_iso_5_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_5_wd = reg_wdata[5];
 
-  assign iso_iso_6_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_6_wd = reg_wdata[6];
 
-  assign iso_iso_7_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_7_wd = reg_wdata[7];
 
-  assign iso_iso_8_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_8_wd = reg_wdata[8];
 
-  assign iso_iso_9_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_9_wd = reg_wdata[9];
 
-  assign iso_iso_10_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_10_wd = reg_wdata[10];
 
-  assign iso_iso_11_we = addr_hit[23] & reg_we & !reg_error;
   assign iso_iso_11_wd = reg_wdata[11];
+  assign data_toggle_clear_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign data_toggle_clear_clear_0_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_0_wd = reg_wdata[0];
 
-  assign data_toggle_clear_clear_1_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_1_wd = reg_wdata[1];
 
-  assign data_toggle_clear_clear_2_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_2_wd = reg_wdata[2];
 
-  assign data_toggle_clear_clear_3_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_3_wd = reg_wdata[3];
 
-  assign data_toggle_clear_clear_4_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_4_wd = reg_wdata[4];
 
-  assign data_toggle_clear_clear_5_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_5_wd = reg_wdata[5];
 
-  assign data_toggle_clear_clear_6_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_6_wd = reg_wdata[6];
 
-  assign data_toggle_clear_clear_7_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_7_wd = reg_wdata[7];
 
-  assign data_toggle_clear_clear_8_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_8_wd = reg_wdata[8];
 
-  assign data_toggle_clear_clear_9_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_9_wd = reg_wdata[9];
 
-  assign data_toggle_clear_clear_10_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_10_wd = reg_wdata[10];
 
-  assign data_toggle_clear_clear_11_we = addr_hit[24] & reg_we & !reg_error;
   assign data_toggle_clear_clear_11_wd = reg_wdata[11];
+  assign phy_pins_sense_re = addr_hit[25] & reg_re & !reg_error;
+  assign phy_pins_drive_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign phy_pins_sense_rx_dp_i_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_rx_dn_i_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_rx_d_i_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_tx_dp_o_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_tx_dn_o_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_tx_d_o_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_tx_se0_o_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_tx_oe_o_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_suspend_o_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_sense_pwr_sense_re = addr_hit[25] & reg_re & !reg_error;
-
-  assign phy_pins_drive_dp_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dp_o_wd = reg_wdata[0];
 
-  assign phy_pins_drive_dn_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dn_o_wd = reg_wdata[1];
 
-  assign phy_pins_drive_d_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_d_o_wd = reg_wdata[2];
 
-  assign phy_pins_drive_se0_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_se0_o_wd = reg_wdata[3];
 
-  assign phy_pins_drive_oe_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_oe_o_wd = reg_wdata[4];
 
-  assign phy_pins_drive_tx_mode_se_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_tx_mode_se_o_wd = reg_wdata[5];
 
-  assign phy_pins_drive_dp_pullup_en_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dp_pullup_en_o_wd = reg_wdata[6];
 
-  assign phy_pins_drive_dn_pullup_en_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_dn_pullup_en_o_wd = reg_wdata[7];
 
-  assign phy_pins_drive_suspend_o_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_suspend_o_wd = reg_wdata[8];
 
-  assign phy_pins_drive_en_we = addr_hit[26] & reg_we & !reg_error;
   assign phy_pins_drive_en_wd = reg_wdata[16];
+  assign phy_config_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign phy_config_rx_differential_mode_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_rx_differential_mode_wd = reg_wdata[0];
 
-  assign phy_config_tx_differential_mode_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_tx_differential_mode_wd = reg_wdata[1];
 
-  assign phy_config_eop_single_bit_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_eop_single_bit_wd = reg_wdata[2];
 
-  assign phy_config_override_pwr_sense_en_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_override_pwr_sense_en_wd = reg_wdata[3];
 
-  assign phy_config_override_pwr_sense_val_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_override_pwr_sense_val_wd = reg_wdata[4];
 
-  assign phy_config_pinflip_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_pinflip_wd = reg_wdata[5];
 
-  assign phy_config_usb_ref_disable_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_usb_ref_disable_wd = reg_wdata[6];
 
-  assign phy_config_tx_osc_test_mode_we = addr_hit[27] & reg_we & !reg_error;
   assign phy_config_tx_osc_test_mode_wd = reg_wdata[7];
+  assign wake_config_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign wake_config_wake_en_we = addr_hit[28] & reg_we & !reg_error;
   assign wake_config_wake_en_wd = reg_wdata[0];
 
-  assign wake_config_wake_ack_we = addr_hit[28] & reg_we & !reg_error;
   assign wake_config_wake_ack_wd = reg_wdata[1];
 
   // Read data return

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -104,155 +104,111 @@ module usbuart_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_tx_watermark_qs;
   logic intr_state_tx_watermark_wd;
-  logic intr_state_tx_watermark_we;
   logic intr_state_rx_watermark_qs;
   logic intr_state_rx_watermark_wd;
-  logic intr_state_rx_watermark_we;
   logic intr_state_tx_overflow_qs;
   logic intr_state_tx_overflow_wd;
-  logic intr_state_tx_overflow_we;
   logic intr_state_rx_overflow_qs;
   logic intr_state_rx_overflow_wd;
-  logic intr_state_rx_overflow_we;
   logic intr_state_rx_frame_err_qs;
   logic intr_state_rx_frame_err_wd;
-  logic intr_state_rx_frame_err_we;
   logic intr_state_rx_break_err_qs;
   logic intr_state_rx_break_err_wd;
-  logic intr_state_rx_break_err_we;
   logic intr_state_rx_timeout_qs;
   logic intr_state_rx_timeout_wd;
-  logic intr_state_rx_timeout_we;
   logic intr_state_rx_parity_err_qs;
   logic intr_state_rx_parity_err_wd;
-  logic intr_state_rx_parity_err_we;
+  logic intr_enable_we;
   logic intr_enable_tx_watermark_qs;
   logic intr_enable_tx_watermark_wd;
-  logic intr_enable_tx_watermark_we;
   logic intr_enable_rx_watermark_qs;
   logic intr_enable_rx_watermark_wd;
-  logic intr_enable_rx_watermark_we;
   logic intr_enable_tx_overflow_qs;
   logic intr_enable_tx_overflow_wd;
-  logic intr_enable_tx_overflow_we;
   logic intr_enable_rx_overflow_qs;
   logic intr_enable_rx_overflow_wd;
-  logic intr_enable_rx_overflow_we;
   logic intr_enable_rx_frame_err_qs;
   logic intr_enable_rx_frame_err_wd;
-  logic intr_enable_rx_frame_err_we;
   logic intr_enable_rx_break_err_qs;
   logic intr_enable_rx_break_err_wd;
-  logic intr_enable_rx_break_err_we;
   logic intr_enable_rx_timeout_qs;
   logic intr_enable_rx_timeout_wd;
-  logic intr_enable_rx_timeout_we;
   logic intr_enable_rx_parity_err_qs;
   logic intr_enable_rx_parity_err_wd;
-  logic intr_enable_rx_parity_err_we;
+  logic intr_test_we;
   logic intr_test_tx_watermark_wd;
-  logic intr_test_tx_watermark_we;
   logic intr_test_rx_watermark_wd;
-  logic intr_test_rx_watermark_we;
   logic intr_test_tx_overflow_wd;
-  logic intr_test_tx_overflow_we;
   logic intr_test_rx_overflow_wd;
-  logic intr_test_rx_overflow_we;
   logic intr_test_rx_frame_err_wd;
-  logic intr_test_rx_frame_err_we;
   logic intr_test_rx_break_err_wd;
-  logic intr_test_rx_break_err_we;
   logic intr_test_rx_timeout_wd;
-  logic intr_test_rx_timeout_we;
   logic intr_test_rx_parity_err_wd;
-  logic intr_test_rx_parity_err_we;
+  logic ctrl_we;
   logic ctrl_tx_qs;
   logic ctrl_tx_wd;
-  logic ctrl_tx_we;
   logic ctrl_rx_qs;
   logic ctrl_rx_wd;
-  logic ctrl_rx_we;
   logic ctrl_nf_qs;
   logic ctrl_nf_wd;
-  logic ctrl_nf_we;
   logic ctrl_slpbk_qs;
   logic ctrl_slpbk_wd;
-  logic ctrl_slpbk_we;
   logic ctrl_llpbk_qs;
   logic ctrl_llpbk_wd;
-  logic ctrl_llpbk_we;
   logic ctrl_parity_en_qs;
   logic ctrl_parity_en_wd;
-  logic ctrl_parity_en_we;
   logic ctrl_parity_odd_qs;
   logic ctrl_parity_odd_wd;
-  logic ctrl_parity_odd_we;
   logic [1:0] ctrl_rxblvl_qs;
   logic [1:0] ctrl_rxblvl_wd;
-  logic ctrl_rxblvl_we;
   logic [15:0] ctrl_nco_qs;
   logic [15:0] ctrl_nco_wd;
-  logic ctrl_nco_we;
+  logic status_re;
   logic status_txfull_qs;
-  logic status_txfull_re;
   logic status_rxfull_qs;
-  logic status_rxfull_re;
   logic status_txempty_qs;
-  logic status_txempty_re;
   logic status_txidle_qs;
-  logic status_txidle_re;
   logic status_rxidle_qs;
-  logic status_rxidle_re;
   logic status_rxempty_qs;
-  logic status_rxempty_re;
-  logic [7:0] rdata_qs;
   logic rdata_re;
-  logic [7:0] wdata_wd;
+  logic [7:0] rdata_qs;
   logic wdata_we;
+  logic [7:0] wdata_wd;
+  logic fifo_ctrl_we;
   logic fifo_ctrl_rxrst_qs;
   logic fifo_ctrl_rxrst_wd;
-  logic fifo_ctrl_rxrst_we;
   logic fifo_ctrl_txrst_qs;
   logic fifo_ctrl_txrst_wd;
-  logic fifo_ctrl_txrst_we;
   logic [2:0] fifo_ctrl_rxilvl_qs;
   logic [2:0] fifo_ctrl_rxilvl_wd;
-  logic fifo_ctrl_rxilvl_we;
   logic [1:0] fifo_ctrl_txilvl_qs;
   logic [1:0] fifo_ctrl_txilvl_wd;
-  logic fifo_ctrl_txilvl_we;
+  logic fifo_status_re;
   logic [5:0] fifo_status_txlvl_qs;
-  logic fifo_status_txlvl_re;
   logic [5:0] fifo_status_rxlvl_qs;
-  logic fifo_status_rxlvl_re;
+  logic ovrd_we;
   logic ovrd_txen_qs;
   logic ovrd_txen_wd;
-  logic ovrd_txen_we;
   logic ovrd_txval_qs;
   logic ovrd_txval_wd;
-  logic ovrd_txval_we;
-  logic [15:0] val_qs;
   logic val_re;
+  logic [15:0] val_qs;
+  logic timeout_ctrl_we;
   logic [23:0] timeout_ctrl_val_qs;
   logic [23:0] timeout_ctrl_val_wd;
-  logic timeout_ctrl_val_we;
   logic timeout_ctrl_en_qs;
   logic timeout_ctrl_en_wd;
-  logic timeout_ctrl_en_we;
+  logic usbstat_re;
   logic [10:0] usbstat_frame_qs;
-  logic usbstat_frame_re;
   logic usbstat_host_timeout_qs;
-  logic usbstat_host_timeout_re;
   logic usbstat_host_lost_qs;
-  logic usbstat_host_lost_re;
   logic [6:0] usbstat_device_address_qs;
-  logic usbstat_device_address_re;
+  logic usbparam_re;
   logic [15:0] usbparam_baud_req_qs;
-  logic usbparam_baud_req_re;
   logic [1:0] usbparam_parity_req_qs;
-  logic usbparam_parity_req_re;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -267,7 +223,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_watermark_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_watermark_wd),
 
     // from internal hardware
@@ -293,7 +249,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_watermark_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_watermark_wd),
 
     // from internal hardware
@@ -319,7 +275,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_tx_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_tx_overflow_wd),
 
     // from internal hardware
@@ -345,7 +301,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_overflow_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_overflow_wd),
 
     // from internal hardware
@@ -371,7 +327,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_frame_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_frame_err_wd),
 
     // from internal hardware
@@ -397,7 +353,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_break_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_break_err_wd),
 
     // from internal hardware
@@ -423,7 +379,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_timeout_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_timeout_wd),
 
     // from internal hardware
@@ -449,7 +405,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rx_parity_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rx_parity_err_wd),
 
     // from internal hardware
@@ -477,7 +433,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_watermark_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_watermark_wd),
 
     // from internal hardware
@@ -503,7 +459,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_watermark_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_watermark_wd),
 
     // from internal hardware
@@ -529,7 +485,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_tx_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_tx_overflow_wd),
 
     // from internal hardware
@@ -555,7 +511,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_overflow_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_overflow_wd),
 
     // from internal hardware
@@ -581,7 +537,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_frame_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_frame_err_wd),
 
     // from internal hardware
@@ -607,7 +563,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_break_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_break_err_wd),
 
     // from internal hardware
@@ -633,7 +589,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_timeout_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_timeout_wd),
 
     // from internal hardware
@@ -659,7 +615,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rx_parity_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rx_parity_err_wd),
 
     // from internal hardware
@@ -682,7 +638,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_tx_watermark (
     .re     (1'b0),
-    .we     (intr_test_tx_watermark_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_watermark_wd),
     .d      ('0),
     .qre    (),
@@ -697,7 +653,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_watermark (
     .re     (1'b0),
-    .we     (intr_test_rx_watermark_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_watermark_wd),
     .d      ('0),
     .qre    (),
@@ -712,7 +668,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_tx_overflow (
     .re     (1'b0),
-    .we     (intr_test_tx_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_tx_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -727,7 +683,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_overflow (
     .re     (1'b0),
-    .we     (intr_test_rx_overflow_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_overflow_wd),
     .d      ('0),
     .qre    (),
@@ -742,7 +698,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_frame_err (
     .re     (1'b0),
-    .we     (intr_test_rx_frame_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_frame_err_wd),
     .d      ('0),
     .qre    (),
@@ -757,7 +713,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_break_err (
     .re     (1'b0),
-    .we     (intr_test_rx_break_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_break_err_wd),
     .d      ('0),
     .qre    (),
@@ -772,7 +728,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_timeout (
     .re     (1'b0),
-    .we     (intr_test_rx_timeout_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_timeout_wd),
     .d      ('0),
     .qre    (),
@@ -787,7 +743,7 @@ module usbuart_reg_top (
     .DW    (1)
   ) u_intr_test_rx_parity_err (
     .re     (1'b0),
-    .we     (intr_test_rx_parity_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rx_parity_err_wd),
     .d      ('0),
     .qre    (),
@@ -809,7 +765,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_tx_we),
+    .we     (ctrl_we),
     .wd     (ctrl_tx_wd),
 
     // from internal hardware
@@ -835,7 +791,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_rx_we),
+    .we     (ctrl_we),
     .wd     (ctrl_rx_wd),
 
     // from internal hardware
@@ -861,7 +817,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_nf_we),
+    .we     (ctrl_we),
     .wd     (ctrl_nf_wd),
 
     // from internal hardware
@@ -887,7 +843,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_slpbk_we),
+    .we     (ctrl_we),
     .wd     (ctrl_slpbk_wd),
 
     // from internal hardware
@@ -913,7 +869,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_llpbk_we),
+    .we     (ctrl_we),
     .wd     (ctrl_llpbk_wd),
 
     // from internal hardware
@@ -939,7 +895,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_parity_en_we),
+    .we     (ctrl_we),
     .wd     (ctrl_parity_en_wd),
 
     // from internal hardware
@@ -965,7 +921,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_parity_odd_we),
+    .we     (ctrl_we),
     .wd     (ctrl_parity_odd_wd),
 
     // from internal hardware
@@ -991,7 +947,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_rxblvl_we),
+    .we     (ctrl_we),
     .wd     (ctrl_rxblvl_wd),
 
     // from internal hardware
@@ -1017,7 +973,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ctrl_nco_we),
+    .we     (ctrl_we),
     .wd     (ctrl_nco_wd),
 
     // from internal hardware
@@ -1039,7 +995,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txfull (
-    .re     (status_txfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txfull.d),
@@ -1054,7 +1010,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxfull (
-    .re     (status_rxfull_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxfull.d),
@@ -1069,7 +1025,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txempty (
-    .re     (status_txempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txempty.d),
@@ -1084,7 +1040,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_txidle (
-    .re     (status_txidle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.txidle.d),
@@ -1099,7 +1055,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxidle (
-    .re     (status_rxidle_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxidle.d),
@@ -1114,7 +1070,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_status_rxempty (
-    .re     (status_rxempty_re),
+    .re     (status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.status.rxempty.d),
@@ -1180,7 +1136,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_rxrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_rxrst_wd),
 
     // from internal hardware
@@ -1206,7 +1162,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_txrst_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_txrst_wd),
 
     // from internal hardware
@@ -1232,7 +1188,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_rxilvl_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_rxilvl_wd),
 
     // from internal hardware
@@ -1258,7 +1214,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_ctrl_txilvl_we),
+    .we     (fifo_ctrl_we),
     .wd     (fifo_ctrl_txilvl_wd),
 
     // from internal hardware
@@ -1280,7 +1236,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (6)
   ) u_fifo_status_txlvl (
-    .re     (fifo_status_txlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.txlvl.d),
@@ -1295,7 +1251,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (6)
   ) u_fifo_status_rxlvl (
-    .re     (fifo_status_rxlvl_re),
+    .re     (fifo_status_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.fifo_status.rxlvl.d),
@@ -1318,7 +1274,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_txen_we),
+    .we     (ovrd_we),
     .wd     (ovrd_txen_wd),
 
     // from internal hardware
@@ -1344,7 +1300,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ovrd_txval_we),
+    .we     (ovrd_we),
     .wd     (ovrd_txval_wd),
 
     // from internal hardware
@@ -1388,7 +1344,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timeout_ctrl_val_we),
+    .we     (timeout_ctrl_we),
     .wd     (timeout_ctrl_val_wd),
 
     // from internal hardware
@@ -1414,7 +1370,7 @@ module usbuart_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (timeout_ctrl_en_we),
+    .we     (timeout_ctrl_we),
     .wd     (timeout_ctrl_en_wd),
 
     // from internal hardware
@@ -1436,7 +1392,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (11)
   ) u_usbstat_frame (
-    .re     (usbstat_frame_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.frame.d),
@@ -1451,7 +1407,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_host_timeout (
-    .re     (usbstat_host_timeout_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.host_timeout.d),
@@ -1466,7 +1422,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_usbstat_host_lost (
-    .re     (usbstat_host_lost_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.host_lost.d),
@@ -1481,7 +1437,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (7)
   ) u_usbstat_device_address (
-    .re     (usbstat_device_address_re),
+    .re     (usbstat_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbstat.device_address.d),
@@ -1498,7 +1454,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (16)
   ) u_usbparam_baud_req (
-    .re     (usbparam_baud_req_re),
+    .re     (usbparam_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbparam.baud_req.d),
@@ -1513,7 +1469,7 @@ module usbuart_reg_top (
   prim_subreg_ext #(
     .DW    (2)
   ) u_usbparam_parity_req (
-    .re     (usbparam_parity_req_re),
+    .re     (usbparam_re),
     .we     (1'b0),
     .wd     ('0),
     .d      (hw2reg.usbparam.parity_req.d),
@@ -1565,164 +1521,104 @@ module usbuart_reg_top (
                (addr_hit[12] & (|(USBUART_PERMIT[12] & ~reg_be))) |
                (addr_hit[13] & (|(USBUART_PERMIT[13] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_tx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_state_rx_watermark_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_state_tx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_tx_overflow_wd = reg_wdata[2];
 
-  assign intr_state_rx_overflow_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_state_rx_frame_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_state_rx_break_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_state_rx_timeout_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_state_rx_parity_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rx_parity_err_wd = reg_wdata[7];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_tx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_enable_rx_watermark_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_enable_tx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_tx_overflow_wd = reg_wdata[2];
 
-  assign intr_enable_rx_overflow_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_enable_rx_frame_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_enable_rx_break_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_enable_rx_timeout_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_enable_rx_parity_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rx_parity_err_wd = reg_wdata[7];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_tx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_watermark_wd = reg_wdata[0];
 
-  assign intr_test_rx_watermark_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_watermark_wd = reg_wdata[1];
 
-  assign intr_test_tx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_tx_overflow_wd = reg_wdata[2];
 
-  assign intr_test_rx_overflow_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_overflow_wd = reg_wdata[3];
 
-  assign intr_test_rx_frame_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_frame_err_wd = reg_wdata[4];
 
-  assign intr_test_rx_break_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_break_err_wd = reg_wdata[5];
 
-  assign intr_test_rx_timeout_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_timeout_wd = reg_wdata[6];
 
-  assign intr_test_rx_parity_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rx_parity_err_wd = reg_wdata[7];
+  assign ctrl_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign ctrl_tx_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_tx_wd = reg_wdata[0];
 
-  assign ctrl_rx_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_rx_wd = reg_wdata[1];
 
-  assign ctrl_nf_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_nf_wd = reg_wdata[2];
 
-  assign ctrl_slpbk_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_slpbk_wd = reg_wdata[4];
 
-  assign ctrl_llpbk_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_llpbk_wd = reg_wdata[5];
 
-  assign ctrl_parity_en_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_parity_en_wd = reg_wdata[6];
 
-  assign ctrl_parity_odd_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_parity_odd_wd = reg_wdata[7];
 
-  assign ctrl_rxblvl_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_rxblvl_wd = reg_wdata[9:8];
 
-  assign ctrl_nco_we = addr_hit[3] & reg_we & !reg_error;
   assign ctrl_nco_wd = reg_wdata[31:16];
-
-  assign status_txfull_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_rxfull_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_txempty_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_txidle_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_rxidle_re = addr_hit[4] & reg_re & !reg_error;
-
-  assign status_rxempty_re = addr_hit[4] & reg_re & !reg_error;
-
+  assign status_re = addr_hit[4] & reg_re & !reg_error;
   assign rdata_re = addr_hit[5] & reg_re & !reg_error;
-
   assign wdata_we = addr_hit[6] & reg_we & !reg_error;
-  assign wdata_wd = reg_wdata[7:0];
 
-  assign fifo_ctrl_rxrst_we = addr_hit[7] & reg_we & !reg_error;
+  assign wdata_wd = reg_wdata[7:0];
+  assign fifo_ctrl_we = addr_hit[7] & reg_we & !reg_error;
+
   assign fifo_ctrl_rxrst_wd = reg_wdata[0];
 
-  assign fifo_ctrl_txrst_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txrst_wd = reg_wdata[1];
 
-  assign fifo_ctrl_rxilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_rxilvl_wd = reg_wdata[4:2];
 
-  assign fifo_ctrl_txilvl_we = addr_hit[7] & reg_we & !reg_error;
   assign fifo_ctrl_txilvl_wd = reg_wdata[6:5];
+  assign fifo_status_re = addr_hit[8] & reg_re & !reg_error;
+  assign ovrd_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign fifo_status_txlvl_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign fifo_status_rxlvl_re = addr_hit[8] & reg_re & !reg_error;
-
-  assign ovrd_txen_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txen_wd = reg_wdata[0];
 
-  assign ovrd_txval_we = addr_hit[9] & reg_we & !reg_error;
   assign ovrd_txval_wd = reg_wdata[1];
-
   assign val_re = addr_hit[10] & reg_re & !reg_error;
+  assign timeout_ctrl_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign timeout_ctrl_val_we = addr_hit[11] & reg_we & !reg_error;
   assign timeout_ctrl_val_wd = reg_wdata[23:0];
 
-  assign timeout_ctrl_en_we = addr_hit[11] & reg_we & !reg_error;
   assign timeout_ctrl_en_wd = reg_wdata[31];
-
-  assign usbstat_frame_re = addr_hit[12] & reg_re & !reg_error;
-
-  assign usbstat_host_timeout_re = addr_hit[12] & reg_re & !reg_error;
-
-  assign usbstat_host_lost_re = addr_hit[12] & reg_re & !reg_error;
-
-  assign usbstat_device_address_re = addr_hit[12] & reg_re & !reg_error;
-
-  assign usbparam_baud_req_re = addr_hit[13] & reg_re & !reg_error;
-
-  assign usbparam_parity_req_re = addr_hit[13] & reg_re & !reg_error;
+  assign usbstat_re = addr_hit[12] & reg_re & !reg_error;
+  assign usbparam_re = addr_hit[13] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -104,1015 +104,970 @@ module alert_handler_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_classa_qs;
   logic intr_state_classa_wd;
-  logic intr_state_classa_we;
   logic intr_state_classb_qs;
   logic intr_state_classb_wd;
-  logic intr_state_classb_we;
   logic intr_state_classc_qs;
   logic intr_state_classc_wd;
-  logic intr_state_classc_we;
   logic intr_state_classd_qs;
   logic intr_state_classd_wd;
-  logic intr_state_classd_we;
+  logic intr_enable_we;
   logic intr_enable_classa_qs;
   logic intr_enable_classa_wd;
-  logic intr_enable_classa_we;
   logic intr_enable_classb_qs;
   logic intr_enable_classb_wd;
-  logic intr_enable_classb_we;
   logic intr_enable_classc_qs;
   logic intr_enable_classc_wd;
-  logic intr_enable_classc_we;
   logic intr_enable_classd_qs;
   logic intr_enable_classd_wd;
-  logic intr_enable_classd_we;
+  logic intr_test_we;
   logic intr_test_classa_wd;
-  logic intr_test_classa_we;
   logic intr_test_classb_wd;
-  logic intr_test_classb_we;
   logic intr_test_classc_wd;
-  logic intr_test_classc_we;
   logic intr_test_classd_wd;
-  logic intr_test_classd_we;
+  logic ping_timer_regwen_we;
   logic ping_timer_regwen_qs;
   logic ping_timer_regwen_wd;
-  logic ping_timer_regwen_we;
+  logic ping_timeout_cyc_we;
   logic [15:0] ping_timeout_cyc_qs;
   logic [15:0] ping_timeout_cyc_wd;
-  logic ping_timeout_cyc_we;
+  logic ping_timer_en_we;
   logic ping_timer_en_qs;
   logic ping_timer_en_wd;
-  logic ping_timer_en_we;
+  logic alert_regwen_0_we;
   logic alert_regwen_0_qs;
   logic alert_regwen_0_wd;
-  logic alert_regwen_0_we;
+  logic alert_regwen_1_we;
   logic alert_regwen_1_qs;
   logic alert_regwen_1_wd;
-  logic alert_regwen_1_we;
+  logic alert_regwen_2_we;
   logic alert_regwen_2_qs;
   logic alert_regwen_2_wd;
-  logic alert_regwen_2_we;
+  logic alert_regwen_3_we;
   logic alert_regwen_3_qs;
   logic alert_regwen_3_wd;
-  logic alert_regwen_3_we;
+  logic alert_regwen_4_we;
   logic alert_regwen_4_qs;
   logic alert_regwen_4_wd;
-  logic alert_regwen_4_we;
+  logic alert_regwen_5_we;
   logic alert_regwen_5_qs;
   logic alert_regwen_5_wd;
-  logic alert_regwen_5_we;
+  logic alert_regwen_6_we;
   logic alert_regwen_6_qs;
   logic alert_regwen_6_wd;
-  logic alert_regwen_6_we;
+  logic alert_regwen_7_we;
   logic alert_regwen_7_qs;
   logic alert_regwen_7_wd;
-  logic alert_regwen_7_we;
+  logic alert_regwen_8_we;
   logic alert_regwen_8_qs;
   logic alert_regwen_8_wd;
-  logic alert_regwen_8_we;
+  logic alert_regwen_9_we;
   logic alert_regwen_9_qs;
   logic alert_regwen_9_wd;
-  logic alert_regwen_9_we;
+  logic alert_regwen_10_we;
   logic alert_regwen_10_qs;
   logic alert_regwen_10_wd;
-  logic alert_regwen_10_we;
+  logic alert_regwen_11_we;
   logic alert_regwen_11_qs;
   logic alert_regwen_11_wd;
-  logic alert_regwen_11_we;
+  logic alert_regwen_12_we;
   logic alert_regwen_12_qs;
   logic alert_regwen_12_wd;
-  logic alert_regwen_12_we;
+  logic alert_regwen_13_we;
   logic alert_regwen_13_qs;
   logic alert_regwen_13_wd;
-  logic alert_regwen_13_we;
+  logic alert_regwen_14_we;
   logic alert_regwen_14_qs;
   logic alert_regwen_14_wd;
-  logic alert_regwen_14_we;
+  logic alert_regwen_15_we;
   logic alert_regwen_15_qs;
   logic alert_regwen_15_wd;
-  logic alert_regwen_15_we;
+  logic alert_regwen_16_we;
   logic alert_regwen_16_qs;
   logic alert_regwen_16_wd;
-  logic alert_regwen_16_we;
+  logic alert_regwen_17_we;
   logic alert_regwen_17_qs;
   logic alert_regwen_17_wd;
-  logic alert_regwen_17_we;
+  logic alert_regwen_18_we;
   logic alert_regwen_18_qs;
   logic alert_regwen_18_wd;
-  logic alert_regwen_18_we;
+  logic alert_regwen_19_we;
   logic alert_regwen_19_qs;
   logic alert_regwen_19_wd;
-  logic alert_regwen_19_we;
+  logic alert_regwen_20_we;
   logic alert_regwen_20_qs;
   logic alert_regwen_20_wd;
-  logic alert_regwen_20_we;
+  logic alert_regwen_21_we;
   logic alert_regwen_21_qs;
   logic alert_regwen_21_wd;
-  logic alert_regwen_21_we;
+  logic alert_regwen_22_we;
   logic alert_regwen_22_qs;
   logic alert_regwen_22_wd;
-  logic alert_regwen_22_we;
+  logic alert_regwen_23_we;
   logic alert_regwen_23_qs;
   logic alert_regwen_23_wd;
-  logic alert_regwen_23_we;
+  logic alert_regwen_24_we;
   logic alert_regwen_24_qs;
   logic alert_regwen_24_wd;
-  logic alert_regwen_24_we;
+  logic alert_regwen_25_we;
   logic alert_regwen_25_qs;
   logic alert_regwen_25_wd;
-  logic alert_regwen_25_we;
+  logic alert_regwen_26_we;
   logic alert_regwen_26_qs;
   logic alert_regwen_26_wd;
-  logic alert_regwen_26_we;
+  logic alert_regwen_27_we;
   logic alert_regwen_27_qs;
   logic alert_regwen_27_wd;
-  logic alert_regwen_27_we;
+  logic alert_regwen_28_we;
   logic alert_regwen_28_qs;
   logic alert_regwen_28_wd;
-  logic alert_regwen_28_we;
+  logic alert_regwen_29_we;
   logic alert_regwen_29_qs;
   logic alert_regwen_29_wd;
-  logic alert_regwen_29_we;
+  logic alert_regwen_30_we;
   logic alert_regwen_30_qs;
   logic alert_regwen_30_wd;
-  logic alert_regwen_30_we;
+  logic alert_regwen_31_we;
   logic alert_regwen_31_qs;
   logic alert_regwen_31_wd;
-  logic alert_regwen_31_we;
+  logic alert_regwen_32_we;
   logic alert_regwen_32_qs;
   logic alert_regwen_32_wd;
-  logic alert_regwen_32_we;
+  logic alert_regwen_33_we;
   logic alert_regwen_33_qs;
   logic alert_regwen_33_wd;
-  logic alert_regwen_33_we;
+  logic alert_regwen_34_we;
   logic alert_regwen_34_qs;
   logic alert_regwen_34_wd;
-  logic alert_regwen_34_we;
+  logic alert_regwen_35_we;
   logic alert_regwen_35_qs;
   logic alert_regwen_35_wd;
-  logic alert_regwen_35_we;
+  logic alert_regwen_36_we;
   logic alert_regwen_36_qs;
   logic alert_regwen_36_wd;
-  logic alert_regwen_36_we;
+  logic alert_regwen_37_we;
   logic alert_regwen_37_qs;
   logic alert_regwen_37_wd;
-  logic alert_regwen_37_we;
+  logic alert_regwen_38_we;
   logic alert_regwen_38_qs;
   logic alert_regwen_38_wd;
-  logic alert_regwen_38_we;
+  logic alert_regwen_39_we;
   logic alert_regwen_39_qs;
   logic alert_regwen_39_wd;
-  logic alert_regwen_39_we;
+  logic alert_regwen_40_we;
   logic alert_regwen_40_qs;
   logic alert_regwen_40_wd;
-  logic alert_regwen_40_we;
+  logic alert_regwen_41_we;
   logic alert_regwen_41_qs;
   logic alert_regwen_41_wd;
-  logic alert_regwen_41_we;
+  logic alert_regwen_42_we;
   logic alert_regwen_42_qs;
   logic alert_regwen_42_wd;
-  logic alert_regwen_42_we;
+  logic alert_regwen_43_we;
   logic alert_regwen_43_qs;
   logic alert_regwen_43_wd;
-  logic alert_regwen_43_we;
+  logic alert_regwen_44_we;
   logic alert_regwen_44_qs;
   logic alert_regwen_44_wd;
-  logic alert_regwen_44_we;
+  logic alert_regwen_45_we;
   logic alert_regwen_45_qs;
   logic alert_regwen_45_wd;
-  logic alert_regwen_45_we;
+  logic alert_regwen_46_we;
   logic alert_regwen_46_qs;
   logic alert_regwen_46_wd;
-  logic alert_regwen_46_we;
+  logic alert_regwen_47_we;
   logic alert_regwen_47_qs;
   logic alert_regwen_47_wd;
-  logic alert_regwen_47_we;
+  logic alert_regwen_48_we;
   logic alert_regwen_48_qs;
   logic alert_regwen_48_wd;
-  logic alert_regwen_48_we;
+  logic alert_regwen_49_we;
   logic alert_regwen_49_qs;
   logic alert_regwen_49_wd;
-  logic alert_regwen_49_we;
+  logic alert_regwen_50_we;
   logic alert_regwen_50_qs;
   logic alert_regwen_50_wd;
-  logic alert_regwen_50_we;
+  logic alert_regwen_51_we;
   logic alert_regwen_51_qs;
   logic alert_regwen_51_wd;
-  logic alert_regwen_51_we;
+  logic alert_regwen_52_we;
   logic alert_regwen_52_qs;
   logic alert_regwen_52_wd;
-  logic alert_regwen_52_we;
+  logic alert_regwen_53_we;
   logic alert_regwen_53_qs;
   logic alert_regwen_53_wd;
-  logic alert_regwen_53_we;
+  logic alert_regwen_54_we;
   logic alert_regwen_54_qs;
   logic alert_regwen_54_wd;
-  logic alert_regwen_54_we;
+  logic alert_en_0_we;
   logic alert_en_0_qs;
   logic alert_en_0_wd;
-  logic alert_en_0_we;
+  logic alert_en_1_we;
   logic alert_en_1_qs;
   logic alert_en_1_wd;
-  logic alert_en_1_we;
+  logic alert_en_2_we;
   logic alert_en_2_qs;
   logic alert_en_2_wd;
-  logic alert_en_2_we;
+  logic alert_en_3_we;
   logic alert_en_3_qs;
   logic alert_en_3_wd;
-  logic alert_en_3_we;
+  logic alert_en_4_we;
   logic alert_en_4_qs;
   logic alert_en_4_wd;
-  logic alert_en_4_we;
+  logic alert_en_5_we;
   logic alert_en_5_qs;
   logic alert_en_5_wd;
-  logic alert_en_5_we;
+  logic alert_en_6_we;
   logic alert_en_6_qs;
   logic alert_en_6_wd;
-  logic alert_en_6_we;
+  logic alert_en_7_we;
   logic alert_en_7_qs;
   logic alert_en_7_wd;
-  logic alert_en_7_we;
+  logic alert_en_8_we;
   logic alert_en_8_qs;
   logic alert_en_8_wd;
-  logic alert_en_8_we;
+  logic alert_en_9_we;
   logic alert_en_9_qs;
   logic alert_en_9_wd;
-  logic alert_en_9_we;
+  logic alert_en_10_we;
   logic alert_en_10_qs;
   logic alert_en_10_wd;
-  logic alert_en_10_we;
+  logic alert_en_11_we;
   logic alert_en_11_qs;
   logic alert_en_11_wd;
-  logic alert_en_11_we;
+  logic alert_en_12_we;
   logic alert_en_12_qs;
   logic alert_en_12_wd;
-  logic alert_en_12_we;
+  logic alert_en_13_we;
   logic alert_en_13_qs;
   logic alert_en_13_wd;
-  logic alert_en_13_we;
+  logic alert_en_14_we;
   logic alert_en_14_qs;
   logic alert_en_14_wd;
-  logic alert_en_14_we;
+  logic alert_en_15_we;
   logic alert_en_15_qs;
   logic alert_en_15_wd;
-  logic alert_en_15_we;
+  logic alert_en_16_we;
   logic alert_en_16_qs;
   logic alert_en_16_wd;
-  logic alert_en_16_we;
+  logic alert_en_17_we;
   logic alert_en_17_qs;
   logic alert_en_17_wd;
-  logic alert_en_17_we;
+  logic alert_en_18_we;
   logic alert_en_18_qs;
   logic alert_en_18_wd;
-  logic alert_en_18_we;
+  logic alert_en_19_we;
   logic alert_en_19_qs;
   logic alert_en_19_wd;
-  logic alert_en_19_we;
+  logic alert_en_20_we;
   logic alert_en_20_qs;
   logic alert_en_20_wd;
-  logic alert_en_20_we;
+  logic alert_en_21_we;
   logic alert_en_21_qs;
   logic alert_en_21_wd;
-  logic alert_en_21_we;
+  logic alert_en_22_we;
   logic alert_en_22_qs;
   logic alert_en_22_wd;
-  logic alert_en_22_we;
+  logic alert_en_23_we;
   logic alert_en_23_qs;
   logic alert_en_23_wd;
-  logic alert_en_23_we;
+  logic alert_en_24_we;
   logic alert_en_24_qs;
   logic alert_en_24_wd;
-  logic alert_en_24_we;
+  logic alert_en_25_we;
   logic alert_en_25_qs;
   logic alert_en_25_wd;
-  logic alert_en_25_we;
+  logic alert_en_26_we;
   logic alert_en_26_qs;
   logic alert_en_26_wd;
-  logic alert_en_26_we;
+  logic alert_en_27_we;
   logic alert_en_27_qs;
   logic alert_en_27_wd;
-  logic alert_en_27_we;
+  logic alert_en_28_we;
   logic alert_en_28_qs;
   logic alert_en_28_wd;
-  logic alert_en_28_we;
+  logic alert_en_29_we;
   logic alert_en_29_qs;
   logic alert_en_29_wd;
-  logic alert_en_29_we;
+  logic alert_en_30_we;
   logic alert_en_30_qs;
   logic alert_en_30_wd;
-  logic alert_en_30_we;
+  logic alert_en_31_we;
   logic alert_en_31_qs;
   logic alert_en_31_wd;
-  logic alert_en_31_we;
+  logic alert_en_32_we;
   logic alert_en_32_qs;
   logic alert_en_32_wd;
-  logic alert_en_32_we;
+  logic alert_en_33_we;
   logic alert_en_33_qs;
   logic alert_en_33_wd;
-  logic alert_en_33_we;
+  logic alert_en_34_we;
   logic alert_en_34_qs;
   logic alert_en_34_wd;
-  logic alert_en_34_we;
+  logic alert_en_35_we;
   logic alert_en_35_qs;
   logic alert_en_35_wd;
-  logic alert_en_35_we;
+  logic alert_en_36_we;
   logic alert_en_36_qs;
   logic alert_en_36_wd;
-  logic alert_en_36_we;
+  logic alert_en_37_we;
   logic alert_en_37_qs;
   logic alert_en_37_wd;
-  logic alert_en_37_we;
+  logic alert_en_38_we;
   logic alert_en_38_qs;
   logic alert_en_38_wd;
-  logic alert_en_38_we;
+  logic alert_en_39_we;
   logic alert_en_39_qs;
   logic alert_en_39_wd;
-  logic alert_en_39_we;
+  logic alert_en_40_we;
   logic alert_en_40_qs;
   logic alert_en_40_wd;
-  logic alert_en_40_we;
+  logic alert_en_41_we;
   logic alert_en_41_qs;
   logic alert_en_41_wd;
-  logic alert_en_41_we;
+  logic alert_en_42_we;
   logic alert_en_42_qs;
   logic alert_en_42_wd;
-  logic alert_en_42_we;
+  logic alert_en_43_we;
   logic alert_en_43_qs;
   logic alert_en_43_wd;
-  logic alert_en_43_we;
+  logic alert_en_44_we;
   logic alert_en_44_qs;
   logic alert_en_44_wd;
-  logic alert_en_44_we;
+  logic alert_en_45_we;
   logic alert_en_45_qs;
   logic alert_en_45_wd;
-  logic alert_en_45_we;
+  logic alert_en_46_we;
   logic alert_en_46_qs;
   logic alert_en_46_wd;
-  logic alert_en_46_we;
+  logic alert_en_47_we;
   logic alert_en_47_qs;
   logic alert_en_47_wd;
-  logic alert_en_47_we;
+  logic alert_en_48_we;
   logic alert_en_48_qs;
   logic alert_en_48_wd;
-  logic alert_en_48_we;
+  logic alert_en_49_we;
   logic alert_en_49_qs;
   logic alert_en_49_wd;
-  logic alert_en_49_we;
+  logic alert_en_50_we;
   logic alert_en_50_qs;
   logic alert_en_50_wd;
-  logic alert_en_50_we;
+  logic alert_en_51_we;
   logic alert_en_51_qs;
   logic alert_en_51_wd;
-  logic alert_en_51_we;
+  logic alert_en_52_we;
   logic alert_en_52_qs;
   logic alert_en_52_wd;
-  logic alert_en_52_we;
+  logic alert_en_53_we;
   logic alert_en_53_qs;
   logic alert_en_53_wd;
-  logic alert_en_53_we;
+  logic alert_en_54_we;
   logic alert_en_54_qs;
   logic alert_en_54_wd;
-  logic alert_en_54_we;
+  logic alert_class_0_we;
   logic [1:0] alert_class_0_qs;
   logic [1:0] alert_class_0_wd;
-  logic alert_class_0_we;
+  logic alert_class_1_we;
   logic [1:0] alert_class_1_qs;
   logic [1:0] alert_class_1_wd;
-  logic alert_class_1_we;
+  logic alert_class_2_we;
   logic [1:0] alert_class_2_qs;
   logic [1:0] alert_class_2_wd;
-  logic alert_class_2_we;
+  logic alert_class_3_we;
   logic [1:0] alert_class_3_qs;
   logic [1:0] alert_class_3_wd;
-  logic alert_class_3_we;
+  logic alert_class_4_we;
   logic [1:0] alert_class_4_qs;
   logic [1:0] alert_class_4_wd;
-  logic alert_class_4_we;
+  logic alert_class_5_we;
   logic [1:0] alert_class_5_qs;
   logic [1:0] alert_class_5_wd;
-  logic alert_class_5_we;
+  logic alert_class_6_we;
   logic [1:0] alert_class_6_qs;
   logic [1:0] alert_class_6_wd;
-  logic alert_class_6_we;
+  logic alert_class_7_we;
   logic [1:0] alert_class_7_qs;
   logic [1:0] alert_class_7_wd;
-  logic alert_class_7_we;
+  logic alert_class_8_we;
   logic [1:0] alert_class_8_qs;
   logic [1:0] alert_class_8_wd;
-  logic alert_class_8_we;
+  logic alert_class_9_we;
   logic [1:0] alert_class_9_qs;
   logic [1:0] alert_class_9_wd;
-  logic alert_class_9_we;
+  logic alert_class_10_we;
   logic [1:0] alert_class_10_qs;
   logic [1:0] alert_class_10_wd;
-  logic alert_class_10_we;
+  logic alert_class_11_we;
   logic [1:0] alert_class_11_qs;
   logic [1:0] alert_class_11_wd;
-  logic alert_class_11_we;
+  logic alert_class_12_we;
   logic [1:0] alert_class_12_qs;
   logic [1:0] alert_class_12_wd;
-  logic alert_class_12_we;
+  logic alert_class_13_we;
   logic [1:0] alert_class_13_qs;
   logic [1:0] alert_class_13_wd;
-  logic alert_class_13_we;
+  logic alert_class_14_we;
   logic [1:0] alert_class_14_qs;
   logic [1:0] alert_class_14_wd;
-  logic alert_class_14_we;
+  logic alert_class_15_we;
   logic [1:0] alert_class_15_qs;
   logic [1:0] alert_class_15_wd;
-  logic alert_class_15_we;
+  logic alert_class_16_we;
   logic [1:0] alert_class_16_qs;
   logic [1:0] alert_class_16_wd;
-  logic alert_class_16_we;
+  logic alert_class_17_we;
   logic [1:0] alert_class_17_qs;
   logic [1:0] alert_class_17_wd;
-  logic alert_class_17_we;
+  logic alert_class_18_we;
   logic [1:0] alert_class_18_qs;
   logic [1:0] alert_class_18_wd;
-  logic alert_class_18_we;
+  logic alert_class_19_we;
   logic [1:0] alert_class_19_qs;
   logic [1:0] alert_class_19_wd;
-  logic alert_class_19_we;
+  logic alert_class_20_we;
   logic [1:0] alert_class_20_qs;
   logic [1:0] alert_class_20_wd;
-  logic alert_class_20_we;
+  logic alert_class_21_we;
   logic [1:0] alert_class_21_qs;
   logic [1:0] alert_class_21_wd;
-  logic alert_class_21_we;
+  logic alert_class_22_we;
   logic [1:0] alert_class_22_qs;
   logic [1:0] alert_class_22_wd;
-  logic alert_class_22_we;
+  logic alert_class_23_we;
   logic [1:0] alert_class_23_qs;
   logic [1:0] alert_class_23_wd;
-  logic alert_class_23_we;
+  logic alert_class_24_we;
   logic [1:0] alert_class_24_qs;
   logic [1:0] alert_class_24_wd;
-  logic alert_class_24_we;
+  logic alert_class_25_we;
   logic [1:0] alert_class_25_qs;
   logic [1:0] alert_class_25_wd;
-  logic alert_class_25_we;
+  logic alert_class_26_we;
   logic [1:0] alert_class_26_qs;
   logic [1:0] alert_class_26_wd;
-  logic alert_class_26_we;
+  logic alert_class_27_we;
   logic [1:0] alert_class_27_qs;
   logic [1:0] alert_class_27_wd;
-  logic alert_class_27_we;
+  logic alert_class_28_we;
   logic [1:0] alert_class_28_qs;
   logic [1:0] alert_class_28_wd;
-  logic alert_class_28_we;
+  logic alert_class_29_we;
   logic [1:0] alert_class_29_qs;
   logic [1:0] alert_class_29_wd;
-  logic alert_class_29_we;
+  logic alert_class_30_we;
   logic [1:0] alert_class_30_qs;
   logic [1:0] alert_class_30_wd;
-  logic alert_class_30_we;
+  logic alert_class_31_we;
   logic [1:0] alert_class_31_qs;
   logic [1:0] alert_class_31_wd;
-  logic alert_class_31_we;
+  logic alert_class_32_we;
   logic [1:0] alert_class_32_qs;
   logic [1:0] alert_class_32_wd;
-  logic alert_class_32_we;
+  logic alert_class_33_we;
   logic [1:0] alert_class_33_qs;
   logic [1:0] alert_class_33_wd;
-  logic alert_class_33_we;
+  logic alert_class_34_we;
   logic [1:0] alert_class_34_qs;
   logic [1:0] alert_class_34_wd;
-  logic alert_class_34_we;
+  logic alert_class_35_we;
   logic [1:0] alert_class_35_qs;
   logic [1:0] alert_class_35_wd;
-  logic alert_class_35_we;
+  logic alert_class_36_we;
   logic [1:0] alert_class_36_qs;
   logic [1:0] alert_class_36_wd;
-  logic alert_class_36_we;
+  logic alert_class_37_we;
   logic [1:0] alert_class_37_qs;
   logic [1:0] alert_class_37_wd;
-  logic alert_class_37_we;
+  logic alert_class_38_we;
   logic [1:0] alert_class_38_qs;
   logic [1:0] alert_class_38_wd;
-  logic alert_class_38_we;
+  logic alert_class_39_we;
   logic [1:0] alert_class_39_qs;
   logic [1:0] alert_class_39_wd;
-  logic alert_class_39_we;
+  logic alert_class_40_we;
   logic [1:0] alert_class_40_qs;
   logic [1:0] alert_class_40_wd;
-  logic alert_class_40_we;
+  logic alert_class_41_we;
   logic [1:0] alert_class_41_qs;
   logic [1:0] alert_class_41_wd;
-  logic alert_class_41_we;
+  logic alert_class_42_we;
   logic [1:0] alert_class_42_qs;
   logic [1:0] alert_class_42_wd;
-  logic alert_class_42_we;
+  logic alert_class_43_we;
   logic [1:0] alert_class_43_qs;
   logic [1:0] alert_class_43_wd;
-  logic alert_class_43_we;
+  logic alert_class_44_we;
   logic [1:0] alert_class_44_qs;
   logic [1:0] alert_class_44_wd;
-  logic alert_class_44_we;
+  logic alert_class_45_we;
   logic [1:0] alert_class_45_qs;
   logic [1:0] alert_class_45_wd;
-  logic alert_class_45_we;
+  logic alert_class_46_we;
   logic [1:0] alert_class_46_qs;
   logic [1:0] alert_class_46_wd;
-  logic alert_class_46_we;
+  logic alert_class_47_we;
   logic [1:0] alert_class_47_qs;
   logic [1:0] alert_class_47_wd;
-  logic alert_class_47_we;
+  logic alert_class_48_we;
   logic [1:0] alert_class_48_qs;
   logic [1:0] alert_class_48_wd;
-  logic alert_class_48_we;
+  logic alert_class_49_we;
   logic [1:0] alert_class_49_qs;
   logic [1:0] alert_class_49_wd;
-  logic alert_class_49_we;
+  logic alert_class_50_we;
   logic [1:0] alert_class_50_qs;
   logic [1:0] alert_class_50_wd;
-  logic alert_class_50_we;
+  logic alert_class_51_we;
   logic [1:0] alert_class_51_qs;
   logic [1:0] alert_class_51_wd;
-  logic alert_class_51_we;
+  logic alert_class_52_we;
   logic [1:0] alert_class_52_qs;
   logic [1:0] alert_class_52_wd;
-  logic alert_class_52_we;
+  logic alert_class_53_we;
   logic [1:0] alert_class_53_qs;
   logic [1:0] alert_class_53_wd;
-  logic alert_class_53_we;
+  logic alert_class_54_we;
   logic [1:0] alert_class_54_qs;
   logic [1:0] alert_class_54_wd;
-  logic alert_class_54_we;
+  logic alert_cause_0_we;
   logic alert_cause_0_qs;
   logic alert_cause_0_wd;
-  logic alert_cause_0_we;
+  logic alert_cause_1_we;
   logic alert_cause_1_qs;
   logic alert_cause_1_wd;
-  logic alert_cause_1_we;
+  logic alert_cause_2_we;
   logic alert_cause_2_qs;
   logic alert_cause_2_wd;
-  logic alert_cause_2_we;
+  logic alert_cause_3_we;
   logic alert_cause_3_qs;
   logic alert_cause_3_wd;
-  logic alert_cause_3_we;
+  logic alert_cause_4_we;
   logic alert_cause_4_qs;
   logic alert_cause_4_wd;
-  logic alert_cause_4_we;
+  logic alert_cause_5_we;
   logic alert_cause_5_qs;
   logic alert_cause_5_wd;
-  logic alert_cause_5_we;
+  logic alert_cause_6_we;
   logic alert_cause_6_qs;
   logic alert_cause_6_wd;
-  logic alert_cause_6_we;
+  logic alert_cause_7_we;
   logic alert_cause_7_qs;
   logic alert_cause_7_wd;
-  logic alert_cause_7_we;
+  logic alert_cause_8_we;
   logic alert_cause_8_qs;
   logic alert_cause_8_wd;
-  logic alert_cause_8_we;
+  logic alert_cause_9_we;
   logic alert_cause_9_qs;
   logic alert_cause_9_wd;
-  logic alert_cause_9_we;
+  logic alert_cause_10_we;
   logic alert_cause_10_qs;
   logic alert_cause_10_wd;
-  logic alert_cause_10_we;
+  logic alert_cause_11_we;
   logic alert_cause_11_qs;
   logic alert_cause_11_wd;
-  logic alert_cause_11_we;
+  logic alert_cause_12_we;
   logic alert_cause_12_qs;
   logic alert_cause_12_wd;
-  logic alert_cause_12_we;
+  logic alert_cause_13_we;
   logic alert_cause_13_qs;
   logic alert_cause_13_wd;
-  logic alert_cause_13_we;
+  logic alert_cause_14_we;
   logic alert_cause_14_qs;
   logic alert_cause_14_wd;
-  logic alert_cause_14_we;
+  logic alert_cause_15_we;
   logic alert_cause_15_qs;
   logic alert_cause_15_wd;
-  logic alert_cause_15_we;
+  logic alert_cause_16_we;
   logic alert_cause_16_qs;
   logic alert_cause_16_wd;
-  logic alert_cause_16_we;
+  logic alert_cause_17_we;
   logic alert_cause_17_qs;
   logic alert_cause_17_wd;
-  logic alert_cause_17_we;
+  logic alert_cause_18_we;
   logic alert_cause_18_qs;
   logic alert_cause_18_wd;
-  logic alert_cause_18_we;
+  logic alert_cause_19_we;
   logic alert_cause_19_qs;
   logic alert_cause_19_wd;
-  logic alert_cause_19_we;
+  logic alert_cause_20_we;
   logic alert_cause_20_qs;
   logic alert_cause_20_wd;
-  logic alert_cause_20_we;
+  logic alert_cause_21_we;
   logic alert_cause_21_qs;
   logic alert_cause_21_wd;
-  logic alert_cause_21_we;
+  logic alert_cause_22_we;
   logic alert_cause_22_qs;
   logic alert_cause_22_wd;
-  logic alert_cause_22_we;
+  logic alert_cause_23_we;
   logic alert_cause_23_qs;
   logic alert_cause_23_wd;
-  logic alert_cause_23_we;
+  logic alert_cause_24_we;
   logic alert_cause_24_qs;
   logic alert_cause_24_wd;
-  logic alert_cause_24_we;
+  logic alert_cause_25_we;
   logic alert_cause_25_qs;
   logic alert_cause_25_wd;
-  logic alert_cause_25_we;
+  logic alert_cause_26_we;
   logic alert_cause_26_qs;
   logic alert_cause_26_wd;
-  logic alert_cause_26_we;
+  logic alert_cause_27_we;
   logic alert_cause_27_qs;
   logic alert_cause_27_wd;
-  logic alert_cause_27_we;
+  logic alert_cause_28_we;
   logic alert_cause_28_qs;
   logic alert_cause_28_wd;
-  logic alert_cause_28_we;
+  logic alert_cause_29_we;
   logic alert_cause_29_qs;
   logic alert_cause_29_wd;
-  logic alert_cause_29_we;
+  logic alert_cause_30_we;
   logic alert_cause_30_qs;
   logic alert_cause_30_wd;
-  logic alert_cause_30_we;
+  logic alert_cause_31_we;
   logic alert_cause_31_qs;
   logic alert_cause_31_wd;
-  logic alert_cause_31_we;
+  logic alert_cause_32_we;
   logic alert_cause_32_qs;
   logic alert_cause_32_wd;
-  logic alert_cause_32_we;
+  logic alert_cause_33_we;
   logic alert_cause_33_qs;
   logic alert_cause_33_wd;
-  logic alert_cause_33_we;
+  logic alert_cause_34_we;
   logic alert_cause_34_qs;
   logic alert_cause_34_wd;
-  logic alert_cause_34_we;
+  logic alert_cause_35_we;
   logic alert_cause_35_qs;
   logic alert_cause_35_wd;
-  logic alert_cause_35_we;
+  logic alert_cause_36_we;
   logic alert_cause_36_qs;
   logic alert_cause_36_wd;
-  logic alert_cause_36_we;
+  logic alert_cause_37_we;
   logic alert_cause_37_qs;
   logic alert_cause_37_wd;
-  logic alert_cause_37_we;
+  logic alert_cause_38_we;
   logic alert_cause_38_qs;
   logic alert_cause_38_wd;
-  logic alert_cause_38_we;
+  logic alert_cause_39_we;
   logic alert_cause_39_qs;
   logic alert_cause_39_wd;
-  logic alert_cause_39_we;
+  logic alert_cause_40_we;
   logic alert_cause_40_qs;
   logic alert_cause_40_wd;
-  logic alert_cause_40_we;
+  logic alert_cause_41_we;
   logic alert_cause_41_qs;
   logic alert_cause_41_wd;
-  logic alert_cause_41_we;
+  logic alert_cause_42_we;
   logic alert_cause_42_qs;
   logic alert_cause_42_wd;
-  logic alert_cause_42_we;
+  logic alert_cause_43_we;
   logic alert_cause_43_qs;
   logic alert_cause_43_wd;
-  logic alert_cause_43_we;
+  logic alert_cause_44_we;
   logic alert_cause_44_qs;
   logic alert_cause_44_wd;
-  logic alert_cause_44_we;
+  logic alert_cause_45_we;
   logic alert_cause_45_qs;
   logic alert_cause_45_wd;
-  logic alert_cause_45_we;
+  logic alert_cause_46_we;
   logic alert_cause_46_qs;
   logic alert_cause_46_wd;
-  logic alert_cause_46_we;
+  logic alert_cause_47_we;
   logic alert_cause_47_qs;
   logic alert_cause_47_wd;
-  logic alert_cause_47_we;
+  logic alert_cause_48_we;
   logic alert_cause_48_qs;
   logic alert_cause_48_wd;
-  logic alert_cause_48_we;
+  logic alert_cause_49_we;
   logic alert_cause_49_qs;
   logic alert_cause_49_wd;
-  logic alert_cause_49_we;
+  logic alert_cause_50_we;
   logic alert_cause_50_qs;
   logic alert_cause_50_wd;
-  logic alert_cause_50_we;
+  logic alert_cause_51_we;
   logic alert_cause_51_qs;
   logic alert_cause_51_wd;
-  logic alert_cause_51_we;
+  logic alert_cause_52_we;
   logic alert_cause_52_qs;
   logic alert_cause_52_wd;
-  logic alert_cause_52_we;
+  logic alert_cause_53_we;
   logic alert_cause_53_qs;
   logic alert_cause_53_wd;
-  logic alert_cause_53_we;
+  logic alert_cause_54_we;
   logic alert_cause_54_qs;
   logic alert_cause_54_wd;
-  logic alert_cause_54_we;
+  logic loc_alert_regwen_0_we;
   logic loc_alert_regwen_0_qs;
   logic loc_alert_regwen_0_wd;
-  logic loc_alert_regwen_0_we;
+  logic loc_alert_regwen_1_we;
   logic loc_alert_regwen_1_qs;
   logic loc_alert_regwen_1_wd;
-  logic loc_alert_regwen_1_we;
+  logic loc_alert_regwen_2_we;
   logic loc_alert_regwen_2_qs;
   logic loc_alert_regwen_2_wd;
-  logic loc_alert_regwen_2_we;
+  logic loc_alert_regwen_3_we;
   logic loc_alert_regwen_3_qs;
   logic loc_alert_regwen_3_wd;
-  logic loc_alert_regwen_3_we;
+  logic loc_alert_regwen_4_we;
   logic loc_alert_regwen_4_qs;
   logic loc_alert_regwen_4_wd;
-  logic loc_alert_regwen_4_we;
+  logic loc_alert_en_0_we;
   logic loc_alert_en_0_qs;
   logic loc_alert_en_0_wd;
-  logic loc_alert_en_0_we;
+  logic loc_alert_en_1_we;
   logic loc_alert_en_1_qs;
   logic loc_alert_en_1_wd;
-  logic loc_alert_en_1_we;
+  logic loc_alert_en_2_we;
   logic loc_alert_en_2_qs;
   logic loc_alert_en_2_wd;
-  logic loc_alert_en_2_we;
+  logic loc_alert_en_3_we;
   logic loc_alert_en_3_qs;
   logic loc_alert_en_3_wd;
-  logic loc_alert_en_3_we;
+  logic loc_alert_en_4_we;
   logic loc_alert_en_4_qs;
   logic loc_alert_en_4_wd;
-  logic loc_alert_en_4_we;
+  logic loc_alert_class_0_we;
   logic [1:0] loc_alert_class_0_qs;
   logic [1:0] loc_alert_class_0_wd;
-  logic loc_alert_class_0_we;
+  logic loc_alert_class_1_we;
   logic [1:0] loc_alert_class_1_qs;
   logic [1:0] loc_alert_class_1_wd;
-  logic loc_alert_class_1_we;
+  logic loc_alert_class_2_we;
   logic [1:0] loc_alert_class_2_qs;
   logic [1:0] loc_alert_class_2_wd;
-  logic loc_alert_class_2_we;
+  logic loc_alert_class_3_we;
   logic [1:0] loc_alert_class_3_qs;
   logic [1:0] loc_alert_class_3_wd;
-  logic loc_alert_class_3_we;
+  logic loc_alert_class_4_we;
   logic [1:0] loc_alert_class_4_qs;
   logic [1:0] loc_alert_class_4_wd;
-  logic loc_alert_class_4_we;
+  logic loc_alert_cause_0_we;
   logic loc_alert_cause_0_qs;
   logic loc_alert_cause_0_wd;
-  logic loc_alert_cause_0_we;
+  logic loc_alert_cause_1_we;
   logic loc_alert_cause_1_qs;
   logic loc_alert_cause_1_wd;
-  logic loc_alert_cause_1_we;
+  logic loc_alert_cause_2_we;
   logic loc_alert_cause_2_qs;
   logic loc_alert_cause_2_wd;
-  logic loc_alert_cause_2_we;
+  logic loc_alert_cause_3_we;
   logic loc_alert_cause_3_qs;
   logic loc_alert_cause_3_wd;
-  logic loc_alert_cause_3_we;
+  logic loc_alert_cause_4_we;
   logic loc_alert_cause_4_qs;
   logic loc_alert_cause_4_wd;
-  logic loc_alert_cause_4_we;
+  logic classa_regwen_we;
   logic classa_regwen_qs;
   logic classa_regwen_wd;
-  logic classa_regwen_we;
+  logic classa_ctrl_we;
   logic classa_ctrl_en_qs;
   logic classa_ctrl_en_wd;
-  logic classa_ctrl_en_we;
   logic classa_ctrl_lock_qs;
   logic classa_ctrl_lock_wd;
-  logic classa_ctrl_lock_we;
   logic classa_ctrl_en_e0_qs;
   logic classa_ctrl_en_e0_wd;
-  logic classa_ctrl_en_e0_we;
   logic classa_ctrl_en_e1_qs;
   logic classa_ctrl_en_e1_wd;
-  logic classa_ctrl_en_e1_we;
   logic classa_ctrl_en_e2_qs;
   logic classa_ctrl_en_e2_wd;
-  logic classa_ctrl_en_e2_we;
   logic classa_ctrl_en_e3_qs;
   logic classa_ctrl_en_e3_wd;
-  logic classa_ctrl_en_e3_we;
   logic [1:0] classa_ctrl_map_e0_qs;
   logic [1:0] classa_ctrl_map_e0_wd;
-  logic classa_ctrl_map_e0_we;
   logic [1:0] classa_ctrl_map_e1_qs;
   logic [1:0] classa_ctrl_map_e1_wd;
-  logic classa_ctrl_map_e1_we;
   logic [1:0] classa_ctrl_map_e2_qs;
   logic [1:0] classa_ctrl_map_e2_wd;
-  logic classa_ctrl_map_e2_we;
   logic [1:0] classa_ctrl_map_e3_qs;
   logic [1:0] classa_ctrl_map_e3_wd;
-  logic classa_ctrl_map_e3_we;
+  logic classa_clr_regwen_we;
   logic classa_clr_regwen_qs;
   logic classa_clr_regwen_wd;
-  logic classa_clr_regwen_we;
-  logic classa_clr_wd;
   logic classa_clr_we;
-  logic [15:0] classa_accum_cnt_qs;
+  logic classa_clr_wd;
   logic classa_accum_cnt_re;
+  logic [15:0] classa_accum_cnt_qs;
+  logic classa_accum_thresh_we;
   logic [15:0] classa_accum_thresh_qs;
   logic [15:0] classa_accum_thresh_wd;
-  logic classa_accum_thresh_we;
+  logic classa_timeout_cyc_we;
   logic [31:0] classa_timeout_cyc_qs;
   logic [31:0] classa_timeout_cyc_wd;
-  logic classa_timeout_cyc_we;
+  logic classa_phase0_cyc_we;
   logic [31:0] classa_phase0_cyc_qs;
   logic [31:0] classa_phase0_cyc_wd;
-  logic classa_phase0_cyc_we;
+  logic classa_phase1_cyc_we;
   logic [31:0] classa_phase1_cyc_qs;
   logic [31:0] classa_phase1_cyc_wd;
-  logic classa_phase1_cyc_we;
+  logic classa_phase2_cyc_we;
   logic [31:0] classa_phase2_cyc_qs;
   logic [31:0] classa_phase2_cyc_wd;
-  logic classa_phase2_cyc_we;
+  logic classa_phase3_cyc_we;
   logic [31:0] classa_phase3_cyc_qs;
   logic [31:0] classa_phase3_cyc_wd;
-  logic classa_phase3_cyc_we;
-  logic [31:0] classa_esc_cnt_qs;
   logic classa_esc_cnt_re;
-  logic [2:0] classa_state_qs;
+  logic [31:0] classa_esc_cnt_qs;
   logic classa_state_re;
+  logic [2:0] classa_state_qs;
+  logic classb_regwen_we;
   logic classb_regwen_qs;
   logic classb_regwen_wd;
-  logic classb_regwen_we;
+  logic classb_ctrl_we;
   logic classb_ctrl_en_qs;
   logic classb_ctrl_en_wd;
-  logic classb_ctrl_en_we;
   logic classb_ctrl_lock_qs;
   logic classb_ctrl_lock_wd;
-  logic classb_ctrl_lock_we;
   logic classb_ctrl_en_e0_qs;
   logic classb_ctrl_en_e0_wd;
-  logic classb_ctrl_en_e0_we;
   logic classb_ctrl_en_e1_qs;
   logic classb_ctrl_en_e1_wd;
-  logic classb_ctrl_en_e1_we;
   logic classb_ctrl_en_e2_qs;
   logic classb_ctrl_en_e2_wd;
-  logic classb_ctrl_en_e2_we;
   logic classb_ctrl_en_e3_qs;
   logic classb_ctrl_en_e3_wd;
-  logic classb_ctrl_en_e3_we;
   logic [1:0] classb_ctrl_map_e0_qs;
   logic [1:0] classb_ctrl_map_e0_wd;
-  logic classb_ctrl_map_e0_we;
   logic [1:0] classb_ctrl_map_e1_qs;
   logic [1:0] classb_ctrl_map_e1_wd;
-  logic classb_ctrl_map_e1_we;
   logic [1:0] classb_ctrl_map_e2_qs;
   logic [1:0] classb_ctrl_map_e2_wd;
-  logic classb_ctrl_map_e2_we;
   logic [1:0] classb_ctrl_map_e3_qs;
   logic [1:0] classb_ctrl_map_e3_wd;
-  logic classb_ctrl_map_e3_we;
+  logic classb_clr_regwen_we;
   logic classb_clr_regwen_qs;
   logic classb_clr_regwen_wd;
-  logic classb_clr_regwen_we;
-  logic classb_clr_wd;
   logic classb_clr_we;
-  logic [15:0] classb_accum_cnt_qs;
+  logic classb_clr_wd;
   logic classb_accum_cnt_re;
+  logic [15:0] classb_accum_cnt_qs;
+  logic classb_accum_thresh_we;
   logic [15:0] classb_accum_thresh_qs;
   logic [15:0] classb_accum_thresh_wd;
-  logic classb_accum_thresh_we;
+  logic classb_timeout_cyc_we;
   logic [31:0] classb_timeout_cyc_qs;
   logic [31:0] classb_timeout_cyc_wd;
-  logic classb_timeout_cyc_we;
+  logic classb_phase0_cyc_we;
   logic [31:0] classb_phase0_cyc_qs;
   logic [31:0] classb_phase0_cyc_wd;
-  logic classb_phase0_cyc_we;
+  logic classb_phase1_cyc_we;
   logic [31:0] classb_phase1_cyc_qs;
   logic [31:0] classb_phase1_cyc_wd;
-  logic classb_phase1_cyc_we;
+  logic classb_phase2_cyc_we;
   logic [31:0] classb_phase2_cyc_qs;
   logic [31:0] classb_phase2_cyc_wd;
-  logic classb_phase2_cyc_we;
+  logic classb_phase3_cyc_we;
   logic [31:0] classb_phase3_cyc_qs;
   logic [31:0] classb_phase3_cyc_wd;
-  logic classb_phase3_cyc_we;
-  logic [31:0] classb_esc_cnt_qs;
   logic classb_esc_cnt_re;
-  logic [2:0] classb_state_qs;
+  logic [31:0] classb_esc_cnt_qs;
   logic classb_state_re;
+  logic [2:0] classb_state_qs;
+  logic classc_regwen_we;
   logic classc_regwen_qs;
   logic classc_regwen_wd;
-  logic classc_regwen_we;
+  logic classc_ctrl_we;
   logic classc_ctrl_en_qs;
   logic classc_ctrl_en_wd;
-  logic classc_ctrl_en_we;
   logic classc_ctrl_lock_qs;
   logic classc_ctrl_lock_wd;
-  logic classc_ctrl_lock_we;
   logic classc_ctrl_en_e0_qs;
   logic classc_ctrl_en_e0_wd;
-  logic classc_ctrl_en_e0_we;
   logic classc_ctrl_en_e1_qs;
   logic classc_ctrl_en_e1_wd;
-  logic classc_ctrl_en_e1_we;
   logic classc_ctrl_en_e2_qs;
   logic classc_ctrl_en_e2_wd;
-  logic classc_ctrl_en_e2_we;
   logic classc_ctrl_en_e3_qs;
   logic classc_ctrl_en_e3_wd;
-  logic classc_ctrl_en_e3_we;
   logic [1:0] classc_ctrl_map_e0_qs;
   logic [1:0] classc_ctrl_map_e0_wd;
-  logic classc_ctrl_map_e0_we;
   logic [1:0] classc_ctrl_map_e1_qs;
   logic [1:0] classc_ctrl_map_e1_wd;
-  logic classc_ctrl_map_e1_we;
   logic [1:0] classc_ctrl_map_e2_qs;
   logic [1:0] classc_ctrl_map_e2_wd;
-  logic classc_ctrl_map_e2_we;
   logic [1:0] classc_ctrl_map_e3_qs;
   logic [1:0] classc_ctrl_map_e3_wd;
-  logic classc_ctrl_map_e3_we;
+  logic classc_clr_regwen_we;
   logic classc_clr_regwen_qs;
   logic classc_clr_regwen_wd;
-  logic classc_clr_regwen_we;
-  logic classc_clr_wd;
   logic classc_clr_we;
-  logic [15:0] classc_accum_cnt_qs;
+  logic classc_clr_wd;
   logic classc_accum_cnt_re;
+  logic [15:0] classc_accum_cnt_qs;
+  logic classc_accum_thresh_we;
   logic [15:0] classc_accum_thresh_qs;
   logic [15:0] classc_accum_thresh_wd;
-  logic classc_accum_thresh_we;
+  logic classc_timeout_cyc_we;
   logic [31:0] classc_timeout_cyc_qs;
   logic [31:0] classc_timeout_cyc_wd;
-  logic classc_timeout_cyc_we;
+  logic classc_phase0_cyc_we;
   logic [31:0] classc_phase0_cyc_qs;
   logic [31:0] classc_phase0_cyc_wd;
-  logic classc_phase0_cyc_we;
+  logic classc_phase1_cyc_we;
   logic [31:0] classc_phase1_cyc_qs;
   logic [31:0] classc_phase1_cyc_wd;
-  logic classc_phase1_cyc_we;
+  logic classc_phase2_cyc_we;
   logic [31:0] classc_phase2_cyc_qs;
   logic [31:0] classc_phase2_cyc_wd;
-  logic classc_phase2_cyc_we;
+  logic classc_phase3_cyc_we;
   logic [31:0] classc_phase3_cyc_qs;
   logic [31:0] classc_phase3_cyc_wd;
-  logic classc_phase3_cyc_we;
-  logic [31:0] classc_esc_cnt_qs;
   logic classc_esc_cnt_re;
-  logic [2:0] classc_state_qs;
+  logic [31:0] classc_esc_cnt_qs;
   logic classc_state_re;
+  logic [2:0] classc_state_qs;
+  logic classd_regwen_we;
   logic classd_regwen_qs;
   logic classd_regwen_wd;
-  logic classd_regwen_we;
+  logic classd_ctrl_we;
   logic classd_ctrl_en_qs;
   logic classd_ctrl_en_wd;
-  logic classd_ctrl_en_we;
   logic classd_ctrl_lock_qs;
   logic classd_ctrl_lock_wd;
-  logic classd_ctrl_lock_we;
   logic classd_ctrl_en_e0_qs;
   logic classd_ctrl_en_e0_wd;
-  logic classd_ctrl_en_e0_we;
   logic classd_ctrl_en_e1_qs;
   logic classd_ctrl_en_e1_wd;
-  logic classd_ctrl_en_e1_we;
   logic classd_ctrl_en_e2_qs;
   logic classd_ctrl_en_e2_wd;
-  logic classd_ctrl_en_e2_we;
   logic classd_ctrl_en_e3_qs;
   logic classd_ctrl_en_e3_wd;
-  logic classd_ctrl_en_e3_we;
   logic [1:0] classd_ctrl_map_e0_qs;
   logic [1:0] classd_ctrl_map_e0_wd;
-  logic classd_ctrl_map_e0_we;
   logic [1:0] classd_ctrl_map_e1_qs;
   logic [1:0] classd_ctrl_map_e1_wd;
-  logic classd_ctrl_map_e1_we;
   logic [1:0] classd_ctrl_map_e2_qs;
   logic [1:0] classd_ctrl_map_e2_wd;
-  logic classd_ctrl_map_e2_we;
   logic [1:0] classd_ctrl_map_e3_qs;
   logic [1:0] classd_ctrl_map_e3_wd;
-  logic classd_ctrl_map_e3_we;
+  logic classd_clr_regwen_we;
   logic classd_clr_regwen_qs;
   logic classd_clr_regwen_wd;
-  logic classd_clr_regwen_we;
-  logic classd_clr_wd;
   logic classd_clr_we;
-  logic [15:0] classd_accum_cnt_qs;
+  logic classd_clr_wd;
   logic classd_accum_cnt_re;
+  logic [15:0] classd_accum_cnt_qs;
+  logic classd_accum_thresh_we;
   logic [15:0] classd_accum_thresh_qs;
   logic [15:0] classd_accum_thresh_wd;
-  logic classd_accum_thresh_we;
+  logic classd_timeout_cyc_we;
   logic [31:0] classd_timeout_cyc_qs;
   logic [31:0] classd_timeout_cyc_wd;
-  logic classd_timeout_cyc_we;
+  logic classd_phase0_cyc_we;
   logic [31:0] classd_phase0_cyc_qs;
   logic [31:0] classd_phase0_cyc_wd;
-  logic classd_phase0_cyc_we;
+  logic classd_phase1_cyc_we;
   logic [31:0] classd_phase1_cyc_qs;
   logic [31:0] classd_phase1_cyc_wd;
-  logic classd_phase1_cyc_we;
+  logic classd_phase2_cyc_we;
   logic [31:0] classd_phase2_cyc_qs;
   logic [31:0] classd_phase2_cyc_wd;
-  logic classd_phase2_cyc_we;
+  logic classd_phase3_cyc_we;
   logic [31:0] classd_phase3_cyc_qs;
   logic [31:0] classd_phase3_cyc_wd;
-  logic classd_phase3_cyc_we;
-  logic [31:0] classd_esc_cnt_qs;
   logic classd_esc_cnt_re;
-  logic [2:0] classd_state_qs;
+  logic [31:0] classd_esc_cnt_qs;
   logic classd_state_re;
+  logic [2:0] classd_state_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1127,7 +1082,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classa_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classa_wd),
 
     // from internal hardware
@@ -1153,7 +1108,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classb_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classb_wd),
 
     // from internal hardware
@@ -1179,7 +1134,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classc_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classc_wd),
 
     // from internal hardware
@@ -1205,7 +1160,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_classd_we),
+    .we     (intr_state_we),
     .wd     (intr_state_classd_wd),
 
     // from internal hardware
@@ -1233,7 +1188,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classa_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classa_wd),
 
     // from internal hardware
@@ -1259,7 +1214,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classb_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classb_wd),
 
     // from internal hardware
@@ -1285,7 +1240,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classc_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classc_wd),
 
     // from internal hardware
@@ -1311,7 +1266,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_classd_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_classd_wd),
 
     // from internal hardware
@@ -1334,7 +1289,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classa (
     .re     (1'b0),
-    .we     (intr_test_classa_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classa_wd),
     .d      ('0),
     .qre    (),
@@ -1349,7 +1304,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classb (
     .re     (1'b0),
-    .we     (intr_test_classb_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classb_wd),
     .d      ('0),
     .qre    (),
@@ -1364,7 +1319,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classc (
     .re     (1'b0),
-    .we     (intr_test_classc_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classc_wd),
     .d      ('0),
     .qre    (),
@@ -1379,7 +1334,7 @@ module alert_handler_reg_top (
     .DW    (1)
   ) u_intr_test_classd (
     .re     (1'b0),
-    .we     (intr_test_classd_we),
+    .we     (intr_test_we),
     .wd     (intr_test_classd_wd),
     .d      ('0),
     .qre    (),
@@ -8005,7 +7960,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_wd),
 
     // from internal hardware
@@ -8031,7 +7986,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_lock_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_lock_wd),
 
     // from internal hardware
@@ -8057,7 +8012,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e0_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -8083,7 +8038,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e1_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -8109,7 +8064,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e2_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -8135,7 +8090,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_en_e3_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -8161,7 +8116,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e0_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -8187,7 +8142,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e1_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -8213,7 +8168,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e2_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -8239,7 +8194,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classa_ctrl_map_e3_we & classa_regwen_qs),
+    .we     (classa_ctrl_we & classa_regwen_qs),
     .wd     (classa_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -8558,7 +8513,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_wd),
 
     // from internal hardware
@@ -8584,7 +8539,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_lock_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_lock_wd),
 
     // from internal hardware
@@ -8610,7 +8565,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e0_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -8636,7 +8591,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e1_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -8662,7 +8617,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e2_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -8688,7 +8643,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_en_e3_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -8714,7 +8669,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e0_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -8740,7 +8695,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e1_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -8766,7 +8721,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e2_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -8792,7 +8747,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classb_ctrl_map_e3_we & classb_regwen_qs),
+    .we     (classb_ctrl_we & classb_regwen_qs),
     .wd     (classb_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -9111,7 +9066,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_wd),
 
     // from internal hardware
@@ -9137,7 +9092,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_lock_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_lock_wd),
 
     // from internal hardware
@@ -9163,7 +9118,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e0_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -9189,7 +9144,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e1_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -9215,7 +9170,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e2_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -9241,7 +9196,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_en_e3_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -9267,7 +9222,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e0_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -9293,7 +9248,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e1_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -9319,7 +9274,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e2_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -9345,7 +9300,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classc_ctrl_map_e3_we & classc_regwen_qs),
+    .we     (classc_ctrl_we & classc_regwen_qs),
     .wd     (classc_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -9664,7 +9619,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_wd),
 
     // from internal hardware
@@ -9690,7 +9645,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_lock_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_lock_wd),
 
     // from internal hardware
@@ -9716,7 +9671,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e0_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e0_wd),
 
     // from internal hardware
@@ -9742,7 +9697,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e1_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e1_wd),
 
     // from internal hardware
@@ -9768,7 +9723,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e2_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e2_wd),
 
     // from internal hardware
@@ -9794,7 +9749,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_en_e3_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_en_e3_wd),
 
     // from internal hardware
@@ -9820,7 +9775,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e0_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e0_wd),
 
     // from internal hardware
@@ -9846,7 +9801,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e1_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e1_wd),
 
     // from internal hardware
@@ -9872,7 +9827,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e2_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e2_wd),
 
     // from internal hardware
@@ -9898,7 +9853,7 @@ module alert_handler_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (classd_ctrl_map_e3_we & classd_regwen_qs),
+    .we     (classd_ctrl_we & classd_regwen_qs),
     .wd     (classd_ctrl_map_e3_wd),
 
     // from internal hardware
@@ -10787,1022 +10742,965 @@ module alert_handler_reg_top (
                (addr_hit[296] & (|(ALERT_HANDLER_PERMIT[296] & ~reg_be))) |
                (addr_hit[297] & (|(ALERT_HANDLER_PERMIT[297] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_classa_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classa_wd = reg_wdata[0];
 
-  assign intr_state_classb_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classb_wd = reg_wdata[1];
 
-  assign intr_state_classc_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classc_wd = reg_wdata[2];
 
-  assign intr_state_classd_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_classd_wd = reg_wdata[3];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_classa_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classa_wd = reg_wdata[0];
 
-  assign intr_enable_classb_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classb_wd = reg_wdata[1];
 
-  assign intr_enable_classc_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classc_wd = reg_wdata[2];
 
-  assign intr_enable_classd_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_classd_wd = reg_wdata[3];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_classa_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classa_wd = reg_wdata[0];
 
-  assign intr_test_classb_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classb_wd = reg_wdata[1];
 
-  assign intr_test_classc_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classc_wd = reg_wdata[2];
 
-  assign intr_test_classd_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_classd_wd = reg_wdata[3];
-
   assign ping_timer_regwen_we = addr_hit[3] & reg_we & !reg_error;
+
   assign ping_timer_regwen_wd = reg_wdata[0];
-
   assign ping_timeout_cyc_we = addr_hit[4] & reg_we & !reg_error;
+
   assign ping_timeout_cyc_wd = reg_wdata[15:0];
-
   assign ping_timer_en_we = addr_hit[5] & reg_we & !reg_error;
+
   assign ping_timer_en_wd = reg_wdata[0];
-
   assign alert_regwen_0_we = addr_hit[6] & reg_we & !reg_error;
+
   assign alert_regwen_0_wd = reg_wdata[0];
-
   assign alert_regwen_1_we = addr_hit[7] & reg_we & !reg_error;
+
   assign alert_regwen_1_wd = reg_wdata[0];
-
   assign alert_regwen_2_we = addr_hit[8] & reg_we & !reg_error;
+
   assign alert_regwen_2_wd = reg_wdata[0];
-
   assign alert_regwen_3_we = addr_hit[9] & reg_we & !reg_error;
+
   assign alert_regwen_3_wd = reg_wdata[0];
-
   assign alert_regwen_4_we = addr_hit[10] & reg_we & !reg_error;
+
   assign alert_regwen_4_wd = reg_wdata[0];
-
   assign alert_regwen_5_we = addr_hit[11] & reg_we & !reg_error;
+
   assign alert_regwen_5_wd = reg_wdata[0];
-
   assign alert_regwen_6_we = addr_hit[12] & reg_we & !reg_error;
+
   assign alert_regwen_6_wd = reg_wdata[0];
-
   assign alert_regwen_7_we = addr_hit[13] & reg_we & !reg_error;
+
   assign alert_regwen_7_wd = reg_wdata[0];
-
   assign alert_regwen_8_we = addr_hit[14] & reg_we & !reg_error;
+
   assign alert_regwen_8_wd = reg_wdata[0];
-
   assign alert_regwen_9_we = addr_hit[15] & reg_we & !reg_error;
+
   assign alert_regwen_9_wd = reg_wdata[0];
-
   assign alert_regwen_10_we = addr_hit[16] & reg_we & !reg_error;
+
   assign alert_regwen_10_wd = reg_wdata[0];
-
   assign alert_regwen_11_we = addr_hit[17] & reg_we & !reg_error;
+
   assign alert_regwen_11_wd = reg_wdata[0];
-
   assign alert_regwen_12_we = addr_hit[18] & reg_we & !reg_error;
+
   assign alert_regwen_12_wd = reg_wdata[0];
-
   assign alert_regwen_13_we = addr_hit[19] & reg_we & !reg_error;
+
   assign alert_regwen_13_wd = reg_wdata[0];
-
   assign alert_regwen_14_we = addr_hit[20] & reg_we & !reg_error;
+
   assign alert_regwen_14_wd = reg_wdata[0];
-
   assign alert_regwen_15_we = addr_hit[21] & reg_we & !reg_error;
+
   assign alert_regwen_15_wd = reg_wdata[0];
-
   assign alert_regwen_16_we = addr_hit[22] & reg_we & !reg_error;
+
   assign alert_regwen_16_wd = reg_wdata[0];
-
   assign alert_regwen_17_we = addr_hit[23] & reg_we & !reg_error;
+
   assign alert_regwen_17_wd = reg_wdata[0];
-
   assign alert_regwen_18_we = addr_hit[24] & reg_we & !reg_error;
+
   assign alert_regwen_18_wd = reg_wdata[0];
-
   assign alert_regwen_19_we = addr_hit[25] & reg_we & !reg_error;
+
   assign alert_regwen_19_wd = reg_wdata[0];
-
   assign alert_regwen_20_we = addr_hit[26] & reg_we & !reg_error;
+
   assign alert_regwen_20_wd = reg_wdata[0];
-
   assign alert_regwen_21_we = addr_hit[27] & reg_we & !reg_error;
+
   assign alert_regwen_21_wd = reg_wdata[0];
-
   assign alert_regwen_22_we = addr_hit[28] & reg_we & !reg_error;
+
   assign alert_regwen_22_wd = reg_wdata[0];
-
   assign alert_regwen_23_we = addr_hit[29] & reg_we & !reg_error;
+
   assign alert_regwen_23_wd = reg_wdata[0];
-
   assign alert_regwen_24_we = addr_hit[30] & reg_we & !reg_error;
+
   assign alert_regwen_24_wd = reg_wdata[0];
-
   assign alert_regwen_25_we = addr_hit[31] & reg_we & !reg_error;
+
   assign alert_regwen_25_wd = reg_wdata[0];
-
   assign alert_regwen_26_we = addr_hit[32] & reg_we & !reg_error;
+
   assign alert_regwen_26_wd = reg_wdata[0];
-
   assign alert_regwen_27_we = addr_hit[33] & reg_we & !reg_error;
+
   assign alert_regwen_27_wd = reg_wdata[0];
-
   assign alert_regwen_28_we = addr_hit[34] & reg_we & !reg_error;
+
   assign alert_regwen_28_wd = reg_wdata[0];
-
   assign alert_regwen_29_we = addr_hit[35] & reg_we & !reg_error;
+
   assign alert_regwen_29_wd = reg_wdata[0];
-
   assign alert_regwen_30_we = addr_hit[36] & reg_we & !reg_error;
+
   assign alert_regwen_30_wd = reg_wdata[0];
-
   assign alert_regwen_31_we = addr_hit[37] & reg_we & !reg_error;
+
   assign alert_regwen_31_wd = reg_wdata[0];
-
   assign alert_regwen_32_we = addr_hit[38] & reg_we & !reg_error;
+
   assign alert_regwen_32_wd = reg_wdata[0];
-
   assign alert_regwen_33_we = addr_hit[39] & reg_we & !reg_error;
+
   assign alert_regwen_33_wd = reg_wdata[0];
-
   assign alert_regwen_34_we = addr_hit[40] & reg_we & !reg_error;
+
   assign alert_regwen_34_wd = reg_wdata[0];
-
   assign alert_regwen_35_we = addr_hit[41] & reg_we & !reg_error;
+
   assign alert_regwen_35_wd = reg_wdata[0];
-
   assign alert_regwen_36_we = addr_hit[42] & reg_we & !reg_error;
+
   assign alert_regwen_36_wd = reg_wdata[0];
-
   assign alert_regwen_37_we = addr_hit[43] & reg_we & !reg_error;
+
   assign alert_regwen_37_wd = reg_wdata[0];
-
   assign alert_regwen_38_we = addr_hit[44] & reg_we & !reg_error;
+
   assign alert_regwen_38_wd = reg_wdata[0];
-
   assign alert_regwen_39_we = addr_hit[45] & reg_we & !reg_error;
+
   assign alert_regwen_39_wd = reg_wdata[0];
-
   assign alert_regwen_40_we = addr_hit[46] & reg_we & !reg_error;
+
   assign alert_regwen_40_wd = reg_wdata[0];
-
   assign alert_regwen_41_we = addr_hit[47] & reg_we & !reg_error;
+
   assign alert_regwen_41_wd = reg_wdata[0];
-
   assign alert_regwen_42_we = addr_hit[48] & reg_we & !reg_error;
+
   assign alert_regwen_42_wd = reg_wdata[0];
-
   assign alert_regwen_43_we = addr_hit[49] & reg_we & !reg_error;
+
   assign alert_regwen_43_wd = reg_wdata[0];
-
   assign alert_regwen_44_we = addr_hit[50] & reg_we & !reg_error;
+
   assign alert_regwen_44_wd = reg_wdata[0];
-
   assign alert_regwen_45_we = addr_hit[51] & reg_we & !reg_error;
+
   assign alert_regwen_45_wd = reg_wdata[0];
-
   assign alert_regwen_46_we = addr_hit[52] & reg_we & !reg_error;
+
   assign alert_regwen_46_wd = reg_wdata[0];
-
   assign alert_regwen_47_we = addr_hit[53] & reg_we & !reg_error;
+
   assign alert_regwen_47_wd = reg_wdata[0];
-
   assign alert_regwen_48_we = addr_hit[54] & reg_we & !reg_error;
+
   assign alert_regwen_48_wd = reg_wdata[0];
-
   assign alert_regwen_49_we = addr_hit[55] & reg_we & !reg_error;
+
   assign alert_regwen_49_wd = reg_wdata[0];
-
   assign alert_regwen_50_we = addr_hit[56] & reg_we & !reg_error;
+
   assign alert_regwen_50_wd = reg_wdata[0];
-
   assign alert_regwen_51_we = addr_hit[57] & reg_we & !reg_error;
+
   assign alert_regwen_51_wd = reg_wdata[0];
-
   assign alert_regwen_52_we = addr_hit[58] & reg_we & !reg_error;
+
   assign alert_regwen_52_wd = reg_wdata[0];
-
   assign alert_regwen_53_we = addr_hit[59] & reg_we & !reg_error;
+
   assign alert_regwen_53_wd = reg_wdata[0];
-
   assign alert_regwen_54_we = addr_hit[60] & reg_we & !reg_error;
+
   assign alert_regwen_54_wd = reg_wdata[0];
-
   assign alert_en_0_we = addr_hit[61] & reg_we & !reg_error;
+
   assign alert_en_0_wd = reg_wdata[0];
-
   assign alert_en_1_we = addr_hit[62] & reg_we & !reg_error;
+
   assign alert_en_1_wd = reg_wdata[0];
-
   assign alert_en_2_we = addr_hit[63] & reg_we & !reg_error;
+
   assign alert_en_2_wd = reg_wdata[0];
-
   assign alert_en_3_we = addr_hit[64] & reg_we & !reg_error;
+
   assign alert_en_3_wd = reg_wdata[0];
-
   assign alert_en_4_we = addr_hit[65] & reg_we & !reg_error;
+
   assign alert_en_4_wd = reg_wdata[0];
-
   assign alert_en_5_we = addr_hit[66] & reg_we & !reg_error;
+
   assign alert_en_5_wd = reg_wdata[0];
-
   assign alert_en_6_we = addr_hit[67] & reg_we & !reg_error;
+
   assign alert_en_6_wd = reg_wdata[0];
-
   assign alert_en_7_we = addr_hit[68] & reg_we & !reg_error;
+
   assign alert_en_7_wd = reg_wdata[0];
-
   assign alert_en_8_we = addr_hit[69] & reg_we & !reg_error;
+
   assign alert_en_8_wd = reg_wdata[0];
-
   assign alert_en_9_we = addr_hit[70] & reg_we & !reg_error;
+
   assign alert_en_9_wd = reg_wdata[0];
-
   assign alert_en_10_we = addr_hit[71] & reg_we & !reg_error;
+
   assign alert_en_10_wd = reg_wdata[0];
-
   assign alert_en_11_we = addr_hit[72] & reg_we & !reg_error;
+
   assign alert_en_11_wd = reg_wdata[0];
-
   assign alert_en_12_we = addr_hit[73] & reg_we & !reg_error;
+
   assign alert_en_12_wd = reg_wdata[0];
-
   assign alert_en_13_we = addr_hit[74] & reg_we & !reg_error;
+
   assign alert_en_13_wd = reg_wdata[0];
-
   assign alert_en_14_we = addr_hit[75] & reg_we & !reg_error;
+
   assign alert_en_14_wd = reg_wdata[0];
-
   assign alert_en_15_we = addr_hit[76] & reg_we & !reg_error;
+
   assign alert_en_15_wd = reg_wdata[0];
-
   assign alert_en_16_we = addr_hit[77] & reg_we & !reg_error;
+
   assign alert_en_16_wd = reg_wdata[0];
-
   assign alert_en_17_we = addr_hit[78] & reg_we & !reg_error;
+
   assign alert_en_17_wd = reg_wdata[0];
-
   assign alert_en_18_we = addr_hit[79] & reg_we & !reg_error;
+
   assign alert_en_18_wd = reg_wdata[0];
-
   assign alert_en_19_we = addr_hit[80] & reg_we & !reg_error;
+
   assign alert_en_19_wd = reg_wdata[0];
-
   assign alert_en_20_we = addr_hit[81] & reg_we & !reg_error;
+
   assign alert_en_20_wd = reg_wdata[0];
-
   assign alert_en_21_we = addr_hit[82] & reg_we & !reg_error;
+
   assign alert_en_21_wd = reg_wdata[0];
-
   assign alert_en_22_we = addr_hit[83] & reg_we & !reg_error;
+
   assign alert_en_22_wd = reg_wdata[0];
-
   assign alert_en_23_we = addr_hit[84] & reg_we & !reg_error;
+
   assign alert_en_23_wd = reg_wdata[0];
-
   assign alert_en_24_we = addr_hit[85] & reg_we & !reg_error;
+
   assign alert_en_24_wd = reg_wdata[0];
-
   assign alert_en_25_we = addr_hit[86] & reg_we & !reg_error;
+
   assign alert_en_25_wd = reg_wdata[0];
-
   assign alert_en_26_we = addr_hit[87] & reg_we & !reg_error;
+
   assign alert_en_26_wd = reg_wdata[0];
-
   assign alert_en_27_we = addr_hit[88] & reg_we & !reg_error;
+
   assign alert_en_27_wd = reg_wdata[0];
-
   assign alert_en_28_we = addr_hit[89] & reg_we & !reg_error;
+
   assign alert_en_28_wd = reg_wdata[0];
-
   assign alert_en_29_we = addr_hit[90] & reg_we & !reg_error;
+
   assign alert_en_29_wd = reg_wdata[0];
-
   assign alert_en_30_we = addr_hit[91] & reg_we & !reg_error;
+
   assign alert_en_30_wd = reg_wdata[0];
-
   assign alert_en_31_we = addr_hit[92] & reg_we & !reg_error;
+
   assign alert_en_31_wd = reg_wdata[0];
-
   assign alert_en_32_we = addr_hit[93] & reg_we & !reg_error;
+
   assign alert_en_32_wd = reg_wdata[0];
-
   assign alert_en_33_we = addr_hit[94] & reg_we & !reg_error;
+
   assign alert_en_33_wd = reg_wdata[0];
-
   assign alert_en_34_we = addr_hit[95] & reg_we & !reg_error;
+
   assign alert_en_34_wd = reg_wdata[0];
-
   assign alert_en_35_we = addr_hit[96] & reg_we & !reg_error;
+
   assign alert_en_35_wd = reg_wdata[0];
-
   assign alert_en_36_we = addr_hit[97] & reg_we & !reg_error;
+
   assign alert_en_36_wd = reg_wdata[0];
-
   assign alert_en_37_we = addr_hit[98] & reg_we & !reg_error;
+
   assign alert_en_37_wd = reg_wdata[0];
-
   assign alert_en_38_we = addr_hit[99] & reg_we & !reg_error;
+
   assign alert_en_38_wd = reg_wdata[0];
-
   assign alert_en_39_we = addr_hit[100] & reg_we & !reg_error;
+
   assign alert_en_39_wd = reg_wdata[0];
-
   assign alert_en_40_we = addr_hit[101] & reg_we & !reg_error;
+
   assign alert_en_40_wd = reg_wdata[0];
-
   assign alert_en_41_we = addr_hit[102] & reg_we & !reg_error;
+
   assign alert_en_41_wd = reg_wdata[0];
-
   assign alert_en_42_we = addr_hit[103] & reg_we & !reg_error;
+
   assign alert_en_42_wd = reg_wdata[0];
-
   assign alert_en_43_we = addr_hit[104] & reg_we & !reg_error;
+
   assign alert_en_43_wd = reg_wdata[0];
-
   assign alert_en_44_we = addr_hit[105] & reg_we & !reg_error;
+
   assign alert_en_44_wd = reg_wdata[0];
-
   assign alert_en_45_we = addr_hit[106] & reg_we & !reg_error;
+
   assign alert_en_45_wd = reg_wdata[0];
-
   assign alert_en_46_we = addr_hit[107] & reg_we & !reg_error;
+
   assign alert_en_46_wd = reg_wdata[0];
-
   assign alert_en_47_we = addr_hit[108] & reg_we & !reg_error;
+
   assign alert_en_47_wd = reg_wdata[0];
-
   assign alert_en_48_we = addr_hit[109] & reg_we & !reg_error;
+
   assign alert_en_48_wd = reg_wdata[0];
-
   assign alert_en_49_we = addr_hit[110] & reg_we & !reg_error;
+
   assign alert_en_49_wd = reg_wdata[0];
-
   assign alert_en_50_we = addr_hit[111] & reg_we & !reg_error;
+
   assign alert_en_50_wd = reg_wdata[0];
-
   assign alert_en_51_we = addr_hit[112] & reg_we & !reg_error;
+
   assign alert_en_51_wd = reg_wdata[0];
-
   assign alert_en_52_we = addr_hit[113] & reg_we & !reg_error;
+
   assign alert_en_52_wd = reg_wdata[0];
-
   assign alert_en_53_we = addr_hit[114] & reg_we & !reg_error;
+
   assign alert_en_53_wd = reg_wdata[0];
-
   assign alert_en_54_we = addr_hit[115] & reg_we & !reg_error;
+
   assign alert_en_54_wd = reg_wdata[0];
-
   assign alert_class_0_we = addr_hit[116] & reg_we & !reg_error;
+
   assign alert_class_0_wd = reg_wdata[1:0];
-
   assign alert_class_1_we = addr_hit[117] & reg_we & !reg_error;
+
   assign alert_class_1_wd = reg_wdata[1:0];
-
   assign alert_class_2_we = addr_hit[118] & reg_we & !reg_error;
+
   assign alert_class_2_wd = reg_wdata[1:0];
-
   assign alert_class_3_we = addr_hit[119] & reg_we & !reg_error;
+
   assign alert_class_3_wd = reg_wdata[1:0];
-
   assign alert_class_4_we = addr_hit[120] & reg_we & !reg_error;
+
   assign alert_class_4_wd = reg_wdata[1:0];
-
   assign alert_class_5_we = addr_hit[121] & reg_we & !reg_error;
+
   assign alert_class_5_wd = reg_wdata[1:0];
-
   assign alert_class_6_we = addr_hit[122] & reg_we & !reg_error;
+
   assign alert_class_6_wd = reg_wdata[1:0];
-
   assign alert_class_7_we = addr_hit[123] & reg_we & !reg_error;
+
   assign alert_class_7_wd = reg_wdata[1:0];
-
   assign alert_class_8_we = addr_hit[124] & reg_we & !reg_error;
+
   assign alert_class_8_wd = reg_wdata[1:0];
-
   assign alert_class_9_we = addr_hit[125] & reg_we & !reg_error;
+
   assign alert_class_9_wd = reg_wdata[1:0];
-
   assign alert_class_10_we = addr_hit[126] & reg_we & !reg_error;
+
   assign alert_class_10_wd = reg_wdata[1:0];
-
   assign alert_class_11_we = addr_hit[127] & reg_we & !reg_error;
+
   assign alert_class_11_wd = reg_wdata[1:0];
-
   assign alert_class_12_we = addr_hit[128] & reg_we & !reg_error;
+
   assign alert_class_12_wd = reg_wdata[1:0];
-
   assign alert_class_13_we = addr_hit[129] & reg_we & !reg_error;
+
   assign alert_class_13_wd = reg_wdata[1:0];
-
   assign alert_class_14_we = addr_hit[130] & reg_we & !reg_error;
+
   assign alert_class_14_wd = reg_wdata[1:0];
-
   assign alert_class_15_we = addr_hit[131] & reg_we & !reg_error;
+
   assign alert_class_15_wd = reg_wdata[1:0];
-
   assign alert_class_16_we = addr_hit[132] & reg_we & !reg_error;
+
   assign alert_class_16_wd = reg_wdata[1:0];
-
   assign alert_class_17_we = addr_hit[133] & reg_we & !reg_error;
+
   assign alert_class_17_wd = reg_wdata[1:0];
-
   assign alert_class_18_we = addr_hit[134] & reg_we & !reg_error;
+
   assign alert_class_18_wd = reg_wdata[1:0];
-
   assign alert_class_19_we = addr_hit[135] & reg_we & !reg_error;
+
   assign alert_class_19_wd = reg_wdata[1:0];
-
   assign alert_class_20_we = addr_hit[136] & reg_we & !reg_error;
+
   assign alert_class_20_wd = reg_wdata[1:0];
-
   assign alert_class_21_we = addr_hit[137] & reg_we & !reg_error;
+
   assign alert_class_21_wd = reg_wdata[1:0];
-
   assign alert_class_22_we = addr_hit[138] & reg_we & !reg_error;
+
   assign alert_class_22_wd = reg_wdata[1:0];
-
   assign alert_class_23_we = addr_hit[139] & reg_we & !reg_error;
+
   assign alert_class_23_wd = reg_wdata[1:0];
-
   assign alert_class_24_we = addr_hit[140] & reg_we & !reg_error;
+
   assign alert_class_24_wd = reg_wdata[1:0];
-
   assign alert_class_25_we = addr_hit[141] & reg_we & !reg_error;
+
   assign alert_class_25_wd = reg_wdata[1:0];
-
   assign alert_class_26_we = addr_hit[142] & reg_we & !reg_error;
+
   assign alert_class_26_wd = reg_wdata[1:0];
-
   assign alert_class_27_we = addr_hit[143] & reg_we & !reg_error;
+
   assign alert_class_27_wd = reg_wdata[1:0];
-
   assign alert_class_28_we = addr_hit[144] & reg_we & !reg_error;
+
   assign alert_class_28_wd = reg_wdata[1:0];
-
   assign alert_class_29_we = addr_hit[145] & reg_we & !reg_error;
+
   assign alert_class_29_wd = reg_wdata[1:0];
-
   assign alert_class_30_we = addr_hit[146] & reg_we & !reg_error;
+
   assign alert_class_30_wd = reg_wdata[1:0];
-
   assign alert_class_31_we = addr_hit[147] & reg_we & !reg_error;
+
   assign alert_class_31_wd = reg_wdata[1:0];
-
   assign alert_class_32_we = addr_hit[148] & reg_we & !reg_error;
+
   assign alert_class_32_wd = reg_wdata[1:0];
-
   assign alert_class_33_we = addr_hit[149] & reg_we & !reg_error;
+
   assign alert_class_33_wd = reg_wdata[1:0];
-
   assign alert_class_34_we = addr_hit[150] & reg_we & !reg_error;
+
   assign alert_class_34_wd = reg_wdata[1:0];
-
   assign alert_class_35_we = addr_hit[151] & reg_we & !reg_error;
+
   assign alert_class_35_wd = reg_wdata[1:0];
-
   assign alert_class_36_we = addr_hit[152] & reg_we & !reg_error;
+
   assign alert_class_36_wd = reg_wdata[1:0];
-
   assign alert_class_37_we = addr_hit[153] & reg_we & !reg_error;
+
   assign alert_class_37_wd = reg_wdata[1:0];
-
   assign alert_class_38_we = addr_hit[154] & reg_we & !reg_error;
+
   assign alert_class_38_wd = reg_wdata[1:0];
-
   assign alert_class_39_we = addr_hit[155] & reg_we & !reg_error;
+
   assign alert_class_39_wd = reg_wdata[1:0];
-
   assign alert_class_40_we = addr_hit[156] & reg_we & !reg_error;
+
   assign alert_class_40_wd = reg_wdata[1:0];
-
   assign alert_class_41_we = addr_hit[157] & reg_we & !reg_error;
+
   assign alert_class_41_wd = reg_wdata[1:0];
-
   assign alert_class_42_we = addr_hit[158] & reg_we & !reg_error;
+
   assign alert_class_42_wd = reg_wdata[1:0];
-
   assign alert_class_43_we = addr_hit[159] & reg_we & !reg_error;
+
   assign alert_class_43_wd = reg_wdata[1:0];
-
   assign alert_class_44_we = addr_hit[160] & reg_we & !reg_error;
+
   assign alert_class_44_wd = reg_wdata[1:0];
-
   assign alert_class_45_we = addr_hit[161] & reg_we & !reg_error;
+
   assign alert_class_45_wd = reg_wdata[1:0];
-
   assign alert_class_46_we = addr_hit[162] & reg_we & !reg_error;
+
   assign alert_class_46_wd = reg_wdata[1:0];
-
   assign alert_class_47_we = addr_hit[163] & reg_we & !reg_error;
+
   assign alert_class_47_wd = reg_wdata[1:0];
-
   assign alert_class_48_we = addr_hit[164] & reg_we & !reg_error;
+
   assign alert_class_48_wd = reg_wdata[1:0];
-
   assign alert_class_49_we = addr_hit[165] & reg_we & !reg_error;
+
   assign alert_class_49_wd = reg_wdata[1:0];
-
   assign alert_class_50_we = addr_hit[166] & reg_we & !reg_error;
+
   assign alert_class_50_wd = reg_wdata[1:0];
-
   assign alert_class_51_we = addr_hit[167] & reg_we & !reg_error;
+
   assign alert_class_51_wd = reg_wdata[1:0];
-
   assign alert_class_52_we = addr_hit[168] & reg_we & !reg_error;
+
   assign alert_class_52_wd = reg_wdata[1:0];
-
   assign alert_class_53_we = addr_hit[169] & reg_we & !reg_error;
+
   assign alert_class_53_wd = reg_wdata[1:0];
-
   assign alert_class_54_we = addr_hit[170] & reg_we & !reg_error;
+
   assign alert_class_54_wd = reg_wdata[1:0];
-
   assign alert_cause_0_we = addr_hit[171] & reg_we & !reg_error;
+
   assign alert_cause_0_wd = reg_wdata[0];
-
   assign alert_cause_1_we = addr_hit[172] & reg_we & !reg_error;
+
   assign alert_cause_1_wd = reg_wdata[0];
-
   assign alert_cause_2_we = addr_hit[173] & reg_we & !reg_error;
+
   assign alert_cause_2_wd = reg_wdata[0];
-
   assign alert_cause_3_we = addr_hit[174] & reg_we & !reg_error;
+
   assign alert_cause_3_wd = reg_wdata[0];
-
   assign alert_cause_4_we = addr_hit[175] & reg_we & !reg_error;
+
   assign alert_cause_4_wd = reg_wdata[0];
-
   assign alert_cause_5_we = addr_hit[176] & reg_we & !reg_error;
+
   assign alert_cause_5_wd = reg_wdata[0];
-
   assign alert_cause_6_we = addr_hit[177] & reg_we & !reg_error;
+
   assign alert_cause_6_wd = reg_wdata[0];
-
   assign alert_cause_7_we = addr_hit[178] & reg_we & !reg_error;
+
   assign alert_cause_7_wd = reg_wdata[0];
-
   assign alert_cause_8_we = addr_hit[179] & reg_we & !reg_error;
+
   assign alert_cause_8_wd = reg_wdata[0];
-
   assign alert_cause_9_we = addr_hit[180] & reg_we & !reg_error;
+
   assign alert_cause_9_wd = reg_wdata[0];
-
   assign alert_cause_10_we = addr_hit[181] & reg_we & !reg_error;
+
   assign alert_cause_10_wd = reg_wdata[0];
-
   assign alert_cause_11_we = addr_hit[182] & reg_we & !reg_error;
+
   assign alert_cause_11_wd = reg_wdata[0];
-
   assign alert_cause_12_we = addr_hit[183] & reg_we & !reg_error;
+
   assign alert_cause_12_wd = reg_wdata[0];
-
   assign alert_cause_13_we = addr_hit[184] & reg_we & !reg_error;
+
   assign alert_cause_13_wd = reg_wdata[0];
-
   assign alert_cause_14_we = addr_hit[185] & reg_we & !reg_error;
+
   assign alert_cause_14_wd = reg_wdata[0];
-
   assign alert_cause_15_we = addr_hit[186] & reg_we & !reg_error;
+
   assign alert_cause_15_wd = reg_wdata[0];
-
   assign alert_cause_16_we = addr_hit[187] & reg_we & !reg_error;
+
   assign alert_cause_16_wd = reg_wdata[0];
-
   assign alert_cause_17_we = addr_hit[188] & reg_we & !reg_error;
+
   assign alert_cause_17_wd = reg_wdata[0];
-
   assign alert_cause_18_we = addr_hit[189] & reg_we & !reg_error;
+
   assign alert_cause_18_wd = reg_wdata[0];
-
   assign alert_cause_19_we = addr_hit[190] & reg_we & !reg_error;
+
   assign alert_cause_19_wd = reg_wdata[0];
-
   assign alert_cause_20_we = addr_hit[191] & reg_we & !reg_error;
+
   assign alert_cause_20_wd = reg_wdata[0];
-
   assign alert_cause_21_we = addr_hit[192] & reg_we & !reg_error;
+
   assign alert_cause_21_wd = reg_wdata[0];
-
   assign alert_cause_22_we = addr_hit[193] & reg_we & !reg_error;
+
   assign alert_cause_22_wd = reg_wdata[0];
-
   assign alert_cause_23_we = addr_hit[194] & reg_we & !reg_error;
+
   assign alert_cause_23_wd = reg_wdata[0];
-
   assign alert_cause_24_we = addr_hit[195] & reg_we & !reg_error;
+
   assign alert_cause_24_wd = reg_wdata[0];
-
   assign alert_cause_25_we = addr_hit[196] & reg_we & !reg_error;
+
   assign alert_cause_25_wd = reg_wdata[0];
-
   assign alert_cause_26_we = addr_hit[197] & reg_we & !reg_error;
+
   assign alert_cause_26_wd = reg_wdata[0];
-
   assign alert_cause_27_we = addr_hit[198] & reg_we & !reg_error;
+
   assign alert_cause_27_wd = reg_wdata[0];
-
   assign alert_cause_28_we = addr_hit[199] & reg_we & !reg_error;
+
   assign alert_cause_28_wd = reg_wdata[0];
-
   assign alert_cause_29_we = addr_hit[200] & reg_we & !reg_error;
+
   assign alert_cause_29_wd = reg_wdata[0];
-
   assign alert_cause_30_we = addr_hit[201] & reg_we & !reg_error;
+
   assign alert_cause_30_wd = reg_wdata[0];
-
   assign alert_cause_31_we = addr_hit[202] & reg_we & !reg_error;
+
   assign alert_cause_31_wd = reg_wdata[0];
-
   assign alert_cause_32_we = addr_hit[203] & reg_we & !reg_error;
+
   assign alert_cause_32_wd = reg_wdata[0];
-
   assign alert_cause_33_we = addr_hit[204] & reg_we & !reg_error;
+
   assign alert_cause_33_wd = reg_wdata[0];
-
   assign alert_cause_34_we = addr_hit[205] & reg_we & !reg_error;
+
   assign alert_cause_34_wd = reg_wdata[0];
-
   assign alert_cause_35_we = addr_hit[206] & reg_we & !reg_error;
+
   assign alert_cause_35_wd = reg_wdata[0];
-
   assign alert_cause_36_we = addr_hit[207] & reg_we & !reg_error;
+
   assign alert_cause_36_wd = reg_wdata[0];
-
   assign alert_cause_37_we = addr_hit[208] & reg_we & !reg_error;
+
   assign alert_cause_37_wd = reg_wdata[0];
-
   assign alert_cause_38_we = addr_hit[209] & reg_we & !reg_error;
+
   assign alert_cause_38_wd = reg_wdata[0];
-
   assign alert_cause_39_we = addr_hit[210] & reg_we & !reg_error;
+
   assign alert_cause_39_wd = reg_wdata[0];
-
   assign alert_cause_40_we = addr_hit[211] & reg_we & !reg_error;
+
   assign alert_cause_40_wd = reg_wdata[0];
-
   assign alert_cause_41_we = addr_hit[212] & reg_we & !reg_error;
+
   assign alert_cause_41_wd = reg_wdata[0];
-
   assign alert_cause_42_we = addr_hit[213] & reg_we & !reg_error;
+
   assign alert_cause_42_wd = reg_wdata[0];
-
   assign alert_cause_43_we = addr_hit[214] & reg_we & !reg_error;
+
   assign alert_cause_43_wd = reg_wdata[0];
-
   assign alert_cause_44_we = addr_hit[215] & reg_we & !reg_error;
+
   assign alert_cause_44_wd = reg_wdata[0];
-
   assign alert_cause_45_we = addr_hit[216] & reg_we & !reg_error;
+
   assign alert_cause_45_wd = reg_wdata[0];
-
   assign alert_cause_46_we = addr_hit[217] & reg_we & !reg_error;
+
   assign alert_cause_46_wd = reg_wdata[0];
-
   assign alert_cause_47_we = addr_hit[218] & reg_we & !reg_error;
+
   assign alert_cause_47_wd = reg_wdata[0];
-
   assign alert_cause_48_we = addr_hit[219] & reg_we & !reg_error;
+
   assign alert_cause_48_wd = reg_wdata[0];
-
   assign alert_cause_49_we = addr_hit[220] & reg_we & !reg_error;
+
   assign alert_cause_49_wd = reg_wdata[0];
-
   assign alert_cause_50_we = addr_hit[221] & reg_we & !reg_error;
+
   assign alert_cause_50_wd = reg_wdata[0];
-
   assign alert_cause_51_we = addr_hit[222] & reg_we & !reg_error;
+
   assign alert_cause_51_wd = reg_wdata[0];
-
   assign alert_cause_52_we = addr_hit[223] & reg_we & !reg_error;
+
   assign alert_cause_52_wd = reg_wdata[0];
-
   assign alert_cause_53_we = addr_hit[224] & reg_we & !reg_error;
+
   assign alert_cause_53_wd = reg_wdata[0];
-
   assign alert_cause_54_we = addr_hit[225] & reg_we & !reg_error;
+
   assign alert_cause_54_wd = reg_wdata[0];
-
   assign loc_alert_regwen_0_we = addr_hit[226] & reg_we & !reg_error;
+
   assign loc_alert_regwen_0_wd = reg_wdata[0];
-
   assign loc_alert_regwen_1_we = addr_hit[227] & reg_we & !reg_error;
+
   assign loc_alert_regwen_1_wd = reg_wdata[0];
-
   assign loc_alert_regwen_2_we = addr_hit[228] & reg_we & !reg_error;
+
   assign loc_alert_regwen_2_wd = reg_wdata[0];
-
   assign loc_alert_regwen_3_we = addr_hit[229] & reg_we & !reg_error;
+
   assign loc_alert_regwen_3_wd = reg_wdata[0];
-
   assign loc_alert_regwen_4_we = addr_hit[230] & reg_we & !reg_error;
+
   assign loc_alert_regwen_4_wd = reg_wdata[0];
-
   assign loc_alert_en_0_we = addr_hit[231] & reg_we & !reg_error;
+
   assign loc_alert_en_0_wd = reg_wdata[0];
-
   assign loc_alert_en_1_we = addr_hit[232] & reg_we & !reg_error;
+
   assign loc_alert_en_1_wd = reg_wdata[0];
-
   assign loc_alert_en_2_we = addr_hit[233] & reg_we & !reg_error;
+
   assign loc_alert_en_2_wd = reg_wdata[0];
-
   assign loc_alert_en_3_we = addr_hit[234] & reg_we & !reg_error;
+
   assign loc_alert_en_3_wd = reg_wdata[0];
-
   assign loc_alert_en_4_we = addr_hit[235] & reg_we & !reg_error;
+
   assign loc_alert_en_4_wd = reg_wdata[0];
-
   assign loc_alert_class_0_we = addr_hit[236] & reg_we & !reg_error;
+
   assign loc_alert_class_0_wd = reg_wdata[1:0];
-
   assign loc_alert_class_1_we = addr_hit[237] & reg_we & !reg_error;
+
   assign loc_alert_class_1_wd = reg_wdata[1:0];
-
   assign loc_alert_class_2_we = addr_hit[238] & reg_we & !reg_error;
+
   assign loc_alert_class_2_wd = reg_wdata[1:0];
-
   assign loc_alert_class_3_we = addr_hit[239] & reg_we & !reg_error;
+
   assign loc_alert_class_3_wd = reg_wdata[1:0];
-
   assign loc_alert_class_4_we = addr_hit[240] & reg_we & !reg_error;
+
   assign loc_alert_class_4_wd = reg_wdata[1:0];
-
   assign loc_alert_cause_0_we = addr_hit[241] & reg_we & !reg_error;
+
   assign loc_alert_cause_0_wd = reg_wdata[0];
-
   assign loc_alert_cause_1_we = addr_hit[242] & reg_we & !reg_error;
+
   assign loc_alert_cause_1_wd = reg_wdata[0];
-
   assign loc_alert_cause_2_we = addr_hit[243] & reg_we & !reg_error;
+
   assign loc_alert_cause_2_wd = reg_wdata[0];
-
   assign loc_alert_cause_3_we = addr_hit[244] & reg_we & !reg_error;
+
   assign loc_alert_cause_3_wd = reg_wdata[0];
-
   assign loc_alert_cause_4_we = addr_hit[245] & reg_we & !reg_error;
+
   assign loc_alert_cause_4_wd = reg_wdata[0];
-
   assign classa_regwen_we = addr_hit[246] & reg_we & !reg_error;
-  assign classa_regwen_wd = reg_wdata[0];
 
-  assign classa_ctrl_en_we = addr_hit[247] & reg_we & !reg_error;
+  assign classa_regwen_wd = reg_wdata[0];
+  assign classa_ctrl_we = addr_hit[247] & reg_we & !reg_error;
+
   assign classa_ctrl_en_wd = reg_wdata[0];
 
-  assign classa_ctrl_lock_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_lock_wd = reg_wdata[1];
 
-  assign classa_ctrl_en_e0_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classa_ctrl_en_e1_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classa_ctrl_en_e2_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classa_ctrl_en_e3_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classa_ctrl_map_e0_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classa_ctrl_map_e1_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classa_ctrl_map_e2_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classa_ctrl_map_e3_we = addr_hit[247] & reg_we & !reg_error;
   assign classa_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classa_clr_regwen_we = addr_hit[248] & reg_we & !reg_error;
+
   assign classa_clr_regwen_wd = reg_wdata[0];
-
   assign classa_clr_we = addr_hit[249] & reg_we & !reg_error;
+
   assign classa_clr_wd = reg_wdata[0];
-
   assign classa_accum_cnt_re = addr_hit[250] & reg_re & !reg_error;
-
   assign classa_accum_thresh_we = addr_hit[251] & reg_we & !reg_error;
+
   assign classa_accum_thresh_wd = reg_wdata[15:0];
-
   assign classa_timeout_cyc_we = addr_hit[252] & reg_we & !reg_error;
+
   assign classa_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase0_cyc_we = addr_hit[253] & reg_we & !reg_error;
+
   assign classa_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase1_cyc_we = addr_hit[254] & reg_we & !reg_error;
+
   assign classa_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase2_cyc_we = addr_hit[255] & reg_we & !reg_error;
+
   assign classa_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classa_phase3_cyc_we = addr_hit[256] & reg_we & !reg_error;
+
   assign classa_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classa_esc_cnt_re = addr_hit[257] & reg_re & !reg_error;
-
   assign classa_state_re = addr_hit[258] & reg_re & !reg_error;
-
   assign classb_regwen_we = addr_hit[259] & reg_we & !reg_error;
-  assign classb_regwen_wd = reg_wdata[0];
 
-  assign classb_ctrl_en_we = addr_hit[260] & reg_we & !reg_error;
+  assign classb_regwen_wd = reg_wdata[0];
+  assign classb_ctrl_we = addr_hit[260] & reg_we & !reg_error;
+
   assign classb_ctrl_en_wd = reg_wdata[0];
 
-  assign classb_ctrl_lock_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_lock_wd = reg_wdata[1];
 
-  assign classb_ctrl_en_e0_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classb_ctrl_en_e1_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classb_ctrl_en_e2_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classb_ctrl_en_e3_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classb_ctrl_map_e0_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classb_ctrl_map_e1_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classb_ctrl_map_e2_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classb_ctrl_map_e3_we = addr_hit[260] & reg_we & !reg_error;
   assign classb_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classb_clr_regwen_we = addr_hit[261] & reg_we & !reg_error;
+
   assign classb_clr_regwen_wd = reg_wdata[0];
-
   assign classb_clr_we = addr_hit[262] & reg_we & !reg_error;
+
   assign classb_clr_wd = reg_wdata[0];
-
   assign classb_accum_cnt_re = addr_hit[263] & reg_re & !reg_error;
-
   assign classb_accum_thresh_we = addr_hit[264] & reg_we & !reg_error;
+
   assign classb_accum_thresh_wd = reg_wdata[15:0];
-
   assign classb_timeout_cyc_we = addr_hit[265] & reg_we & !reg_error;
+
   assign classb_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase0_cyc_we = addr_hit[266] & reg_we & !reg_error;
+
   assign classb_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase1_cyc_we = addr_hit[267] & reg_we & !reg_error;
+
   assign classb_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase2_cyc_we = addr_hit[268] & reg_we & !reg_error;
+
   assign classb_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classb_phase3_cyc_we = addr_hit[269] & reg_we & !reg_error;
+
   assign classb_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classb_esc_cnt_re = addr_hit[270] & reg_re & !reg_error;
-
   assign classb_state_re = addr_hit[271] & reg_re & !reg_error;
-
   assign classc_regwen_we = addr_hit[272] & reg_we & !reg_error;
-  assign classc_regwen_wd = reg_wdata[0];
 
-  assign classc_ctrl_en_we = addr_hit[273] & reg_we & !reg_error;
+  assign classc_regwen_wd = reg_wdata[0];
+  assign classc_ctrl_we = addr_hit[273] & reg_we & !reg_error;
+
   assign classc_ctrl_en_wd = reg_wdata[0];
 
-  assign classc_ctrl_lock_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_lock_wd = reg_wdata[1];
 
-  assign classc_ctrl_en_e0_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classc_ctrl_en_e1_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classc_ctrl_en_e2_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classc_ctrl_en_e3_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classc_ctrl_map_e0_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classc_ctrl_map_e1_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classc_ctrl_map_e2_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classc_ctrl_map_e3_we = addr_hit[273] & reg_we & !reg_error;
   assign classc_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classc_clr_regwen_we = addr_hit[274] & reg_we & !reg_error;
+
   assign classc_clr_regwen_wd = reg_wdata[0];
-
   assign classc_clr_we = addr_hit[275] & reg_we & !reg_error;
+
   assign classc_clr_wd = reg_wdata[0];
-
   assign classc_accum_cnt_re = addr_hit[276] & reg_re & !reg_error;
-
   assign classc_accum_thresh_we = addr_hit[277] & reg_we & !reg_error;
+
   assign classc_accum_thresh_wd = reg_wdata[15:0];
-
   assign classc_timeout_cyc_we = addr_hit[278] & reg_we & !reg_error;
+
   assign classc_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase0_cyc_we = addr_hit[279] & reg_we & !reg_error;
+
   assign classc_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase1_cyc_we = addr_hit[280] & reg_we & !reg_error;
+
   assign classc_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase2_cyc_we = addr_hit[281] & reg_we & !reg_error;
+
   assign classc_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classc_phase3_cyc_we = addr_hit[282] & reg_we & !reg_error;
+
   assign classc_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classc_esc_cnt_re = addr_hit[283] & reg_re & !reg_error;
-
   assign classc_state_re = addr_hit[284] & reg_re & !reg_error;
-
   assign classd_regwen_we = addr_hit[285] & reg_we & !reg_error;
-  assign classd_regwen_wd = reg_wdata[0];
 
-  assign classd_ctrl_en_we = addr_hit[286] & reg_we & !reg_error;
+  assign classd_regwen_wd = reg_wdata[0];
+  assign classd_ctrl_we = addr_hit[286] & reg_we & !reg_error;
+
   assign classd_ctrl_en_wd = reg_wdata[0];
 
-  assign classd_ctrl_lock_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_lock_wd = reg_wdata[1];
 
-  assign classd_ctrl_en_e0_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_en_e0_wd = reg_wdata[2];
 
-  assign classd_ctrl_en_e1_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_en_e1_wd = reg_wdata[3];
 
-  assign classd_ctrl_en_e2_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_en_e2_wd = reg_wdata[4];
 
-  assign classd_ctrl_en_e3_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_en_e3_wd = reg_wdata[5];
 
-  assign classd_ctrl_map_e0_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_map_e0_wd = reg_wdata[7:6];
 
-  assign classd_ctrl_map_e1_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_map_e1_wd = reg_wdata[9:8];
 
-  assign classd_ctrl_map_e2_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_map_e2_wd = reg_wdata[11:10];
 
-  assign classd_ctrl_map_e3_we = addr_hit[286] & reg_we & !reg_error;
   assign classd_ctrl_map_e3_wd = reg_wdata[13:12];
-
   assign classd_clr_regwen_we = addr_hit[287] & reg_we & !reg_error;
+
   assign classd_clr_regwen_wd = reg_wdata[0];
-
   assign classd_clr_we = addr_hit[288] & reg_we & !reg_error;
+
   assign classd_clr_wd = reg_wdata[0];
-
   assign classd_accum_cnt_re = addr_hit[289] & reg_re & !reg_error;
-
   assign classd_accum_thresh_we = addr_hit[290] & reg_we & !reg_error;
+
   assign classd_accum_thresh_wd = reg_wdata[15:0];
-
   assign classd_timeout_cyc_we = addr_hit[291] & reg_we & !reg_error;
+
   assign classd_timeout_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase0_cyc_we = addr_hit[292] & reg_we & !reg_error;
+
   assign classd_phase0_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase1_cyc_we = addr_hit[293] & reg_we & !reg_error;
+
   assign classd_phase1_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase2_cyc_we = addr_hit[294] & reg_we & !reg_error;
+
   assign classd_phase2_cyc_wd = reg_wdata[31:0];
-
   assign classd_phase3_cyc_we = addr_hit[295] & reg_we & !reg_error;
+
   assign classd_phase3_cyc_wd = reg_wdata[31:0];
-
   assign classd_esc_cnt_re = addr_hit[296] & reg_re & !reg_error;
-
   assign classd_state_re = addr_hit[297] & reg_re & !reg_error;
 
   // Read data return

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -105,186 +105,186 @@ module ast_reg_top (
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
   logic [7:0] revid_qs;
+  logic rega_0_we;
   logic [31:0] rega_0_qs;
   logic [31:0] rega_0_wd;
-  logic rega_0_we;
+  logic rega_1_we;
   logic [31:0] rega_1_qs;
   logic [31:0] rega_1_wd;
-  logic rega_1_we;
+  logic rega_2_we;
   logic [31:0] rega_2_qs;
   logic [31:0] rega_2_wd;
-  logic rega_2_we;
+  logic rega_3_we;
   logic [31:0] rega_3_qs;
   logic [31:0] rega_3_wd;
-  logic rega_3_we;
+  logic rega_4_we;
   logic [31:0] rega_4_qs;
   logic [31:0] rega_4_wd;
-  logic rega_4_we;
+  logic rega_5_we;
   logic [31:0] rega_5_qs;
   logic [31:0] rega_5_wd;
-  logic rega_5_we;
+  logic rega_6_we;
   logic [31:0] rega_6_qs;
   logic [31:0] rega_6_wd;
-  logic rega_6_we;
+  logic rega_7_we;
   logic [31:0] rega_7_qs;
   logic [31:0] rega_7_wd;
-  logic rega_7_we;
+  logic rega_8_we;
   logic [31:0] rega_8_qs;
   logic [31:0] rega_8_wd;
-  logic rega_8_we;
+  logic rega_9_we;
   logic [31:0] rega_9_qs;
   logic [31:0] rega_9_wd;
-  logic rega_9_we;
+  logic rega_10_we;
   logic [31:0] rega_10_qs;
   logic [31:0] rega_10_wd;
-  logic rega_10_we;
+  logic rega_11_we;
   logic [31:0] rega_11_qs;
   logic [31:0] rega_11_wd;
-  logic rega_11_we;
+  logic rega_12_we;
   logic [31:0] rega_12_qs;
   logic [31:0] rega_12_wd;
-  logic rega_12_we;
+  logic rega_13_we;
   logic [31:0] rega_13_qs;
   logic [31:0] rega_13_wd;
-  logic rega_13_we;
+  logic rega_14_we;
   logic [31:0] rega_14_qs;
   logic [31:0] rega_14_wd;
-  logic rega_14_we;
+  logic rega_15_we;
   logic [31:0] rega_15_qs;
   logic [31:0] rega_15_wd;
-  logic rega_15_we;
+  logic rega_16_we;
   logic [31:0] rega_16_qs;
   logic [31:0] rega_16_wd;
-  logic rega_16_we;
+  logic rega_17_we;
   logic [31:0] rega_17_qs;
   logic [31:0] rega_17_wd;
-  logic rega_17_we;
+  logic rega_18_we;
   logic [31:0] rega_18_qs;
   logic [31:0] rega_18_wd;
-  logic rega_18_we;
+  logic rega_19_we;
   logic [31:0] rega_19_qs;
   logic [31:0] rega_19_wd;
-  logic rega_19_we;
+  logic rega_20_we;
   logic [31:0] rega_20_qs;
   logic [31:0] rega_20_wd;
-  logic rega_20_we;
+  logic rega_21_we;
   logic [31:0] rega_21_qs;
   logic [31:0] rega_21_wd;
-  logic rega_21_we;
+  logic rega_22_we;
   logic [31:0] rega_22_qs;
   logic [31:0] rega_22_wd;
-  logic rega_22_we;
+  logic rega_23_we;
   logic [31:0] rega_23_qs;
   logic [31:0] rega_23_wd;
-  logic rega_23_we;
+  logic rega_24_we;
   logic [31:0] rega_24_qs;
   logic [31:0] rega_24_wd;
-  logic rega_24_we;
+  logic rega_25_we;
   logic [31:0] rega_25_qs;
   logic [31:0] rega_25_wd;
-  logic rega_25_we;
+  logic rega_26_we;
   logic [31:0] rega_26_qs;
   logic [31:0] rega_26_wd;
-  logic rega_26_we;
+  logic rega_27_we;
   logic [31:0] rega_27_qs;
   logic [31:0] rega_27_wd;
-  logic rega_27_we;
+  logic rega_28_we;
   logic [31:0] rega_28_qs;
   logic [31:0] rega_28_wd;
-  logic rega_28_we;
+  logic rega_29_we;
   logic [31:0] rega_29_qs;
   logic [31:0] rega_29_wd;
-  logic rega_29_we;
+  logic rega_30_we;
   logic [31:0] rega_30_qs;
   logic [31:0] rega_30_wd;
-  logic rega_30_we;
+  logic rega_31_we;
   logic [31:0] rega_31_qs;
   logic [31:0] rega_31_wd;
-  logic rega_31_we;
+  logic rega_32_we;
   logic [31:0] rega_32_qs;
   logic [31:0] rega_32_wd;
-  logic rega_32_we;
+  logic rega_33_we;
   logic [31:0] rega_33_qs;
   logic [31:0] rega_33_wd;
-  logic rega_33_we;
+  logic rega_34_we;
   logic [31:0] rega_34_qs;
   logic [31:0] rega_34_wd;
-  logic rega_34_we;
+  logic rega_35_we;
   logic [31:0] rega_35_qs;
   logic [31:0] rega_35_wd;
-  logic rega_35_we;
+  logic rega_36_we;
   logic [31:0] rega_36_qs;
   logic [31:0] rega_36_wd;
-  logic rega_36_we;
+  logic rega_37_we;
   logic [31:0] rega_37_qs;
   logic [31:0] rega_37_wd;
-  logic rega_37_we;
+  logic rega_38_we;
   logic [31:0] rega_38_qs;
   logic [31:0] rega_38_wd;
-  logic rega_38_we;
+  logic rega_39_we;
   logic [31:0] rega_39_qs;
   logic [31:0] rega_39_wd;
-  logic rega_39_we;
+  logic rega_40_we;
   logic [31:0] rega_40_qs;
   logic [31:0] rega_40_wd;
-  logic rega_40_we;
+  logic rega_41_we;
   logic [31:0] rega_41_qs;
   logic [31:0] rega_41_wd;
-  logic rega_41_we;
+  logic rega_42_we;
   logic [31:0] rega_42_qs;
   logic [31:0] rega_42_wd;
-  logic rega_42_we;
+  logic rega_43_we;
   logic [31:0] rega_43_qs;
   logic [31:0] rega_43_wd;
-  logic rega_43_we;
+  logic rega_44_we;
   logic [31:0] rega_44_qs;
   logic [31:0] rega_44_wd;
-  logic rega_44_we;
+  logic rega_45_we;
   logic [31:0] rega_45_qs;
   logic [31:0] rega_45_wd;
-  logic rega_45_we;
+  logic rega_46_we;
   logic [31:0] rega_46_qs;
   logic [31:0] rega_46_wd;
-  logic rega_46_we;
+  logic rega_47_we;
   logic [31:0] rega_47_qs;
   logic [31:0] rega_47_wd;
-  logic rega_47_we;
+  logic rega_48_we;
   logic [31:0] rega_48_qs;
   logic [31:0] rega_48_wd;
-  logic rega_48_we;
+  logic rega_49_we;
   logic [31:0] rega_49_qs;
   logic [31:0] rega_49_wd;
-  logic rega_49_we;
+  logic regb_0_we;
   logic [31:0] regb_0_qs;
   logic [31:0] regb_0_wd;
-  logic regb_0_we;
+  logic regb_1_we;
   logic [31:0] regb_1_qs;
   logic [31:0] regb_1_wd;
-  logic regb_1_we;
+  logic regb_2_we;
   logic [31:0] regb_2_qs;
   logic [31:0] regb_2_wd;
-  logic regb_2_we;
+  logic regb_3_we;
   logic [31:0] regb_3_qs;
   logic [31:0] regb_3_wd;
-  logic regb_3_we;
+  logic regb_4_we;
   logic [31:0] regb_4_qs;
   logic [31:0] regb_4_wd;
-  logic regb_4_we;
+  logic regb_5_we;
   logic [31:0] regb_5_qs;
   logic [31:0] regb_5_wd;
-  logic regb_5_we;
+  logic regb_6_we;
   logic [31:0] regb_6_qs;
   logic [31:0] regb_6_wd;
-  logic regb_6_we;
+  logic regb_7_we;
   logic [31:0] regb_7_qs;
   logic [31:0] regb_7_wd;
-  logic regb_7_we;
+  logic regb_8_we;
   logic [31:0] regb_8_qs;
   logic [31:0] regb_8_wd;
-  logic regb_8_we;
+  logic regb_9_we;
   logic [31:0] regb_9_qs;
   logic [31:0] regb_9_wd;
-  logic regb_9_we;
 
   // Register instances
   // R[revid]: V(False)
@@ -2073,185 +2073,185 @@ module ast_reg_top (
                (addr_hit[59] & (|(AST_PERMIT[59] & ~reg_be))) |
                (addr_hit[60] & (|(AST_PERMIT[60] & ~reg_be)))));
   end
-
   assign rega_0_we = addr_hit[1] & reg_we & !reg_error;
+
   assign rega_0_wd = reg_wdata[31:0];
-
   assign rega_1_we = addr_hit[2] & reg_we & !reg_error;
+
   assign rega_1_wd = reg_wdata[31:0];
-
   assign rega_2_we = addr_hit[3] & reg_we & !reg_error;
+
   assign rega_2_wd = reg_wdata[31:0];
-
   assign rega_3_we = addr_hit[4] & reg_we & !reg_error;
+
   assign rega_3_wd = reg_wdata[31:0];
-
   assign rega_4_we = addr_hit[5] & reg_we & !reg_error;
+
   assign rega_4_wd = reg_wdata[31:0];
-
   assign rega_5_we = addr_hit[6] & reg_we & !reg_error;
+
   assign rega_5_wd = reg_wdata[31:0];
-
   assign rega_6_we = addr_hit[7] & reg_we & !reg_error;
+
   assign rega_6_wd = reg_wdata[31:0];
-
   assign rega_7_we = addr_hit[8] & reg_we & !reg_error;
+
   assign rega_7_wd = reg_wdata[31:0];
-
   assign rega_8_we = addr_hit[9] & reg_we & !reg_error;
+
   assign rega_8_wd = reg_wdata[31:0];
-
   assign rega_9_we = addr_hit[10] & reg_we & !reg_error;
+
   assign rega_9_wd = reg_wdata[31:0];
-
   assign rega_10_we = addr_hit[11] & reg_we & !reg_error;
+
   assign rega_10_wd = reg_wdata[31:0];
-
   assign rega_11_we = addr_hit[12] & reg_we & !reg_error;
+
   assign rega_11_wd = reg_wdata[31:0];
-
   assign rega_12_we = addr_hit[13] & reg_we & !reg_error;
+
   assign rega_12_wd = reg_wdata[31:0];
-
   assign rega_13_we = addr_hit[14] & reg_we & !reg_error;
+
   assign rega_13_wd = reg_wdata[31:0];
-
   assign rega_14_we = addr_hit[15] & reg_we & !reg_error;
+
   assign rega_14_wd = reg_wdata[31:0];
-
   assign rega_15_we = addr_hit[16] & reg_we & !reg_error;
+
   assign rega_15_wd = reg_wdata[31:0];
-
   assign rega_16_we = addr_hit[17] & reg_we & !reg_error;
+
   assign rega_16_wd = reg_wdata[31:0];
-
   assign rega_17_we = addr_hit[18] & reg_we & !reg_error;
+
   assign rega_17_wd = reg_wdata[31:0];
-
   assign rega_18_we = addr_hit[19] & reg_we & !reg_error;
+
   assign rega_18_wd = reg_wdata[31:0];
-
   assign rega_19_we = addr_hit[20] & reg_we & !reg_error;
+
   assign rega_19_wd = reg_wdata[31:0];
-
   assign rega_20_we = addr_hit[21] & reg_we & !reg_error;
+
   assign rega_20_wd = reg_wdata[31:0];
-
   assign rega_21_we = addr_hit[22] & reg_we & !reg_error;
+
   assign rega_21_wd = reg_wdata[31:0];
-
   assign rega_22_we = addr_hit[23] & reg_we & !reg_error;
+
   assign rega_22_wd = reg_wdata[31:0];
-
   assign rega_23_we = addr_hit[24] & reg_we & !reg_error;
+
   assign rega_23_wd = reg_wdata[31:0];
-
   assign rega_24_we = addr_hit[25] & reg_we & !reg_error;
+
   assign rega_24_wd = reg_wdata[31:0];
-
   assign rega_25_we = addr_hit[26] & reg_we & !reg_error;
+
   assign rega_25_wd = reg_wdata[31:0];
-
   assign rega_26_we = addr_hit[27] & reg_we & !reg_error;
+
   assign rega_26_wd = reg_wdata[31:0];
-
   assign rega_27_we = addr_hit[28] & reg_we & !reg_error;
+
   assign rega_27_wd = reg_wdata[31:0];
-
   assign rega_28_we = addr_hit[29] & reg_we & !reg_error;
+
   assign rega_28_wd = reg_wdata[31:0];
-
   assign rega_29_we = addr_hit[30] & reg_we & !reg_error;
+
   assign rega_29_wd = reg_wdata[31:0];
-
   assign rega_30_we = addr_hit[31] & reg_we & !reg_error;
+
   assign rega_30_wd = reg_wdata[31:0];
-
   assign rega_31_we = addr_hit[32] & reg_we & !reg_error;
+
   assign rega_31_wd = reg_wdata[31:0];
-
   assign rega_32_we = addr_hit[33] & reg_we & !reg_error;
+
   assign rega_32_wd = reg_wdata[31:0];
-
   assign rega_33_we = addr_hit[34] & reg_we & !reg_error;
+
   assign rega_33_wd = reg_wdata[31:0];
-
   assign rega_34_we = addr_hit[35] & reg_we & !reg_error;
+
   assign rega_34_wd = reg_wdata[31:0];
-
   assign rega_35_we = addr_hit[36] & reg_we & !reg_error;
+
   assign rega_35_wd = reg_wdata[31:0];
-
   assign rega_36_we = addr_hit[37] & reg_we & !reg_error;
+
   assign rega_36_wd = reg_wdata[31:0];
-
   assign rega_37_we = addr_hit[38] & reg_we & !reg_error;
+
   assign rega_37_wd = reg_wdata[31:0];
-
   assign rega_38_we = addr_hit[39] & reg_we & !reg_error;
+
   assign rega_38_wd = reg_wdata[31:0];
-
   assign rega_39_we = addr_hit[40] & reg_we & !reg_error;
+
   assign rega_39_wd = reg_wdata[31:0];
-
   assign rega_40_we = addr_hit[41] & reg_we & !reg_error;
+
   assign rega_40_wd = reg_wdata[31:0];
-
   assign rega_41_we = addr_hit[42] & reg_we & !reg_error;
+
   assign rega_41_wd = reg_wdata[31:0];
-
   assign rega_42_we = addr_hit[43] & reg_we & !reg_error;
+
   assign rega_42_wd = reg_wdata[31:0];
-
   assign rega_43_we = addr_hit[44] & reg_we & !reg_error;
+
   assign rega_43_wd = reg_wdata[31:0];
-
   assign rega_44_we = addr_hit[45] & reg_we & !reg_error;
+
   assign rega_44_wd = reg_wdata[31:0];
-
   assign rega_45_we = addr_hit[46] & reg_we & !reg_error;
+
   assign rega_45_wd = reg_wdata[31:0];
-
   assign rega_46_we = addr_hit[47] & reg_we & !reg_error;
+
   assign rega_46_wd = reg_wdata[31:0];
-
   assign rega_47_we = addr_hit[48] & reg_we & !reg_error;
+
   assign rega_47_wd = reg_wdata[31:0];
-
   assign rega_48_we = addr_hit[49] & reg_we & !reg_error;
+
   assign rega_48_wd = reg_wdata[31:0];
-
   assign rega_49_we = addr_hit[50] & reg_we & !reg_error;
+
   assign rega_49_wd = reg_wdata[31:0];
-
   assign regb_0_we = addr_hit[51] & reg_we & !reg_error;
+
   assign regb_0_wd = reg_wdata[31:0];
-
   assign regb_1_we = addr_hit[52] & reg_we & !reg_error;
+
   assign regb_1_wd = reg_wdata[31:0];
-
   assign regb_2_we = addr_hit[53] & reg_we & !reg_error;
+
   assign regb_2_wd = reg_wdata[31:0];
-
   assign regb_3_we = addr_hit[54] & reg_we & !reg_error;
+
   assign regb_3_wd = reg_wdata[31:0];
-
   assign regb_4_we = addr_hit[55] & reg_we & !reg_error;
+
   assign regb_4_wd = reg_wdata[31:0];
-
   assign regb_5_we = addr_hit[56] & reg_we & !reg_error;
+
   assign regb_5_wd = reg_wdata[31:0];
-
   assign regb_6_we = addr_hit[57] & reg_we & !reg_error;
+
   assign regb_6_wd = reg_wdata[31:0];
-
   assign regb_7_we = addr_hit[58] & reg_we & !reg_error;
+
   assign regb_7_wd = reg_wdata[31:0];
-
   assign regb_8_we = addr_hit[59] & reg_we & !reg_error;
-  assign regb_8_wd = reg_wdata[31:0];
 
+  assign regb_8_wd = reg_wdata[31:0];
   assign regb_9_we = addr_hit[60] & reg_we & !reg_error;
+
   assign regb_9_wd = reg_wdata[31:0];
 
   // Read data return

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -104,39 +104,33 @@ module clkmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic extclk_sel_regwen_we;
   logic extclk_sel_regwen_qs;
   logic extclk_sel_regwen_wd;
-  logic extclk_sel_regwen_we;
+  logic extclk_sel_we;
   logic [3:0] extclk_sel_qs;
   logic [3:0] extclk_sel_wd;
-  logic extclk_sel_we;
+  logic jitter_enable_we;
   logic jitter_enable_qs;
   logic jitter_enable_wd;
-  logic jitter_enable_we;
+  logic clk_enables_we;
   logic clk_enables_clk_io_div4_peri_en_qs;
   logic clk_enables_clk_io_div4_peri_en_wd;
-  logic clk_enables_clk_io_div4_peri_en_we;
   logic clk_enables_clk_io_div2_peri_en_qs;
   logic clk_enables_clk_io_div2_peri_en_wd;
-  logic clk_enables_clk_io_div2_peri_en_we;
   logic clk_enables_clk_io_peri_en_qs;
   logic clk_enables_clk_io_peri_en_wd;
-  logic clk_enables_clk_io_peri_en_we;
   logic clk_enables_clk_usb_peri_en_qs;
   logic clk_enables_clk_usb_peri_en_wd;
-  logic clk_enables_clk_usb_peri_en_we;
+  logic clk_hints_we;
   logic clk_hints_clk_main_aes_hint_qs;
   logic clk_hints_clk_main_aes_hint_wd;
-  logic clk_hints_clk_main_aes_hint_we;
   logic clk_hints_clk_main_hmac_hint_qs;
   logic clk_hints_clk_main_hmac_hint_wd;
-  logic clk_hints_clk_main_hmac_hint_we;
   logic clk_hints_clk_main_kmac_hint_qs;
   logic clk_hints_clk_main_kmac_hint_wd;
-  logic clk_hints_clk_main_kmac_hint_we;
   logic clk_hints_clk_main_otbn_hint_qs;
   logic clk_hints_clk_main_otbn_hint_wd;
-  logic clk_hints_clk_main_otbn_hint_we;
   logic clk_hints_status_clk_main_aes_val_qs;
   logic clk_hints_status_clk_main_hmac_val_qs;
   logic clk_hints_status_clk_main_kmac_val_qs;
@@ -236,7 +230,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_enables_clk_io_div4_peri_en_we),
+    .we     (clk_enables_we),
     .wd     (clk_enables_clk_io_div4_peri_en_wd),
 
     // from internal hardware
@@ -262,7 +256,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_enables_clk_io_div2_peri_en_we),
+    .we     (clk_enables_we),
     .wd     (clk_enables_clk_io_div2_peri_en_wd),
 
     // from internal hardware
@@ -288,7 +282,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_enables_clk_io_peri_en_we),
+    .we     (clk_enables_we),
     .wd     (clk_enables_clk_io_peri_en_wd),
 
     // from internal hardware
@@ -314,7 +308,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_enables_clk_usb_peri_en_we),
+    .we     (clk_enables_we),
     .wd     (clk_enables_clk_usb_peri_en_wd),
 
     // from internal hardware
@@ -342,7 +336,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_hints_clk_main_aes_hint_we),
+    .we     (clk_hints_we),
     .wd     (clk_hints_clk_main_aes_hint_wd),
 
     // from internal hardware
@@ -368,7 +362,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_hints_clk_main_hmac_hint_we),
+    .we     (clk_hints_we),
     .wd     (clk_hints_clk_main_hmac_hint_wd),
 
     // from internal hardware
@@ -394,7 +388,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_hints_clk_main_kmac_hint_we),
+    .we     (clk_hints_we),
     .wd     (clk_hints_clk_main_kmac_hint_wd),
 
     // from internal hardware
@@ -420,7 +414,7 @@ module clkmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (clk_hints_clk_main_otbn_hint_we),
+    .we     (clk_hints_we),
     .wd     (clk_hints_clk_main_otbn_hint_wd),
 
     // from internal hardware
@@ -567,38 +561,32 @@ module clkmgr_reg_top (
                (addr_hit[4] & (|(CLKMGR_PERMIT[4] & ~reg_be))) |
                (addr_hit[5] & (|(CLKMGR_PERMIT[5] & ~reg_be)))));
   end
-
   assign extclk_sel_regwen_we = addr_hit[0] & reg_we & !reg_error;
+
   assign extclk_sel_regwen_wd = reg_wdata[0];
-
   assign extclk_sel_we = addr_hit[1] & reg_we & !reg_error;
+
   assign extclk_sel_wd = reg_wdata[3:0];
-
   assign jitter_enable_we = addr_hit[2] & reg_we & !reg_error;
-  assign jitter_enable_wd = reg_wdata[0];
 
-  assign clk_enables_clk_io_div4_peri_en_we = addr_hit[3] & reg_we & !reg_error;
+  assign jitter_enable_wd = reg_wdata[0];
+  assign clk_enables_we = addr_hit[3] & reg_we & !reg_error;
+
   assign clk_enables_clk_io_div4_peri_en_wd = reg_wdata[0];
 
-  assign clk_enables_clk_io_div2_peri_en_we = addr_hit[3] & reg_we & !reg_error;
   assign clk_enables_clk_io_div2_peri_en_wd = reg_wdata[1];
 
-  assign clk_enables_clk_io_peri_en_we = addr_hit[3] & reg_we & !reg_error;
   assign clk_enables_clk_io_peri_en_wd = reg_wdata[2];
 
-  assign clk_enables_clk_usb_peri_en_we = addr_hit[3] & reg_we & !reg_error;
   assign clk_enables_clk_usb_peri_en_wd = reg_wdata[3];
+  assign clk_hints_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign clk_hints_clk_main_aes_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
 
-  assign clk_hints_clk_main_hmac_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
 
-  assign clk_hints_clk_main_kmac_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign clk_hints_clk_main_kmac_hint_wd = reg_wdata[2];
 
-  assign clk_hints_clk_main_otbn_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[3];
 
   // Read data return

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -157,1070 +157,808 @@ module flash_ctrl_core_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_prog_empty_qs;
   logic intr_state_prog_empty_wd;
-  logic intr_state_prog_empty_we;
   logic intr_state_prog_lvl_qs;
   logic intr_state_prog_lvl_wd;
-  logic intr_state_prog_lvl_we;
   logic intr_state_rd_full_qs;
   logic intr_state_rd_full_wd;
-  logic intr_state_rd_full_we;
   logic intr_state_rd_lvl_qs;
   logic intr_state_rd_lvl_wd;
-  logic intr_state_rd_lvl_we;
   logic intr_state_op_done_qs;
   logic intr_state_op_done_wd;
-  logic intr_state_op_done_we;
   logic intr_state_err_qs;
   logic intr_state_err_wd;
-  logic intr_state_err_we;
+  logic intr_enable_we;
   logic intr_enable_prog_empty_qs;
   logic intr_enable_prog_empty_wd;
-  logic intr_enable_prog_empty_we;
   logic intr_enable_prog_lvl_qs;
   logic intr_enable_prog_lvl_wd;
-  logic intr_enable_prog_lvl_we;
   logic intr_enable_rd_full_qs;
   logic intr_enable_rd_full_wd;
-  logic intr_enable_rd_full_we;
   logic intr_enable_rd_lvl_qs;
   logic intr_enable_rd_lvl_wd;
-  logic intr_enable_rd_lvl_we;
   logic intr_enable_op_done_qs;
   logic intr_enable_op_done_wd;
-  logic intr_enable_op_done_we;
   logic intr_enable_err_qs;
   logic intr_enable_err_wd;
-  logic intr_enable_err_we;
+  logic intr_test_we;
   logic intr_test_prog_empty_wd;
-  logic intr_test_prog_empty_we;
   logic intr_test_prog_lvl_wd;
-  logic intr_test_prog_lvl_we;
   logic intr_test_rd_full_wd;
-  logic intr_test_rd_full_we;
   logic intr_test_rd_lvl_wd;
-  logic intr_test_rd_lvl_we;
   logic intr_test_op_done_wd;
-  logic intr_test_op_done_we;
   logic intr_test_err_wd;
-  logic intr_test_err_we;
+  logic alert_test_we;
   logic alert_test_recov_err_wd;
-  logic alert_test_recov_err_we;
   logic alert_test_recov_mp_err_wd;
-  logic alert_test_recov_mp_err_we;
   logic alert_test_recov_ecc_err_wd;
-  logic alert_test_recov_ecc_err_we;
   logic alert_test_fatal_intg_err_wd;
-  logic alert_test_fatal_intg_err_we;
+  logic init_we;
   logic init_qs;
   logic init_wd;
-  logic init_we;
-  logic ctrl_regwen_qs;
   logic ctrl_regwen_re;
+  logic ctrl_regwen_qs;
+  logic control_we;
   logic control_start_qs;
   logic control_start_wd;
-  logic control_start_we;
   logic [1:0] control_op_qs;
   logic [1:0] control_op_wd;
-  logic control_op_we;
   logic control_prog_sel_qs;
   logic control_prog_sel_wd;
-  logic control_prog_sel_we;
   logic control_erase_sel_qs;
   logic control_erase_sel_wd;
-  logic control_erase_sel_we;
   logic control_partition_sel_qs;
   logic control_partition_sel_wd;
-  logic control_partition_sel_we;
   logic [1:0] control_info_sel_qs;
   logic [1:0] control_info_sel_wd;
-  logic control_info_sel_we;
   logic [11:0] control_num_qs;
   logic [11:0] control_num_wd;
-  logic control_num_we;
+  logic addr_we;
   logic [31:0] addr_qs;
   logic [31:0] addr_wd;
-  logic addr_we;
+  logic prog_type_en_we;
   logic prog_type_en_normal_qs;
   logic prog_type_en_normal_wd;
-  logic prog_type_en_normal_we;
   logic prog_type_en_repair_qs;
   logic prog_type_en_repair_wd;
-  logic prog_type_en_repair_we;
+  logic erase_suspend_we;
   logic erase_suspend_qs;
   logic erase_suspend_wd;
-  logic erase_suspend_we;
+  logic region_cfg_regwen_0_we;
   logic region_cfg_regwen_0_qs;
   logic region_cfg_regwen_0_wd;
-  logic region_cfg_regwen_0_we;
+  logic region_cfg_regwen_1_we;
   logic region_cfg_regwen_1_qs;
   logic region_cfg_regwen_1_wd;
-  logic region_cfg_regwen_1_we;
+  logic region_cfg_regwen_2_we;
   logic region_cfg_regwen_2_qs;
   logic region_cfg_regwen_2_wd;
-  logic region_cfg_regwen_2_we;
+  logic region_cfg_regwen_3_we;
   logic region_cfg_regwen_3_qs;
   logic region_cfg_regwen_3_wd;
-  logic region_cfg_regwen_3_we;
+  logic region_cfg_regwen_4_we;
   logic region_cfg_regwen_4_qs;
   logic region_cfg_regwen_4_wd;
-  logic region_cfg_regwen_4_we;
+  logic region_cfg_regwen_5_we;
   logic region_cfg_regwen_5_qs;
   logic region_cfg_regwen_5_wd;
-  logic region_cfg_regwen_5_we;
+  logic region_cfg_regwen_6_we;
   logic region_cfg_regwen_6_qs;
   logic region_cfg_regwen_6_wd;
-  logic region_cfg_regwen_6_we;
+  logic region_cfg_regwen_7_we;
   logic region_cfg_regwen_7_qs;
   logic region_cfg_regwen_7_wd;
-  logic region_cfg_regwen_7_we;
+  logic mp_region_cfg_0_we;
   logic mp_region_cfg_0_en_0_qs;
   logic mp_region_cfg_0_en_0_wd;
-  logic mp_region_cfg_0_en_0_we;
   logic mp_region_cfg_0_rd_en_0_qs;
   logic mp_region_cfg_0_rd_en_0_wd;
-  logic mp_region_cfg_0_rd_en_0_we;
   logic mp_region_cfg_0_prog_en_0_qs;
   logic mp_region_cfg_0_prog_en_0_wd;
-  logic mp_region_cfg_0_prog_en_0_we;
   logic mp_region_cfg_0_erase_en_0_qs;
   logic mp_region_cfg_0_erase_en_0_wd;
-  logic mp_region_cfg_0_erase_en_0_we;
   logic mp_region_cfg_0_scramble_en_0_qs;
   logic mp_region_cfg_0_scramble_en_0_wd;
-  logic mp_region_cfg_0_scramble_en_0_we;
   logic mp_region_cfg_0_ecc_en_0_qs;
   logic mp_region_cfg_0_ecc_en_0_wd;
-  logic mp_region_cfg_0_ecc_en_0_we;
   logic mp_region_cfg_0_he_en_0_qs;
   logic mp_region_cfg_0_he_en_0_wd;
-  logic mp_region_cfg_0_he_en_0_we;
   logic [8:0] mp_region_cfg_0_base_0_qs;
   logic [8:0] mp_region_cfg_0_base_0_wd;
-  logic mp_region_cfg_0_base_0_we;
   logic [9:0] mp_region_cfg_0_size_0_qs;
   logic [9:0] mp_region_cfg_0_size_0_wd;
-  logic mp_region_cfg_0_size_0_we;
+  logic mp_region_cfg_1_we;
   logic mp_region_cfg_1_en_1_qs;
   logic mp_region_cfg_1_en_1_wd;
-  logic mp_region_cfg_1_en_1_we;
   logic mp_region_cfg_1_rd_en_1_qs;
   logic mp_region_cfg_1_rd_en_1_wd;
-  logic mp_region_cfg_1_rd_en_1_we;
   logic mp_region_cfg_1_prog_en_1_qs;
   logic mp_region_cfg_1_prog_en_1_wd;
-  logic mp_region_cfg_1_prog_en_1_we;
   logic mp_region_cfg_1_erase_en_1_qs;
   logic mp_region_cfg_1_erase_en_1_wd;
-  logic mp_region_cfg_1_erase_en_1_we;
   logic mp_region_cfg_1_scramble_en_1_qs;
   logic mp_region_cfg_1_scramble_en_1_wd;
-  logic mp_region_cfg_1_scramble_en_1_we;
   logic mp_region_cfg_1_ecc_en_1_qs;
   logic mp_region_cfg_1_ecc_en_1_wd;
-  logic mp_region_cfg_1_ecc_en_1_we;
   logic mp_region_cfg_1_he_en_1_qs;
   logic mp_region_cfg_1_he_en_1_wd;
-  logic mp_region_cfg_1_he_en_1_we;
   logic [8:0] mp_region_cfg_1_base_1_qs;
   logic [8:0] mp_region_cfg_1_base_1_wd;
-  logic mp_region_cfg_1_base_1_we;
   logic [9:0] mp_region_cfg_1_size_1_qs;
   logic [9:0] mp_region_cfg_1_size_1_wd;
-  logic mp_region_cfg_1_size_1_we;
+  logic mp_region_cfg_2_we;
   logic mp_region_cfg_2_en_2_qs;
   logic mp_region_cfg_2_en_2_wd;
-  logic mp_region_cfg_2_en_2_we;
   logic mp_region_cfg_2_rd_en_2_qs;
   logic mp_region_cfg_2_rd_en_2_wd;
-  logic mp_region_cfg_2_rd_en_2_we;
   logic mp_region_cfg_2_prog_en_2_qs;
   logic mp_region_cfg_2_prog_en_2_wd;
-  logic mp_region_cfg_2_prog_en_2_we;
   logic mp_region_cfg_2_erase_en_2_qs;
   logic mp_region_cfg_2_erase_en_2_wd;
-  logic mp_region_cfg_2_erase_en_2_we;
   logic mp_region_cfg_2_scramble_en_2_qs;
   logic mp_region_cfg_2_scramble_en_2_wd;
-  logic mp_region_cfg_2_scramble_en_2_we;
   logic mp_region_cfg_2_ecc_en_2_qs;
   logic mp_region_cfg_2_ecc_en_2_wd;
-  logic mp_region_cfg_2_ecc_en_2_we;
   logic mp_region_cfg_2_he_en_2_qs;
   logic mp_region_cfg_2_he_en_2_wd;
-  logic mp_region_cfg_2_he_en_2_we;
   logic [8:0] mp_region_cfg_2_base_2_qs;
   logic [8:0] mp_region_cfg_2_base_2_wd;
-  logic mp_region_cfg_2_base_2_we;
   logic [9:0] mp_region_cfg_2_size_2_qs;
   logic [9:0] mp_region_cfg_2_size_2_wd;
-  logic mp_region_cfg_2_size_2_we;
+  logic mp_region_cfg_3_we;
   logic mp_region_cfg_3_en_3_qs;
   logic mp_region_cfg_3_en_3_wd;
-  logic mp_region_cfg_3_en_3_we;
   logic mp_region_cfg_3_rd_en_3_qs;
   logic mp_region_cfg_3_rd_en_3_wd;
-  logic mp_region_cfg_3_rd_en_3_we;
   logic mp_region_cfg_3_prog_en_3_qs;
   logic mp_region_cfg_3_prog_en_3_wd;
-  logic mp_region_cfg_3_prog_en_3_we;
   logic mp_region_cfg_3_erase_en_3_qs;
   logic mp_region_cfg_3_erase_en_3_wd;
-  logic mp_region_cfg_3_erase_en_3_we;
   logic mp_region_cfg_3_scramble_en_3_qs;
   logic mp_region_cfg_3_scramble_en_3_wd;
-  logic mp_region_cfg_3_scramble_en_3_we;
   logic mp_region_cfg_3_ecc_en_3_qs;
   logic mp_region_cfg_3_ecc_en_3_wd;
-  logic mp_region_cfg_3_ecc_en_3_we;
   logic mp_region_cfg_3_he_en_3_qs;
   logic mp_region_cfg_3_he_en_3_wd;
-  logic mp_region_cfg_3_he_en_3_we;
   logic [8:0] mp_region_cfg_3_base_3_qs;
   logic [8:0] mp_region_cfg_3_base_3_wd;
-  logic mp_region_cfg_3_base_3_we;
   logic [9:0] mp_region_cfg_3_size_3_qs;
   logic [9:0] mp_region_cfg_3_size_3_wd;
-  logic mp_region_cfg_3_size_3_we;
+  logic mp_region_cfg_4_we;
   logic mp_region_cfg_4_en_4_qs;
   logic mp_region_cfg_4_en_4_wd;
-  logic mp_region_cfg_4_en_4_we;
   logic mp_region_cfg_4_rd_en_4_qs;
   logic mp_region_cfg_4_rd_en_4_wd;
-  logic mp_region_cfg_4_rd_en_4_we;
   logic mp_region_cfg_4_prog_en_4_qs;
   logic mp_region_cfg_4_prog_en_4_wd;
-  logic mp_region_cfg_4_prog_en_4_we;
   logic mp_region_cfg_4_erase_en_4_qs;
   logic mp_region_cfg_4_erase_en_4_wd;
-  logic mp_region_cfg_4_erase_en_4_we;
   logic mp_region_cfg_4_scramble_en_4_qs;
   logic mp_region_cfg_4_scramble_en_4_wd;
-  logic mp_region_cfg_4_scramble_en_4_we;
   logic mp_region_cfg_4_ecc_en_4_qs;
   logic mp_region_cfg_4_ecc_en_4_wd;
-  logic mp_region_cfg_4_ecc_en_4_we;
   logic mp_region_cfg_4_he_en_4_qs;
   logic mp_region_cfg_4_he_en_4_wd;
-  logic mp_region_cfg_4_he_en_4_we;
   logic [8:0] mp_region_cfg_4_base_4_qs;
   logic [8:0] mp_region_cfg_4_base_4_wd;
-  logic mp_region_cfg_4_base_4_we;
   logic [9:0] mp_region_cfg_4_size_4_qs;
   logic [9:0] mp_region_cfg_4_size_4_wd;
-  logic mp_region_cfg_4_size_4_we;
+  logic mp_region_cfg_5_we;
   logic mp_region_cfg_5_en_5_qs;
   logic mp_region_cfg_5_en_5_wd;
-  logic mp_region_cfg_5_en_5_we;
   logic mp_region_cfg_5_rd_en_5_qs;
   logic mp_region_cfg_5_rd_en_5_wd;
-  logic mp_region_cfg_5_rd_en_5_we;
   logic mp_region_cfg_5_prog_en_5_qs;
   logic mp_region_cfg_5_prog_en_5_wd;
-  logic mp_region_cfg_5_prog_en_5_we;
   logic mp_region_cfg_5_erase_en_5_qs;
   logic mp_region_cfg_5_erase_en_5_wd;
-  logic mp_region_cfg_5_erase_en_5_we;
   logic mp_region_cfg_5_scramble_en_5_qs;
   logic mp_region_cfg_5_scramble_en_5_wd;
-  logic mp_region_cfg_5_scramble_en_5_we;
   logic mp_region_cfg_5_ecc_en_5_qs;
   logic mp_region_cfg_5_ecc_en_5_wd;
-  logic mp_region_cfg_5_ecc_en_5_we;
   logic mp_region_cfg_5_he_en_5_qs;
   logic mp_region_cfg_5_he_en_5_wd;
-  logic mp_region_cfg_5_he_en_5_we;
   logic [8:0] mp_region_cfg_5_base_5_qs;
   logic [8:0] mp_region_cfg_5_base_5_wd;
-  logic mp_region_cfg_5_base_5_we;
   logic [9:0] mp_region_cfg_5_size_5_qs;
   logic [9:0] mp_region_cfg_5_size_5_wd;
-  logic mp_region_cfg_5_size_5_we;
+  logic mp_region_cfg_6_we;
   logic mp_region_cfg_6_en_6_qs;
   logic mp_region_cfg_6_en_6_wd;
-  logic mp_region_cfg_6_en_6_we;
   logic mp_region_cfg_6_rd_en_6_qs;
   logic mp_region_cfg_6_rd_en_6_wd;
-  logic mp_region_cfg_6_rd_en_6_we;
   logic mp_region_cfg_6_prog_en_6_qs;
   logic mp_region_cfg_6_prog_en_6_wd;
-  logic mp_region_cfg_6_prog_en_6_we;
   logic mp_region_cfg_6_erase_en_6_qs;
   logic mp_region_cfg_6_erase_en_6_wd;
-  logic mp_region_cfg_6_erase_en_6_we;
   logic mp_region_cfg_6_scramble_en_6_qs;
   logic mp_region_cfg_6_scramble_en_6_wd;
-  logic mp_region_cfg_6_scramble_en_6_we;
   logic mp_region_cfg_6_ecc_en_6_qs;
   logic mp_region_cfg_6_ecc_en_6_wd;
-  logic mp_region_cfg_6_ecc_en_6_we;
   logic mp_region_cfg_6_he_en_6_qs;
   logic mp_region_cfg_6_he_en_6_wd;
-  logic mp_region_cfg_6_he_en_6_we;
   logic [8:0] mp_region_cfg_6_base_6_qs;
   logic [8:0] mp_region_cfg_6_base_6_wd;
-  logic mp_region_cfg_6_base_6_we;
   logic [9:0] mp_region_cfg_6_size_6_qs;
   logic [9:0] mp_region_cfg_6_size_6_wd;
-  logic mp_region_cfg_6_size_6_we;
+  logic mp_region_cfg_7_we;
   logic mp_region_cfg_7_en_7_qs;
   logic mp_region_cfg_7_en_7_wd;
-  logic mp_region_cfg_7_en_7_we;
   logic mp_region_cfg_7_rd_en_7_qs;
   logic mp_region_cfg_7_rd_en_7_wd;
-  logic mp_region_cfg_7_rd_en_7_we;
   logic mp_region_cfg_7_prog_en_7_qs;
   logic mp_region_cfg_7_prog_en_7_wd;
-  logic mp_region_cfg_7_prog_en_7_we;
   logic mp_region_cfg_7_erase_en_7_qs;
   logic mp_region_cfg_7_erase_en_7_wd;
-  logic mp_region_cfg_7_erase_en_7_we;
   logic mp_region_cfg_7_scramble_en_7_qs;
   logic mp_region_cfg_7_scramble_en_7_wd;
-  logic mp_region_cfg_7_scramble_en_7_we;
   logic mp_region_cfg_7_ecc_en_7_qs;
   logic mp_region_cfg_7_ecc_en_7_wd;
-  logic mp_region_cfg_7_ecc_en_7_we;
   logic mp_region_cfg_7_he_en_7_qs;
   logic mp_region_cfg_7_he_en_7_wd;
-  logic mp_region_cfg_7_he_en_7_we;
   logic [8:0] mp_region_cfg_7_base_7_qs;
   logic [8:0] mp_region_cfg_7_base_7_wd;
-  logic mp_region_cfg_7_base_7_we;
   logic [9:0] mp_region_cfg_7_size_7_qs;
   logic [9:0] mp_region_cfg_7_size_7_wd;
-  logic mp_region_cfg_7_size_7_we;
+  logic default_region_we;
   logic default_region_rd_en_qs;
   logic default_region_rd_en_wd;
-  logic default_region_rd_en_we;
   logic default_region_prog_en_qs;
   logic default_region_prog_en_wd;
-  logic default_region_prog_en_we;
   logic default_region_erase_en_qs;
   logic default_region_erase_en_wd;
-  logic default_region_erase_en_we;
   logic default_region_scramble_en_qs;
   logic default_region_scramble_en_wd;
-  logic default_region_scramble_en_we;
   logic default_region_ecc_en_qs;
   logic default_region_ecc_en_wd;
-  logic default_region_ecc_en_we;
   logic default_region_he_en_qs;
   logic default_region_he_en_wd;
-  logic default_region_he_en_we;
+  logic bank0_info0_regwen_0_we;
   logic bank0_info0_regwen_0_qs;
   logic bank0_info0_regwen_0_wd;
-  logic bank0_info0_regwen_0_we;
+  logic bank0_info0_regwen_1_we;
   logic bank0_info0_regwen_1_qs;
   logic bank0_info0_regwen_1_wd;
-  logic bank0_info0_regwen_1_we;
+  logic bank0_info0_regwen_2_we;
   logic bank0_info0_regwen_2_qs;
   logic bank0_info0_regwen_2_wd;
-  logic bank0_info0_regwen_2_we;
+  logic bank0_info0_regwen_3_we;
   logic bank0_info0_regwen_3_qs;
   logic bank0_info0_regwen_3_wd;
-  logic bank0_info0_regwen_3_we;
+  logic bank0_info0_regwen_4_we;
   logic bank0_info0_regwen_4_qs;
   logic bank0_info0_regwen_4_wd;
-  logic bank0_info0_regwen_4_we;
+  logic bank0_info0_regwen_5_we;
   logic bank0_info0_regwen_5_qs;
   logic bank0_info0_regwen_5_wd;
-  logic bank0_info0_regwen_5_we;
+  logic bank0_info0_regwen_6_we;
   logic bank0_info0_regwen_6_qs;
   logic bank0_info0_regwen_6_wd;
-  logic bank0_info0_regwen_6_we;
+  logic bank0_info0_regwen_7_we;
   logic bank0_info0_regwen_7_qs;
   logic bank0_info0_regwen_7_wd;
-  logic bank0_info0_regwen_7_we;
+  logic bank0_info0_regwen_8_we;
   logic bank0_info0_regwen_8_qs;
   logic bank0_info0_regwen_8_wd;
-  logic bank0_info0_regwen_8_we;
+  logic bank0_info0_regwen_9_we;
   logic bank0_info0_regwen_9_qs;
   logic bank0_info0_regwen_9_wd;
-  logic bank0_info0_regwen_9_we;
+  logic bank0_info0_page_cfg_0_we;
   logic bank0_info0_page_cfg_0_en_0_qs;
   logic bank0_info0_page_cfg_0_en_0_wd;
-  logic bank0_info0_page_cfg_0_en_0_we;
   logic bank0_info0_page_cfg_0_rd_en_0_qs;
   logic bank0_info0_page_cfg_0_rd_en_0_wd;
-  logic bank0_info0_page_cfg_0_rd_en_0_we;
   logic bank0_info0_page_cfg_0_prog_en_0_qs;
   logic bank0_info0_page_cfg_0_prog_en_0_wd;
-  logic bank0_info0_page_cfg_0_prog_en_0_we;
   logic bank0_info0_page_cfg_0_erase_en_0_qs;
   logic bank0_info0_page_cfg_0_erase_en_0_wd;
-  logic bank0_info0_page_cfg_0_erase_en_0_we;
   logic bank0_info0_page_cfg_0_scramble_en_0_qs;
   logic bank0_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info0_page_cfg_0_scramble_en_0_we;
   logic bank0_info0_page_cfg_0_ecc_en_0_qs;
   logic bank0_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info0_page_cfg_0_ecc_en_0_we;
   logic bank0_info0_page_cfg_0_he_en_0_qs;
   logic bank0_info0_page_cfg_0_he_en_0_wd;
-  logic bank0_info0_page_cfg_0_he_en_0_we;
+  logic bank0_info0_page_cfg_1_we;
   logic bank0_info0_page_cfg_1_en_1_qs;
   logic bank0_info0_page_cfg_1_en_1_wd;
-  logic bank0_info0_page_cfg_1_en_1_we;
   logic bank0_info0_page_cfg_1_rd_en_1_qs;
   logic bank0_info0_page_cfg_1_rd_en_1_wd;
-  logic bank0_info0_page_cfg_1_rd_en_1_we;
   logic bank0_info0_page_cfg_1_prog_en_1_qs;
   logic bank0_info0_page_cfg_1_prog_en_1_wd;
-  logic bank0_info0_page_cfg_1_prog_en_1_we;
   logic bank0_info0_page_cfg_1_erase_en_1_qs;
   logic bank0_info0_page_cfg_1_erase_en_1_wd;
-  logic bank0_info0_page_cfg_1_erase_en_1_we;
   logic bank0_info0_page_cfg_1_scramble_en_1_qs;
   logic bank0_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info0_page_cfg_1_scramble_en_1_we;
   logic bank0_info0_page_cfg_1_ecc_en_1_qs;
   logic bank0_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info0_page_cfg_1_ecc_en_1_we;
   logic bank0_info0_page_cfg_1_he_en_1_qs;
   logic bank0_info0_page_cfg_1_he_en_1_wd;
-  logic bank0_info0_page_cfg_1_he_en_1_we;
+  logic bank0_info0_page_cfg_2_we;
   logic bank0_info0_page_cfg_2_en_2_qs;
   logic bank0_info0_page_cfg_2_en_2_wd;
-  logic bank0_info0_page_cfg_2_en_2_we;
   logic bank0_info0_page_cfg_2_rd_en_2_qs;
   logic bank0_info0_page_cfg_2_rd_en_2_wd;
-  logic bank0_info0_page_cfg_2_rd_en_2_we;
   logic bank0_info0_page_cfg_2_prog_en_2_qs;
   logic bank0_info0_page_cfg_2_prog_en_2_wd;
-  logic bank0_info0_page_cfg_2_prog_en_2_we;
   logic bank0_info0_page_cfg_2_erase_en_2_qs;
   logic bank0_info0_page_cfg_2_erase_en_2_wd;
-  logic bank0_info0_page_cfg_2_erase_en_2_we;
   logic bank0_info0_page_cfg_2_scramble_en_2_qs;
   logic bank0_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank0_info0_page_cfg_2_scramble_en_2_we;
   logic bank0_info0_page_cfg_2_ecc_en_2_qs;
   logic bank0_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank0_info0_page_cfg_2_ecc_en_2_we;
   logic bank0_info0_page_cfg_2_he_en_2_qs;
   logic bank0_info0_page_cfg_2_he_en_2_wd;
-  logic bank0_info0_page_cfg_2_he_en_2_we;
+  logic bank0_info0_page_cfg_3_we;
   logic bank0_info0_page_cfg_3_en_3_qs;
   logic bank0_info0_page_cfg_3_en_3_wd;
-  logic bank0_info0_page_cfg_3_en_3_we;
   logic bank0_info0_page_cfg_3_rd_en_3_qs;
   logic bank0_info0_page_cfg_3_rd_en_3_wd;
-  logic bank0_info0_page_cfg_3_rd_en_3_we;
   logic bank0_info0_page_cfg_3_prog_en_3_qs;
   logic bank0_info0_page_cfg_3_prog_en_3_wd;
-  logic bank0_info0_page_cfg_3_prog_en_3_we;
   logic bank0_info0_page_cfg_3_erase_en_3_qs;
   logic bank0_info0_page_cfg_3_erase_en_3_wd;
-  logic bank0_info0_page_cfg_3_erase_en_3_we;
   logic bank0_info0_page_cfg_3_scramble_en_3_qs;
   logic bank0_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank0_info0_page_cfg_3_scramble_en_3_we;
   logic bank0_info0_page_cfg_3_ecc_en_3_qs;
   logic bank0_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank0_info0_page_cfg_3_ecc_en_3_we;
   logic bank0_info0_page_cfg_3_he_en_3_qs;
   logic bank0_info0_page_cfg_3_he_en_3_wd;
-  logic bank0_info0_page_cfg_3_he_en_3_we;
+  logic bank0_info0_page_cfg_4_we;
   logic bank0_info0_page_cfg_4_en_4_qs;
   logic bank0_info0_page_cfg_4_en_4_wd;
-  logic bank0_info0_page_cfg_4_en_4_we;
   logic bank0_info0_page_cfg_4_rd_en_4_qs;
   logic bank0_info0_page_cfg_4_rd_en_4_wd;
-  logic bank0_info0_page_cfg_4_rd_en_4_we;
   logic bank0_info0_page_cfg_4_prog_en_4_qs;
   logic bank0_info0_page_cfg_4_prog_en_4_wd;
-  logic bank0_info0_page_cfg_4_prog_en_4_we;
   logic bank0_info0_page_cfg_4_erase_en_4_qs;
   logic bank0_info0_page_cfg_4_erase_en_4_wd;
-  logic bank0_info0_page_cfg_4_erase_en_4_we;
   logic bank0_info0_page_cfg_4_scramble_en_4_qs;
   logic bank0_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank0_info0_page_cfg_4_scramble_en_4_we;
   logic bank0_info0_page_cfg_4_ecc_en_4_qs;
   logic bank0_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank0_info0_page_cfg_4_ecc_en_4_we;
   logic bank0_info0_page_cfg_4_he_en_4_qs;
   logic bank0_info0_page_cfg_4_he_en_4_wd;
-  logic bank0_info0_page_cfg_4_he_en_4_we;
+  logic bank0_info0_page_cfg_5_we;
   logic bank0_info0_page_cfg_5_en_5_qs;
   logic bank0_info0_page_cfg_5_en_5_wd;
-  logic bank0_info0_page_cfg_5_en_5_we;
   logic bank0_info0_page_cfg_5_rd_en_5_qs;
   logic bank0_info0_page_cfg_5_rd_en_5_wd;
-  logic bank0_info0_page_cfg_5_rd_en_5_we;
   logic bank0_info0_page_cfg_5_prog_en_5_qs;
   logic bank0_info0_page_cfg_5_prog_en_5_wd;
-  logic bank0_info0_page_cfg_5_prog_en_5_we;
   logic bank0_info0_page_cfg_5_erase_en_5_qs;
   logic bank0_info0_page_cfg_5_erase_en_5_wd;
-  logic bank0_info0_page_cfg_5_erase_en_5_we;
   logic bank0_info0_page_cfg_5_scramble_en_5_qs;
   logic bank0_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank0_info0_page_cfg_5_scramble_en_5_we;
   logic bank0_info0_page_cfg_5_ecc_en_5_qs;
   logic bank0_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank0_info0_page_cfg_5_ecc_en_5_we;
   logic bank0_info0_page_cfg_5_he_en_5_qs;
   logic bank0_info0_page_cfg_5_he_en_5_wd;
-  logic bank0_info0_page_cfg_5_he_en_5_we;
+  logic bank0_info0_page_cfg_6_we;
   logic bank0_info0_page_cfg_6_en_6_qs;
   logic bank0_info0_page_cfg_6_en_6_wd;
-  logic bank0_info0_page_cfg_6_en_6_we;
   logic bank0_info0_page_cfg_6_rd_en_6_qs;
   logic bank0_info0_page_cfg_6_rd_en_6_wd;
-  logic bank0_info0_page_cfg_6_rd_en_6_we;
   logic bank0_info0_page_cfg_6_prog_en_6_qs;
   logic bank0_info0_page_cfg_6_prog_en_6_wd;
-  logic bank0_info0_page_cfg_6_prog_en_6_we;
   logic bank0_info0_page_cfg_6_erase_en_6_qs;
   logic bank0_info0_page_cfg_6_erase_en_6_wd;
-  logic bank0_info0_page_cfg_6_erase_en_6_we;
   logic bank0_info0_page_cfg_6_scramble_en_6_qs;
   logic bank0_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank0_info0_page_cfg_6_scramble_en_6_we;
   logic bank0_info0_page_cfg_6_ecc_en_6_qs;
   logic bank0_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank0_info0_page_cfg_6_ecc_en_6_we;
   logic bank0_info0_page_cfg_6_he_en_6_qs;
   logic bank0_info0_page_cfg_6_he_en_6_wd;
-  logic bank0_info0_page_cfg_6_he_en_6_we;
+  logic bank0_info0_page_cfg_7_we;
   logic bank0_info0_page_cfg_7_en_7_qs;
   logic bank0_info0_page_cfg_7_en_7_wd;
-  logic bank0_info0_page_cfg_7_en_7_we;
   logic bank0_info0_page_cfg_7_rd_en_7_qs;
   logic bank0_info0_page_cfg_7_rd_en_7_wd;
-  logic bank0_info0_page_cfg_7_rd_en_7_we;
   logic bank0_info0_page_cfg_7_prog_en_7_qs;
   logic bank0_info0_page_cfg_7_prog_en_7_wd;
-  logic bank0_info0_page_cfg_7_prog_en_7_we;
   logic bank0_info0_page_cfg_7_erase_en_7_qs;
   logic bank0_info0_page_cfg_7_erase_en_7_wd;
-  logic bank0_info0_page_cfg_7_erase_en_7_we;
   logic bank0_info0_page_cfg_7_scramble_en_7_qs;
   logic bank0_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank0_info0_page_cfg_7_scramble_en_7_we;
   logic bank0_info0_page_cfg_7_ecc_en_7_qs;
   logic bank0_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank0_info0_page_cfg_7_ecc_en_7_we;
   logic bank0_info0_page_cfg_7_he_en_7_qs;
   logic bank0_info0_page_cfg_7_he_en_7_wd;
-  logic bank0_info0_page_cfg_7_he_en_7_we;
+  logic bank0_info0_page_cfg_8_we;
   logic bank0_info0_page_cfg_8_en_8_qs;
   logic bank0_info0_page_cfg_8_en_8_wd;
-  logic bank0_info0_page_cfg_8_en_8_we;
   logic bank0_info0_page_cfg_8_rd_en_8_qs;
   logic bank0_info0_page_cfg_8_rd_en_8_wd;
-  logic bank0_info0_page_cfg_8_rd_en_8_we;
   logic bank0_info0_page_cfg_8_prog_en_8_qs;
   logic bank0_info0_page_cfg_8_prog_en_8_wd;
-  logic bank0_info0_page_cfg_8_prog_en_8_we;
   logic bank0_info0_page_cfg_8_erase_en_8_qs;
   logic bank0_info0_page_cfg_8_erase_en_8_wd;
-  logic bank0_info0_page_cfg_8_erase_en_8_we;
   logic bank0_info0_page_cfg_8_scramble_en_8_qs;
   logic bank0_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank0_info0_page_cfg_8_scramble_en_8_we;
   logic bank0_info0_page_cfg_8_ecc_en_8_qs;
   logic bank0_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank0_info0_page_cfg_8_ecc_en_8_we;
   logic bank0_info0_page_cfg_8_he_en_8_qs;
   logic bank0_info0_page_cfg_8_he_en_8_wd;
-  logic bank0_info0_page_cfg_8_he_en_8_we;
+  logic bank0_info0_page_cfg_9_we;
   logic bank0_info0_page_cfg_9_en_9_qs;
   logic bank0_info0_page_cfg_9_en_9_wd;
-  logic bank0_info0_page_cfg_9_en_9_we;
   logic bank0_info0_page_cfg_9_rd_en_9_qs;
   logic bank0_info0_page_cfg_9_rd_en_9_wd;
-  logic bank0_info0_page_cfg_9_rd_en_9_we;
   logic bank0_info0_page_cfg_9_prog_en_9_qs;
   logic bank0_info0_page_cfg_9_prog_en_9_wd;
-  logic bank0_info0_page_cfg_9_prog_en_9_we;
   logic bank0_info0_page_cfg_9_erase_en_9_qs;
   logic bank0_info0_page_cfg_9_erase_en_9_wd;
-  logic bank0_info0_page_cfg_9_erase_en_9_we;
   logic bank0_info0_page_cfg_9_scramble_en_9_qs;
   logic bank0_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank0_info0_page_cfg_9_scramble_en_9_we;
   logic bank0_info0_page_cfg_9_ecc_en_9_qs;
   logic bank0_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank0_info0_page_cfg_9_ecc_en_9_we;
   logic bank0_info0_page_cfg_9_he_en_9_qs;
   logic bank0_info0_page_cfg_9_he_en_9_wd;
-  logic bank0_info0_page_cfg_9_he_en_9_we;
+  logic bank0_info1_regwen_we;
   logic bank0_info1_regwen_qs;
   logic bank0_info1_regwen_wd;
-  logic bank0_info1_regwen_we;
+  logic bank0_info1_page_cfg_we;
   logic bank0_info1_page_cfg_en_0_qs;
   logic bank0_info1_page_cfg_en_0_wd;
-  logic bank0_info1_page_cfg_en_0_we;
   logic bank0_info1_page_cfg_rd_en_0_qs;
   logic bank0_info1_page_cfg_rd_en_0_wd;
-  logic bank0_info1_page_cfg_rd_en_0_we;
   logic bank0_info1_page_cfg_prog_en_0_qs;
   logic bank0_info1_page_cfg_prog_en_0_wd;
-  logic bank0_info1_page_cfg_prog_en_0_we;
   logic bank0_info1_page_cfg_erase_en_0_qs;
   logic bank0_info1_page_cfg_erase_en_0_wd;
-  logic bank0_info1_page_cfg_erase_en_0_we;
   logic bank0_info1_page_cfg_scramble_en_0_qs;
   logic bank0_info1_page_cfg_scramble_en_0_wd;
-  logic bank0_info1_page_cfg_scramble_en_0_we;
   logic bank0_info1_page_cfg_ecc_en_0_qs;
   logic bank0_info1_page_cfg_ecc_en_0_wd;
-  logic bank0_info1_page_cfg_ecc_en_0_we;
   logic bank0_info1_page_cfg_he_en_0_qs;
   logic bank0_info1_page_cfg_he_en_0_wd;
-  logic bank0_info1_page_cfg_he_en_0_we;
+  logic bank0_info2_regwen_0_we;
   logic bank0_info2_regwen_0_qs;
   logic bank0_info2_regwen_0_wd;
-  logic bank0_info2_regwen_0_we;
+  logic bank0_info2_regwen_1_we;
   logic bank0_info2_regwen_1_qs;
   logic bank0_info2_regwen_1_wd;
-  logic bank0_info2_regwen_1_we;
+  logic bank0_info2_page_cfg_0_we;
   logic bank0_info2_page_cfg_0_en_0_qs;
   logic bank0_info2_page_cfg_0_en_0_wd;
-  logic bank0_info2_page_cfg_0_en_0_we;
   logic bank0_info2_page_cfg_0_rd_en_0_qs;
   logic bank0_info2_page_cfg_0_rd_en_0_wd;
-  logic bank0_info2_page_cfg_0_rd_en_0_we;
   logic bank0_info2_page_cfg_0_prog_en_0_qs;
   logic bank0_info2_page_cfg_0_prog_en_0_wd;
-  logic bank0_info2_page_cfg_0_prog_en_0_we;
   logic bank0_info2_page_cfg_0_erase_en_0_qs;
   logic bank0_info2_page_cfg_0_erase_en_0_wd;
-  logic bank0_info2_page_cfg_0_erase_en_0_we;
   logic bank0_info2_page_cfg_0_scramble_en_0_qs;
   logic bank0_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info2_page_cfg_0_scramble_en_0_we;
   logic bank0_info2_page_cfg_0_ecc_en_0_qs;
   logic bank0_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info2_page_cfg_0_ecc_en_0_we;
   logic bank0_info2_page_cfg_0_he_en_0_qs;
   logic bank0_info2_page_cfg_0_he_en_0_wd;
-  logic bank0_info2_page_cfg_0_he_en_0_we;
+  logic bank0_info2_page_cfg_1_we;
   logic bank0_info2_page_cfg_1_en_1_qs;
   logic bank0_info2_page_cfg_1_en_1_wd;
-  logic bank0_info2_page_cfg_1_en_1_we;
   logic bank0_info2_page_cfg_1_rd_en_1_qs;
   logic bank0_info2_page_cfg_1_rd_en_1_wd;
-  logic bank0_info2_page_cfg_1_rd_en_1_we;
   logic bank0_info2_page_cfg_1_prog_en_1_qs;
   logic bank0_info2_page_cfg_1_prog_en_1_wd;
-  logic bank0_info2_page_cfg_1_prog_en_1_we;
   logic bank0_info2_page_cfg_1_erase_en_1_qs;
   logic bank0_info2_page_cfg_1_erase_en_1_wd;
-  logic bank0_info2_page_cfg_1_erase_en_1_we;
   logic bank0_info2_page_cfg_1_scramble_en_1_qs;
   logic bank0_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info2_page_cfg_1_scramble_en_1_we;
   logic bank0_info2_page_cfg_1_ecc_en_1_qs;
   logic bank0_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info2_page_cfg_1_ecc_en_1_we;
   logic bank0_info2_page_cfg_1_he_en_1_qs;
   logic bank0_info2_page_cfg_1_he_en_1_wd;
-  logic bank0_info2_page_cfg_1_he_en_1_we;
+  logic bank1_info0_regwen_0_we;
   logic bank1_info0_regwen_0_qs;
   logic bank1_info0_regwen_0_wd;
-  logic bank1_info0_regwen_0_we;
+  logic bank1_info0_regwen_1_we;
   logic bank1_info0_regwen_1_qs;
   logic bank1_info0_regwen_1_wd;
-  logic bank1_info0_regwen_1_we;
+  logic bank1_info0_regwen_2_we;
   logic bank1_info0_regwen_2_qs;
   logic bank1_info0_regwen_2_wd;
-  logic bank1_info0_regwen_2_we;
+  logic bank1_info0_regwen_3_we;
   logic bank1_info0_regwen_3_qs;
   logic bank1_info0_regwen_3_wd;
-  logic bank1_info0_regwen_3_we;
+  logic bank1_info0_regwen_4_we;
   logic bank1_info0_regwen_4_qs;
   logic bank1_info0_regwen_4_wd;
-  logic bank1_info0_regwen_4_we;
+  logic bank1_info0_regwen_5_we;
   logic bank1_info0_regwen_5_qs;
   logic bank1_info0_regwen_5_wd;
-  logic bank1_info0_regwen_5_we;
+  logic bank1_info0_regwen_6_we;
   logic bank1_info0_regwen_6_qs;
   logic bank1_info0_regwen_6_wd;
-  logic bank1_info0_regwen_6_we;
+  logic bank1_info0_regwen_7_we;
   logic bank1_info0_regwen_7_qs;
   logic bank1_info0_regwen_7_wd;
-  logic bank1_info0_regwen_7_we;
+  logic bank1_info0_regwen_8_we;
   logic bank1_info0_regwen_8_qs;
   logic bank1_info0_regwen_8_wd;
-  logic bank1_info0_regwen_8_we;
+  logic bank1_info0_regwen_9_we;
   logic bank1_info0_regwen_9_qs;
   logic bank1_info0_regwen_9_wd;
-  logic bank1_info0_regwen_9_we;
+  logic bank1_info0_page_cfg_0_we;
   logic bank1_info0_page_cfg_0_en_0_qs;
   logic bank1_info0_page_cfg_0_en_0_wd;
-  logic bank1_info0_page_cfg_0_en_0_we;
   logic bank1_info0_page_cfg_0_rd_en_0_qs;
   logic bank1_info0_page_cfg_0_rd_en_0_wd;
-  logic bank1_info0_page_cfg_0_rd_en_0_we;
   logic bank1_info0_page_cfg_0_prog_en_0_qs;
   logic bank1_info0_page_cfg_0_prog_en_0_wd;
-  logic bank1_info0_page_cfg_0_prog_en_0_we;
   logic bank1_info0_page_cfg_0_erase_en_0_qs;
   logic bank1_info0_page_cfg_0_erase_en_0_wd;
-  logic bank1_info0_page_cfg_0_erase_en_0_we;
   logic bank1_info0_page_cfg_0_scramble_en_0_qs;
   logic bank1_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info0_page_cfg_0_scramble_en_0_we;
   logic bank1_info0_page_cfg_0_ecc_en_0_qs;
   logic bank1_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info0_page_cfg_0_ecc_en_0_we;
   logic bank1_info0_page_cfg_0_he_en_0_qs;
   logic bank1_info0_page_cfg_0_he_en_0_wd;
-  logic bank1_info0_page_cfg_0_he_en_0_we;
+  logic bank1_info0_page_cfg_1_we;
   logic bank1_info0_page_cfg_1_en_1_qs;
   logic bank1_info0_page_cfg_1_en_1_wd;
-  logic bank1_info0_page_cfg_1_en_1_we;
   logic bank1_info0_page_cfg_1_rd_en_1_qs;
   logic bank1_info0_page_cfg_1_rd_en_1_wd;
-  logic bank1_info0_page_cfg_1_rd_en_1_we;
   logic bank1_info0_page_cfg_1_prog_en_1_qs;
   logic bank1_info0_page_cfg_1_prog_en_1_wd;
-  logic bank1_info0_page_cfg_1_prog_en_1_we;
   logic bank1_info0_page_cfg_1_erase_en_1_qs;
   logic bank1_info0_page_cfg_1_erase_en_1_wd;
-  logic bank1_info0_page_cfg_1_erase_en_1_we;
   logic bank1_info0_page_cfg_1_scramble_en_1_qs;
   logic bank1_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info0_page_cfg_1_scramble_en_1_we;
   logic bank1_info0_page_cfg_1_ecc_en_1_qs;
   logic bank1_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info0_page_cfg_1_ecc_en_1_we;
   logic bank1_info0_page_cfg_1_he_en_1_qs;
   logic bank1_info0_page_cfg_1_he_en_1_wd;
-  logic bank1_info0_page_cfg_1_he_en_1_we;
+  logic bank1_info0_page_cfg_2_we;
   logic bank1_info0_page_cfg_2_en_2_qs;
   logic bank1_info0_page_cfg_2_en_2_wd;
-  logic bank1_info0_page_cfg_2_en_2_we;
   logic bank1_info0_page_cfg_2_rd_en_2_qs;
   logic bank1_info0_page_cfg_2_rd_en_2_wd;
-  logic bank1_info0_page_cfg_2_rd_en_2_we;
   logic bank1_info0_page_cfg_2_prog_en_2_qs;
   logic bank1_info0_page_cfg_2_prog_en_2_wd;
-  logic bank1_info0_page_cfg_2_prog_en_2_we;
   logic bank1_info0_page_cfg_2_erase_en_2_qs;
   logic bank1_info0_page_cfg_2_erase_en_2_wd;
-  logic bank1_info0_page_cfg_2_erase_en_2_we;
   logic bank1_info0_page_cfg_2_scramble_en_2_qs;
   logic bank1_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank1_info0_page_cfg_2_scramble_en_2_we;
   logic bank1_info0_page_cfg_2_ecc_en_2_qs;
   logic bank1_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank1_info0_page_cfg_2_ecc_en_2_we;
   logic bank1_info0_page_cfg_2_he_en_2_qs;
   logic bank1_info0_page_cfg_2_he_en_2_wd;
-  logic bank1_info0_page_cfg_2_he_en_2_we;
+  logic bank1_info0_page_cfg_3_we;
   logic bank1_info0_page_cfg_3_en_3_qs;
   logic bank1_info0_page_cfg_3_en_3_wd;
-  logic bank1_info0_page_cfg_3_en_3_we;
   logic bank1_info0_page_cfg_3_rd_en_3_qs;
   logic bank1_info0_page_cfg_3_rd_en_3_wd;
-  logic bank1_info0_page_cfg_3_rd_en_3_we;
   logic bank1_info0_page_cfg_3_prog_en_3_qs;
   logic bank1_info0_page_cfg_3_prog_en_3_wd;
-  logic bank1_info0_page_cfg_3_prog_en_3_we;
   logic bank1_info0_page_cfg_3_erase_en_3_qs;
   logic bank1_info0_page_cfg_3_erase_en_3_wd;
-  logic bank1_info0_page_cfg_3_erase_en_3_we;
   logic bank1_info0_page_cfg_3_scramble_en_3_qs;
   logic bank1_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank1_info0_page_cfg_3_scramble_en_3_we;
   logic bank1_info0_page_cfg_3_ecc_en_3_qs;
   logic bank1_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank1_info0_page_cfg_3_ecc_en_3_we;
   logic bank1_info0_page_cfg_3_he_en_3_qs;
   logic bank1_info0_page_cfg_3_he_en_3_wd;
-  logic bank1_info0_page_cfg_3_he_en_3_we;
+  logic bank1_info0_page_cfg_4_we;
   logic bank1_info0_page_cfg_4_en_4_qs;
   logic bank1_info0_page_cfg_4_en_4_wd;
-  logic bank1_info0_page_cfg_4_en_4_we;
   logic bank1_info0_page_cfg_4_rd_en_4_qs;
   logic bank1_info0_page_cfg_4_rd_en_4_wd;
-  logic bank1_info0_page_cfg_4_rd_en_4_we;
   logic bank1_info0_page_cfg_4_prog_en_4_qs;
   logic bank1_info0_page_cfg_4_prog_en_4_wd;
-  logic bank1_info0_page_cfg_4_prog_en_4_we;
   logic bank1_info0_page_cfg_4_erase_en_4_qs;
   logic bank1_info0_page_cfg_4_erase_en_4_wd;
-  logic bank1_info0_page_cfg_4_erase_en_4_we;
   logic bank1_info0_page_cfg_4_scramble_en_4_qs;
   logic bank1_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank1_info0_page_cfg_4_scramble_en_4_we;
   logic bank1_info0_page_cfg_4_ecc_en_4_qs;
   logic bank1_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank1_info0_page_cfg_4_ecc_en_4_we;
   logic bank1_info0_page_cfg_4_he_en_4_qs;
   logic bank1_info0_page_cfg_4_he_en_4_wd;
-  logic bank1_info0_page_cfg_4_he_en_4_we;
+  logic bank1_info0_page_cfg_5_we;
   logic bank1_info0_page_cfg_5_en_5_qs;
   logic bank1_info0_page_cfg_5_en_5_wd;
-  logic bank1_info0_page_cfg_5_en_5_we;
   logic bank1_info0_page_cfg_5_rd_en_5_qs;
   logic bank1_info0_page_cfg_5_rd_en_5_wd;
-  logic bank1_info0_page_cfg_5_rd_en_5_we;
   logic bank1_info0_page_cfg_5_prog_en_5_qs;
   logic bank1_info0_page_cfg_5_prog_en_5_wd;
-  logic bank1_info0_page_cfg_5_prog_en_5_we;
   logic bank1_info0_page_cfg_5_erase_en_5_qs;
   logic bank1_info0_page_cfg_5_erase_en_5_wd;
-  logic bank1_info0_page_cfg_5_erase_en_5_we;
   logic bank1_info0_page_cfg_5_scramble_en_5_qs;
   logic bank1_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank1_info0_page_cfg_5_scramble_en_5_we;
   logic bank1_info0_page_cfg_5_ecc_en_5_qs;
   logic bank1_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank1_info0_page_cfg_5_ecc_en_5_we;
   logic bank1_info0_page_cfg_5_he_en_5_qs;
   logic bank1_info0_page_cfg_5_he_en_5_wd;
-  logic bank1_info0_page_cfg_5_he_en_5_we;
+  logic bank1_info0_page_cfg_6_we;
   logic bank1_info0_page_cfg_6_en_6_qs;
   logic bank1_info0_page_cfg_6_en_6_wd;
-  logic bank1_info0_page_cfg_6_en_6_we;
   logic bank1_info0_page_cfg_6_rd_en_6_qs;
   logic bank1_info0_page_cfg_6_rd_en_6_wd;
-  logic bank1_info0_page_cfg_6_rd_en_6_we;
   logic bank1_info0_page_cfg_6_prog_en_6_qs;
   logic bank1_info0_page_cfg_6_prog_en_6_wd;
-  logic bank1_info0_page_cfg_6_prog_en_6_we;
   logic bank1_info0_page_cfg_6_erase_en_6_qs;
   logic bank1_info0_page_cfg_6_erase_en_6_wd;
-  logic bank1_info0_page_cfg_6_erase_en_6_we;
   logic bank1_info0_page_cfg_6_scramble_en_6_qs;
   logic bank1_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank1_info0_page_cfg_6_scramble_en_6_we;
   logic bank1_info0_page_cfg_6_ecc_en_6_qs;
   logic bank1_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank1_info0_page_cfg_6_ecc_en_6_we;
   logic bank1_info0_page_cfg_6_he_en_6_qs;
   logic bank1_info0_page_cfg_6_he_en_6_wd;
-  logic bank1_info0_page_cfg_6_he_en_6_we;
+  logic bank1_info0_page_cfg_7_we;
   logic bank1_info0_page_cfg_7_en_7_qs;
   logic bank1_info0_page_cfg_7_en_7_wd;
-  logic bank1_info0_page_cfg_7_en_7_we;
   logic bank1_info0_page_cfg_7_rd_en_7_qs;
   logic bank1_info0_page_cfg_7_rd_en_7_wd;
-  logic bank1_info0_page_cfg_7_rd_en_7_we;
   logic bank1_info0_page_cfg_7_prog_en_7_qs;
   logic bank1_info0_page_cfg_7_prog_en_7_wd;
-  logic bank1_info0_page_cfg_7_prog_en_7_we;
   logic bank1_info0_page_cfg_7_erase_en_7_qs;
   logic bank1_info0_page_cfg_7_erase_en_7_wd;
-  logic bank1_info0_page_cfg_7_erase_en_7_we;
   logic bank1_info0_page_cfg_7_scramble_en_7_qs;
   logic bank1_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank1_info0_page_cfg_7_scramble_en_7_we;
   logic bank1_info0_page_cfg_7_ecc_en_7_qs;
   logic bank1_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank1_info0_page_cfg_7_ecc_en_7_we;
   logic bank1_info0_page_cfg_7_he_en_7_qs;
   logic bank1_info0_page_cfg_7_he_en_7_wd;
-  logic bank1_info0_page_cfg_7_he_en_7_we;
+  logic bank1_info0_page_cfg_8_we;
   logic bank1_info0_page_cfg_8_en_8_qs;
   logic bank1_info0_page_cfg_8_en_8_wd;
-  logic bank1_info0_page_cfg_8_en_8_we;
   logic bank1_info0_page_cfg_8_rd_en_8_qs;
   logic bank1_info0_page_cfg_8_rd_en_8_wd;
-  logic bank1_info0_page_cfg_8_rd_en_8_we;
   logic bank1_info0_page_cfg_8_prog_en_8_qs;
   logic bank1_info0_page_cfg_8_prog_en_8_wd;
-  logic bank1_info0_page_cfg_8_prog_en_8_we;
   logic bank1_info0_page_cfg_8_erase_en_8_qs;
   logic bank1_info0_page_cfg_8_erase_en_8_wd;
-  logic bank1_info0_page_cfg_8_erase_en_8_we;
   logic bank1_info0_page_cfg_8_scramble_en_8_qs;
   logic bank1_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank1_info0_page_cfg_8_scramble_en_8_we;
   logic bank1_info0_page_cfg_8_ecc_en_8_qs;
   logic bank1_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank1_info0_page_cfg_8_ecc_en_8_we;
   logic bank1_info0_page_cfg_8_he_en_8_qs;
   logic bank1_info0_page_cfg_8_he_en_8_wd;
-  logic bank1_info0_page_cfg_8_he_en_8_we;
+  logic bank1_info0_page_cfg_9_we;
   logic bank1_info0_page_cfg_9_en_9_qs;
   logic bank1_info0_page_cfg_9_en_9_wd;
-  logic bank1_info0_page_cfg_9_en_9_we;
   logic bank1_info0_page_cfg_9_rd_en_9_qs;
   logic bank1_info0_page_cfg_9_rd_en_9_wd;
-  logic bank1_info0_page_cfg_9_rd_en_9_we;
   logic bank1_info0_page_cfg_9_prog_en_9_qs;
   logic bank1_info0_page_cfg_9_prog_en_9_wd;
-  logic bank1_info0_page_cfg_9_prog_en_9_we;
   logic bank1_info0_page_cfg_9_erase_en_9_qs;
   logic bank1_info0_page_cfg_9_erase_en_9_wd;
-  logic bank1_info0_page_cfg_9_erase_en_9_we;
   logic bank1_info0_page_cfg_9_scramble_en_9_qs;
   logic bank1_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank1_info0_page_cfg_9_scramble_en_9_we;
   logic bank1_info0_page_cfg_9_ecc_en_9_qs;
   logic bank1_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank1_info0_page_cfg_9_ecc_en_9_we;
   logic bank1_info0_page_cfg_9_he_en_9_qs;
   logic bank1_info0_page_cfg_9_he_en_9_wd;
-  logic bank1_info0_page_cfg_9_he_en_9_we;
+  logic bank1_info1_regwen_we;
   logic bank1_info1_regwen_qs;
   logic bank1_info1_regwen_wd;
-  logic bank1_info1_regwen_we;
+  logic bank1_info1_page_cfg_we;
   logic bank1_info1_page_cfg_en_0_qs;
   logic bank1_info1_page_cfg_en_0_wd;
-  logic bank1_info1_page_cfg_en_0_we;
   logic bank1_info1_page_cfg_rd_en_0_qs;
   logic bank1_info1_page_cfg_rd_en_0_wd;
-  logic bank1_info1_page_cfg_rd_en_0_we;
   logic bank1_info1_page_cfg_prog_en_0_qs;
   logic bank1_info1_page_cfg_prog_en_0_wd;
-  logic bank1_info1_page_cfg_prog_en_0_we;
   logic bank1_info1_page_cfg_erase_en_0_qs;
   logic bank1_info1_page_cfg_erase_en_0_wd;
-  logic bank1_info1_page_cfg_erase_en_0_we;
   logic bank1_info1_page_cfg_scramble_en_0_qs;
   logic bank1_info1_page_cfg_scramble_en_0_wd;
-  logic bank1_info1_page_cfg_scramble_en_0_we;
   logic bank1_info1_page_cfg_ecc_en_0_qs;
   logic bank1_info1_page_cfg_ecc_en_0_wd;
-  logic bank1_info1_page_cfg_ecc_en_0_we;
   logic bank1_info1_page_cfg_he_en_0_qs;
   logic bank1_info1_page_cfg_he_en_0_wd;
-  logic bank1_info1_page_cfg_he_en_0_we;
+  logic bank1_info2_regwen_0_we;
   logic bank1_info2_regwen_0_qs;
   logic bank1_info2_regwen_0_wd;
-  logic bank1_info2_regwen_0_we;
+  logic bank1_info2_regwen_1_we;
   logic bank1_info2_regwen_1_qs;
   logic bank1_info2_regwen_1_wd;
-  logic bank1_info2_regwen_1_we;
+  logic bank1_info2_page_cfg_0_we;
   logic bank1_info2_page_cfg_0_en_0_qs;
   logic bank1_info2_page_cfg_0_en_0_wd;
-  logic bank1_info2_page_cfg_0_en_0_we;
   logic bank1_info2_page_cfg_0_rd_en_0_qs;
   logic bank1_info2_page_cfg_0_rd_en_0_wd;
-  logic bank1_info2_page_cfg_0_rd_en_0_we;
   logic bank1_info2_page_cfg_0_prog_en_0_qs;
   logic bank1_info2_page_cfg_0_prog_en_0_wd;
-  logic bank1_info2_page_cfg_0_prog_en_0_we;
   logic bank1_info2_page_cfg_0_erase_en_0_qs;
   logic bank1_info2_page_cfg_0_erase_en_0_wd;
-  logic bank1_info2_page_cfg_0_erase_en_0_we;
   logic bank1_info2_page_cfg_0_scramble_en_0_qs;
   logic bank1_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info2_page_cfg_0_scramble_en_0_we;
   logic bank1_info2_page_cfg_0_ecc_en_0_qs;
   logic bank1_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info2_page_cfg_0_ecc_en_0_we;
   logic bank1_info2_page_cfg_0_he_en_0_qs;
   logic bank1_info2_page_cfg_0_he_en_0_wd;
-  logic bank1_info2_page_cfg_0_he_en_0_we;
+  logic bank1_info2_page_cfg_1_we;
   logic bank1_info2_page_cfg_1_en_1_qs;
   logic bank1_info2_page_cfg_1_en_1_wd;
-  logic bank1_info2_page_cfg_1_en_1_we;
   logic bank1_info2_page_cfg_1_rd_en_1_qs;
   logic bank1_info2_page_cfg_1_rd_en_1_wd;
-  logic bank1_info2_page_cfg_1_rd_en_1_we;
   logic bank1_info2_page_cfg_1_prog_en_1_qs;
   logic bank1_info2_page_cfg_1_prog_en_1_wd;
-  logic bank1_info2_page_cfg_1_prog_en_1_we;
   logic bank1_info2_page_cfg_1_erase_en_1_qs;
   logic bank1_info2_page_cfg_1_erase_en_1_wd;
-  logic bank1_info2_page_cfg_1_erase_en_1_we;
   logic bank1_info2_page_cfg_1_scramble_en_1_qs;
   logic bank1_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info2_page_cfg_1_scramble_en_1_we;
   logic bank1_info2_page_cfg_1_ecc_en_1_qs;
   logic bank1_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info2_page_cfg_1_ecc_en_1_we;
   logic bank1_info2_page_cfg_1_he_en_1_qs;
   logic bank1_info2_page_cfg_1_he_en_1_wd;
-  logic bank1_info2_page_cfg_1_he_en_1_we;
+  logic bank_cfg_regwen_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
-  logic bank_cfg_regwen_we;
+  logic mp_bank_cfg_we;
   logic mp_bank_cfg_erase_en_0_qs;
   logic mp_bank_cfg_erase_en_0_wd;
-  logic mp_bank_cfg_erase_en_0_we;
   logic mp_bank_cfg_erase_en_1_qs;
   logic mp_bank_cfg_erase_en_1_wd;
-  logic mp_bank_cfg_erase_en_1_we;
+  logic op_status_we;
   logic op_status_done_qs;
   logic op_status_done_wd;
-  logic op_status_done_we;
   logic op_status_err_qs;
   logic op_status_err_wd;
-  logic op_status_err_we;
   logic status_rd_full_qs;
   logic status_rd_empty_qs;
   logic status_prog_full_qs;
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
+  logic err_code_intr_en_we;
   logic err_code_intr_en_flash_err_en_qs;
   logic err_code_intr_en_flash_err_en_wd;
-  logic err_code_intr_en_flash_err_en_we;
   logic err_code_intr_en_flash_alert_en_qs;
   logic err_code_intr_en_flash_alert_en_wd;
-  logic err_code_intr_en_flash_alert_en_we;
   logic err_code_intr_en_mp_err_qs;
   logic err_code_intr_en_mp_err_wd;
-  logic err_code_intr_en_mp_err_we;
   logic err_code_intr_en_ecc_single_err_qs;
   logic err_code_intr_en_ecc_single_err_wd;
-  logic err_code_intr_en_ecc_single_err_we;
   logic err_code_intr_en_ecc_multi_err_qs;
   logic err_code_intr_en_ecc_multi_err_wd;
-  logic err_code_intr_en_ecc_multi_err_we;
+  logic err_code_we;
   logic err_code_flash_err_qs;
   logic err_code_flash_err_wd;
-  logic err_code_flash_err_we;
   logic err_code_flash_alert_qs;
   logic err_code_flash_alert_wd;
-  logic err_code_flash_alert_we;
   logic err_code_mp_err_qs;
   logic err_code_mp_err_wd;
-  logic err_code_mp_err_we;
   logic err_code_ecc_single_err_qs;
   logic err_code_ecc_single_err_wd;
-  logic err_code_ecc_single_err_we;
   logic err_code_ecc_multi_err_qs;
   logic err_code_ecc_multi_err_wd;
-  logic err_code_ecc_multi_err_we;
   logic [8:0] err_addr_qs;
+  logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_qs;
   logic [7:0] ecc_single_err_cnt_wd;
-  logic ecc_single_err_cnt_we;
   logic [19:0] ecc_single_err_addr_0_qs;
   logic [19:0] ecc_single_err_addr_1_qs;
+  logic ecc_multi_err_cnt_we;
   logic [7:0] ecc_multi_err_cnt_qs;
   logic [7:0] ecc_multi_err_cnt_wd;
-  logic ecc_multi_err_cnt_we;
   logic [19:0] ecc_multi_err_addr_0_qs;
   logic [19:0] ecc_multi_err_addr_1_qs;
+  logic phy_err_cfg_regwen_we;
   logic phy_err_cfg_regwen_qs;
   logic phy_err_cfg_regwen_wd;
-  logic phy_err_cfg_regwen_we;
+  logic phy_err_cfg_we;
   logic phy_err_cfg_qs;
   logic phy_err_cfg_wd;
-  logic phy_err_cfg_we;
+  logic phy_alert_cfg_we;
   logic phy_alert_cfg_alert_ack_qs;
   logic phy_alert_cfg_alert_ack_wd;
-  logic phy_alert_cfg_alert_ack_we;
   logic phy_alert_cfg_alert_trig_qs;
   logic phy_alert_cfg_alert_trig_wd;
-  logic phy_alert_cfg_alert_trig_we;
   logic phy_status_init_wip_qs;
   logic phy_status_prog_normal_avail_qs;
   logic phy_status_prog_repair_avail_qs;
+  logic scratch_we;
   logic [31:0] scratch_qs;
   logic [31:0] scratch_wd;
-  logic scratch_we;
+  logic fifo_lvl_we;
   logic [4:0] fifo_lvl_prog_qs;
   logic [4:0] fifo_lvl_prog_wd;
-  logic fifo_lvl_prog_we;
   logic [4:0] fifo_lvl_rd_qs;
   logic [4:0] fifo_lvl_rd_wd;
-  logic fifo_lvl_rd_we;
+  logic fifo_rst_we;
   logic fifo_rst_qs;
   logic fifo_rst_wd;
-  logic fifo_rst_we;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1235,7 +973,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_prog_empty_we),
+    .we     (intr_state_we),
     .wd     (intr_state_prog_empty_wd),
 
     // from internal hardware
@@ -1261,7 +999,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_prog_lvl_we),
+    .we     (intr_state_we),
     .wd     (intr_state_prog_lvl_wd),
 
     // from internal hardware
@@ -1287,7 +1025,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rd_full_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rd_full_wd),
 
     // from internal hardware
@@ -1313,7 +1051,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_rd_lvl_we),
+    .we     (intr_state_we),
     .wd     (intr_state_rd_lvl_wd),
 
     // from internal hardware
@@ -1339,7 +1077,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_op_done_we),
+    .we     (intr_state_we),
     .wd     (intr_state_op_done_wd),
 
     // from internal hardware
@@ -1365,7 +1103,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_state_err_we),
+    .we     (intr_state_we),
     .wd     (intr_state_err_wd),
 
     // from internal hardware
@@ -1393,7 +1131,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_prog_empty_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_prog_empty_wd),
 
     // from internal hardware
@@ -1419,7 +1157,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_prog_lvl_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_prog_lvl_wd),
 
     // from internal hardware
@@ -1445,7 +1183,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rd_full_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rd_full_wd),
 
     // from internal hardware
@@ -1471,7 +1209,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_rd_lvl_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_rd_lvl_wd),
 
     // from internal hardware
@@ -1497,7 +1235,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_op_done_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_op_done_wd),
 
     // from internal hardware
@@ -1523,7 +1261,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (intr_enable_err_we),
+    .we     (intr_enable_we),
     .wd     (intr_enable_err_wd),
 
     // from internal hardware
@@ -1546,7 +1284,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_prog_empty (
     .re     (1'b0),
-    .we     (intr_test_prog_empty_we),
+    .we     (intr_test_we),
     .wd     (intr_test_prog_empty_wd),
     .d      ('0),
     .qre    (),
@@ -1561,7 +1299,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_prog_lvl (
     .re     (1'b0),
-    .we     (intr_test_prog_lvl_we),
+    .we     (intr_test_we),
     .wd     (intr_test_prog_lvl_wd),
     .d      ('0),
     .qre    (),
@@ -1576,7 +1314,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_rd_full (
     .re     (1'b0),
-    .we     (intr_test_rd_full_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rd_full_wd),
     .d      ('0),
     .qre    (),
@@ -1591,7 +1329,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_rd_lvl (
     .re     (1'b0),
-    .we     (intr_test_rd_lvl_we),
+    .we     (intr_test_we),
     .wd     (intr_test_rd_lvl_wd),
     .d      ('0),
     .qre    (),
@@ -1606,7 +1344,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_op_done (
     .re     (1'b0),
-    .we     (intr_test_op_done_we),
+    .we     (intr_test_we),
     .wd     (intr_test_op_done_wd),
     .d      ('0),
     .qre    (),
@@ -1621,7 +1359,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_intr_test_err (
     .re     (1'b0),
-    .we     (intr_test_err_we),
+    .we     (intr_test_we),
     .wd     (intr_test_err_wd),
     .d      ('0),
     .qre    (),
@@ -1638,7 +1376,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_err (
     .re     (1'b0),
-    .we     (alert_test_recov_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
@@ -1653,7 +1391,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_mp_err (
     .re     (1'b0),
-    .we     (alert_test_recov_mp_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_mp_err_wd),
     .d      ('0),
     .qre    (),
@@ -1668,7 +1406,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ecc_err (
     .re     (1'b0),
-    .we     (alert_test_recov_ecc_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ecc_err_wd),
     .d      ('0),
     .qre    (),
@@ -1683,7 +1421,7 @@ module flash_ctrl_core_reg_top (
     .DW    (1)
   ) u_alert_test_fatal_intg_err (
     .re     (1'b0),
-    .we     (alert_test_fatal_intg_err_we),
+    .we     (alert_test_we),
     .wd     (alert_test_fatal_intg_err_wd),
     .d      ('0),
     .qre    (),
@@ -1748,7 +1486,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_start_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_start_wd),
 
     // from internal hardware
@@ -1774,7 +1512,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_op_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_op_wd),
 
     // from internal hardware
@@ -1800,7 +1538,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_prog_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_prog_sel_wd),
 
     // from internal hardware
@@ -1826,7 +1564,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_erase_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_erase_sel_wd),
 
     // from internal hardware
@@ -1852,7 +1590,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_partition_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_partition_sel_wd),
 
     // from internal hardware
@@ -1878,7 +1616,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_info_sel_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_info_sel_wd),
 
     // from internal hardware
@@ -1904,7 +1642,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_num_we & ctrl_regwen_qs),
+    .we     (control_we & ctrl_regwen_qs),
     .wd     (control_num_wd),
 
     // from internal hardware
@@ -1959,7 +1697,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_normal_we),
+    .we     (prog_type_en_we),
     .wd     (prog_type_en_normal_wd),
 
     // from internal hardware
@@ -1985,7 +1723,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (prog_type_en_repair_we),
+    .we     (prog_type_en_we),
     .wd     (prog_type_en_repair_wd),
 
     // from internal hardware
@@ -2260,7 +1998,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -2286,7 +2024,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_rd_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -2312,7 +2050,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_prog_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -2338,7 +2076,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_erase_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -2364,7 +2102,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_scramble_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -2390,7 +2128,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_ecc_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -2416,7 +2154,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_he_en_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -2442,7 +2180,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_base_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_base_0_wd),
 
     // from internal hardware
@@ -2468,7 +2206,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_size_0_we & region_cfg_regwen_0_qs),
+    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
     .wd     (mp_region_cfg_0_size_0_wd),
 
     // from internal hardware
@@ -2497,7 +2235,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -2523,7 +2261,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_rd_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -2549,7 +2287,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_prog_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -2575,7 +2313,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_erase_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -2601,7 +2339,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_scramble_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -2627,7 +2365,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_ecc_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -2653,7 +2391,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_he_en_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -2679,7 +2417,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_base_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_base_1_wd),
 
     // from internal hardware
@@ -2705,7 +2443,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_size_1_we & region_cfg_regwen_1_qs),
+    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
     .wd     (mp_region_cfg_1_size_1_wd),
 
     // from internal hardware
@@ -2734,7 +2472,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_en_2_wd),
 
     // from internal hardware
@@ -2760,7 +2498,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_rd_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_rd_en_2_wd),
 
     // from internal hardware
@@ -2786,7 +2524,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_prog_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_prog_en_2_wd),
 
     // from internal hardware
@@ -2812,7 +2550,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_erase_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_erase_en_2_wd),
 
     // from internal hardware
@@ -2838,7 +2576,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_scramble_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_scramble_en_2_wd),
 
     // from internal hardware
@@ -2864,7 +2602,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_ecc_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_ecc_en_2_wd),
 
     // from internal hardware
@@ -2890,7 +2628,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_he_en_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_he_en_2_wd),
 
     // from internal hardware
@@ -2916,7 +2654,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_base_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_base_2_wd),
 
     // from internal hardware
@@ -2942,7 +2680,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_size_2_we & region_cfg_regwen_2_qs),
+    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
     .wd     (mp_region_cfg_2_size_2_wd),
 
     // from internal hardware
@@ -2971,7 +2709,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_en_3_wd),
 
     // from internal hardware
@@ -2997,7 +2735,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_rd_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_rd_en_3_wd),
 
     // from internal hardware
@@ -3023,7 +2761,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_prog_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_prog_en_3_wd),
 
     // from internal hardware
@@ -3049,7 +2787,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_erase_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_erase_en_3_wd),
 
     // from internal hardware
@@ -3075,7 +2813,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_scramble_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_scramble_en_3_wd),
 
     // from internal hardware
@@ -3101,7 +2839,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_ecc_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_ecc_en_3_wd),
 
     // from internal hardware
@@ -3127,7 +2865,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_he_en_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_he_en_3_wd),
 
     // from internal hardware
@@ -3153,7 +2891,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_base_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_base_3_wd),
 
     // from internal hardware
@@ -3179,7 +2917,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_size_3_we & region_cfg_regwen_3_qs),
+    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
     .wd     (mp_region_cfg_3_size_3_wd),
 
     // from internal hardware
@@ -3208,7 +2946,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_en_4_wd),
 
     // from internal hardware
@@ -3234,7 +2972,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_rd_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_rd_en_4_wd),
 
     // from internal hardware
@@ -3260,7 +2998,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_prog_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_prog_en_4_wd),
 
     // from internal hardware
@@ -3286,7 +3024,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_erase_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_erase_en_4_wd),
 
     // from internal hardware
@@ -3312,7 +3050,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_scramble_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_scramble_en_4_wd),
 
     // from internal hardware
@@ -3338,7 +3076,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_ecc_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_ecc_en_4_wd),
 
     // from internal hardware
@@ -3364,7 +3102,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_he_en_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_he_en_4_wd),
 
     // from internal hardware
@@ -3390,7 +3128,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_base_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_base_4_wd),
 
     // from internal hardware
@@ -3416,7 +3154,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_size_4_we & region_cfg_regwen_4_qs),
+    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
     .wd     (mp_region_cfg_4_size_4_wd),
 
     // from internal hardware
@@ -3445,7 +3183,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_en_5_wd),
 
     // from internal hardware
@@ -3471,7 +3209,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_rd_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_rd_en_5_wd),
 
     // from internal hardware
@@ -3497,7 +3235,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_prog_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_prog_en_5_wd),
 
     // from internal hardware
@@ -3523,7 +3261,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_erase_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_erase_en_5_wd),
 
     // from internal hardware
@@ -3549,7 +3287,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_scramble_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_scramble_en_5_wd),
 
     // from internal hardware
@@ -3575,7 +3313,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_ecc_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_ecc_en_5_wd),
 
     // from internal hardware
@@ -3601,7 +3339,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_he_en_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_he_en_5_wd),
 
     // from internal hardware
@@ -3627,7 +3365,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_base_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_base_5_wd),
 
     // from internal hardware
@@ -3653,7 +3391,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_size_5_we & region_cfg_regwen_5_qs),
+    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
     .wd     (mp_region_cfg_5_size_5_wd),
 
     // from internal hardware
@@ -3682,7 +3420,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_en_6_wd),
 
     // from internal hardware
@@ -3708,7 +3446,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_rd_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_rd_en_6_wd),
 
     // from internal hardware
@@ -3734,7 +3472,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_prog_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_prog_en_6_wd),
 
     // from internal hardware
@@ -3760,7 +3498,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_erase_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_erase_en_6_wd),
 
     // from internal hardware
@@ -3786,7 +3524,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_scramble_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_scramble_en_6_wd),
 
     // from internal hardware
@@ -3812,7 +3550,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_ecc_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_ecc_en_6_wd),
 
     // from internal hardware
@@ -3838,7 +3576,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_he_en_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_he_en_6_wd),
 
     // from internal hardware
@@ -3864,7 +3602,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_base_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_base_6_wd),
 
     // from internal hardware
@@ -3890,7 +3628,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_size_6_we & region_cfg_regwen_6_qs),
+    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
     .wd     (mp_region_cfg_6_size_6_wd),
 
     // from internal hardware
@@ -3919,7 +3657,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_en_7_wd),
 
     // from internal hardware
@@ -3945,7 +3683,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_rd_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_rd_en_7_wd),
 
     // from internal hardware
@@ -3971,7 +3709,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_prog_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_prog_en_7_wd),
 
     // from internal hardware
@@ -3997,7 +3735,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_erase_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_erase_en_7_wd),
 
     // from internal hardware
@@ -4023,7 +3761,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_scramble_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_scramble_en_7_wd),
 
     // from internal hardware
@@ -4049,7 +3787,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_ecc_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_ecc_en_7_wd),
 
     // from internal hardware
@@ -4075,7 +3813,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_he_en_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_he_en_7_wd),
 
     // from internal hardware
@@ -4101,7 +3839,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_base_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_base_7_wd),
 
     // from internal hardware
@@ -4127,7 +3865,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_size_7_we & region_cfg_regwen_7_qs),
+    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
     .wd     (mp_region_cfg_7_size_7_wd),
 
     // from internal hardware
@@ -4156,7 +3894,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_rd_en_we),
+    .we     (default_region_we),
     .wd     (default_region_rd_en_wd),
 
     // from internal hardware
@@ -4182,7 +3920,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_prog_en_we),
+    .we     (default_region_we),
     .wd     (default_region_prog_en_wd),
 
     // from internal hardware
@@ -4208,7 +3946,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_erase_en_we),
+    .we     (default_region_we),
     .wd     (default_region_erase_en_wd),
 
     // from internal hardware
@@ -4234,7 +3972,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_scramble_en_we),
+    .we     (default_region_we),
     .wd     (default_region_scramble_en_wd),
 
     // from internal hardware
@@ -4260,7 +3998,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_ecc_en_we),
+    .we     (default_region_we),
     .wd     (default_region_ecc_en_wd),
 
     // from internal hardware
@@ -4286,7 +4024,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (default_region_he_en_we),
+    .we     (default_region_we),
     .wd     (default_region_he_en_wd),
 
     // from internal hardware
@@ -4588,7 +4326,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -4614,7 +4352,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_rd_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -4640,7 +4378,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_prog_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -4666,7 +4404,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_erase_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -4692,7 +4430,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_scramble_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -4718,7 +4456,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_ecc_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -4744,7 +4482,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_he_en_0_we & bank0_info0_regwen_0_qs),
+    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
     .wd     (bank0_info0_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -4773,7 +4511,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -4799,7 +4537,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_rd_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -4825,7 +4563,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_prog_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -4851,7 +4589,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_erase_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -4877,7 +4615,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_scramble_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -4903,7 +4641,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_ecc_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -4929,7 +4667,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_he_en_1_we & bank0_info0_regwen_1_qs),
+    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
     .wd     (bank0_info0_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -4958,7 +4696,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_en_2_wd),
 
     // from internal hardware
@@ -4984,7 +4722,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_rd_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_rd_en_2_wd),
 
     // from internal hardware
@@ -5010,7 +4748,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_prog_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_prog_en_2_wd),
 
     // from internal hardware
@@ -5036,7 +4774,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_erase_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_erase_en_2_wd),
 
     // from internal hardware
@@ -5062,7 +4800,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_scramble_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_scramble_en_2_wd),
 
     // from internal hardware
@@ -5088,7 +4826,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_ecc_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_ecc_en_2_wd),
 
     // from internal hardware
@@ -5114,7 +4852,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_he_en_2_we & bank0_info0_regwen_2_qs),
+    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
     .wd     (bank0_info0_page_cfg_2_he_en_2_wd),
 
     // from internal hardware
@@ -5143,7 +4881,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_en_3_wd),
 
     // from internal hardware
@@ -5169,7 +4907,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_rd_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_rd_en_3_wd),
 
     // from internal hardware
@@ -5195,7 +4933,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_prog_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_prog_en_3_wd),
 
     // from internal hardware
@@ -5221,7 +4959,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_erase_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_erase_en_3_wd),
 
     // from internal hardware
@@ -5247,7 +4985,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_scramble_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_scramble_en_3_wd),
 
     // from internal hardware
@@ -5273,7 +5011,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_ecc_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_ecc_en_3_wd),
 
     // from internal hardware
@@ -5299,7 +5037,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_he_en_3_we & bank0_info0_regwen_3_qs),
+    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
     .wd     (bank0_info0_page_cfg_3_he_en_3_wd),
 
     // from internal hardware
@@ -5328,7 +5066,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_en_4_wd),
 
     // from internal hardware
@@ -5354,7 +5092,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_rd_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_rd_en_4_wd),
 
     // from internal hardware
@@ -5380,7 +5118,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_prog_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_prog_en_4_wd),
 
     // from internal hardware
@@ -5406,7 +5144,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_erase_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_erase_en_4_wd),
 
     // from internal hardware
@@ -5432,7 +5170,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_scramble_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_scramble_en_4_wd),
 
     // from internal hardware
@@ -5458,7 +5196,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_ecc_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_ecc_en_4_wd),
 
     // from internal hardware
@@ -5484,7 +5222,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_he_en_4_we & bank0_info0_regwen_4_qs),
+    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
     .wd     (bank0_info0_page_cfg_4_he_en_4_wd),
 
     // from internal hardware
@@ -5513,7 +5251,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_en_5_wd),
 
     // from internal hardware
@@ -5539,7 +5277,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_rd_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_rd_en_5_wd),
 
     // from internal hardware
@@ -5565,7 +5303,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_prog_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_prog_en_5_wd),
 
     // from internal hardware
@@ -5591,7 +5329,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_erase_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_erase_en_5_wd),
 
     // from internal hardware
@@ -5617,7 +5355,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_scramble_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_scramble_en_5_wd),
 
     // from internal hardware
@@ -5643,7 +5381,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_ecc_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_ecc_en_5_wd),
 
     // from internal hardware
@@ -5669,7 +5407,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_he_en_5_we & bank0_info0_regwen_5_qs),
+    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
     .wd     (bank0_info0_page_cfg_5_he_en_5_wd),
 
     // from internal hardware
@@ -5698,7 +5436,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_en_6_wd),
 
     // from internal hardware
@@ -5724,7 +5462,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_rd_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_rd_en_6_wd),
 
     // from internal hardware
@@ -5750,7 +5488,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_prog_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_prog_en_6_wd),
 
     // from internal hardware
@@ -5776,7 +5514,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_erase_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_erase_en_6_wd),
 
     // from internal hardware
@@ -5802,7 +5540,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_scramble_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_scramble_en_6_wd),
 
     // from internal hardware
@@ -5828,7 +5566,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_ecc_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_ecc_en_6_wd),
 
     // from internal hardware
@@ -5854,7 +5592,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_he_en_6_we & bank0_info0_regwen_6_qs),
+    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
     .wd     (bank0_info0_page_cfg_6_he_en_6_wd),
 
     // from internal hardware
@@ -5883,7 +5621,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_en_7_wd),
 
     // from internal hardware
@@ -5909,7 +5647,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_rd_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_rd_en_7_wd),
 
     // from internal hardware
@@ -5935,7 +5673,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_prog_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_prog_en_7_wd),
 
     // from internal hardware
@@ -5961,7 +5699,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_erase_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_erase_en_7_wd),
 
     // from internal hardware
@@ -5987,7 +5725,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_scramble_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_scramble_en_7_wd),
 
     // from internal hardware
@@ -6013,7 +5751,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_ecc_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_ecc_en_7_wd),
 
     // from internal hardware
@@ -6039,7 +5777,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_he_en_7_we & bank0_info0_regwen_7_qs),
+    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
     .wd     (bank0_info0_page_cfg_7_he_en_7_wd),
 
     // from internal hardware
@@ -6068,7 +5806,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_en_8_wd),
 
     // from internal hardware
@@ -6094,7 +5832,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_rd_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_rd_en_8_wd),
 
     // from internal hardware
@@ -6120,7 +5858,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_prog_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_prog_en_8_wd),
 
     // from internal hardware
@@ -6146,7 +5884,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_erase_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_erase_en_8_wd),
 
     // from internal hardware
@@ -6172,7 +5910,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_scramble_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_scramble_en_8_wd),
 
     // from internal hardware
@@ -6198,7 +5936,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_ecc_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_ecc_en_8_wd),
 
     // from internal hardware
@@ -6224,7 +5962,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_he_en_8_we & bank0_info0_regwen_8_qs),
+    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
     .wd     (bank0_info0_page_cfg_8_he_en_8_wd),
 
     // from internal hardware
@@ -6253,7 +5991,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_en_9_wd),
 
     // from internal hardware
@@ -6279,7 +6017,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_rd_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_rd_en_9_wd),
 
     // from internal hardware
@@ -6305,7 +6043,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_prog_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_prog_en_9_wd),
 
     // from internal hardware
@@ -6331,7 +6069,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_erase_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_erase_en_9_wd),
 
     // from internal hardware
@@ -6357,7 +6095,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_scramble_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_scramble_en_9_wd),
 
     // from internal hardware
@@ -6383,7 +6121,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_ecc_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_ecc_en_9_wd),
 
     // from internal hardware
@@ -6409,7 +6147,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_he_en_9_we & bank0_info0_regwen_9_qs),
+    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
     .wd     (bank0_info0_page_cfg_9_he_en_9_wd),
 
     // from internal hardware
@@ -6469,7 +6207,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_en_0_wd),
 
     // from internal hardware
@@ -6495,7 +6233,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_rd_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_rd_en_0_wd),
 
     // from internal hardware
@@ -6521,7 +6259,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_prog_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_prog_en_0_wd),
 
     // from internal hardware
@@ -6547,7 +6285,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_erase_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_erase_en_0_wd),
 
     // from internal hardware
@@ -6573,7 +6311,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_scramble_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_scramble_en_0_wd),
 
     // from internal hardware
@@ -6599,7 +6337,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_ecc_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_ecc_en_0_wd),
 
     // from internal hardware
@@ -6625,7 +6363,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_he_en_0_we & bank0_info1_regwen_qs),
+    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
     .wd     (bank0_info1_page_cfg_he_en_0_wd),
 
     // from internal hardware
@@ -6712,7 +6450,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -6738,7 +6476,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_rd_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -6764,7 +6502,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_prog_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -6790,7 +6528,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_erase_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -6816,7 +6554,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_scramble_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -6842,7 +6580,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_ecc_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -6868,7 +6606,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_he_en_0_we & bank0_info2_regwen_0_qs),
+    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
     .wd     (bank0_info2_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -6897,7 +6635,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -6923,7 +6661,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_rd_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -6949,7 +6687,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_prog_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -6975,7 +6713,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_erase_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -7001,7 +6739,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_scramble_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -7027,7 +6765,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_ecc_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -7053,7 +6791,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_he_en_1_we & bank0_info2_regwen_1_qs),
+    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
     .wd     (bank0_info2_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -7356,7 +7094,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -7382,7 +7120,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_rd_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -7408,7 +7146,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_prog_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -7434,7 +7172,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_erase_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -7460,7 +7198,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_scramble_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -7486,7 +7224,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_ecc_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -7512,7 +7250,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_he_en_0_we & bank1_info0_regwen_0_qs),
+    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
     .wd     (bank1_info0_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -7541,7 +7279,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -7567,7 +7305,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_rd_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -7593,7 +7331,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_prog_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -7619,7 +7357,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_erase_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -7645,7 +7383,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_scramble_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -7671,7 +7409,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_ecc_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -7697,7 +7435,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_he_en_1_we & bank1_info0_regwen_1_qs),
+    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
     .wd     (bank1_info0_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -7726,7 +7464,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_en_2_wd),
 
     // from internal hardware
@@ -7752,7 +7490,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_rd_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_rd_en_2_wd),
 
     // from internal hardware
@@ -7778,7 +7516,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_prog_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_prog_en_2_wd),
 
     // from internal hardware
@@ -7804,7 +7542,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_erase_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_erase_en_2_wd),
 
     // from internal hardware
@@ -7830,7 +7568,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_scramble_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_scramble_en_2_wd),
 
     // from internal hardware
@@ -7856,7 +7594,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_ecc_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_ecc_en_2_wd),
 
     // from internal hardware
@@ -7882,7 +7620,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_he_en_2_we & bank1_info0_regwen_2_qs),
+    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
     .wd     (bank1_info0_page_cfg_2_he_en_2_wd),
 
     // from internal hardware
@@ -7911,7 +7649,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_en_3_wd),
 
     // from internal hardware
@@ -7937,7 +7675,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_rd_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_rd_en_3_wd),
 
     // from internal hardware
@@ -7963,7 +7701,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_prog_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_prog_en_3_wd),
 
     // from internal hardware
@@ -7989,7 +7727,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_erase_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_erase_en_3_wd),
 
     // from internal hardware
@@ -8015,7 +7753,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_scramble_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_scramble_en_3_wd),
 
     // from internal hardware
@@ -8041,7 +7779,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_ecc_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_ecc_en_3_wd),
 
     // from internal hardware
@@ -8067,7 +7805,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_he_en_3_we & bank1_info0_regwen_3_qs),
+    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
     .wd     (bank1_info0_page_cfg_3_he_en_3_wd),
 
     // from internal hardware
@@ -8096,7 +7834,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_en_4_wd),
 
     // from internal hardware
@@ -8122,7 +7860,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_rd_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_rd_en_4_wd),
 
     // from internal hardware
@@ -8148,7 +7886,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_prog_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_prog_en_4_wd),
 
     // from internal hardware
@@ -8174,7 +7912,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_erase_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_erase_en_4_wd),
 
     // from internal hardware
@@ -8200,7 +7938,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_scramble_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_scramble_en_4_wd),
 
     // from internal hardware
@@ -8226,7 +7964,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_ecc_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_ecc_en_4_wd),
 
     // from internal hardware
@@ -8252,7 +7990,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_he_en_4_we & bank1_info0_regwen_4_qs),
+    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
     .wd     (bank1_info0_page_cfg_4_he_en_4_wd),
 
     // from internal hardware
@@ -8281,7 +8019,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_en_5_wd),
 
     // from internal hardware
@@ -8307,7 +8045,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_rd_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_rd_en_5_wd),
 
     // from internal hardware
@@ -8333,7 +8071,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_prog_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_prog_en_5_wd),
 
     // from internal hardware
@@ -8359,7 +8097,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_erase_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_erase_en_5_wd),
 
     // from internal hardware
@@ -8385,7 +8123,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_scramble_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_scramble_en_5_wd),
 
     // from internal hardware
@@ -8411,7 +8149,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_ecc_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_ecc_en_5_wd),
 
     // from internal hardware
@@ -8437,7 +8175,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_he_en_5_we & bank1_info0_regwen_5_qs),
+    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
     .wd     (bank1_info0_page_cfg_5_he_en_5_wd),
 
     // from internal hardware
@@ -8466,7 +8204,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_en_6_wd),
 
     // from internal hardware
@@ -8492,7 +8230,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_rd_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_rd_en_6_wd),
 
     // from internal hardware
@@ -8518,7 +8256,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_prog_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_prog_en_6_wd),
 
     // from internal hardware
@@ -8544,7 +8282,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_erase_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_erase_en_6_wd),
 
     // from internal hardware
@@ -8570,7 +8308,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_scramble_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_scramble_en_6_wd),
 
     // from internal hardware
@@ -8596,7 +8334,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_ecc_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_ecc_en_6_wd),
 
     // from internal hardware
@@ -8622,7 +8360,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_he_en_6_we & bank1_info0_regwen_6_qs),
+    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
     .wd     (bank1_info0_page_cfg_6_he_en_6_wd),
 
     // from internal hardware
@@ -8651,7 +8389,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_en_7_wd),
 
     // from internal hardware
@@ -8677,7 +8415,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_rd_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_rd_en_7_wd),
 
     // from internal hardware
@@ -8703,7 +8441,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_prog_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_prog_en_7_wd),
 
     // from internal hardware
@@ -8729,7 +8467,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_erase_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_erase_en_7_wd),
 
     // from internal hardware
@@ -8755,7 +8493,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_scramble_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_scramble_en_7_wd),
 
     // from internal hardware
@@ -8781,7 +8519,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_ecc_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_ecc_en_7_wd),
 
     // from internal hardware
@@ -8807,7 +8545,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_he_en_7_we & bank1_info0_regwen_7_qs),
+    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
     .wd     (bank1_info0_page_cfg_7_he_en_7_wd),
 
     // from internal hardware
@@ -8836,7 +8574,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_en_8_wd),
 
     // from internal hardware
@@ -8862,7 +8600,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_rd_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_rd_en_8_wd),
 
     // from internal hardware
@@ -8888,7 +8626,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_prog_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_prog_en_8_wd),
 
     // from internal hardware
@@ -8914,7 +8652,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_erase_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_erase_en_8_wd),
 
     // from internal hardware
@@ -8940,7 +8678,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_scramble_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_scramble_en_8_wd),
 
     // from internal hardware
@@ -8966,7 +8704,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_ecc_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_ecc_en_8_wd),
 
     // from internal hardware
@@ -8992,7 +8730,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_he_en_8_we & bank1_info0_regwen_8_qs),
+    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
     .wd     (bank1_info0_page_cfg_8_he_en_8_wd),
 
     // from internal hardware
@@ -9021,7 +8759,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_en_9_wd),
 
     // from internal hardware
@@ -9047,7 +8785,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_rd_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_rd_en_9_wd),
 
     // from internal hardware
@@ -9073,7 +8811,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_prog_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_prog_en_9_wd),
 
     // from internal hardware
@@ -9099,7 +8837,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_erase_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_erase_en_9_wd),
 
     // from internal hardware
@@ -9125,7 +8863,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_scramble_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_scramble_en_9_wd),
 
     // from internal hardware
@@ -9151,7 +8889,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_ecc_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_ecc_en_9_wd),
 
     // from internal hardware
@@ -9177,7 +8915,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_he_en_9_we & bank1_info0_regwen_9_qs),
+    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
     .wd     (bank1_info0_page_cfg_9_he_en_9_wd),
 
     // from internal hardware
@@ -9237,7 +8975,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_en_0_wd),
 
     // from internal hardware
@@ -9263,7 +9001,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_rd_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_rd_en_0_wd),
 
     // from internal hardware
@@ -9289,7 +9027,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_prog_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_prog_en_0_wd),
 
     // from internal hardware
@@ -9315,7 +9053,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_erase_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_erase_en_0_wd),
 
     // from internal hardware
@@ -9341,7 +9079,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_scramble_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_scramble_en_0_wd),
 
     // from internal hardware
@@ -9367,7 +9105,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_ecc_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_ecc_en_0_wd),
 
     // from internal hardware
@@ -9393,7 +9131,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_he_en_0_we & bank1_info1_regwen_qs),
+    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
     .wd     (bank1_info1_page_cfg_he_en_0_wd),
 
     // from internal hardware
@@ -9480,7 +9218,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_en_0_wd),
 
     // from internal hardware
@@ -9506,7 +9244,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_rd_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_rd_en_0_wd),
 
     // from internal hardware
@@ -9532,7 +9270,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_prog_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_prog_en_0_wd),
 
     // from internal hardware
@@ -9558,7 +9296,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_erase_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_erase_en_0_wd),
 
     // from internal hardware
@@ -9584,7 +9322,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_scramble_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_scramble_en_0_wd),
 
     // from internal hardware
@@ -9610,7 +9348,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_ecc_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_ecc_en_0_wd),
 
     // from internal hardware
@@ -9636,7 +9374,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_he_en_0_we & bank1_info2_regwen_0_qs),
+    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
     .wd     (bank1_info2_page_cfg_0_he_en_0_wd),
 
     // from internal hardware
@@ -9665,7 +9403,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_en_1_wd),
 
     // from internal hardware
@@ -9691,7 +9429,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_rd_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_rd_en_1_wd),
 
     // from internal hardware
@@ -9717,7 +9455,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_prog_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_prog_en_1_wd),
 
     // from internal hardware
@@ -9743,7 +9481,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_erase_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_erase_en_1_wd),
 
     // from internal hardware
@@ -9769,7 +9507,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_scramble_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_scramble_en_1_wd),
 
     // from internal hardware
@@ -9795,7 +9533,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_ecc_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_ecc_en_1_wd),
 
     // from internal hardware
@@ -9821,7 +9559,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_he_en_1_we & bank1_info2_regwen_1_qs),
+    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
     .wd     (bank1_info2_page_cfg_1_he_en_1_wd),
 
     // from internal hardware
@@ -9879,7 +9617,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_erase_en_0_we & bank_cfg_regwen_qs),
+    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
     .wd     (mp_bank_cfg_erase_en_0_wd),
 
     // from internal hardware
@@ -9905,7 +9643,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_erase_en_1_we & bank_cfg_regwen_qs),
+    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
     .wd     (mp_bank_cfg_erase_en_1_wd),
 
     // from internal hardware
@@ -9934,7 +9672,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (op_status_done_we),
+    .we     (op_status_we),
     .wd     (op_status_done_wd),
 
     // from internal hardware
@@ -9960,7 +9698,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (op_status_err_we),
+    .we     (op_status_we),
     .wd     (op_status_err_wd),
 
     // from internal hardware
@@ -10120,7 +9858,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_flash_err_en_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_flash_err_en_wd),
 
     // from internal hardware
@@ -10146,7 +9884,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_flash_alert_en_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_flash_alert_en_wd),
 
     // from internal hardware
@@ -10172,7 +9910,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_mp_err_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_mp_err_wd),
 
     // from internal hardware
@@ -10198,7 +9936,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_ecc_single_err_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_ecc_single_err_wd),
 
     // from internal hardware
@@ -10224,7 +9962,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_intr_en_ecc_multi_err_we),
+    .we     (err_code_intr_en_we),
     .wd     (err_code_intr_en_ecc_multi_err_wd),
 
     // from internal hardware
@@ -10252,7 +9990,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_flash_err_we),
+    .we     (err_code_we),
     .wd     (err_code_flash_err_wd),
 
     // from internal hardware
@@ -10278,7 +10016,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_flash_alert_we),
+    .we     (err_code_we),
     .wd     (err_code_flash_alert_wd),
 
     // from internal hardware
@@ -10304,7 +10042,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_mp_err_we),
+    .we     (err_code_we),
     .wd     (err_code_mp_err_wd),
 
     // from internal hardware
@@ -10330,7 +10068,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_ecc_single_err_we),
+    .we     (err_code_we),
     .wd     (err_code_ecc_single_err_wd),
 
     // from internal hardware
@@ -10356,7 +10094,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (err_code_ecc_multi_err_we),
+    .we     (err_code_we),
     .wd     (err_code_ecc_multi_err_wd),
 
     // from internal hardware
@@ -10631,7 +10369,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_alert_cfg_alert_ack_we),
+    .we     (phy_alert_cfg_we),
     .wd     (phy_alert_cfg_alert_ack_wd),
 
     // from internal hardware
@@ -10657,7 +10395,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (phy_alert_cfg_alert_trig_we),
+    .we     (phy_alert_cfg_we),
     .wd     (phy_alert_cfg_alert_trig_wd),
 
     // from internal hardware
@@ -10792,7 +10530,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_lvl_prog_we),
+    .we     (fifo_lvl_we),
     .wd     (fifo_lvl_prog_wd),
 
     // from internal hardware
@@ -10818,7 +10556,7 @@ module flash_ctrl_core_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (fifo_lvl_rd_we),
+    .we     (fifo_lvl_we),
     .wd     (fifo_lvl_rd_wd),
 
     // from internal hardware
@@ -11072,1066 +10810,803 @@ module flash_ctrl_core_reg_top (
                (addr_hit[97] & (|(FLASH_CTRL_CORE_PERMIT[97] & ~reg_be))) |
                (addr_hit[98] & (|(FLASH_CTRL_CORE_PERMIT[98] & ~reg_be)))));
   end
+  assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign intr_state_prog_empty_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_empty_wd = reg_wdata[0];
 
-  assign intr_state_prog_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_state_rd_full_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_full_wd = reg_wdata[2];
 
-  assign intr_state_rd_lvl_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_state_op_done_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_op_done_wd = reg_wdata[4];
 
-  assign intr_state_err_we = addr_hit[0] & reg_we & !reg_error;
   assign intr_state_err_wd = reg_wdata[5];
+  assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign intr_enable_prog_empty_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_empty_wd = reg_wdata[0];
 
-  assign intr_enable_prog_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_enable_rd_full_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_full_wd = reg_wdata[2];
 
-  assign intr_enable_rd_lvl_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_enable_op_done_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_op_done_wd = reg_wdata[4];
 
-  assign intr_enable_err_we = addr_hit[1] & reg_we & !reg_error;
   assign intr_enable_err_wd = reg_wdata[5];
+  assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign intr_test_prog_empty_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_empty_wd = reg_wdata[0];
 
-  assign intr_test_prog_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_prog_lvl_wd = reg_wdata[1];
 
-  assign intr_test_rd_full_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_full_wd = reg_wdata[2];
 
-  assign intr_test_rd_lvl_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_rd_lvl_wd = reg_wdata[3];
 
-  assign intr_test_op_done_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_op_done_wd = reg_wdata[4];
 
-  assign intr_test_err_we = addr_hit[2] & reg_we & !reg_error;
   assign intr_test_err_wd = reg_wdata[5];
+  assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_test_recov_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_err_wd = reg_wdata[0];
 
-  assign alert_test_recov_mp_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_mp_err_wd = reg_wdata[1];
 
-  assign alert_test_recov_ecc_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_recov_ecc_err_wd = reg_wdata[2];
 
-  assign alert_test_fatal_intg_err_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_test_fatal_intg_err_wd = reg_wdata[3];
-
   assign init_we = addr_hit[4] & reg_we & !reg_error;
+
   assign init_wd = reg_wdata[0];
-
   assign ctrl_regwen_re = addr_hit[5] & reg_re & !reg_error;
+  assign control_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign control_start_we = addr_hit[6] & reg_we & !reg_error;
   assign control_start_wd = reg_wdata[0];
 
-  assign control_op_we = addr_hit[6] & reg_we & !reg_error;
   assign control_op_wd = reg_wdata[5:4];
 
-  assign control_prog_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_prog_sel_wd = reg_wdata[6];
 
-  assign control_erase_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_erase_sel_wd = reg_wdata[7];
 
-  assign control_partition_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_partition_sel_wd = reg_wdata[8];
 
-  assign control_info_sel_we = addr_hit[6] & reg_we & !reg_error;
   assign control_info_sel_wd = reg_wdata[10:9];
 
-  assign control_num_we = addr_hit[6] & reg_we & !reg_error;
   assign control_num_wd = reg_wdata[27:16];
-
   assign addr_we = addr_hit[7] & reg_we & !reg_error;
-  assign addr_wd = reg_wdata[31:0];
 
-  assign prog_type_en_normal_we = addr_hit[8] & reg_we & !reg_error;
+  assign addr_wd = reg_wdata[31:0];
+  assign prog_type_en_we = addr_hit[8] & reg_we & !reg_error;
+
   assign prog_type_en_normal_wd = reg_wdata[0];
 
-  assign prog_type_en_repair_we = addr_hit[8] & reg_we & !reg_error;
   assign prog_type_en_repair_wd = reg_wdata[1];
-
   assign erase_suspend_we = addr_hit[9] & reg_we & !reg_error;
+
   assign erase_suspend_wd = reg_wdata[0];
-
   assign region_cfg_regwen_0_we = addr_hit[10] & reg_we & !reg_error;
+
   assign region_cfg_regwen_0_wd = reg_wdata[0];
-
   assign region_cfg_regwen_1_we = addr_hit[11] & reg_we & !reg_error;
+
   assign region_cfg_regwen_1_wd = reg_wdata[0];
-
   assign region_cfg_regwen_2_we = addr_hit[12] & reg_we & !reg_error;
+
   assign region_cfg_regwen_2_wd = reg_wdata[0];
-
   assign region_cfg_regwen_3_we = addr_hit[13] & reg_we & !reg_error;
+
   assign region_cfg_regwen_3_wd = reg_wdata[0];
-
   assign region_cfg_regwen_4_we = addr_hit[14] & reg_we & !reg_error;
+
   assign region_cfg_regwen_4_wd = reg_wdata[0];
-
   assign region_cfg_regwen_5_we = addr_hit[15] & reg_we & !reg_error;
+
   assign region_cfg_regwen_5_wd = reg_wdata[0];
-
   assign region_cfg_regwen_6_we = addr_hit[16] & reg_we & !reg_error;
+
   assign region_cfg_regwen_6_wd = reg_wdata[0];
-
   assign region_cfg_regwen_7_we = addr_hit[17] & reg_we & !reg_error;
-  assign region_cfg_regwen_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_en_0_we = addr_hit[18] & reg_we & !reg_error;
+  assign region_cfg_regwen_7_wd = reg_wdata[0];
+  assign mp_region_cfg_0_we = addr_hit[18] & reg_we & !reg_error;
+
   assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_we = addr_hit[18] & reg_we & !reg_error;
   assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
+  assign mp_region_cfg_1_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign mp_region_cfg_1_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_we = addr_hit[19] & reg_we & !reg_error;
   assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
+  assign mp_region_cfg_2_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign mp_region_cfg_2_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_we = addr_hit[20] & reg_we & !reg_error;
   assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
+  assign mp_region_cfg_3_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign mp_region_cfg_3_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_we = addr_hit[21] & reg_we & !reg_error;
   assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
+  assign mp_region_cfg_4_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign mp_region_cfg_4_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_we = addr_hit[22] & reg_we & !reg_error;
   assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
+  assign mp_region_cfg_5_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign mp_region_cfg_5_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_we = addr_hit[23] & reg_we & !reg_error;
   assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
+  assign mp_region_cfg_6_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign mp_region_cfg_6_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_we = addr_hit[24] & reg_we & !reg_error;
   assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
+  assign mp_region_cfg_7_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign mp_region_cfg_7_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_we = addr_hit[25] & reg_we & !reg_error;
   assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
+  assign default_region_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign default_region_rd_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_we = addr_hit[26] & reg_we & !reg_error;
   assign default_region_he_en_wd = reg_wdata[5];
-
   assign bank0_info0_regwen_0_we = addr_hit[27] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_1_we = addr_hit[28] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_1_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_2_we = addr_hit[29] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_2_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_3_we = addr_hit[30] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_3_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_4_we = addr_hit[31] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_4_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_5_we = addr_hit[32] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_5_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_6_we = addr_hit[33] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_6_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_7_we = addr_hit[34] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_7_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_8_we = addr_hit[35] & reg_we & !reg_error;
+
   assign bank0_info0_regwen_8_wd = reg_wdata[0];
-
   assign bank0_info0_regwen_9_we = addr_hit[36] & reg_we & !reg_error;
-  assign bank0_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_en_0_we = addr_hit[37] & reg_we & !reg_error;
+  assign bank0_info0_regwen_9_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_0_we = addr_hit[37] & reg_we & !reg_error;
+
   assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_we = addr_hit[37] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_1_we = addr_hit[38] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_1_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_we = addr_hit[38] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_2_we = addr_hit[39] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_2_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_we = addr_hit[39] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_3_we = addr_hit[40] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_3_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_we = addr_hit[40] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_4_we = addr_hit[41] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_4_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_we = addr_hit[41] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_5_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_5_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_we = addr_hit[42] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_6_we = addr_hit[43] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_6_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_we = addr_hit[43] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_7_we = addr_hit[44] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_7_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_we = addr_hit[44] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_8_we = addr_hit[45] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_8_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_we = addr_hit[45] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_9_we = addr_hit[46] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_9_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_we = addr_hit[46] & reg_we & !reg_error;
   assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
-
   assign bank0_info1_regwen_we = addr_hit[47] & reg_we & !reg_error;
-  assign bank0_info1_regwen_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_en_0_we = addr_hit[48] & reg_we & !reg_error;
+  assign bank0_info1_regwen_wd = reg_wdata[0];
+  assign bank0_info1_page_cfg_we = addr_hit[48] & reg_we & !reg_error;
+
   assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_we = addr_hit[48] & reg_we & !reg_error;
   assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
-
   assign bank0_info2_regwen_0_we = addr_hit[49] & reg_we & !reg_error;
+
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
-
   assign bank0_info2_regwen_1_we = addr_hit[50] & reg_we & !reg_error;
-  assign bank0_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_en_0_we = addr_hit[51] & reg_we & !reg_error;
+  assign bank0_info2_regwen_1_wd = reg_wdata[0];
+  assign bank0_info2_page_cfg_0_we = addr_hit[51] & reg_we & !reg_error;
+
   assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_we = addr_hit[51] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info2_page_cfg_1_we = addr_hit[52] & reg_we & !reg_error;
 
-  assign bank0_info2_page_cfg_1_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_we = addr_hit[52] & reg_we & !reg_error;
   assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
-
   assign bank1_info0_regwen_0_we = addr_hit[53] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_1_we = addr_hit[54] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_1_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_2_we = addr_hit[55] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_2_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_3_we = addr_hit[56] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_3_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_4_we = addr_hit[57] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_4_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_5_we = addr_hit[58] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_5_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_6_we = addr_hit[59] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_6_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_7_we = addr_hit[60] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_7_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_8_we = addr_hit[61] & reg_we & !reg_error;
+
   assign bank1_info0_regwen_8_wd = reg_wdata[0];
-
   assign bank1_info0_regwen_9_we = addr_hit[62] & reg_we & !reg_error;
-  assign bank1_info0_regwen_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_en_0_we = addr_hit[63] & reg_we & !reg_error;
+  assign bank1_info0_regwen_9_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_0_we = addr_hit[63] & reg_we & !reg_error;
+
   assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_we = addr_hit[63] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_1_we = addr_hit[64] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_1_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_we = addr_hit[64] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_2_we = addr_hit[65] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_2_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_we = addr_hit[65] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_3_we = addr_hit[66] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_3_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_we = addr_hit[66] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_4_we = addr_hit[67] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_4_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_we = addr_hit[67] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_5_we = addr_hit[68] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_5_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_we = addr_hit[68] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_6_we = addr_hit[69] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_6_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_we = addr_hit[69] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_7_we = addr_hit[70] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_7_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_we = addr_hit[70] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_8_we = addr_hit[71] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_8_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_we = addr_hit[71] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_9_we = addr_hit[72] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_9_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_we = addr_hit[72] & reg_we & !reg_error;
   assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
-
   assign bank1_info1_regwen_we = addr_hit[73] & reg_we & !reg_error;
-  assign bank1_info1_regwen_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_en_0_we = addr_hit[74] & reg_we & !reg_error;
+  assign bank1_info1_regwen_wd = reg_wdata[0];
+  assign bank1_info1_page_cfg_we = addr_hit[74] & reg_we & !reg_error;
+
   assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_we = addr_hit[74] & reg_we & !reg_error;
   assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
-
   assign bank1_info2_regwen_0_we = addr_hit[75] & reg_we & !reg_error;
+
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
-
   assign bank1_info2_regwen_1_we = addr_hit[76] & reg_we & !reg_error;
-  assign bank1_info2_regwen_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_en_0_we = addr_hit[77] & reg_we & !reg_error;
+  assign bank1_info2_regwen_1_wd = reg_wdata[0];
+  assign bank1_info2_page_cfg_0_we = addr_hit[77] & reg_we & !reg_error;
+
   assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_we = addr_hit[77] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info2_page_cfg_1_we = addr_hit[78] & reg_we & !reg_error;
 
-  assign bank1_info2_page_cfg_1_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_we = addr_hit[78] & reg_we & !reg_error;
   assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
-
   assign bank_cfg_regwen_we = addr_hit[79] & reg_we & !reg_error;
-  assign bank_cfg_regwen_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_0_we = addr_hit[80] & reg_we & !reg_error;
+  assign bank_cfg_regwen_wd = reg_wdata[0];
+  assign mp_bank_cfg_we = addr_hit[80] & reg_we & !reg_error;
+
   assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_we = addr_hit[80] & reg_we & !reg_error;
   assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
+  assign op_status_we = addr_hit[81] & reg_we & !reg_error;
 
-  assign op_status_done_we = addr_hit[81] & reg_we & !reg_error;
   assign op_status_done_wd = reg_wdata[0];
 
-  assign op_status_err_we = addr_hit[81] & reg_we & !reg_error;
   assign op_status_err_wd = reg_wdata[1];
+  assign err_code_intr_en_we = addr_hit[83] & reg_we & !reg_error;
 
-  assign err_code_intr_en_flash_err_en_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_flash_err_en_wd = reg_wdata[0];
 
-  assign err_code_intr_en_flash_alert_en_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_flash_alert_en_wd = reg_wdata[1];
 
-  assign err_code_intr_en_mp_err_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_mp_err_wd = reg_wdata[2];
 
-  assign err_code_intr_en_ecc_single_err_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_ecc_single_err_wd = reg_wdata[3];
 
-  assign err_code_intr_en_ecc_multi_err_we = addr_hit[83] & reg_we & !reg_error;
   assign err_code_intr_en_ecc_multi_err_wd = reg_wdata[4];
+  assign err_code_we = addr_hit[84] & reg_we & !reg_error;
 
-  assign err_code_flash_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_flash_err_wd = reg_wdata[0];
 
-  assign err_code_flash_alert_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_flash_alert_wd = reg_wdata[1];
 
-  assign err_code_mp_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_mp_err_wd = reg_wdata[2];
 
-  assign err_code_ecc_single_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_ecc_single_err_wd = reg_wdata[3];
 
-  assign err_code_ecc_multi_err_we = addr_hit[84] & reg_we & !reg_error;
   assign err_code_ecc_multi_err_wd = reg_wdata[4];
-
   assign ecc_single_err_cnt_we = addr_hit[86] & reg_we & !reg_error;
+
   assign ecc_single_err_cnt_wd = reg_wdata[7:0];
-
   assign ecc_multi_err_cnt_we = addr_hit[89] & reg_we & !reg_error;
+
   assign ecc_multi_err_cnt_wd = reg_wdata[7:0];
-
   assign phy_err_cfg_regwen_we = addr_hit[92] & reg_we & !reg_error;
+
   assign phy_err_cfg_regwen_wd = reg_wdata[0];
-
   assign phy_err_cfg_we = addr_hit[93] & reg_we & !reg_error;
-  assign phy_err_cfg_wd = reg_wdata[0];
 
-  assign phy_alert_cfg_alert_ack_we = addr_hit[94] & reg_we & !reg_error;
+  assign phy_err_cfg_wd = reg_wdata[0];
+  assign phy_alert_cfg_we = addr_hit[94] & reg_we & !reg_error;
+
   assign phy_alert_cfg_alert_ack_wd = reg_wdata[0];
 
-  assign phy_alert_cfg_alert_trig_we = addr_hit[94] & reg_we & !reg_error;
   assign phy_alert_cfg_alert_trig_wd = reg_wdata[1];
-
   assign scratch_we = addr_hit[96] & reg_we & !reg_error;
-  assign scratch_wd = reg_wdata[31:0];
 
-  assign fifo_lvl_prog_we = addr_hit[97] & reg_we & !reg_error;
+  assign scratch_wd = reg_wdata[31:0];
+  assign fifo_lvl_we = addr_hit[97] & reg_we & !reg_error;
+
   assign fifo_lvl_prog_wd = reg_wdata[4:0];
 
-  assign fifo_lvl_rd_we = addr_hit[97] & reg_we & !reg_error;
   assign fifo_lvl_rd_wd = reg_wdata[12:8];
-
   assign fifo_rst_we = addr_hit[98] & reg_we & !reg_error;
+
   assign fifo_rst_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -104,2175 +104,2077 @@ module pinmux_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic alert_test_wd;
   logic alert_test_we;
+  logic alert_test_wd;
+  logic mio_periph_insel_regwen_0_we;
   logic mio_periph_insel_regwen_0_qs;
   logic mio_periph_insel_regwen_0_wd;
-  logic mio_periph_insel_regwen_0_we;
+  logic mio_periph_insel_regwen_1_we;
   logic mio_periph_insel_regwen_1_qs;
   logic mio_periph_insel_regwen_1_wd;
-  logic mio_periph_insel_regwen_1_we;
+  logic mio_periph_insel_regwen_2_we;
   logic mio_periph_insel_regwen_2_qs;
   logic mio_periph_insel_regwen_2_wd;
-  logic mio_periph_insel_regwen_2_we;
+  logic mio_periph_insel_regwen_3_we;
   logic mio_periph_insel_regwen_3_qs;
   logic mio_periph_insel_regwen_3_wd;
-  logic mio_periph_insel_regwen_3_we;
+  logic mio_periph_insel_regwen_4_we;
   logic mio_periph_insel_regwen_4_qs;
   logic mio_periph_insel_regwen_4_wd;
-  logic mio_periph_insel_regwen_4_we;
+  logic mio_periph_insel_regwen_5_we;
   logic mio_periph_insel_regwen_5_qs;
   logic mio_periph_insel_regwen_5_wd;
-  logic mio_periph_insel_regwen_5_we;
+  logic mio_periph_insel_regwen_6_we;
   logic mio_periph_insel_regwen_6_qs;
   logic mio_periph_insel_regwen_6_wd;
-  logic mio_periph_insel_regwen_6_we;
+  logic mio_periph_insel_regwen_7_we;
   logic mio_periph_insel_regwen_7_qs;
   logic mio_periph_insel_regwen_7_wd;
-  logic mio_periph_insel_regwen_7_we;
+  logic mio_periph_insel_regwen_8_we;
   logic mio_periph_insel_regwen_8_qs;
   logic mio_periph_insel_regwen_8_wd;
-  logic mio_periph_insel_regwen_8_we;
+  logic mio_periph_insel_regwen_9_we;
   logic mio_periph_insel_regwen_9_qs;
   logic mio_periph_insel_regwen_9_wd;
-  logic mio_periph_insel_regwen_9_we;
+  logic mio_periph_insel_regwen_10_we;
   logic mio_periph_insel_regwen_10_qs;
   logic mio_periph_insel_regwen_10_wd;
-  logic mio_periph_insel_regwen_10_we;
+  logic mio_periph_insel_regwen_11_we;
   logic mio_periph_insel_regwen_11_qs;
   logic mio_periph_insel_regwen_11_wd;
-  logic mio_periph_insel_regwen_11_we;
+  logic mio_periph_insel_regwen_12_we;
   logic mio_periph_insel_regwen_12_qs;
   logic mio_periph_insel_regwen_12_wd;
-  logic mio_periph_insel_regwen_12_we;
+  logic mio_periph_insel_regwen_13_we;
   logic mio_periph_insel_regwen_13_qs;
   logic mio_periph_insel_regwen_13_wd;
-  logic mio_periph_insel_regwen_13_we;
+  logic mio_periph_insel_regwen_14_we;
   logic mio_periph_insel_regwen_14_qs;
   logic mio_periph_insel_regwen_14_wd;
-  logic mio_periph_insel_regwen_14_we;
+  logic mio_periph_insel_regwen_15_we;
   logic mio_periph_insel_regwen_15_qs;
   logic mio_periph_insel_regwen_15_wd;
-  logic mio_periph_insel_regwen_15_we;
+  logic mio_periph_insel_regwen_16_we;
   logic mio_periph_insel_regwen_16_qs;
   logic mio_periph_insel_regwen_16_wd;
-  logic mio_periph_insel_regwen_16_we;
+  logic mio_periph_insel_regwen_17_we;
   logic mio_periph_insel_regwen_17_qs;
   logic mio_periph_insel_regwen_17_wd;
-  logic mio_periph_insel_regwen_17_we;
+  logic mio_periph_insel_regwen_18_we;
   logic mio_periph_insel_regwen_18_qs;
   logic mio_periph_insel_regwen_18_wd;
-  logic mio_periph_insel_regwen_18_we;
+  logic mio_periph_insel_regwen_19_we;
   logic mio_periph_insel_regwen_19_qs;
   logic mio_periph_insel_regwen_19_wd;
-  logic mio_periph_insel_regwen_19_we;
+  logic mio_periph_insel_regwen_20_we;
   logic mio_periph_insel_regwen_20_qs;
   logic mio_periph_insel_regwen_20_wd;
-  logic mio_periph_insel_regwen_20_we;
+  logic mio_periph_insel_regwen_21_we;
   logic mio_periph_insel_regwen_21_qs;
   logic mio_periph_insel_regwen_21_wd;
-  logic mio_periph_insel_regwen_21_we;
+  logic mio_periph_insel_regwen_22_we;
   logic mio_periph_insel_regwen_22_qs;
   logic mio_periph_insel_regwen_22_wd;
-  logic mio_periph_insel_regwen_22_we;
+  logic mio_periph_insel_regwen_23_we;
   logic mio_periph_insel_regwen_23_qs;
   logic mio_periph_insel_regwen_23_wd;
-  logic mio_periph_insel_regwen_23_we;
+  logic mio_periph_insel_regwen_24_we;
   logic mio_periph_insel_regwen_24_qs;
   logic mio_periph_insel_regwen_24_wd;
-  logic mio_periph_insel_regwen_24_we;
+  logic mio_periph_insel_regwen_25_we;
   logic mio_periph_insel_regwen_25_qs;
   logic mio_periph_insel_regwen_25_wd;
-  logic mio_periph_insel_regwen_25_we;
+  logic mio_periph_insel_regwen_26_we;
   logic mio_periph_insel_regwen_26_qs;
   logic mio_periph_insel_regwen_26_wd;
-  logic mio_periph_insel_regwen_26_we;
+  logic mio_periph_insel_regwen_27_we;
   logic mio_periph_insel_regwen_27_qs;
   logic mio_periph_insel_regwen_27_wd;
-  logic mio_periph_insel_regwen_27_we;
+  logic mio_periph_insel_regwen_28_we;
   logic mio_periph_insel_regwen_28_qs;
   logic mio_periph_insel_regwen_28_wd;
-  logic mio_periph_insel_regwen_28_we;
+  logic mio_periph_insel_regwen_29_we;
   logic mio_periph_insel_regwen_29_qs;
   logic mio_periph_insel_regwen_29_wd;
-  logic mio_periph_insel_regwen_29_we;
+  logic mio_periph_insel_regwen_30_we;
   logic mio_periph_insel_regwen_30_qs;
   logic mio_periph_insel_regwen_30_wd;
-  logic mio_periph_insel_regwen_30_we;
+  logic mio_periph_insel_regwen_31_we;
   logic mio_periph_insel_regwen_31_qs;
   logic mio_periph_insel_regwen_31_wd;
-  logic mio_periph_insel_regwen_31_we;
+  logic mio_periph_insel_regwen_32_we;
   logic mio_periph_insel_regwen_32_qs;
   logic mio_periph_insel_regwen_32_wd;
-  logic mio_periph_insel_regwen_32_we;
+  logic mio_periph_insel_regwen_33_we;
   logic mio_periph_insel_regwen_33_qs;
   logic mio_periph_insel_regwen_33_wd;
-  logic mio_periph_insel_regwen_33_we;
+  logic mio_periph_insel_regwen_34_we;
   logic mio_periph_insel_regwen_34_qs;
   logic mio_periph_insel_regwen_34_wd;
-  logic mio_periph_insel_regwen_34_we;
+  logic mio_periph_insel_regwen_35_we;
   logic mio_periph_insel_regwen_35_qs;
   logic mio_periph_insel_regwen_35_wd;
-  logic mio_periph_insel_regwen_35_we;
+  logic mio_periph_insel_regwen_36_we;
   logic mio_periph_insel_regwen_36_qs;
   logic mio_periph_insel_regwen_36_wd;
-  logic mio_periph_insel_regwen_36_we;
+  logic mio_periph_insel_regwen_37_we;
   logic mio_periph_insel_regwen_37_qs;
   logic mio_periph_insel_regwen_37_wd;
-  logic mio_periph_insel_regwen_37_we;
+  logic mio_periph_insel_regwen_38_we;
   logic mio_periph_insel_regwen_38_qs;
   logic mio_periph_insel_regwen_38_wd;
-  logic mio_periph_insel_regwen_38_we;
+  logic mio_periph_insel_regwen_39_we;
   logic mio_periph_insel_regwen_39_qs;
   logic mio_periph_insel_regwen_39_wd;
-  logic mio_periph_insel_regwen_39_we;
+  logic mio_periph_insel_regwen_40_we;
   logic mio_periph_insel_regwen_40_qs;
   logic mio_periph_insel_regwen_40_wd;
-  logic mio_periph_insel_regwen_40_we;
+  logic mio_periph_insel_regwen_41_we;
   logic mio_periph_insel_regwen_41_qs;
   logic mio_periph_insel_regwen_41_wd;
-  logic mio_periph_insel_regwen_41_we;
+  logic mio_periph_insel_regwen_42_we;
   logic mio_periph_insel_regwen_42_qs;
   logic mio_periph_insel_regwen_42_wd;
-  logic mio_periph_insel_regwen_42_we;
+  logic mio_periph_insel_regwen_43_we;
   logic mio_periph_insel_regwen_43_qs;
   logic mio_periph_insel_regwen_43_wd;
-  logic mio_periph_insel_regwen_43_we;
+  logic mio_periph_insel_regwen_44_we;
   logic mio_periph_insel_regwen_44_qs;
   logic mio_periph_insel_regwen_44_wd;
-  logic mio_periph_insel_regwen_44_we;
+  logic mio_periph_insel_regwen_45_we;
   logic mio_periph_insel_regwen_45_qs;
   logic mio_periph_insel_regwen_45_wd;
-  logic mio_periph_insel_regwen_45_we;
+  logic mio_periph_insel_regwen_46_we;
   logic mio_periph_insel_regwen_46_qs;
   logic mio_periph_insel_regwen_46_wd;
-  logic mio_periph_insel_regwen_46_we;
+  logic mio_periph_insel_regwen_47_we;
   logic mio_periph_insel_regwen_47_qs;
   logic mio_periph_insel_regwen_47_wd;
-  logic mio_periph_insel_regwen_47_we;
+  logic mio_periph_insel_regwen_48_we;
   logic mio_periph_insel_regwen_48_qs;
   logic mio_periph_insel_regwen_48_wd;
-  logic mio_periph_insel_regwen_48_we;
+  logic mio_periph_insel_regwen_49_we;
   logic mio_periph_insel_regwen_49_qs;
   logic mio_periph_insel_regwen_49_wd;
-  logic mio_periph_insel_regwen_49_we;
+  logic mio_periph_insel_regwen_50_we;
   logic mio_periph_insel_regwen_50_qs;
   logic mio_periph_insel_regwen_50_wd;
-  logic mio_periph_insel_regwen_50_we;
+  logic mio_periph_insel_regwen_51_we;
   logic mio_periph_insel_regwen_51_qs;
   logic mio_periph_insel_regwen_51_wd;
-  logic mio_periph_insel_regwen_51_we;
+  logic mio_periph_insel_regwen_52_we;
   logic mio_periph_insel_regwen_52_qs;
   logic mio_periph_insel_regwen_52_wd;
-  logic mio_periph_insel_regwen_52_we;
+  logic mio_periph_insel_regwen_53_we;
   logic mio_periph_insel_regwen_53_qs;
   logic mio_periph_insel_regwen_53_wd;
-  logic mio_periph_insel_regwen_53_we;
+  logic mio_periph_insel_regwen_54_we;
   logic mio_periph_insel_regwen_54_qs;
   logic mio_periph_insel_regwen_54_wd;
-  logic mio_periph_insel_regwen_54_we;
+  logic mio_periph_insel_regwen_55_we;
   logic mio_periph_insel_regwen_55_qs;
   logic mio_periph_insel_regwen_55_wd;
-  logic mio_periph_insel_regwen_55_we;
+  logic mio_periph_insel_0_we;
   logic [5:0] mio_periph_insel_0_qs;
   logic [5:0] mio_periph_insel_0_wd;
-  logic mio_periph_insel_0_we;
+  logic mio_periph_insel_1_we;
   logic [5:0] mio_periph_insel_1_qs;
   logic [5:0] mio_periph_insel_1_wd;
-  logic mio_periph_insel_1_we;
+  logic mio_periph_insel_2_we;
   logic [5:0] mio_periph_insel_2_qs;
   logic [5:0] mio_periph_insel_2_wd;
-  logic mio_periph_insel_2_we;
+  logic mio_periph_insel_3_we;
   logic [5:0] mio_periph_insel_3_qs;
   logic [5:0] mio_periph_insel_3_wd;
-  logic mio_periph_insel_3_we;
+  logic mio_periph_insel_4_we;
   logic [5:0] mio_periph_insel_4_qs;
   logic [5:0] mio_periph_insel_4_wd;
-  logic mio_periph_insel_4_we;
+  logic mio_periph_insel_5_we;
   logic [5:0] mio_periph_insel_5_qs;
   logic [5:0] mio_periph_insel_5_wd;
-  logic mio_periph_insel_5_we;
+  logic mio_periph_insel_6_we;
   logic [5:0] mio_periph_insel_6_qs;
   logic [5:0] mio_periph_insel_6_wd;
-  logic mio_periph_insel_6_we;
+  logic mio_periph_insel_7_we;
   logic [5:0] mio_periph_insel_7_qs;
   logic [5:0] mio_periph_insel_7_wd;
-  logic mio_periph_insel_7_we;
+  logic mio_periph_insel_8_we;
   logic [5:0] mio_periph_insel_8_qs;
   logic [5:0] mio_periph_insel_8_wd;
-  logic mio_periph_insel_8_we;
+  logic mio_periph_insel_9_we;
   logic [5:0] mio_periph_insel_9_qs;
   logic [5:0] mio_periph_insel_9_wd;
-  logic mio_periph_insel_9_we;
+  logic mio_periph_insel_10_we;
   logic [5:0] mio_periph_insel_10_qs;
   logic [5:0] mio_periph_insel_10_wd;
-  logic mio_periph_insel_10_we;
+  logic mio_periph_insel_11_we;
   logic [5:0] mio_periph_insel_11_qs;
   logic [5:0] mio_periph_insel_11_wd;
-  logic mio_periph_insel_11_we;
+  logic mio_periph_insel_12_we;
   logic [5:0] mio_periph_insel_12_qs;
   logic [5:0] mio_periph_insel_12_wd;
-  logic mio_periph_insel_12_we;
+  logic mio_periph_insel_13_we;
   logic [5:0] mio_periph_insel_13_qs;
   logic [5:0] mio_periph_insel_13_wd;
-  logic mio_periph_insel_13_we;
+  logic mio_periph_insel_14_we;
   logic [5:0] mio_periph_insel_14_qs;
   logic [5:0] mio_periph_insel_14_wd;
-  logic mio_periph_insel_14_we;
+  logic mio_periph_insel_15_we;
   logic [5:0] mio_periph_insel_15_qs;
   logic [5:0] mio_periph_insel_15_wd;
-  logic mio_periph_insel_15_we;
+  logic mio_periph_insel_16_we;
   logic [5:0] mio_periph_insel_16_qs;
   logic [5:0] mio_periph_insel_16_wd;
-  logic mio_periph_insel_16_we;
+  logic mio_periph_insel_17_we;
   logic [5:0] mio_periph_insel_17_qs;
   logic [5:0] mio_periph_insel_17_wd;
-  logic mio_periph_insel_17_we;
+  logic mio_periph_insel_18_we;
   logic [5:0] mio_periph_insel_18_qs;
   logic [5:0] mio_periph_insel_18_wd;
-  logic mio_periph_insel_18_we;
+  logic mio_periph_insel_19_we;
   logic [5:0] mio_periph_insel_19_qs;
   logic [5:0] mio_periph_insel_19_wd;
-  logic mio_periph_insel_19_we;
+  logic mio_periph_insel_20_we;
   logic [5:0] mio_periph_insel_20_qs;
   logic [5:0] mio_periph_insel_20_wd;
-  logic mio_periph_insel_20_we;
+  logic mio_periph_insel_21_we;
   logic [5:0] mio_periph_insel_21_qs;
   logic [5:0] mio_periph_insel_21_wd;
-  logic mio_periph_insel_21_we;
+  logic mio_periph_insel_22_we;
   logic [5:0] mio_periph_insel_22_qs;
   logic [5:0] mio_periph_insel_22_wd;
-  logic mio_periph_insel_22_we;
+  logic mio_periph_insel_23_we;
   logic [5:0] mio_periph_insel_23_qs;
   logic [5:0] mio_periph_insel_23_wd;
-  logic mio_periph_insel_23_we;
+  logic mio_periph_insel_24_we;
   logic [5:0] mio_periph_insel_24_qs;
   logic [5:0] mio_periph_insel_24_wd;
-  logic mio_periph_insel_24_we;
+  logic mio_periph_insel_25_we;
   logic [5:0] mio_periph_insel_25_qs;
   logic [5:0] mio_periph_insel_25_wd;
-  logic mio_periph_insel_25_we;
+  logic mio_periph_insel_26_we;
   logic [5:0] mio_periph_insel_26_qs;
   logic [5:0] mio_periph_insel_26_wd;
-  logic mio_periph_insel_26_we;
+  logic mio_periph_insel_27_we;
   logic [5:0] mio_periph_insel_27_qs;
   logic [5:0] mio_periph_insel_27_wd;
-  logic mio_periph_insel_27_we;
+  logic mio_periph_insel_28_we;
   logic [5:0] mio_periph_insel_28_qs;
   logic [5:0] mio_periph_insel_28_wd;
-  logic mio_periph_insel_28_we;
+  logic mio_periph_insel_29_we;
   logic [5:0] mio_periph_insel_29_qs;
   logic [5:0] mio_periph_insel_29_wd;
-  logic mio_periph_insel_29_we;
+  logic mio_periph_insel_30_we;
   logic [5:0] mio_periph_insel_30_qs;
   logic [5:0] mio_periph_insel_30_wd;
-  logic mio_periph_insel_30_we;
+  logic mio_periph_insel_31_we;
   logic [5:0] mio_periph_insel_31_qs;
   logic [5:0] mio_periph_insel_31_wd;
-  logic mio_periph_insel_31_we;
+  logic mio_periph_insel_32_we;
   logic [5:0] mio_periph_insel_32_qs;
   logic [5:0] mio_periph_insel_32_wd;
-  logic mio_periph_insel_32_we;
+  logic mio_periph_insel_33_we;
   logic [5:0] mio_periph_insel_33_qs;
   logic [5:0] mio_periph_insel_33_wd;
-  logic mio_periph_insel_33_we;
+  logic mio_periph_insel_34_we;
   logic [5:0] mio_periph_insel_34_qs;
   logic [5:0] mio_periph_insel_34_wd;
-  logic mio_periph_insel_34_we;
+  logic mio_periph_insel_35_we;
   logic [5:0] mio_periph_insel_35_qs;
   logic [5:0] mio_periph_insel_35_wd;
-  logic mio_periph_insel_35_we;
+  logic mio_periph_insel_36_we;
   logic [5:0] mio_periph_insel_36_qs;
   logic [5:0] mio_periph_insel_36_wd;
-  logic mio_periph_insel_36_we;
+  logic mio_periph_insel_37_we;
   logic [5:0] mio_periph_insel_37_qs;
   logic [5:0] mio_periph_insel_37_wd;
-  logic mio_periph_insel_37_we;
+  logic mio_periph_insel_38_we;
   logic [5:0] mio_periph_insel_38_qs;
   logic [5:0] mio_periph_insel_38_wd;
-  logic mio_periph_insel_38_we;
+  logic mio_periph_insel_39_we;
   logic [5:0] mio_periph_insel_39_qs;
   logic [5:0] mio_periph_insel_39_wd;
-  logic mio_periph_insel_39_we;
+  logic mio_periph_insel_40_we;
   logic [5:0] mio_periph_insel_40_qs;
   logic [5:0] mio_periph_insel_40_wd;
-  logic mio_periph_insel_40_we;
+  logic mio_periph_insel_41_we;
   logic [5:0] mio_periph_insel_41_qs;
   logic [5:0] mio_periph_insel_41_wd;
-  logic mio_periph_insel_41_we;
+  logic mio_periph_insel_42_we;
   logic [5:0] mio_periph_insel_42_qs;
   logic [5:0] mio_periph_insel_42_wd;
-  logic mio_periph_insel_42_we;
+  logic mio_periph_insel_43_we;
   logic [5:0] mio_periph_insel_43_qs;
   logic [5:0] mio_periph_insel_43_wd;
-  logic mio_periph_insel_43_we;
+  logic mio_periph_insel_44_we;
   logic [5:0] mio_periph_insel_44_qs;
   logic [5:0] mio_periph_insel_44_wd;
-  logic mio_periph_insel_44_we;
+  logic mio_periph_insel_45_we;
   logic [5:0] mio_periph_insel_45_qs;
   logic [5:0] mio_periph_insel_45_wd;
-  logic mio_periph_insel_45_we;
+  logic mio_periph_insel_46_we;
   logic [5:0] mio_periph_insel_46_qs;
   logic [5:0] mio_periph_insel_46_wd;
-  logic mio_periph_insel_46_we;
+  logic mio_periph_insel_47_we;
   logic [5:0] mio_periph_insel_47_qs;
   logic [5:0] mio_periph_insel_47_wd;
-  logic mio_periph_insel_47_we;
+  logic mio_periph_insel_48_we;
   logic [5:0] mio_periph_insel_48_qs;
   logic [5:0] mio_periph_insel_48_wd;
-  logic mio_periph_insel_48_we;
+  logic mio_periph_insel_49_we;
   logic [5:0] mio_periph_insel_49_qs;
   logic [5:0] mio_periph_insel_49_wd;
-  logic mio_periph_insel_49_we;
+  logic mio_periph_insel_50_we;
   logic [5:0] mio_periph_insel_50_qs;
   logic [5:0] mio_periph_insel_50_wd;
-  logic mio_periph_insel_50_we;
+  logic mio_periph_insel_51_we;
   logic [5:0] mio_periph_insel_51_qs;
   logic [5:0] mio_periph_insel_51_wd;
-  logic mio_periph_insel_51_we;
+  logic mio_periph_insel_52_we;
   logic [5:0] mio_periph_insel_52_qs;
   logic [5:0] mio_periph_insel_52_wd;
-  logic mio_periph_insel_52_we;
+  logic mio_periph_insel_53_we;
   logic [5:0] mio_periph_insel_53_qs;
   logic [5:0] mio_periph_insel_53_wd;
-  logic mio_periph_insel_53_we;
+  logic mio_periph_insel_54_we;
   logic [5:0] mio_periph_insel_54_qs;
   logic [5:0] mio_periph_insel_54_wd;
-  logic mio_periph_insel_54_we;
+  logic mio_periph_insel_55_we;
   logic [5:0] mio_periph_insel_55_qs;
   logic [5:0] mio_periph_insel_55_wd;
-  logic mio_periph_insel_55_we;
+  logic mio_outsel_regwen_0_we;
   logic mio_outsel_regwen_0_qs;
   logic mio_outsel_regwen_0_wd;
-  logic mio_outsel_regwen_0_we;
+  logic mio_outsel_regwen_1_we;
   logic mio_outsel_regwen_1_qs;
   logic mio_outsel_regwen_1_wd;
-  logic mio_outsel_regwen_1_we;
+  logic mio_outsel_regwen_2_we;
   logic mio_outsel_regwen_2_qs;
   logic mio_outsel_regwen_2_wd;
-  logic mio_outsel_regwen_2_we;
+  logic mio_outsel_regwen_3_we;
   logic mio_outsel_regwen_3_qs;
   logic mio_outsel_regwen_3_wd;
-  logic mio_outsel_regwen_3_we;
+  logic mio_outsel_regwen_4_we;
   logic mio_outsel_regwen_4_qs;
   logic mio_outsel_regwen_4_wd;
-  logic mio_outsel_regwen_4_we;
+  logic mio_outsel_regwen_5_we;
   logic mio_outsel_regwen_5_qs;
   logic mio_outsel_regwen_5_wd;
-  logic mio_outsel_regwen_5_we;
+  logic mio_outsel_regwen_6_we;
   logic mio_outsel_regwen_6_qs;
   logic mio_outsel_regwen_6_wd;
-  logic mio_outsel_regwen_6_we;
+  logic mio_outsel_regwen_7_we;
   logic mio_outsel_regwen_7_qs;
   logic mio_outsel_regwen_7_wd;
-  logic mio_outsel_regwen_7_we;
+  logic mio_outsel_regwen_8_we;
   logic mio_outsel_regwen_8_qs;
   logic mio_outsel_regwen_8_wd;
-  logic mio_outsel_regwen_8_we;
+  logic mio_outsel_regwen_9_we;
   logic mio_outsel_regwen_9_qs;
   logic mio_outsel_regwen_9_wd;
-  logic mio_outsel_regwen_9_we;
+  logic mio_outsel_regwen_10_we;
   logic mio_outsel_regwen_10_qs;
   logic mio_outsel_regwen_10_wd;
-  logic mio_outsel_regwen_10_we;
+  logic mio_outsel_regwen_11_we;
   logic mio_outsel_regwen_11_qs;
   logic mio_outsel_regwen_11_wd;
-  logic mio_outsel_regwen_11_we;
+  logic mio_outsel_regwen_12_we;
   logic mio_outsel_regwen_12_qs;
   logic mio_outsel_regwen_12_wd;
-  logic mio_outsel_regwen_12_we;
+  logic mio_outsel_regwen_13_we;
   logic mio_outsel_regwen_13_qs;
   logic mio_outsel_regwen_13_wd;
-  logic mio_outsel_regwen_13_we;
+  logic mio_outsel_regwen_14_we;
   logic mio_outsel_regwen_14_qs;
   logic mio_outsel_regwen_14_wd;
-  logic mio_outsel_regwen_14_we;
+  logic mio_outsel_regwen_15_we;
   logic mio_outsel_regwen_15_qs;
   logic mio_outsel_regwen_15_wd;
-  logic mio_outsel_regwen_15_we;
+  logic mio_outsel_regwen_16_we;
   logic mio_outsel_regwen_16_qs;
   logic mio_outsel_regwen_16_wd;
-  logic mio_outsel_regwen_16_we;
+  logic mio_outsel_regwen_17_we;
   logic mio_outsel_regwen_17_qs;
   logic mio_outsel_regwen_17_wd;
-  logic mio_outsel_regwen_17_we;
+  logic mio_outsel_regwen_18_we;
   logic mio_outsel_regwen_18_qs;
   logic mio_outsel_regwen_18_wd;
-  logic mio_outsel_regwen_18_we;
+  logic mio_outsel_regwen_19_we;
   logic mio_outsel_regwen_19_qs;
   logic mio_outsel_regwen_19_wd;
-  logic mio_outsel_regwen_19_we;
+  logic mio_outsel_regwen_20_we;
   logic mio_outsel_regwen_20_qs;
   logic mio_outsel_regwen_20_wd;
-  logic mio_outsel_regwen_20_we;
+  logic mio_outsel_regwen_21_we;
   logic mio_outsel_regwen_21_qs;
   logic mio_outsel_regwen_21_wd;
-  logic mio_outsel_regwen_21_we;
+  logic mio_outsel_regwen_22_we;
   logic mio_outsel_regwen_22_qs;
   logic mio_outsel_regwen_22_wd;
-  logic mio_outsel_regwen_22_we;
+  logic mio_outsel_regwen_23_we;
   logic mio_outsel_regwen_23_qs;
   logic mio_outsel_regwen_23_wd;
-  logic mio_outsel_regwen_23_we;
+  logic mio_outsel_regwen_24_we;
   logic mio_outsel_regwen_24_qs;
   logic mio_outsel_regwen_24_wd;
-  logic mio_outsel_regwen_24_we;
+  logic mio_outsel_regwen_25_we;
   logic mio_outsel_regwen_25_qs;
   logic mio_outsel_regwen_25_wd;
-  logic mio_outsel_regwen_25_we;
+  logic mio_outsel_regwen_26_we;
   logic mio_outsel_regwen_26_qs;
   logic mio_outsel_regwen_26_wd;
-  logic mio_outsel_regwen_26_we;
+  logic mio_outsel_regwen_27_we;
   logic mio_outsel_regwen_27_qs;
   logic mio_outsel_regwen_27_wd;
-  logic mio_outsel_regwen_27_we;
+  logic mio_outsel_regwen_28_we;
   logic mio_outsel_regwen_28_qs;
   logic mio_outsel_regwen_28_wd;
-  logic mio_outsel_regwen_28_we;
+  logic mio_outsel_regwen_29_we;
   logic mio_outsel_regwen_29_qs;
   logic mio_outsel_regwen_29_wd;
-  logic mio_outsel_regwen_29_we;
+  logic mio_outsel_regwen_30_we;
   logic mio_outsel_regwen_30_qs;
   logic mio_outsel_regwen_30_wd;
-  logic mio_outsel_regwen_30_we;
+  logic mio_outsel_regwen_31_we;
   logic mio_outsel_regwen_31_qs;
   logic mio_outsel_regwen_31_wd;
-  logic mio_outsel_regwen_31_we;
+  logic mio_outsel_regwen_32_we;
   logic mio_outsel_regwen_32_qs;
   logic mio_outsel_regwen_32_wd;
-  logic mio_outsel_regwen_32_we;
+  logic mio_outsel_regwen_33_we;
   logic mio_outsel_regwen_33_qs;
   logic mio_outsel_regwen_33_wd;
-  logic mio_outsel_regwen_33_we;
+  logic mio_outsel_regwen_34_we;
   logic mio_outsel_regwen_34_qs;
   logic mio_outsel_regwen_34_wd;
-  logic mio_outsel_regwen_34_we;
+  logic mio_outsel_regwen_35_we;
   logic mio_outsel_regwen_35_qs;
   logic mio_outsel_regwen_35_wd;
-  logic mio_outsel_regwen_35_we;
+  logic mio_outsel_regwen_36_we;
   logic mio_outsel_regwen_36_qs;
   logic mio_outsel_regwen_36_wd;
-  logic mio_outsel_regwen_36_we;
+  logic mio_outsel_regwen_37_we;
   logic mio_outsel_regwen_37_qs;
   logic mio_outsel_regwen_37_wd;
-  logic mio_outsel_regwen_37_we;
+  logic mio_outsel_regwen_38_we;
   logic mio_outsel_regwen_38_qs;
   logic mio_outsel_regwen_38_wd;
-  logic mio_outsel_regwen_38_we;
+  logic mio_outsel_regwen_39_we;
   logic mio_outsel_regwen_39_qs;
   logic mio_outsel_regwen_39_wd;
-  logic mio_outsel_regwen_39_we;
+  logic mio_outsel_regwen_40_we;
   logic mio_outsel_regwen_40_qs;
   logic mio_outsel_regwen_40_wd;
-  logic mio_outsel_regwen_40_we;
+  logic mio_outsel_regwen_41_we;
   logic mio_outsel_regwen_41_qs;
   logic mio_outsel_regwen_41_wd;
-  logic mio_outsel_regwen_41_we;
+  logic mio_outsel_regwen_42_we;
   logic mio_outsel_regwen_42_qs;
   logic mio_outsel_regwen_42_wd;
-  logic mio_outsel_regwen_42_we;
+  logic mio_outsel_regwen_43_we;
   logic mio_outsel_regwen_43_qs;
   logic mio_outsel_regwen_43_wd;
-  logic mio_outsel_regwen_43_we;
+  logic mio_outsel_regwen_44_we;
   logic mio_outsel_regwen_44_qs;
   logic mio_outsel_regwen_44_wd;
-  logic mio_outsel_regwen_44_we;
+  logic mio_outsel_regwen_45_we;
   logic mio_outsel_regwen_45_qs;
   logic mio_outsel_regwen_45_wd;
-  logic mio_outsel_regwen_45_we;
+  logic mio_outsel_regwen_46_we;
   logic mio_outsel_regwen_46_qs;
   logic mio_outsel_regwen_46_wd;
-  logic mio_outsel_regwen_46_we;
+  logic mio_outsel_0_we;
   logic [6:0] mio_outsel_0_qs;
   logic [6:0] mio_outsel_0_wd;
-  logic mio_outsel_0_we;
+  logic mio_outsel_1_we;
   logic [6:0] mio_outsel_1_qs;
   logic [6:0] mio_outsel_1_wd;
-  logic mio_outsel_1_we;
+  logic mio_outsel_2_we;
   logic [6:0] mio_outsel_2_qs;
   logic [6:0] mio_outsel_2_wd;
-  logic mio_outsel_2_we;
+  logic mio_outsel_3_we;
   logic [6:0] mio_outsel_3_qs;
   logic [6:0] mio_outsel_3_wd;
-  logic mio_outsel_3_we;
+  logic mio_outsel_4_we;
   logic [6:0] mio_outsel_4_qs;
   logic [6:0] mio_outsel_4_wd;
-  logic mio_outsel_4_we;
+  logic mio_outsel_5_we;
   logic [6:0] mio_outsel_5_qs;
   logic [6:0] mio_outsel_5_wd;
-  logic mio_outsel_5_we;
+  logic mio_outsel_6_we;
   logic [6:0] mio_outsel_6_qs;
   logic [6:0] mio_outsel_6_wd;
-  logic mio_outsel_6_we;
+  logic mio_outsel_7_we;
   logic [6:0] mio_outsel_7_qs;
   logic [6:0] mio_outsel_7_wd;
-  logic mio_outsel_7_we;
+  logic mio_outsel_8_we;
   logic [6:0] mio_outsel_8_qs;
   logic [6:0] mio_outsel_8_wd;
-  logic mio_outsel_8_we;
+  logic mio_outsel_9_we;
   logic [6:0] mio_outsel_9_qs;
   logic [6:0] mio_outsel_9_wd;
-  logic mio_outsel_9_we;
+  logic mio_outsel_10_we;
   logic [6:0] mio_outsel_10_qs;
   logic [6:0] mio_outsel_10_wd;
-  logic mio_outsel_10_we;
+  logic mio_outsel_11_we;
   logic [6:0] mio_outsel_11_qs;
   logic [6:0] mio_outsel_11_wd;
-  logic mio_outsel_11_we;
+  logic mio_outsel_12_we;
   logic [6:0] mio_outsel_12_qs;
   logic [6:0] mio_outsel_12_wd;
-  logic mio_outsel_12_we;
+  logic mio_outsel_13_we;
   logic [6:0] mio_outsel_13_qs;
   logic [6:0] mio_outsel_13_wd;
-  logic mio_outsel_13_we;
+  logic mio_outsel_14_we;
   logic [6:0] mio_outsel_14_qs;
   logic [6:0] mio_outsel_14_wd;
-  logic mio_outsel_14_we;
+  logic mio_outsel_15_we;
   logic [6:0] mio_outsel_15_qs;
   logic [6:0] mio_outsel_15_wd;
-  logic mio_outsel_15_we;
+  logic mio_outsel_16_we;
   logic [6:0] mio_outsel_16_qs;
   logic [6:0] mio_outsel_16_wd;
-  logic mio_outsel_16_we;
+  logic mio_outsel_17_we;
   logic [6:0] mio_outsel_17_qs;
   logic [6:0] mio_outsel_17_wd;
-  logic mio_outsel_17_we;
+  logic mio_outsel_18_we;
   logic [6:0] mio_outsel_18_qs;
   logic [6:0] mio_outsel_18_wd;
-  logic mio_outsel_18_we;
+  logic mio_outsel_19_we;
   logic [6:0] mio_outsel_19_qs;
   logic [6:0] mio_outsel_19_wd;
-  logic mio_outsel_19_we;
+  logic mio_outsel_20_we;
   logic [6:0] mio_outsel_20_qs;
   logic [6:0] mio_outsel_20_wd;
-  logic mio_outsel_20_we;
+  logic mio_outsel_21_we;
   logic [6:0] mio_outsel_21_qs;
   logic [6:0] mio_outsel_21_wd;
-  logic mio_outsel_21_we;
+  logic mio_outsel_22_we;
   logic [6:0] mio_outsel_22_qs;
   logic [6:0] mio_outsel_22_wd;
-  logic mio_outsel_22_we;
+  logic mio_outsel_23_we;
   logic [6:0] mio_outsel_23_qs;
   logic [6:0] mio_outsel_23_wd;
-  logic mio_outsel_23_we;
+  logic mio_outsel_24_we;
   logic [6:0] mio_outsel_24_qs;
   logic [6:0] mio_outsel_24_wd;
-  logic mio_outsel_24_we;
+  logic mio_outsel_25_we;
   logic [6:0] mio_outsel_25_qs;
   logic [6:0] mio_outsel_25_wd;
-  logic mio_outsel_25_we;
+  logic mio_outsel_26_we;
   logic [6:0] mio_outsel_26_qs;
   logic [6:0] mio_outsel_26_wd;
-  logic mio_outsel_26_we;
+  logic mio_outsel_27_we;
   logic [6:0] mio_outsel_27_qs;
   logic [6:0] mio_outsel_27_wd;
-  logic mio_outsel_27_we;
+  logic mio_outsel_28_we;
   logic [6:0] mio_outsel_28_qs;
   logic [6:0] mio_outsel_28_wd;
-  logic mio_outsel_28_we;
+  logic mio_outsel_29_we;
   logic [6:0] mio_outsel_29_qs;
   logic [6:0] mio_outsel_29_wd;
-  logic mio_outsel_29_we;
+  logic mio_outsel_30_we;
   logic [6:0] mio_outsel_30_qs;
   logic [6:0] mio_outsel_30_wd;
-  logic mio_outsel_30_we;
+  logic mio_outsel_31_we;
   logic [6:0] mio_outsel_31_qs;
   logic [6:0] mio_outsel_31_wd;
-  logic mio_outsel_31_we;
+  logic mio_outsel_32_we;
   logic [6:0] mio_outsel_32_qs;
   logic [6:0] mio_outsel_32_wd;
-  logic mio_outsel_32_we;
+  logic mio_outsel_33_we;
   logic [6:0] mio_outsel_33_qs;
   logic [6:0] mio_outsel_33_wd;
-  logic mio_outsel_33_we;
+  logic mio_outsel_34_we;
   logic [6:0] mio_outsel_34_qs;
   logic [6:0] mio_outsel_34_wd;
-  logic mio_outsel_34_we;
+  logic mio_outsel_35_we;
   logic [6:0] mio_outsel_35_qs;
   logic [6:0] mio_outsel_35_wd;
-  logic mio_outsel_35_we;
+  logic mio_outsel_36_we;
   logic [6:0] mio_outsel_36_qs;
   logic [6:0] mio_outsel_36_wd;
-  logic mio_outsel_36_we;
+  logic mio_outsel_37_we;
   logic [6:0] mio_outsel_37_qs;
   logic [6:0] mio_outsel_37_wd;
-  logic mio_outsel_37_we;
+  logic mio_outsel_38_we;
   logic [6:0] mio_outsel_38_qs;
   logic [6:0] mio_outsel_38_wd;
-  logic mio_outsel_38_we;
+  logic mio_outsel_39_we;
   logic [6:0] mio_outsel_39_qs;
   logic [6:0] mio_outsel_39_wd;
-  logic mio_outsel_39_we;
+  logic mio_outsel_40_we;
   logic [6:0] mio_outsel_40_qs;
   logic [6:0] mio_outsel_40_wd;
-  logic mio_outsel_40_we;
+  logic mio_outsel_41_we;
   logic [6:0] mio_outsel_41_qs;
   logic [6:0] mio_outsel_41_wd;
-  logic mio_outsel_41_we;
+  logic mio_outsel_42_we;
   logic [6:0] mio_outsel_42_qs;
   logic [6:0] mio_outsel_42_wd;
-  logic mio_outsel_42_we;
+  logic mio_outsel_43_we;
   logic [6:0] mio_outsel_43_qs;
   logic [6:0] mio_outsel_43_wd;
-  logic mio_outsel_43_we;
+  logic mio_outsel_44_we;
   logic [6:0] mio_outsel_44_qs;
   logic [6:0] mio_outsel_44_wd;
-  logic mio_outsel_44_we;
+  logic mio_outsel_45_we;
   logic [6:0] mio_outsel_45_qs;
   logic [6:0] mio_outsel_45_wd;
-  logic mio_outsel_45_we;
+  logic mio_outsel_46_we;
   logic [6:0] mio_outsel_46_qs;
   logic [6:0] mio_outsel_46_wd;
-  logic mio_outsel_46_we;
+  logic mio_pad_attr_regwen_0_we;
   logic mio_pad_attr_regwen_0_qs;
   logic mio_pad_attr_regwen_0_wd;
-  logic mio_pad_attr_regwen_0_we;
+  logic mio_pad_attr_regwen_1_we;
   logic mio_pad_attr_regwen_1_qs;
   logic mio_pad_attr_regwen_1_wd;
-  logic mio_pad_attr_regwen_1_we;
+  logic mio_pad_attr_regwen_2_we;
   logic mio_pad_attr_regwen_2_qs;
   logic mio_pad_attr_regwen_2_wd;
-  logic mio_pad_attr_regwen_2_we;
+  logic mio_pad_attr_regwen_3_we;
   logic mio_pad_attr_regwen_3_qs;
   logic mio_pad_attr_regwen_3_wd;
-  logic mio_pad_attr_regwen_3_we;
+  logic mio_pad_attr_regwen_4_we;
   logic mio_pad_attr_regwen_4_qs;
   logic mio_pad_attr_regwen_4_wd;
-  logic mio_pad_attr_regwen_4_we;
+  logic mio_pad_attr_regwen_5_we;
   logic mio_pad_attr_regwen_5_qs;
   logic mio_pad_attr_regwen_5_wd;
-  logic mio_pad_attr_regwen_5_we;
+  logic mio_pad_attr_regwen_6_we;
   logic mio_pad_attr_regwen_6_qs;
   logic mio_pad_attr_regwen_6_wd;
-  logic mio_pad_attr_regwen_6_we;
+  logic mio_pad_attr_regwen_7_we;
   logic mio_pad_attr_regwen_7_qs;
   logic mio_pad_attr_regwen_7_wd;
-  logic mio_pad_attr_regwen_7_we;
+  logic mio_pad_attr_regwen_8_we;
   logic mio_pad_attr_regwen_8_qs;
   logic mio_pad_attr_regwen_8_wd;
-  logic mio_pad_attr_regwen_8_we;
+  logic mio_pad_attr_regwen_9_we;
   logic mio_pad_attr_regwen_9_qs;
   logic mio_pad_attr_regwen_9_wd;
-  logic mio_pad_attr_regwen_9_we;
+  logic mio_pad_attr_regwen_10_we;
   logic mio_pad_attr_regwen_10_qs;
   logic mio_pad_attr_regwen_10_wd;
-  logic mio_pad_attr_regwen_10_we;
+  logic mio_pad_attr_regwen_11_we;
   logic mio_pad_attr_regwen_11_qs;
   logic mio_pad_attr_regwen_11_wd;
-  logic mio_pad_attr_regwen_11_we;
+  logic mio_pad_attr_regwen_12_we;
   logic mio_pad_attr_regwen_12_qs;
   logic mio_pad_attr_regwen_12_wd;
-  logic mio_pad_attr_regwen_12_we;
+  logic mio_pad_attr_regwen_13_we;
   logic mio_pad_attr_regwen_13_qs;
   logic mio_pad_attr_regwen_13_wd;
-  logic mio_pad_attr_regwen_13_we;
+  logic mio_pad_attr_regwen_14_we;
   logic mio_pad_attr_regwen_14_qs;
   logic mio_pad_attr_regwen_14_wd;
-  logic mio_pad_attr_regwen_14_we;
+  logic mio_pad_attr_regwen_15_we;
   logic mio_pad_attr_regwen_15_qs;
   logic mio_pad_attr_regwen_15_wd;
-  logic mio_pad_attr_regwen_15_we;
+  logic mio_pad_attr_regwen_16_we;
   logic mio_pad_attr_regwen_16_qs;
   logic mio_pad_attr_regwen_16_wd;
-  logic mio_pad_attr_regwen_16_we;
+  logic mio_pad_attr_regwen_17_we;
   logic mio_pad_attr_regwen_17_qs;
   logic mio_pad_attr_regwen_17_wd;
-  logic mio_pad_attr_regwen_17_we;
+  logic mio_pad_attr_regwen_18_we;
   logic mio_pad_attr_regwen_18_qs;
   logic mio_pad_attr_regwen_18_wd;
-  logic mio_pad_attr_regwen_18_we;
+  logic mio_pad_attr_regwen_19_we;
   logic mio_pad_attr_regwen_19_qs;
   logic mio_pad_attr_regwen_19_wd;
-  logic mio_pad_attr_regwen_19_we;
+  logic mio_pad_attr_regwen_20_we;
   logic mio_pad_attr_regwen_20_qs;
   logic mio_pad_attr_regwen_20_wd;
-  logic mio_pad_attr_regwen_20_we;
+  logic mio_pad_attr_regwen_21_we;
   logic mio_pad_attr_regwen_21_qs;
   logic mio_pad_attr_regwen_21_wd;
-  logic mio_pad_attr_regwen_21_we;
+  logic mio_pad_attr_regwen_22_we;
   logic mio_pad_attr_regwen_22_qs;
   logic mio_pad_attr_regwen_22_wd;
-  logic mio_pad_attr_regwen_22_we;
+  logic mio_pad_attr_regwen_23_we;
   logic mio_pad_attr_regwen_23_qs;
   logic mio_pad_attr_regwen_23_wd;
-  logic mio_pad_attr_regwen_23_we;
+  logic mio_pad_attr_regwen_24_we;
   logic mio_pad_attr_regwen_24_qs;
   logic mio_pad_attr_regwen_24_wd;
-  logic mio_pad_attr_regwen_24_we;
+  logic mio_pad_attr_regwen_25_we;
   logic mio_pad_attr_regwen_25_qs;
   logic mio_pad_attr_regwen_25_wd;
-  logic mio_pad_attr_regwen_25_we;
+  logic mio_pad_attr_regwen_26_we;
   logic mio_pad_attr_regwen_26_qs;
   logic mio_pad_attr_regwen_26_wd;
-  logic mio_pad_attr_regwen_26_we;
+  logic mio_pad_attr_regwen_27_we;
   logic mio_pad_attr_regwen_27_qs;
   logic mio_pad_attr_regwen_27_wd;
-  logic mio_pad_attr_regwen_27_we;
+  logic mio_pad_attr_regwen_28_we;
   logic mio_pad_attr_regwen_28_qs;
   logic mio_pad_attr_regwen_28_wd;
-  logic mio_pad_attr_regwen_28_we;
+  logic mio_pad_attr_regwen_29_we;
   logic mio_pad_attr_regwen_29_qs;
   logic mio_pad_attr_regwen_29_wd;
-  logic mio_pad_attr_regwen_29_we;
+  logic mio_pad_attr_regwen_30_we;
   logic mio_pad_attr_regwen_30_qs;
   logic mio_pad_attr_regwen_30_wd;
-  logic mio_pad_attr_regwen_30_we;
+  logic mio_pad_attr_regwen_31_we;
   logic mio_pad_attr_regwen_31_qs;
   logic mio_pad_attr_regwen_31_wd;
-  logic mio_pad_attr_regwen_31_we;
+  logic mio_pad_attr_regwen_32_we;
   logic mio_pad_attr_regwen_32_qs;
   logic mio_pad_attr_regwen_32_wd;
-  logic mio_pad_attr_regwen_32_we;
+  logic mio_pad_attr_regwen_33_we;
   logic mio_pad_attr_regwen_33_qs;
   logic mio_pad_attr_regwen_33_wd;
-  logic mio_pad_attr_regwen_33_we;
+  logic mio_pad_attr_regwen_34_we;
   logic mio_pad_attr_regwen_34_qs;
   logic mio_pad_attr_regwen_34_wd;
-  logic mio_pad_attr_regwen_34_we;
+  logic mio_pad_attr_regwen_35_we;
   logic mio_pad_attr_regwen_35_qs;
   logic mio_pad_attr_regwen_35_wd;
-  logic mio_pad_attr_regwen_35_we;
+  logic mio_pad_attr_regwen_36_we;
   logic mio_pad_attr_regwen_36_qs;
   logic mio_pad_attr_regwen_36_wd;
-  logic mio_pad_attr_regwen_36_we;
+  logic mio_pad_attr_regwen_37_we;
   logic mio_pad_attr_regwen_37_qs;
   logic mio_pad_attr_regwen_37_wd;
-  logic mio_pad_attr_regwen_37_we;
+  logic mio_pad_attr_regwen_38_we;
   logic mio_pad_attr_regwen_38_qs;
   logic mio_pad_attr_regwen_38_wd;
-  logic mio_pad_attr_regwen_38_we;
+  logic mio_pad_attr_regwen_39_we;
   logic mio_pad_attr_regwen_39_qs;
   logic mio_pad_attr_regwen_39_wd;
-  logic mio_pad_attr_regwen_39_we;
+  logic mio_pad_attr_regwen_40_we;
   logic mio_pad_attr_regwen_40_qs;
   logic mio_pad_attr_regwen_40_wd;
-  logic mio_pad_attr_regwen_40_we;
+  logic mio_pad_attr_regwen_41_we;
   logic mio_pad_attr_regwen_41_qs;
   logic mio_pad_attr_regwen_41_wd;
-  logic mio_pad_attr_regwen_41_we;
+  logic mio_pad_attr_regwen_42_we;
   logic mio_pad_attr_regwen_42_qs;
   logic mio_pad_attr_regwen_42_wd;
-  logic mio_pad_attr_regwen_42_we;
+  logic mio_pad_attr_regwen_43_we;
   logic mio_pad_attr_regwen_43_qs;
   logic mio_pad_attr_regwen_43_wd;
-  logic mio_pad_attr_regwen_43_we;
+  logic mio_pad_attr_regwen_44_we;
   logic mio_pad_attr_regwen_44_qs;
   logic mio_pad_attr_regwen_44_wd;
-  logic mio_pad_attr_regwen_44_we;
+  logic mio_pad_attr_regwen_45_we;
   logic mio_pad_attr_regwen_45_qs;
   logic mio_pad_attr_regwen_45_wd;
-  logic mio_pad_attr_regwen_45_we;
+  logic mio_pad_attr_regwen_46_we;
   logic mio_pad_attr_regwen_46_qs;
   logic mio_pad_attr_regwen_46_wd;
-  logic mio_pad_attr_regwen_46_we;
+  logic mio_pad_attr_0_re;
+  logic mio_pad_attr_0_we;
   logic [12:0] mio_pad_attr_0_qs;
   logic [12:0] mio_pad_attr_0_wd;
-  logic mio_pad_attr_0_we;
-  logic mio_pad_attr_0_re;
+  logic mio_pad_attr_1_re;
+  logic mio_pad_attr_1_we;
   logic [12:0] mio_pad_attr_1_qs;
   logic [12:0] mio_pad_attr_1_wd;
-  logic mio_pad_attr_1_we;
-  logic mio_pad_attr_1_re;
+  logic mio_pad_attr_2_re;
+  logic mio_pad_attr_2_we;
   logic [12:0] mio_pad_attr_2_qs;
   logic [12:0] mio_pad_attr_2_wd;
-  logic mio_pad_attr_2_we;
-  logic mio_pad_attr_2_re;
+  logic mio_pad_attr_3_re;
+  logic mio_pad_attr_3_we;
   logic [12:0] mio_pad_attr_3_qs;
   logic [12:0] mio_pad_attr_3_wd;
-  logic mio_pad_attr_3_we;
-  logic mio_pad_attr_3_re;
+  logic mio_pad_attr_4_re;
+  logic mio_pad_attr_4_we;
   logic [12:0] mio_pad_attr_4_qs;
   logic [12:0] mio_pad_attr_4_wd;
-  logic mio_pad_attr_4_we;
-  logic mio_pad_attr_4_re;
+  logic mio_pad_attr_5_re;
+  logic mio_pad_attr_5_we;
   logic [12:0] mio_pad_attr_5_qs;
   logic [12:0] mio_pad_attr_5_wd;
-  logic mio_pad_attr_5_we;
-  logic mio_pad_attr_5_re;
+  logic mio_pad_attr_6_re;
+  logic mio_pad_attr_6_we;
   logic [12:0] mio_pad_attr_6_qs;
   logic [12:0] mio_pad_attr_6_wd;
-  logic mio_pad_attr_6_we;
-  logic mio_pad_attr_6_re;
+  logic mio_pad_attr_7_re;
+  logic mio_pad_attr_7_we;
   logic [12:0] mio_pad_attr_7_qs;
   logic [12:0] mio_pad_attr_7_wd;
-  logic mio_pad_attr_7_we;
-  logic mio_pad_attr_7_re;
+  logic mio_pad_attr_8_re;
+  logic mio_pad_attr_8_we;
   logic [12:0] mio_pad_attr_8_qs;
   logic [12:0] mio_pad_attr_8_wd;
-  logic mio_pad_attr_8_we;
-  logic mio_pad_attr_8_re;
+  logic mio_pad_attr_9_re;
+  logic mio_pad_attr_9_we;
   logic [12:0] mio_pad_attr_9_qs;
   logic [12:0] mio_pad_attr_9_wd;
-  logic mio_pad_attr_9_we;
-  logic mio_pad_attr_9_re;
+  logic mio_pad_attr_10_re;
+  logic mio_pad_attr_10_we;
   logic [12:0] mio_pad_attr_10_qs;
   logic [12:0] mio_pad_attr_10_wd;
-  logic mio_pad_attr_10_we;
-  logic mio_pad_attr_10_re;
+  logic mio_pad_attr_11_re;
+  logic mio_pad_attr_11_we;
   logic [12:0] mio_pad_attr_11_qs;
   logic [12:0] mio_pad_attr_11_wd;
-  logic mio_pad_attr_11_we;
-  logic mio_pad_attr_11_re;
+  logic mio_pad_attr_12_re;
+  logic mio_pad_attr_12_we;
   logic [12:0] mio_pad_attr_12_qs;
   logic [12:0] mio_pad_attr_12_wd;
-  logic mio_pad_attr_12_we;
-  logic mio_pad_attr_12_re;
+  logic mio_pad_attr_13_re;
+  logic mio_pad_attr_13_we;
   logic [12:0] mio_pad_attr_13_qs;
   logic [12:0] mio_pad_attr_13_wd;
-  logic mio_pad_attr_13_we;
-  logic mio_pad_attr_13_re;
+  logic mio_pad_attr_14_re;
+  logic mio_pad_attr_14_we;
   logic [12:0] mio_pad_attr_14_qs;
   logic [12:0] mio_pad_attr_14_wd;
-  logic mio_pad_attr_14_we;
-  logic mio_pad_attr_14_re;
+  logic mio_pad_attr_15_re;
+  logic mio_pad_attr_15_we;
   logic [12:0] mio_pad_attr_15_qs;
   logic [12:0] mio_pad_attr_15_wd;
-  logic mio_pad_attr_15_we;
-  logic mio_pad_attr_15_re;
+  logic mio_pad_attr_16_re;
+  logic mio_pad_attr_16_we;
   logic [12:0] mio_pad_attr_16_qs;
   logic [12:0] mio_pad_attr_16_wd;
-  logic mio_pad_attr_16_we;
-  logic mio_pad_attr_16_re;
+  logic mio_pad_attr_17_re;
+  logic mio_pad_attr_17_we;
   logic [12:0] mio_pad_attr_17_qs;
   logic [12:0] mio_pad_attr_17_wd;
-  logic mio_pad_attr_17_we;
-  logic mio_pad_attr_17_re;
+  logic mio_pad_attr_18_re;
+  logic mio_pad_attr_18_we;
   logic [12:0] mio_pad_attr_18_qs;
   logic [12:0] mio_pad_attr_18_wd;
-  logic mio_pad_attr_18_we;
-  logic mio_pad_attr_18_re;
+  logic mio_pad_attr_19_re;
+  logic mio_pad_attr_19_we;
   logic [12:0] mio_pad_attr_19_qs;
   logic [12:0] mio_pad_attr_19_wd;
-  logic mio_pad_attr_19_we;
-  logic mio_pad_attr_19_re;
+  logic mio_pad_attr_20_re;
+  logic mio_pad_attr_20_we;
   logic [12:0] mio_pad_attr_20_qs;
   logic [12:0] mio_pad_attr_20_wd;
-  logic mio_pad_attr_20_we;
-  logic mio_pad_attr_20_re;
+  logic mio_pad_attr_21_re;
+  logic mio_pad_attr_21_we;
   logic [12:0] mio_pad_attr_21_qs;
   logic [12:0] mio_pad_attr_21_wd;
-  logic mio_pad_attr_21_we;
-  logic mio_pad_attr_21_re;
+  logic mio_pad_attr_22_re;
+  logic mio_pad_attr_22_we;
   logic [12:0] mio_pad_attr_22_qs;
   logic [12:0] mio_pad_attr_22_wd;
-  logic mio_pad_attr_22_we;
-  logic mio_pad_attr_22_re;
+  logic mio_pad_attr_23_re;
+  logic mio_pad_attr_23_we;
   logic [12:0] mio_pad_attr_23_qs;
   logic [12:0] mio_pad_attr_23_wd;
-  logic mio_pad_attr_23_we;
-  logic mio_pad_attr_23_re;
+  logic mio_pad_attr_24_re;
+  logic mio_pad_attr_24_we;
   logic [12:0] mio_pad_attr_24_qs;
   logic [12:0] mio_pad_attr_24_wd;
-  logic mio_pad_attr_24_we;
-  logic mio_pad_attr_24_re;
+  logic mio_pad_attr_25_re;
+  logic mio_pad_attr_25_we;
   logic [12:0] mio_pad_attr_25_qs;
   logic [12:0] mio_pad_attr_25_wd;
-  logic mio_pad_attr_25_we;
-  logic mio_pad_attr_25_re;
+  logic mio_pad_attr_26_re;
+  logic mio_pad_attr_26_we;
   logic [12:0] mio_pad_attr_26_qs;
   logic [12:0] mio_pad_attr_26_wd;
-  logic mio_pad_attr_26_we;
-  logic mio_pad_attr_26_re;
+  logic mio_pad_attr_27_re;
+  logic mio_pad_attr_27_we;
   logic [12:0] mio_pad_attr_27_qs;
   logic [12:0] mio_pad_attr_27_wd;
-  logic mio_pad_attr_27_we;
-  logic mio_pad_attr_27_re;
+  logic mio_pad_attr_28_re;
+  logic mio_pad_attr_28_we;
   logic [12:0] mio_pad_attr_28_qs;
   logic [12:0] mio_pad_attr_28_wd;
-  logic mio_pad_attr_28_we;
-  logic mio_pad_attr_28_re;
+  logic mio_pad_attr_29_re;
+  logic mio_pad_attr_29_we;
   logic [12:0] mio_pad_attr_29_qs;
   logic [12:0] mio_pad_attr_29_wd;
-  logic mio_pad_attr_29_we;
-  logic mio_pad_attr_29_re;
+  logic mio_pad_attr_30_re;
+  logic mio_pad_attr_30_we;
   logic [12:0] mio_pad_attr_30_qs;
   logic [12:0] mio_pad_attr_30_wd;
-  logic mio_pad_attr_30_we;
-  logic mio_pad_attr_30_re;
+  logic mio_pad_attr_31_re;
+  logic mio_pad_attr_31_we;
   logic [12:0] mio_pad_attr_31_qs;
   logic [12:0] mio_pad_attr_31_wd;
-  logic mio_pad_attr_31_we;
-  logic mio_pad_attr_31_re;
+  logic mio_pad_attr_32_re;
+  logic mio_pad_attr_32_we;
   logic [12:0] mio_pad_attr_32_qs;
   logic [12:0] mio_pad_attr_32_wd;
-  logic mio_pad_attr_32_we;
-  logic mio_pad_attr_32_re;
+  logic mio_pad_attr_33_re;
+  logic mio_pad_attr_33_we;
   logic [12:0] mio_pad_attr_33_qs;
   logic [12:0] mio_pad_attr_33_wd;
-  logic mio_pad_attr_33_we;
-  logic mio_pad_attr_33_re;
+  logic mio_pad_attr_34_re;
+  logic mio_pad_attr_34_we;
   logic [12:0] mio_pad_attr_34_qs;
   logic [12:0] mio_pad_attr_34_wd;
-  logic mio_pad_attr_34_we;
-  logic mio_pad_attr_34_re;
+  logic mio_pad_attr_35_re;
+  logic mio_pad_attr_35_we;
   logic [12:0] mio_pad_attr_35_qs;
   logic [12:0] mio_pad_attr_35_wd;
-  logic mio_pad_attr_35_we;
-  logic mio_pad_attr_35_re;
+  logic mio_pad_attr_36_re;
+  logic mio_pad_attr_36_we;
   logic [12:0] mio_pad_attr_36_qs;
   logic [12:0] mio_pad_attr_36_wd;
-  logic mio_pad_attr_36_we;
-  logic mio_pad_attr_36_re;
+  logic mio_pad_attr_37_re;
+  logic mio_pad_attr_37_we;
   logic [12:0] mio_pad_attr_37_qs;
   logic [12:0] mio_pad_attr_37_wd;
-  logic mio_pad_attr_37_we;
-  logic mio_pad_attr_37_re;
+  logic mio_pad_attr_38_re;
+  logic mio_pad_attr_38_we;
   logic [12:0] mio_pad_attr_38_qs;
   logic [12:0] mio_pad_attr_38_wd;
-  logic mio_pad_attr_38_we;
-  logic mio_pad_attr_38_re;
+  logic mio_pad_attr_39_re;
+  logic mio_pad_attr_39_we;
   logic [12:0] mio_pad_attr_39_qs;
   logic [12:0] mio_pad_attr_39_wd;
-  logic mio_pad_attr_39_we;
-  logic mio_pad_attr_39_re;
+  logic mio_pad_attr_40_re;
+  logic mio_pad_attr_40_we;
   logic [12:0] mio_pad_attr_40_qs;
   logic [12:0] mio_pad_attr_40_wd;
-  logic mio_pad_attr_40_we;
-  logic mio_pad_attr_40_re;
+  logic mio_pad_attr_41_re;
+  logic mio_pad_attr_41_we;
   logic [12:0] mio_pad_attr_41_qs;
   logic [12:0] mio_pad_attr_41_wd;
-  logic mio_pad_attr_41_we;
-  logic mio_pad_attr_41_re;
+  logic mio_pad_attr_42_re;
+  logic mio_pad_attr_42_we;
   logic [12:0] mio_pad_attr_42_qs;
   logic [12:0] mio_pad_attr_42_wd;
-  logic mio_pad_attr_42_we;
-  logic mio_pad_attr_42_re;
+  logic mio_pad_attr_43_re;
+  logic mio_pad_attr_43_we;
   logic [12:0] mio_pad_attr_43_qs;
   logic [12:0] mio_pad_attr_43_wd;
-  logic mio_pad_attr_43_we;
-  logic mio_pad_attr_43_re;
+  logic mio_pad_attr_44_re;
+  logic mio_pad_attr_44_we;
   logic [12:0] mio_pad_attr_44_qs;
   logic [12:0] mio_pad_attr_44_wd;
-  logic mio_pad_attr_44_we;
-  logic mio_pad_attr_44_re;
+  logic mio_pad_attr_45_re;
+  logic mio_pad_attr_45_we;
   logic [12:0] mio_pad_attr_45_qs;
   logic [12:0] mio_pad_attr_45_wd;
-  logic mio_pad_attr_45_we;
-  logic mio_pad_attr_45_re;
+  logic mio_pad_attr_46_re;
+  logic mio_pad_attr_46_we;
   logic [12:0] mio_pad_attr_46_qs;
   logic [12:0] mio_pad_attr_46_wd;
-  logic mio_pad_attr_46_we;
-  logic mio_pad_attr_46_re;
+  logic dio_pad_attr_regwen_0_we;
   logic dio_pad_attr_regwen_0_qs;
   logic dio_pad_attr_regwen_0_wd;
-  logic dio_pad_attr_regwen_0_we;
+  logic dio_pad_attr_regwen_1_we;
   logic dio_pad_attr_regwen_1_qs;
   logic dio_pad_attr_regwen_1_wd;
-  logic dio_pad_attr_regwen_1_we;
+  logic dio_pad_attr_regwen_2_we;
   logic dio_pad_attr_regwen_2_qs;
   logic dio_pad_attr_regwen_2_wd;
-  logic dio_pad_attr_regwen_2_we;
+  logic dio_pad_attr_regwen_3_we;
   logic dio_pad_attr_regwen_3_qs;
   logic dio_pad_attr_regwen_3_wd;
-  logic dio_pad_attr_regwen_3_we;
+  logic dio_pad_attr_regwen_4_we;
   logic dio_pad_attr_regwen_4_qs;
   logic dio_pad_attr_regwen_4_wd;
-  logic dio_pad_attr_regwen_4_we;
+  logic dio_pad_attr_regwen_5_we;
   logic dio_pad_attr_regwen_5_qs;
   logic dio_pad_attr_regwen_5_wd;
-  logic dio_pad_attr_regwen_5_we;
+  logic dio_pad_attr_regwen_6_we;
   logic dio_pad_attr_regwen_6_qs;
   logic dio_pad_attr_regwen_6_wd;
-  logic dio_pad_attr_regwen_6_we;
+  logic dio_pad_attr_regwen_7_we;
   logic dio_pad_attr_regwen_7_qs;
   logic dio_pad_attr_regwen_7_wd;
-  logic dio_pad_attr_regwen_7_we;
+  logic dio_pad_attr_regwen_8_we;
   logic dio_pad_attr_regwen_8_qs;
   logic dio_pad_attr_regwen_8_wd;
-  logic dio_pad_attr_regwen_8_we;
+  logic dio_pad_attr_regwen_9_we;
   logic dio_pad_attr_regwen_9_qs;
   logic dio_pad_attr_regwen_9_wd;
-  logic dio_pad_attr_regwen_9_we;
+  logic dio_pad_attr_regwen_10_we;
   logic dio_pad_attr_regwen_10_qs;
   logic dio_pad_attr_regwen_10_wd;
-  logic dio_pad_attr_regwen_10_we;
+  logic dio_pad_attr_regwen_11_we;
   logic dio_pad_attr_regwen_11_qs;
   logic dio_pad_attr_regwen_11_wd;
-  logic dio_pad_attr_regwen_11_we;
+  logic dio_pad_attr_regwen_12_we;
   logic dio_pad_attr_regwen_12_qs;
   logic dio_pad_attr_regwen_12_wd;
-  logic dio_pad_attr_regwen_12_we;
+  logic dio_pad_attr_regwen_13_we;
   logic dio_pad_attr_regwen_13_qs;
   logic dio_pad_attr_regwen_13_wd;
-  logic dio_pad_attr_regwen_13_we;
+  logic dio_pad_attr_regwen_14_we;
   logic dio_pad_attr_regwen_14_qs;
   logic dio_pad_attr_regwen_14_wd;
-  logic dio_pad_attr_regwen_14_we;
+  logic dio_pad_attr_regwen_15_we;
   logic dio_pad_attr_regwen_15_qs;
   logic dio_pad_attr_regwen_15_wd;
-  logic dio_pad_attr_regwen_15_we;
+  logic dio_pad_attr_regwen_16_we;
   logic dio_pad_attr_regwen_16_qs;
   logic dio_pad_attr_regwen_16_wd;
-  logic dio_pad_attr_regwen_16_we;
+  logic dio_pad_attr_regwen_17_we;
   logic dio_pad_attr_regwen_17_qs;
   logic dio_pad_attr_regwen_17_wd;
-  logic dio_pad_attr_regwen_17_we;
+  logic dio_pad_attr_regwen_18_we;
   logic dio_pad_attr_regwen_18_qs;
   logic dio_pad_attr_regwen_18_wd;
-  logic dio_pad_attr_regwen_18_we;
+  logic dio_pad_attr_regwen_19_we;
   logic dio_pad_attr_regwen_19_qs;
   logic dio_pad_attr_regwen_19_wd;
-  logic dio_pad_attr_regwen_19_we;
+  logic dio_pad_attr_regwen_20_we;
   logic dio_pad_attr_regwen_20_qs;
   logic dio_pad_attr_regwen_20_wd;
-  logic dio_pad_attr_regwen_20_we;
+  logic dio_pad_attr_regwen_21_we;
   logic dio_pad_attr_regwen_21_qs;
   logic dio_pad_attr_regwen_21_wd;
-  logic dio_pad_attr_regwen_21_we;
+  logic dio_pad_attr_regwen_22_we;
   logic dio_pad_attr_regwen_22_qs;
   logic dio_pad_attr_regwen_22_wd;
-  logic dio_pad_attr_regwen_22_we;
+  logic dio_pad_attr_regwen_23_we;
   logic dio_pad_attr_regwen_23_qs;
   logic dio_pad_attr_regwen_23_wd;
-  logic dio_pad_attr_regwen_23_we;
+  logic dio_pad_attr_0_re;
+  logic dio_pad_attr_0_we;
   logic [12:0] dio_pad_attr_0_qs;
   logic [12:0] dio_pad_attr_0_wd;
-  logic dio_pad_attr_0_we;
-  logic dio_pad_attr_0_re;
+  logic dio_pad_attr_1_re;
+  logic dio_pad_attr_1_we;
   logic [12:0] dio_pad_attr_1_qs;
   logic [12:0] dio_pad_attr_1_wd;
-  logic dio_pad_attr_1_we;
-  logic dio_pad_attr_1_re;
+  logic dio_pad_attr_2_re;
+  logic dio_pad_attr_2_we;
   logic [12:0] dio_pad_attr_2_qs;
   logic [12:0] dio_pad_attr_2_wd;
-  logic dio_pad_attr_2_we;
-  logic dio_pad_attr_2_re;
+  logic dio_pad_attr_3_re;
+  logic dio_pad_attr_3_we;
   logic [12:0] dio_pad_attr_3_qs;
   logic [12:0] dio_pad_attr_3_wd;
-  logic dio_pad_attr_3_we;
-  logic dio_pad_attr_3_re;
+  logic dio_pad_attr_4_re;
+  logic dio_pad_attr_4_we;
   logic [12:0] dio_pad_attr_4_qs;
   logic [12:0] dio_pad_attr_4_wd;
-  logic dio_pad_attr_4_we;
-  logic dio_pad_attr_4_re;
+  logic dio_pad_attr_5_re;
+  logic dio_pad_attr_5_we;
   logic [12:0] dio_pad_attr_5_qs;
   logic [12:0] dio_pad_attr_5_wd;
-  logic dio_pad_attr_5_we;
-  logic dio_pad_attr_5_re;
+  logic dio_pad_attr_6_re;
+  logic dio_pad_attr_6_we;
   logic [12:0] dio_pad_attr_6_qs;
   logic [12:0] dio_pad_attr_6_wd;
-  logic dio_pad_attr_6_we;
-  logic dio_pad_attr_6_re;
+  logic dio_pad_attr_7_re;
+  logic dio_pad_attr_7_we;
   logic [12:0] dio_pad_attr_7_qs;
   logic [12:0] dio_pad_attr_7_wd;
-  logic dio_pad_attr_7_we;
-  logic dio_pad_attr_7_re;
+  logic dio_pad_attr_8_re;
+  logic dio_pad_attr_8_we;
   logic [12:0] dio_pad_attr_8_qs;
   logic [12:0] dio_pad_attr_8_wd;
-  logic dio_pad_attr_8_we;
-  logic dio_pad_attr_8_re;
+  logic dio_pad_attr_9_re;
+  logic dio_pad_attr_9_we;
   logic [12:0] dio_pad_attr_9_qs;
   logic [12:0] dio_pad_attr_9_wd;
-  logic dio_pad_attr_9_we;
-  logic dio_pad_attr_9_re;
+  logic dio_pad_attr_10_re;
+  logic dio_pad_attr_10_we;
   logic [12:0] dio_pad_attr_10_qs;
   logic [12:0] dio_pad_attr_10_wd;
-  logic dio_pad_attr_10_we;
-  logic dio_pad_attr_10_re;
+  logic dio_pad_attr_11_re;
+  logic dio_pad_attr_11_we;
   logic [12:0] dio_pad_attr_11_qs;
   logic [12:0] dio_pad_attr_11_wd;
-  logic dio_pad_attr_11_we;
-  logic dio_pad_attr_11_re;
+  logic dio_pad_attr_12_re;
+  logic dio_pad_attr_12_we;
   logic [12:0] dio_pad_attr_12_qs;
   logic [12:0] dio_pad_attr_12_wd;
-  logic dio_pad_attr_12_we;
-  logic dio_pad_attr_12_re;
+  logic dio_pad_attr_13_re;
+  logic dio_pad_attr_13_we;
   logic [12:0] dio_pad_attr_13_qs;
   logic [12:0] dio_pad_attr_13_wd;
-  logic dio_pad_attr_13_we;
-  logic dio_pad_attr_13_re;
+  logic dio_pad_attr_14_re;
+  logic dio_pad_attr_14_we;
   logic [12:0] dio_pad_attr_14_qs;
   logic [12:0] dio_pad_attr_14_wd;
-  logic dio_pad_attr_14_we;
-  logic dio_pad_attr_14_re;
+  logic dio_pad_attr_15_re;
+  logic dio_pad_attr_15_we;
   logic [12:0] dio_pad_attr_15_qs;
   logic [12:0] dio_pad_attr_15_wd;
-  logic dio_pad_attr_15_we;
-  logic dio_pad_attr_15_re;
+  logic dio_pad_attr_16_re;
+  logic dio_pad_attr_16_we;
   logic [12:0] dio_pad_attr_16_qs;
   logic [12:0] dio_pad_attr_16_wd;
-  logic dio_pad_attr_16_we;
-  logic dio_pad_attr_16_re;
+  logic dio_pad_attr_17_re;
+  logic dio_pad_attr_17_we;
   logic [12:0] dio_pad_attr_17_qs;
   logic [12:0] dio_pad_attr_17_wd;
-  logic dio_pad_attr_17_we;
-  logic dio_pad_attr_17_re;
+  logic dio_pad_attr_18_re;
+  logic dio_pad_attr_18_we;
   logic [12:0] dio_pad_attr_18_qs;
   logic [12:0] dio_pad_attr_18_wd;
-  logic dio_pad_attr_18_we;
-  logic dio_pad_attr_18_re;
+  logic dio_pad_attr_19_re;
+  logic dio_pad_attr_19_we;
   logic [12:0] dio_pad_attr_19_qs;
   logic [12:0] dio_pad_attr_19_wd;
-  logic dio_pad_attr_19_we;
-  logic dio_pad_attr_19_re;
+  logic dio_pad_attr_20_re;
+  logic dio_pad_attr_20_we;
   logic [12:0] dio_pad_attr_20_qs;
   logic [12:0] dio_pad_attr_20_wd;
-  logic dio_pad_attr_20_we;
-  logic dio_pad_attr_20_re;
+  logic dio_pad_attr_21_re;
+  logic dio_pad_attr_21_we;
   logic [12:0] dio_pad_attr_21_qs;
   logic [12:0] dio_pad_attr_21_wd;
-  logic dio_pad_attr_21_we;
-  logic dio_pad_attr_21_re;
+  logic dio_pad_attr_22_re;
+  logic dio_pad_attr_22_we;
   logic [12:0] dio_pad_attr_22_qs;
   logic [12:0] dio_pad_attr_22_wd;
-  logic dio_pad_attr_22_we;
-  logic dio_pad_attr_22_re;
+  logic dio_pad_attr_23_re;
+  logic dio_pad_attr_23_we;
   logic [12:0] dio_pad_attr_23_qs;
   logic [12:0] dio_pad_attr_23_wd;
-  logic dio_pad_attr_23_we;
-  logic dio_pad_attr_23_re;
+  logic mio_pad_sleep_status_0_we;
   logic mio_pad_sleep_status_0_en_0_qs;
   logic mio_pad_sleep_status_0_en_0_wd;
-  logic mio_pad_sleep_status_0_en_0_we;
   logic mio_pad_sleep_status_0_en_1_qs;
   logic mio_pad_sleep_status_0_en_1_wd;
-  logic mio_pad_sleep_status_0_en_1_we;
   logic mio_pad_sleep_status_0_en_2_qs;
   logic mio_pad_sleep_status_0_en_2_wd;
-  logic mio_pad_sleep_status_0_en_2_we;
   logic mio_pad_sleep_status_0_en_3_qs;
   logic mio_pad_sleep_status_0_en_3_wd;
-  logic mio_pad_sleep_status_0_en_3_we;
   logic mio_pad_sleep_status_0_en_4_qs;
   logic mio_pad_sleep_status_0_en_4_wd;
-  logic mio_pad_sleep_status_0_en_4_we;
   logic mio_pad_sleep_status_0_en_5_qs;
   logic mio_pad_sleep_status_0_en_5_wd;
-  logic mio_pad_sleep_status_0_en_5_we;
   logic mio_pad_sleep_status_0_en_6_qs;
   logic mio_pad_sleep_status_0_en_6_wd;
-  logic mio_pad_sleep_status_0_en_6_we;
   logic mio_pad_sleep_status_0_en_7_qs;
   logic mio_pad_sleep_status_0_en_7_wd;
-  logic mio_pad_sleep_status_0_en_7_we;
   logic mio_pad_sleep_status_0_en_8_qs;
   logic mio_pad_sleep_status_0_en_8_wd;
-  logic mio_pad_sleep_status_0_en_8_we;
   logic mio_pad_sleep_status_0_en_9_qs;
   logic mio_pad_sleep_status_0_en_9_wd;
-  logic mio_pad_sleep_status_0_en_9_we;
   logic mio_pad_sleep_status_0_en_10_qs;
   logic mio_pad_sleep_status_0_en_10_wd;
-  logic mio_pad_sleep_status_0_en_10_we;
   logic mio_pad_sleep_status_0_en_11_qs;
   logic mio_pad_sleep_status_0_en_11_wd;
-  logic mio_pad_sleep_status_0_en_11_we;
   logic mio_pad_sleep_status_0_en_12_qs;
   logic mio_pad_sleep_status_0_en_12_wd;
-  logic mio_pad_sleep_status_0_en_12_we;
   logic mio_pad_sleep_status_0_en_13_qs;
   logic mio_pad_sleep_status_0_en_13_wd;
-  logic mio_pad_sleep_status_0_en_13_we;
   logic mio_pad_sleep_status_0_en_14_qs;
   logic mio_pad_sleep_status_0_en_14_wd;
-  logic mio_pad_sleep_status_0_en_14_we;
   logic mio_pad_sleep_status_0_en_15_qs;
   logic mio_pad_sleep_status_0_en_15_wd;
-  logic mio_pad_sleep_status_0_en_15_we;
   logic mio_pad_sleep_status_0_en_16_qs;
   logic mio_pad_sleep_status_0_en_16_wd;
-  logic mio_pad_sleep_status_0_en_16_we;
   logic mio_pad_sleep_status_0_en_17_qs;
   logic mio_pad_sleep_status_0_en_17_wd;
-  logic mio_pad_sleep_status_0_en_17_we;
   logic mio_pad_sleep_status_0_en_18_qs;
   logic mio_pad_sleep_status_0_en_18_wd;
-  logic mio_pad_sleep_status_0_en_18_we;
   logic mio_pad_sleep_status_0_en_19_qs;
   logic mio_pad_sleep_status_0_en_19_wd;
-  logic mio_pad_sleep_status_0_en_19_we;
   logic mio_pad_sleep_status_0_en_20_qs;
   logic mio_pad_sleep_status_0_en_20_wd;
-  logic mio_pad_sleep_status_0_en_20_we;
   logic mio_pad_sleep_status_0_en_21_qs;
   logic mio_pad_sleep_status_0_en_21_wd;
-  logic mio_pad_sleep_status_0_en_21_we;
   logic mio_pad_sleep_status_0_en_22_qs;
   logic mio_pad_sleep_status_0_en_22_wd;
-  logic mio_pad_sleep_status_0_en_22_we;
   logic mio_pad_sleep_status_0_en_23_qs;
   logic mio_pad_sleep_status_0_en_23_wd;
-  logic mio_pad_sleep_status_0_en_23_we;
   logic mio_pad_sleep_status_0_en_24_qs;
   logic mio_pad_sleep_status_0_en_24_wd;
-  logic mio_pad_sleep_status_0_en_24_we;
   logic mio_pad_sleep_status_0_en_25_qs;
   logic mio_pad_sleep_status_0_en_25_wd;
-  logic mio_pad_sleep_status_0_en_25_we;
   logic mio_pad_sleep_status_0_en_26_qs;
   logic mio_pad_sleep_status_0_en_26_wd;
-  logic mio_pad_sleep_status_0_en_26_we;
   logic mio_pad_sleep_status_0_en_27_qs;
   logic mio_pad_sleep_status_0_en_27_wd;
-  logic mio_pad_sleep_status_0_en_27_we;
   logic mio_pad_sleep_status_0_en_28_qs;
   logic mio_pad_sleep_status_0_en_28_wd;
-  logic mio_pad_sleep_status_0_en_28_we;
   logic mio_pad_sleep_status_0_en_29_qs;
   logic mio_pad_sleep_status_0_en_29_wd;
-  logic mio_pad_sleep_status_0_en_29_we;
   logic mio_pad_sleep_status_0_en_30_qs;
   logic mio_pad_sleep_status_0_en_30_wd;
-  logic mio_pad_sleep_status_0_en_30_we;
   logic mio_pad_sleep_status_0_en_31_qs;
   logic mio_pad_sleep_status_0_en_31_wd;
-  logic mio_pad_sleep_status_0_en_31_we;
+  logic mio_pad_sleep_status_1_we;
   logic mio_pad_sleep_status_1_en_32_qs;
   logic mio_pad_sleep_status_1_en_32_wd;
-  logic mio_pad_sleep_status_1_en_32_we;
   logic mio_pad_sleep_status_1_en_33_qs;
   logic mio_pad_sleep_status_1_en_33_wd;
-  logic mio_pad_sleep_status_1_en_33_we;
   logic mio_pad_sleep_status_1_en_34_qs;
   logic mio_pad_sleep_status_1_en_34_wd;
-  logic mio_pad_sleep_status_1_en_34_we;
   logic mio_pad_sleep_status_1_en_35_qs;
   logic mio_pad_sleep_status_1_en_35_wd;
-  logic mio_pad_sleep_status_1_en_35_we;
   logic mio_pad_sleep_status_1_en_36_qs;
   logic mio_pad_sleep_status_1_en_36_wd;
-  logic mio_pad_sleep_status_1_en_36_we;
   logic mio_pad_sleep_status_1_en_37_qs;
   logic mio_pad_sleep_status_1_en_37_wd;
-  logic mio_pad_sleep_status_1_en_37_we;
   logic mio_pad_sleep_status_1_en_38_qs;
   logic mio_pad_sleep_status_1_en_38_wd;
-  logic mio_pad_sleep_status_1_en_38_we;
   logic mio_pad_sleep_status_1_en_39_qs;
   logic mio_pad_sleep_status_1_en_39_wd;
-  logic mio_pad_sleep_status_1_en_39_we;
   logic mio_pad_sleep_status_1_en_40_qs;
   logic mio_pad_sleep_status_1_en_40_wd;
-  logic mio_pad_sleep_status_1_en_40_we;
   logic mio_pad_sleep_status_1_en_41_qs;
   logic mio_pad_sleep_status_1_en_41_wd;
-  logic mio_pad_sleep_status_1_en_41_we;
   logic mio_pad_sleep_status_1_en_42_qs;
   logic mio_pad_sleep_status_1_en_42_wd;
-  logic mio_pad_sleep_status_1_en_42_we;
   logic mio_pad_sleep_status_1_en_43_qs;
   logic mio_pad_sleep_status_1_en_43_wd;
-  logic mio_pad_sleep_status_1_en_43_we;
   logic mio_pad_sleep_status_1_en_44_qs;
   logic mio_pad_sleep_status_1_en_44_wd;
-  logic mio_pad_sleep_status_1_en_44_we;
   logic mio_pad_sleep_status_1_en_45_qs;
   logic mio_pad_sleep_status_1_en_45_wd;
-  logic mio_pad_sleep_status_1_en_45_we;
   logic mio_pad_sleep_status_1_en_46_qs;
   logic mio_pad_sleep_status_1_en_46_wd;
-  logic mio_pad_sleep_status_1_en_46_we;
+  logic mio_pad_sleep_regwen_0_we;
   logic mio_pad_sleep_regwen_0_qs;
   logic mio_pad_sleep_regwen_0_wd;
-  logic mio_pad_sleep_regwen_0_we;
+  logic mio_pad_sleep_regwen_1_we;
   logic mio_pad_sleep_regwen_1_qs;
   logic mio_pad_sleep_regwen_1_wd;
-  logic mio_pad_sleep_regwen_1_we;
+  logic mio_pad_sleep_regwen_2_we;
   logic mio_pad_sleep_regwen_2_qs;
   logic mio_pad_sleep_regwen_2_wd;
-  logic mio_pad_sleep_regwen_2_we;
+  logic mio_pad_sleep_regwen_3_we;
   logic mio_pad_sleep_regwen_3_qs;
   logic mio_pad_sleep_regwen_3_wd;
-  logic mio_pad_sleep_regwen_3_we;
+  logic mio_pad_sleep_regwen_4_we;
   logic mio_pad_sleep_regwen_4_qs;
   logic mio_pad_sleep_regwen_4_wd;
-  logic mio_pad_sleep_regwen_4_we;
+  logic mio_pad_sleep_regwen_5_we;
   logic mio_pad_sleep_regwen_5_qs;
   logic mio_pad_sleep_regwen_5_wd;
-  logic mio_pad_sleep_regwen_5_we;
+  logic mio_pad_sleep_regwen_6_we;
   logic mio_pad_sleep_regwen_6_qs;
   logic mio_pad_sleep_regwen_6_wd;
-  logic mio_pad_sleep_regwen_6_we;
+  logic mio_pad_sleep_regwen_7_we;
   logic mio_pad_sleep_regwen_7_qs;
   logic mio_pad_sleep_regwen_7_wd;
-  logic mio_pad_sleep_regwen_7_we;
+  logic mio_pad_sleep_regwen_8_we;
   logic mio_pad_sleep_regwen_8_qs;
   logic mio_pad_sleep_regwen_8_wd;
-  logic mio_pad_sleep_regwen_8_we;
+  logic mio_pad_sleep_regwen_9_we;
   logic mio_pad_sleep_regwen_9_qs;
   logic mio_pad_sleep_regwen_9_wd;
-  logic mio_pad_sleep_regwen_9_we;
+  logic mio_pad_sleep_regwen_10_we;
   logic mio_pad_sleep_regwen_10_qs;
   logic mio_pad_sleep_regwen_10_wd;
-  logic mio_pad_sleep_regwen_10_we;
+  logic mio_pad_sleep_regwen_11_we;
   logic mio_pad_sleep_regwen_11_qs;
   logic mio_pad_sleep_regwen_11_wd;
-  logic mio_pad_sleep_regwen_11_we;
+  logic mio_pad_sleep_regwen_12_we;
   logic mio_pad_sleep_regwen_12_qs;
   logic mio_pad_sleep_regwen_12_wd;
-  logic mio_pad_sleep_regwen_12_we;
+  logic mio_pad_sleep_regwen_13_we;
   logic mio_pad_sleep_regwen_13_qs;
   logic mio_pad_sleep_regwen_13_wd;
-  logic mio_pad_sleep_regwen_13_we;
+  logic mio_pad_sleep_regwen_14_we;
   logic mio_pad_sleep_regwen_14_qs;
   logic mio_pad_sleep_regwen_14_wd;
-  logic mio_pad_sleep_regwen_14_we;
+  logic mio_pad_sleep_regwen_15_we;
   logic mio_pad_sleep_regwen_15_qs;
   logic mio_pad_sleep_regwen_15_wd;
-  logic mio_pad_sleep_regwen_15_we;
+  logic mio_pad_sleep_regwen_16_we;
   logic mio_pad_sleep_regwen_16_qs;
   logic mio_pad_sleep_regwen_16_wd;
-  logic mio_pad_sleep_regwen_16_we;
+  logic mio_pad_sleep_regwen_17_we;
   logic mio_pad_sleep_regwen_17_qs;
   logic mio_pad_sleep_regwen_17_wd;
-  logic mio_pad_sleep_regwen_17_we;
+  logic mio_pad_sleep_regwen_18_we;
   logic mio_pad_sleep_regwen_18_qs;
   logic mio_pad_sleep_regwen_18_wd;
-  logic mio_pad_sleep_regwen_18_we;
+  logic mio_pad_sleep_regwen_19_we;
   logic mio_pad_sleep_regwen_19_qs;
   logic mio_pad_sleep_regwen_19_wd;
-  logic mio_pad_sleep_regwen_19_we;
+  logic mio_pad_sleep_regwen_20_we;
   logic mio_pad_sleep_regwen_20_qs;
   logic mio_pad_sleep_regwen_20_wd;
-  logic mio_pad_sleep_regwen_20_we;
+  logic mio_pad_sleep_regwen_21_we;
   logic mio_pad_sleep_regwen_21_qs;
   logic mio_pad_sleep_regwen_21_wd;
-  logic mio_pad_sleep_regwen_21_we;
+  logic mio_pad_sleep_regwen_22_we;
   logic mio_pad_sleep_regwen_22_qs;
   logic mio_pad_sleep_regwen_22_wd;
-  logic mio_pad_sleep_regwen_22_we;
+  logic mio_pad_sleep_regwen_23_we;
   logic mio_pad_sleep_regwen_23_qs;
   logic mio_pad_sleep_regwen_23_wd;
-  logic mio_pad_sleep_regwen_23_we;
+  logic mio_pad_sleep_regwen_24_we;
   logic mio_pad_sleep_regwen_24_qs;
   logic mio_pad_sleep_regwen_24_wd;
-  logic mio_pad_sleep_regwen_24_we;
+  logic mio_pad_sleep_regwen_25_we;
   logic mio_pad_sleep_regwen_25_qs;
   logic mio_pad_sleep_regwen_25_wd;
-  logic mio_pad_sleep_regwen_25_we;
+  logic mio_pad_sleep_regwen_26_we;
   logic mio_pad_sleep_regwen_26_qs;
   logic mio_pad_sleep_regwen_26_wd;
-  logic mio_pad_sleep_regwen_26_we;
+  logic mio_pad_sleep_regwen_27_we;
   logic mio_pad_sleep_regwen_27_qs;
   logic mio_pad_sleep_regwen_27_wd;
-  logic mio_pad_sleep_regwen_27_we;
+  logic mio_pad_sleep_regwen_28_we;
   logic mio_pad_sleep_regwen_28_qs;
   logic mio_pad_sleep_regwen_28_wd;
-  logic mio_pad_sleep_regwen_28_we;
+  logic mio_pad_sleep_regwen_29_we;
   logic mio_pad_sleep_regwen_29_qs;
   logic mio_pad_sleep_regwen_29_wd;
-  logic mio_pad_sleep_regwen_29_we;
+  logic mio_pad_sleep_regwen_30_we;
   logic mio_pad_sleep_regwen_30_qs;
   logic mio_pad_sleep_regwen_30_wd;
-  logic mio_pad_sleep_regwen_30_we;
+  logic mio_pad_sleep_regwen_31_we;
   logic mio_pad_sleep_regwen_31_qs;
   logic mio_pad_sleep_regwen_31_wd;
-  logic mio_pad_sleep_regwen_31_we;
+  logic mio_pad_sleep_regwen_32_we;
   logic mio_pad_sleep_regwen_32_qs;
   logic mio_pad_sleep_regwen_32_wd;
-  logic mio_pad_sleep_regwen_32_we;
+  logic mio_pad_sleep_regwen_33_we;
   logic mio_pad_sleep_regwen_33_qs;
   logic mio_pad_sleep_regwen_33_wd;
-  logic mio_pad_sleep_regwen_33_we;
+  logic mio_pad_sleep_regwen_34_we;
   logic mio_pad_sleep_regwen_34_qs;
   logic mio_pad_sleep_regwen_34_wd;
-  logic mio_pad_sleep_regwen_34_we;
+  logic mio_pad_sleep_regwen_35_we;
   logic mio_pad_sleep_regwen_35_qs;
   logic mio_pad_sleep_regwen_35_wd;
-  logic mio_pad_sleep_regwen_35_we;
+  logic mio_pad_sleep_regwen_36_we;
   logic mio_pad_sleep_regwen_36_qs;
   logic mio_pad_sleep_regwen_36_wd;
-  logic mio_pad_sleep_regwen_36_we;
+  logic mio_pad_sleep_regwen_37_we;
   logic mio_pad_sleep_regwen_37_qs;
   logic mio_pad_sleep_regwen_37_wd;
-  logic mio_pad_sleep_regwen_37_we;
+  logic mio_pad_sleep_regwen_38_we;
   logic mio_pad_sleep_regwen_38_qs;
   logic mio_pad_sleep_regwen_38_wd;
-  logic mio_pad_sleep_regwen_38_we;
+  logic mio_pad_sleep_regwen_39_we;
   logic mio_pad_sleep_regwen_39_qs;
   logic mio_pad_sleep_regwen_39_wd;
-  logic mio_pad_sleep_regwen_39_we;
+  logic mio_pad_sleep_regwen_40_we;
   logic mio_pad_sleep_regwen_40_qs;
   logic mio_pad_sleep_regwen_40_wd;
-  logic mio_pad_sleep_regwen_40_we;
+  logic mio_pad_sleep_regwen_41_we;
   logic mio_pad_sleep_regwen_41_qs;
   logic mio_pad_sleep_regwen_41_wd;
-  logic mio_pad_sleep_regwen_41_we;
+  logic mio_pad_sleep_regwen_42_we;
   logic mio_pad_sleep_regwen_42_qs;
   logic mio_pad_sleep_regwen_42_wd;
-  logic mio_pad_sleep_regwen_42_we;
+  logic mio_pad_sleep_regwen_43_we;
   logic mio_pad_sleep_regwen_43_qs;
   logic mio_pad_sleep_regwen_43_wd;
-  logic mio_pad_sleep_regwen_43_we;
+  logic mio_pad_sleep_regwen_44_we;
   logic mio_pad_sleep_regwen_44_qs;
   logic mio_pad_sleep_regwen_44_wd;
-  logic mio_pad_sleep_regwen_44_we;
+  logic mio_pad_sleep_regwen_45_we;
   logic mio_pad_sleep_regwen_45_qs;
   logic mio_pad_sleep_regwen_45_wd;
-  logic mio_pad_sleep_regwen_45_we;
+  logic mio_pad_sleep_regwen_46_we;
   logic mio_pad_sleep_regwen_46_qs;
   logic mio_pad_sleep_regwen_46_wd;
-  logic mio_pad_sleep_regwen_46_we;
+  logic mio_pad_sleep_en_0_we;
   logic mio_pad_sleep_en_0_qs;
   logic mio_pad_sleep_en_0_wd;
-  logic mio_pad_sleep_en_0_we;
+  logic mio_pad_sleep_en_1_we;
   logic mio_pad_sleep_en_1_qs;
   logic mio_pad_sleep_en_1_wd;
-  logic mio_pad_sleep_en_1_we;
+  logic mio_pad_sleep_en_2_we;
   logic mio_pad_sleep_en_2_qs;
   logic mio_pad_sleep_en_2_wd;
-  logic mio_pad_sleep_en_2_we;
+  logic mio_pad_sleep_en_3_we;
   logic mio_pad_sleep_en_3_qs;
   logic mio_pad_sleep_en_3_wd;
-  logic mio_pad_sleep_en_3_we;
+  logic mio_pad_sleep_en_4_we;
   logic mio_pad_sleep_en_4_qs;
   logic mio_pad_sleep_en_4_wd;
-  logic mio_pad_sleep_en_4_we;
+  logic mio_pad_sleep_en_5_we;
   logic mio_pad_sleep_en_5_qs;
   logic mio_pad_sleep_en_5_wd;
-  logic mio_pad_sleep_en_5_we;
+  logic mio_pad_sleep_en_6_we;
   logic mio_pad_sleep_en_6_qs;
   logic mio_pad_sleep_en_6_wd;
-  logic mio_pad_sleep_en_6_we;
+  logic mio_pad_sleep_en_7_we;
   logic mio_pad_sleep_en_7_qs;
   logic mio_pad_sleep_en_7_wd;
-  logic mio_pad_sleep_en_7_we;
+  logic mio_pad_sleep_en_8_we;
   logic mio_pad_sleep_en_8_qs;
   logic mio_pad_sleep_en_8_wd;
-  logic mio_pad_sleep_en_8_we;
+  logic mio_pad_sleep_en_9_we;
   logic mio_pad_sleep_en_9_qs;
   logic mio_pad_sleep_en_9_wd;
-  logic mio_pad_sleep_en_9_we;
+  logic mio_pad_sleep_en_10_we;
   logic mio_pad_sleep_en_10_qs;
   logic mio_pad_sleep_en_10_wd;
-  logic mio_pad_sleep_en_10_we;
+  logic mio_pad_sleep_en_11_we;
   logic mio_pad_sleep_en_11_qs;
   logic mio_pad_sleep_en_11_wd;
-  logic mio_pad_sleep_en_11_we;
+  logic mio_pad_sleep_en_12_we;
   logic mio_pad_sleep_en_12_qs;
   logic mio_pad_sleep_en_12_wd;
-  logic mio_pad_sleep_en_12_we;
+  logic mio_pad_sleep_en_13_we;
   logic mio_pad_sleep_en_13_qs;
   logic mio_pad_sleep_en_13_wd;
-  logic mio_pad_sleep_en_13_we;
+  logic mio_pad_sleep_en_14_we;
   logic mio_pad_sleep_en_14_qs;
   logic mio_pad_sleep_en_14_wd;
-  logic mio_pad_sleep_en_14_we;
+  logic mio_pad_sleep_en_15_we;
   logic mio_pad_sleep_en_15_qs;
   logic mio_pad_sleep_en_15_wd;
-  logic mio_pad_sleep_en_15_we;
+  logic mio_pad_sleep_en_16_we;
   logic mio_pad_sleep_en_16_qs;
   logic mio_pad_sleep_en_16_wd;
-  logic mio_pad_sleep_en_16_we;
+  logic mio_pad_sleep_en_17_we;
   logic mio_pad_sleep_en_17_qs;
   logic mio_pad_sleep_en_17_wd;
-  logic mio_pad_sleep_en_17_we;
+  logic mio_pad_sleep_en_18_we;
   logic mio_pad_sleep_en_18_qs;
   logic mio_pad_sleep_en_18_wd;
-  logic mio_pad_sleep_en_18_we;
+  logic mio_pad_sleep_en_19_we;
   logic mio_pad_sleep_en_19_qs;
   logic mio_pad_sleep_en_19_wd;
-  logic mio_pad_sleep_en_19_we;
+  logic mio_pad_sleep_en_20_we;
   logic mio_pad_sleep_en_20_qs;
   logic mio_pad_sleep_en_20_wd;
-  logic mio_pad_sleep_en_20_we;
+  logic mio_pad_sleep_en_21_we;
   logic mio_pad_sleep_en_21_qs;
   logic mio_pad_sleep_en_21_wd;
-  logic mio_pad_sleep_en_21_we;
+  logic mio_pad_sleep_en_22_we;
   logic mio_pad_sleep_en_22_qs;
   logic mio_pad_sleep_en_22_wd;
-  logic mio_pad_sleep_en_22_we;
+  logic mio_pad_sleep_en_23_we;
   logic mio_pad_sleep_en_23_qs;
   logic mio_pad_sleep_en_23_wd;
-  logic mio_pad_sleep_en_23_we;
+  logic mio_pad_sleep_en_24_we;
   logic mio_pad_sleep_en_24_qs;
   logic mio_pad_sleep_en_24_wd;
-  logic mio_pad_sleep_en_24_we;
+  logic mio_pad_sleep_en_25_we;
   logic mio_pad_sleep_en_25_qs;
   logic mio_pad_sleep_en_25_wd;
-  logic mio_pad_sleep_en_25_we;
+  logic mio_pad_sleep_en_26_we;
   logic mio_pad_sleep_en_26_qs;
   logic mio_pad_sleep_en_26_wd;
-  logic mio_pad_sleep_en_26_we;
+  logic mio_pad_sleep_en_27_we;
   logic mio_pad_sleep_en_27_qs;
   logic mio_pad_sleep_en_27_wd;
-  logic mio_pad_sleep_en_27_we;
+  logic mio_pad_sleep_en_28_we;
   logic mio_pad_sleep_en_28_qs;
   logic mio_pad_sleep_en_28_wd;
-  logic mio_pad_sleep_en_28_we;
+  logic mio_pad_sleep_en_29_we;
   logic mio_pad_sleep_en_29_qs;
   logic mio_pad_sleep_en_29_wd;
-  logic mio_pad_sleep_en_29_we;
+  logic mio_pad_sleep_en_30_we;
   logic mio_pad_sleep_en_30_qs;
   logic mio_pad_sleep_en_30_wd;
-  logic mio_pad_sleep_en_30_we;
+  logic mio_pad_sleep_en_31_we;
   logic mio_pad_sleep_en_31_qs;
   logic mio_pad_sleep_en_31_wd;
-  logic mio_pad_sleep_en_31_we;
+  logic mio_pad_sleep_en_32_we;
   logic mio_pad_sleep_en_32_qs;
   logic mio_pad_sleep_en_32_wd;
-  logic mio_pad_sleep_en_32_we;
+  logic mio_pad_sleep_en_33_we;
   logic mio_pad_sleep_en_33_qs;
   logic mio_pad_sleep_en_33_wd;
-  logic mio_pad_sleep_en_33_we;
+  logic mio_pad_sleep_en_34_we;
   logic mio_pad_sleep_en_34_qs;
   logic mio_pad_sleep_en_34_wd;
-  logic mio_pad_sleep_en_34_we;
+  logic mio_pad_sleep_en_35_we;
   logic mio_pad_sleep_en_35_qs;
   logic mio_pad_sleep_en_35_wd;
-  logic mio_pad_sleep_en_35_we;
+  logic mio_pad_sleep_en_36_we;
   logic mio_pad_sleep_en_36_qs;
   logic mio_pad_sleep_en_36_wd;
-  logic mio_pad_sleep_en_36_we;
+  logic mio_pad_sleep_en_37_we;
   logic mio_pad_sleep_en_37_qs;
   logic mio_pad_sleep_en_37_wd;
-  logic mio_pad_sleep_en_37_we;
+  logic mio_pad_sleep_en_38_we;
   logic mio_pad_sleep_en_38_qs;
   logic mio_pad_sleep_en_38_wd;
-  logic mio_pad_sleep_en_38_we;
+  logic mio_pad_sleep_en_39_we;
   logic mio_pad_sleep_en_39_qs;
   logic mio_pad_sleep_en_39_wd;
-  logic mio_pad_sleep_en_39_we;
+  logic mio_pad_sleep_en_40_we;
   logic mio_pad_sleep_en_40_qs;
   logic mio_pad_sleep_en_40_wd;
-  logic mio_pad_sleep_en_40_we;
+  logic mio_pad_sleep_en_41_we;
   logic mio_pad_sleep_en_41_qs;
   logic mio_pad_sleep_en_41_wd;
-  logic mio_pad_sleep_en_41_we;
+  logic mio_pad_sleep_en_42_we;
   logic mio_pad_sleep_en_42_qs;
   logic mio_pad_sleep_en_42_wd;
-  logic mio_pad_sleep_en_42_we;
+  logic mio_pad_sleep_en_43_we;
   logic mio_pad_sleep_en_43_qs;
   logic mio_pad_sleep_en_43_wd;
-  logic mio_pad_sleep_en_43_we;
+  logic mio_pad_sleep_en_44_we;
   logic mio_pad_sleep_en_44_qs;
   logic mio_pad_sleep_en_44_wd;
-  logic mio_pad_sleep_en_44_we;
+  logic mio_pad_sleep_en_45_we;
   logic mio_pad_sleep_en_45_qs;
   logic mio_pad_sleep_en_45_wd;
-  logic mio_pad_sleep_en_45_we;
+  logic mio_pad_sleep_en_46_we;
   logic mio_pad_sleep_en_46_qs;
   logic mio_pad_sleep_en_46_wd;
-  logic mio_pad_sleep_en_46_we;
+  logic mio_pad_sleep_mode_0_we;
   logic [1:0] mio_pad_sleep_mode_0_qs;
   logic [1:0] mio_pad_sleep_mode_0_wd;
-  logic mio_pad_sleep_mode_0_we;
+  logic mio_pad_sleep_mode_1_we;
   logic [1:0] mio_pad_sleep_mode_1_qs;
   logic [1:0] mio_pad_sleep_mode_1_wd;
-  logic mio_pad_sleep_mode_1_we;
+  logic mio_pad_sleep_mode_2_we;
   logic [1:0] mio_pad_sleep_mode_2_qs;
   logic [1:0] mio_pad_sleep_mode_2_wd;
-  logic mio_pad_sleep_mode_2_we;
+  logic mio_pad_sleep_mode_3_we;
   logic [1:0] mio_pad_sleep_mode_3_qs;
   logic [1:0] mio_pad_sleep_mode_3_wd;
-  logic mio_pad_sleep_mode_3_we;
+  logic mio_pad_sleep_mode_4_we;
   logic [1:0] mio_pad_sleep_mode_4_qs;
   logic [1:0] mio_pad_sleep_mode_4_wd;
-  logic mio_pad_sleep_mode_4_we;
+  logic mio_pad_sleep_mode_5_we;
   logic [1:0] mio_pad_sleep_mode_5_qs;
   logic [1:0] mio_pad_sleep_mode_5_wd;
-  logic mio_pad_sleep_mode_5_we;
+  logic mio_pad_sleep_mode_6_we;
   logic [1:0] mio_pad_sleep_mode_6_qs;
   logic [1:0] mio_pad_sleep_mode_6_wd;
-  logic mio_pad_sleep_mode_6_we;
+  logic mio_pad_sleep_mode_7_we;
   logic [1:0] mio_pad_sleep_mode_7_qs;
   logic [1:0] mio_pad_sleep_mode_7_wd;
-  logic mio_pad_sleep_mode_7_we;
+  logic mio_pad_sleep_mode_8_we;
   logic [1:0] mio_pad_sleep_mode_8_qs;
   logic [1:0] mio_pad_sleep_mode_8_wd;
-  logic mio_pad_sleep_mode_8_we;
+  logic mio_pad_sleep_mode_9_we;
   logic [1:0] mio_pad_sleep_mode_9_qs;
   logic [1:0] mio_pad_sleep_mode_9_wd;
-  logic mio_pad_sleep_mode_9_we;
+  logic mio_pad_sleep_mode_10_we;
   logic [1:0] mio_pad_sleep_mode_10_qs;
   logic [1:0] mio_pad_sleep_mode_10_wd;
-  logic mio_pad_sleep_mode_10_we;
+  logic mio_pad_sleep_mode_11_we;
   logic [1:0] mio_pad_sleep_mode_11_qs;
   logic [1:0] mio_pad_sleep_mode_11_wd;
-  logic mio_pad_sleep_mode_11_we;
+  logic mio_pad_sleep_mode_12_we;
   logic [1:0] mio_pad_sleep_mode_12_qs;
   logic [1:0] mio_pad_sleep_mode_12_wd;
-  logic mio_pad_sleep_mode_12_we;
+  logic mio_pad_sleep_mode_13_we;
   logic [1:0] mio_pad_sleep_mode_13_qs;
   logic [1:0] mio_pad_sleep_mode_13_wd;
-  logic mio_pad_sleep_mode_13_we;
+  logic mio_pad_sleep_mode_14_we;
   logic [1:0] mio_pad_sleep_mode_14_qs;
   logic [1:0] mio_pad_sleep_mode_14_wd;
-  logic mio_pad_sleep_mode_14_we;
+  logic mio_pad_sleep_mode_15_we;
   logic [1:0] mio_pad_sleep_mode_15_qs;
   logic [1:0] mio_pad_sleep_mode_15_wd;
-  logic mio_pad_sleep_mode_15_we;
+  logic mio_pad_sleep_mode_16_we;
   logic [1:0] mio_pad_sleep_mode_16_qs;
   logic [1:0] mio_pad_sleep_mode_16_wd;
-  logic mio_pad_sleep_mode_16_we;
+  logic mio_pad_sleep_mode_17_we;
   logic [1:0] mio_pad_sleep_mode_17_qs;
   logic [1:0] mio_pad_sleep_mode_17_wd;
-  logic mio_pad_sleep_mode_17_we;
+  logic mio_pad_sleep_mode_18_we;
   logic [1:0] mio_pad_sleep_mode_18_qs;
   logic [1:0] mio_pad_sleep_mode_18_wd;
-  logic mio_pad_sleep_mode_18_we;
+  logic mio_pad_sleep_mode_19_we;
   logic [1:0] mio_pad_sleep_mode_19_qs;
   logic [1:0] mio_pad_sleep_mode_19_wd;
-  logic mio_pad_sleep_mode_19_we;
+  logic mio_pad_sleep_mode_20_we;
   logic [1:0] mio_pad_sleep_mode_20_qs;
   logic [1:0] mio_pad_sleep_mode_20_wd;
-  logic mio_pad_sleep_mode_20_we;
+  logic mio_pad_sleep_mode_21_we;
   logic [1:0] mio_pad_sleep_mode_21_qs;
   logic [1:0] mio_pad_sleep_mode_21_wd;
-  logic mio_pad_sleep_mode_21_we;
+  logic mio_pad_sleep_mode_22_we;
   logic [1:0] mio_pad_sleep_mode_22_qs;
   logic [1:0] mio_pad_sleep_mode_22_wd;
-  logic mio_pad_sleep_mode_22_we;
+  logic mio_pad_sleep_mode_23_we;
   logic [1:0] mio_pad_sleep_mode_23_qs;
   logic [1:0] mio_pad_sleep_mode_23_wd;
-  logic mio_pad_sleep_mode_23_we;
+  logic mio_pad_sleep_mode_24_we;
   logic [1:0] mio_pad_sleep_mode_24_qs;
   logic [1:0] mio_pad_sleep_mode_24_wd;
-  logic mio_pad_sleep_mode_24_we;
+  logic mio_pad_sleep_mode_25_we;
   logic [1:0] mio_pad_sleep_mode_25_qs;
   logic [1:0] mio_pad_sleep_mode_25_wd;
-  logic mio_pad_sleep_mode_25_we;
+  logic mio_pad_sleep_mode_26_we;
   logic [1:0] mio_pad_sleep_mode_26_qs;
   logic [1:0] mio_pad_sleep_mode_26_wd;
-  logic mio_pad_sleep_mode_26_we;
+  logic mio_pad_sleep_mode_27_we;
   logic [1:0] mio_pad_sleep_mode_27_qs;
   logic [1:0] mio_pad_sleep_mode_27_wd;
-  logic mio_pad_sleep_mode_27_we;
+  logic mio_pad_sleep_mode_28_we;
   logic [1:0] mio_pad_sleep_mode_28_qs;
   logic [1:0] mio_pad_sleep_mode_28_wd;
-  logic mio_pad_sleep_mode_28_we;
+  logic mio_pad_sleep_mode_29_we;
   logic [1:0] mio_pad_sleep_mode_29_qs;
   logic [1:0] mio_pad_sleep_mode_29_wd;
-  logic mio_pad_sleep_mode_29_we;
+  logic mio_pad_sleep_mode_30_we;
   logic [1:0] mio_pad_sleep_mode_30_qs;
   logic [1:0] mio_pad_sleep_mode_30_wd;
-  logic mio_pad_sleep_mode_30_we;
+  logic mio_pad_sleep_mode_31_we;
   logic [1:0] mio_pad_sleep_mode_31_qs;
   logic [1:0] mio_pad_sleep_mode_31_wd;
-  logic mio_pad_sleep_mode_31_we;
+  logic mio_pad_sleep_mode_32_we;
   logic [1:0] mio_pad_sleep_mode_32_qs;
   logic [1:0] mio_pad_sleep_mode_32_wd;
-  logic mio_pad_sleep_mode_32_we;
+  logic mio_pad_sleep_mode_33_we;
   logic [1:0] mio_pad_sleep_mode_33_qs;
   logic [1:0] mio_pad_sleep_mode_33_wd;
-  logic mio_pad_sleep_mode_33_we;
+  logic mio_pad_sleep_mode_34_we;
   logic [1:0] mio_pad_sleep_mode_34_qs;
   logic [1:0] mio_pad_sleep_mode_34_wd;
-  logic mio_pad_sleep_mode_34_we;
+  logic mio_pad_sleep_mode_35_we;
   logic [1:0] mio_pad_sleep_mode_35_qs;
   logic [1:0] mio_pad_sleep_mode_35_wd;
-  logic mio_pad_sleep_mode_35_we;
+  logic mio_pad_sleep_mode_36_we;
   logic [1:0] mio_pad_sleep_mode_36_qs;
   logic [1:0] mio_pad_sleep_mode_36_wd;
-  logic mio_pad_sleep_mode_36_we;
+  logic mio_pad_sleep_mode_37_we;
   logic [1:0] mio_pad_sleep_mode_37_qs;
   logic [1:0] mio_pad_sleep_mode_37_wd;
-  logic mio_pad_sleep_mode_37_we;
+  logic mio_pad_sleep_mode_38_we;
   logic [1:0] mio_pad_sleep_mode_38_qs;
   logic [1:0] mio_pad_sleep_mode_38_wd;
-  logic mio_pad_sleep_mode_38_we;
+  logic mio_pad_sleep_mode_39_we;
   logic [1:0] mio_pad_sleep_mode_39_qs;
   logic [1:0] mio_pad_sleep_mode_39_wd;
-  logic mio_pad_sleep_mode_39_we;
+  logic mio_pad_sleep_mode_40_we;
   logic [1:0] mio_pad_sleep_mode_40_qs;
   logic [1:0] mio_pad_sleep_mode_40_wd;
-  logic mio_pad_sleep_mode_40_we;
+  logic mio_pad_sleep_mode_41_we;
   logic [1:0] mio_pad_sleep_mode_41_qs;
   logic [1:0] mio_pad_sleep_mode_41_wd;
-  logic mio_pad_sleep_mode_41_we;
+  logic mio_pad_sleep_mode_42_we;
   logic [1:0] mio_pad_sleep_mode_42_qs;
   logic [1:0] mio_pad_sleep_mode_42_wd;
-  logic mio_pad_sleep_mode_42_we;
+  logic mio_pad_sleep_mode_43_we;
   logic [1:0] mio_pad_sleep_mode_43_qs;
   logic [1:0] mio_pad_sleep_mode_43_wd;
-  logic mio_pad_sleep_mode_43_we;
+  logic mio_pad_sleep_mode_44_we;
   logic [1:0] mio_pad_sleep_mode_44_qs;
   logic [1:0] mio_pad_sleep_mode_44_wd;
-  logic mio_pad_sleep_mode_44_we;
+  logic mio_pad_sleep_mode_45_we;
   logic [1:0] mio_pad_sleep_mode_45_qs;
   logic [1:0] mio_pad_sleep_mode_45_wd;
-  logic mio_pad_sleep_mode_45_we;
+  logic mio_pad_sleep_mode_46_we;
   logic [1:0] mio_pad_sleep_mode_46_qs;
   logic [1:0] mio_pad_sleep_mode_46_wd;
-  logic mio_pad_sleep_mode_46_we;
+  logic dio_pad_sleep_status_we;
   logic dio_pad_sleep_status_en_0_qs;
   logic dio_pad_sleep_status_en_0_wd;
-  logic dio_pad_sleep_status_en_0_we;
   logic dio_pad_sleep_status_en_1_qs;
   logic dio_pad_sleep_status_en_1_wd;
-  logic dio_pad_sleep_status_en_1_we;
   logic dio_pad_sleep_status_en_2_qs;
   logic dio_pad_sleep_status_en_2_wd;
-  logic dio_pad_sleep_status_en_2_we;
   logic dio_pad_sleep_status_en_3_qs;
   logic dio_pad_sleep_status_en_3_wd;
-  logic dio_pad_sleep_status_en_3_we;
   logic dio_pad_sleep_status_en_4_qs;
   logic dio_pad_sleep_status_en_4_wd;
-  logic dio_pad_sleep_status_en_4_we;
   logic dio_pad_sleep_status_en_5_qs;
   logic dio_pad_sleep_status_en_5_wd;
-  logic dio_pad_sleep_status_en_5_we;
   logic dio_pad_sleep_status_en_6_qs;
   logic dio_pad_sleep_status_en_6_wd;
-  logic dio_pad_sleep_status_en_6_we;
   logic dio_pad_sleep_status_en_7_qs;
   logic dio_pad_sleep_status_en_7_wd;
-  logic dio_pad_sleep_status_en_7_we;
   logic dio_pad_sleep_status_en_8_qs;
   logic dio_pad_sleep_status_en_8_wd;
-  logic dio_pad_sleep_status_en_8_we;
   logic dio_pad_sleep_status_en_9_qs;
   logic dio_pad_sleep_status_en_9_wd;
-  logic dio_pad_sleep_status_en_9_we;
   logic dio_pad_sleep_status_en_10_qs;
   logic dio_pad_sleep_status_en_10_wd;
-  logic dio_pad_sleep_status_en_10_we;
   logic dio_pad_sleep_status_en_11_qs;
   logic dio_pad_sleep_status_en_11_wd;
-  logic dio_pad_sleep_status_en_11_we;
   logic dio_pad_sleep_status_en_12_qs;
   logic dio_pad_sleep_status_en_12_wd;
-  logic dio_pad_sleep_status_en_12_we;
   logic dio_pad_sleep_status_en_13_qs;
   logic dio_pad_sleep_status_en_13_wd;
-  logic dio_pad_sleep_status_en_13_we;
   logic dio_pad_sleep_status_en_14_qs;
   logic dio_pad_sleep_status_en_14_wd;
-  logic dio_pad_sleep_status_en_14_we;
   logic dio_pad_sleep_status_en_15_qs;
   logic dio_pad_sleep_status_en_15_wd;
-  logic dio_pad_sleep_status_en_15_we;
   logic dio_pad_sleep_status_en_16_qs;
   logic dio_pad_sleep_status_en_16_wd;
-  logic dio_pad_sleep_status_en_16_we;
   logic dio_pad_sleep_status_en_17_qs;
   logic dio_pad_sleep_status_en_17_wd;
-  logic dio_pad_sleep_status_en_17_we;
   logic dio_pad_sleep_status_en_18_qs;
   logic dio_pad_sleep_status_en_18_wd;
-  logic dio_pad_sleep_status_en_18_we;
   logic dio_pad_sleep_status_en_19_qs;
   logic dio_pad_sleep_status_en_19_wd;
-  logic dio_pad_sleep_status_en_19_we;
   logic dio_pad_sleep_status_en_20_qs;
   logic dio_pad_sleep_status_en_20_wd;
-  logic dio_pad_sleep_status_en_20_we;
   logic dio_pad_sleep_status_en_21_qs;
   logic dio_pad_sleep_status_en_21_wd;
-  logic dio_pad_sleep_status_en_21_we;
   logic dio_pad_sleep_status_en_22_qs;
   logic dio_pad_sleep_status_en_22_wd;
-  logic dio_pad_sleep_status_en_22_we;
   logic dio_pad_sleep_status_en_23_qs;
   logic dio_pad_sleep_status_en_23_wd;
-  logic dio_pad_sleep_status_en_23_we;
+  logic dio_pad_sleep_regwen_0_we;
   logic dio_pad_sleep_regwen_0_qs;
   logic dio_pad_sleep_regwen_0_wd;
-  logic dio_pad_sleep_regwen_0_we;
+  logic dio_pad_sleep_regwen_1_we;
   logic dio_pad_sleep_regwen_1_qs;
   logic dio_pad_sleep_regwen_1_wd;
-  logic dio_pad_sleep_regwen_1_we;
+  logic dio_pad_sleep_regwen_2_we;
   logic dio_pad_sleep_regwen_2_qs;
   logic dio_pad_sleep_regwen_2_wd;
-  logic dio_pad_sleep_regwen_2_we;
+  logic dio_pad_sleep_regwen_3_we;
   logic dio_pad_sleep_regwen_3_qs;
   logic dio_pad_sleep_regwen_3_wd;
-  logic dio_pad_sleep_regwen_3_we;
+  logic dio_pad_sleep_regwen_4_we;
   logic dio_pad_sleep_regwen_4_qs;
   logic dio_pad_sleep_regwen_4_wd;
-  logic dio_pad_sleep_regwen_4_we;
+  logic dio_pad_sleep_regwen_5_we;
   logic dio_pad_sleep_regwen_5_qs;
   logic dio_pad_sleep_regwen_5_wd;
-  logic dio_pad_sleep_regwen_5_we;
+  logic dio_pad_sleep_regwen_6_we;
   logic dio_pad_sleep_regwen_6_qs;
   logic dio_pad_sleep_regwen_6_wd;
-  logic dio_pad_sleep_regwen_6_we;
+  logic dio_pad_sleep_regwen_7_we;
   logic dio_pad_sleep_regwen_7_qs;
   logic dio_pad_sleep_regwen_7_wd;
-  logic dio_pad_sleep_regwen_7_we;
+  logic dio_pad_sleep_regwen_8_we;
   logic dio_pad_sleep_regwen_8_qs;
   logic dio_pad_sleep_regwen_8_wd;
-  logic dio_pad_sleep_regwen_8_we;
+  logic dio_pad_sleep_regwen_9_we;
   logic dio_pad_sleep_regwen_9_qs;
   logic dio_pad_sleep_regwen_9_wd;
-  logic dio_pad_sleep_regwen_9_we;
+  logic dio_pad_sleep_regwen_10_we;
   logic dio_pad_sleep_regwen_10_qs;
   logic dio_pad_sleep_regwen_10_wd;
-  logic dio_pad_sleep_regwen_10_we;
+  logic dio_pad_sleep_regwen_11_we;
   logic dio_pad_sleep_regwen_11_qs;
   logic dio_pad_sleep_regwen_11_wd;
-  logic dio_pad_sleep_regwen_11_we;
+  logic dio_pad_sleep_regwen_12_we;
   logic dio_pad_sleep_regwen_12_qs;
   logic dio_pad_sleep_regwen_12_wd;
-  logic dio_pad_sleep_regwen_12_we;
+  logic dio_pad_sleep_regwen_13_we;
   logic dio_pad_sleep_regwen_13_qs;
   logic dio_pad_sleep_regwen_13_wd;
-  logic dio_pad_sleep_regwen_13_we;
+  logic dio_pad_sleep_regwen_14_we;
   logic dio_pad_sleep_regwen_14_qs;
   logic dio_pad_sleep_regwen_14_wd;
-  logic dio_pad_sleep_regwen_14_we;
+  logic dio_pad_sleep_regwen_15_we;
   logic dio_pad_sleep_regwen_15_qs;
   logic dio_pad_sleep_regwen_15_wd;
-  logic dio_pad_sleep_regwen_15_we;
+  logic dio_pad_sleep_regwen_16_we;
   logic dio_pad_sleep_regwen_16_qs;
   logic dio_pad_sleep_regwen_16_wd;
-  logic dio_pad_sleep_regwen_16_we;
+  logic dio_pad_sleep_regwen_17_we;
   logic dio_pad_sleep_regwen_17_qs;
   logic dio_pad_sleep_regwen_17_wd;
-  logic dio_pad_sleep_regwen_17_we;
+  logic dio_pad_sleep_regwen_18_we;
   logic dio_pad_sleep_regwen_18_qs;
   logic dio_pad_sleep_regwen_18_wd;
-  logic dio_pad_sleep_regwen_18_we;
+  logic dio_pad_sleep_regwen_19_we;
   logic dio_pad_sleep_regwen_19_qs;
   logic dio_pad_sleep_regwen_19_wd;
-  logic dio_pad_sleep_regwen_19_we;
+  logic dio_pad_sleep_regwen_20_we;
   logic dio_pad_sleep_regwen_20_qs;
   logic dio_pad_sleep_regwen_20_wd;
-  logic dio_pad_sleep_regwen_20_we;
+  logic dio_pad_sleep_regwen_21_we;
   logic dio_pad_sleep_regwen_21_qs;
   logic dio_pad_sleep_regwen_21_wd;
-  logic dio_pad_sleep_regwen_21_we;
+  logic dio_pad_sleep_regwen_22_we;
   logic dio_pad_sleep_regwen_22_qs;
   logic dio_pad_sleep_regwen_22_wd;
-  logic dio_pad_sleep_regwen_22_we;
+  logic dio_pad_sleep_regwen_23_we;
   logic dio_pad_sleep_regwen_23_qs;
   logic dio_pad_sleep_regwen_23_wd;
-  logic dio_pad_sleep_regwen_23_we;
+  logic dio_pad_sleep_en_0_we;
   logic dio_pad_sleep_en_0_qs;
   logic dio_pad_sleep_en_0_wd;
-  logic dio_pad_sleep_en_0_we;
+  logic dio_pad_sleep_en_1_we;
   logic dio_pad_sleep_en_1_qs;
   logic dio_pad_sleep_en_1_wd;
-  logic dio_pad_sleep_en_1_we;
+  logic dio_pad_sleep_en_2_we;
   logic dio_pad_sleep_en_2_qs;
   logic dio_pad_sleep_en_2_wd;
-  logic dio_pad_sleep_en_2_we;
+  logic dio_pad_sleep_en_3_we;
   logic dio_pad_sleep_en_3_qs;
   logic dio_pad_sleep_en_3_wd;
-  logic dio_pad_sleep_en_3_we;
+  logic dio_pad_sleep_en_4_we;
   logic dio_pad_sleep_en_4_qs;
   logic dio_pad_sleep_en_4_wd;
-  logic dio_pad_sleep_en_4_we;
+  logic dio_pad_sleep_en_5_we;
   logic dio_pad_sleep_en_5_qs;
   logic dio_pad_sleep_en_5_wd;
-  logic dio_pad_sleep_en_5_we;
+  logic dio_pad_sleep_en_6_we;
   logic dio_pad_sleep_en_6_qs;
   logic dio_pad_sleep_en_6_wd;
-  logic dio_pad_sleep_en_6_we;
+  logic dio_pad_sleep_en_7_we;
   logic dio_pad_sleep_en_7_qs;
   logic dio_pad_sleep_en_7_wd;
-  logic dio_pad_sleep_en_7_we;
+  logic dio_pad_sleep_en_8_we;
   logic dio_pad_sleep_en_8_qs;
   logic dio_pad_sleep_en_8_wd;
-  logic dio_pad_sleep_en_8_we;
+  logic dio_pad_sleep_en_9_we;
   logic dio_pad_sleep_en_9_qs;
   logic dio_pad_sleep_en_9_wd;
-  logic dio_pad_sleep_en_9_we;
+  logic dio_pad_sleep_en_10_we;
   logic dio_pad_sleep_en_10_qs;
   logic dio_pad_sleep_en_10_wd;
-  logic dio_pad_sleep_en_10_we;
+  logic dio_pad_sleep_en_11_we;
   logic dio_pad_sleep_en_11_qs;
   logic dio_pad_sleep_en_11_wd;
-  logic dio_pad_sleep_en_11_we;
+  logic dio_pad_sleep_en_12_we;
   logic dio_pad_sleep_en_12_qs;
   logic dio_pad_sleep_en_12_wd;
-  logic dio_pad_sleep_en_12_we;
+  logic dio_pad_sleep_en_13_we;
   logic dio_pad_sleep_en_13_qs;
   logic dio_pad_sleep_en_13_wd;
-  logic dio_pad_sleep_en_13_we;
+  logic dio_pad_sleep_en_14_we;
   logic dio_pad_sleep_en_14_qs;
   logic dio_pad_sleep_en_14_wd;
-  logic dio_pad_sleep_en_14_we;
+  logic dio_pad_sleep_en_15_we;
   logic dio_pad_sleep_en_15_qs;
   logic dio_pad_sleep_en_15_wd;
-  logic dio_pad_sleep_en_15_we;
+  logic dio_pad_sleep_en_16_we;
   logic dio_pad_sleep_en_16_qs;
   logic dio_pad_sleep_en_16_wd;
-  logic dio_pad_sleep_en_16_we;
+  logic dio_pad_sleep_en_17_we;
   logic dio_pad_sleep_en_17_qs;
   logic dio_pad_sleep_en_17_wd;
-  logic dio_pad_sleep_en_17_we;
+  logic dio_pad_sleep_en_18_we;
   logic dio_pad_sleep_en_18_qs;
   logic dio_pad_sleep_en_18_wd;
-  logic dio_pad_sleep_en_18_we;
+  logic dio_pad_sleep_en_19_we;
   logic dio_pad_sleep_en_19_qs;
   logic dio_pad_sleep_en_19_wd;
-  logic dio_pad_sleep_en_19_we;
+  logic dio_pad_sleep_en_20_we;
   logic dio_pad_sleep_en_20_qs;
   logic dio_pad_sleep_en_20_wd;
-  logic dio_pad_sleep_en_20_we;
+  logic dio_pad_sleep_en_21_we;
   logic dio_pad_sleep_en_21_qs;
   logic dio_pad_sleep_en_21_wd;
-  logic dio_pad_sleep_en_21_we;
+  logic dio_pad_sleep_en_22_we;
   logic dio_pad_sleep_en_22_qs;
   logic dio_pad_sleep_en_22_wd;
-  logic dio_pad_sleep_en_22_we;
+  logic dio_pad_sleep_en_23_we;
   logic dio_pad_sleep_en_23_qs;
   logic dio_pad_sleep_en_23_wd;
-  logic dio_pad_sleep_en_23_we;
+  logic dio_pad_sleep_mode_0_we;
   logic [1:0] dio_pad_sleep_mode_0_qs;
   logic [1:0] dio_pad_sleep_mode_0_wd;
-  logic dio_pad_sleep_mode_0_we;
+  logic dio_pad_sleep_mode_1_we;
   logic [1:0] dio_pad_sleep_mode_1_qs;
   logic [1:0] dio_pad_sleep_mode_1_wd;
-  logic dio_pad_sleep_mode_1_we;
+  logic dio_pad_sleep_mode_2_we;
   logic [1:0] dio_pad_sleep_mode_2_qs;
   logic [1:0] dio_pad_sleep_mode_2_wd;
-  logic dio_pad_sleep_mode_2_we;
+  logic dio_pad_sleep_mode_3_we;
   logic [1:0] dio_pad_sleep_mode_3_qs;
   logic [1:0] dio_pad_sleep_mode_3_wd;
-  logic dio_pad_sleep_mode_3_we;
+  logic dio_pad_sleep_mode_4_we;
   logic [1:0] dio_pad_sleep_mode_4_qs;
   logic [1:0] dio_pad_sleep_mode_4_wd;
-  logic dio_pad_sleep_mode_4_we;
+  logic dio_pad_sleep_mode_5_we;
   logic [1:0] dio_pad_sleep_mode_5_qs;
   logic [1:0] dio_pad_sleep_mode_5_wd;
-  logic dio_pad_sleep_mode_5_we;
+  logic dio_pad_sleep_mode_6_we;
   logic [1:0] dio_pad_sleep_mode_6_qs;
   logic [1:0] dio_pad_sleep_mode_6_wd;
-  logic dio_pad_sleep_mode_6_we;
+  logic dio_pad_sleep_mode_7_we;
   logic [1:0] dio_pad_sleep_mode_7_qs;
   logic [1:0] dio_pad_sleep_mode_7_wd;
-  logic dio_pad_sleep_mode_7_we;
+  logic dio_pad_sleep_mode_8_we;
   logic [1:0] dio_pad_sleep_mode_8_qs;
   logic [1:0] dio_pad_sleep_mode_8_wd;
-  logic dio_pad_sleep_mode_8_we;
+  logic dio_pad_sleep_mode_9_we;
   logic [1:0] dio_pad_sleep_mode_9_qs;
   logic [1:0] dio_pad_sleep_mode_9_wd;
-  logic dio_pad_sleep_mode_9_we;
+  logic dio_pad_sleep_mode_10_we;
   logic [1:0] dio_pad_sleep_mode_10_qs;
   logic [1:0] dio_pad_sleep_mode_10_wd;
-  logic dio_pad_sleep_mode_10_we;
+  logic dio_pad_sleep_mode_11_we;
   logic [1:0] dio_pad_sleep_mode_11_qs;
   logic [1:0] dio_pad_sleep_mode_11_wd;
-  logic dio_pad_sleep_mode_11_we;
+  logic dio_pad_sleep_mode_12_we;
   logic [1:0] dio_pad_sleep_mode_12_qs;
   logic [1:0] dio_pad_sleep_mode_12_wd;
-  logic dio_pad_sleep_mode_12_we;
+  logic dio_pad_sleep_mode_13_we;
   logic [1:0] dio_pad_sleep_mode_13_qs;
   logic [1:0] dio_pad_sleep_mode_13_wd;
-  logic dio_pad_sleep_mode_13_we;
+  logic dio_pad_sleep_mode_14_we;
   logic [1:0] dio_pad_sleep_mode_14_qs;
   logic [1:0] dio_pad_sleep_mode_14_wd;
-  logic dio_pad_sleep_mode_14_we;
+  logic dio_pad_sleep_mode_15_we;
   logic [1:0] dio_pad_sleep_mode_15_qs;
   logic [1:0] dio_pad_sleep_mode_15_wd;
-  logic dio_pad_sleep_mode_15_we;
+  logic dio_pad_sleep_mode_16_we;
   logic [1:0] dio_pad_sleep_mode_16_qs;
   logic [1:0] dio_pad_sleep_mode_16_wd;
-  logic dio_pad_sleep_mode_16_we;
+  logic dio_pad_sleep_mode_17_we;
   logic [1:0] dio_pad_sleep_mode_17_qs;
   logic [1:0] dio_pad_sleep_mode_17_wd;
-  logic dio_pad_sleep_mode_17_we;
+  logic dio_pad_sleep_mode_18_we;
   logic [1:0] dio_pad_sleep_mode_18_qs;
   logic [1:0] dio_pad_sleep_mode_18_wd;
-  logic dio_pad_sleep_mode_18_we;
+  logic dio_pad_sleep_mode_19_we;
   logic [1:0] dio_pad_sleep_mode_19_qs;
   logic [1:0] dio_pad_sleep_mode_19_wd;
-  logic dio_pad_sleep_mode_19_we;
+  logic dio_pad_sleep_mode_20_we;
   logic [1:0] dio_pad_sleep_mode_20_qs;
   logic [1:0] dio_pad_sleep_mode_20_wd;
-  logic dio_pad_sleep_mode_20_we;
+  logic dio_pad_sleep_mode_21_we;
   logic [1:0] dio_pad_sleep_mode_21_qs;
   logic [1:0] dio_pad_sleep_mode_21_wd;
-  logic dio_pad_sleep_mode_21_we;
+  logic dio_pad_sleep_mode_22_we;
   logic [1:0] dio_pad_sleep_mode_22_qs;
   logic [1:0] dio_pad_sleep_mode_22_wd;
-  logic dio_pad_sleep_mode_22_we;
+  logic dio_pad_sleep_mode_23_we;
   logic [1:0] dio_pad_sleep_mode_23_qs;
   logic [1:0] dio_pad_sleep_mode_23_wd;
-  logic dio_pad_sleep_mode_23_we;
+  logic wkup_detector_regwen_0_we;
   logic wkup_detector_regwen_0_qs;
   logic wkup_detector_regwen_0_wd;
-  logic wkup_detector_regwen_0_we;
+  logic wkup_detector_regwen_1_we;
   logic wkup_detector_regwen_1_qs;
   logic wkup_detector_regwen_1_wd;
-  logic wkup_detector_regwen_1_we;
+  logic wkup_detector_regwen_2_we;
   logic wkup_detector_regwen_2_qs;
   logic wkup_detector_regwen_2_wd;
-  logic wkup_detector_regwen_2_we;
+  logic wkup_detector_regwen_3_we;
   logic wkup_detector_regwen_3_qs;
   logic wkup_detector_regwen_3_wd;
-  logic wkup_detector_regwen_3_we;
+  logic wkup_detector_regwen_4_we;
   logic wkup_detector_regwen_4_qs;
   logic wkup_detector_regwen_4_wd;
-  logic wkup_detector_regwen_4_we;
+  logic wkup_detector_regwen_5_we;
   logic wkup_detector_regwen_5_qs;
   logic wkup_detector_regwen_5_wd;
-  logic wkup_detector_regwen_5_we;
+  logic wkup_detector_regwen_6_we;
   logic wkup_detector_regwen_6_qs;
   logic wkup_detector_regwen_6_wd;
-  logic wkup_detector_regwen_6_we;
+  logic wkup_detector_regwen_7_we;
   logic wkup_detector_regwen_7_qs;
   logic wkup_detector_regwen_7_wd;
-  logic wkup_detector_regwen_7_we;
+  logic wkup_detector_en_0_we;
   logic wkup_detector_en_0_qs;
   logic wkup_detector_en_0_wd;
-  logic wkup_detector_en_0_we;
+  logic wkup_detector_en_1_we;
   logic wkup_detector_en_1_qs;
   logic wkup_detector_en_1_wd;
-  logic wkup_detector_en_1_we;
+  logic wkup_detector_en_2_we;
   logic wkup_detector_en_2_qs;
   logic wkup_detector_en_2_wd;
-  logic wkup_detector_en_2_we;
+  logic wkup_detector_en_3_we;
   logic wkup_detector_en_3_qs;
   logic wkup_detector_en_3_wd;
-  logic wkup_detector_en_3_we;
+  logic wkup_detector_en_4_we;
   logic wkup_detector_en_4_qs;
   logic wkup_detector_en_4_wd;
-  logic wkup_detector_en_4_we;
+  logic wkup_detector_en_5_we;
   logic wkup_detector_en_5_qs;
   logic wkup_detector_en_5_wd;
-  logic wkup_detector_en_5_we;
+  logic wkup_detector_en_6_we;
   logic wkup_detector_en_6_qs;
   logic wkup_detector_en_6_wd;
-  logic wkup_detector_en_6_we;
+  logic wkup_detector_en_7_we;
   logic wkup_detector_en_7_qs;
   logic wkup_detector_en_7_wd;
-  logic wkup_detector_en_7_we;
+  logic wkup_detector_0_we;
   logic [2:0] wkup_detector_0_mode_0_qs;
   logic [2:0] wkup_detector_0_mode_0_wd;
-  logic wkup_detector_0_mode_0_we;
   logic wkup_detector_0_filter_0_qs;
   logic wkup_detector_0_filter_0_wd;
-  logic wkup_detector_0_filter_0_we;
   logic wkup_detector_0_miodio_0_qs;
   logic wkup_detector_0_miodio_0_wd;
-  logic wkup_detector_0_miodio_0_we;
+  logic wkup_detector_1_we;
   logic [2:0] wkup_detector_1_mode_1_qs;
   logic [2:0] wkup_detector_1_mode_1_wd;
-  logic wkup_detector_1_mode_1_we;
   logic wkup_detector_1_filter_1_qs;
   logic wkup_detector_1_filter_1_wd;
-  logic wkup_detector_1_filter_1_we;
   logic wkup_detector_1_miodio_1_qs;
   logic wkup_detector_1_miodio_1_wd;
-  logic wkup_detector_1_miodio_1_we;
+  logic wkup_detector_2_we;
   logic [2:0] wkup_detector_2_mode_2_qs;
   logic [2:0] wkup_detector_2_mode_2_wd;
-  logic wkup_detector_2_mode_2_we;
   logic wkup_detector_2_filter_2_qs;
   logic wkup_detector_2_filter_2_wd;
-  logic wkup_detector_2_filter_2_we;
   logic wkup_detector_2_miodio_2_qs;
   logic wkup_detector_2_miodio_2_wd;
-  logic wkup_detector_2_miodio_2_we;
+  logic wkup_detector_3_we;
   logic [2:0] wkup_detector_3_mode_3_qs;
   logic [2:0] wkup_detector_3_mode_3_wd;
-  logic wkup_detector_3_mode_3_we;
   logic wkup_detector_3_filter_3_qs;
   logic wkup_detector_3_filter_3_wd;
-  logic wkup_detector_3_filter_3_we;
   logic wkup_detector_3_miodio_3_qs;
   logic wkup_detector_3_miodio_3_wd;
-  logic wkup_detector_3_miodio_3_we;
+  logic wkup_detector_4_we;
   logic [2:0] wkup_detector_4_mode_4_qs;
   logic [2:0] wkup_detector_4_mode_4_wd;
-  logic wkup_detector_4_mode_4_we;
   logic wkup_detector_4_filter_4_qs;
   logic wkup_detector_4_filter_4_wd;
-  logic wkup_detector_4_filter_4_we;
   logic wkup_detector_4_miodio_4_qs;
   logic wkup_detector_4_miodio_4_wd;
-  logic wkup_detector_4_miodio_4_we;
+  logic wkup_detector_5_we;
   logic [2:0] wkup_detector_5_mode_5_qs;
   logic [2:0] wkup_detector_5_mode_5_wd;
-  logic wkup_detector_5_mode_5_we;
   logic wkup_detector_5_filter_5_qs;
   logic wkup_detector_5_filter_5_wd;
-  logic wkup_detector_5_filter_5_we;
   logic wkup_detector_5_miodio_5_qs;
   logic wkup_detector_5_miodio_5_wd;
-  logic wkup_detector_5_miodio_5_we;
+  logic wkup_detector_6_we;
   logic [2:0] wkup_detector_6_mode_6_qs;
   logic [2:0] wkup_detector_6_mode_6_wd;
-  logic wkup_detector_6_mode_6_we;
   logic wkup_detector_6_filter_6_qs;
   logic wkup_detector_6_filter_6_wd;
-  logic wkup_detector_6_filter_6_we;
   logic wkup_detector_6_miodio_6_qs;
   logic wkup_detector_6_miodio_6_wd;
-  logic wkup_detector_6_miodio_6_we;
+  logic wkup_detector_7_we;
   logic [2:0] wkup_detector_7_mode_7_qs;
   logic [2:0] wkup_detector_7_mode_7_wd;
-  logic wkup_detector_7_mode_7_we;
   logic wkup_detector_7_filter_7_qs;
   logic wkup_detector_7_filter_7_wd;
-  logic wkup_detector_7_filter_7_we;
   logic wkup_detector_7_miodio_7_qs;
   logic wkup_detector_7_miodio_7_wd;
-  logic wkup_detector_7_miodio_7_we;
+  logic wkup_detector_cnt_th_0_we;
   logic [7:0] wkup_detector_cnt_th_0_qs;
   logic [7:0] wkup_detector_cnt_th_0_wd;
-  logic wkup_detector_cnt_th_0_we;
+  logic wkup_detector_cnt_th_1_we;
   logic [7:0] wkup_detector_cnt_th_1_qs;
   logic [7:0] wkup_detector_cnt_th_1_wd;
-  logic wkup_detector_cnt_th_1_we;
+  logic wkup_detector_cnt_th_2_we;
   logic [7:0] wkup_detector_cnt_th_2_qs;
   logic [7:0] wkup_detector_cnt_th_2_wd;
-  logic wkup_detector_cnt_th_2_we;
+  logic wkup_detector_cnt_th_3_we;
   logic [7:0] wkup_detector_cnt_th_3_qs;
   logic [7:0] wkup_detector_cnt_th_3_wd;
-  logic wkup_detector_cnt_th_3_we;
+  logic wkup_detector_cnt_th_4_we;
   logic [7:0] wkup_detector_cnt_th_4_qs;
   logic [7:0] wkup_detector_cnt_th_4_wd;
-  logic wkup_detector_cnt_th_4_we;
+  logic wkup_detector_cnt_th_5_we;
   logic [7:0] wkup_detector_cnt_th_5_qs;
   logic [7:0] wkup_detector_cnt_th_5_wd;
-  logic wkup_detector_cnt_th_5_we;
+  logic wkup_detector_cnt_th_6_we;
   logic [7:0] wkup_detector_cnt_th_6_qs;
   logic [7:0] wkup_detector_cnt_th_6_wd;
-  logic wkup_detector_cnt_th_6_we;
+  logic wkup_detector_cnt_th_7_we;
   logic [7:0] wkup_detector_cnt_th_7_qs;
   logic [7:0] wkup_detector_cnt_th_7_wd;
-  logic wkup_detector_cnt_th_7_we;
+  logic wkup_detector_padsel_0_we;
   logic [5:0] wkup_detector_padsel_0_qs;
   logic [5:0] wkup_detector_padsel_0_wd;
-  logic wkup_detector_padsel_0_we;
+  logic wkup_detector_padsel_1_we;
   logic [5:0] wkup_detector_padsel_1_qs;
   logic [5:0] wkup_detector_padsel_1_wd;
-  logic wkup_detector_padsel_1_we;
+  logic wkup_detector_padsel_2_we;
   logic [5:0] wkup_detector_padsel_2_qs;
   logic [5:0] wkup_detector_padsel_2_wd;
-  logic wkup_detector_padsel_2_we;
+  logic wkup_detector_padsel_3_we;
   logic [5:0] wkup_detector_padsel_3_qs;
   logic [5:0] wkup_detector_padsel_3_wd;
-  logic wkup_detector_padsel_3_we;
+  logic wkup_detector_padsel_4_we;
   logic [5:0] wkup_detector_padsel_4_qs;
   logic [5:0] wkup_detector_padsel_4_wd;
-  logic wkup_detector_padsel_4_we;
+  logic wkup_detector_padsel_5_we;
   logic [5:0] wkup_detector_padsel_5_qs;
   logic [5:0] wkup_detector_padsel_5_wd;
-  logic wkup_detector_padsel_5_we;
+  logic wkup_detector_padsel_6_we;
   logic [5:0] wkup_detector_padsel_6_qs;
   logic [5:0] wkup_detector_padsel_6_wd;
-  logic wkup_detector_padsel_6_we;
+  logic wkup_detector_padsel_7_we;
   logic [5:0] wkup_detector_padsel_7_qs;
   logic [5:0] wkup_detector_padsel_7_wd;
-  logic wkup_detector_padsel_7_we;
+  logic wkup_cause_re;
+  logic wkup_cause_we;
   logic wkup_cause_cause_0_qs;
   logic wkup_cause_cause_0_wd;
-  logic wkup_cause_cause_0_we;
-  logic wkup_cause_cause_0_re;
   logic wkup_cause_cause_1_qs;
   logic wkup_cause_cause_1_wd;
-  logic wkup_cause_cause_1_we;
-  logic wkup_cause_cause_1_re;
   logic wkup_cause_cause_2_qs;
   logic wkup_cause_cause_2_wd;
-  logic wkup_cause_cause_2_we;
-  logic wkup_cause_cause_2_re;
   logic wkup_cause_cause_3_qs;
   logic wkup_cause_cause_3_wd;
-  logic wkup_cause_cause_3_we;
-  logic wkup_cause_cause_3_re;
   logic wkup_cause_cause_4_qs;
   logic wkup_cause_cause_4_wd;
-  logic wkup_cause_cause_4_we;
-  logic wkup_cause_cause_4_re;
   logic wkup_cause_cause_5_qs;
   logic wkup_cause_cause_5_wd;
-  logic wkup_cause_cause_5_we;
-  logic wkup_cause_cause_5_re;
   logic wkup_cause_cause_6_qs;
   logic wkup_cause_cause_6_wd;
-  logic wkup_cause_cause_6_we;
-  logic wkup_cause_cause_6_re;
   logic wkup_cause_cause_7_qs;
   logic wkup_cause_cause_7_wd;
-  logic wkup_cause_cause_7_we;
-  logic wkup_cause_cause_7_re;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -10936,7 +10838,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_0_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_0_wd),
 
     // from internal hardware
@@ -10962,7 +10864,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_1_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_1_wd),
 
     // from internal hardware
@@ -10988,7 +10890,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_2_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_2_wd),
 
     // from internal hardware
@@ -11014,7 +10916,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_3_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_3_wd),
 
     // from internal hardware
@@ -11040,7 +10942,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_4_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_4_wd),
 
     // from internal hardware
@@ -11066,7 +10968,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_5_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_5_wd),
 
     // from internal hardware
@@ -11092,7 +10994,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_6_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_6_wd),
 
     // from internal hardware
@@ -11118,7 +11020,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_7_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_7_wd),
 
     // from internal hardware
@@ -11144,7 +11046,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_8_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_8_wd),
 
     // from internal hardware
@@ -11170,7 +11072,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_9_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_9_wd),
 
     // from internal hardware
@@ -11196,7 +11098,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_10_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_10_wd),
 
     // from internal hardware
@@ -11222,7 +11124,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_11_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_11_wd),
 
     // from internal hardware
@@ -11248,7 +11150,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_12_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_12_wd),
 
     // from internal hardware
@@ -11274,7 +11176,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_13_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_13_wd),
 
     // from internal hardware
@@ -11300,7 +11202,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_14_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_14_wd),
 
     // from internal hardware
@@ -11326,7 +11228,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_15_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_15_wd),
 
     // from internal hardware
@@ -11352,7 +11254,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_16_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_16_wd),
 
     // from internal hardware
@@ -11378,7 +11280,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_17_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_17_wd),
 
     // from internal hardware
@@ -11404,7 +11306,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_18_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_18_wd),
 
     // from internal hardware
@@ -11430,7 +11332,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_19_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_19_wd),
 
     // from internal hardware
@@ -11456,7 +11358,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_20_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_20_wd),
 
     // from internal hardware
@@ -11482,7 +11384,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_21_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_21_wd),
 
     // from internal hardware
@@ -11508,7 +11410,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_22_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_22_wd),
 
     // from internal hardware
@@ -11534,7 +11436,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_23_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_23_wd),
 
     // from internal hardware
@@ -11560,7 +11462,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_24_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_24_wd),
 
     // from internal hardware
@@ -11586,7 +11488,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_25_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_25_wd),
 
     // from internal hardware
@@ -11612,7 +11514,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_26_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_26_wd),
 
     // from internal hardware
@@ -11638,7 +11540,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_27_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_27_wd),
 
     // from internal hardware
@@ -11664,7 +11566,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_28_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_28_wd),
 
     // from internal hardware
@@ -11690,7 +11592,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_29_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_29_wd),
 
     // from internal hardware
@@ -11716,7 +11618,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_30_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_30_wd),
 
     // from internal hardware
@@ -11742,7 +11644,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_0_en_31_we),
+    .we     (mio_pad_sleep_status_0_we),
     .wd     (mio_pad_sleep_status_0_en_31_wd),
 
     // from internal hardware
@@ -11771,7 +11673,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_32_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_32_wd),
 
     // from internal hardware
@@ -11797,7 +11699,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_33_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_33_wd),
 
     // from internal hardware
@@ -11823,7 +11725,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_34_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_34_wd),
 
     // from internal hardware
@@ -11849,7 +11751,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_35_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_35_wd),
 
     // from internal hardware
@@ -11875,7 +11777,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_36_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_36_wd),
 
     // from internal hardware
@@ -11901,7 +11803,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_37_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_37_wd),
 
     // from internal hardware
@@ -11927,7 +11829,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_38_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_38_wd),
 
     // from internal hardware
@@ -11953,7 +11855,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_39_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_39_wd),
 
     // from internal hardware
@@ -11979,7 +11881,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_40_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_40_wd),
 
     // from internal hardware
@@ -12005,7 +11907,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_41_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_41_wd),
 
     // from internal hardware
@@ -12031,7 +11933,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_42_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_42_wd),
 
     // from internal hardware
@@ -12057,7 +11959,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_43_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_43_wd),
 
     // from internal hardware
@@ -12083,7 +11985,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_44_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_44_wd),
 
     // from internal hardware
@@ -12109,7 +12011,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_45_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_45_wd),
 
     // from internal hardware
@@ -12135,7 +12037,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mio_pad_sleep_status_1_en_46_we),
+    .we     (mio_pad_sleep_status_1_we),
     .wd     (mio_pad_sleep_status_1_en_46_wd),
 
     // from internal hardware
@@ -15979,7 +15881,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_0_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_0_wd),
 
     // from internal hardware
@@ -16005,7 +15907,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_1_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_1_wd),
 
     // from internal hardware
@@ -16031,7 +15933,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_2_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_2_wd),
 
     // from internal hardware
@@ -16057,7 +15959,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_3_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_3_wd),
 
     // from internal hardware
@@ -16083,7 +15985,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_4_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_4_wd),
 
     // from internal hardware
@@ -16109,7 +16011,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_5_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_5_wd),
 
     // from internal hardware
@@ -16135,7 +16037,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_6_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_6_wd),
 
     // from internal hardware
@@ -16161,7 +16063,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_7_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_7_wd),
 
     // from internal hardware
@@ -16187,7 +16089,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_8_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_8_wd),
 
     // from internal hardware
@@ -16213,7 +16115,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_9_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_9_wd),
 
     // from internal hardware
@@ -16239,7 +16141,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_10_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_10_wd),
 
     // from internal hardware
@@ -16265,7 +16167,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_11_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_11_wd),
 
     // from internal hardware
@@ -16291,7 +16193,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_12_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_12_wd),
 
     // from internal hardware
@@ -16317,7 +16219,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_13_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_13_wd),
 
     // from internal hardware
@@ -16343,7 +16245,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_14_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_14_wd),
 
     // from internal hardware
@@ -16369,7 +16271,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_15_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_15_wd),
 
     // from internal hardware
@@ -16395,7 +16297,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_16_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_16_wd),
 
     // from internal hardware
@@ -16421,7 +16323,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_17_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_17_wd),
 
     // from internal hardware
@@ -16447,7 +16349,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_18_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_18_wd),
 
     // from internal hardware
@@ -16473,7 +16375,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_19_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_19_wd),
 
     // from internal hardware
@@ -16499,7 +16401,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_20_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_20_wd),
 
     // from internal hardware
@@ -16525,7 +16427,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_21_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_21_wd),
 
     // from internal hardware
@@ -16551,7 +16453,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_22_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_22_wd),
 
     // from internal hardware
@@ -16577,7 +16479,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (dio_pad_sleep_status_en_23_we),
+    .we     (dio_pad_sleep_status_we),
     .wd     (dio_pad_sleep_status_en_23_wd),
 
     // from internal hardware
@@ -18994,7 +18896,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_0_mode_0_we & wkup_detector_regwen_0_qs),
+    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
     .wd     (wkup_detector_0_mode_0_wd),
 
     // from internal hardware
@@ -19020,7 +18922,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_0_filter_0_we & wkup_detector_regwen_0_qs),
+    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
     .wd     (wkup_detector_0_filter_0_wd),
 
     // from internal hardware
@@ -19046,7 +18948,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_0_miodio_0_we & wkup_detector_regwen_0_qs),
+    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
     .wd     (wkup_detector_0_miodio_0_wd),
 
     // from internal hardware
@@ -19075,7 +18977,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_1_mode_1_we & wkup_detector_regwen_1_qs),
+    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
     .wd     (wkup_detector_1_mode_1_wd),
 
     // from internal hardware
@@ -19101,7 +19003,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_1_filter_1_we & wkup_detector_regwen_1_qs),
+    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
     .wd     (wkup_detector_1_filter_1_wd),
 
     // from internal hardware
@@ -19127,7 +19029,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_1_miodio_1_we & wkup_detector_regwen_1_qs),
+    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
     .wd     (wkup_detector_1_miodio_1_wd),
 
     // from internal hardware
@@ -19156,7 +19058,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_2_mode_2_we & wkup_detector_regwen_2_qs),
+    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
     .wd     (wkup_detector_2_mode_2_wd),
 
     // from internal hardware
@@ -19182,7 +19084,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_2_filter_2_we & wkup_detector_regwen_2_qs),
+    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
     .wd     (wkup_detector_2_filter_2_wd),
 
     // from internal hardware
@@ -19208,7 +19110,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_2_miodio_2_we & wkup_detector_regwen_2_qs),
+    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
     .wd     (wkup_detector_2_miodio_2_wd),
 
     // from internal hardware
@@ -19237,7 +19139,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_3_mode_3_we & wkup_detector_regwen_3_qs),
+    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
     .wd     (wkup_detector_3_mode_3_wd),
 
     // from internal hardware
@@ -19263,7 +19165,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_3_filter_3_we & wkup_detector_regwen_3_qs),
+    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
     .wd     (wkup_detector_3_filter_3_wd),
 
     // from internal hardware
@@ -19289,7 +19191,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_3_miodio_3_we & wkup_detector_regwen_3_qs),
+    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
     .wd     (wkup_detector_3_miodio_3_wd),
 
     // from internal hardware
@@ -19318,7 +19220,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_4_mode_4_we & wkup_detector_regwen_4_qs),
+    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
     .wd     (wkup_detector_4_mode_4_wd),
 
     // from internal hardware
@@ -19344,7 +19246,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_4_filter_4_we & wkup_detector_regwen_4_qs),
+    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
     .wd     (wkup_detector_4_filter_4_wd),
 
     // from internal hardware
@@ -19370,7 +19272,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_4_miodio_4_we & wkup_detector_regwen_4_qs),
+    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
     .wd     (wkup_detector_4_miodio_4_wd),
 
     // from internal hardware
@@ -19399,7 +19301,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_5_mode_5_we & wkup_detector_regwen_5_qs),
+    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
     .wd     (wkup_detector_5_mode_5_wd),
 
     // from internal hardware
@@ -19425,7 +19327,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_5_filter_5_we & wkup_detector_regwen_5_qs),
+    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
     .wd     (wkup_detector_5_filter_5_wd),
 
     // from internal hardware
@@ -19451,7 +19353,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_5_miodio_5_we & wkup_detector_regwen_5_qs),
+    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
     .wd     (wkup_detector_5_miodio_5_wd),
 
     // from internal hardware
@@ -19480,7 +19382,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_6_mode_6_we & wkup_detector_regwen_6_qs),
+    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
     .wd     (wkup_detector_6_mode_6_wd),
 
     // from internal hardware
@@ -19506,7 +19408,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_6_filter_6_we & wkup_detector_regwen_6_qs),
+    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
     .wd     (wkup_detector_6_filter_6_wd),
 
     // from internal hardware
@@ -19532,7 +19434,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_6_miodio_6_we & wkup_detector_regwen_6_qs),
+    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
     .wd     (wkup_detector_6_miodio_6_wd),
 
     // from internal hardware
@@ -19561,7 +19463,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_7_mode_7_we & wkup_detector_regwen_7_qs),
+    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
     .wd     (wkup_detector_7_mode_7_wd),
 
     // from internal hardware
@@ -19587,7 +19489,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_7_filter_7_we & wkup_detector_regwen_7_qs),
+    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
     .wd     (wkup_detector_7_filter_7_wd),
 
     // from internal hardware
@@ -19613,7 +19515,7 @@ module pinmux_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wkup_detector_7_miodio_7_we & wkup_detector_regwen_7_qs),
+    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
     .wd     (wkup_detector_7_miodio_7_wd),
 
     // from internal hardware
@@ -20074,8 +19976,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_0 (
-    .re     (wkup_cause_cause_0_re),
-    .we     (wkup_cause_cause_0_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_0_wd),
     .d      (hw2reg.wkup_cause[0].d),
     .qre    (),
@@ -20089,8 +19991,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_1 (
-    .re     (wkup_cause_cause_1_re),
-    .we     (wkup_cause_cause_1_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_1_wd),
     .d      (hw2reg.wkup_cause[1].d),
     .qre    (),
@@ -20104,8 +20006,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_2 (
-    .re     (wkup_cause_cause_2_re),
-    .we     (wkup_cause_cause_2_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_2_wd),
     .d      (hw2reg.wkup_cause[2].d),
     .qre    (),
@@ -20119,8 +20021,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_3 (
-    .re     (wkup_cause_cause_3_re),
-    .we     (wkup_cause_cause_3_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_3_wd),
     .d      (hw2reg.wkup_cause[3].d),
     .qre    (),
@@ -20134,8 +20036,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_4 (
-    .re     (wkup_cause_cause_4_re),
-    .we     (wkup_cause_cause_4_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_4_wd),
     .d      (hw2reg.wkup_cause[4].d),
     .qre    (),
@@ -20149,8 +20051,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_5 (
-    .re     (wkup_cause_cause_5_re),
-    .we     (wkup_cause_cause_5_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_5_wd),
     .d      (hw2reg.wkup_cause[5].d),
     .qre    (),
@@ -20164,8 +20066,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_6 (
-    .re     (wkup_cause_cause_6_re),
-    .we     (wkup_cause_cause_6_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_6_wd),
     .d      (hw2reg.wkup_cause[6].d),
     .qre    (),
@@ -20179,8 +20081,8 @@ module pinmux_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wkup_cause_cause_7 (
-    .re     (wkup_cause_cause_7_re),
-    .we     (wkup_cause_cause_7_we),
+    .re     (wkup_cause_re),
+    .we     (wkup_cause_we),
     .wd     (wkup_cause_cause_7_wd),
     .d      (hw2reg.wkup_cause[7].d),
     .qre    (),
@@ -21416,2176 +21318,2078 @@ module pinmux_reg_top (
                (addr_hit[604] & (|(PINMUX_PERMIT[604] & ~reg_be))) |
                (addr_hit[605] & (|(PINMUX_PERMIT[605] & ~reg_be)))));
   end
-
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
+
   assign alert_test_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_0_we = addr_hit[1] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_0_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_1_we = addr_hit[2] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_1_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_2_we = addr_hit[3] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_2_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_3_we = addr_hit[4] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_3_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_4_we = addr_hit[5] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_4_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_5_we = addr_hit[6] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_5_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_6_we = addr_hit[7] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_6_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_7_we = addr_hit[8] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_7_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_8_we = addr_hit[9] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_8_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_9_we = addr_hit[10] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_9_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_10_we = addr_hit[11] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_10_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_11_we = addr_hit[12] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_11_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_12_we = addr_hit[13] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_12_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_13_we = addr_hit[14] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_13_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_14_we = addr_hit[15] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_14_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_15_we = addr_hit[16] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_15_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_16_we = addr_hit[17] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_16_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_17_we = addr_hit[18] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_17_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_18_we = addr_hit[19] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_18_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_19_we = addr_hit[20] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_19_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_20_we = addr_hit[21] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_20_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_21_we = addr_hit[22] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_21_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_22_we = addr_hit[23] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_22_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_23_we = addr_hit[24] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_23_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_24_we = addr_hit[25] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_24_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_25_we = addr_hit[26] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_25_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_26_we = addr_hit[27] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_26_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_27_we = addr_hit[28] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_27_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_28_we = addr_hit[29] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_28_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_29_we = addr_hit[30] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_29_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_30_we = addr_hit[31] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_30_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_31_we = addr_hit[32] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_31_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_32_we = addr_hit[33] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_32_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_33_we = addr_hit[34] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_33_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_34_we = addr_hit[35] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_34_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_35_we = addr_hit[36] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_35_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_36_we = addr_hit[37] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_36_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_37_we = addr_hit[38] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_37_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_38_we = addr_hit[39] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_38_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_39_we = addr_hit[40] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_39_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_40_we = addr_hit[41] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_40_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_41_we = addr_hit[42] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_41_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_42_we = addr_hit[43] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_42_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_43_we = addr_hit[44] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_43_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_44_we = addr_hit[45] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_44_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_45_we = addr_hit[46] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_45_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_46_we = addr_hit[47] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_46_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_47_we = addr_hit[48] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_47_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_48_we = addr_hit[49] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_48_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_49_we = addr_hit[50] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_49_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_50_we = addr_hit[51] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_50_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_51_we = addr_hit[52] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_51_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_52_we = addr_hit[53] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_52_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_53_we = addr_hit[54] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_53_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_54_we = addr_hit[55] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_54_wd = reg_wdata[0];
-
   assign mio_periph_insel_regwen_55_we = addr_hit[56] & reg_we & !reg_error;
+
   assign mio_periph_insel_regwen_55_wd = reg_wdata[0];
-
   assign mio_periph_insel_0_we = addr_hit[57] & reg_we & !reg_error;
+
   assign mio_periph_insel_0_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_1_we = addr_hit[58] & reg_we & !reg_error;
+
   assign mio_periph_insel_1_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_2_we = addr_hit[59] & reg_we & !reg_error;
+
   assign mio_periph_insel_2_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_3_we = addr_hit[60] & reg_we & !reg_error;
+
   assign mio_periph_insel_3_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_4_we = addr_hit[61] & reg_we & !reg_error;
+
   assign mio_periph_insel_4_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_5_we = addr_hit[62] & reg_we & !reg_error;
+
   assign mio_periph_insel_5_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_6_we = addr_hit[63] & reg_we & !reg_error;
+
   assign mio_periph_insel_6_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_7_we = addr_hit[64] & reg_we & !reg_error;
+
   assign mio_periph_insel_7_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_8_we = addr_hit[65] & reg_we & !reg_error;
+
   assign mio_periph_insel_8_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_9_we = addr_hit[66] & reg_we & !reg_error;
+
   assign mio_periph_insel_9_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_10_we = addr_hit[67] & reg_we & !reg_error;
+
   assign mio_periph_insel_10_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_11_we = addr_hit[68] & reg_we & !reg_error;
+
   assign mio_periph_insel_11_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_12_we = addr_hit[69] & reg_we & !reg_error;
+
   assign mio_periph_insel_12_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_13_we = addr_hit[70] & reg_we & !reg_error;
+
   assign mio_periph_insel_13_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_14_we = addr_hit[71] & reg_we & !reg_error;
+
   assign mio_periph_insel_14_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_15_we = addr_hit[72] & reg_we & !reg_error;
+
   assign mio_periph_insel_15_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_16_we = addr_hit[73] & reg_we & !reg_error;
+
   assign mio_periph_insel_16_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_17_we = addr_hit[74] & reg_we & !reg_error;
+
   assign mio_periph_insel_17_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_18_we = addr_hit[75] & reg_we & !reg_error;
+
   assign mio_periph_insel_18_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_19_we = addr_hit[76] & reg_we & !reg_error;
+
   assign mio_periph_insel_19_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_20_we = addr_hit[77] & reg_we & !reg_error;
+
   assign mio_periph_insel_20_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_21_we = addr_hit[78] & reg_we & !reg_error;
+
   assign mio_periph_insel_21_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_22_we = addr_hit[79] & reg_we & !reg_error;
+
   assign mio_periph_insel_22_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_23_we = addr_hit[80] & reg_we & !reg_error;
+
   assign mio_periph_insel_23_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_24_we = addr_hit[81] & reg_we & !reg_error;
+
   assign mio_periph_insel_24_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_25_we = addr_hit[82] & reg_we & !reg_error;
+
   assign mio_periph_insel_25_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_26_we = addr_hit[83] & reg_we & !reg_error;
+
   assign mio_periph_insel_26_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_27_we = addr_hit[84] & reg_we & !reg_error;
+
   assign mio_periph_insel_27_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_28_we = addr_hit[85] & reg_we & !reg_error;
+
   assign mio_periph_insel_28_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_29_we = addr_hit[86] & reg_we & !reg_error;
+
   assign mio_periph_insel_29_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_30_we = addr_hit[87] & reg_we & !reg_error;
+
   assign mio_periph_insel_30_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_31_we = addr_hit[88] & reg_we & !reg_error;
+
   assign mio_periph_insel_31_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_32_we = addr_hit[89] & reg_we & !reg_error;
+
   assign mio_periph_insel_32_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_33_we = addr_hit[90] & reg_we & !reg_error;
+
   assign mio_periph_insel_33_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_34_we = addr_hit[91] & reg_we & !reg_error;
+
   assign mio_periph_insel_34_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_35_we = addr_hit[92] & reg_we & !reg_error;
+
   assign mio_periph_insel_35_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_36_we = addr_hit[93] & reg_we & !reg_error;
+
   assign mio_periph_insel_36_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_37_we = addr_hit[94] & reg_we & !reg_error;
+
   assign mio_periph_insel_37_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_38_we = addr_hit[95] & reg_we & !reg_error;
+
   assign mio_periph_insel_38_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_39_we = addr_hit[96] & reg_we & !reg_error;
+
   assign mio_periph_insel_39_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_40_we = addr_hit[97] & reg_we & !reg_error;
+
   assign mio_periph_insel_40_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_41_we = addr_hit[98] & reg_we & !reg_error;
+
   assign mio_periph_insel_41_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_42_we = addr_hit[99] & reg_we & !reg_error;
+
   assign mio_periph_insel_42_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_43_we = addr_hit[100] & reg_we & !reg_error;
+
   assign mio_periph_insel_43_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_44_we = addr_hit[101] & reg_we & !reg_error;
+
   assign mio_periph_insel_44_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_45_we = addr_hit[102] & reg_we & !reg_error;
+
   assign mio_periph_insel_45_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_46_we = addr_hit[103] & reg_we & !reg_error;
+
   assign mio_periph_insel_46_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_47_we = addr_hit[104] & reg_we & !reg_error;
+
   assign mio_periph_insel_47_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_48_we = addr_hit[105] & reg_we & !reg_error;
+
   assign mio_periph_insel_48_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_49_we = addr_hit[106] & reg_we & !reg_error;
+
   assign mio_periph_insel_49_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_50_we = addr_hit[107] & reg_we & !reg_error;
+
   assign mio_periph_insel_50_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_51_we = addr_hit[108] & reg_we & !reg_error;
+
   assign mio_periph_insel_51_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_52_we = addr_hit[109] & reg_we & !reg_error;
+
   assign mio_periph_insel_52_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_53_we = addr_hit[110] & reg_we & !reg_error;
+
   assign mio_periph_insel_53_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_54_we = addr_hit[111] & reg_we & !reg_error;
+
   assign mio_periph_insel_54_wd = reg_wdata[5:0];
-
   assign mio_periph_insel_55_we = addr_hit[112] & reg_we & !reg_error;
+
   assign mio_periph_insel_55_wd = reg_wdata[5:0];
-
   assign mio_outsel_regwen_0_we = addr_hit[113] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_0_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_1_we = addr_hit[114] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_1_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_2_we = addr_hit[115] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_2_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_3_we = addr_hit[116] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_3_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_4_we = addr_hit[117] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_4_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_5_we = addr_hit[118] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_5_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_6_we = addr_hit[119] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_6_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_7_we = addr_hit[120] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_7_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_8_we = addr_hit[121] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_8_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_9_we = addr_hit[122] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_9_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_10_we = addr_hit[123] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_10_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_11_we = addr_hit[124] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_11_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_12_we = addr_hit[125] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_12_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_13_we = addr_hit[126] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_13_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_14_we = addr_hit[127] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_14_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_15_we = addr_hit[128] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_15_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_16_we = addr_hit[129] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_16_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_17_we = addr_hit[130] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_17_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_18_we = addr_hit[131] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_18_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_19_we = addr_hit[132] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_19_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_20_we = addr_hit[133] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_20_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_21_we = addr_hit[134] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_21_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_22_we = addr_hit[135] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_22_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_23_we = addr_hit[136] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_23_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_24_we = addr_hit[137] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_24_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_25_we = addr_hit[138] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_25_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_26_we = addr_hit[139] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_26_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_27_we = addr_hit[140] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_27_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_28_we = addr_hit[141] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_28_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_29_we = addr_hit[142] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_29_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_30_we = addr_hit[143] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_30_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_31_we = addr_hit[144] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_31_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_32_we = addr_hit[145] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_32_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_33_we = addr_hit[146] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_33_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_34_we = addr_hit[147] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_34_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_35_we = addr_hit[148] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_35_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_36_we = addr_hit[149] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_36_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_37_we = addr_hit[150] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_37_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_38_we = addr_hit[151] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_38_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_39_we = addr_hit[152] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_39_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_40_we = addr_hit[153] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_40_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_41_we = addr_hit[154] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_41_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_42_we = addr_hit[155] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_42_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_43_we = addr_hit[156] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_43_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_44_we = addr_hit[157] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_44_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_45_we = addr_hit[158] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_45_wd = reg_wdata[0];
-
   assign mio_outsel_regwen_46_we = addr_hit[159] & reg_we & !reg_error;
+
   assign mio_outsel_regwen_46_wd = reg_wdata[0];
-
   assign mio_outsel_0_we = addr_hit[160] & reg_we & !reg_error;
+
   assign mio_outsel_0_wd = reg_wdata[6:0];
-
   assign mio_outsel_1_we = addr_hit[161] & reg_we & !reg_error;
+
   assign mio_outsel_1_wd = reg_wdata[6:0];
-
   assign mio_outsel_2_we = addr_hit[162] & reg_we & !reg_error;
+
   assign mio_outsel_2_wd = reg_wdata[6:0];
-
   assign mio_outsel_3_we = addr_hit[163] & reg_we & !reg_error;
+
   assign mio_outsel_3_wd = reg_wdata[6:0];
-
   assign mio_outsel_4_we = addr_hit[164] & reg_we & !reg_error;
+
   assign mio_outsel_4_wd = reg_wdata[6:0];
-
   assign mio_outsel_5_we = addr_hit[165] & reg_we & !reg_error;
+
   assign mio_outsel_5_wd = reg_wdata[6:0];
-
   assign mio_outsel_6_we = addr_hit[166] & reg_we & !reg_error;
+
   assign mio_outsel_6_wd = reg_wdata[6:0];
-
   assign mio_outsel_7_we = addr_hit[167] & reg_we & !reg_error;
+
   assign mio_outsel_7_wd = reg_wdata[6:0];
-
   assign mio_outsel_8_we = addr_hit[168] & reg_we & !reg_error;
+
   assign mio_outsel_8_wd = reg_wdata[6:0];
-
   assign mio_outsel_9_we = addr_hit[169] & reg_we & !reg_error;
+
   assign mio_outsel_9_wd = reg_wdata[6:0];
-
   assign mio_outsel_10_we = addr_hit[170] & reg_we & !reg_error;
+
   assign mio_outsel_10_wd = reg_wdata[6:0];
-
   assign mio_outsel_11_we = addr_hit[171] & reg_we & !reg_error;
+
   assign mio_outsel_11_wd = reg_wdata[6:0];
-
   assign mio_outsel_12_we = addr_hit[172] & reg_we & !reg_error;
+
   assign mio_outsel_12_wd = reg_wdata[6:0];
-
   assign mio_outsel_13_we = addr_hit[173] & reg_we & !reg_error;
+
   assign mio_outsel_13_wd = reg_wdata[6:0];
-
   assign mio_outsel_14_we = addr_hit[174] & reg_we & !reg_error;
+
   assign mio_outsel_14_wd = reg_wdata[6:0];
-
   assign mio_outsel_15_we = addr_hit[175] & reg_we & !reg_error;
+
   assign mio_outsel_15_wd = reg_wdata[6:0];
-
   assign mio_outsel_16_we = addr_hit[176] & reg_we & !reg_error;
+
   assign mio_outsel_16_wd = reg_wdata[6:0];
-
   assign mio_outsel_17_we = addr_hit[177] & reg_we & !reg_error;
+
   assign mio_outsel_17_wd = reg_wdata[6:0];
-
   assign mio_outsel_18_we = addr_hit[178] & reg_we & !reg_error;
+
   assign mio_outsel_18_wd = reg_wdata[6:0];
-
   assign mio_outsel_19_we = addr_hit[179] & reg_we & !reg_error;
+
   assign mio_outsel_19_wd = reg_wdata[6:0];
-
   assign mio_outsel_20_we = addr_hit[180] & reg_we & !reg_error;
+
   assign mio_outsel_20_wd = reg_wdata[6:0];
-
   assign mio_outsel_21_we = addr_hit[181] & reg_we & !reg_error;
+
   assign mio_outsel_21_wd = reg_wdata[6:0];
-
   assign mio_outsel_22_we = addr_hit[182] & reg_we & !reg_error;
+
   assign mio_outsel_22_wd = reg_wdata[6:0];
-
   assign mio_outsel_23_we = addr_hit[183] & reg_we & !reg_error;
+
   assign mio_outsel_23_wd = reg_wdata[6:0];
-
   assign mio_outsel_24_we = addr_hit[184] & reg_we & !reg_error;
+
   assign mio_outsel_24_wd = reg_wdata[6:0];
-
   assign mio_outsel_25_we = addr_hit[185] & reg_we & !reg_error;
+
   assign mio_outsel_25_wd = reg_wdata[6:0];
-
   assign mio_outsel_26_we = addr_hit[186] & reg_we & !reg_error;
+
   assign mio_outsel_26_wd = reg_wdata[6:0];
-
   assign mio_outsel_27_we = addr_hit[187] & reg_we & !reg_error;
+
   assign mio_outsel_27_wd = reg_wdata[6:0];
-
   assign mio_outsel_28_we = addr_hit[188] & reg_we & !reg_error;
+
   assign mio_outsel_28_wd = reg_wdata[6:0];
-
   assign mio_outsel_29_we = addr_hit[189] & reg_we & !reg_error;
+
   assign mio_outsel_29_wd = reg_wdata[6:0];
-
   assign mio_outsel_30_we = addr_hit[190] & reg_we & !reg_error;
+
   assign mio_outsel_30_wd = reg_wdata[6:0];
-
   assign mio_outsel_31_we = addr_hit[191] & reg_we & !reg_error;
+
   assign mio_outsel_31_wd = reg_wdata[6:0];
-
   assign mio_outsel_32_we = addr_hit[192] & reg_we & !reg_error;
+
   assign mio_outsel_32_wd = reg_wdata[6:0];
-
   assign mio_outsel_33_we = addr_hit[193] & reg_we & !reg_error;
+
   assign mio_outsel_33_wd = reg_wdata[6:0];
-
   assign mio_outsel_34_we = addr_hit[194] & reg_we & !reg_error;
+
   assign mio_outsel_34_wd = reg_wdata[6:0];
-
   assign mio_outsel_35_we = addr_hit[195] & reg_we & !reg_error;
+
   assign mio_outsel_35_wd = reg_wdata[6:0];
-
   assign mio_outsel_36_we = addr_hit[196] & reg_we & !reg_error;
+
   assign mio_outsel_36_wd = reg_wdata[6:0];
-
   assign mio_outsel_37_we = addr_hit[197] & reg_we & !reg_error;
+
   assign mio_outsel_37_wd = reg_wdata[6:0];
-
   assign mio_outsel_38_we = addr_hit[198] & reg_we & !reg_error;
+
   assign mio_outsel_38_wd = reg_wdata[6:0];
-
   assign mio_outsel_39_we = addr_hit[199] & reg_we & !reg_error;
+
   assign mio_outsel_39_wd = reg_wdata[6:0];
-
   assign mio_outsel_40_we = addr_hit[200] & reg_we & !reg_error;
+
   assign mio_outsel_40_wd = reg_wdata[6:0];
-
   assign mio_outsel_41_we = addr_hit[201] & reg_we & !reg_error;
+
   assign mio_outsel_41_wd = reg_wdata[6:0];
-
   assign mio_outsel_42_we = addr_hit[202] & reg_we & !reg_error;
+
   assign mio_outsel_42_wd = reg_wdata[6:0];
-
   assign mio_outsel_43_we = addr_hit[203] & reg_we & !reg_error;
+
   assign mio_outsel_43_wd = reg_wdata[6:0];
-
   assign mio_outsel_44_we = addr_hit[204] & reg_we & !reg_error;
+
   assign mio_outsel_44_wd = reg_wdata[6:0];
-
   assign mio_outsel_45_we = addr_hit[205] & reg_we & !reg_error;
+
   assign mio_outsel_45_wd = reg_wdata[6:0];
-
   assign mio_outsel_46_we = addr_hit[206] & reg_we & !reg_error;
+
   assign mio_outsel_46_wd = reg_wdata[6:0];
-
   assign mio_pad_attr_regwen_0_we = addr_hit[207] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_0_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_1_we = addr_hit[208] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_1_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_2_we = addr_hit[209] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_2_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_3_we = addr_hit[210] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_3_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_4_we = addr_hit[211] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_4_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_5_we = addr_hit[212] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_5_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_6_we = addr_hit[213] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_6_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_7_we = addr_hit[214] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_7_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_8_we = addr_hit[215] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_8_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_9_we = addr_hit[216] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_9_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_10_we = addr_hit[217] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_10_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_11_we = addr_hit[218] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_11_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_12_we = addr_hit[219] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_12_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_13_we = addr_hit[220] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_13_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_14_we = addr_hit[221] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_14_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_15_we = addr_hit[222] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_15_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_16_we = addr_hit[223] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_16_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_17_we = addr_hit[224] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_17_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_18_we = addr_hit[225] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_18_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_19_we = addr_hit[226] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_19_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_20_we = addr_hit[227] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_20_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_21_we = addr_hit[228] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_21_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_22_we = addr_hit[229] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_22_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_23_we = addr_hit[230] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_23_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_24_we = addr_hit[231] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_24_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_25_we = addr_hit[232] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_25_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_26_we = addr_hit[233] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_26_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_27_we = addr_hit[234] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_27_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_28_we = addr_hit[235] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_28_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_29_we = addr_hit[236] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_29_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_30_we = addr_hit[237] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_30_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_31_we = addr_hit[238] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_31_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_32_we = addr_hit[239] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_32_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_33_we = addr_hit[240] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_33_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_34_we = addr_hit[241] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_34_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_35_we = addr_hit[242] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_35_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_36_we = addr_hit[243] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_36_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_37_we = addr_hit[244] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_37_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_38_we = addr_hit[245] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_38_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_39_we = addr_hit[246] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_39_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_40_we = addr_hit[247] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_40_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_41_we = addr_hit[248] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_41_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_42_we = addr_hit[249] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_42_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_43_we = addr_hit[250] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_43_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_44_we = addr_hit[251] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_44_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_45_we = addr_hit[252] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_45_wd = reg_wdata[0];
-
   assign mio_pad_attr_regwen_46_we = addr_hit[253] & reg_we & !reg_error;
+
   assign mio_pad_attr_regwen_46_wd = reg_wdata[0];
-
-  assign mio_pad_attr_0_we = addr_hit[254] & reg_we & !reg_error;
-  assign mio_pad_attr_0_wd = reg_wdata[12:0];
   assign mio_pad_attr_0_re = addr_hit[254] & reg_re & !reg_error;
+  assign mio_pad_attr_0_we = addr_hit[254] & reg_we & !reg_error;
 
-  assign mio_pad_attr_1_we = addr_hit[255] & reg_we & !reg_error;
-  assign mio_pad_attr_1_wd = reg_wdata[12:0];
+  assign mio_pad_attr_0_wd = reg_wdata[12:0];
   assign mio_pad_attr_1_re = addr_hit[255] & reg_re & !reg_error;
+  assign mio_pad_attr_1_we = addr_hit[255] & reg_we & !reg_error;
 
-  assign mio_pad_attr_2_we = addr_hit[256] & reg_we & !reg_error;
-  assign mio_pad_attr_2_wd = reg_wdata[12:0];
+  assign mio_pad_attr_1_wd = reg_wdata[12:0];
   assign mio_pad_attr_2_re = addr_hit[256] & reg_re & !reg_error;
+  assign mio_pad_attr_2_we = addr_hit[256] & reg_we & !reg_error;
 
-  assign mio_pad_attr_3_we = addr_hit[257] & reg_we & !reg_error;
-  assign mio_pad_attr_3_wd = reg_wdata[12:0];
+  assign mio_pad_attr_2_wd = reg_wdata[12:0];
   assign mio_pad_attr_3_re = addr_hit[257] & reg_re & !reg_error;
+  assign mio_pad_attr_3_we = addr_hit[257] & reg_we & !reg_error;
 
-  assign mio_pad_attr_4_we = addr_hit[258] & reg_we & !reg_error;
-  assign mio_pad_attr_4_wd = reg_wdata[12:0];
+  assign mio_pad_attr_3_wd = reg_wdata[12:0];
   assign mio_pad_attr_4_re = addr_hit[258] & reg_re & !reg_error;
+  assign mio_pad_attr_4_we = addr_hit[258] & reg_we & !reg_error;
 
-  assign mio_pad_attr_5_we = addr_hit[259] & reg_we & !reg_error;
-  assign mio_pad_attr_5_wd = reg_wdata[12:0];
+  assign mio_pad_attr_4_wd = reg_wdata[12:0];
   assign mio_pad_attr_5_re = addr_hit[259] & reg_re & !reg_error;
+  assign mio_pad_attr_5_we = addr_hit[259] & reg_we & !reg_error;
 
-  assign mio_pad_attr_6_we = addr_hit[260] & reg_we & !reg_error;
-  assign mio_pad_attr_6_wd = reg_wdata[12:0];
+  assign mio_pad_attr_5_wd = reg_wdata[12:0];
   assign mio_pad_attr_6_re = addr_hit[260] & reg_re & !reg_error;
+  assign mio_pad_attr_6_we = addr_hit[260] & reg_we & !reg_error;
 
-  assign mio_pad_attr_7_we = addr_hit[261] & reg_we & !reg_error;
-  assign mio_pad_attr_7_wd = reg_wdata[12:0];
+  assign mio_pad_attr_6_wd = reg_wdata[12:0];
   assign mio_pad_attr_7_re = addr_hit[261] & reg_re & !reg_error;
+  assign mio_pad_attr_7_we = addr_hit[261] & reg_we & !reg_error;
 
-  assign mio_pad_attr_8_we = addr_hit[262] & reg_we & !reg_error;
-  assign mio_pad_attr_8_wd = reg_wdata[12:0];
+  assign mio_pad_attr_7_wd = reg_wdata[12:0];
   assign mio_pad_attr_8_re = addr_hit[262] & reg_re & !reg_error;
+  assign mio_pad_attr_8_we = addr_hit[262] & reg_we & !reg_error;
 
-  assign mio_pad_attr_9_we = addr_hit[263] & reg_we & !reg_error;
-  assign mio_pad_attr_9_wd = reg_wdata[12:0];
+  assign mio_pad_attr_8_wd = reg_wdata[12:0];
   assign mio_pad_attr_9_re = addr_hit[263] & reg_re & !reg_error;
+  assign mio_pad_attr_9_we = addr_hit[263] & reg_we & !reg_error;
 
-  assign mio_pad_attr_10_we = addr_hit[264] & reg_we & !reg_error;
-  assign mio_pad_attr_10_wd = reg_wdata[12:0];
+  assign mio_pad_attr_9_wd = reg_wdata[12:0];
   assign mio_pad_attr_10_re = addr_hit[264] & reg_re & !reg_error;
+  assign mio_pad_attr_10_we = addr_hit[264] & reg_we & !reg_error;
 
-  assign mio_pad_attr_11_we = addr_hit[265] & reg_we & !reg_error;
-  assign mio_pad_attr_11_wd = reg_wdata[12:0];
+  assign mio_pad_attr_10_wd = reg_wdata[12:0];
   assign mio_pad_attr_11_re = addr_hit[265] & reg_re & !reg_error;
+  assign mio_pad_attr_11_we = addr_hit[265] & reg_we & !reg_error;
 
-  assign mio_pad_attr_12_we = addr_hit[266] & reg_we & !reg_error;
-  assign mio_pad_attr_12_wd = reg_wdata[12:0];
+  assign mio_pad_attr_11_wd = reg_wdata[12:0];
   assign mio_pad_attr_12_re = addr_hit[266] & reg_re & !reg_error;
+  assign mio_pad_attr_12_we = addr_hit[266] & reg_we & !reg_error;
 
-  assign mio_pad_attr_13_we = addr_hit[267] & reg_we & !reg_error;
-  assign mio_pad_attr_13_wd = reg_wdata[12:0];
+  assign mio_pad_attr_12_wd = reg_wdata[12:0];
   assign mio_pad_attr_13_re = addr_hit[267] & reg_re & !reg_error;
+  assign mio_pad_attr_13_we = addr_hit[267] & reg_we & !reg_error;
 
-  assign mio_pad_attr_14_we = addr_hit[268] & reg_we & !reg_error;
-  assign mio_pad_attr_14_wd = reg_wdata[12:0];
+  assign mio_pad_attr_13_wd = reg_wdata[12:0];
   assign mio_pad_attr_14_re = addr_hit[268] & reg_re & !reg_error;
+  assign mio_pad_attr_14_we = addr_hit[268] & reg_we & !reg_error;
 
-  assign mio_pad_attr_15_we = addr_hit[269] & reg_we & !reg_error;
-  assign mio_pad_attr_15_wd = reg_wdata[12:0];
+  assign mio_pad_attr_14_wd = reg_wdata[12:0];
   assign mio_pad_attr_15_re = addr_hit[269] & reg_re & !reg_error;
+  assign mio_pad_attr_15_we = addr_hit[269] & reg_we & !reg_error;
 
-  assign mio_pad_attr_16_we = addr_hit[270] & reg_we & !reg_error;
-  assign mio_pad_attr_16_wd = reg_wdata[12:0];
+  assign mio_pad_attr_15_wd = reg_wdata[12:0];
   assign mio_pad_attr_16_re = addr_hit[270] & reg_re & !reg_error;
+  assign mio_pad_attr_16_we = addr_hit[270] & reg_we & !reg_error;
 
-  assign mio_pad_attr_17_we = addr_hit[271] & reg_we & !reg_error;
-  assign mio_pad_attr_17_wd = reg_wdata[12:0];
+  assign mio_pad_attr_16_wd = reg_wdata[12:0];
   assign mio_pad_attr_17_re = addr_hit[271] & reg_re & !reg_error;
+  assign mio_pad_attr_17_we = addr_hit[271] & reg_we & !reg_error;
 
-  assign mio_pad_attr_18_we = addr_hit[272] & reg_we & !reg_error;
-  assign mio_pad_attr_18_wd = reg_wdata[12:0];
+  assign mio_pad_attr_17_wd = reg_wdata[12:0];
   assign mio_pad_attr_18_re = addr_hit[272] & reg_re & !reg_error;
+  assign mio_pad_attr_18_we = addr_hit[272] & reg_we & !reg_error;
 
-  assign mio_pad_attr_19_we = addr_hit[273] & reg_we & !reg_error;
-  assign mio_pad_attr_19_wd = reg_wdata[12:0];
+  assign mio_pad_attr_18_wd = reg_wdata[12:0];
   assign mio_pad_attr_19_re = addr_hit[273] & reg_re & !reg_error;
+  assign mio_pad_attr_19_we = addr_hit[273] & reg_we & !reg_error;
 
-  assign mio_pad_attr_20_we = addr_hit[274] & reg_we & !reg_error;
-  assign mio_pad_attr_20_wd = reg_wdata[12:0];
+  assign mio_pad_attr_19_wd = reg_wdata[12:0];
   assign mio_pad_attr_20_re = addr_hit[274] & reg_re & !reg_error;
+  assign mio_pad_attr_20_we = addr_hit[274] & reg_we & !reg_error;
 
-  assign mio_pad_attr_21_we = addr_hit[275] & reg_we & !reg_error;
-  assign mio_pad_attr_21_wd = reg_wdata[12:0];
+  assign mio_pad_attr_20_wd = reg_wdata[12:0];
   assign mio_pad_attr_21_re = addr_hit[275] & reg_re & !reg_error;
+  assign mio_pad_attr_21_we = addr_hit[275] & reg_we & !reg_error;
 
-  assign mio_pad_attr_22_we = addr_hit[276] & reg_we & !reg_error;
-  assign mio_pad_attr_22_wd = reg_wdata[12:0];
+  assign mio_pad_attr_21_wd = reg_wdata[12:0];
   assign mio_pad_attr_22_re = addr_hit[276] & reg_re & !reg_error;
+  assign mio_pad_attr_22_we = addr_hit[276] & reg_we & !reg_error;
 
-  assign mio_pad_attr_23_we = addr_hit[277] & reg_we & !reg_error;
-  assign mio_pad_attr_23_wd = reg_wdata[12:0];
+  assign mio_pad_attr_22_wd = reg_wdata[12:0];
   assign mio_pad_attr_23_re = addr_hit[277] & reg_re & !reg_error;
+  assign mio_pad_attr_23_we = addr_hit[277] & reg_we & !reg_error;
 
-  assign mio_pad_attr_24_we = addr_hit[278] & reg_we & !reg_error;
-  assign mio_pad_attr_24_wd = reg_wdata[12:0];
+  assign mio_pad_attr_23_wd = reg_wdata[12:0];
   assign mio_pad_attr_24_re = addr_hit[278] & reg_re & !reg_error;
+  assign mio_pad_attr_24_we = addr_hit[278] & reg_we & !reg_error;
 
-  assign mio_pad_attr_25_we = addr_hit[279] & reg_we & !reg_error;
-  assign mio_pad_attr_25_wd = reg_wdata[12:0];
+  assign mio_pad_attr_24_wd = reg_wdata[12:0];
   assign mio_pad_attr_25_re = addr_hit[279] & reg_re & !reg_error;
+  assign mio_pad_attr_25_we = addr_hit[279] & reg_we & !reg_error;
 
-  assign mio_pad_attr_26_we = addr_hit[280] & reg_we & !reg_error;
-  assign mio_pad_attr_26_wd = reg_wdata[12:0];
+  assign mio_pad_attr_25_wd = reg_wdata[12:0];
   assign mio_pad_attr_26_re = addr_hit[280] & reg_re & !reg_error;
+  assign mio_pad_attr_26_we = addr_hit[280] & reg_we & !reg_error;
 
-  assign mio_pad_attr_27_we = addr_hit[281] & reg_we & !reg_error;
-  assign mio_pad_attr_27_wd = reg_wdata[12:0];
+  assign mio_pad_attr_26_wd = reg_wdata[12:0];
   assign mio_pad_attr_27_re = addr_hit[281] & reg_re & !reg_error;
+  assign mio_pad_attr_27_we = addr_hit[281] & reg_we & !reg_error;
 
-  assign mio_pad_attr_28_we = addr_hit[282] & reg_we & !reg_error;
-  assign mio_pad_attr_28_wd = reg_wdata[12:0];
+  assign mio_pad_attr_27_wd = reg_wdata[12:0];
   assign mio_pad_attr_28_re = addr_hit[282] & reg_re & !reg_error;
+  assign mio_pad_attr_28_we = addr_hit[282] & reg_we & !reg_error;
 
-  assign mio_pad_attr_29_we = addr_hit[283] & reg_we & !reg_error;
-  assign mio_pad_attr_29_wd = reg_wdata[12:0];
+  assign mio_pad_attr_28_wd = reg_wdata[12:0];
   assign mio_pad_attr_29_re = addr_hit[283] & reg_re & !reg_error;
+  assign mio_pad_attr_29_we = addr_hit[283] & reg_we & !reg_error;
 
-  assign mio_pad_attr_30_we = addr_hit[284] & reg_we & !reg_error;
-  assign mio_pad_attr_30_wd = reg_wdata[12:0];
+  assign mio_pad_attr_29_wd = reg_wdata[12:0];
   assign mio_pad_attr_30_re = addr_hit[284] & reg_re & !reg_error;
+  assign mio_pad_attr_30_we = addr_hit[284] & reg_we & !reg_error;
 
-  assign mio_pad_attr_31_we = addr_hit[285] & reg_we & !reg_error;
-  assign mio_pad_attr_31_wd = reg_wdata[12:0];
+  assign mio_pad_attr_30_wd = reg_wdata[12:0];
   assign mio_pad_attr_31_re = addr_hit[285] & reg_re & !reg_error;
+  assign mio_pad_attr_31_we = addr_hit[285] & reg_we & !reg_error;
 
-  assign mio_pad_attr_32_we = addr_hit[286] & reg_we & !reg_error;
-  assign mio_pad_attr_32_wd = reg_wdata[12:0];
+  assign mio_pad_attr_31_wd = reg_wdata[12:0];
   assign mio_pad_attr_32_re = addr_hit[286] & reg_re & !reg_error;
+  assign mio_pad_attr_32_we = addr_hit[286] & reg_we & !reg_error;
 
-  assign mio_pad_attr_33_we = addr_hit[287] & reg_we & !reg_error;
-  assign mio_pad_attr_33_wd = reg_wdata[12:0];
+  assign mio_pad_attr_32_wd = reg_wdata[12:0];
   assign mio_pad_attr_33_re = addr_hit[287] & reg_re & !reg_error;
+  assign mio_pad_attr_33_we = addr_hit[287] & reg_we & !reg_error;
 
-  assign mio_pad_attr_34_we = addr_hit[288] & reg_we & !reg_error;
-  assign mio_pad_attr_34_wd = reg_wdata[12:0];
+  assign mio_pad_attr_33_wd = reg_wdata[12:0];
   assign mio_pad_attr_34_re = addr_hit[288] & reg_re & !reg_error;
+  assign mio_pad_attr_34_we = addr_hit[288] & reg_we & !reg_error;
 
-  assign mio_pad_attr_35_we = addr_hit[289] & reg_we & !reg_error;
-  assign mio_pad_attr_35_wd = reg_wdata[12:0];
+  assign mio_pad_attr_34_wd = reg_wdata[12:0];
   assign mio_pad_attr_35_re = addr_hit[289] & reg_re & !reg_error;
+  assign mio_pad_attr_35_we = addr_hit[289] & reg_we & !reg_error;
 
-  assign mio_pad_attr_36_we = addr_hit[290] & reg_we & !reg_error;
-  assign mio_pad_attr_36_wd = reg_wdata[12:0];
+  assign mio_pad_attr_35_wd = reg_wdata[12:0];
   assign mio_pad_attr_36_re = addr_hit[290] & reg_re & !reg_error;
+  assign mio_pad_attr_36_we = addr_hit[290] & reg_we & !reg_error;
 
-  assign mio_pad_attr_37_we = addr_hit[291] & reg_we & !reg_error;
-  assign mio_pad_attr_37_wd = reg_wdata[12:0];
+  assign mio_pad_attr_36_wd = reg_wdata[12:0];
   assign mio_pad_attr_37_re = addr_hit[291] & reg_re & !reg_error;
+  assign mio_pad_attr_37_we = addr_hit[291] & reg_we & !reg_error;
 
-  assign mio_pad_attr_38_we = addr_hit[292] & reg_we & !reg_error;
-  assign mio_pad_attr_38_wd = reg_wdata[12:0];
+  assign mio_pad_attr_37_wd = reg_wdata[12:0];
   assign mio_pad_attr_38_re = addr_hit[292] & reg_re & !reg_error;
+  assign mio_pad_attr_38_we = addr_hit[292] & reg_we & !reg_error;
 
-  assign mio_pad_attr_39_we = addr_hit[293] & reg_we & !reg_error;
-  assign mio_pad_attr_39_wd = reg_wdata[12:0];
+  assign mio_pad_attr_38_wd = reg_wdata[12:0];
   assign mio_pad_attr_39_re = addr_hit[293] & reg_re & !reg_error;
+  assign mio_pad_attr_39_we = addr_hit[293] & reg_we & !reg_error;
 
-  assign mio_pad_attr_40_we = addr_hit[294] & reg_we & !reg_error;
-  assign mio_pad_attr_40_wd = reg_wdata[12:0];
+  assign mio_pad_attr_39_wd = reg_wdata[12:0];
   assign mio_pad_attr_40_re = addr_hit[294] & reg_re & !reg_error;
+  assign mio_pad_attr_40_we = addr_hit[294] & reg_we & !reg_error;
 
-  assign mio_pad_attr_41_we = addr_hit[295] & reg_we & !reg_error;
-  assign mio_pad_attr_41_wd = reg_wdata[12:0];
+  assign mio_pad_attr_40_wd = reg_wdata[12:0];
   assign mio_pad_attr_41_re = addr_hit[295] & reg_re & !reg_error;
+  assign mio_pad_attr_41_we = addr_hit[295] & reg_we & !reg_error;
 
-  assign mio_pad_attr_42_we = addr_hit[296] & reg_we & !reg_error;
-  assign mio_pad_attr_42_wd = reg_wdata[12:0];
+  assign mio_pad_attr_41_wd = reg_wdata[12:0];
   assign mio_pad_attr_42_re = addr_hit[296] & reg_re & !reg_error;
+  assign mio_pad_attr_42_we = addr_hit[296] & reg_we & !reg_error;
 
-  assign mio_pad_attr_43_we = addr_hit[297] & reg_we & !reg_error;
-  assign mio_pad_attr_43_wd = reg_wdata[12:0];
+  assign mio_pad_attr_42_wd = reg_wdata[12:0];
   assign mio_pad_attr_43_re = addr_hit[297] & reg_re & !reg_error;
+  assign mio_pad_attr_43_we = addr_hit[297] & reg_we & !reg_error;
 
-  assign mio_pad_attr_44_we = addr_hit[298] & reg_we & !reg_error;
-  assign mio_pad_attr_44_wd = reg_wdata[12:0];
+  assign mio_pad_attr_43_wd = reg_wdata[12:0];
   assign mio_pad_attr_44_re = addr_hit[298] & reg_re & !reg_error;
+  assign mio_pad_attr_44_we = addr_hit[298] & reg_we & !reg_error;
 
-  assign mio_pad_attr_45_we = addr_hit[299] & reg_we & !reg_error;
-  assign mio_pad_attr_45_wd = reg_wdata[12:0];
+  assign mio_pad_attr_44_wd = reg_wdata[12:0];
   assign mio_pad_attr_45_re = addr_hit[299] & reg_re & !reg_error;
+  assign mio_pad_attr_45_we = addr_hit[299] & reg_we & !reg_error;
 
-  assign mio_pad_attr_46_we = addr_hit[300] & reg_we & !reg_error;
-  assign mio_pad_attr_46_wd = reg_wdata[12:0];
+  assign mio_pad_attr_45_wd = reg_wdata[12:0];
   assign mio_pad_attr_46_re = addr_hit[300] & reg_re & !reg_error;
+  assign mio_pad_attr_46_we = addr_hit[300] & reg_we & !reg_error;
 
+  assign mio_pad_attr_46_wd = reg_wdata[12:0];
   assign dio_pad_attr_regwen_0_we = addr_hit[301] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_0_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_1_we = addr_hit[302] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_1_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_2_we = addr_hit[303] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_2_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_3_we = addr_hit[304] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_3_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_4_we = addr_hit[305] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_4_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_5_we = addr_hit[306] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_5_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_6_we = addr_hit[307] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_6_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_7_we = addr_hit[308] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_7_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_8_we = addr_hit[309] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_8_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_9_we = addr_hit[310] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_9_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_10_we = addr_hit[311] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_10_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_11_we = addr_hit[312] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_11_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_12_we = addr_hit[313] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_12_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_13_we = addr_hit[314] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_13_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_14_we = addr_hit[315] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_14_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_15_we = addr_hit[316] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_15_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_16_we = addr_hit[317] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_16_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_17_we = addr_hit[318] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_17_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_18_we = addr_hit[319] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_18_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_19_we = addr_hit[320] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_19_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_20_we = addr_hit[321] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_20_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_21_we = addr_hit[322] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_21_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_22_we = addr_hit[323] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_22_wd = reg_wdata[0];
-
   assign dio_pad_attr_regwen_23_we = addr_hit[324] & reg_we & !reg_error;
+
   assign dio_pad_attr_regwen_23_wd = reg_wdata[0];
-
-  assign dio_pad_attr_0_we = addr_hit[325] & reg_we & !reg_error;
-  assign dio_pad_attr_0_wd = reg_wdata[12:0];
   assign dio_pad_attr_0_re = addr_hit[325] & reg_re & !reg_error;
+  assign dio_pad_attr_0_we = addr_hit[325] & reg_we & !reg_error;
 
-  assign dio_pad_attr_1_we = addr_hit[326] & reg_we & !reg_error;
-  assign dio_pad_attr_1_wd = reg_wdata[12:0];
+  assign dio_pad_attr_0_wd = reg_wdata[12:0];
   assign dio_pad_attr_1_re = addr_hit[326] & reg_re & !reg_error;
+  assign dio_pad_attr_1_we = addr_hit[326] & reg_we & !reg_error;
 
-  assign dio_pad_attr_2_we = addr_hit[327] & reg_we & !reg_error;
-  assign dio_pad_attr_2_wd = reg_wdata[12:0];
+  assign dio_pad_attr_1_wd = reg_wdata[12:0];
   assign dio_pad_attr_2_re = addr_hit[327] & reg_re & !reg_error;
+  assign dio_pad_attr_2_we = addr_hit[327] & reg_we & !reg_error;
 
-  assign dio_pad_attr_3_we = addr_hit[328] & reg_we & !reg_error;
-  assign dio_pad_attr_3_wd = reg_wdata[12:0];
+  assign dio_pad_attr_2_wd = reg_wdata[12:0];
   assign dio_pad_attr_3_re = addr_hit[328] & reg_re & !reg_error;
+  assign dio_pad_attr_3_we = addr_hit[328] & reg_we & !reg_error;
 
-  assign dio_pad_attr_4_we = addr_hit[329] & reg_we & !reg_error;
-  assign dio_pad_attr_4_wd = reg_wdata[12:0];
+  assign dio_pad_attr_3_wd = reg_wdata[12:0];
   assign dio_pad_attr_4_re = addr_hit[329] & reg_re & !reg_error;
+  assign dio_pad_attr_4_we = addr_hit[329] & reg_we & !reg_error;
 
-  assign dio_pad_attr_5_we = addr_hit[330] & reg_we & !reg_error;
-  assign dio_pad_attr_5_wd = reg_wdata[12:0];
+  assign dio_pad_attr_4_wd = reg_wdata[12:0];
   assign dio_pad_attr_5_re = addr_hit[330] & reg_re & !reg_error;
+  assign dio_pad_attr_5_we = addr_hit[330] & reg_we & !reg_error;
 
-  assign dio_pad_attr_6_we = addr_hit[331] & reg_we & !reg_error;
-  assign dio_pad_attr_6_wd = reg_wdata[12:0];
+  assign dio_pad_attr_5_wd = reg_wdata[12:0];
   assign dio_pad_attr_6_re = addr_hit[331] & reg_re & !reg_error;
+  assign dio_pad_attr_6_we = addr_hit[331] & reg_we & !reg_error;
 
-  assign dio_pad_attr_7_we = addr_hit[332] & reg_we & !reg_error;
-  assign dio_pad_attr_7_wd = reg_wdata[12:0];
+  assign dio_pad_attr_6_wd = reg_wdata[12:0];
   assign dio_pad_attr_7_re = addr_hit[332] & reg_re & !reg_error;
+  assign dio_pad_attr_7_we = addr_hit[332] & reg_we & !reg_error;
 
-  assign dio_pad_attr_8_we = addr_hit[333] & reg_we & !reg_error;
-  assign dio_pad_attr_8_wd = reg_wdata[12:0];
+  assign dio_pad_attr_7_wd = reg_wdata[12:0];
   assign dio_pad_attr_8_re = addr_hit[333] & reg_re & !reg_error;
+  assign dio_pad_attr_8_we = addr_hit[333] & reg_we & !reg_error;
 
-  assign dio_pad_attr_9_we = addr_hit[334] & reg_we & !reg_error;
-  assign dio_pad_attr_9_wd = reg_wdata[12:0];
+  assign dio_pad_attr_8_wd = reg_wdata[12:0];
   assign dio_pad_attr_9_re = addr_hit[334] & reg_re & !reg_error;
+  assign dio_pad_attr_9_we = addr_hit[334] & reg_we & !reg_error;
 
-  assign dio_pad_attr_10_we = addr_hit[335] & reg_we & !reg_error;
-  assign dio_pad_attr_10_wd = reg_wdata[12:0];
+  assign dio_pad_attr_9_wd = reg_wdata[12:0];
   assign dio_pad_attr_10_re = addr_hit[335] & reg_re & !reg_error;
+  assign dio_pad_attr_10_we = addr_hit[335] & reg_we & !reg_error;
 
-  assign dio_pad_attr_11_we = addr_hit[336] & reg_we & !reg_error;
-  assign dio_pad_attr_11_wd = reg_wdata[12:0];
+  assign dio_pad_attr_10_wd = reg_wdata[12:0];
   assign dio_pad_attr_11_re = addr_hit[336] & reg_re & !reg_error;
+  assign dio_pad_attr_11_we = addr_hit[336] & reg_we & !reg_error;
 
-  assign dio_pad_attr_12_we = addr_hit[337] & reg_we & !reg_error;
-  assign dio_pad_attr_12_wd = reg_wdata[12:0];
+  assign dio_pad_attr_11_wd = reg_wdata[12:0];
   assign dio_pad_attr_12_re = addr_hit[337] & reg_re & !reg_error;
+  assign dio_pad_attr_12_we = addr_hit[337] & reg_we & !reg_error;
 
-  assign dio_pad_attr_13_we = addr_hit[338] & reg_we & !reg_error;
-  assign dio_pad_attr_13_wd = reg_wdata[12:0];
+  assign dio_pad_attr_12_wd = reg_wdata[12:0];
   assign dio_pad_attr_13_re = addr_hit[338] & reg_re & !reg_error;
+  assign dio_pad_attr_13_we = addr_hit[338] & reg_we & !reg_error;
 
-  assign dio_pad_attr_14_we = addr_hit[339] & reg_we & !reg_error;
-  assign dio_pad_attr_14_wd = reg_wdata[12:0];
+  assign dio_pad_attr_13_wd = reg_wdata[12:0];
   assign dio_pad_attr_14_re = addr_hit[339] & reg_re & !reg_error;
+  assign dio_pad_attr_14_we = addr_hit[339] & reg_we & !reg_error;
 
-  assign dio_pad_attr_15_we = addr_hit[340] & reg_we & !reg_error;
-  assign dio_pad_attr_15_wd = reg_wdata[12:0];
+  assign dio_pad_attr_14_wd = reg_wdata[12:0];
   assign dio_pad_attr_15_re = addr_hit[340] & reg_re & !reg_error;
+  assign dio_pad_attr_15_we = addr_hit[340] & reg_we & !reg_error;
 
-  assign dio_pad_attr_16_we = addr_hit[341] & reg_we & !reg_error;
-  assign dio_pad_attr_16_wd = reg_wdata[12:0];
+  assign dio_pad_attr_15_wd = reg_wdata[12:0];
   assign dio_pad_attr_16_re = addr_hit[341] & reg_re & !reg_error;
+  assign dio_pad_attr_16_we = addr_hit[341] & reg_we & !reg_error;
 
-  assign dio_pad_attr_17_we = addr_hit[342] & reg_we & !reg_error;
-  assign dio_pad_attr_17_wd = reg_wdata[12:0];
+  assign dio_pad_attr_16_wd = reg_wdata[12:0];
   assign dio_pad_attr_17_re = addr_hit[342] & reg_re & !reg_error;
+  assign dio_pad_attr_17_we = addr_hit[342] & reg_we & !reg_error;
 
-  assign dio_pad_attr_18_we = addr_hit[343] & reg_we & !reg_error;
-  assign dio_pad_attr_18_wd = reg_wdata[12:0];
+  assign dio_pad_attr_17_wd = reg_wdata[12:0];
   assign dio_pad_attr_18_re = addr_hit[343] & reg_re & !reg_error;
+  assign dio_pad_attr_18_we = addr_hit[343] & reg_we & !reg_error;
 
-  assign dio_pad_attr_19_we = addr_hit[344] & reg_we & !reg_error;
-  assign dio_pad_attr_19_wd = reg_wdata[12:0];
+  assign dio_pad_attr_18_wd = reg_wdata[12:0];
   assign dio_pad_attr_19_re = addr_hit[344] & reg_re & !reg_error;
+  assign dio_pad_attr_19_we = addr_hit[344] & reg_we & !reg_error;
 
-  assign dio_pad_attr_20_we = addr_hit[345] & reg_we & !reg_error;
-  assign dio_pad_attr_20_wd = reg_wdata[12:0];
+  assign dio_pad_attr_19_wd = reg_wdata[12:0];
   assign dio_pad_attr_20_re = addr_hit[345] & reg_re & !reg_error;
+  assign dio_pad_attr_20_we = addr_hit[345] & reg_we & !reg_error;
 
-  assign dio_pad_attr_21_we = addr_hit[346] & reg_we & !reg_error;
-  assign dio_pad_attr_21_wd = reg_wdata[12:0];
+  assign dio_pad_attr_20_wd = reg_wdata[12:0];
   assign dio_pad_attr_21_re = addr_hit[346] & reg_re & !reg_error;
+  assign dio_pad_attr_21_we = addr_hit[346] & reg_we & !reg_error;
 
-  assign dio_pad_attr_22_we = addr_hit[347] & reg_we & !reg_error;
-  assign dio_pad_attr_22_wd = reg_wdata[12:0];
+  assign dio_pad_attr_21_wd = reg_wdata[12:0];
   assign dio_pad_attr_22_re = addr_hit[347] & reg_re & !reg_error;
+  assign dio_pad_attr_22_we = addr_hit[347] & reg_we & !reg_error;
 
-  assign dio_pad_attr_23_we = addr_hit[348] & reg_we & !reg_error;
-  assign dio_pad_attr_23_wd = reg_wdata[12:0];
+  assign dio_pad_attr_22_wd = reg_wdata[12:0];
   assign dio_pad_attr_23_re = addr_hit[348] & reg_re & !reg_error;
+  assign dio_pad_attr_23_we = addr_hit[348] & reg_we & !reg_error;
 
-  assign mio_pad_sleep_status_0_en_0_we = addr_hit[349] & reg_we & !reg_error;
+  assign dio_pad_attr_23_wd = reg_wdata[12:0];
+  assign mio_pad_sleep_status_0_we = addr_hit[349] & reg_we & !reg_error;
+
   assign mio_pad_sleep_status_0_en_0_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_0_en_1_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_1_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_0_en_2_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_2_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_0_en_3_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_3_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_0_en_4_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_4_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_0_en_5_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_5_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_0_en_6_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_6_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_0_en_7_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_7_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_0_en_8_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_8_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_0_en_9_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_9_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_0_en_10_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_10_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_0_en_11_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_11_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_0_en_12_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_12_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_0_en_13_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_13_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_0_en_14_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_14_wd = reg_wdata[14];
 
-  assign mio_pad_sleep_status_0_en_15_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_15_wd = reg_wdata[15];
 
-  assign mio_pad_sleep_status_0_en_16_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_16_wd = reg_wdata[16];
 
-  assign mio_pad_sleep_status_0_en_17_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_17_wd = reg_wdata[17];
 
-  assign mio_pad_sleep_status_0_en_18_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_18_wd = reg_wdata[18];
 
-  assign mio_pad_sleep_status_0_en_19_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_19_wd = reg_wdata[19];
 
-  assign mio_pad_sleep_status_0_en_20_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_20_wd = reg_wdata[20];
 
-  assign mio_pad_sleep_status_0_en_21_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_21_wd = reg_wdata[21];
 
-  assign mio_pad_sleep_status_0_en_22_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_22_wd = reg_wdata[22];
 
-  assign mio_pad_sleep_status_0_en_23_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_23_wd = reg_wdata[23];
 
-  assign mio_pad_sleep_status_0_en_24_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_24_wd = reg_wdata[24];
 
-  assign mio_pad_sleep_status_0_en_25_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_25_wd = reg_wdata[25];
 
-  assign mio_pad_sleep_status_0_en_26_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_26_wd = reg_wdata[26];
 
-  assign mio_pad_sleep_status_0_en_27_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_27_wd = reg_wdata[27];
 
-  assign mio_pad_sleep_status_0_en_28_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_28_wd = reg_wdata[28];
 
-  assign mio_pad_sleep_status_0_en_29_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_29_wd = reg_wdata[29];
 
-  assign mio_pad_sleep_status_0_en_30_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_30_wd = reg_wdata[30];
 
-  assign mio_pad_sleep_status_0_en_31_we = addr_hit[349] & reg_we & !reg_error;
   assign mio_pad_sleep_status_0_en_31_wd = reg_wdata[31];
+  assign mio_pad_sleep_status_1_we = addr_hit[350] & reg_we & !reg_error;
 
-  assign mio_pad_sleep_status_1_en_32_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_32_wd = reg_wdata[0];
 
-  assign mio_pad_sleep_status_1_en_33_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_33_wd = reg_wdata[1];
 
-  assign mio_pad_sleep_status_1_en_34_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_34_wd = reg_wdata[2];
 
-  assign mio_pad_sleep_status_1_en_35_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_35_wd = reg_wdata[3];
 
-  assign mio_pad_sleep_status_1_en_36_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_36_wd = reg_wdata[4];
 
-  assign mio_pad_sleep_status_1_en_37_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_37_wd = reg_wdata[5];
 
-  assign mio_pad_sleep_status_1_en_38_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_38_wd = reg_wdata[6];
 
-  assign mio_pad_sleep_status_1_en_39_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_39_wd = reg_wdata[7];
 
-  assign mio_pad_sleep_status_1_en_40_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_40_wd = reg_wdata[8];
 
-  assign mio_pad_sleep_status_1_en_41_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_41_wd = reg_wdata[9];
 
-  assign mio_pad_sleep_status_1_en_42_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_42_wd = reg_wdata[10];
 
-  assign mio_pad_sleep_status_1_en_43_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_43_wd = reg_wdata[11];
 
-  assign mio_pad_sleep_status_1_en_44_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_44_wd = reg_wdata[12];
 
-  assign mio_pad_sleep_status_1_en_45_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_45_wd = reg_wdata[13];
 
-  assign mio_pad_sleep_status_1_en_46_we = addr_hit[350] & reg_we & !reg_error;
   assign mio_pad_sleep_status_1_en_46_wd = reg_wdata[14];
-
   assign mio_pad_sleep_regwen_0_we = addr_hit[351] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_0_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_1_we = addr_hit[352] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_1_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_2_we = addr_hit[353] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_2_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_3_we = addr_hit[354] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_3_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_4_we = addr_hit[355] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_4_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_5_we = addr_hit[356] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_5_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_6_we = addr_hit[357] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_6_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_7_we = addr_hit[358] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_7_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_8_we = addr_hit[359] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_8_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_9_we = addr_hit[360] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_9_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_10_we = addr_hit[361] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_10_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_11_we = addr_hit[362] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_11_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_12_we = addr_hit[363] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_12_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_13_we = addr_hit[364] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_13_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_14_we = addr_hit[365] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_14_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_15_we = addr_hit[366] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_15_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_16_we = addr_hit[367] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_16_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_17_we = addr_hit[368] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_17_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_18_we = addr_hit[369] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_18_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_19_we = addr_hit[370] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_19_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_20_we = addr_hit[371] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_20_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_21_we = addr_hit[372] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_21_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_22_we = addr_hit[373] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_22_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_23_we = addr_hit[374] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_23_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_24_we = addr_hit[375] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_24_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_25_we = addr_hit[376] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_25_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_26_we = addr_hit[377] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_26_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_27_we = addr_hit[378] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_27_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_28_we = addr_hit[379] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_28_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_29_we = addr_hit[380] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_29_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_30_we = addr_hit[381] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_30_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_31_we = addr_hit[382] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_31_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_32_we = addr_hit[383] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_32_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_33_we = addr_hit[384] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_33_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_34_we = addr_hit[385] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_34_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_35_we = addr_hit[386] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_35_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_36_we = addr_hit[387] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_36_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_37_we = addr_hit[388] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_37_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_38_we = addr_hit[389] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_38_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_39_we = addr_hit[390] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_39_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_40_we = addr_hit[391] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_40_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_41_we = addr_hit[392] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_41_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_42_we = addr_hit[393] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_42_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_43_we = addr_hit[394] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_43_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_44_we = addr_hit[395] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_44_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_45_we = addr_hit[396] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_45_wd = reg_wdata[0];
-
   assign mio_pad_sleep_regwen_46_we = addr_hit[397] & reg_we & !reg_error;
+
   assign mio_pad_sleep_regwen_46_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_0_we = addr_hit[398] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_0_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_1_we = addr_hit[399] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_1_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_2_we = addr_hit[400] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_2_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_3_we = addr_hit[401] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_3_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_4_we = addr_hit[402] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_4_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_5_we = addr_hit[403] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_5_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_6_we = addr_hit[404] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_6_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_7_we = addr_hit[405] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_7_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_8_we = addr_hit[406] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_8_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_9_we = addr_hit[407] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_9_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_10_we = addr_hit[408] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_10_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_11_we = addr_hit[409] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_11_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_12_we = addr_hit[410] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_12_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_13_we = addr_hit[411] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_13_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_14_we = addr_hit[412] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_14_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_15_we = addr_hit[413] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_15_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_16_we = addr_hit[414] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_16_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_17_we = addr_hit[415] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_17_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_18_we = addr_hit[416] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_18_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_19_we = addr_hit[417] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_19_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_20_we = addr_hit[418] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_20_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_21_we = addr_hit[419] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_21_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_22_we = addr_hit[420] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_22_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_23_we = addr_hit[421] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_23_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_24_we = addr_hit[422] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_24_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_25_we = addr_hit[423] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_25_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_26_we = addr_hit[424] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_26_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_27_we = addr_hit[425] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_27_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_28_we = addr_hit[426] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_28_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_29_we = addr_hit[427] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_29_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_30_we = addr_hit[428] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_30_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_31_we = addr_hit[429] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_31_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_32_we = addr_hit[430] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_32_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_33_we = addr_hit[431] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_33_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_34_we = addr_hit[432] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_34_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_35_we = addr_hit[433] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_35_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_36_we = addr_hit[434] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_36_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_37_we = addr_hit[435] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_37_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_38_we = addr_hit[436] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_38_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_39_we = addr_hit[437] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_39_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_40_we = addr_hit[438] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_40_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_41_we = addr_hit[439] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_41_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_42_we = addr_hit[440] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_42_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_43_we = addr_hit[441] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_43_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_44_we = addr_hit[442] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_44_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_45_we = addr_hit[443] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_45_wd = reg_wdata[0];
-
   assign mio_pad_sleep_en_46_we = addr_hit[444] & reg_we & !reg_error;
+
   assign mio_pad_sleep_en_46_wd = reg_wdata[0];
-
   assign mio_pad_sleep_mode_0_we = addr_hit[445] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_0_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_1_we = addr_hit[446] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_1_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_2_we = addr_hit[447] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_2_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_3_we = addr_hit[448] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_3_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_4_we = addr_hit[449] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_4_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_5_we = addr_hit[450] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_5_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_6_we = addr_hit[451] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_6_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_7_we = addr_hit[452] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_7_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_8_we = addr_hit[453] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_8_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_9_we = addr_hit[454] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_9_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_10_we = addr_hit[455] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_10_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_11_we = addr_hit[456] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_11_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_12_we = addr_hit[457] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_12_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_13_we = addr_hit[458] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_13_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_14_we = addr_hit[459] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_14_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_15_we = addr_hit[460] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_15_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_16_we = addr_hit[461] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_16_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_17_we = addr_hit[462] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_17_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_18_we = addr_hit[463] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_18_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_19_we = addr_hit[464] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_19_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_20_we = addr_hit[465] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_20_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_21_we = addr_hit[466] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_21_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_22_we = addr_hit[467] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_22_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_23_we = addr_hit[468] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_23_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_24_we = addr_hit[469] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_24_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_25_we = addr_hit[470] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_25_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_26_we = addr_hit[471] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_26_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_27_we = addr_hit[472] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_27_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_28_we = addr_hit[473] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_28_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_29_we = addr_hit[474] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_29_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_30_we = addr_hit[475] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_30_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_31_we = addr_hit[476] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_31_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_32_we = addr_hit[477] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_32_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_33_we = addr_hit[478] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_33_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_34_we = addr_hit[479] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_34_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_35_we = addr_hit[480] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_35_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_36_we = addr_hit[481] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_36_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_37_we = addr_hit[482] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_37_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_38_we = addr_hit[483] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_38_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_39_we = addr_hit[484] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_39_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_40_we = addr_hit[485] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_40_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_41_we = addr_hit[486] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_41_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_42_we = addr_hit[487] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_42_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_43_we = addr_hit[488] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_43_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_44_we = addr_hit[489] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_44_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_45_we = addr_hit[490] & reg_we & !reg_error;
+
   assign mio_pad_sleep_mode_45_wd = reg_wdata[1:0];
-
   assign mio_pad_sleep_mode_46_we = addr_hit[491] & reg_we & !reg_error;
-  assign mio_pad_sleep_mode_46_wd = reg_wdata[1:0];
 
-  assign dio_pad_sleep_status_en_0_we = addr_hit[492] & reg_we & !reg_error;
+  assign mio_pad_sleep_mode_46_wd = reg_wdata[1:0];
+  assign dio_pad_sleep_status_we = addr_hit[492] & reg_we & !reg_error;
+
   assign dio_pad_sleep_status_en_0_wd = reg_wdata[0];
 
-  assign dio_pad_sleep_status_en_1_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_1_wd = reg_wdata[1];
 
-  assign dio_pad_sleep_status_en_2_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_2_wd = reg_wdata[2];
 
-  assign dio_pad_sleep_status_en_3_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_3_wd = reg_wdata[3];
 
-  assign dio_pad_sleep_status_en_4_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_4_wd = reg_wdata[4];
 
-  assign dio_pad_sleep_status_en_5_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_5_wd = reg_wdata[5];
 
-  assign dio_pad_sleep_status_en_6_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_6_wd = reg_wdata[6];
 
-  assign dio_pad_sleep_status_en_7_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_7_wd = reg_wdata[7];
 
-  assign dio_pad_sleep_status_en_8_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_8_wd = reg_wdata[8];
 
-  assign dio_pad_sleep_status_en_9_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_9_wd = reg_wdata[9];
 
-  assign dio_pad_sleep_status_en_10_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_10_wd = reg_wdata[10];
 
-  assign dio_pad_sleep_status_en_11_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_11_wd = reg_wdata[11];
 
-  assign dio_pad_sleep_status_en_12_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_12_wd = reg_wdata[12];
 
-  assign dio_pad_sleep_status_en_13_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_13_wd = reg_wdata[13];
 
-  assign dio_pad_sleep_status_en_14_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_14_wd = reg_wdata[14];
 
-  assign dio_pad_sleep_status_en_15_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_15_wd = reg_wdata[15];
 
-  assign dio_pad_sleep_status_en_16_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_16_wd = reg_wdata[16];
 
-  assign dio_pad_sleep_status_en_17_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_17_wd = reg_wdata[17];
 
-  assign dio_pad_sleep_status_en_18_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_18_wd = reg_wdata[18];
 
-  assign dio_pad_sleep_status_en_19_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_19_wd = reg_wdata[19];
 
-  assign dio_pad_sleep_status_en_20_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_20_wd = reg_wdata[20];
 
-  assign dio_pad_sleep_status_en_21_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_21_wd = reg_wdata[21];
 
-  assign dio_pad_sleep_status_en_22_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_22_wd = reg_wdata[22];
 
-  assign dio_pad_sleep_status_en_23_we = addr_hit[492] & reg_we & !reg_error;
   assign dio_pad_sleep_status_en_23_wd = reg_wdata[23];
-
   assign dio_pad_sleep_regwen_0_we = addr_hit[493] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_0_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_1_we = addr_hit[494] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_1_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_2_we = addr_hit[495] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_2_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_3_we = addr_hit[496] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_3_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_4_we = addr_hit[497] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_4_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_5_we = addr_hit[498] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_5_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_6_we = addr_hit[499] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_6_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_7_we = addr_hit[500] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_7_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_8_we = addr_hit[501] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_8_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_9_we = addr_hit[502] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_9_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_10_we = addr_hit[503] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_10_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_11_we = addr_hit[504] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_11_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_12_we = addr_hit[505] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_12_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_13_we = addr_hit[506] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_13_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_14_we = addr_hit[507] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_14_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_15_we = addr_hit[508] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_15_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_16_we = addr_hit[509] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_16_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_17_we = addr_hit[510] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_17_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_18_we = addr_hit[511] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_18_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_19_we = addr_hit[512] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_19_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_20_we = addr_hit[513] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_20_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_21_we = addr_hit[514] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_21_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_22_we = addr_hit[515] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_22_wd = reg_wdata[0];
-
   assign dio_pad_sleep_regwen_23_we = addr_hit[516] & reg_we & !reg_error;
+
   assign dio_pad_sleep_regwen_23_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_0_we = addr_hit[517] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_0_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_1_we = addr_hit[518] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_1_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_2_we = addr_hit[519] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_2_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_3_we = addr_hit[520] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_3_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_4_we = addr_hit[521] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_4_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_5_we = addr_hit[522] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_5_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_6_we = addr_hit[523] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_6_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_7_we = addr_hit[524] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_7_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_8_we = addr_hit[525] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_8_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_9_we = addr_hit[526] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_9_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_10_we = addr_hit[527] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_10_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_11_we = addr_hit[528] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_11_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_12_we = addr_hit[529] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_12_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_13_we = addr_hit[530] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_13_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_14_we = addr_hit[531] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_14_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_15_we = addr_hit[532] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_15_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_16_we = addr_hit[533] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_16_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_17_we = addr_hit[534] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_17_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_18_we = addr_hit[535] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_18_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_19_we = addr_hit[536] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_19_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_20_we = addr_hit[537] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_20_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_21_we = addr_hit[538] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_21_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_22_we = addr_hit[539] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_22_wd = reg_wdata[0];
-
   assign dio_pad_sleep_en_23_we = addr_hit[540] & reg_we & !reg_error;
+
   assign dio_pad_sleep_en_23_wd = reg_wdata[0];
-
   assign dio_pad_sleep_mode_0_we = addr_hit[541] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_0_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_1_we = addr_hit[542] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_1_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_2_we = addr_hit[543] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_2_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_3_we = addr_hit[544] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_3_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_4_we = addr_hit[545] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_4_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_5_we = addr_hit[546] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_5_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_6_we = addr_hit[547] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_6_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_7_we = addr_hit[548] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_7_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_8_we = addr_hit[549] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_8_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_9_we = addr_hit[550] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_9_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_10_we = addr_hit[551] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_10_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_11_we = addr_hit[552] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_11_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_12_we = addr_hit[553] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_12_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_13_we = addr_hit[554] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_13_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_14_we = addr_hit[555] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_14_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_15_we = addr_hit[556] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_15_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_16_we = addr_hit[557] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_16_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_17_we = addr_hit[558] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_17_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_18_we = addr_hit[559] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_18_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_19_we = addr_hit[560] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_19_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_20_we = addr_hit[561] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_20_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_21_we = addr_hit[562] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_21_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_22_we = addr_hit[563] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_22_wd = reg_wdata[1:0];
-
   assign dio_pad_sleep_mode_23_we = addr_hit[564] & reg_we & !reg_error;
+
   assign dio_pad_sleep_mode_23_wd = reg_wdata[1:0];
-
   assign wkup_detector_regwen_0_we = addr_hit[565] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_0_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_1_we = addr_hit[566] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_1_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_2_we = addr_hit[567] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_2_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_3_we = addr_hit[568] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_3_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_4_we = addr_hit[569] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_4_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_5_we = addr_hit[570] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_5_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_6_we = addr_hit[571] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_6_wd = reg_wdata[0];
-
   assign wkup_detector_regwen_7_we = addr_hit[572] & reg_we & !reg_error;
+
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
-
   assign wkup_detector_en_0_we = addr_hit[573] & reg_we & !reg_error;
+
   assign wkup_detector_en_0_wd = reg_wdata[0];
-
   assign wkup_detector_en_1_we = addr_hit[574] & reg_we & !reg_error;
+
   assign wkup_detector_en_1_wd = reg_wdata[0];
-
   assign wkup_detector_en_2_we = addr_hit[575] & reg_we & !reg_error;
+
   assign wkup_detector_en_2_wd = reg_wdata[0];
-
   assign wkup_detector_en_3_we = addr_hit[576] & reg_we & !reg_error;
+
   assign wkup_detector_en_3_wd = reg_wdata[0];
-
   assign wkup_detector_en_4_we = addr_hit[577] & reg_we & !reg_error;
+
   assign wkup_detector_en_4_wd = reg_wdata[0];
-
   assign wkup_detector_en_5_we = addr_hit[578] & reg_we & !reg_error;
+
   assign wkup_detector_en_5_wd = reg_wdata[0];
-
   assign wkup_detector_en_6_we = addr_hit[579] & reg_we & !reg_error;
+
   assign wkup_detector_en_6_wd = reg_wdata[0];
-
   assign wkup_detector_en_7_we = addr_hit[580] & reg_we & !reg_error;
-  assign wkup_detector_en_7_wd = reg_wdata[0];
 
-  assign wkup_detector_0_mode_0_we = addr_hit[581] & reg_we & !reg_error;
+  assign wkup_detector_en_7_wd = reg_wdata[0];
+  assign wkup_detector_0_we = addr_hit[581] & reg_we & !reg_error;
+
   assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_we = addr_hit[581] & reg_we & !reg_error;
   assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_we = addr_hit[581] & reg_we & !reg_error;
   assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
+  assign wkup_detector_1_we = addr_hit[582] & reg_we & !reg_error;
 
-  assign wkup_detector_1_mode_1_we = addr_hit[582] & reg_we & !reg_error;
   assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_we = addr_hit[582] & reg_we & !reg_error;
   assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_we = addr_hit[582] & reg_we & !reg_error;
   assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
+  assign wkup_detector_2_we = addr_hit[583] & reg_we & !reg_error;
 
-  assign wkup_detector_2_mode_2_we = addr_hit[583] & reg_we & !reg_error;
   assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_we = addr_hit[583] & reg_we & !reg_error;
   assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_we = addr_hit[583] & reg_we & !reg_error;
   assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
+  assign wkup_detector_3_we = addr_hit[584] & reg_we & !reg_error;
 
-  assign wkup_detector_3_mode_3_we = addr_hit[584] & reg_we & !reg_error;
   assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_we = addr_hit[584] & reg_we & !reg_error;
   assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_we = addr_hit[584] & reg_we & !reg_error;
   assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
+  assign wkup_detector_4_we = addr_hit[585] & reg_we & !reg_error;
 
-  assign wkup_detector_4_mode_4_we = addr_hit[585] & reg_we & !reg_error;
   assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_we = addr_hit[585] & reg_we & !reg_error;
   assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_we = addr_hit[585] & reg_we & !reg_error;
   assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
+  assign wkup_detector_5_we = addr_hit[586] & reg_we & !reg_error;
 
-  assign wkup_detector_5_mode_5_we = addr_hit[586] & reg_we & !reg_error;
   assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_we = addr_hit[586] & reg_we & !reg_error;
   assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_we = addr_hit[586] & reg_we & !reg_error;
   assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
+  assign wkup_detector_6_we = addr_hit[587] & reg_we & !reg_error;
 
-  assign wkup_detector_6_mode_6_we = addr_hit[587] & reg_we & !reg_error;
   assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_we = addr_hit[587] & reg_we & !reg_error;
   assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_we = addr_hit[587] & reg_we & !reg_error;
   assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
+  assign wkup_detector_7_we = addr_hit[588] & reg_we & !reg_error;
 
-  assign wkup_detector_7_mode_7_we = addr_hit[588] & reg_we & !reg_error;
   assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_we = addr_hit[588] & reg_we & !reg_error;
   assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_we = addr_hit[588] & reg_we & !reg_error;
   assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
-
   assign wkup_detector_cnt_th_0_we = addr_hit[589] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_1_we = addr_hit[590] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_2_we = addr_hit[591] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_3_we = addr_hit[592] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_4_we = addr_hit[593] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_5_we = addr_hit[594] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_6_we = addr_hit[595] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
-
   assign wkup_detector_cnt_th_7_we = addr_hit[596] & reg_we & !reg_error;
+
   assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
-
   assign wkup_detector_padsel_0_we = addr_hit[597] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_1_we = addr_hit[598] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_1_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_2_we = addr_hit[599] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_2_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_3_we = addr_hit[600] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_3_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_4_we = addr_hit[601] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_4_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_5_we = addr_hit[602] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_5_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_6_we = addr_hit[603] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_6_wd = reg_wdata[5:0];
-
   assign wkup_detector_padsel_7_we = addr_hit[604] & reg_we & !reg_error;
+
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
+  assign wkup_cause_re = addr_hit[605] & reg_re & !reg_error;
+  assign wkup_cause_we = addr_hit[605] & reg_we & !reg_error;
 
-  assign wkup_cause_cause_0_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_0_wd = reg_wdata[0];
-  assign wkup_cause_cause_0_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_1_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_1_wd = reg_wdata[1];
-  assign wkup_cause_cause_1_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_2_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_2_wd = reg_wdata[2];
-  assign wkup_cause_cause_2_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_3_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_3_wd = reg_wdata[3];
-  assign wkup_cause_cause_3_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_4_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_4_wd = reg_wdata[4];
-  assign wkup_cause_cause_4_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_5_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_5_wd = reg_wdata[5];
-  assign wkup_cause_cause_5_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_6_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_6_wd = reg_wdata[6];
-  assign wkup_cause_cause_6_re = addr_hit[605] & reg_re & !reg_error;
 
-  assign wkup_cause_cause_7_we = addr_hit[605] & reg_we & !reg_error;
   assign wkup_cause_cause_7_wd = reg_wdata[7];
-  assign wkup_cause_cause_7_re = addr_hit[605] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -104,87 +104,73 @@ module pwrmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic intr_state_we;
   logic intr_state_qs;
   logic intr_state_wd;
-  logic intr_state_we;
+  logic intr_enable_we;
   logic intr_enable_qs;
   logic intr_enable_wd;
-  logic intr_enable_we;
-  logic intr_test_wd;
   logic intr_test_we;
-  logic ctrl_cfg_regwen_qs;
+  logic intr_test_wd;
   logic ctrl_cfg_regwen_re;
+  logic ctrl_cfg_regwen_qs;
+  logic control_we;
   logic control_low_power_hint_qs;
   logic control_low_power_hint_wd;
-  logic control_low_power_hint_we;
   logic control_core_clk_en_qs;
   logic control_core_clk_en_wd;
-  logic control_core_clk_en_we;
   logic control_io_clk_en_qs;
   logic control_io_clk_en_wd;
-  logic control_io_clk_en_we;
   logic control_usb_clk_en_lp_qs;
   logic control_usb_clk_en_lp_wd;
-  logic control_usb_clk_en_lp_we;
   logic control_usb_clk_en_active_qs;
   logic control_usb_clk_en_active_wd;
-  logic control_usb_clk_en_active_we;
   logic control_main_pd_n_qs;
   logic control_main_pd_n_wd;
-  logic control_main_pd_n_we;
+  logic cfg_cdc_sync_we;
   logic cfg_cdc_sync_qs;
   logic cfg_cdc_sync_wd;
-  logic cfg_cdc_sync_we;
+  logic wakeup_en_regwen_we;
   logic wakeup_en_regwen_qs;
   logic wakeup_en_regwen_wd;
-  logic wakeup_en_regwen_we;
+  logic wakeup_en_we;
   logic wakeup_en_en_0_qs;
   logic wakeup_en_en_0_wd;
-  logic wakeup_en_en_0_we;
   logic wakeup_en_en_1_qs;
   logic wakeup_en_en_1_wd;
-  logic wakeup_en_en_1_we;
   logic wakeup_en_en_2_qs;
   logic wakeup_en_en_2_wd;
-  logic wakeup_en_en_2_we;
   logic wakeup_en_en_3_qs;
   logic wakeup_en_en_3_wd;
-  logic wakeup_en_en_3_we;
   logic wakeup_en_en_4_qs;
   logic wakeup_en_en_4_wd;
-  logic wakeup_en_en_4_we;
   logic wake_status_val_0_qs;
   logic wake_status_val_1_qs;
   logic wake_status_val_2_qs;
   logic wake_status_val_3_qs;
   logic wake_status_val_4_qs;
+  logic reset_en_regwen_we;
   logic reset_en_regwen_qs;
   logic reset_en_regwen_wd;
-  logic reset_en_regwen_we;
+  logic reset_en_we;
   logic reset_en_en_0_qs;
   logic reset_en_en_0_wd;
-  logic reset_en_en_0_we;
   logic reset_en_en_1_qs;
   logic reset_en_en_1_wd;
-  logic reset_en_en_1_we;
   logic reset_status_val_0_qs;
   logic reset_status_val_1_qs;
   logic escalate_reset_status_qs;
+  logic wake_info_capture_dis_we;
   logic wake_info_capture_dis_qs;
   logic wake_info_capture_dis_wd;
-  logic wake_info_capture_dis_we;
+  logic wake_info_re;
+  logic wake_info_we;
   logic [4:0] wake_info_reasons_qs;
   logic [4:0] wake_info_reasons_wd;
-  logic wake_info_reasons_we;
-  logic wake_info_reasons_re;
   logic wake_info_fall_through_qs;
   logic wake_info_fall_through_wd;
-  logic wake_info_fall_through_we;
-  logic wake_info_fall_through_re;
   logic wake_info_abort_qs;
   logic wake_info_abort_wd;
-  logic wake_info_abort_we;
-  logic wake_info_abort_re;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -285,7 +271,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_low_power_hint_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_low_power_hint_wd),
 
     // from internal hardware
@@ -311,7 +297,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_core_clk_en_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_core_clk_en_wd),
 
     // from internal hardware
@@ -337,7 +323,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_io_clk_en_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_io_clk_en_wd),
 
     // from internal hardware
@@ -363,7 +349,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_usb_clk_en_lp_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_usb_clk_en_lp_wd),
 
     // from internal hardware
@@ -389,7 +375,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_usb_clk_en_active_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_usb_clk_en_active_wd),
 
     // from internal hardware
@@ -415,7 +401,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (control_main_pd_n_we & ctrl_cfg_regwen_qs),
+    .we     (control_we & ctrl_cfg_regwen_qs),
     .wd     (control_main_pd_n_wd),
 
     // from internal hardware
@@ -499,7 +485,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wakeup_en_en_0_we & wakeup_en_regwen_qs),
+    .we     (wakeup_en_we & wakeup_en_regwen_qs),
     .wd     (wakeup_en_en_0_wd),
 
     // from internal hardware
@@ -525,7 +511,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wakeup_en_en_1_we & wakeup_en_regwen_qs),
+    .we     (wakeup_en_we & wakeup_en_regwen_qs),
     .wd     (wakeup_en_en_1_wd),
 
     // from internal hardware
@@ -551,7 +537,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wakeup_en_en_2_we & wakeup_en_regwen_qs),
+    .we     (wakeup_en_we & wakeup_en_regwen_qs),
     .wd     (wakeup_en_en_2_wd),
 
     // from internal hardware
@@ -577,7 +563,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wakeup_en_en_3_we & wakeup_en_regwen_qs),
+    .we     (wakeup_en_we & wakeup_en_regwen_qs),
     .wd     (wakeup_en_en_3_wd),
 
     // from internal hardware
@@ -603,7 +589,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (wakeup_en_en_4_we & wakeup_en_regwen_qs),
+    .we     (wakeup_en_we & wakeup_en_regwen_qs),
     .wd     (wakeup_en_en_4_wd),
 
     // from internal hardware
@@ -796,7 +782,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_en_en_0_we & reset_en_regwen_qs),
+    .we     (reset_en_we & reset_en_regwen_qs),
     .wd     (reset_en_en_0_wd),
 
     // from internal hardware
@@ -822,7 +808,7 @@ module pwrmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_en_en_1_we & reset_en_regwen_qs),
+    .we     (reset_en_we & reset_en_regwen_qs),
     .wd     (reset_en_en_1_wd),
 
     // from internal hardware
@@ -956,8 +942,8 @@ module pwrmgr_reg_top (
   prim_subreg_ext #(
     .DW    (5)
   ) u_wake_info_reasons (
-    .re     (wake_info_reasons_re),
-    .we     (wake_info_reasons_we),
+    .re     (wake_info_re),
+    .we     (wake_info_we),
     .wd     (wake_info_reasons_wd),
     .d      (hw2reg.wake_info.reasons.d),
     .qre    (),
@@ -971,8 +957,8 @@ module pwrmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_fall_through (
-    .re     (wake_info_fall_through_re),
-    .we     (wake_info_fall_through_we),
+    .re     (wake_info_re),
+    .we     (wake_info_we),
     .wd     (wake_info_fall_through_wd),
     .d      (hw2reg.wake_info.fall_through.d),
     .qre    (),
@@ -986,8 +972,8 @@ module pwrmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_wake_info_abort (
-    .re     (wake_info_abort_re),
-    .we     (wake_info_abort_we),
+    .re     (wake_info_re),
+    .we     (wake_info_we),
     .wd     (wake_info_abort_wd),
     .d      (hw2reg.wake_info.abort.d),
     .qre    (),
@@ -1040,80 +1026,65 @@ module pwrmgr_reg_top (
                (addr_hit[13] & (|(PWRMGR_PERMIT[13] & ~reg_be))) |
                (addr_hit[14] & (|(PWRMGR_PERMIT[14] & ~reg_be)))));
   end
-
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
+
   assign intr_state_wd = reg_wdata[0];
-
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
+
   assign intr_enable_wd = reg_wdata[0];
-
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
+
   assign intr_test_wd = reg_wdata[0];
-
   assign ctrl_cfg_regwen_re = addr_hit[3] & reg_re & !reg_error;
+  assign control_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign control_low_power_hint_we = addr_hit[4] & reg_we & !reg_error;
   assign control_low_power_hint_wd = reg_wdata[0];
 
-  assign control_core_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_core_clk_en_wd = reg_wdata[4];
 
-  assign control_io_clk_en_we = addr_hit[4] & reg_we & !reg_error;
   assign control_io_clk_en_wd = reg_wdata[5];
 
-  assign control_usb_clk_en_lp_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_lp_wd = reg_wdata[6];
 
-  assign control_usb_clk_en_active_we = addr_hit[4] & reg_we & !reg_error;
   assign control_usb_clk_en_active_wd = reg_wdata[7];
 
-  assign control_main_pd_n_we = addr_hit[4] & reg_we & !reg_error;
   assign control_main_pd_n_wd = reg_wdata[8];
-
   assign cfg_cdc_sync_we = addr_hit[5] & reg_we & !reg_error;
+
   assign cfg_cdc_sync_wd = reg_wdata[0];
-
   assign wakeup_en_regwen_we = addr_hit[6] & reg_we & !reg_error;
-  assign wakeup_en_regwen_wd = reg_wdata[0];
 
-  assign wakeup_en_en_0_we = addr_hit[7] & reg_we & !reg_error;
+  assign wakeup_en_regwen_wd = reg_wdata[0];
+  assign wakeup_en_we = addr_hit[7] & reg_we & !reg_error;
+
   assign wakeup_en_en_0_wd = reg_wdata[0];
 
-  assign wakeup_en_en_1_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_1_wd = reg_wdata[1];
 
-  assign wakeup_en_en_2_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_2_wd = reg_wdata[2];
 
-  assign wakeup_en_en_3_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_3_wd = reg_wdata[3];
 
-  assign wakeup_en_en_4_we = addr_hit[7] & reg_we & !reg_error;
   assign wakeup_en_en_4_wd = reg_wdata[4];
-
   assign reset_en_regwen_we = addr_hit[9] & reg_we & !reg_error;
-  assign reset_en_regwen_wd = reg_wdata[0];
 
-  assign reset_en_en_0_we = addr_hit[10] & reg_we & !reg_error;
+  assign reset_en_regwen_wd = reg_wdata[0];
+  assign reset_en_we = addr_hit[10] & reg_we & !reg_error;
+
   assign reset_en_en_0_wd = reg_wdata[0];
 
-  assign reset_en_en_1_we = addr_hit[10] & reg_we & !reg_error;
   assign reset_en_en_1_wd = reg_wdata[1];
-
   assign wake_info_capture_dis_we = addr_hit[13] & reg_we & !reg_error;
+
   assign wake_info_capture_dis_wd = reg_wdata[0];
+  assign wake_info_re = addr_hit[14] & reg_re & !reg_error;
+  assign wake_info_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign wake_info_reasons_we = addr_hit[14] & reg_we & !reg_error;
   assign wake_info_reasons_wd = reg_wdata[4:0];
-  assign wake_info_reasons_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign wake_info_fall_through_we = addr_hit[14] & reg_we & !reg_error;
   assign wake_info_fall_through_wd = reg_wdata[5];
-  assign wake_info_fall_through_re = addr_hit[14] & reg_re & !reg_error;
 
-  assign wake_info_abort_we = addr_hit[14] & reg_we & !reg_error;
   assign wake_info_abort_wd = reg_wdata[6];
-  assign wake_info_abort_re = addr_hit[14] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -104,93 +104,70 @@ module rstmgr_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic reset_info_we;
   logic reset_info_por_qs;
   logic reset_info_por_wd;
-  logic reset_info_por_we;
   logic reset_info_low_power_exit_qs;
   logic reset_info_low_power_exit_wd;
-  logic reset_info_low_power_exit_we;
   logic reset_info_ndm_reset_qs;
   logic reset_info_ndm_reset_wd;
-  logic reset_info_ndm_reset_we;
   logic [2:0] reset_info_hw_req_qs;
   logic [2:0] reset_info_hw_req_wd;
-  logic reset_info_hw_req_we;
+  logic alert_regwen_we;
   logic alert_regwen_qs;
   logic alert_regwen_wd;
-  logic alert_regwen_we;
+  logic alert_info_ctrl_we;
   logic alert_info_ctrl_en_qs;
   logic alert_info_ctrl_en_wd;
-  logic alert_info_ctrl_en_we;
   logic [3:0] alert_info_ctrl_index_qs;
   logic [3:0] alert_info_ctrl_index_wd;
-  logic alert_info_ctrl_index_we;
-  logic [3:0] alert_info_attr_qs;
   logic alert_info_attr_re;
-  logic [31:0] alert_info_qs;
+  logic [3:0] alert_info_attr_qs;
   logic alert_info_re;
+  logic [31:0] alert_info_qs;
+  logic cpu_regwen_we;
   logic cpu_regwen_qs;
   logic cpu_regwen_wd;
-  logic cpu_regwen_we;
+  logic cpu_info_ctrl_we;
   logic cpu_info_ctrl_en_qs;
   logic cpu_info_ctrl_en_wd;
-  logic cpu_info_ctrl_en_we;
   logic [3:0] cpu_info_ctrl_index_qs;
   logic [3:0] cpu_info_ctrl_index_wd;
-  logic cpu_info_ctrl_index_we;
-  logic [3:0] cpu_info_attr_qs;
   logic cpu_info_attr_re;
-  logic [31:0] cpu_info_qs;
+  logic [3:0] cpu_info_attr_qs;
   logic cpu_info_re;
+  logic [31:0] cpu_info_qs;
+  logic sw_rst_regen_we;
   logic sw_rst_regen_en_0_qs;
   logic sw_rst_regen_en_0_wd;
-  logic sw_rst_regen_en_0_we;
   logic sw_rst_regen_en_1_qs;
   logic sw_rst_regen_en_1_wd;
-  logic sw_rst_regen_en_1_we;
   logic sw_rst_regen_en_2_qs;
   logic sw_rst_regen_en_2_wd;
-  logic sw_rst_regen_en_2_we;
   logic sw_rst_regen_en_3_qs;
   logic sw_rst_regen_en_3_wd;
-  logic sw_rst_regen_en_3_we;
   logic sw_rst_regen_en_4_qs;
   logic sw_rst_regen_en_4_wd;
-  logic sw_rst_regen_en_4_we;
   logic sw_rst_regen_en_5_qs;
   logic sw_rst_regen_en_5_wd;
-  logic sw_rst_regen_en_5_we;
   logic sw_rst_regen_en_6_qs;
   logic sw_rst_regen_en_6_wd;
-  logic sw_rst_regen_en_6_we;
+  logic sw_rst_ctrl_n_re;
+  logic sw_rst_ctrl_n_we;
   logic sw_rst_ctrl_n_val_0_qs;
   logic sw_rst_ctrl_n_val_0_wd;
-  logic sw_rst_ctrl_n_val_0_we;
-  logic sw_rst_ctrl_n_val_0_re;
   logic sw_rst_ctrl_n_val_1_qs;
   logic sw_rst_ctrl_n_val_1_wd;
-  logic sw_rst_ctrl_n_val_1_we;
-  logic sw_rst_ctrl_n_val_1_re;
   logic sw_rst_ctrl_n_val_2_qs;
   logic sw_rst_ctrl_n_val_2_wd;
-  logic sw_rst_ctrl_n_val_2_we;
-  logic sw_rst_ctrl_n_val_2_re;
   logic sw_rst_ctrl_n_val_3_qs;
   logic sw_rst_ctrl_n_val_3_wd;
-  logic sw_rst_ctrl_n_val_3_we;
-  logic sw_rst_ctrl_n_val_3_re;
   logic sw_rst_ctrl_n_val_4_qs;
   logic sw_rst_ctrl_n_val_4_wd;
-  logic sw_rst_ctrl_n_val_4_we;
-  logic sw_rst_ctrl_n_val_4_re;
   logic sw_rst_ctrl_n_val_5_qs;
   logic sw_rst_ctrl_n_val_5_wd;
-  logic sw_rst_ctrl_n_val_5_we;
-  logic sw_rst_ctrl_n_val_5_re;
   logic sw_rst_ctrl_n_val_6_qs;
   logic sw_rst_ctrl_n_val_6_wd;
-  logic sw_rst_ctrl_n_val_6_we;
-  logic sw_rst_ctrl_n_val_6_re;
 
   // Register instances
   // R[reset_info]: V(False)
@@ -205,7 +182,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_por_we),
+    .we     (reset_info_we),
     .wd     (reset_info_por_wd),
 
     // from internal hardware
@@ -231,7 +208,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_low_power_exit_we),
+    .we     (reset_info_we),
     .wd     (reset_info_low_power_exit_wd),
 
     // from internal hardware
@@ -257,7 +234,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_ndm_reset_we),
+    .we     (reset_info_we),
     .wd     (reset_info_ndm_reset_wd),
 
     // from internal hardware
@@ -283,7 +260,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (reset_info_hw_req_we),
+    .we     (reset_info_we),
     .wd     (reset_info_hw_req_wd),
 
     // from internal hardware
@@ -338,7 +315,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_info_ctrl_en_we & alert_regwen_qs),
+    .we     (alert_info_ctrl_we & alert_regwen_qs),
     .wd     (alert_info_ctrl_en_wd),
 
     // from internal hardware
@@ -364,7 +341,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_info_ctrl_index_we & alert_regwen_qs),
+    .we     (alert_info_ctrl_we & alert_regwen_qs),
     .wd     (alert_info_ctrl_index_wd),
 
     // from internal hardware
@@ -451,7 +428,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cpu_info_ctrl_en_we & cpu_regwen_qs),
+    .we     (cpu_info_ctrl_we & cpu_regwen_qs),
     .wd     (cpu_info_ctrl_en_wd),
 
     // from internal hardware
@@ -477,7 +454,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (cpu_info_ctrl_index_we & cpu_regwen_qs),
+    .we     (cpu_info_ctrl_we & cpu_regwen_qs),
     .wd     (cpu_info_ctrl_index_wd),
 
     // from internal hardware
@@ -539,7 +516,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_0_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_0_wd),
 
     // from internal hardware
@@ -565,7 +542,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_1_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_1_wd),
 
     // from internal hardware
@@ -591,7 +568,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_2_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_2_wd),
 
     // from internal hardware
@@ -617,7 +594,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_3_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_3_wd),
 
     // from internal hardware
@@ -643,7 +620,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_4_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_4_wd),
 
     // from internal hardware
@@ -669,7 +646,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_5_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_5_wd),
 
     // from internal hardware
@@ -695,7 +672,7 @@ module rstmgr_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_en_6_we),
+    .we     (sw_rst_regen_we),
     .wd     (sw_rst_regen_en_6_wd),
 
     // from internal hardware
@@ -720,8 +697,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_0 (
-    .re     (sw_rst_ctrl_n_val_0_re),
-    .we     (sw_rst_ctrl_n_val_0_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_0_wd),
     .d      (hw2reg.sw_rst_ctrl_n[0].d),
     .qre    (),
@@ -735,8 +712,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_1 (
-    .re     (sw_rst_ctrl_n_val_1_re),
-    .we     (sw_rst_ctrl_n_val_1_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_1_wd),
     .d      (hw2reg.sw_rst_ctrl_n[1].d),
     .qre    (),
@@ -750,8 +727,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_2 (
-    .re     (sw_rst_ctrl_n_val_2_re),
-    .we     (sw_rst_ctrl_n_val_2_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_2_wd),
     .d      (hw2reg.sw_rst_ctrl_n[2].d),
     .qre    (),
@@ -765,8 +742,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_3 (
-    .re     (sw_rst_ctrl_n_val_3_re),
-    .we     (sw_rst_ctrl_n_val_3_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_3_wd),
     .d      (hw2reg.sw_rst_ctrl_n[3].d),
     .qre    (),
@@ -780,8 +757,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_4 (
-    .re     (sw_rst_ctrl_n_val_4_re),
-    .we     (sw_rst_ctrl_n_val_4_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_4_wd),
     .d      (hw2reg.sw_rst_ctrl_n[4].d),
     .qre    (),
@@ -795,8 +772,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_5 (
-    .re     (sw_rst_ctrl_n_val_5_re),
-    .we     (sw_rst_ctrl_n_val_5_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_5_wd),
     .d      (hw2reg.sw_rst_ctrl_n[5].d),
     .qre    (),
@@ -810,8 +787,8 @@ module rstmgr_reg_top (
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_6 (
-    .re     (sw_rst_ctrl_n_val_6_re),
-    .we     (sw_rst_ctrl_n_val_6_we),
+    .re     (sw_rst_ctrl_n_re),
+    .we     (sw_rst_ctrl_n_we),
     .wd     (sw_rst_ctrl_n_val_6_wd),
     .d      (hw2reg.sw_rst_ctrl_n[6].d),
     .qre    (),
@@ -857,93 +834,66 @@ module rstmgr_reg_top (
                (addr_hit[ 9] & (|(RSTMGR_PERMIT[ 9] & ~reg_be))) |
                (addr_hit[10] & (|(RSTMGR_PERMIT[10] & ~reg_be)))));
   end
+  assign reset_info_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign reset_info_por_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_por_wd = reg_wdata[0];
 
-  assign reset_info_low_power_exit_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_low_power_exit_wd = reg_wdata[1];
 
-  assign reset_info_ndm_reset_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_ndm_reset_wd = reg_wdata[2];
 
-  assign reset_info_hw_req_we = addr_hit[0] & reg_we & !reg_error;
   assign reset_info_hw_req_wd = reg_wdata[5:3];
-
   assign alert_regwen_we = addr_hit[1] & reg_we & !reg_error;
-  assign alert_regwen_wd = reg_wdata[0];
 
-  assign alert_info_ctrl_en_we = addr_hit[2] & reg_we & !reg_error;
+  assign alert_regwen_wd = reg_wdata[0];
+  assign alert_info_ctrl_we = addr_hit[2] & reg_we & !reg_error;
+
   assign alert_info_ctrl_en_wd = reg_wdata[0];
 
-  assign alert_info_ctrl_index_we = addr_hit[2] & reg_we & !reg_error;
   assign alert_info_ctrl_index_wd = reg_wdata[7:4];
-
   assign alert_info_attr_re = addr_hit[3] & reg_re & !reg_error;
-
   assign alert_info_re = addr_hit[4] & reg_re & !reg_error;
-
   assign cpu_regwen_we = addr_hit[5] & reg_we & !reg_error;
-  assign cpu_regwen_wd = reg_wdata[0];
 
-  assign cpu_info_ctrl_en_we = addr_hit[6] & reg_we & !reg_error;
+  assign cpu_regwen_wd = reg_wdata[0];
+  assign cpu_info_ctrl_we = addr_hit[6] & reg_we & !reg_error;
+
   assign cpu_info_ctrl_en_wd = reg_wdata[0];
 
-  assign cpu_info_ctrl_index_we = addr_hit[6] & reg_we & !reg_error;
   assign cpu_info_ctrl_index_wd = reg_wdata[7:4];
-
   assign cpu_info_attr_re = addr_hit[7] & reg_re & !reg_error;
-
   assign cpu_info_re = addr_hit[8] & reg_re & !reg_error;
+  assign sw_rst_regen_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_0_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_0_wd = reg_wdata[0];
 
-  assign sw_rst_regen_en_1_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_1_wd = reg_wdata[1];
 
-  assign sw_rst_regen_en_2_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_2_wd = reg_wdata[2];
 
-  assign sw_rst_regen_en_3_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_3_wd = reg_wdata[3];
 
-  assign sw_rst_regen_en_4_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_4_wd = reg_wdata[4];
 
-  assign sw_rst_regen_en_5_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_5_wd = reg_wdata[5];
 
-  assign sw_rst_regen_en_6_we = addr_hit[9] & reg_we & !reg_error;
   assign sw_rst_regen_en_6_wd = reg_wdata[6];
+  assign sw_rst_ctrl_n_re = addr_hit[10] & reg_re & !reg_error;
+  assign sw_rst_ctrl_n_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_0_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_0_wd = reg_wdata[0];
-  assign sw_rst_ctrl_n_val_0_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_1_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_1_wd = reg_wdata[1];
-  assign sw_rst_ctrl_n_val_1_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_2_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_2_wd = reg_wdata[2];
-  assign sw_rst_ctrl_n_val_2_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_3_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_3_wd = reg_wdata[3];
-  assign sw_rst_ctrl_n_val_3_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_4_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_4_wd = reg_wdata[4];
-  assign sw_rst_ctrl_n_val_4_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_5_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_5_wd = reg_wdata[5];
-  assign sw_rst_ctrl_n_val_5_re = addr_hit[10] & reg_re & !reg_error;
 
-  assign sw_rst_ctrl_n_val_6_we = addr_hit[10] & reg_we & !reg_error;
   assign sw_rst_ctrl_n_val_6_wd = reg_wdata[6];
-  assign sw_rst_ctrl_n_val_6_re = addr_hit[10] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -284,1636 +284,1288 @@ module rv_plic_reg_top (
   logic ip_5_p_177_qs;
   logic ip_5_p_178_qs;
   logic ip_5_p_179_qs;
+  logic le_0_we;
   logic le_0_le_0_qs;
   logic le_0_le_0_wd;
-  logic le_0_le_0_we;
   logic le_0_le_1_qs;
   logic le_0_le_1_wd;
-  logic le_0_le_1_we;
   logic le_0_le_2_qs;
   logic le_0_le_2_wd;
-  logic le_0_le_2_we;
   logic le_0_le_3_qs;
   logic le_0_le_3_wd;
-  logic le_0_le_3_we;
   logic le_0_le_4_qs;
   logic le_0_le_4_wd;
-  logic le_0_le_4_we;
   logic le_0_le_5_qs;
   logic le_0_le_5_wd;
-  logic le_0_le_5_we;
   logic le_0_le_6_qs;
   logic le_0_le_6_wd;
-  logic le_0_le_6_we;
   logic le_0_le_7_qs;
   logic le_0_le_7_wd;
-  logic le_0_le_7_we;
   logic le_0_le_8_qs;
   logic le_0_le_8_wd;
-  logic le_0_le_8_we;
   logic le_0_le_9_qs;
   logic le_0_le_9_wd;
-  logic le_0_le_9_we;
   logic le_0_le_10_qs;
   logic le_0_le_10_wd;
-  logic le_0_le_10_we;
   logic le_0_le_11_qs;
   logic le_0_le_11_wd;
-  logic le_0_le_11_we;
   logic le_0_le_12_qs;
   logic le_0_le_12_wd;
-  logic le_0_le_12_we;
   logic le_0_le_13_qs;
   logic le_0_le_13_wd;
-  logic le_0_le_13_we;
   logic le_0_le_14_qs;
   logic le_0_le_14_wd;
-  logic le_0_le_14_we;
   logic le_0_le_15_qs;
   logic le_0_le_15_wd;
-  logic le_0_le_15_we;
   logic le_0_le_16_qs;
   logic le_0_le_16_wd;
-  logic le_0_le_16_we;
   logic le_0_le_17_qs;
   logic le_0_le_17_wd;
-  logic le_0_le_17_we;
   logic le_0_le_18_qs;
   logic le_0_le_18_wd;
-  logic le_0_le_18_we;
   logic le_0_le_19_qs;
   logic le_0_le_19_wd;
-  logic le_0_le_19_we;
   logic le_0_le_20_qs;
   logic le_0_le_20_wd;
-  logic le_0_le_20_we;
   logic le_0_le_21_qs;
   logic le_0_le_21_wd;
-  logic le_0_le_21_we;
   logic le_0_le_22_qs;
   logic le_0_le_22_wd;
-  logic le_0_le_22_we;
   logic le_0_le_23_qs;
   logic le_0_le_23_wd;
-  logic le_0_le_23_we;
   logic le_0_le_24_qs;
   logic le_0_le_24_wd;
-  logic le_0_le_24_we;
   logic le_0_le_25_qs;
   logic le_0_le_25_wd;
-  logic le_0_le_25_we;
   logic le_0_le_26_qs;
   logic le_0_le_26_wd;
-  logic le_0_le_26_we;
   logic le_0_le_27_qs;
   logic le_0_le_27_wd;
-  logic le_0_le_27_we;
   logic le_0_le_28_qs;
   logic le_0_le_28_wd;
-  logic le_0_le_28_we;
   logic le_0_le_29_qs;
   logic le_0_le_29_wd;
-  logic le_0_le_29_we;
   logic le_0_le_30_qs;
   logic le_0_le_30_wd;
-  logic le_0_le_30_we;
   logic le_0_le_31_qs;
   logic le_0_le_31_wd;
-  logic le_0_le_31_we;
+  logic le_1_we;
   logic le_1_le_32_qs;
   logic le_1_le_32_wd;
-  logic le_1_le_32_we;
   logic le_1_le_33_qs;
   logic le_1_le_33_wd;
-  logic le_1_le_33_we;
   logic le_1_le_34_qs;
   logic le_1_le_34_wd;
-  logic le_1_le_34_we;
   logic le_1_le_35_qs;
   logic le_1_le_35_wd;
-  logic le_1_le_35_we;
   logic le_1_le_36_qs;
   logic le_1_le_36_wd;
-  logic le_1_le_36_we;
   logic le_1_le_37_qs;
   logic le_1_le_37_wd;
-  logic le_1_le_37_we;
   logic le_1_le_38_qs;
   logic le_1_le_38_wd;
-  logic le_1_le_38_we;
   logic le_1_le_39_qs;
   logic le_1_le_39_wd;
-  logic le_1_le_39_we;
   logic le_1_le_40_qs;
   logic le_1_le_40_wd;
-  logic le_1_le_40_we;
   logic le_1_le_41_qs;
   logic le_1_le_41_wd;
-  logic le_1_le_41_we;
   logic le_1_le_42_qs;
   logic le_1_le_42_wd;
-  logic le_1_le_42_we;
   logic le_1_le_43_qs;
   logic le_1_le_43_wd;
-  logic le_1_le_43_we;
   logic le_1_le_44_qs;
   logic le_1_le_44_wd;
-  logic le_1_le_44_we;
   logic le_1_le_45_qs;
   logic le_1_le_45_wd;
-  logic le_1_le_45_we;
   logic le_1_le_46_qs;
   logic le_1_le_46_wd;
-  logic le_1_le_46_we;
   logic le_1_le_47_qs;
   logic le_1_le_47_wd;
-  logic le_1_le_47_we;
   logic le_1_le_48_qs;
   logic le_1_le_48_wd;
-  logic le_1_le_48_we;
   logic le_1_le_49_qs;
   logic le_1_le_49_wd;
-  logic le_1_le_49_we;
   logic le_1_le_50_qs;
   logic le_1_le_50_wd;
-  logic le_1_le_50_we;
   logic le_1_le_51_qs;
   logic le_1_le_51_wd;
-  logic le_1_le_51_we;
   logic le_1_le_52_qs;
   logic le_1_le_52_wd;
-  logic le_1_le_52_we;
   logic le_1_le_53_qs;
   logic le_1_le_53_wd;
-  logic le_1_le_53_we;
   logic le_1_le_54_qs;
   logic le_1_le_54_wd;
-  logic le_1_le_54_we;
   logic le_1_le_55_qs;
   logic le_1_le_55_wd;
-  logic le_1_le_55_we;
   logic le_1_le_56_qs;
   logic le_1_le_56_wd;
-  logic le_1_le_56_we;
   logic le_1_le_57_qs;
   logic le_1_le_57_wd;
-  logic le_1_le_57_we;
   logic le_1_le_58_qs;
   logic le_1_le_58_wd;
-  logic le_1_le_58_we;
   logic le_1_le_59_qs;
   logic le_1_le_59_wd;
-  logic le_1_le_59_we;
   logic le_1_le_60_qs;
   logic le_1_le_60_wd;
-  logic le_1_le_60_we;
   logic le_1_le_61_qs;
   logic le_1_le_61_wd;
-  logic le_1_le_61_we;
   logic le_1_le_62_qs;
   logic le_1_le_62_wd;
-  logic le_1_le_62_we;
   logic le_1_le_63_qs;
   logic le_1_le_63_wd;
-  logic le_1_le_63_we;
+  logic le_2_we;
   logic le_2_le_64_qs;
   logic le_2_le_64_wd;
-  logic le_2_le_64_we;
   logic le_2_le_65_qs;
   logic le_2_le_65_wd;
-  logic le_2_le_65_we;
   logic le_2_le_66_qs;
   logic le_2_le_66_wd;
-  logic le_2_le_66_we;
   logic le_2_le_67_qs;
   logic le_2_le_67_wd;
-  logic le_2_le_67_we;
   logic le_2_le_68_qs;
   logic le_2_le_68_wd;
-  logic le_2_le_68_we;
   logic le_2_le_69_qs;
   logic le_2_le_69_wd;
-  logic le_2_le_69_we;
   logic le_2_le_70_qs;
   logic le_2_le_70_wd;
-  logic le_2_le_70_we;
   logic le_2_le_71_qs;
   logic le_2_le_71_wd;
-  logic le_2_le_71_we;
   logic le_2_le_72_qs;
   logic le_2_le_72_wd;
-  logic le_2_le_72_we;
   logic le_2_le_73_qs;
   logic le_2_le_73_wd;
-  logic le_2_le_73_we;
   logic le_2_le_74_qs;
   logic le_2_le_74_wd;
-  logic le_2_le_74_we;
   logic le_2_le_75_qs;
   logic le_2_le_75_wd;
-  logic le_2_le_75_we;
   logic le_2_le_76_qs;
   logic le_2_le_76_wd;
-  logic le_2_le_76_we;
   logic le_2_le_77_qs;
   logic le_2_le_77_wd;
-  logic le_2_le_77_we;
   logic le_2_le_78_qs;
   logic le_2_le_78_wd;
-  logic le_2_le_78_we;
   logic le_2_le_79_qs;
   logic le_2_le_79_wd;
-  logic le_2_le_79_we;
   logic le_2_le_80_qs;
   logic le_2_le_80_wd;
-  logic le_2_le_80_we;
   logic le_2_le_81_qs;
   logic le_2_le_81_wd;
-  logic le_2_le_81_we;
   logic le_2_le_82_qs;
   logic le_2_le_82_wd;
-  logic le_2_le_82_we;
   logic le_2_le_83_qs;
   logic le_2_le_83_wd;
-  logic le_2_le_83_we;
   logic le_2_le_84_qs;
   logic le_2_le_84_wd;
-  logic le_2_le_84_we;
   logic le_2_le_85_qs;
   logic le_2_le_85_wd;
-  logic le_2_le_85_we;
   logic le_2_le_86_qs;
   logic le_2_le_86_wd;
-  logic le_2_le_86_we;
   logic le_2_le_87_qs;
   logic le_2_le_87_wd;
-  logic le_2_le_87_we;
   logic le_2_le_88_qs;
   logic le_2_le_88_wd;
-  logic le_2_le_88_we;
   logic le_2_le_89_qs;
   logic le_2_le_89_wd;
-  logic le_2_le_89_we;
   logic le_2_le_90_qs;
   logic le_2_le_90_wd;
-  logic le_2_le_90_we;
   logic le_2_le_91_qs;
   logic le_2_le_91_wd;
-  logic le_2_le_91_we;
   logic le_2_le_92_qs;
   logic le_2_le_92_wd;
-  logic le_2_le_92_we;
   logic le_2_le_93_qs;
   logic le_2_le_93_wd;
-  logic le_2_le_93_we;
   logic le_2_le_94_qs;
   logic le_2_le_94_wd;
-  logic le_2_le_94_we;
   logic le_2_le_95_qs;
   logic le_2_le_95_wd;
-  logic le_2_le_95_we;
+  logic le_3_we;
   logic le_3_le_96_qs;
   logic le_3_le_96_wd;
-  logic le_3_le_96_we;
   logic le_3_le_97_qs;
   logic le_3_le_97_wd;
-  logic le_3_le_97_we;
   logic le_3_le_98_qs;
   logic le_3_le_98_wd;
-  logic le_3_le_98_we;
   logic le_3_le_99_qs;
   logic le_3_le_99_wd;
-  logic le_3_le_99_we;
   logic le_3_le_100_qs;
   logic le_3_le_100_wd;
-  logic le_3_le_100_we;
   logic le_3_le_101_qs;
   logic le_3_le_101_wd;
-  logic le_3_le_101_we;
   logic le_3_le_102_qs;
   logic le_3_le_102_wd;
-  logic le_3_le_102_we;
   logic le_3_le_103_qs;
   logic le_3_le_103_wd;
-  logic le_3_le_103_we;
   logic le_3_le_104_qs;
   logic le_3_le_104_wd;
-  logic le_3_le_104_we;
   logic le_3_le_105_qs;
   logic le_3_le_105_wd;
-  logic le_3_le_105_we;
   logic le_3_le_106_qs;
   logic le_3_le_106_wd;
-  logic le_3_le_106_we;
   logic le_3_le_107_qs;
   logic le_3_le_107_wd;
-  logic le_3_le_107_we;
   logic le_3_le_108_qs;
   logic le_3_le_108_wd;
-  logic le_3_le_108_we;
   logic le_3_le_109_qs;
   logic le_3_le_109_wd;
-  logic le_3_le_109_we;
   logic le_3_le_110_qs;
   logic le_3_le_110_wd;
-  logic le_3_le_110_we;
   logic le_3_le_111_qs;
   logic le_3_le_111_wd;
-  logic le_3_le_111_we;
   logic le_3_le_112_qs;
   logic le_3_le_112_wd;
-  logic le_3_le_112_we;
   logic le_3_le_113_qs;
   logic le_3_le_113_wd;
-  logic le_3_le_113_we;
   logic le_3_le_114_qs;
   logic le_3_le_114_wd;
-  logic le_3_le_114_we;
   logic le_3_le_115_qs;
   logic le_3_le_115_wd;
-  logic le_3_le_115_we;
   logic le_3_le_116_qs;
   logic le_3_le_116_wd;
-  logic le_3_le_116_we;
   logic le_3_le_117_qs;
   logic le_3_le_117_wd;
-  logic le_3_le_117_we;
   logic le_3_le_118_qs;
   logic le_3_le_118_wd;
-  logic le_3_le_118_we;
   logic le_3_le_119_qs;
   logic le_3_le_119_wd;
-  logic le_3_le_119_we;
   logic le_3_le_120_qs;
   logic le_3_le_120_wd;
-  logic le_3_le_120_we;
   logic le_3_le_121_qs;
   logic le_3_le_121_wd;
-  logic le_3_le_121_we;
   logic le_3_le_122_qs;
   logic le_3_le_122_wd;
-  logic le_3_le_122_we;
   logic le_3_le_123_qs;
   logic le_3_le_123_wd;
-  logic le_3_le_123_we;
   logic le_3_le_124_qs;
   logic le_3_le_124_wd;
-  logic le_3_le_124_we;
   logic le_3_le_125_qs;
   logic le_3_le_125_wd;
-  logic le_3_le_125_we;
   logic le_3_le_126_qs;
   logic le_3_le_126_wd;
-  logic le_3_le_126_we;
   logic le_3_le_127_qs;
   logic le_3_le_127_wd;
-  logic le_3_le_127_we;
+  logic le_4_we;
   logic le_4_le_128_qs;
   logic le_4_le_128_wd;
-  logic le_4_le_128_we;
   logic le_4_le_129_qs;
   logic le_4_le_129_wd;
-  logic le_4_le_129_we;
   logic le_4_le_130_qs;
   logic le_4_le_130_wd;
-  logic le_4_le_130_we;
   logic le_4_le_131_qs;
   logic le_4_le_131_wd;
-  logic le_4_le_131_we;
   logic le_4_le_132_qs;
   logic le_4_le_132_wd;
-  logic le_4_le_132_we;
   logic le_4_le_133_qs;
   logic le_4_le_133_wd;
-  logic le_4_le_133_we;
   logic le_4_le_134_qs;
   logic le_4_le_134_wd;
-  logic le_4_le_134_we;
   logic le_4_le_135_qs;
   logic le_4_le_135_wd;
-  logic le_4_le_135_we;
   logic le_4_le_136_qs;
   logic le_4_le_136_wd;
-  logic le_4_le_136_we;
   logic le_4_le_137_qs;
   logic le_4_le_137_wd;
-  logic le_4_le_137_we;
   logic le_4_le_138_qs;
   logic le_4_le_138_wd;
-  logic le_4_le_138_we;
   logic le_4_le_139_qs;
   logic le_4_le_139_wd;
-  logic le_4_le_139_we;
   logic le_4_le_140_qs;
   logic le_4_le_140_wd;
-  logic le_4_le_140_we;
   logic le_4_le_141_qs;
   logic le_4_le_141_wd;
-  logic le_4_le_141_we;
   logic le_4_le_142_qs;
   logic le_4_le_142_wd;
-  logic le_4_le_142_we;
   logic le_4_le_143_qs;
   logic le_4_le_143_wd;
-  logic le_4_le_143_we;
   logic le_4_le_144_qs;
   logic le_4_le_144_wd;
-  logic le_4_le_144_we;
   logic le_4_le_145_qs;
   logic le_4_le_145_wd;
-  logic le_4_le_145_we;
   logic le_4_le_146_qs;
   logic le_4_le_146_wd;
-  logic le_4_le_146_we;
   logic le_4_le_147_qs;
   logic le_4_le_147_wd;
-  logic le_4_le_147_we;
   logic le_4_le_148_qs;
   logic le_4_le_148_wd;
-  logic le_4_le_148_we;
   logic le_4_le_149_qs;
   logic le_4_le_149_wd;
-  logic le_4_le_149_we;
   logic le_4_le_150_qs;
   logic le_4_le_150_wd;
-  logic le_4_le_150_we;
   logic le_4_le_151_qs;
   logic le_4_le_151_wd;
-  logic le_4_le_151_we;
   logic le_4_le_152_qs;
   logic le_4_le_152_wd;
-  logic le_4_le_152_we;
   logic le_4_le_153_qs;
   logic le_4_le_153_wd;
-  logic le_4_le_153_we;
   logic le_4_le_154_qs;
   logic le_4_le_154_wd;
-  logic le_4_le_154_we;
   logic le_4_le_155_qs;
   logic le_4_le_155_wd;
-  logic le_4_le_155_we;
   logic le_4_le_156_qs;
   logic le_4_le_156_wd;
-  logic le_4_le_156_we;
   logic le_4_le_157_qs;
   logic le_4_le_157_wd;
-  logic le_4_le_157_we;
   logic le_4_le_158_qs;
   logic le_4_le_158_wd;
-  logic le_4_le_158_we;
   logic le_4_le_159_qs;
   logic le_4_le_159_wd;
-  logic le_4_le_159_we;
+  logic le_5_we;
   logic le_5_le_160_qs;
   logic le_5_le_160_wd;
-  logic le_5_le_160_we;
   logic le_5_le_161_qs;
   logic le_5_le_161_wd;
-  logic le_5_le_161_we;
   logic le_5_le_162_qs;
   logic le_5_le_162_wd;
-  logic le_5_le_162_we;
   logic le_5_le_163_qs;
   logic le_5_le_163_wd;
-  logic le_5_le_163_we;
   logic le_5_le_164_qs;
   logic le_5_le_164_wd;
-  logic le_5_le_164_we;
   logic le_5_le_165_qs;
   logic le_5_le_165_wd;
-  logic le_5_le_165_we;
   logic le_5_le_166_qs;
   logic le_5_le_166_wd;
-  logic le_5_le_166_we;
   logic le_5_le_167_qs;
   logic le_5_le_167_wd;
-  logic le_5_le_167_we;
   logic le_5_le_168_qs;
   logic le_5_le_168_wd;
-  logic le_5_le_168_we;
   logic le_5_le_169_qs;
   logic le_5_le_169_wd;
-  logic le_5_le_169_we;
   logic le_5_le_170_qs;
   logic le_5_le_170_wd;
-  logic le_5_le_170_we;
   logic le_5_le_171_qs;
   logic le_5_le_171_wd;
-  logic le_5_le_171_we;
   logic le_5_le_172_qs;
   logic le_5_le_172_wd;
-  logic le_5_le_172_we;
   logic le_5_le_173_qs;
   logic le_5_le_173_wd;
-  logic le_5_le_173_we;
   logic le_5_le_174_qs;
   logic le_5_le_174_wd;
-  logic le_5_le_174_we;
   logic le_5_le_175_qs;
   logic le_5_le_175_wd;
-  logic le_5_le_175_we;
   logic le_5_le_176_qs;
   logic le_5_le_176_wd;
-  logic le_5_le_176_we;
   logic le_5_le_177_qs;
   logic le_5_le_177_wd;
-  logic le_5_le_177_we;
   logic le_5_le_178_qs;
   logic le_5_le_178_wd;
-  logic le_5_le_178_we;
   logic le_5_le_179_qs;
   logic le_5_le_179_wd;
-  logic le_5_le_179_we;
+  logic prio0_we;
   logic [1:0] prio0_qs;
   logic [1:0] prio0_wd;
-  logic prio0_we;
+  logic prio1_we;
   logic [1:0] prio1_qs;
   logic [1:0] prio1_wd;
-  logic prio1_we;
+  logic prio2_we;
   logic [1:0] prio2_qs;
   logic [1:0] prio2_wd;
-  logic prio2_we;
+  logic prio3_we;
   logic [1:0] prio3_qs;
   logic [1:0] prio3_wd;
-  logic prio3_we;
+  logic prio4_we;
   logic [1:0] prio4_qs;
   logic [1:0] prio4_wd;
-  logic prio4_we;
+  logic prio5_we;
   logic [1:0] prio5_qs;
   logic [1:0] prio5_wd;
-  logic prio5_we;
+  logic prio6_we;
   logic [1:0] prio6_qs;
   logic [1:0] prio6_wd;
-  logic prio6_we;
+  logic prio7_we;
   logic [1:0] prio7_qs;
   logic [1:0] prio7_wd;
-  logic prio7_we;
+  logic prio8_we;
   logic [1:0] prio8_qs;
   logic [1:0] prio8_wd;
-  logic prio8_we;
+  logic prio9_we;
   logic [1:0] prio9_qs;
   logic [1:0] prio9_wd;
-  logic prio9_we;
+  logic prio10_we;
   logic [1:0] prio10_qs;
   logic [1:0] prio10_wd;
-  logic prio10_we;
+  logic prio11_we;
   logic [1:0] prio11_qs;
   logic [1:0] prio11_wd;
-  logic prio11_we;
+  logic prio12_we;
   logic [1:0] prio12_qs;
   logic [1:0] prio12_wd;
-  logic prio12_we;
+  logic prio13_we;
   logic [1:0] prio13_qs;
   logic [1:0] prio13_wd;
-  logic prio13_we;
+  logic prio14_we;
   logic [1:0] prio14_qs;
   logic [1:0] prio14_wd;
-  logic prio14_we;
+  logic prio15_we;
   logic [1:0] prio15_qs;
   logic [1:0] prio15_wd;
-  logic prio15_we;
+  logic prio16_we;
   logic [1:0] prio16_qs;
   logic [1:0] prio16_wd;
-  logic prio16_we;
+  logic prio17_we;
   logic [1:0] prio17_qs;
   logic [1:0] prio17_wd;
-  logic prio17_we;
+  logic prio18_we;
   logic [1:0] prio18_qs;
   logic [1:0] prio18_wd;
-  logic prio18_we;
+  logic prio19_we;
   logic [1:0] prio19_qs;
   logic [1:0] prio19_wd;
-  logic prio19_we;
+  logic prio20_we;
   logic [1:0] prio20_qs;
   logic [1:0] prio20_wd;
-  logic prio20_we;
+  logic prio21_we;
   logic [1:0] prio21_qs;
   logic [1:0] prio21_wd;
-  logic prio21_we;
+  logic prio22_we;
   logic [1:0] prio22_qs;
   logic [1:0] prio22_wd;
-  logic prio22_we;
+  logic prio23_we;
   logic [1:0] prio23_qs;
   logic [1:0] prio23_wd;
-  logic prio23_we;
+  logic prio24_we;
   logic [1:0] prio24_qs;
   logic [1:0] prio24_wd;
-  logic prio24_we;
+  logic prio25_we;
   logic [1:0] prio25_qs;
   logic [1:0] prio25_wd;
-  logic prio25_we;
+  logic prio26_we;
   logic [1:0] prio26_qs;
   logic [1:0] prio26_wd;
-  logic prio26_we;
+  logic prio27_we;
   logic [1:0] prio27_qs;
   logic [1:0] prio27_wd;
-  logic prio27_we;
+  logic prio28_we;
   logic [1:0] prio28_qs;
   logic [1:0] prio28_wd;
-  logic prio28_we;
+  logic prio29_we;
   logic [1:0] prio29_qs;
   logic [1:0] prio29_wd;
-  logic prio29_we;
+  logic prio30_we;
   logic [1:0] prio30_qs;
   logic [1:0] prio30_wd;
-  logic prio30_we;
+  logic prio31_we;
   logic [1:0] prio31_qs;
   logic [1:0] prio31_wd;
-  logic prio31_we;
+  logic prio32_we;
   logic [1:0] prio32_qs;
   logic [1:0] prio32_wd;
-  logic prio32_we;
+  logic prio33_we;
   logic [1:0] prio33_qs;
   logic [1:0] prio33_wd;
-  logic prio33_we;
+  logic prio34_we;
   logic [1:0] prio34_qs;
   logic [1:0] prio34_wd;
-  logic prio34_we;
+  logic prio35_we;
   logic [1:0] prio35_qs;
   logic [1:0] prio35_wd;
-  logic prio35_we;
+  logic prio36_we;
   logic [1:0] prio36_qs;
   logic [1:0] prio36_wd;
-  logic prio36_we;
+  logic prio37_we;
   logic [1:0] prio37_qs;
   logic [1:0] prio37_wd;
-  logic prio37_we;
+  logic prio38_we;
   logic [1:0] prio38_qs;
   logic [1:0] prio38_wd;
-  logic prio38_we;
+  logic prio39_we;
   logic [1:0] prio39_qs;
   logic [1:0] prio39_wd;
-  logic prio39_we;
+  logic prio40_we;
   logic [1:0] prio40_qs;
   logic [1:0] prio40_wd;
-  logic prio40_we;
+  logic prio41_we;
   logic [1:0] prio41_qs;
   logic [1:0] prio41_wd;
-  logic prio41_we;
+  logic prio42_we;
   logic [1:0] prio42_qs;
   logic [1:0] prio42_wd;
-  logic prio42_we;
+  logic prio43_we;
   logic [1:0] prio43_qs;
   logic [1:0] prio43_wd;
-  logic prio43_we;
+  logic prio44_we;
   logic [1:0] prio44_qs;
   logic [1:0] prio44_wd;
-  logic prio44_we;
+  logic prio45_we;
   logic [1:0] prio45_qs;
   logic [1:0] prio45_wd;
-  logic prio45_we;
+  logic prio46_we;
   logic [1:0] prio46_qs;
   logic [1:0] prio46_wd;
-  logic prio46_we;
+  logic prio47_we;
   logic [1:0] prio47_qs;
   logic [1:0] prio47_wd;
-  logic prio47_we;
+  logic prio48_we;
   logic [1:0] prio48_qs;
   logic [1:0] prio48_wd;
-  logic prio48_we;
+  logic prio49_we;
   logic [1:0] prio49_qs;
   logic [1:0] prio49_wd;
-  logic prio49_we;
+  logic prio50_we;
   logic [1:0] prio50_qs;
   logic [1:0] prio50_wd;
-  logic prio50_we;
+  logic prio51_we;
   logic [1:0] prio51_qs;
   logic [1:0] prio51_wd;
-  logic prio51_we;
+  logic prio52_we;
   logic [1:0] prio52_qs;
   logic [1:0] prio52_wd;
-  logic prio52_we;
+  logic prio53_we;
   logic [1:0] prio53_qs;
   logic [1:0] prio53_wd;
-  logic prio53_we;
+  logic prio54_we;
   logic [1:0] prio54_qs;
   logic [1:0] prio54_wd;
-  logic prio54_we;
+  logic prio55_we;
   logic [1:0] prio55_qs;
   logic [1:0] prio55_wd;
-  logic prio55_we;
+  logic prio56_we;
   logic [1:0] prio56_qs;
   logic [1:0] prio56_wd;
-  logic prio56_we;
+  logic prio57_we;
   logic [1:0] prio57_qs;
   logic [1:0] prio57_wd;
-  logic prio57_we;
+  logic prio58_we;
   logic [1:0] prio58_qs;
   logic [1:0] prio58_wd;
-  logic prio58_we;
+  logic prio59_we;
   logic [1:0] prio59_qs;
   logic [1:0] prio59_wd;
-  logic prio59_we;
+  logic prio60_we;
   logic [1:0] prio60_qs;
   logic [1:0] prio60_wd;
-  logic prio60_we;
+  logic prio61_we;
   logic [1:0] prio61_qs;
   logic [1:0] prio61_wd;
-  logic prio61_we;
+  logic prio62_we;
   logic [1:0] prio62_qs;
   logic [1:0] prio62_wd;
-  logic prio62_we;
+  logic prio63_we;
   logic [1:0] prio63_qs;
   logic [1:0] prio63_wd;
-  logic prio63_we;
+  logic prio64_we;
   logic [1:0] prio64_qs;
   logic [1:0] prio64_wd;
-  logic prio64_we;
+  logic prio65_we;
   logic [1:0] prio65_qs;
   logic [1:0] prio65_wd;
-  logic prio65_we;
+  logic prio66_we;
   logic [1:0] prio66_qs;
   logic [1:0] prio66_wd;
-  logic prio66_we;
+  logic prio67_we;
   logic [1:0] prio67_qs;
   logic [1:0] prio67_wd;
-  logic prio67_we;
+  logic prio68_we;
   logic [1:0] prio68_qs;
   logic [1:0] prio68_wd;
-  logic prio68_we;
+  logic prio69_we;
   logic [1:0] prio69_qs;
   logic [1:0] prio69_wd;
-  logic prio69_we;
+  logic prio70_we;
   logic [1:0] prio70_qs;
   logic [1:0] prio70_wd;
-  logic prio70_we;
+  logic prio71_we;
   logic [1:0] prio71_qs;
   logic [1:0] prio71_wd;
-  logic prio71_we;
+  logic prio72_we;
   logic [1:0] prio72_qs;
   logic [1:0] prio72_wd;
-  logic prio72_we;
+  logic prio73_we;
   logic [1:0] prio73_qs;
   logic [1:0] prio73_wd;
-  logic prio73_we;
+  logic prio74_we;
   logic [1:0] prio74_qs;
   logic [1:0] prio74_wd;
-  logic prio74_we;
+  logic prio75_we;
   logic [1:0] prio75_qs;
   logic [1:0] prio75_wd;
-  logic prio75_we;
+  logic prio76_we;
   logic [1:0] prio76_qs;
   logic [1:0] prio76_wd;
-  logic prio76_we;
+  logic prio77_we;
   logic [1:0] prio77_qs;
   logic [1:0] prio77_wd;
-  logic prio77_we;
+  logic prio78_we;
   logic [1:0] prio78_qs;
   logic [1:0] prio78_wd;
-  logic prio78_we;
+  logic prio79_we;
   logic [1:0] prio79_qs;
   logic [1:0] prio79_wd;
-  logic prio79_we;
+  logic prio80_we;
   logic [1:0] prio80_qs;
   logic [1:0] prio80_wd;
-  logic prio80_we;
+  logic prio81_we;
   logic [1:0] prio81_qs;
   logic [1:0] prio81_wd;
-  logic prio81_we;
+  logic prio82_we;
   logic [1:0] prio82_qs;
   logic [1:0] prio82_wd;
-  logic prio82_we;
+  logic prio83_we;
   logic [1:0] prio83_qs;
   logic [1:0] prio83_wd;
-  logic prio83_we;
+  logic prio84_we;
   logic [1:0] prio84_qs;
   logic [1:0] prio84_wd;
-  logic prio84_we;
+  logic prio85_we;
   logic [1:0] prio85_qs;
   logic [1:0] prio85_wd;
-  logic prio85_we;
+  logic prio86_we;
   logic [1:0] prio86_qs;
   logic [1:0] prio86_wd;
-  logic prio86_we;
+  logic prio87_we;
   logic [1:0] prio87_qs;
   logic [1:0] prio87_wd;
-  logic prio87_we;
+  logic prio88_we;
   logic [1:0] prio88_qs;
   logic [1:0] prio88_wd;
-  logic prio88_we;
+  logic prio89_we;
   logic [1:0] prio89_qs;
   logic [1:0] prio89_wd;
-  logic prio89_we;
+  logic prio90_we;
   logic [1:0] prio90_qs;
   logic [1:0] prio90_wd;
-  logic prio90_we;
+  logic prio91_we;
   logic [1:0] prio91_qs;
   logic [1:0] prio91_wd;
-  logic prio91_we;
+  logic prio92_we;
   logic [1:0] prio92_qs;
   logic [1:0] prio92_wd;
-  logic prio92_we;
+  logic prio93_we;
   logic [1:0] prio93_qs;
   logic [1:0] prio93_wd;
-  logic prio93_we;
+  logic prio94_we;
   logic [1:0] prio94_qs;
   logic [1:0] prio94_wd;
-  logic prio94_we;
+  logic prio95_we;
   logic [1:0] prio95_qs;
   logic [1:0] prio95_wd;
-  logic prio95_we;
+  logic prio96_we;
   logic [1:0] prio96_qs;
   logic [1:0] prio96_wd;
-  logic prio96_we;
+  logic prio97_we;
   logic [1:0] prio97_qs;
   logic [1:0] prio97_wd;
-  logic prio97_we;
+  logic prio98_we;
   logic [1:0] prio98_qs;
   logic [1:0] prio98_wd;
-  logic prio98_we;
+  logic prio99_we;
   logic [1:0] prio99_qs;
   logic [1:0] prio99_wd;
-  logic prio99_we;
+  logic prio100_we;
   logic [1:0] prio100_qs;
   logic [1:0] prio100_wd;
-  logic prio100_we;
+  logic prio101_we;
   logic [1:0] prio101_qs;
   logic [1:0] prio101_wd;
-  logic prio101_we;
+  logic prio102_we;
   logic [1:0] prio102_qs;
   logic [1:0] prio102_wd;
-  logic prio102_we;
+  logic prio103_we;
   logic [1:0] prio103_qs;
   logic [1:0] prio103_wd;
-  logic prio103_we;
+  logic prio104_we;
   logic [1:0] prio104_qs;
   logic [1:0] prio104_wd;
-  logic prio104_we;
+  logic prio105_we;
   logic [1:0] prio105_qs;
   logic [1:0] prio105_wd;
-  logic prio105_we;
+  logic prio106_we;
   logic [1:0] prio106_qs;
   logic [1:0] prio106_wd;
-  logic prio106_we;
+  logic prio107_we;
   logic [1:0] prio107_qs;
   logic [1:0] prio107_wd;
-  logic prio107_we;
+  logic prio108_we;
   logic [1:0] prio108_qs;
   logic [1:0] prio108_wd;
-  logic prio108_we;
+  logic prio109_we;
   logic [1:0] prio109_qs;
   logic [1:0] prio109_wd;
-  logic prio109_we;
+  logic prio110_we;
   logic [1:0] prio110_qs;
   logic [1:0] prio110_wd;
-  logic prio110_we;
+  logic prio111_we;
   logic [1:0] prio111_qs;
   logic [1:0] prio111_wd;
-  logic prio111_we;
+  logic prio112_we;
   logic [1:0] prio112_qs;
   logic [1:0] prio112_wd;
-  logic prio112_we;
+  logic prio113_we;
   logic [1:0] prio113_qs;
   logic [1:0] prio113_wd;
-  logic prio113_we;
+  logic prio114_we;
   logic [1:0] prio114_qs;
   logic [1:0] prio114_wd;
-  logic prio114_we;
+  logic prio115_we;
   logic [1:0] prio115_qs;
   logic [1:0] prio115_wd;
-  logic prio115_we;
+  logic prio116_we;
   logic [1:0] prio116_qs;
   logic [1:0] prio116_wd;
-  logic prio116_we;
+  logic prio117_we;
   logic [1:0] prio117_qs;
   logic [1:0] prio117_wd;
-  logic prio117_we;
+  logic prio118_we;
   logic [1:0] prio118_qs;
   logic [1:0] prio118_wd;
-  logic prio118_we;
+  logic prio119_we;
   logic [1:0] prio119_qs;
   logic [1:0] prio119_wd;
-  logic prio119_we;
+  logic prio120_we;
   logic [1:0] prio120_qs;
   logic [1:0] prio120_wd;
-  logic prio120_we;
+  logic prio121_we;
   logic [1:0] prio121_qs;
   logic [1:0] prio121_wd;
-  logic prio121_we;
+  logic prio122_we;
   logic [1:0] prio122_qs;
   logic [1:0] prio122_wd;
-  logic prio122_we;
+  logic prio123_we;
   logic [1:0] prio123_qs;
   logic [1:0] prio123_wd;
-  logic prio123_we;
+  logic prio124_we;
   logic [1:0] prio124_qs;
   logic [1:0] prio124_wd;
-  logic prio124_we;
+  logic prio125_we;
   logic [1:0] prio125_qs;
   logic [1:0] prio125_wd;
-  logic prio125_we;
+  logic prio126_we;
   logic [1:0] prio126_qs;
   logic [1:0] prio126_wd;
-  logic prio126_we;
+  logic prio127_we;
   logic [1:0] prio127_qs;
   logic [1:0] prio127_wd;
-  logic prio127_we;
+  logic prio128_we;
   logic [1:0] prio128_qs;
   logic [1:0] prio128_wd;
-  logic prio128_we;
+  logic prio129_we;
   logic [1:0] prio129_qs;
   logic [1:0] prio129_wd;
-  logic prio129_we;
+  logic prio130_we;
   logic [1:0] prio130_qs;
   logic [1:0] prio130_wd;
-  logic prio130_we;
+  logic prio131_we;
   logic [1:0] prio131_qs;
   logic [1:0] prio131_wd;
-  logic prio131_we;
+  logic prio132_we;
   logic [1:0] prio132_qs;
   logic [1:0] prio132_wd;
-  logic prio132_we;
+  logic prio133_we;
   logic [1:0] prio133_qs;
   logic [1:0] prio133_wd;
-  logic prio133_we;
+  logic prio134_we;
   logic [1:0] prio134_qs;
   logic [1:0] prio134_wd;
-  logic prio134_we;
+  logic prio135_we;
   logic [1:0] prio135_qs;
   logic [1:0] prio135_wd;
-  logic prio135_we;
+  logic prio136_we;
   logic [1:0] prio136_qs;
   logic [1:0] prio136_wd;
-  logic prio136_we;
+  logic prio137_we;
   logic [1:0] prio137_qs;
   logic [1:0] prio137_wd;
-  logic prio137_we;
+  logic prio138_we;
   logic [1:0] prio138_qs;
   logic [1:0] prio138_wd;
-  logic prio138_we;
+  logic prio139_we;
   logic [1:0] prio139_qs;
   logic [1:0] prio139_wd;
-  logic prio139_we;
+  logic prio140_we;
   logic [1:0] prio140_qs;
   logic [1:0] prio140_wd;
-  logic prio140_we;
+  logic prio141_we;
   logic [1:0] prio141_qs;
   logic [1:0] prio141_wd;
-  logic prio141_we;
+  logic prio142_we;
   logic [1:0] prio142_qs;
   logic [1:0] prio142_wd;
-  logic prio142_we;
+  logic prio143_we;
   logic [1:0] prio143_qs;
   logic [1:0] prio143_wd;
-  logic prio143_we;
+  logic prio144_we;
   logic [1:0] prio144_qs;
   logic [1:0] prio144_wd;
-  logic prio144_we;
+  logic prio145_we;
   logic [1:0] prio145_qs;
   logic [1:0] prio145_wd;
-  logic prio145_we;
+  logic prio146_we;
   logic [1:0] prio146_qs;
   logic [1:0] prio146_wd;
-  logic prio146_we;
+  logic prio147_we;
   logic [1:0] prio147_qs;
   logic [1:0] prio147_wd;
-  logic prio147_we;
+  logic prio148_we;
   logic [1:0] prio148_qs;
   logic [1:0] prio148_wd;
-  logic prio148_we;
+  logic prio149_we;
   logic [1:0] prio149_qs;
   logic [1:0] prio149_wd;
-  logic prio149_we;
+  logic prio150_we;
   logic [1:0] prio150_qs;
   logic [1:0] prio150_wd;
-  logic prio150_we;
+  logic prio151_we;
   logic [1:0] prio151_qs;
   logic [1:0] prio151_wd;
-  logic prio151_we;
+  logic prio152_we;
   logic [1:0] prio152_qs;
   logic [1:0] prio152_wd;
-  logic prio152_we;
+  logic prio153_we;
   logic [1:0] prio153_qs;
   logic [1:0] prio153_wd;
-  logic prio153_we;
+  logic prio154_we;
   logic [1:0] prio154_qs;
   logic [1:0] prio154_wd;
-  logic prio154_we;
+  logic prio155_we;
   logic [1:0] prio155_qs;
   logic [1:0] prio155_wd;
-  logic prio155_we;
+  logic prio156_we;
   logic [1:0] prio156_qs;
   logic [1:0] prio156_wd;
-  logic prio156_we;
+  logic prio157_we;
   logic [1:0] prio157_qs;
   logic [1:0] prio157_wd;
-  logic prio157_we;
+  logic prio158_we;
   logic [1:0] prio158_qs;
   logic [1:0] prio158_wd;
-  logic prio158_we;
+  logic prio159_we;
   logic [1:0] prio159_qs;
   logic [1:0] prio159_wd;
-  logic prio159_we;
+  logic prio160_we;
   logic [1:0] prio160_qs;
   logic [1:0] prio160_wd;
-  logic prio160_we;
+  logic prio161_we;
   logic [1:0] prio161_qs;
   logic [1:0] prio161_wd;
-  logic prio161_we;
+  logic prio162_we;
   logic [1:0] prio162_qs;
   logic [1:0] prio162_wd;
-  logic prio162_we;
+  logic prio163_we;
   logic [1:0] prio163_qs;
   logic [1:0] prio163_wd;
-  logic prio163_we;
+  logic prio164_we;
   logic [1:0] prio164_qs;
   logic [1:0] prio164_wd;
-  logic prio164_we;
+  logic prio165_we;
   logic [1:0] prio165_qs;
   logic [1:0] prio165_wd;
-  logic prio165_we;
+  logic prio166_we;
   logic [1:0] prio166_qs;
   logic [1:0] prio166_wd;
-  logic prio166_we;
+  logic prio167_we;
   logic [1:0] prio167_qs;
   logic [1:0] prio167_wd;
-  logic prio167_we;
+  logic prio168_we;
   logic [1:0] prio168_qs;
   logic [1:0] prio168_wd;
-  logic prio168_we;
+  logic prio169_we;
   logic [1:0] prio169_qs;
   logic [1:0] prio169_wd;
-  logic prio169_we;
+  logic prio170_we;
   logic [1:0] prio170_qs;
   logic [1:0] prio170_wd;
-  logic prio170_we;
+  logic prio171_we;
   logic [1:0] prio171_qs;
   logic [1:0] prio171_wd;
-  logic prio171_we;
+  logic prio172_we;
   logic [1:0] prio172_qs;
   logic [1:0] prio172_wd;
-  logic prio172_we;
+  logic prio173_we;
   logic [1:0] prio173_qs;
   logic [1:0] prio173_wd;
-  logic prio173_we;
+  logic prio174_we;
   logic [1:0] prio174_qs;
   logic [1:0] prio174_wd;
-  logic prio174_we;
+  logic prio175_we;
   logic [1:0] prio175_qs;
   logic [1:0] prio175_wd;
-  logic prio175_we;
+  logic prio176_we;
   logic [1:0] prio176_qs;
   logic [1:0] prio176_wd;
-  logic prio176_we;
+  logic prio177_we;
   logic [1:0] prio177_qs;
   logic [1:0] prio177_wd;
-  logic prio177_we;
+  logic prio178_we;
   logic [1:0] prio178_qs;
   logic [1:0] prio178_wd;
-  logic prio178_we;
+  logic prio179_we;
   logic [1:0] prio179_qs;
   logic [1:0] prio179_wd;
-  logic prio179_we;
+  logic ie0_0_we;
   logic ie0_0_e_0_qs;
   logic ie0_0_e_0_wd;
-  logic ie0_0_e_0_we;
   logic ie0_0_e_1_qs;
   logic ie0_0_e_1_wd;
-  logic ie0_0_e_1_we;
   logic ie0_0_e_2_qs;
   logic ie0_0_e_2_wd;
-  logic ie0_0_e_2_we;
   logic ie0_0_e_3_qs;
   logic ie0_0_e_3_wd;
-  logic ie0_0_e_3_we;
   logic ie0_0_e_4_qs;
   logic ie0_0_e_4_wd;
-  logic ie0_0_e_4_we;
   logic ie0_0_e_5_qs;
   logic ie0_0_e_5_wd;
-  logic ie0_0_e_5_we;
   logic ie0_0_e_6_qs;
   logic ie0_0_e_6_wd;
-  logic ie0_0_e_6_we;
   logic ie0_0_e_7_qs;
   logic ie0_0_e_7_wd;
-  logic ie0_0_e_7_we;
   logic ie0_0_e_8_qs;
   logic ie0_0_e_8_wd;
-  logic ie0_0_e_8_we;
   logic ie0_0_e_9_qs;
   logic ie0_0_e_9_wd;
-  logic ie0_0_e_9_we;
   logic ie0_0_e_10_qs;
   logic ie0_0_e_10_wd;
-  logic ie0_0_e_10_we;
   logic ie0_0_e_11_qs;
   logic ie0_0_e_11_wd;
-  logic ie0_0_e_11_we;
   logic ie0_0_e_12_qs;
   logic ie0_0_e_12_wd;
-  logic ie0_0_e_12_we;
   logic ie0_0_e_13_qs;
   logic ie0_0_e_13_wd;
-  logic ie0_0_e_13_we;
   logic ie0_0_e_14_qs;
   logic ie0_0_e_14_wd;
-  logic ie0_0_e_14_we;
   logic ie0_0_e_15_qs;
   logic ie0_0_e_15_wd;
-  logic ie0_0_e_15_we;
   logic ie0_0_e_16_qs;
   logic ie0_0_e_16_wd;
-  logic ie0_0_e_16_we;
   logic ie0_0_e_17_qs;
   logic ie0_0_e_17_wd;
-  logic ie0_0_e_17_we;
   logic ie0_0_e_18_qs;
   logic ie0_0_e_18_wd;
-  logic ie0_0_e_18_we;
   logic ie0_0_e_19_qs;
   logic ie0_0_e_19_wd;
-  logic ie0_0_e_19_we;
   logic ie0_0_e_20_qs;
   logic ie0_0_e_20_wd;
-  logic ie0_0_e_20_we;
   logic ie0_0_e_21_qs;
   logic ie0_0_e_21_wd;
-  logic ie0_0_e_21_we;
   logic ie0_0_e_22_qs;
   logic ie0_0_e_22_wd;
-  logic ie0_0_e_22_we;
   logic ie0_0_e_23_qs;
   logic ie0_0_e_23_wd;
-  logic ie0_0_e_23_we;
   logic ie0_0_e_24_qs;
   logic ie0_0_e_24_wd;
-  logic ie0_0_e_24_we;
   logic ie0_0_e_25_qs;
   logic ie0_0_e_25_wd;
-  logic ie0_0_e_25_we;
   logic ie0_0_e_26_qs;
   logic ie0_0_e_26_wd;
-  logic ie0_0_e_26_we;
   logic ie0_0_e_27_qs;
   logic ie0_0_e_27_wd;
-  logic ie0_0_e_27_we;
   logic ie0_0_e_28_qs;
   logic ie0_0_e_28_wd;
-  logic ie0_0_e_28_we;
   logic ie0_0_e_29_qs;
   logic ie0_0_e_29_wd;
-  logic ie0_0_e_29_we;
   logic ie0_0_e_30_qs;
   logic ie0_0_e_30_wd;
-  logic ie0_0_e_30_we;
   logic ie0_0_e_31_qs;
   logic ie0_0_e_31_wd;
-  logic ie0_0_e_31_we;
+  logic ie0_1_we;
   logic ie0_1_e_32_qs;
   logic ie0_1_e_32_wd;
-  logic ie0_1_e_32_we;
   logic ie0_1_e_33_qs;
   logic ie0_1_e_33_wd;
-  logic ie0_1_e_33_we;
   logic ie0_1_e_34_qs;
   logic ie0_1_e_34_wd;
-  logic ie0_1_e_34_we;
   logic ie0_1_e_35_qs;
   logic ie0_1_e_35_wd;
-  logic ie0_1_e_35_we;
   logic ie0_1_e_36_qs;
   logic ie0_1_e_36_wd;
-  logic ie0_1_e_36_we;
   logic ie0_1_e_37_qs;
   logic ie0_1_e_37_wd;
-  logic ie0_1_e_37_we;
   logic ie0_1_e_38_qs;
   logic ie0_1_e_38_wd;
-  logic ie0_1_e_38_we;
   logic ie0_1_e_39_qs;
   logic ie0_1_e_39_wd;
-  logic ie0_1_e_39_we;
   logic ie0_1_e_40_qs;
   logic ie0_1_e_40_wd;
-  logic ie0_1_e_40_we;
   logic ie0_1_e_41_qs;
   logic ie0_1_e_41_wd;
-  logic ie0_1_e_41_we;
   logic ie0_1_e_42_qs;
   logic ie0_1_e_42_wd;
-  logic ie0_1_e_42_we;
   logic ie0_1_e_43_qs;
   logic ie0_1_e_43_wd;
-  logic ie0_1_e_43_we;
   logic ie0_1_e_44_qs;
   logic ie0_1_e_44_wd;
-  logic ie0_1_e_44_we;
   logic ie0_1_e_45_qs;
   logic ie0_1_e_45_wd;
-  logic ie0_1_e_45_we;
   logic ie0_1_e_46_qs;
   logic ie0_1_e_46_wd;
-  logic ie0_1_e_46_we;
   logic ie0_1_e_47_qs;
   logic ie0_1_e_47_wd;
-  logic ie0_1_e_47_we;
   logic ie0_1_e_48_qs;
   logic ie0_1_e_48_wd;
-  logic ie0_1_e_48_we;
   logic ie0_1_e_49_qs;
   logic ie0_1_e_49_wd;
-  logic ie0_1_e_49_we;
   logic ie0_1_e_50_qs;
   logic ie0_1_e_50_wd;
-  logic ie0_1_e_50_we;
   logic ie0_1_e_51_qs;
   logic ie0_1_e_51_wd;
-  logic ie0_1_e_51_we;
   logic ie0_1_e_52_qs;
   logic ie0_1_e_52_wd;
-  logic ie0_1_e_52_we;
   logic ie0_1_e_53_qs;
   logic ie0_1_e_53_wd;
-  logic ie0_1_e_53_we;
   logic ie0_1_e_54_qs;
   logic ie0_1_e_54_wd;
-  logic ie0_1_e_54_we;
   logic ie0_1_e_55_qs;
   logic ie0_1_e_55_wd;
-  logic ie0_1_e_55_we;
   logic ie0_1_e_56_qs;
   logic ie0_1_e_56_wd;
-  logic ie0_1_e_56_we;
   logic ie0_1_e_57_qs;
   logic ie0_1_e_57_wd;
-  logic ie0_1_e_57_we;
   logic ie0_1_e_58_qs;
   logic ie0_1_e_58_wd;
-  logic ie0_1_e_58_we;
   logic ie0_1_e_59_qs;
   logic ie0_1_e_59_wd;
-  logic ie0_1_e_59_we;
   logic ie0_1_e_60_qs;
   logic ie0_1_e_60_wd;
-  logic ie0_1_e_60_we;
   logic ie0_1_e_61_qs;
   logic ie0_1_e_61_wd;
-  logic ie0_1_e_61_we;
   logic ie0_1_e_62_qs;
   logic ie0_1_e_62_wd;
-  logic ie0_1_e_62_we;
   logic ie0_1_e_63_qs;
   logic ie0_1_e_63_wd;
-  logic ie0_1_e_63_we;
+  logic ie0_2_we;
   logic ie0_2_e_64_qs;
   logic ie0_2_e_64_wd;
-  logic ie0_2_e_64_we;
   logic ie0_2_e_65_qs;
   logic ie0_2_e_65_wd;
-  logic ie0_2_e_65_we;
   logic ie0_2_e_66_qs;
   logic ie0_2_e_66_wd;
-  logic ie0_2_e_66_we;
   logic ie0_2_e_67_qs;
   logic ie0_2_e_67_wd;
-  logic ie0_2_e_67_we;
   logic ie0_2_e_68_qs;
   logic ie0_2_e_68_wd;
-  logic ie0_2_e_68_we;
   logic ie0_2_e_69_qs;
   logic ie0_2_e_69_wd;
-  logic ie0_2_e_69_we;
   logic ie0_2_e_70_qs;
   logic ie0_2_e_70_wd;
-  logic ie0_2_e_70_we;
   logic ie0_2_e_71_qs;
   logic ie0_2_e_71_wd;
-  logic ie0_2_e_71_we;
   logic ie0_2_e_72_qs;
   logic ie0_2_e_72_wd;
-  logic ie0_2_e_72_we;
   logic ie0_2_e_73_qs;
   logic ie0_2_e_73_wd;
-  logic ie0_2_e_73_we;
   logic ie0_2_e_74_qs;
   logic ie0_2_e_74_wd;
-  logic ie0_2_e_74_we;
   logic ie0_2_e_75_qs;
   logic ie0_2_e_75_wd;
-  logic ie0_2_e_75_we;
   logic ie0_2_e_76_qs;
   logic ie0_2_e_76_wd;
-  logic ie0_2_e_76_we;
   logic ie0_2_e_77_qs;
   logic ie0_2_e_77_wd;
-  logic ie0_2_e_77_we;
   logic ie0_2_e_78_qs;
   logic ie0_2_e_78_wd;
-  logic ie0_2_e_78_we;
   logic ie0_2_e_79_qs;
   logic ie0_2_e_79_wd;
-  logic ie0_2_e_79_we;
   logic ie0_2_e_80_qs;
   logic ie0_2_e_80_wd;
-  logic ie0_2_e_80_we;
   logic ie0_2_e_81_qs;
   logic ie0_2_e_81_wd;
-  logic ie0_2_e_81_we;
   logic ie0_2_e_82_qs;
   logic ie0_2_e_82_wd;
-  logic ie0_2_e_82_we;
   logic ie0_2_e_83_qs;
   logic ie0_2_e_83_wd;
-  logic ie0_2_e_83_we;
   logic ie0_2_e_84_qs;
   logic ie0_2_e_84_wd;
-  logic ie0_2_e_84_we;
   logic ie0_2_e_85_qs;
   logic ie0_2_e_85_wd;
-  logic ie0_2_e_85_we;
   logic ie0_2_e_86_qs;
   logic ie0_2_e_86_wd;
-  logic ie0_2_e_86_we;
   logic ie0_2_e_87_qs;
   logic ie0_2_e_87_wd;
-  logic ie0_2_e_87_we;
   logic ie0_2_e_88_qs;
   logic ie0_2_e_88_wd;
-  logic ie0_2_e_88_we;
   logic ie0_2_e_89_qs;
   logic ie0_2_e_89_wd;
-  logic ie0_2_e_89_we;
   logic ie0_2_e_90_qs;
   logic ie0_2_e_90_wd;
-  logic ie0_2_e_90_we;
   logic ie0_2_e_91_qs;
   logic ie0_2_e_91_wd;
-  logic ie0_2_e_91_we;
   logic ie0_2_e_92_qs;
   logic ie0_2_e_92_wd;
-  logic ie0_2_e_92_we;
   logic ie0_2_e_93_qs;
   logic ie0_2_e_93_wd;
-  logic ie0_2_e_93_we;
   logic ie0_2_e_94_qs;
   logic ie0_2_e_94_wd;
-  logic ie0_2_e_94_we;
   logic ie0_2_e_95_qs;
   logic ie0_2_e_95_wd;
-  logic ie0_2_e_95_we;
+  logic ie0_3_we;
   logic ie0_3_e_96_qs;
   logic ie0_3_e_96_wd;
-  logic ie0_3_e_96_we;
   logic ie0_3_e_97_qs;
   logic ie0_3_e_97_wd;
-  logic ie0_3_e_97_we;
   logic ie0_3_e_98_qs;
   logic ie0_3_e_98_wd;
-  logic ie0_3_e_98_we;
   logic ie0_3_e_99_qs;
   logic ie0_3_e_99_wd;
-  logic ie0_3_e_99_we;
   logic ie0_3_e_100_qs;
   logic ie0_3_e_100_wd;
-  logic ie0_3_e_100_we;
   logic ie0_3_e_101_qs;
   logic ie0_3_e_101_wd;
-  logic ie0_3_e_101_we;
   logic ie0_3_e_102_qs;
   logic ie0_3_e_102_wd;
-  logic ie0_3_e_102_we;
   logic ie0_3_e_103_qs;
   logic ie0_3_e_103_wd;
-  logic ie0_3_e_103_we;
   logic ie0_3_e_104_qs;
   logic ie0_3_e_104_wd;
-  logic ie0_3_e_104_we;
   logic ie0_3_e_105_qs;
   logic ie0_3_e_105_wd;
-  logic ie0_3_e_105_we;
   logic ie0_3_e_106_qs;
   logic ie0_3_e_106_wd;
-  logic ie0_3_e_106_we;
   logic ie0_3_e_107_qs;
   logic ie0_3_e_107_wd;
-  logic ie0_3_e_107_we;
   logic ie0_3_e_108_qs;
   logic ie0_3_e_108_wd;
-  logic ie0_3_e_108_we;
   logic ie0_3_e_109_qs;
   logic ie0_3_e_109_wd;
-  logic ie0_3_e_109_we;
   logic ie0_3_e_110_qs;
   logic ie0_3_e_110_wd;
-  logic ie0_3_e_110_we;
   logic ie0_3_e_111_qs;
   logic ie0_3_e_111_wd;
-  logic ie0_3_e_111_we;
   logic ie0_3_e_112_qs;
   logic ie0_3_e_112_wd;
-  logic ie0_3_e_112_we;
   logic ie0_3_e_113_qs;
   logic ie0_3_e_113_wd;
-  logic ie0_3_e_113_we;
   logic ie0_3_e_114_qs;
   logic ie0_3_e_114_wd;
-  logic ie0_3_e_114_we;
   logic ie0_3_e_115_qs;
   logic ie0_3_e_115_wd;
-  logic ie0_3_e_115_we;
   logic ie0_3_e_116_qs;
   logic ie0_3_e_116_wd;
-  logic ie0_3_e_116_we;
   logic ie0_3_e_117_qs;
   logic ie0_3_e_117_wd;
-  logic ie0_3_e_117_we;
   logic ie0_3_e_118_qs;
   logic ie0_3_e_118_wd;
-  logic ie0_3_e_118_we;
   logic ie0_3_e_119_qs;
   logic ie0_3_e_119_wd;
-  logic ie0_3_e_119_we;
   logic ie0_3_e_120_qs;
   logic ie0_3_e_120_wd;
-  logic ie0_3_e_120_we;
   logic ie0_3_e_121_qs;
   logic ie0_3_e_121_wd;
-  logic ie0_3_e_121_we;
   logic ie0_3_e_122_qs;
   logic ie0_3_e_122_wd;
-  logic ie0_3_e_122_we;
   logic ie0_3_e_123_qs;
   logic ie0_3_e_123_wd;
-  logic ie0_3_e_123_we;
   logic ie0_3_e_124_qs;
   logic ie0_3_e_124_wd;
-  logic ie0_3_e_124_we;
   logic ie0_3_e_125_qs;
   logic ie0_3_e_125_wd;
-  logic ie0_3_e_125_we;
   logic ie0_3_e_126_qs;
   logic ie0_3_e_126_wd;
-  logic ie0_3_e_126_we;
   logic ie0_3_e_127_qs;
   logic ie0_3_e_127_wd;
-  logic ie0_3_e_127_we;
+  logic ie0_4_we;
   logic ie0_4_e_128_qs;
   logic ie0_4_e_128_wd;
-  logic ie0_4_e_128_we;
   logic ie0_4_e_129_qs;
   logic ie0_4_e_129_wd;
-  logic ie0_4_e_129_we;
   logic ie0_4_e_130_qs;
   logic ie0_4_e_130_wd;
-  logic ie0_4_e_130_we;
   logic ie0_4_e_131_qs;
   logic ie0_4_e_131_wd;
-  logic ie0_4_e_131_we;
   logic ie0_4_e_132_qs;
   logic ie0_4_e_132_wd;
-  logic ie0_4_e_132_we;
   logic ie0_4_e_133_qs;
   logic ie0_4_e_133_wd;
-  logic ie0_4_e_133_we;
   logic ie0_4_e_134_qs;
   logic ie0_4_e_134_wd;
-  logic ie0_4_e_134_we;
   logic ie0_4_e_135_qs;
   logic ie0_4_e_135_wd;
-  logic ie0_4_e_135_we;
   logic ie0_4_e_136_qs;
   logic ie0_4_e_136_wd;
-  logic ie0_4_e_136_we;
   logic ie0_4_e_137_qs;
   logic ie0_4_e_137_wd;
-  logic ie0_4_e_137_we;
   logic ie0_4_e_138_qs;
   logic ie0_4_e_138_wd;
-  logic ie0_4_e_138_we;
   logic ie0_4_e_139_qs;
   logic ie0_4_e_139_wd;
-  logic ie0_4_e_139_we;
   logic ie0_4_e_140_qs;
   logic ie0_4_e_140_wd;
-  logic ie0_4_e_140_we;
   logic ie0_4_e_141_qs;
   logic ie0_4_e_141_wd;
-  logic ie0_4_e_141_we;
   logic ie0_4_e_142_qs;
   logic ie0_4_e_142_wd;
-  logic ie0_4_e_142_we;
   logic ie0_4_e_143_qs;
   logic ie0_4_e_143_wd;
-  logic ie0_4_e_143_we;
   logic ie0_4_e_144_qs;
   logic ie0_4_e_144_wd;
-  logic ie0_4_e_144_we;
   logic ie0_4_e_145_qs;
   logic ie0_4_e_145_wd;
-  logic ie0_4_e_145_we;
   logic ie0_4_e_146_qs;
   logic ie0_4_e_146_wd;
-  logic ie0_4_e_146_we;
   logic ie0_4_e_147_qs;
   logic ie0_4_e_147_wd;
-  logic ie0_4_e_147_we;
   logic ie0_4_e_148_qs;
   logic ie0_4_e_148_wd;
-  logic ie0_4_e_148_we;
   logic ie0_4_e_149_qs;
   logic ie0_4_e_149_wd;
-  logic ie0_4_e_149_we;
   logic ie0_4_e_150_qs;
   logic ie0_4_e_150_wd;
-  logic ie0_4_e_150_we;
   logic ie0_4_e_151_qs;
   logic ie0_4_e_151_wd;
-  logic ie0_4_e_151_we;
   logic ie0_4_e_152_qs;
   logic ie0_4_e_152_wd;
-  logic ie0_4_e_152_we;
   logic ie0_4_e_153_qs;
   logic ie0_4_e_153_wd;
-  logic ie0_4_e_153_we;
   logic ie0_4_e_154_qs;
   logic ie0_4_e_154_wd;
-  logic ie0_4_e_154_we;
   logic ie0_4_e_155_qs;
   logic ie0_4_e_155_wd;
-  logic ie0_4_e_155_we;
   logic ie0_4_e_156_qs;
   logic ie0_4_e_156_wd;
-  logic ie0_4_e_156_we;
   logic ie0_4_e_157_qs;
   logic ie0_4_e_157_wd;
-  logic ie0_4_e_157_we;
   logic ie0_4_e_158_qs;
   logic ie0_4_e_158_wd;
-  logic ie0_4_e_158_we;
   logic ie0_4_e_159_qs;
   logic ie0_4_e_159_wd;
-  logic ie0_4_e_159_we;
+  logic ie0_5_we;
   logic ie0_5_e_160_qs;
   logic ie0_5_e_160_wd;
-  logic ie0_5_e_160_we;
   logic ie0_5_e_161_qs;
   logic ie0_5_e_161_wd;
-  logic ie0_5_e_161_we;
   logic ie0_5_e_162_qs;
   logic ie0_5_e_162_wd;
-  logic ie0_5_e_162_we;
   logic ie0_5_e_163_qs;
   logic ie0_5_e_163_wd;
-  logic ie0_5_e_163_we;
   logic ie0_5_e_164_qs;
   logic ie0_5_e_164_wd;
-  logic ie0_5_e_164_we;
   logic ie0_5_e_165_qs;
   logic ie0_5_e_165_wd;
-  logic ie0_5_e_165_we;
   logic ie0_5_e_166_qs;
   logic ie0_5_e_166_wd;
-  logic ie0_5_e_166_we;
   logic ie0_5_e_167_qs;
   logic ie0_5_e_167_wd;
-  logic ie0_5_e_167_we;
   logic ie0_5_e_168_qs;
   logic ie0_5_e_168_wd;
-  logic ie0_5_e_168_we;
   logic ie0_5_e_169_qs;
   logic ie0_5_e_169_wd;
-  logic ie0_5_e_169_we;
   logic ie0_5_e_170_qs;
   logic ie0_5_e_170_wd;
-  logic ie0_5_e_170_we;
   logic ie0_5_e_171_qs;
   logic ie0_5_e_171_wd;
-  logic ie0_5_e_171_we;
   logic ie0_5_e_172_qs;
   logic ie0_5_e_172_wd;
-  logic ie0_5_e_172_we;
   logic ie0_5_e_173_qs;
   logic ie0_5_e_173_wd;
-  logic ie0_5_e_173_we;
   logic ie0_5_e_174_qs;
   logic ie0_5_e_174_wd;
-  logic ie0_5_e_174_we;
   logic ie0_5_e_175_qs;
   logic ie0_5_e_175_wd;
-  logic ie0_5_e_175_we;
   logic ie0_5_e_176_qs;
   logic ie0_5_e_176_wd;
-  logic ie0_5_e_176_we;
   logic ie0_5_e_177_qs;
   logic ie0_5_e_177_wd;
-  logic ie0_5_e_177_we;
   logic ie0_5_e_178_qs;
   logic ie0_5_e_178_wd;
-  logic ie0_5_e_178_we;
   logic ie0_5_e_179_qs;
   logic ie0_5_e_179_wd;
-  logic ie0_5_e_179_we;
+  logic threshold0_we;
   logic [1:0] threshold0_qs;
   logic [1:0] threshold0_wd;
-  logic threshold0_we;
+  logic cc0_re;
+  logic cc0_we;
   logic [7:0] cc0_qs;
   logic [7:0] cc0_wd;
-  logic cc0_we;
-  logic cc0_re;
+  logic msip0_we;
   logic msip0_qs;
   logic msip0_wd;
-  logic msip0_we;
 
   // Register instances
 
@@ -6630,7 +6282,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_0_we),
+    .we     (le_0_we),
     .wd     (le_0_le_0_wd),
 
     // from internal hardware
@@ -6656,7 +6308,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_1_we),
+    .we     (le_0_we),
     .wd     (le_0_le_1_wd),
 
     // from internal hardware
@@ -6682,7 +6334,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_2_we),
+    .we     (le_0_we),
     .wd     (le_0_le_2_wd),
 
     // from internal hardware
@@ -6708,7 +6360,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_3_we),
+    .we     (le_0_we),
     .wd     (le_0_le_3_wd),
 
     // from internal hardware
@@ -6734,7 +6386,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_4_we),
+    .we     (le_0_we),
     .wd     (le_0_le_4_wd),
 
     // from internal hardware
@@ -6760,7 +6412,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_5_we),
+    .we     (le_0_we),
     .wd     (le_0_le_5_wd),
 
     // from internal hardware
@@ -6786,7 +6438,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_6_we),
+    .we     (le_0_we),
     .wd     (le_0_le_6_wd),
 
     // from internal hardware
@@ -6812,7 +6464,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_7_we),
+    .we     (le_0_we),
     .wd     (le_0_le_7_wd),
 
     // from internal hardware
@@ -6838,7 +6490,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_8_we),
+    .we     (le_0_we),
     .wd     (le_0_le_8_wd),
 
     // from internal hardware
@@ -6864,7 +6516,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_9_we),
+    .we     (le_0_we),
     .wd     (le_0_le_9_wd),
 
     // from internal hardware
@@ -6890,7 +6542,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_10_we),
+    .we     (le_0_we),
     .wd     (le_0_le_10_wd),
 
     // from internal hardware
@@ -6916,7 +6568,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_11_we),
+    .we     (le_0_we),
     .wd     (le_0_le_11_wd),
 
     // from internal hardware
@@ -6942,7 +6594,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_12_we),
+    .we     (le_0_we),
     .wd     (le_0_le_12_wd),
 
     // from internal hardware
@@ -6968,7 +6620,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_13_we),
+    .we     (le_0_we),
     .wd     (le_0_le_13_wd),
 
     // from internal hardware
@@ -6994,7 +6646,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_14_we),
+    .we     (le_0_we),
     .wd     (le_0_le_14_wd),
 
     // from internal hardware
@@ -7020,7 +6672,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_15_we),
+    .we     (le_0_we),
     .wd     (le_0_le_15_wd),
 
     // from internal hardware
@@ -7046,7 +6698,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_16_we),
+    .we     (le_0_we),
     .wd     (le_0_le_16_wd),
 
     // from internal hardware
@@ -7072,7 +6724,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_17_we),
+    .we     (le_0_we),
     .wd     (le_0_le_17_wd),
 
     // from internal hardware
@@ -7098,7 +6750,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_18_we),
+    .we     (le_0_we),
     .wd     (le_0_le_18_wd),
 
     // from internal hardware
@@ -7124,7 +6776,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_19_we),
+    .we     (le_0_we),
     .wd     (le_0_le_19_wd),
 
     // from internal hardware
@@ -7150,7 +6802,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_20_we),
+    .we     (le_0_we),
     .wd     (le_0_le_20_wd),
 
     // from internal hardware
@@ -7176,7 +6828,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_21_we),
+    .we     (le_0_we),
     .wd     (le_0_le_21_wd),
 
     // from internal hardware
@@ -7202,7 +6854,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_22_we),
+    .we     (le_0_we),
     .wd     (le_0_le_22_wd),
 
     // from internal hardware
@@ -7228,7 +6880,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_23_we),
+    .we     (le_0_we),
     .wd     (le_0_le_23_wd),
 
     // from internal hardware
@@ -7254,7 +6906,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_24_we),
+    .we     (le_0_we),
     .wd     (le_0_le_24_wd),
 
     // from internal hardware
@@ -7280,7 +6932,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_25_we),
+    .we     (le_0_we),
     .wd     (le_0_le_25_wd),
 
     // from internal hardware
@@ -7306,7 +6958,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_26_we),
+    .we     (le_0_we),
     .wd     (le_0_le_26_wd),
 
     // from internal hardware
@@ -7332,7 +6984,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_27_we),
+    .we     (le_0_we),
     .wd     (le_0_le_27_wd),
 
     // from internal hardware
@@ -7358,7 +7010,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_28_we),
+    .we     (le_0_we),
     .wd     (le_0_le_28_wd),
 
     // from internal hardware
@@ -7384,7 +7036,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_29_we),
+    .we     (le_0_we),
     .wd     (le_0_le_29_wd),
 
     // from internal hardware
@@ -7410,7 +7062,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_30_we),
+    .we     (le_0_we),
     .wd     (le_0_le_30_wd),
 
     // from internal hardware
@@ -7436,7 +7088,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_0_le_31_we),
+    .we     (le_0_we),
     .wd     (le_0_le_31_wd),
 
     // from internal hardware
@@ -7465,7 +7117,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_32_we),
+    .we     (le_1_we),
     .wd     (le_1_le_32_wd),
 
     // from internal hardware
@@ -7491,7 +7143,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_33_we),
+    .we     (le_1_we),
     .wd     (le_1_le_33_wd),
 
     // from internal hardware
@@ -7517,7 +7169,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_34_we),
+    .we     (le_1_we),
     .wd     (le_1_le_34_wd),
 
     // from internal hardware
@@ -7543,7 +7195,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_35_we),
+    .we     (le_1_we),
     .wd     (le_1_le_35_wd),
 
     // from internal hardware
@@ -7569,7 +7221,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_36_we),
+    .we     (le_1_we),
     .wd     (le_1_le_36_wd),
 
     // from internal hardware
@@ -7595,7 +7247,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_37_we),
+    .we     (le_1_we),
     .wd     (le_1_le_37_wd),
 
     // from internal hardware
@@ -7621,7 +7273,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_38_we),
+    .we     (le_1_we),
     .wd     (le_1_le_38_wd),
 
     // from internal hardware
@@ -7647,7 +7299,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_39_we),
+    .we     (le_1_we),
     .wd     (le_1_le_39_wd),
 
     // from internal hardware
@@ -7673,7 +7325,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_40_we),
+    .we     (le_1_we),
     .wd     (le_1_le_40_wd),
 
     // from internal hardware
@@ -7699,7 +7351,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_41_we),
+    .we     (le_1_we),
     .wd     (le_1_le_41_wd),
 
     // from internal hardware
@@ -7725,7 +7377,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_42_we),
+    .we     (le_1_we),
     .wd     (le_1_le_42_wd),
 
     // from internal hardware
@@ -7751,7 +7403,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_43_we),
+    .we     (le_1_we),
     .wd     (le_1_le_43_wd),
 
     // from internal hardware
@@ -7777,7 +7429,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_44_we),
+    .we     (le_1_we),
     .wd     (le_1_le_44_wd),
 
     // from internal hardware
@@ -7803,7 +7455,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_45_we),
+    .we     (le_1_we),
     .wd     (le_1_le_45_wd),
 
     // from internal hardware
@@ -7829,7 +7481,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_46_we),
+    .we     (le_1_we),
     .wd     (le_1_le_46_wd),
 
     // from internal hardware
@@ -7855,7 +7507,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_47_we),
+    .we     (le_1_we),
     .wd     (le_1_le_47_wd),
 
     // from internal hardware
@@ -7881,7 +7533,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_48_we),
+    .we     (le_1_we),
     .wd     (le_1_le_48_wd),
 
     // from internal hardware
@@ -7907,7 +7559,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_49_we),
+    .we     (le_1_we),
     .wd     (le_1_le_49_wd),
 
     // from internal hardware
@@ -7933,7 +7585,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_50_we),
+    .we     (le_1_we),
     .wd     (le_1_le_50_wd),
 
     // from internal hardware
@@ -7959,7 +7611,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_51_we),
+    .we     (le_1_we),
     .wd     (le_1_le_51_wd),
 
     // from internal hardware
@@ -7985,7 +7637,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_52_we),
+    .we     (le_1_we),
     .wd     (le_1_le_52_wd),
 
     // from internal hardware
@@ -8011,7 +7663,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_53_we),
+    .we     (le_1_we),
     .wd     (le_1_le_53_wd),
 
     // from internal hardware
@@ -8037,7 +7689,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_54_we),
+    .we     (le_1_we),
     .wd     (le_1_le_54_wd),
 
     // from internal hardware
@@ -8063,7 +7715,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_55_we),
+    .we     (le_1_we),
     .wd     (le_1_le_55_wd),
 
     // from internal hardware
@@ -8089,7 +7741,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_56_we),
+    .we     (le_1_we),
     .wd     (le_1_le_56_wd),
 
     // from internal hardware
@@ -8115,7 +7767,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_57_we),
+    .we     (le_1_we),
     .wd     (le_1_le_57_wd),
 
     // from internal hardware
@@ -8141,7 +7793,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_58_we),
+    .we     (le_1_we),
     .wd     (le_1_le_58_wd),
 
     // from internal hardware
@@ -8167,7 +7819,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_59_we),
+    .we     (le_1_we),
     .wd     (le_1_le_59_wd),
 
     // from internal hardware
@@ -8193,7 +7845,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_60_we),
+    .we     (le_1_we),
     .wd     (le_1_le_60_wd),
 
     // from internal hardware
@@ -8219,7 +7871,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_61_we),
+    .we     (le_1_we),
     .wd     (le_1_le_61_wd),
 
     // from internal hardware
@@ -8245,7 +7897,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_62_we),
+    .we     (le_1_we),
     .wd     (le_1_le_62_wd),
 
     // from internal hardware
@@ -8271,7 +7923,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_1_le_63_we),
+    .we     (le_1_we),
     .wd     (le_1_le_63_wd),
 
     // from internal hardware
@@ -8300,7 +7952,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_64_we),
+    .we     (le_2_we),
     .wd     (le_2_le_64_wd),
 
     // from internal hardware
@@ -8326,7 +7978,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_65_we),
+    .we     (le_2_we),
     .wd     (le_2_le_65_wd),
 
     // from internal hardware
@@ -8352,7 +8004,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_66_we),
+    .we     (le_2_we),
     .wd     (le_2_le_66_wd),
 
     // from internal hardware
@@ -8378,7 +8030,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_67_we),
+    .we     (le_2_we),
     .wd     (le_2_le_67_wd),
 
     // from internal hardware
@@ -8404,7 +8056,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_68_we),
+    .we     (le_2_we),
     .wd     (le_2_le_68_wd),
 
     // from internal hardware
@@ -8430,7 +8082,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_69_we),
+    .we     (le_2_we),
     .wd     (le_2_le_69_wd),
 
     // from internal hardware
@@ -8456,7 +8108,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_70_we),
+    .we     (le_2_we),
     .wd     (le_2_le_70_wd),
 
     // from internal hardware
@@ -8482,7 +8134,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_71_we),
+    .we     (le_2_we),
     .wd     (le_2_le_71_wd),
 
     // from internal hardware
@@ -8508,7 +8160,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_72_we),
+    .we     (le_2_we),
     .wd     (le_2_le_72_wd),
 
     // from internal hardware
@@ -8534,7 +8186,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_73_we),
+    .we     (le_2_we),
     .wd     (le_2_le_73_wd),
 
     // from internal hardware
@@ -8560,7 +8212,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_74_we),
+    .we     (le_2_we),
     .wd     (le_2_le_74_wd),
 
     // from internal hardware
@@ -8586,7 +8238,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_75_we),
+    .we     (le_2_we),
     .wd     (le_2_le_75_wd),
 
     // from internal hardware
@@ -8612,7 +8264,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_76_we),
+    .we     (le_2_we),
     .wd     (le_2_le_76_wd),
 
     // from internal hardware
@@ -8638,7 +8290,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_77_we),
+    .we     (le_2_we),
     .wd     (le_2_le_77_wd),
 
     // from internal hardware
@@ -8664,7 +8316,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_78_we),
+    .we     (le_2_we),
     .wd     (le_2_le_78_wd),
 
     // from internal hardware
@@ -8690,7 +8342,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_79_we),
+    .we     (le_2_we),
     .wd     (le_2_le_79_wd),
 
     // from internal hardware
@@ -8716,7 +8368,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_80_we),
+    .we     (le_2_we),
     .wd     (le_2_le_80_wd),
 
     // from internal hardware
@@ -8742,7 +8394,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_81_we),
+    .we     (le_2_we),
     .wd     (le_2_le_81_wd),
 
     // from internal hardware
@@ -8768,7 +8420,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_82_we),
+    .we     (le_2_we),
     .wd     (le_2_le_82_wd),
 
     // from internal hardware
@@ -8794,7 +8446,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_83_we),
+    .we     (le_2_we),
     .wd     (le_2_le_83_wd),
 
     // from internal hardware
@@ -8820,7 +8472,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_84_we),
+    .we     (le_2_we),
     .wd     (le_2_le_84_wd),
 
     // from internal hardware
@@ -8846,7 +8498,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_85_we),
+    .we     (le_2_we),
     .wd     (le_2_le_85_wd),
 
     // from internal hardware
@@ -8872,7 +8524,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_86_we),
+    .we     (le_2_we),
     .wd     (le_2_le_86_wd),
 
     // from internal hardware
@@ -8898,7 +8550,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_87_we),
+    .we     (le_2_we),
     .wd     (le_2_le_87_wd),
 
     // from internal hardware
@@ -8924,7 +8576,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_88_we),
+    .we     (le_2_we),
     .wd     (le_2_le_88_wd),
 
     // from internal hardware
@@ -8950,7 +8602,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_89_we),
+    .we     (le_2_we),
     .wd     (le_2_le_89_wd),
 
     // from internal hardware
@@ -8976,7 +8628,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_90_we),
+    .we     (le_2_we),
     .wd     (le_2_le_90_wd),
 
     // from internal hardware
@@ -9002,7 +8654,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_91_we),
+    .we     (le_2_we),
     .wd     (le_2_le_91_wd),
 
     // from internal hardware
@@ -9028,7 +8680,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_92_we),
+    .we     (le_2_we),
     .wd     (le_2_le_92_wd),
 
     // from internal hardware
@@ -9054,7 +8706,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_93_we),
+    .we     (le_2_we),
     .wd     (le_2_le_93_wd),
 
     // from internal hardware
@@ -9080,7 +8732,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_94_we),
+    .we     (le_2_we),
     .wd     (le_2_le_94_wd),
 
     // from internal hardware
@@ -9106,7 +8758,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_2_le_95_we),
+    .we     (le_2_we),
     .wd     (le_2_le_95_wd),
 
     // from internal hardware
@@ -9135,7 +8787,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_96_we),
+    .we     (le_3_we),
     .wd     (le_3_le_96_wd),
 
     // from internal hardware
@@ -9161,7 +8813,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_97_we),
+    .we     (le_3_we),
     .wd     (le_3_le_97_wd),
 
     // from internal hardware
@@ -9187,7 +8839,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_98_we),
+    .we     (le_3_we),
     .wd     (le_3_le_98_wd),
 
     // from internal hardware
@@ -9213,7 +8865,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_99_we),
+    .we     (le_3_we),
     .wd     (le_3_le_99_wd),
 
     // from internal hardware
@@ -9239,7 +8891,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_100_we),
+    .we     (le_3_we),
     .wd     (le_3_le_100_wd),
 
     // from internal hardware
@@ -9265,7 +8917,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_101_we),
+    .we     (le_3_we),
     .wd     (le_3_le_101_wd),
 
     // from internal hardware
@@ -9291,7 +8943,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_102_we),
+    .we     (le_3_we),
     .wd     (le_3_le_102_wd),
 
     // from internal hardware
@@ -9317,7 +8969,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_103_we),
+    .we     (le_3_we),
     .wd     (le_3_le_103_wd),
 
     // from internal hardware
@@ -9343,7 +8995,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_104_we),
+    .we     (le_3_we),
     .wd     (le_3_le_104_wd),
 
     // from internal hardware
@@ -9369,7 +9021,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_105_we),
+    .we     (le_3_we),
     .wd     (le_3_le_105_wd),
 
     // from internal hardware
@@ -9395,7 +9047,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_106_we),
+    .we     (le_3_we),
     .wd     (le_3_le_106_wd),
 
     // from internal hardware
@@ -9421,7 +9073,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_107_we),
+    .we     (le_3_we),
     .wd     (le_3_le_107_wd),
 
     // from internal hardware
@@ -9447,7 +9099,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_108_we),
+    .we     (le_3_we),
     .wd     (le_3_le_108_wd),
 
     // from internal hardware
@@ -9473,7 +9125,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_109_we),
+    .we     (le_3_we),
     .wd     (le_3_le_109_wd),
 
     // from internal hardware
@@ -9499,7 +9151,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_110_we),
+    .we     (le_3_we),
     .wd     (le_3_le_110_wd),
 
     // from internal hardware
@@ -9525,7 +9177,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_111_we),
+    .we     (le_3_we),
     .wd     (le_3_le_111_wd),
 
     // from internal hardware
@@ -9551,7 +9203,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_112_we),
+    .we     (le_3_we),
     .wd     (le_3_le_112_wd),
 
     // from internal hardware
@@ -9577,7 +9229,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_113_we),
+    .we     (le_3_we),
     .wd     (le_3_le_113_wd),
 
     // from internal hardware
@@ -9603,7 +9255,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_114_we),
+    .we     (le_3_we),
     .wd     (le_3_le_114_wd),
 
     // from internal hardware
@@ -9629,7 +9281,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_115_we),
+    .we     (le_3_we),
     .wd     (le_3_le_115_wd),
 
     // from internal hardware
@@ -9655,7 +9307,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_116_we),
+    .we     (le_3_we),
     .wd     (le_3_le_116_wd),
 
     // from internal hardware
@@ -9681,7 +9333,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_117_we),
+    .we     (le_3_we),
     .wd     (le_3_le_117_wd),
 
     // from internal hardware
@@ -9707,7 +9359,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_118_we),
+    .we     (le_3_we),
     .wd     (le_3_le_118_wd),
 
     // from internal hardware
@@ -9733,7 +9385,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_119_we),
+    .we     (le_3_we),
     .wd     (le_3_le_119_wd),
 
     // from internal hardware
@@ -9759,7 +9411,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_120_we),
+    .we     (le_3_we),
     .wd     (le_3_le_120_wd),
 
     // from internal hardware
@@ -9785,7 +9437,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_121_we),
+    .we     (le_3_we),
     .wd     (le_3_le_121_wd),
 
     // from internal hardware
@@ -9811,7 +9463,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_122_we),
+    .we     (le_3_we),
     .wd     (le_3_le_122_wd),
 
     // from internal hardware
@@ -9837,7 +9489,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_123_we),
+    .we     (le_3_we),
     .wd     (le_3_le_123_wd),
 
     // from internal hardware
@@ -9863,7 +9515,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_124_we),
+    .we     (le_3_we),
     .wd     (le_3_le_124_wd),
 
     // from internal hardware
@@ -9889,7 +9541,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_125_we),
+    .we     (le_3_we),
     .wd     (le_3_le_125_wd),
 
     // from internal hardware
@@ -9915,7 +9567,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_126_we),
+    .we     (le_3_we),
     .wd     (le_3_le_126_wd),
 
     // from internal hardware
@@ -9941,7 +9593,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_3_le_127_we),
+    .we     (le_3_we),
     .wd     (le_3_le_127_wd),
 
     // from internal hardware
@@ -9970,7 +9622,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_128_we),
+    .we     (le_4_we),
     .wd     (le_4_le_128_wd),
 
     // from internal hardware
@@ -9996,7 +9648,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_129_we),
+    .we     (le_4_we),
     .wd     (le_4_le_129_wd),
 
     // from internal hardware
@@ -10022,7 +9674,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_130_we),
+    .we     (le_4_we),
     .wd     (le_4_le_130_wd),
 
     // from internal hardware
@@ -10048,7 +9700,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_131_we),
+    .we     (le_4_we),
     .wd     (le_4_le_131_wd),
 
     // from internal hardware
@@ -10074,7 +9726,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_132_we),
+    .we     (le_4_we),
     .wd     (le_4_le_132_wd),
 
     // from internal hardware
@@ -10100,7 +9752,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_133_we),
+    .we     (le_4_we),
     .wd     (le_4_le_133_wd),
 
     // from internal hardware
@@ -10126,7 +9778,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_134_we),
+    .we     (le_4_we),
     .wd     (le_4_le_134_wd),
 
     // from internal hardware
@@ -10152,7 +9804,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_135_we),
+    .we     (le_4_we),
     .wd     (le_4_le_135_wd),
 
     // from internal hardware
@@ -10178,7 +9830,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_136_we),
+    .we     (le_4_we),
     .wd     (le_4_le_136_wd),
 
     // from internal hardware
@@ -10204,7 +9856,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_137_we),
+    .we     (le_4_we),
     .wd     (le_4_le_137_wd),
 
     // from internal hardware
@@ -10230,7 +9882,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_138_we),
+    .we     (le_4_we),
     .wd     (le_4_le_138_wd),
 
     // from internal hardware
@@ -10256,7 +9908,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_139_we),
+    .we     (le_4_we),
     .wd     (le_4_le_139_wd),
 
     // from internal hardware
@@ -10282,7 +9934,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_140_we),
+    .we     (le_4_we),
     .wd     (le_4_le_140_wd),
 
     // from internal hardware
@@ -10308,7 +9960,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_141_we),
+    .we     (le_4_we),
     .wd     (le_4_le_141_wd),
 
     // from internal hardware
@@ -10334,7 +9986,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_142_we),
+    .we     (le_4_we),
     .wd     (le_4_le_142_wd),
 
     // from internal hardware
@@ -10360,7 +10012,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_143_we),
+    .we     (le_4_we),
     .wd     (le_4_le_143_wd),
 
     // from internal hardware
@@ -10386,7 +10038,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_144_we),
+    .we     (le_4_we),
     .wd     (le_4_le_144_wd),
 
     // from internal hardware
@@ -10412,7 +10064,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_145_we),
+    .we     (le_4_we),
     .wd     (le_4_le_145_wd),
 
     // from internal hardware
@@ -10438,7 +10090,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_146_we),
+    .we     (le_4_we),
     .wd     (le_4_le_146_wd),
 
     // from internal hardware
@@ -10464,7 +10116,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_147_we),
+    .we     (le_4_we),
     .wd     (le_4_le_147_wd),
 
     // from internal hardware
@@ -10490,7 +10142,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_148_we),
+    .we     (le_4_we),
     .wd     (le_4_le_148_wd),
 
     // from internal hardware
@@ -10516,7 +10168,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_149_we),
+    .we     (le_4_we),
     .wd     (le_4_le_149_wd),
 
     // from internal hardware
@@ -10542,7 +10194,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_150_we),
+    .we     (le_4_we),
     .wd     (le_4_le_150_wd),
 
     // from internal hardware
@@ -10568,7 +10220,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_151_we),
+    .we     (le_4_we),
     .wd     (le_4_le_151_wd),
 
     // from internal hardware
@@ -10594,7 +10246,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_152_we),
+    .we     (le_4_we),
     .wd     (le_4_le_152_wd),
 
     // from internal hardware
@@ -10620,7 +10272,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_153_we),
+    .we     (le_4_we),
     .wd     (le_4_le_153_wd),
 
     // from internal hardware
@@ -10646,7 +10298,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_154_we),
+    .we     (le_4_we),
     .wd     (le_4_le_154_wd),
 
     // from internal hardware
@@ -10672,7 +10324,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_155_we),
+    .we     (le_4_we),
     .wd     (le_4_le_155_wd),
 
     // from internal hardware
@@ -10698,7 +10350,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_156_we),
+    .we     (le_4_we),
     .wd     (le_4_le_156_wd),
 
     // from internal hardware
@@ -10724,7 +10376,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_157_we),
+    .we     (le_4_we),
     .wd     (le_4_le_157_wd),
 
     // from internal hardware
@@ -10750,7 +10402,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_158_we),
+    .we     (le_4_we),
     .wd     (le_4_le_158_wd),
 
     // from internal hardware
@@ -10776,7 +10428,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_4_le_159_we),
+    .we     (le_4_we),
     .wd     (le_4_le_159_wd),
 
     // from internal hardware
@@ -10805,7 +10457,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_160_we),
+    .we     (le_5_we),
     .wd     (le_5_le_160_wd),
 
     // from internal hardware
@@ -10831,7 +10483,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_161_we),
+    .we     (le_5_we),
     .wd     (le_5_le_161_wd),
 
     // from internal hardware
@@ -10857,7 +10509,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_162_we),
+    .we     (le_5_we),
     .wd     (le_5_le_162_wd),
 
     // from internal hardware
@@ -10883,7 +10535,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_163_we),
+    .we     (le_5_we),
     .wd     (le_5_le_163_wd),
 
     // from internal hardware
@@ -10909,7 +10561,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_164_we),
+    .we     (le_5_we),
     .wd     (le_5_le_164_wd),
 
     // from internal hardware
@@ -10935,7 +10587,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_165_we),
+    .we     (le_5_we),
     .wd     (le_5_le_165_wd),
 
     // from internal hardware
@@ -10961,7 +10613,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_166_we),
+    .we     (le_5_we),
     .wd     (le_5_le_166_wd),
 
     // from internal hardware
@@ -10987,7 +10639,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_167_we),
+    .we     (le_5_we),
     .wd     (le_5_le_167_wd),
 
     // from internal hardware
@@ -11013,7 +10665,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_168_we),
+    .we     (le_5_we),
     .wd     (le_5_le_168_wd),
 
     // from internal hardware
@@ -11039,7 +10691,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_169_we),
+    .we     (le_5_we),
     .wd     (le_5_le_169_wd),
 
     // from internal hardware
@@ -11065,7 +10717,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_170_we),
+    .we     (le_5_we),
     .wd     (le_5_le_170_wd),
 
     // from internal hardware
@@ -11091,7 +10743,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_171_we),
+    .we     (le_5_we),
     .wd     (le_5_le_171_wd),
 
     // from internal hardware
@@ -11117,7 +10769,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_172_we),
+    .we     (le_5_we),
     .wd     (le_5_le_172_wd),
 
     // from internal hardware
@@ -11143,7 +10795,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_173_we),
+    .we     (le_5_we),
     .wd     (le_5_le_173_wd),
 
     // from internal hardware
@@ -11169,7 +10821,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_174_we),
+    .we     (le_5_we),
     .wd     (le_5_le_174_wd),
 
     // from internal hardware
@@ -11195,7 +10847,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_175_we),
+    .we     (le_5_we),
     .wd     (le_5_le_175_wd),
 
     // from internal hardware
@@ -11221,7 +10873,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_176_we),
+    .we     (le_5_we),
     .wd     (le_5_le_176_wd),
 
     // from internal hardware
@@ -11247,7 +10899,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_177_we),
+    .we     (le_5_we),
     .wd     (le_5_le_177_wd),
 
     // from internal hardware
@@ -11273,7 +10925,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_178_we),
+    .we     (le_5_we),
     .wd     (le_5_le_178_wd),
 
     // from internal hardware
@@ -11299,7 +10951,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (le_5_le_179_we),
+    .we     (le_5_we),
     .wd     (le_5_le_179_wd),
 
     // from internal hardware
@@ -16190,7 +15842,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_0_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_0_wd),
 
     // from internal hardware
@@ -16216,7 +15868,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_1_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_1_wd),
 
     // from internal hardware
@@ -16242,7 +15894,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_2_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_2_wd),
 
     // from internal hardware
@@ -16268,7 +15920,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_3_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_3_wd),
 
     // from internal hardware
@@ -16294,7 +15946,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_4_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_4_wd),
 
     // from internal hardware
@@ -16320,7 +15972,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_5_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_5_wd),
 
     // from internal hardware
@@ -16346,7 +15998,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_6_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_6_wd),
 
     // from internal hardware
@@ -16372,7 +16024,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_7_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_7_wd),
 
     // from internal hardware
@@ -16398,7 +16050,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_8_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_8_wd),
 
     // from internal hardware
@@ -16424,7 +16076,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_9_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_9_wd),
 
     // from internal hardware
@@ -16450,7 +16102,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_10_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_10_wd),
 
     // from internal hardware
@@ -16476,7 +16128,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_11_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_11_wd),
 
     // from internal hardware
@@ -16502,7 +16154,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_12_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_12_wd),
 
     // from internal hardware
@@ -16528,7 +16180,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_13_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_13_wd),
 
     // from internal hardware
@@ -16554,7 +16206,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_14_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_14_wd),
 
     // from internal hardware
@@ -16580,7 +16232,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_15_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_15_wd),
 
     // from internal hardware
@@ -16606,7 +16258,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_16_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_16_wd),
 
     // from internal hardware
@@ -16632,7 +16284,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_17_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_17_wd),
 
     // from internal hardware
@@ -16658,7 +16310,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_18_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_18_wd),
 
     // from internal hardware
@@ -16684,7 +16336,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_19_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_19_wd),
 
     // from internal hardware
@@ -16710,7 +16362,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_20_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_20_wd),
 
     // from internal hardware
@@ -16736,7 +16388,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_21_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_21_wd),
 
     // from internal hardware
@@ -16762,7 +16414,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_22_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_22_wd),
 
     // from internal hardware
@@ -16788,7 +16440,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_23_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_23_wd),
 
     // from internal hardware
@@ -16814,7 +16466,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_24_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_24_wd),
 
     // from internal hardware
@@ -16840,7 +16492,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_25_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_25_wd),
 
     // from internal hardware
@@ -16866,7 +16518,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_26_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_26_wd),
 
     // from internal hardware
@@ -16892,7 +16544,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_27_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_27_wd),
 
     // from internal hardware
@@ -16918,7 +16570,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_28_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_28_wd),
 
     // from internal hardware
@@ -16944,7 +16596,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_29_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_29_wd),
 
     // from internal hardware
@@ -16970,7 +16622,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_30_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_30_wd),
 
     // from internal hardware
@@ -16996,7 +16648,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_0_e_31_we),
+    .we     (ie0_0_we),
     .wd     (ie0_0_e_31_wd),
 
     // from internal hardware
@@ -17025,7 +16677,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_32_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_32_wd),
 
     // from internal hardware
@@ -17051,7 +16703,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_33_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_33_wd),
 
     // from internal hardware
@@ -17077,7 +16729,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_34_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_34_wd),
 
     // from internal hardware
@@ -17103,7 +16755,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_35_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_35_wd),
 
     // from internal hardware
@@ -17129,7 +16781,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_36_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_36_wd),
 
     // from internal hardware
@@ -17155,7 +16807,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_37_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_37_wd),
 
     // from internal hardware
@@ -17181,7 +16833,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_38_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_38_wd),
 
     // from internal hardware
@@ -17207,7 +16859,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_39_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_39_wd),
 
     // from internal hardware
@@ -17233,7 +16885,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_40_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_40_wd),
 
     // from internal hardware
@@ -17259,7 +16911,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_41_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_41_wd),
 
     // from internal hardware
@@ -17285,7 +16937,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_42_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_42_wd),
 
     // from internal hardware
@@ -17311,7 +16963,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_43_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_43_wd),
 
     // from internal hardware
@@ -17337,7 +16989,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_44_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_44_wd),
 
     // from internal hardware
@@ -17363,7 +17015,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_45_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_45_wd),
 
     // from internal hardware
@@ -17389,7 +17041,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_46_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_46_wd),
 
     // from internal hardware
@@ -17415,7 +17067,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_47_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_47_wd),
 
     // from internal hardware
@@ -17441,7 +17093,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_48_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_48_wd),
 
     // from internal hardware
@@ -17467,7 +17119,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_49_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_49_wd),
 
     // from internal hardware
@@ -17493,7 +17145,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_50_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_50_wd),
 
     // from internal hardware
@@ -17519,7 +17171,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_51_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_51_wd),
 
     // from internal hardware
@@ -17545,7 +17197,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_52_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_52_wd),
 
     // from internal hardware
@@ -17571,7 +17223,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_53_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_53_wd),
 
     // from internal hardware
@@ -17597,7 +17249,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_54_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_54_wd),
 
     // from internal hardware
@@ -17623,7 +17275,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_55_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_55_wd),
 
     // from internal hardware
@@ -17649,7 +17301,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_56_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_56_wd),
 
     // from internal hardware
@@ -17675,7 +17327,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_57_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_57_wd),
 
     // from internal hardware
@@ -17701,7 +17353,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_58_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_58_wd),
 
     // from internal hardware
@@ -17727,7 +17379,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_59_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_59_wd),
 
     // from internal hardware
@@ -17753,7 +17405,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_60_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_60_wd),
 
     // from internal hardware
@@ -17779,7 +17431,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_61_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_61_wd),
 
     // from internal hardware
@@ -17805,7 +17457,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_62_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_62_wd),
 
     // from internal hardware
@@ -17831,7 +17483,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_1_e_63_we),
+    .we     (ie0_1_we),
     .wd     (ie0_1_e_63_wd),
 
     // from internal hardware
@@ -17860,7 +17512,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_64_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_64_wd),
 
     // from internal hardware
@@ -17886,7 +17538,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_65_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_65_wd),
 
     // from internal hardware
@@ -17912,7 +17564,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_66_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_66_wd),
 
     // from internal hardware
@@ -17938,7 +17590,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_67_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_67_wd),
 
     // from internal hardware
@@ -17964,7 +17616,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_68_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_68_wd),
 
     // from internal hardware
@@ -17990,7 +17642,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_69_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_69_wd),
 
     // from internal hardware
@@ -18016,7 +17668,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_70_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_70_wd),
 
     // from internal hardware
@@ -18042,7 +17694,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_71_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_71_wd),
 
     // from internal hardware
@@ -18068,7 +17720,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_72_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_72_wd),
 
     // from internal hardware
@@ -18094,7 +17746,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_73_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_73_wd),
 
     // from internal hardware
@@ -18120,7 +17772,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_74_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_74_wd),
 
     // from internal hardware
@@ -18146,7 +17798,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_75_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_75_wd),
 
     // from internal hardware
@@ -18172,7 +17824,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_76_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_76_wd),
 
     // from internal hardware
@@ -18198,7 +17850,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_77_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_77_wd),
 
     // from internal hardware
@@ -18224,7 +17876,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_78_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_78_wd),
 
     // from internal hardware
@@ -18250,7 +17902,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_79_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_79_wd),
 
     // from internal hardware
@@ -18276,7 +17928,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_80_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_80_wd),
 
     // from internal hardware
@@ -18302,7 +17954,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_81_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_81_wd),
 
     // from internal hardware
@@ -18328,7 +17980,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_82_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_82_wd),
 
     // from internal hardware
@@ -18354,7 +18006,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_83_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_83_wd),
 
     // from internal hardware
@@ -18380,7 +18032,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_84_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_84_wd),
 
     // from internal hardware
@@ -18406,7 +18058,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_85_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_85_wd),
 
     // from internal hardware
@@ -18432,7 +18084,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_86_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_86_wd),
 
     // from internal hardware
@@ -18458,7 +18110,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_87_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_87_wd),
 
     // from internal hardware
@@ -18484,7 +18136,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_88_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_88_wd),
 
     // from internal hardware
@@ -18510,7 +18162,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_89_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_89_wd),
 
     // from internal hardware
@@ -18536,7 +18188,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_90_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_90_wd),
 
     // from internal hardware
@@ -18562,7 +18214,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_91_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_91_wd),
 
     // from internal hardware
@@ -18588,7 +18240,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_92_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_92_wd),
 
     // from internal hardware
@@ -18614,7 +18266,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_93_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_93_wd),
 
     // from internal hardware
@@ -18640,7 +18292,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_94_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_94_wd),
 
     // from internal hardware
@@ -18666,7 +18318,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_2_e_95_we),
+    .we     (ie0_2_we),
     .wd     (ie0_2_e_95_wd),
 
     // from internal hardware
@@ -18695,7 +18347,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_96_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_96_wd),
 
     // from internal hardware
@@ -18721,7 +18373,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_97_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_97_wd),
 
     // from internal hardware
@@ -18747,7 +18399,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_98_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_98_wd),
 
     // from internal hardware
@@ -18773,7 +18425,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_99_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_99_wd),
 
     // from internal hardware
@@ -18799,7 +18451,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_100_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_100_wd),
 
     // from internal hardware
@@ -18825,7 +18477,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_101_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_101_wd),
 
     // from internal hardware
@@ -18851,7 +18503,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_102_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_102_wd),
 
     // from internal hardware
@@ -18877,7 +18529,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_103_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_103_wd),
 
     // from internal hardware
@@ -18903,7 +18555,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_104_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_104_wd),
 
     // from internal hardware
@@ -18929,7 +18581,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_105_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_105_wd),
 
     // from internal hardware
@@ -18955,7 +18607,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_106_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_106_wd),
 
     // from internal hardware
@@ -18981,7 +18633,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_107_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_107_wd),
 
     // from internal hardware
@@ -19007,7 +18659,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_108_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_108_wd),
 
     // from internal hardware
@@ -19033,7 +18685,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_109_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_109_wd),
 
     // from internal hardware
@@ -19059,7 +18711,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_110_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_110_wd),
 
     // from internal hardware
@@ -19085,7 +18737,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_111_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_111_wd),
 
     // from internal hardware
@@ -19111,7 +18763,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_112_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_112_wd),
 
     // from internal hardware
@@ -19137,7 +18789,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_113_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_113_wd),
 
     // from internal hardware
@@ -19163,7 +18815,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_114_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_114_wd),
 
     // from internal hardware
@@ -19189,7 +18841,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_115_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_115_wd),
 
     // from internal hardware
@@ -19215,7 +18867,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_116_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_116_wd),
 
     // from internal hardware
@@ -19241,7 +18893,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_117_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_117_wd),
 
     // from internal hardware
@@ -19267,7 +18919,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_118_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_118_wd),
 
     // from internal hardware
@@ -19293,7 +18945,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_119_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_119_wd),
 
     // from internal hardware
@@ -19319,7 +18971,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_120_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_120_wd),
 
     // from internal hardware
@@ -19345,7 +18997,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_121_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_121_wd),
 
     // from internal hardware
@@ -19371,7 +19023,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_122_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_122_wd),
 
     // from internal hardware
@@ -19397,7 +19049,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_123_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_123_wd),
 
     // from internal hardware
@@ -19423,7 +19075,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_124_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_124_wd),
 
     // from internal hardware
@@ -19449,7 +19101,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_125_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_125_wd),
 
     // from internal hardware
@@ -19475,7 +19127,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_126_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_126_wd),
 
     // from internal hardware
@@ -19501,7 +19153,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_3_e_127_we),
+    .we     (ie0_3_we),
     .wd     (ie0_3_e_127_wd),
 
     // from internal hardware
@@ -19530,7 +19182,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_128_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_128_wd),
 
     // from internal hardware
@@ -19556,7 +19208,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_129_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_129_wd),
 
     // from internal hardware
@@ -19582,7 +19234,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_130_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_130_wd),
 
     // from internal hardware
@@ -19608,7 +19260,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_131_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_131_wd),
 
     // from internal hardware
@@ -19634,7 +19286,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_132_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_132_wd),
 
     // from internal hardware
@@ -19660,7 +19312,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_133_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_133_wd),
 
     // from internal hardware
@@ -19686,7 +19338,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_134_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_134_wd),
 
     // from internal hardware
@@ -19712,7 +19364,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_135_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_135_wd),
 
     // from internal hardware
@@ -19738,7 +19390,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_136_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_136_wd),
 
     // from internal hardware
@@ -19764,7 +19416,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_137_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_137_wd),
 
     // from internal hardware
@@ -19790,7 +19442,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_138_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_138_wd),
 
     // from internal hardware
@@ -19816,7 +19468,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_139_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_139_wd),
 
     // from internal hardware
@@ -19842,7 +19494,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_140_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_140_wd),
 
     // from internal hardware
@@ -19868,7 +19520,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_141_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_141_wd),
 
     // from internal hardware
@@ -19894,7 +19546,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_142_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_142_wd),
 
     // from internal hardware
@@ -19920,7 +19572,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_143_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_143_wd),
 
     // from internal hardware
@@ -19946,7 +19598,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_144_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_144_wd),
 
     // from internal hardware
@@ -19972,7 +19624,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_145_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_145_wd),
 
     // from internal hardware
@@ -19998,7 +19650,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_146_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_146_wd),
 
     // from internal hardware
@@ -20024,7 +19676,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_147_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_147_wd),
 
     // from internal hardware
@@ -20050,7 +19702,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_148_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_148_wd),
 
     // from internal hardware
@@ -20076,7 +19728,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_149_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_149_wd),
 
     // from internal hardware
@@ -20102,7 +19754,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_150_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_150_wd),
 
     // from internal hardware
@@ -20128,7 +19780,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_151_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_151_wd),
 
     // from internal hardware
@@ -20154,7 +19806,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_152_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_152_wd),
 
     // from internal hardware
@@ -20180,7 +19832,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_153_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_153_wd),
 
     // from internal hardware
@@ -20206,7 +19858,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_154_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_154_wd),
 
     // from internal hardware
@@ -20232,7 +19884,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_155_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_155_wd),
 
     // from internal hardware
@@ -20258,7 +19910,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_156_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_156_wd),
 
     // from internal hardware
@@ -20284,7 +19936,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_157_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_157_wd),
 
     // from internal hardware
@@ -20310,7 +19962,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_158_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_158_wd),
 
     // from internal hardware
@@ -20336,7 +19988,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_4_e_159_we),
+    .we     (ie0_4_we),
     .wd     (ie0_4_e_159_wd),
 
     // from internal hardware
@@ -20365,7 +20017,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_160_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_160_wd),
 
     // from internal hardware
@@ -20391,7 +20043,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_161_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_161_wd),
 
     // from internal hardware
@@ -20417,7 +20069,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_162_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_162_wd),
 
     // from internal hardware
@@ -20443,7 +20095,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_163_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_163_wd),
 
     // from internal hardware
@@ -20469,7 +20121,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_164_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_164_wd),
 
     // from internal hardware
@@ -20495,7 +20147,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_165_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_165_wd),
 
     // from internal hardware
@@ -20521,7 +20173,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_166_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_166_wd),
 
     // from internal hardware
@@ -20547,7 +20199,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_167_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_167_wd),
 
     // from internal hardware
@@ -20573,7 +20225,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_168_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_168_wd),
 
     // from internal hardware
@@ -20599,7 +20251,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_169_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_169_wd),
 
     // from internal hardware
@@ -20625,7 +20277,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_170_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_170_wd),
 
     // from internal hardware
@@ -20651,7 +20303,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_171_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_171_wd),
 
     // from internal hardware
@@ -20677,7 +20329,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_172_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_172_wd),
 
     // from internal hardware
@@ -20703,7 +20355,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_173_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_173_wd),
 
     // from internal hardware
@@ -20729,7 +20381,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_174_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_174_wd),
 
     // from internal hardware
@@ -20755,7 +20407,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_175_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_175_wd),
 
     // from internal hardware
@@ -20781,7 +20433,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_176_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_176_wd),
 
     // from internal hardware
@@ -20807,7 +20459,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_177_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_177_wd),
 
     // from internal hardware
@@ -20833,7 +20485,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_178_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_178_wd),
 
     // from internal hardware
@@ -20859,7 +20511,7 @@ module rv_plic_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ie0_5_e_179_we),
+    .we     (ie0_5_we),
     .wd     (ie0_5_e_179_wd),
 
     // from internal hardware
@@ -21361,1635 +21013,1287 @@ module rv_plic_reg_top (
                (addr_hit[199] & (|(RV_PLIC_PERMIT[199] & ~reg_be))) |
                (addr_hit[200] & (|(RV_PLIC_PERMIT[200] & ~reg_be)))));
   end
+  assign le_0_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign le_0_le_0_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_0_wd = reg_wdata[0];
 
-  assign le_0_le_1_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_1_wd = reg_wdata[1];
 
-  assign le_0_le_2_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_2_wd = reg_wdata[2];
 
-  assign le_0_le_3_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_3_wd = reg_wdata[3];
 
-  assign le_0_le_4_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_4_wd = reg_wdata[4];
 
-  assign le_0_le_5_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_5_wd = reg_wdata[5];
 
-  assign le_0_le_6_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_6_wd = reg_wdata[6];
 
-  assign le_0_le_7_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_7_wd = reg_wdata[7];
 
-  assign le_0_le_8_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_8_wd = reg_wdata[8];
 
-  assign le_0_le_9_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_9_wd = reg_wdata[9];
 
-  assign le_0_le_10_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_10_wd = reg_wdata[10];
 
-  assign le_0_le_11_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_11_wd = reg_wdata[11];
 
-  assign le_0_le_12_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_12_wd = reg_wdata[12];
 
-  assign le_0_le_13_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_13_wd = reg_wdata[13];
 
-  assign le_0_le_14_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_14_wd = reg_wdata[14];
 
-  assign le_0_le_15_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_15_wd = reg_wdata[15];
 
-  assign le_0_le_16_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_16_wd = reg_wdata[16];
 
-  assign le_0_le_17_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_17_wd = reg_wdata[17];
 
-  assign le_0_le_18_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_18_wd = reg_wdata[18];
 
-  assign le_0_le_19_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_19_wd = reg_wdata[19];
 
-  assign le_0_le_20_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_20_wd = reg_wdata[20];
 
-  assign le_0_le_21_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_21_wd = reg_wdata[21];
 
-  assign le_0_le_22_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_22_wd = reg_wdata[22];
 
-  assign le_0_le_23_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_23_wd = reg_wdata[23];
 
-  assign le_0_le_24_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_24_wd = reg_wdata[24];
 
-  assign le_0_le_25_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_25_wd = reg_wdata[25];
 
-  assign le_0_le_26_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_26_wd = reg_wdata[26];
 
-  assign le_0_le_27_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_27_wd = reg_wdata[27];
 
-  assign le_0_le_28_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_28_wd = reg_wdata[28];
 
-  assign le_0_le_29_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_29_wd = reg_wdata[29];
 
-  assign le_0_le_30_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_30_wd = reg_wdata[30];
 
-  assign le_0_le_31_we = addr_hit[6] & reg_we & !reg_error;
   assign le_0_le_31_wd = reg_wdata[31];
+  assign le_1_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign le_1_le_32_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_32_wd = reg_wdata[0];
 
-  assign le_1_le_33_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_33_wd = reg_wdata[1];
 
-  assign le_1_le_34_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_34_wd = reg_wdata[2];
 
-  assign le_1_le_35_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_35_wd = reg_wdata[3];
 
-  assign le_1_le_36_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_36_wd = reg_wdata[4];
 
-  assign le_1_le_37_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_37_wd = reg_wdata[5];
 
-  assign le_1_le_38_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_38_wd = reg_wdata[6];
 
-  assign le_1_le_39_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_39_wd = reg_wdata[7];
 
-  assign le_1_le_40_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_40_wd = reg_wdata[8];
 
-  assign le_1_le_41_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_41_wd = reg_wdata[9];
 
-  assign le_1_le_42_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_42_wd = reg_wdata[10];
 
-  assign le_1_le_43_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_43_wd = reg_wdata[11];
 
-  assign le_1_le_44_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_44_wd = reg_wdata[12];
 
-  assign le_1_le_45_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_45_wd = reg_wdata[13];
 
-  assign le_1_le_46_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_46_wd = reg_wdata[14];
 
-  assign le_1_le_47_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_47_wd = reg_wdata[15];
 
-  assign le_1_le_48_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_48_wd = reg_wdata[16];
 
-  assign le_1_le_49_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_49_wd = reg_wdata[17];
 
-  assign le_1_le_50_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_50_wd = reg_wdata[18];
 
-  assign le_1_le_51_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_51_wd = reg_wdata[19];
 
-  assign le_1_le_52_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_52_wd = reg_wdata[20];
 
-  assign le_1_le_53_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_53_wd = reg_wdata[21];
 
-  assign le_1_le_54_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_54_wd = reg_wdata[22];
 
-  assign le_1_le_55_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_55_wd = reg_wdata[23];
 
-  assign le_1_le_56_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_56_wd = reg_wdata[24];
 
-  assign le_1_le_57_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_57_wd = reg_wdata[25];
 
-  assign le_1_le_58_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_58_wd = reg_wdata[26];
 
-  assign le_1_le_59_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_59_wd = reg_wdata[27];
 
-  assign le_1_le_60_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_60_wd = reg_wdata[28];
 
-  assign le_1_le_61_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_61_wd = reg_wdata[29];
 
-  assign le_1_le_62_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_62_wd = reg_wdata[30];
 
-  assign le_1_le_63_we = addr_hit[7] & reg_we & !reg_error;
   assign le_1_le_63_wd = reg_wdata[31];
+  assign le_2_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign le_2_le_64_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_64_wd = reg_wdata[0];
 
-  assign le_2_le_65_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_65_wd = reg_wdata[1];
 
-  assign le_2_le_66_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_66_wd = reg_wdata[2];
 
-  assign le_2_le_67_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_67_wd = reg_wdata[3];
 
-  assign le_2_le_68_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_68_wd = reg_wdata[4];
 
-  assign le_2_le_69_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_69_wd = reg_wdata[5];
 
-  assign le_2_le_70_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_70_wd = reg_wdata[6];
 
-  assign le_2_le_71_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_71_wd = reg_wdata[7];
 
-  assign le_2_le_72_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_72_wd = reg_wdata[8];
 
-  assign le_2_le_73_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_73_wd = reg_wdata[9];
 
-  assign le_2_le_74_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_74_wd = reg_wdata[10];
 
-  assign le_2_le_75_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_75_wd = reg_wdata[11];
 
-  assign le_2_le_76_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_76_wd = reg_wdata[12];
 
-  assign le_2_le_77_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_77_wd = reg_wdata[13];
 
-  assign le_2_le_78_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_78_wd = reg_wdata[14];
 
-  assign le_2_le_79_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_79_wd = reg_wdata[15];
 
-  assign le_2_le_80_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_80_wd = reg_wdata[16];
 
-  assign le_2_le_81_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_81_wd = reg_wdata[17];
 
-  assign le_2_le_82_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_82_wd = reg_wdata[18];
 
-  assign le_2_le_83_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_83_wd = reg_wdata[19];
 
-  assign le_2_le_84_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_84_wd = reg_wdata[20];
 
-  assign le_2_le_85_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_85_wd = reg_wdata[21];
 
-  assign le_2_le_86_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_86_wd = reg_wdata[22];
 
-  assign le_2_le_87_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_87_wd = reg_wdata[23];
 
-  assign le_2_le_88_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_88_wd = reg_wdata[24];
 
-  assign le_2_le_89_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_89_wd = reg_wdata[25];
 
-  assign le_2_le_90_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_90_wd = reg_wdata[26];
 
-  assign le_2_le_91_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_91_wd = reg_wdata[27];
 
-  assign le_2_le_92_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_92_wd = reg_wdata[28];
 
-  assign le_2_le_93_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_93_wd = reg_wdata[29];
 
-  assign le_2_le_94_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_94_wd = reg_wdata[30];
 
-  assign le_2_le_95_we = addr_hit[8] & reg_we & !reg_error;
   assign le_2_le_95_wd = reg_wdata[31];
+  assign le_3_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign le_3_le_96_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_96_wd = reg_wdata[0];
 
-  assign le_3_le_97_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_97_wd = reg_wdata[1];
 
-  assign le_3_le_98_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_98_wd = reg_wdata[2];
 
-  assign le_3_le_99_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_99_wd = reg_wdata[3];
 
-  assign le_3_le_100_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_100_wd = reg_wdata[4];
 
-  assign le_3_le_101_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_101_wd = reg_wdata[5];
 
-  assign le_3_le_102_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_102_wd = reg_wdata[6];
 
-  assign le_3_le_103_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_103_wd = reg_wdata[7];
 
-  assign le_3_le_104_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_104_wd = reg_wdata[8];
 
-  assign le_3_le_105_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_105_wd = reg_wdata[9];
 
-  assign le_3_le_106_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_106_wd = reg_wdata[10];
 
-  assign le_3_le_107_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_107_wd = reg_wdata[11];
 
-  assign le_3_le_108_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_108_wd = reg_wdata[12];
 
-  assign le_3_le_109_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_109_wd = reg_wdata[13];
 
-  assign le_3_le_110_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_110_wd = reg_wdata[14];
 
-  assign le_3_le_111_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_111_wd = reg_wdata[15];
 
-  assign le_3_le_112_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_112_wd = reg_wdata[16];
 
-  assign le_3_le_113_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_113_wd = reg_wdata[17];
 
-  assign le_3_le_114_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_114_wd = reg_wdata[18];
 
-  assign le_3_le_115_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_115_wd = reg_wdata[19];
 
-  assign le_3_le_116_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_116_wd = reg_wdata[20];
 
-  assign le_3_le_117_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_117_wd = reg_wdata[21];
 
-  assign le_3_le_118_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_118_wd = reg_wdata[22];
 
-  assign le_3_le_119_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_119_wd = reg_wdata[23];
 
-  assign le_3_le_120_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_120_wd = reg_wdata[24];
 
-  assign le_3_le_121_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_121_wd = reg_wdata[25];
 
-  assign le_3_le_122_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_122_wd = reg_wdata[26];
 
-  assign le_3_le_123_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_123_wd = reg_wdata[27];
 
-  assign le_3_le_124_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_124_wd = reg_wdata[28];
 
-  assign le_3_le_125_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_125_wd = reg_wdata[29];
 
-  assign le_3_le_126_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_126_wd = reg_wdata[30];
 
-  assign le_3_le_127_we = addr_hit[9] & reg_we & !reg_error;
   assign le_3_le_127_wd = reg_wdata[31];
+  assign le_4_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign le_4_le_128_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_128_wd = reg_wdata[0];
 
-  assign le_4_le_129_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_129_wd = reg_wdata[1];
 
-  assign le_4_le_130_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_130_wd = reg_wdata[2];
 
-  assign le_4_le_131_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_131_wd = reg_wdata[3];
 
-  assign le_4_le_132_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_132_wd = reg_wdata[4];
 
-  assign le_4_le_133_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_133_wd = reg_wdata[5];
 
-  assign le_4_le_134_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_134_wd = reg_wdata[6];
 
-  assign le_4_le_135_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_135_wd = reg_wdata[7];
 
-  assign le_4_le_136_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_136_wd = reg_wdata[8];
 
-  assign le_4_le_137_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_137_wd = reg_wdata[9];
 
-  assign le_4_le_138_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_138_wd = reg_wdata[10];
 
-  assign le_4_le_139_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_139_wd = reg_wdata[11];
 
-  assign le_4_le_140_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_140_wd = reg_wdata[12];
 
-  assign le_4_le_141_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_141_wd = reg_wdata[13];
 
-  assign le_4_le_142_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_142_wd = reg_wdata[14];
 
-  assign le_4_le_143_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_143_wd = reg_wdata[15];
 
-  assign le_4_le_144_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_144_wd = reg_wdata[16];
 
-  assign le_4_le_145_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_145_wd = reg_wdata[17];
 
-  assign le_4_le_146_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_146_wd = reg_wdata[18];
 
-  assign le_4_le_147_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_147_wd = reg_wdata[19];
 
-  assign le_4_le_148_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_148_wd = reg_wdata[20];
 
-  assign le_4_le_149_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_149_wd = reg_wdata[21];
 
-  assign le_4_le_150_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_150_wd = reg_wdata[22];
 
-  assign le_4_le_151_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_151_wd = reg_wdata[23];
 
-  assign le_4_le_152_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_152_wd = reg_wdata[24];
 
-  assign le_4_le_153_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_153_wd = reg_wdata[25];
 
-  assign le_4_le_154_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_154_wd = reg_wdata[26];
 
-  assign le_4_le_155_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_155_wd = reg_wdata[27];
 
-  assign le_4_le_156_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_156_wd = reg_wdata[28];
 
-  assign le_4_le_157_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_157_wd = reg_wdata[29];
 
-  assign le_4_le_158_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_158_wd = reg_wdata[30];
 
-  assign le_4_le_159_we = addr_hit[10] & reg_we & !reg_error;
   assign le_4_le_159_wd = reg_wdata[31];
+  assign le_5_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign le_5_le_160_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_160_wd = reg_wdata[0];
 
-  assign le_5_le_161_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_161_wd = reg_wdata[1];
 
-  assign le_5_le_162_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_162_wd = reg_wdata[2];
 
-  assign le_5_le_163_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_163_wd = reg_wdata[3];
 
-  assign le_5_le_164_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_164_wd = reg_wdata[4];
 
-  assign le_5_le_165_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_165_wd = reg_wdata[5];
 
-  assign le_5_le_166_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_166_wd = reg_wdata[6];
 
-  assign le_5_le_167_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_167_wd = reg_wdata[7];
 
-  assign le_5_le_168_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_168_wd = reg_wdata[8];
 
-  assign le_5_le_169_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_169_wd = reg_wdata[9];
 
-  assign le_5_le_170_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_170_wd = reg_wdata[10];
 
-  assign le_5_le_171_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_171_wd = reg_wdata[11];
 
-  assign le_5_le_172_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_172_wd = reg_wdata[12];
 
-  assign le_5_le_173_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_173_wd = reg_wdata[13];
 
-  assign le_5_le_174_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_174_wd = reg_wdata[14];
 
-  assign le_5_le_175_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_175_wd = reg_wdata[15];
 
-  assign le_5_le_176_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_176_wd = reg_wdata[16];
 
-  assign le_5_le_177_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_177_wd = reg_wdata[17];
 
-  assign le_5_le_178_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_178_wd = reg_wdata[18];
 
-  assign le_5_le_179_we = addr_hit[11] & reg_we & !reg_error;
   assign le_5_le_179_wd = reg_wdata[19];
-
   assign prio0_we = addr_hit[12] & reg_we & !reg_error;
+
   assign prio0_wd = reg_wdata[1:0];
-
   assign prio1_we = addr_hit[13] & reg_we & !reg_error;
+
   assign prio1_wd = reg_wdata[1:0];
-
   assign prio2_we = addr_hit[14] & reg_we & !reg_error;
+
   assign prio2_wd = reg_wdata[1:0];
-
   assign prio3_we = addr_hit[15] & reg_we & !reg_error;
+
   assign prio3_wd = reg_wdata[1:0];
-
   assign prio4_we = addr_hit[16] & reg_we & !reg_error;
+
   assign prio4_wd = reg_wdata[1:0];
-
   assign prio5_we = addr_hit[17] & reg_we & !reg_error;
+
   assign prio5_wd = reg_wdata[1:0];
-
   assign prio6_we = addr_hit[18] & reg_we & !reg_error;
+
   assign prio6_wd = reg_wdata[1:0];
-
   assign prio7_we = addr_hit[19] & reg_we & !reg_error;
+
   assign prio7_wd = reg_wdata[1:0];
-
   assign prio8_we = addr_hit[20] & reg_we & !reg_error;
+
   assign prio8_wd = reg_wdata[1:0];
-
   assign prio9_we = addr_hit[21] & reg_we & !reg_error;
+
   assign prio9_wd = reg_wdata[1:0];
-
   assign prio10_we = addr_hit[22] & reg_we & !reg_error;
+
   assign prio10_wd = reg_wdata[1:0];
-
   assign prio11_we = addr_hit[23] & reg_we & !reg_error;
+
   assign prio11_wd = reg_wdata[1:0];
-
   assign prio12_we = addr_hit[24] & reg_we & !reg_error;
+
   assign prio12_wd = reg_wdata[1:0];
-
   assign prio13_we = addr_hit[25] & reg_we & !reg_error;
+
   assign prio13_wd = reg_wdata[1:0];
-
   assign prio14_we = addr_hit[26] & reg_we & !reg_error;
+
   assign prio14_wd = reg_wdata[1:0];
-
   assign prio15_we = addr_hit[27] & reg_we & !reg_error;
+
   assign prio15_wd = reg_wdata[1:0];
-
   assign prio16_we = addr_hit[28] & reg_we & !reg_error;
+
   assign prio16_wd = reg_wdata[1:0];
-
   assign prio17_we = addr_hit[29] & reg_we & !reg_error;
+
   assign prio17_wd = reg_wdata[1:0];
-
   assign prio18_we = addr_hit[30] & reg_we & !reg_error;
+
   assign prio18_wd = reg_wdata[1:0];
-
   assign prio19_we = addr_hit[31] & reg_we & !reg_error;
+
   assign prio19_wd = reg_wdata[1:0];
-
   assign prio20_we = addr_hit[32] & reg_we & !reg_error;
+
   assign prio20_wd = reg_wdata[1:0];
-
   assign prio21_we = addr_hit[33] & reg_we & !reg_error;
+
   assign prio21_wd = reg_wdata[1:0];
-
   assign prio22_we = addr_hit[34] & reg_we & !reg_error;
+
   assign prio22_wd = reg_wdata[1:0];
-
   assign prio23_we = addr_hit[35] & reg_we & !reg_error;
+
   assign prio23_wd = reg_wdata[1:0];
-
   assign prio24_we = addr_hit[36] & reg_we & !reg_error;
+
   assign prio24_wd = reg_wdata[1:0];
-
   assign prio25_we = addr_hit[37] & reg_we & !reg_error;
+
   assign prio25_wd = reg_wdata[1:0];
-
   assign prio26_we = addr_hit[38] & reg_we & !reg_error;
+
   assign prio26_wd = reg_wdata[1:0];
-
   assign prio27_we = addr_hit[39] & reg_we & !reg_error;
+
   assign prio27_wd = reg_wdata[1:0];
-
   assign prio28_we = addr_hit[40] & reg_we & !reg_error;
+
   assign prio28_wd = reg_wdata[1:0];
-
   assign prio29_we = addr_hit[41] & reg_we & !reg_error;
+
   assign prio29_wd = reg_wdata[1:0];
-
   assign prio30_we = addr_hit[42] & reg_we & !reg_error;
+
   assign prio30_wd = reg_wdata[1:0];
-
   assign prio31_we = addr_hit[43] & reg_we & !reg_error;
+
   assign prio31_wd = reg_wdata[1:0];
-
   assign prio32_we = addr_hit[44] & reg_we & !reg_error;
+
   assign prio32_wd = reg_wdata[1:0];
-
   assign prio33_we = addr_hit[45] & reg_we & !reg_error;
+
   assign prio33_wd = reg_wdata[1:0];
-
   assign prio34_we = addr_hit[46] & reg_we & !reg_error;
+
   assign prio34_wd = reg_wdata[1:0];
-
   assign prio35_we = addr_hit[47] & reg_we & !reg_error;
+
   assign prio35_wd = reg_wdata[1:0];
-
   assign prio36_we = addr_hit[48] & reg_we & !reg_error;
+
   assign prio36_wd = reg_wdata[1:0];
-
   assign prio37_we = addr_hit[49] & reg_we & !reg_error;
+
   assign prio37_wd = reg_wdata[1:0];
-
   assign prio38_we = addr_hit[50] & reg_we & !reg_error;
+
   assign prio38_wd = reg_wdata[1:0];
-
   assign prio39_we = addr_hit[51] & reg_we & !reg_error;
+
   assign prio39_wd = reg_wdata[1:0];
-
   assign prio40_we = addr_hit[52] & reg_we & !reg_error;
+
   assign prio40_wd = reg_wdata[1:0];
-
   assign prio41_we = addr_hit[53] & reg_we & !reg_error;
+
   assign prio41_wd = reg_wdata[1:0];
-
   assign prio42_we = addr_hit[54] & reg_we & !reg_error;
+
   assign prio42_wd = reg_wdata[1:0];
-
   assign prio43_we = addr_hit[55] & reg_we & !reg_error;
+
   assign prio43_wd = reg_wdata[1:0];
-
   assign prio44_we = addr_hit[56] & reg_we & !reg_error;
+
   assign prio44_wd = reg_wdata[1:0];
-
   assign prio45_we = addr_hit[57] & reg_we & !reg_error;
+
   assign prio45_wd = reg_wdata[1:0];
-
   assign prio46_we = addr_hit[58] & reg_we & !reg_error;
+
   assign prio46_wd = reg_wdata[1:0];
-
   assign prio47_we = addr_hit[59] & reg_we & !reg_error;
+
   assign prio47_wd = reg_wdata[1:0];
-
   assign prio48_we = addr_hit[60] & reg_we & !reg_error;
+
   assign prio48_wd = reg_wdata[1:0];
-
   assign prio49_we = addr_hit[61] & reg_we & !reg_error;
+
   assign prio49_wd = reg_wdata[1:0];
-
   assign prio50_we = addr_hit[62] & reg_we & !reg_error;
+
   assign prio50_wd = reg_wdata[1:0];
-
   assign prio51_we = addr_hit[63] & reg_we & !reg_error;
+
   assign prio51_wd = reg_wdata[1:0];
-
   assign prio52_we = addr_hit[64] & reg_we & !reg_error;
+
   assign prio52_wd = reg_wdata[1:0];
-
   assign prio53_we = addr_hit[65] & reg_we & !reg_error;
+
   assign prio53_wd = reg_wdata[1:0];
-
   assign prio54_we = addr_hit[66] & reg_we & !reg_error;
+
   assign prio54_wd = reg_wdata[1:0];
-
   assign prio55_we = addr_hit[67] & reg_we & !reg_error;
+
   assign prio55_wd = reg_wdata[1:0];
-
   assign prio56_we = addr_hit[68] & reg_we & !reg_error;
+
   assign prio56_wd = reg_wdata[1:0];
-
   assign prio57_we = addr_hit[69] & reg_we & !reg_error;
+
   assign prio57_wd = reg_wdata[1:0];
-
   assign prio58_we = addr_hit[70] & reg_we & !reg_error;
+
   assign prio58_wd = reg_wdata[1:0];
-
   assign prio59_we = addr_hit[71] & reg_we & !reg_error;
+
   assign prio59_wd = reg_wdata[1:0];
-
   assign prio60_we = addr_hit[72] & reg_we & !reg_error;
+
   assign prio60_wd = reg_wdata[1:0];
-
   assign prio61_we = addr_hit[73] & reg_we & !reg_error;
+
   assign prio61_wd = reg_wdata[1:0];
-
   assign prio62_we = addr_hit[74] & reg_we & !reg_error;
+
   assign prio62_wd = reg_wdata[1:0];
-
   assign prio63_we = addr_hit[75] & reg_we & !reg_error;
+
   assign prio63_wd = reg_wdata[1:0];
-
   assign prio64_we = addr_hit[76] & reg_we & !reg_error;
+
   assign prio64_wd = reg_wdata[1:0];
-
   assign prio65_we = addr_hit[77] & reg_we & !reg_error;
+
   assign prio65_wd = reg_wdata[1:0];
-
   assign prio66_we = addr_hit[78] & reg_we & !reg_error;
+
   assign prio66_wd = reg_wdata[1:0];
-
   assign prio67_we = addr_hit[79] & reg_we & !reg_error;
+
   assign prio67_wd = reg_wdata[1:0];
-
   assign prio68_we = addr_hit[80] & reg_we & !reg_error;
+
   assign prio68_wd = reg_wdata[1:0];
-
   assign prio69_we = addr_hit[81] & reg_we & !reg_error;
+
   assign prio69_wd = reg_wdata[1:0];
-
   assign prio70_we = addr_hit[82] & reg_we & !reg_error;
+
   assign prio70_wd = reg_wdata[1:0];
-
   assign prio71_we = addr_hit[83] & reg_we & !reg_error;
+
   assign prio71_wd = reg_wdata[1:0];
-
   assign prio72_we = addr_hit[84] & reg_we & !reg_error;
+
   assign prio72_wd = reg_wdata[1:0];
-
   assign prio73_we = addr_hit[85] & reg_we & !reg_error;
+
   assign prio73_wd = reg_wdata[1:0];
-
   assign prio74_we = addr_hit[86] & reg_we & !reg_error;
+
   assign prio74_wd = reg_wdata[1:0];
-
   assign prio75_we = addr_hit[87] & reg_we & !reg_error;
+
   assign prio75_wd = reg_wdata[1:0];
-
   assign prio76_we = addr_hit[88] & reg_we & !reg_error;
+
   assign prio76_wd = reg_wdata[1:0];
-
   assign prio77_we = addr_hit[89] & reg_we & !reg_error;
+
   assign prio77_wd = reg_wdata[1:0];
-
   assign prio78_we = addr_hit[90] & reg_we & !reg_error;
+
   assign prio78_wd = reg_wdata[1:0];
-
   assign prio79_we = addr_hit[91] & reg_we & !reg_error;
+
   assign prio79_wd = reg_wdata[1:0];
-
   assign prio80_we = addr_hit[92] & reg_we & !reg_error;
+
   assign prio80_wd = reg_wdata[1:0];
-
   assign prio81_we = addr_hit[93] & reg_we & !reg_error;
+
   assign prio81_wd = reg_wdata[1:0];
-
   assign prio82_we = addr_hit[94] & reg_we & !reg_error;
+
   assign prio82_wd = reg_wdata[1:0];
-
   assign prio83_we = addr_hit[95] & reg_we & !reg_error;
+
   assign prio83_wd = reg_wdata[1:0];
-
   assign prio84_we = addr_hit[96] & reg_we & !reg_error;
+
   assign prio84_wd = reg_wdata[1:0];
-
   assign prio85_we = addr_hit[97] & reg_we & !reg_error;
+
   assign prio85_wd = reg_wdata[1:0];
-
   assign prio86_we = addr_hit[98] & reg_we & !reg_error;
+
   assign prio86_wd = reg_wdata[1:0];
-
   assign prio87_we = addr_hit[99] & reg_we & !reg_error;
+
   assign prio87_wd = reg_wdata[1:0];
-
   assign prio88_we = addr_hit[100] & reg_we & !reg_error;
+
   assign prio88_wd = reg_wdata[1:0];
-
   assign prio89_we = addr_hit[101] & reg_we & !reg_error;
+
   assign prio89_wd = reg_wdata[1:0];
-
   assign prio90_we = addr_hit[102] & reg_we & !reg_error;
+
   assign prio90_wd = reg_wdata[1:0];
-
   assign prio91_we = addr_hit[103] & reg_we & !reg_error;
+
   assign prio91_wd = reg_wdata[1:0];
-
   assign prio92_we = addr_hit[104] & reg_we & !reg_error;
+
   assign prio92_wd = reg_wdata[1:0];
-
   assign prio93_we = addr_hit[105] & reg_we & !reg_error;
+
   assign prio93_wd = reg_wdata[1:0];
-
   assign prio94_we = addr_hit[106] & reg_we & !reg_error;
+
   assign prio94_wd = reg_wdata[1:0];
-
   assign prio95_we = addr_hit[107] & reg_we & !reg_error;
+
   assign prio95_wd = reg_wdata[1:0];
-
   assign prio96_we = addr_hit[108] & reg_we & !reg_error;
+
   assign prio96_wd = reg_wdata[1:0];
-
   assign prio97_we = addr_hit[109] & reg_we & !reg_error;
+
   assign prio97_wd = reg_wdata[1:0];
-
   assign prio98_we = addr_hit[110] & reg_we & !reg_error;
+
   assign prio98_wd = reg_wdata[1:0];
-
   assign prio99_we = addr_hit[111] & reg_we & !reg_error;
+
   assign prio99_wd = reg_wdata[1:0];
-
   assign prio100_we = addr_hit[112] & reg_we & !reg_error;
+
   assign prio100_wd = reg_wdata[1:0];
-
   assign prio101_we = addr_hit[113] & reg_we & !reg_error;
+
   assign prio101_wd = reg_wdata[1:0];
-
   assign prio102_we = addr_hit[114] & reg_we & !reg_error;
+
   assign prio102_wd = reg_wdata[1:0];
-
   assign prio103_we = addr_hit[115] & reg_we & !reg_error;
+
   assign prio103_wd = reg_wdata[1:0];
-
   assign prio104_we = addr_hit[116] & reg_we & !reg_error;
+
   assign prio104_wd = reg_wdata[1:0];
-
   assign prio105_we = addr_hit[117] & reg_we & !reg_error;
+
   assign prio105_wd = reg_wdata[1:0];
-
   assign prio106_we = addr_hit[118] & reg_we & !reg_error;
+
   assign prio106_wd = reg_wdata[1:0];
-
   assign prio107_we = addr_hit[119] & reg_we & !reg_error;
+
   assign prio107_wd = reg_wdata[1:0];
-
   assign prio108_we = addr_hit[120] & reg_we & !reg_error;
+
   assign prio108_wd = reg_wdata[1:0];
-
   assign prio109_we = addr_hit[121] & reg_we & !reg_error;
+
   assign prio109_wd = reg_wdata[1:0];
-
   assign prio110_we = addr_hit[122] & reg_we & !reg_error;
+
   assign prio110_wd = reg_wdata[1:0];
-
   assign prio111_we = addr_hit[123] & reg_we & !reg_error;
+
   assign prio111_wd = reg_wdata[1:0];
-
   assign prio112_we = addr_hit[124] & reg_we & !reg_error;
+
   assign prio112_wd = reg_wdata[1:0];
-
   assign prio113_we = addr_hit[125] & reg_we & !reg_error;
+
   assign prio113_wd = reg_wdata[1:0];
-
   assign prio114_we = addr_hit[126] & reg_we & !reg_error;
+
   assign prio114_wd = reg_wdata[1:0];
-
   assign prio115_we = addr_hit[127] & reg_we & !reg_error;
+
   assign prio115_wd = reg_wdata[1:0];
-
   assign prio116_we = addr_hit[128] & reg_we & !reg_error;
+
   assign prio116_wd = reg_wdata[1:0];
-
   assign prio117_we = addr_hit[129] & reg_we & !reg_error;
+
   assign prio117_wd = reg_wdata[1:0];
-
   assign prio118_we = addr_hit[130] & reg_we & !reg_error;
+
   assign prio118_wd = reg_wdata[1:0];
-
   assign prio119_we = addr_hit[131] & reg_we & !reg_error;
+
   assign prio119_wd = reg_wdata[1:0];
-
   assign prio120_we = addr_hit[132] & reg_we & !reg_error;
+
   assign prio120_wd = reg_wdata[1:0];
-
   assign prio121_we = addr_hit[133] & reg_we & !reg_error;
+
   assign prio121_wd = reg_wdata[1:0];
-
   assign prio122_we = addr_hit[134] & reg_we & !reg_error;
+
   assign prio122_wd = reg_wdata[1:0];
-
   assign prio123_we = addr_hit[135] & reg_we & !reg_error;
+
   assign prio123_wd = reg_wdata[1:0];
-
   assign prio124_we = addr_hit[136] & reg_we & !reg_error;
+
   assign prio124_wd = reg_wdata[1:0];
-
   assign prio125_we = addr_hit[137] & reg_we & !reg_error;
+
   assign prio125_wd = reg_wdata[1:0];
-
   assign prio126_we = addr_hit[138] & reg_we & !reg_error;
+
   assign prio126_wd = reg_wdata[1:0];
-
   assign prio127_we = addr_hit[139] & reg_we & !reg_error;
+
   assign prio127_wd = reg_wdata[1:0];
-
   assign prio128_we = addr_hit[140] & reg_we & !reg_error;
+
   assign prio128_wd = reg_wdata[1:0];
-
   assign prio129_we = addr_hit[141] & reg_we & !reg_error;
+
   assign prio129_wd = reg_wdata[1:0];
-
   assign prio130_we = addr_hit[142] & reg_we & !reg_error;
+
   assign prio130_wd = reg_wdata[1:0];
-
   assign prio131_we = addr_hit[143] & reg_we & !reg_error;
+
   assign prio131_wd = reg_wdata[1:0];
-
   assign prio132_we = addr_hit[144] & reg_we & !reg_error;
+
   assign prio132_wd = reg_wdata[1:0];
-
   assign prio133_we = addr_hit[145] & reg_we & !reg_error;
+
   assign prio133_wd = reg_wdata[1:0];
-
   assign prio134_we = addr_hit[146] & reg_we & !reg_error;
+
   assign prio134_wd = reg_wdata[1:0];
-
   assign prio135_we = addr_hit[147] & reg_we & !reg_error;
+
   assign prio135_wd = reg_wdata[1:0];
-
   assign prio136_we = addr_hit[148] & reg_we & !reg_error;
+
   assign prio136_wd = reg_wdata[1:0];
-
   assign prio137_we = addr_hit[149] & reg_we & !reg_error;
+
   assign prio137_wd = reg_wdata[1:0];
-
   assign prio138_we = addr_hit[150] & reg_we & !reg_error;
+
   assign prio138_wd = reg_wdata[1:0];
-
   assign prio139_we = addr_hit[151] & reg_we & !reg_error;
+
   assign prio139_wd = reg_wdata[1:0];
-
   assign prio140_we = addr_hit[152] & reg_we & !reg_error;
+
   assign prio140_wd = reg_wdata[1:0];
-
   assign prio141_we = addr_hit[153] & reg_we & !reg_error;
+
   assign prio141_wd = reg_wdata[1:0];
-
   assign prio142_we = addr_hit[154] & reg_we & !reg_error;
+
   assign prio142_wd = reg_wdata[1:0];
-
   assign prio143_we = addr_hit[155] & reg_we & !reg_error;
+
   assign prio143_wd = reg_wdata[1:0];
-
   assign prio144_we = addr_hit[156] & reg_we & !reg_error;
+
   assign prio144_wd = reg_wdata[1:0];
-
   assign prio145_we = addr_hit[157] & reg_we & !reg_error;
+
   assign prio145_wd = reg_wdata[1:0];
-
   assign prio146_we = addr_hit[158] & reg_we & !reg_error;
+
   assign prio146_wd = reg_wdata[1:0];
-
   assign prio147_we = addr_hit[159] & reg_we & !reg_error;
+
   assign prio147_wd = reg_wdata[1:0];
-
   assign prio148_we = addr_hit[160] & reg_we & !reg_error;
+
   assign prio148_wd = reg_wdata[1:0];
-
   assign prio149_we = addr_hit[161] & reg_we & !reg_error;
+
   assign prio149_wd = reg_wdata[1:0];
-
   assign prio150_we = addr_hit[162] & reg_we & !reg_error;
+
   assign prio150_wd = reg_wdata[1:0];
-
   assign prio151_we = addr_hit[163] & reg_we & !reg_error;
+
   assign prio151_wd = reg_wdata[1:0];
-
   assign prio152_we = addr_hit[164] & reg_we & !reg_error;
+
   assign prio152_wd = reg_wdata[1:0];
-
   assign prio153_we = addr_hit[165] & reg_we & !reg_error;
+
   assign prio153_wd = reg_wdata[1:0];
-
   assign prio154_we = addr_hit[166] & reg_we & !reg_error;
+
   assign prio154_wd = reg_wdata[1:0];
-
   assign prio155_we = addr_hit[167] & reg_we & !reg_error;
+
   assign prio155_wd = reg_wdata[1:0];
-
   assign prio156_we = addr_hit[168] & reg_we & !reg_error;
+
   assign prio156_wd = reg_wdata[1:0];
-
   assign prio157_we = addr_hit[169] & reg_we & !reg_error;
+
   assign prio157_wd = reg_wdata[1:0];
-
   assign prio158_we = addr_hit[170] & reg_we & !reg_error;
+
   assign prio158_wd = reg_wdata[1:0];
-
   assign prio159_we = addr_hit[171] & reg_we & !reg_error;
+
   assign prio159_wd = reg_wdata[1:0];
-
   assign prio160_we = addr_hit[172] & reg_we & !reg_error;
+
   assign prio160_wd = reg_wdata[1:0];
-
   assign prio161_we = addr_hit[173] & reg_we & !reg_error;
+
   assign prio161_wd = reg_wdata[1:0];
-
   assign prio162_we = addr_hit[174] & reg_we & !reg_error;
+
   assign prio162_wd = reg_wdata[1:0];
-
   assign prio163_we = addr_hit[175] & reg_we & !reg_error;
+
   assign prio163_wd = reg_wdata[1:0];
-
   assign prio164_we = addr_hit[176] & reg_we & !reg_error;
+
   assign prio164_wd = reg_wdata[1:0];
-
   assign prio165_we = addr_hit[177] & reg_we & !reg_error;
+
   assign prio165_wd = reg_wdata[1:0];
-
   assign prio166_we = addr_hit[178] & reg_we & !reg_error;
+
   assign prio166_wd = reg_wdata[1:0];
-
   assign prio167_we = addr_hit[179] & reg_we & !reg_error;
+
   assign prio167_wd = reg_wdata[1:0];
-
   assign prio168_we = addr_hit[180] & reg_we & !reg_error;
+
   assign prio168_wd = reg_wdata[1:0];
-
   assign prio169_we = addr_hit[181] & reg_we & !reg_error;
+
   assign prio169_wd = reg_wdata[1:0];
-
   assign prio170_we = addr_hit[182] & reg_we & !reg_error;
+
   assign prio170_wd = reg_wdata[1:0];
-
   assign prio171_we = addr_hit[183] & reg_we & !reg_error;
+
   assign prio171_wd = reg_wdata[1:0];
-
   assign prio172_we = addr_hit[184] & reg_we & !reg_error;
+
   assign prio172_wd = reg_wdata[1:0];
-
   assign prio173_we = addr_hit[185] & reg_we & !reg_error;
+
   assign prio173_wd = reg_wdata[1:0];
-
   assign prio174_we = addr_hit[186] & reg_we & !reg_error;
+
   assign prio174_wd = reg_wdata[1:0];
-
   assign prio175_we = addr_hit[187] & reg_we & !reg_error;
+
   assign prio175_wd = reg_wdata[1:0];
-
   assign prio176_we = addr_hit[188] & reg_we & !reg_error;
+
   assign prio176_wd = reg_wdata[1:0];
-
   assign prio177_we = addr_hit[189] & reg_we & !reg_error;
+
   assign prio177_wd = reg_wdata[1:0];
-
   assign prio178_we = addr_hit[190] & reg_we & !reg_error;
+
   assign prio178_wd = reg_wdata[1:0];
-
   assign prio179_we = addr_hit[191] & reg_we & !reg_error;
-  assign prio179_wd = reg_wdata[1:0];
 
-  assign ie0_0_e_0_we = addr_hit[192] & reg_we & !reg_error;
+  assign prio179_wd = reg_wdata[1:0];
+  assign ie0_0_we = addr_hit[192] & reg_we & !reg_error;
+
   assign ie0_0_e_0_wd = reg_wdata[0];
 
-  assign ie0_0_e_1_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_1_wd = reg_wdata[1];
 
-  assign ie0_0_e_2_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_2_wd = reg_wdata[2];
 
-  assign ie0_0_e_3_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_3_wd = reg_wdata[3];
 
-  assign ie0_0_e_4_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_4_wd = reg_wdata[4];
 
-  assign ie0_0_e_5_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_5_wd = reg_wdata[5];
 
-  assign ie0_0_e_6_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_6_wd = reg_wdata[6];
 
-  assign ie0_0_e_7_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_7_wd = reg_wdata[7];
 
-  assign ie0_0_e_8_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_8_wd = reg_wdata[8];
 
-  assign ie0_0_e_9_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_9_wd = reg_wdata[9];
 
-  assign ie0_0_e_10_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_10_wd = reg_wdata[10];
 
-  assign ie0_0_e_11_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_11_wd = reg_wdata[11];
 
-  assign ie0_0_e_12_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_12_wd = reg_wdata[12];
 
-  assign ie0_0_e_13_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_13_wd = reg_wdata[13];
 
-  assign ie0_0_e_14_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_14_wd = reg_wdata[14];
 
-  assign ie0_0_e_15_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_15_wd = reg_wdata[15];
 
-  assign ie0_0_e_16_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_16_wd = reg_wdata[16];
 
-  assign ie0_0_e_17_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_17_wd = reg_wdata[17];
 
-  assign ie0_0_e_18_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_18_wd = reg_wdata[18];
 
-  assign ie0_0_e_19_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_19_wd = reg_wdata[19];
 
-  assign ie0_0_e_20_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_20_wd = reg_wdata[20];
 
-  assign ie0_0_e_21_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_21_wd = reg_wdata[21];
 
-  assign ie0_0_e_22_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_22_wd = reg_wdata[22];
 
-  assign ie0_0_e_23_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_23_wd = reg_wdata[23];
 
-  assign ie0_0_e_24_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_24_wd = reg_wdata[24];
 
-  assign ie0_0_e_25_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_25_wd = reg_wdata[25];
 
-  assign ie0_0_e_26_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_26_wd = reg_wdata[26];
 
-  assign ie0_0_e_27_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_27_wd = reg_wdata[27];
 
-  assign ie0_0_e_28_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_28_wd = reg_wdata[28];
 
-  assign ie0_0_e_29_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_29_wd = reg_wdata[29];
 
-  assign ie0_0_e_30_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_30_wd = reg_wdata[30];
 
-  assign ie0_0_e_31_we = addr_hit[192] & reg_we & !reg_error;
   assign ie0_0_e_31_wd = reg_wdata[31];
+  assign ie0_1_we = addr_hit[193] & reg_we & !reg_error;
 
-  assign ie0_1_e_32_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_32_wd = reg_wdata[0];
 
-  assign ie0_1_e_33_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_33_wd = reg_wdata[1];
 
-  assign ie0_1_e_34_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_34_wd = reg_wdata[2];
 
-  assign ie0_1_e_35_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_35_wd = reg_wdata[3];
 
-  assign ie0_1_e_36_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_36_wd = reg_wdata[4];
 
-  assign ie0_1_e_37_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_37_wd = reg_wdata[5];
 
-  assign ie0_1_e_38_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_38_wd = reg_wdata[6];
 
-  assign ie0_1_e_39_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_39_wd = reg_wdata[7];
 
-  assign ie0_1_e_40_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_40_wd = reg_wdata[8];
 
-  assign ie0_1_e_41_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_41_wd = reg_wdata[9];
 
-  assign ie0_1_e_42_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_42_wd = reg_wdata[10];
 
-  assign ie0_1_e_43_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_43_wd = reg_wdata[11];
 
-  assign ie0_1_e_44_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_44_wd = reg_wdata[12];
 
-  assign ie0_1_e_45_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_45_wd = reg_wdata[13];
 
-  assign ie0_1_e_46_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_46_wd = reg_wdata[14];
 
-  assign ie0_1_e_47_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_47_wd = reg_wdata[15];
 
-  assign ie0_1_e_48_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_48_wd = reg_wdata[16];
 
-  assign ie0_1_e_49_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_49_wd = reg_wdata[17];
 
-  assign ie0_1_e_50_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_50_wd = reg_wdata[18];
 
-  assign ie0_1_e_51_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_51_wd = reg_wdata[19];
 
-  assign ie0_1_e_52_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_52_wd = reg_wdata[20];
 
-  assign ie0_1_e_53_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_53_wd = reg_wdata[21];
 
-  assign ie0_1_e_54_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_54_wd = reg_wdata[22];
 
-  assign ie0_1_e_55_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_55_wd = reg_wdata[23];
 
-  assign ie0_1_e_56_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_56_wd = reg_wdata[24];
 
-  assign ie0_1_e_57_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_57_wd = reg_wdata[25];
 
-  assign ie0_1_e_58_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_58_wd = reg_wdata[26];
 
-  assign ie0_1_e_59_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_59_wd = reg_wdata[27];
 
-  assign ie0_1_e_60_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_60_wd = reg_wdata[28];
 
-  assign ie0_1_e_61_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_61_wd = reg_wdata[29];
 
-  assign ie0_1_e_62_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_62_wd = reg_wdata[30];
 
-  assign ie0_1_e_63_we = addr_hit[193] & reg_we & !reg_error;
   assign ie0_1_e_63_wd = reg_wdata[31];
+  assign ie0_2_we = addr_hit[194] & reg_we & !reg_error;
 
-  assign ie0_2_e_64_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_64_wd = reg_wdata[0];
 
-  assign ie0_2_e_65_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_65_wd = reg_wdata[1];
 
-  assign ie0_2_e_66_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_66_wd = reg_wdata[2];
 
-  assign ie0_2_e_67_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_67_wd = reg_wdata[3];
 
-  assign ie0_2_e_68_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_68_wd = reg_wdata[4];
 
-  assign ie0_2_e_69_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_69_wd = reg_wdata[5];
 
-  assign ie0_2_e_70_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_70_wd = reg_wdata[6];
 
-  assign ie0_2_e_71_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_71_wd = reg_wdata[7];
 
-  assign ie0_2_e_72_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_72_wd = reg_wdata[8];
 
-  assign ie0_2_e_73_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_73_wd = reg_wdata[9];
 
-  assign ie0_2_e_74_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_74_wd = reg_wdata[10];
 
-  assign ie0_2_e_75_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_75_wd = reg_wdata[11];
 
-  assign ie0_2_e_76_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_76_wd = reg_wdata[12];
 
-  assign ie0_2_e_77_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_77_wd = reg_wdata[13];
 
-  assign ie0_2_e_78_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_78_wd = reg_wdata[14];
 
-  assign ie0_2_e_79_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_79_wd = reg_wdata[15];
 
-  assign ie0_2_e_80_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_80_wd = reg_wdata[16];
 
-  assign ie0_2_e_81_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_81_wd = reg_wdata[17];
 
-  assign ie0_2_e_82_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_82_wd = reg_wdata[18];
 
-  assign ie0_2_e_83_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_83_wd = reg_wdata[19];
 
-  assign ie0_2_e_84_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_84_wd = reg_wdata[20];
 
-  assign ie0_2_e_85_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_85_wd = reg_wdata[21];
 
-  assign ie0_2_e_86_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_86_wd = reg_wdata[22];
 
-  assign ie0_2_e_87_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_87_wd = reg_wdata[23];
 
-  assign ie0_2_e_88_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_88_wd = reg_wdata[24];
 
-  assign ie0_2_e_89_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_89_wd = reg_wdata[25];
 
-  assign ie0_2_e_90_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_90_wd = reg_wdata[26];
 
-  assign ie0_2_e_91_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_91_wd = reg_wdata[27];
 
-  assign ie0_2_e_92_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_92_wd = reg_wdata[28];
 
-  assign ie0_2_e_93_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_93_wd = reg_wdata[29];
 
-  assign ie0_2_e_94_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_94_wd = reg_wdata[30];
 
-  assign ie0_2_e_95_we = addr_hit[194] & reg_we & !reg_error;
   assign ie0_2_e_95_wd = reg_wdata[31];
+  assign ie0_3_we = addr_hit[195] & reg_we & !reg_error;
 
-  assign ie0_3_e_96_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_96_wd = reg_wdata[0];
 
-  assign ie0_3_e_97_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_97_wd = reg_wdata[1];
 
-  assign ie0_3_e_98_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_98_wd = reg_wdata[2];
 
-  assign ie0_3_e_99_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_99_wd = reg_wdata[3];
 
-  assign ie0_3_e_100_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_100_wd = reg_wdata[4];
 
-  assign ie0_3_e_101_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_101_wd = reg_wdata[5];
 
-  assign ie0_3_e_102_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_102_wd = reg_wdata[6];
 
-  assign ie0_3_e_103_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_103_wd = reg_wdata[7];
 
-  assign ie0_3_e_104_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_104_wd = reg_wdata[8];
 
-  assign ie0_3_e_105_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_105_wd = reg_wdata[9];
 
-  assign ie0_3_e_106_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_106_wd = reg_wdata[10];
 
-  assign ie0_3_e_107_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_107_wd = reg_wdata[11];
 
-  assign ie0_3_e_108_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_108_wd = reg_wdata[12];
 
-  assign ie0_3_e_109_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_109_wd = reg_wdata[13];
 
-  assign ie0_3_e_110_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_110_wd = reg_wdata[14];
 
-  assign ie0_3_e_111_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_111_wd = reg_wdata[15];
 
-  assign ie0_3_e_112_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_112_wd = reg_wdata[16];
 
-  assign ie0_3_e_113_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_113_wd = reg_wdata[17];
 
-  assign ie0_3_e_114_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_114_wd = reg_wdata[18];
 
-  assign ie0_3_e_115_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_115_wd = reg_wdata[19];
 
-  assign ie0_3_e_116_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_116_wd = reg_wdata[20];
 
-  assign ie0_3_e_117_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_117_wd = reg_wdata[21];
 
-  assign ie0_3_e_118_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_118_wd = reg_wdata[22];
 
-  assign ie0_3_e_119_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_119_wd = reg_wdata[23];
 
-  assign ie0_3_e_120_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_120_wd = reg_wdata[24];
 
-  assign ie0_3_e_121_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_121_wd = reg_wdata[25];
 
-  assign ie0_3_e_122_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_122_wd = reg_wdata[26];
 
-  assign ie0_3_e_123_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_123_wd = reg_wdata[27];
 
-  assign ie0_3_e_124_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_124_wd = reg_wdata[28];
 
-  assign ie0_3_e_125_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_125_wd = reg_wdata[29];
 
-  assign ie0_3_e_126_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_126_wd = reg_wdata[30];
 
-  assign ie0_3_e_127_we = addr_hit[195] & reg_we & !reg_error;
   assign ie0_3_e_127_wd = reg_wdata[31];
+  assign ie0_4_we = addr_hit[196] & reg_we & !reg_error;
 
-  assign ie0_4_e_128_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_128_wd = reg_wdata[0];
 
-  assign ie0_4_e_129_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_129_wd = reg_wdata[1];
 
-  assign ie0_4_e_130_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_130_wd = reg_wdata[2];
 
-  assign ie0_4_e_131_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_131_wd = reg_wdata[3];
 
-  assign ie0_4_e_132_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_132_wd = reg_wdata[4];
 
-  assign ie0_4_e_133_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_133_wd = reg_wdata[5];
 
-  assign ie0_4_e_134_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_134_wd = reg_wdata[6];
 
-  assign ie0_4_e_135_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_135_wd = reg_wdata[7];
 
-  assign ie0_4_e_136_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_136_wd = reg_wdata[8];
 
-  assign ie0_4_e_137_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_137_wd = reg_wdata[9];
 
-  assign ie0_4_e_138_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_138_wd = reg_wdata[10];
 
-  assign ie0_4_e_139_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_139_wd = reg_wdata[11];
 
-  assign ie0_4_e_140_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_140_wd = reg_wdata[12];
 
-  assign ie0_4_e_141_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_141_wd = reg_wdata[13];
 
-  assign ie0_4_e_142_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_142_wd = reg_wdata[14];
 
-  assign ie0_4_e_143_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_143_wd = reg_wdata[15];
 
-  assign ie0_4_e_144_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_144_wd = reg_wdata[16];
 
-  assign ie0_4_e_145_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_145_wd = reg_wdata[17];
 
-  assign ie0_4_e_146_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_146_wd = reg_wdata[18];
 
-  assign ie0_4_e_147_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_147_wd = reg_wdata[19];
 
-  assign ie0_4_e_148_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_148_wd = reg_wdata[20];
 
-  assign ie0_4_e_149_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_149_wd = reg_wdata[21];
 
-  assign ie0_4_e_150_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_150_wd = reg_wdata[22];
 
-  assign ie0_4_e_151_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_151_wd = reg_wdata[23];
 
-  assign ie0_4_e_152_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_152_wd = reg_wdata[24];
 
-  assign ie0_4_e_153_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_153_wd = reg_wdata[25];
 
-  assign ie0_4_e_154_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_154_wd = reg_wdata[26];
 
-  assign ie0_4_e_155_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_155_wd = reg_wdata[27];
 
-  assign ie0_4_e_156_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_156_wd = reg_wdata[28];
 
-  assign ie0_4_e_157_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_157_wd = reg_wdata[29];
 
-  assign ie0_4_e_158_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_158_wd = reg_wdata[30];
 
-  assign ie0_4_e_159_we = addr_hit[196] & reg_we & !reg_error;
   assign ie0_4_e_159_wd = reg_wdata[31];
+  assign ie0_5_we = addr_hit[197] & reg_we & !reg_error;
 
-  assign ie0_5_e_160_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_160_wd = reg_wdata[0];
 
-  assign ie0_5_e_161_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_161_wd = reg_wdata[1];
 
-  assign ie0_5_e_162_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_162_wd = reg_wdata[2];
 
-  assign ie0_5_e_163_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_163_wd = reg_wdata[3];
 
-  assign ie0_5_e_164_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_164_wd = reg_wdata[4];
 
-  assign ie0_5_e_165_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_165_wd = reg_wdata[5];
 
-  assign ie0_5_e_166_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_166_wd = reg_wdata[6];
 
-  assign ie0_5_e_167_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_167_wd = reg_wdata[7];
 
-  assign ie0_5_e_168_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_168_wd = reg_wdata[8];
 
-  assign ie0_5_e_169_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_169_wd = reg_wdata[9];
 
-  assign ie0_5_e_170_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_170_wd = reg_wdata[10];
 
-  assign ie0_5_e_171_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_171_wd = reg_wdata[11];
 
-  assign ie0_5_e_172_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_172_wd = reg_wdata[12];
 
-  assign ie0_5_e_173_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_173_wd = reg_wdata[13];
 
-  assign ie0_5_e_174_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_174_wd = reg_wdata[14];
 
-  assign ie0_5_e_175_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_175_wd = reg_wdata[15];
 
-  assign ie0_5_e_176_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_176_wd = reg_wdata[16];
 
-  assign ie0_5_e_177_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_177_wd = reg_wdata[17];
 
-  assign ie0_5_e_178_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_178_wd = reg_wdata[18];
 
-  assign ie0_5_e_179_we = addr_hit[197] & reg_we & !reg_error;
   assign ie0_5_e_179_wd = reg_wdata[19];
-
   assign threshold0_we = addr_hit[198] & reg_we & !reg_error;
+
   assign threshold0_wd = reg_wdata[1:0];
-
-  assign cc0_we = addr_hit[199] & reg_we & !reg_error;
-  assign cc0_wd = reg_wdata[7:0];
   assign cc0_re = addr_hit[199] & reg_re & !reg_error;
+  assign cc0_we = addr_hit[199] & reg_we & !reg_error;
 
+  assign cc0_wd = reg_wdata[7:0];
   assign msip0_we = addr_hit[200] & reg_we & !reg_error;
+
   assign msip0_wd = reg_wdata[0];
 
   // Read data return

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -104,152 +104,104 @@ module sensor_ctrl_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
+  logic alert_test_we;
   logic alert_test_recov_as_wd;
-  logic alert_test_recov_as_we;
   logic alert_test_recov_cg_wd;
-  logic alert_test_recov_cg_we;
   logic alert_test_recov_gd_wd;
-  logic alert_test_recov_gd_we;
   logic alert_test_recov_ts_hi_wd;
-  logic alert_test_recov_ts_hi_we;
   logic alert_test_recov_ts_lo_wd;
-  logic alert_test_recov_ts_lo_we;
   logic alert_test_recov_fla_wd;
-  logic alert_test_recov_fla_we;
   logic alert_test_recov_otp_wd;
-  logic alert_test_recov_otp_we;
   logic alert_test_recov_ot0_wd;
-  logic alert_test_recov_ot0_we;
   logic alert_test_recov_ot1_wd;
-  logic alert_test_recov_ot1_we;
   logic alert_test_recov_ot2_wd;
-  logic alert_test_recov_ot2_we;
   logic alert_test_recov_ot3_wd;
-  logic alert_test_recov_ot3_we;
   logic alert_test_recov_ot4_wd;
-  logic alert_test_recov_ot4_we;
   logic alert_test_recov_ot5_wd;
-  logic alert_test_recov_ot5_we;
+  logic cfg_regwen_we;
   logic cfg_regwen_qs;
   logic cfg_regwen_wd;
-  logic cfg_regwen_we;
+  logic ack_mode_we;
   logic [1:0] ack_mode_val_0_qs;
   logic [1:0] ack_mode_val_0_wd;
-  logic ack_mode_val_0_we;
   logic [1:0] ack_mode_val_1_qs;
   logic [1:0] ack_mode_val_1_wd;
-  logic ack_mode_val_1_we;
   logic [1:0] ack_mode_val_2_qs;
   logic [1:0] ack_mode_val_2_wd;
-  logic ack_mode_val_2_we;
   logic [1:0] ack_mode_val_3_qs;
   logic [1:0] ack_mode_val_3_wd;
-  logic ack_mode_val_3_we;
   logic [1:0] ack_mode_val_4_qs;
   logic [1:0] ack_mode_val_4_wd;
-  logic ack_mode_val_4_we;
   logic [1:0] ack_mode_val_5_qs;
   logic [1:0] ack_mode_val_5_wd;
-  logic ack_mode_val_5_we;
   logic [1:0] ack_mode_val_6_qs;
   logic [1:0] ack_mode_val_6_wd;
-  logic ack_mode_val_6_we;
   logic [1:0] ack_mode_val_7_qs;
   logic [1:0] ack_mode_val_7_wd;
-  logic ack_mode_val_7_we;
   logic [1:0] ack_mode_val_8_qs;
   logic [1:0] ack_mode_val_8_wd;
-  logic ack_mode_val_8_we;
   logic [1:0] ack_mode_val_9_qs;
   logic [1:0] ack_mode_val_9_wd;
-  logic ack_mode_val_9_we;
   logic [1:0] ack_mode_val_10_qs;
   logic [1:0] ack_mode_val_10_wd;
-  logic ack_mode_val_10_we;
   logic [1:0] ack_mode_val_11_qs;
   logic [1:0] ack_mode_val_11_wd;
-  logic ack_mode_val_11_we;
   logic [1:0] ack_mode_val_12_qs;
   logic [1:0] ack_mode_val_12_wd;
-  logic ack_mode_val_12_we;
+  logic alert_trig_we;
   logic alert_trig_val_0_qs;
   logic alert_trig_val_0_wd;
-  logic alert_trig_val_0_we;
   logic alert_trig_val_1_qs;
   logic alert_trig_val_1_wd;
-  logic alert_trig_val_1_we;
   logic alert_trig_val_2_qs;
   logic alert_trig_val_2_wd;
-  logic alert_trig_val_2_we;
   logic alert_trig_val_3_qs;
   logic alert_trig_val_3_wd;
-  logic alert_trig_val_3_we;
   logic alert_trig_val_4_qs;
   logic alert_trig_val_4_wd;
-  logic alert_trig_val_4_we;
   logic alert_trig_val_5_qs;
   logic alert_trig_val_5_wd;
-  logic alert_trig_val_5_we;
   logic alert_trig_val_6_qs;
   logic alert_trig_val_6_wd;
-  logic alert_trig_val_6_we;
   logic alert_trig_val_7_qs;
   logic alert_trig_val_7_wd;
-  logic alert_trig_val_7_we;
   logic alert_trig_val_8_qs;
   logic alert_trig_val_8_wd;
-  logic alert_trig_val_8_we;
   logic alert_trig_val_9_qs;
   logic alert_trig_val_9_wd;
-  logic alert_trig_val_9_we;
   logic alert_trig_val_10_qs;
   logic alert_trig_val_10_wd;
-  logic alert_trig_val_10_we;
   logic alert_trig_val_11_qs;
   logic alert_trig_val_11_wd;
-  logic alert_trig_val_11_we;
   logic alert_trig_val_12_qs;
   logic alert_trig_val_12_wd;
-  logic alert_trig_val_12_we;
+  logic alert_state_we;
   logic alert_state_val_0_qs;
   logic alert_state_val_0_wd;
-  logic alert_state_val_0_we;
   logic alert_state_val_1_qs;
   logic alert_state_val_1_wd;
-  logic alert_state_val_1_we;
   logic alert_state_val_2_qs;
   logic alert_state_val_2_wd;
-  logic alert_state_val_2_we;
   logic alert_state_val_3_qs;
   logic alert_state_val_3_wd;
-  logic alert_state_val_3_we;
   logic alert_state_val_4_qs;
   logic alert_state_val_4_wd;
-  logic alert_state_val_4_we;
   logic alert_state_val_5_qs;
   logic alert_state_val_5_wd;
-  logic alert_state_val_5_we;
   logic alert_state_val_6_qs;
   logic alert_state_val_6_wd;
-  logic alert_state_val_6_we;
   logic alert_state_val_7_qs;
   logic alert_state_val_7_wd;
-  logic alert_state_val_7_we;
   logic alert_state_val_8_qs;
   logic alert_state_val_8_wd;
-  logic alert_state_val_8_we;
   logic alert_state_val_9_qs;
   logic alert_state_val_9_wd;
-  logic alert_state_val_9_we;
   logic alert_state_val_10_qs;
   logic alert_state_val_10_wd;
-  logic alert_state_val_10_we;
   logic alert_state_val_11_qs;
   logic alert_state_val_11_wd;
-  logic alert_state_val_11_we;
   logic alert_state_val_12_qs;
   logic alert_state_val_12_wd;
-  logic alert_state_val_12_we;
   logic status_ast_init_done_qs;
   logic [1:0] status_io_pok_qs;
 
@@ -261,7 +213,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_as (
     .re     (1'b0),
-    .we     (alert_test_recov_as_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_as_wd),
     .d      ('0),
     .qre    (),
@@ -276,7 +228,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_cg (
     .re     (1'b0),
-    .we     (alert_test_recov_cg_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_cg_wd),
     .d      ('0),
     .qre    (),
@@ -291,7 +243,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_gd (
     .re     (1'b0),
-    .we     (alert_test_recov_gd_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_gd_wd),
     .d      ('0),
     .qre    (),
@@ -306,7 +258,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ts_hi (
     .re     (1'b0),
-    .we     (alert_test_recov_ts_hi_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ts_hi_wd),
     .d      ('0),
     .qre    (),
@@ -321,7 +273,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ts_lo (
     .re     (1'b0),
-    .we     (alert_test_recov_ts_lo_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ts_lo_wd),
     .d      ('0),
     .qre    (),
@@ -336,7 +288,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_fla (
     .re     (1'b0),
-    .we     (alert_test_recov_fla_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_fla_wd),
     .d      ('0),
     .qre    (),
@@ -351,7 +303,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_otp (
     .re     (1'b0),
-    .we     (alert_test_recov_otp_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_otp_wd),
     .d      ('0),
     .qre    (),
@@ -366,7 +318,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ot0 (
     .re     (1'b0),
-    .we     (alert_test_recov_ot0_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ot0_wd),
     .d      ('0),
     .qre    (),
@@ -381,7 +333,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ot1 (
     .re     (1'b0),
-    .we     (alert_test_recov_ot1_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ot1_wd),
     .d      ('0),
     .qre    (),
@@ -396,7 +348,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ot2 (
     .re     (1'b0),
-    .we     (alert_test_recov_ot2_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ot2_wd),
     .d      ('0),
     .qre    (),
@@ -411,7 +363,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ot3 (
     .re     (1'b0),
-    .we     (alert_test_recov_ot3_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ot3_wd),
     .d      ('0),
     .qre    (),
@@ -426,7 +378,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ot4 (
     .re     (1'b0),
-    .we     (alert_test_recov_ot4_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ot4_wd),
     .d      ('0),
     .qre    (),
@@ -441,7 +393,7 @@ module sensor_ctrl_reg_top (
     .DW    (1)
   ) u_alert_test_recov_ot5 (
     .re     (1'b0),
-    .we     (alert_test_recov_ot5_we),
+    .we     (alert_test_we),
     .wd     (alert_test_recov_ot5_wd),
     .d      ('0),
     .qre    (),
@@ -492,7 +444,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_0_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_0_wd),
 
     // from internal hardware
@@ -518,7 +470,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_1_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_1_wd),
 
     // from internal hardware
@@ -544,7 +496,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_2_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_2_wd),
 
     // from internal hardware
@@ -570,7 +522,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_3_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_3_wd),
 
     // from internal hardware
@@ -596,7 +548,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_4_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_4_wd),
 
     // from internal hardware
@@ -622,7 +574,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_5_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_5_wd),
 
     // from internal hardware
@@ -648,7 +600,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_6_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_6_wd),
 
     // from internal hardware
@@ -674,7 +626,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_7_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_7_wd),
 
     // from internal hardware
@@ -700,7 +652,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_8_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_8_wd),
 
     // from internal hardware
@@ -726,7 +678,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_9_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_9_wd),
 
     // from internal hardware
@@ -752,7 +704,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_10_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_10_wd),
 
     // from internal hardware
@@ -778,7 +730,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_11_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_11_wd),
 
     // from internal hardware
@@ -804,7 +756,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (ack_mode_val_12_we & cfg_regwen_qs),
+    .we     (ack_mode_we & cfg_regwen_qs),
     .wd     (ack_mode_val_12_wd),
 
     // from internal hardware
@@ -835,7 +787,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_0_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_0_wd),
 
     // from internal hardware
@@ -861,7 +813,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_1_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_1_wd),
 
     // from internal hardware
@@ -887,7 +839,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_2_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_2_wd),
 
     // from internal hardware
@@ -913,7 +865,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_3_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_3_wd),
 
     // from internal hardware
@@ -939,7 +891,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_4_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_4_wd),
 
     // from internal hardware
@@ -965,7 +917,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_5_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_5_wd),
 
     // from internal hardware
@@ -991,7 +943,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_6_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_6_wd),
 
     // from internal hardware
@@ -1017,7 +969,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_7_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_7_wd),
 
     // from internal hardware
@@ -1043,7 +995,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_8_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_8_wd),
 
     // from internal hardware
@@ -1069,7 +1021,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_9_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_9_wd),
 
     // from internal hardware
@@ -1095,7 +1047,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_10_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_10_wd),
 
     // from internal hardware
@@ -1121,7 +1073,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_11_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_11_wd),
 
     // from internal hardware
@@ -1147,7 +1099,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_trig_val_12_we),
+    .we     (alert_trig_we),
     .wd     (alert_trig_val_12_wd),
 
     // from internal hardware
@@ -1178,7 +1130,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_0_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_0_wd),
 
     // from internal hardware
@@ -1204,7 +1156,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_1_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_1_wd),
 
     // from internal hardware
@@ -1230,7 +1182,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_2_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_2_wd),
 
     // from internal hardware
@@ -1256,7 +1208,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_3_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_3_wd),
 
     // from internal hardware
@@ -1282,7 +1234,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_4_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_4_wd),
 
     // from internal hardware
@@ -1308,7 +1260,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_5_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_5_wd),
 
     // from internal hardware
@@ -1334,7 +1286,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_6_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_6_wd),
 
     // from internal hardware
@@ -1360,7 +1312,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_7_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_7_wd),
 
     // from internal hardware
@@ -1386,7 +1338,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_8_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_8_wd),
 
     // from internal hardware
@@ -1412,7 +1364,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_9_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_9_wd),
 
     // from internal hardware
@@ -1438,7 +1390,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_10_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_10_wd),
 
     // from internal hardware
@@ -1464,7 +1416,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_11_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_11_wd),
 
     // from internal hardware
@@ -1490,7 +1442,7 @@ module sensor_ctrl_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (alert_state_val_12_we),
+    .we     (alert_state_we),
     .wd     (alert_state_val_12_wd),
 
     // from internal hardware
@@ -1586,164 +1538,116 @@ module sensor_ctrl_reg_top (
                (addr_hit[4] & (|(SENSOR_CTRL_PERMIT[4] & ~reg_be))) |
                (addr_hit[5] & (|(SENSOR_CTRL_PERMIT[5] & ~reg_be)))));
   end
+  assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
-  assign alert_test_recov_as_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_as_wd = reg_wdata[0];
 
-  assign alert_test_recov_cg_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_cg_wd = reg_wdata[1];
 
-  assign alert_test_recov_gd_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_gd_wd = reg_wdata[2];
 
-  assign alert_test_recov_ts_hi_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ts_hi_wd = reg_wdata[3];
 
-  assign alert_test_recov_ts_lo_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ts_lo_wd = reg_wdata[4];
 
-  assign alert_test_recov_fla_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_fla_wd = reg_wdata[5];
 
-  assign alert_test_recov_otp_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_otp_wd = reg_wdata[6];
 
-  assign alert_test_recov_ot0_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot0_wd = reg_wdata[7];
 
-  assign alert_test_recov_ot1_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot1_wd = reg_wdata[8];
 
-  assign alert_test_recov_ot2_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot2_wd = reg_wdata[9];
 
-  assign alert_test_recov_ot3_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot3_wd = reg_wdata[10];
 
-  assign alert_test_recov_ot4_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot4_wd = reg_wdata[11];
 
-  assign alert_test_recov_ot5_we = addr_hit[0] & reg_we & !reg_error;
   assign alert_test_recov_ot5_wd = reg_wdata[12];
-
   assign cfg_regwen_we = addr_hit[1] & reg_we & !reg_error;
-  assign cfg_regwen_wd = reg_wdata[0];
 
-  assign ack_mode_val_0_we = addr_hit[2] & reg_we & !reg_error;
+  assign cfg_regwen_wd = reg_wdata[0];
+  assign ack_mode_we = addr_hit[2] & reg_we & !reg_error;
+
   assign ack_mode_val_0_wd = reg_wdata[1:0];
 
-  assign ack_mode_val_1_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_1_wd = reg_wdata[3:2];
 
-  assign ack_mode_val_2_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_2_wd = reg_wdata[5:4];
 
-  assign ack_mode_val_3_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_3_wd = reg_wdata[7:6];
 
-  assign ack_mode_val_4_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_4_wd = reg_wdata[9:8];
 
-  assign ack_mode_val_5_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_5_wd = reg_wdata[11:10];
 
-  assign ack_mode_val_6_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_6_wd = reg_wdata[13:12];
 
-  assign ack_mode_val_7_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_7_wd = reg_wdata[15:14];
 
-  assign ack_mode_val_8_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_8_wd = reg_wdata[17:16];
 
-  assign ack_mode_val_9_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_9_wd = reg_wdata[19:18];
 
-  assign ack_mode_val_10_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_10_wd = reg_wdata[21:20];
 
-  assign ack_mode_val_11_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_11_wd = reg_wdata[23:22];
 
-  assign ack_mode_val_12_we = addr_hit[2] & reg_we & !reg_error;
   assign ack_mode_val_12_wd = reg_wdata[25:24];
+  assign alert_trig_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign alert_trig_val_0_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_0_wd = reg_wdata[0];
 
-  assign alert_trig_val_1_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_1_wd = reg_wdata[1];
 
-  assign alert_trig_val_2_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_2_wd = reg_wdata[2];
 
-  assign alert_trig_val_3_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_3_wd = reg_wdata[3];
 
-  assign alert_trig_val_4_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_4_wd = reg_wdata[4];
 
-  assign alert_trig_val_5_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_5_wd = reg_wdata[5];
 
-  assign alert_trig_val_6_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_6_wd = reg_wdata[6];
 
-  assign alert_trig_val_7_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_7_wd = reg_wdata[7];
 
-  assign alert_trig_val_8_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_8_wd = reg_wdata[8];
 
-  assign alert_trig_val_9_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_9_wd = reg_wdata[9];
 
-  assign alert_trig_val_10_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_10_wd = reg_wdata[10];
 
-  assign alert_trig_val_11_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_11_wd = reg_wdata[11];
 
-  assign alert_trig_val_12_we = addr_hit[3] & reg_we & !reg_error;
   assign alert_trig_val_12_wd = reg_wdata[12];
+  assign alert_state_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign alert_state_val_0_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_0_wd = reg_wdata[0];
 
-  assign alert_state_val_1_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_1_wd = reg_wdata[1];
 
-  assign alert_state_val_2_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_2_wd = reg_wdata[2];
 
-  assign alert_state_val_3_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_3_wd = reg_wdata[3];
 
-  assign alert_state_val_4_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_4_wd = reg_wdata[4];
 
-  assign alert_state_val_5_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_5_wd = reg_wdata[5];
 
-  assign alert_state_val_6_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_6_wd = reg_wdata[6];
 
-  assign alert_state_val_7_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_7_wd = reg_wdata[7];
 
-  assign alert_state_val_8_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_8_wd = reg_wdata[8];
 
-  assign alert_state_val_9_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_9_wd = reg_wdata[9];
 
-  assign alert_state_val_10_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_10_wd = reg_wdata[10];
 
-  assign alert_state_val_11_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_11_wd = reg_wdata[11];
 
-  assign alert_state_val_12_we = addr_hit[4] & reg_we & !reg_error;
   assign alert_state_val_12_wd = reg_wdata[12];
 
   // Read data return

--- a/util/reggen/access.py
+++ b/util/reggen/access.py
@@ -101,6 +101,16 @@ class SWAccess:
     def allows_write(self) -> bool:
         return self.value[2] == SwWrAccess.WR
 
+    def needs_we(self) -> bool:
+        '''Should the register for this field have a write-enable signal?
+
+        This is almost the same as allows_write(), but doesn't return true for
+        RC registers, which should use a read-enable signal (connected to their
+        prim_subreg's we port).
+
+        '''
+        return self.value[1] != SwAccess.RC and self.allows_write()
+
 
 class HWAccess:
     def __init__(self, where: str, raw: object):


### PR DESCRIPTION
Most of this (enormous) diff is auto-generated. The only manual
changes are to `reg_top.sv.tpl`, `access.py` and `register.py`.

The idea behind this patch is that the write-enable and read-enable
signal for a field are both determined at the register level (by
`reg_we` or `reg_re`, combined with an address check). Before this patch,
each field that needed a write-enable or read-enable signal defined
one. For example, if we had a writeable register `R` with fields `F0` and
`F1`, we were defined both `R_F0_we` and `R_F1_we` and always set them to
the same values. This patch changes things so that we define "`R_we`"
instead and use it as the "we" signal for both `R.F0` and `R.F1`.
