### PR TITLE
[dv/common] Stress_all_with_rand_reset apply reset concurrently

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -123,9 +123,12 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     if (cfg.has_edn && kind == "HARD") cfg.edn_clk_rst_vif.apply_reset();
   endtask
 
-  virtual task apply_resets_concurrently();
-    if (cfg.has_edn) cfg.edn_clk_rst_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    if (cfg.has_edn) begin
+      cfg.edn_clk_rst_vif.drive_rst_pin(0);
+      reset_duration_ps = max2(reset_duration_ps, cfg.edn_clk_rst_vif.clk_period_ps);
+    end
+    super.apply_resets_concurrently(reset_duration_ps);
     if (cfg.has_edn) cfg.edn_clk_rst_vif.drive_rst_pin(1);
   endtask
 

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -94,6 +94,12 @@ package dv_utils_pkg;
     return (a > b) ? a : b;
   endfunction
 
+  // return the biggest value within the given queue of integers.
+  function automatic int max(const ref int int_q[$]);
+    foreach (int_q[i]) max = max2(max, int_q[i]);
+    return max;
+  endfunction
+
   // get absolute value of the input. Usage: absolute(val) or absolute(a - b)
   function automatic uint absolute(int val);
     return val >= 0 ? val : -val;

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -37,9 +37,9 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
     super.apply_reset(kind);
   endtask  // apply_reset
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.clk_aon_rst_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.clk_aon_rst_vif.clk_period_ps);
     cfg.clk_aon_rst_vif.drive_rst_pin(1);
   endtask
 

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -61,9 +61,9 @@ class aon_timer_base_vseq extends cip_base_vseq #(
     end
   endtask // apply_reset
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.aon_clk_rst_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.aon_clk_rst_vif.clk_period_ps);
     cfg.aon_clk_rst_vif.drive_rst_pin(1);
   endtask
 endclass : aon_timer_base_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -82,12 +82,18 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     join
   endtask
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    int clk_periods_q[$] = {reset_duration_ps,
+                            cfg.main_clk_rst_vif.clk_period_ps,
+                            cfg.io_clk_rst_vif.clk_period_ps,
+                            cfg.usb_clk_rst_vif.clk_period_ps};
+    reset_duration_ps = max(clk_periods_q);
+
     cfg.main_clk_rst_vif.drive_rst_pin(0);
     cfg.io_clk_rst_vif.drive_rst_pin(0);
     cfg.usb_clk_rst_vif.drive_rst_pin(0);
 
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(reset_duration_ps);
 
     cfg.main_clk_rst_vif.drive_rst_pin(1);
     cfg.io_clk_rst_vif.drive_rst_pin(1);

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -55,9 +55,9 @@ class pwm_base_vseq extends cip_base_vseq #(
     join
   endtask : apply_reset
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.clk_rst_core_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.clk_rst_core_vif.clk_period_ps);
     cfg.clk_rst_core_vif.drive_rst_pin(1);
   endtask
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -168,9 +168,9 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
     join
   endtask
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.slow_clk_rst_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.slow_clk_rst_vif.clk_period_ps);
     cfg.slow_clk_rst_vif.drive_rst_pin(1);
   endtask
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -70,7 +70,7 @@ class spi_host_base_vseq extends cip_base_vseq #(
         spi_host_regs.tx_watermark, spi_host_regs.rx_watermark), UVM_LOW)
     cfg.clk_rst_core_vif.wait_clks(100);
   endtask : body
-  
+
   virtual task pre_start();
     // sync monitor and scoreboard setting
     cfg.m_spi_agent_cfg.en_monitor_checks = cfg.en_scb;
@@ -176,7 +176,7 @@ class spi_host_base_vseq extends cip_base_vseq #(
 
   virtual task get_transactions(uint num_rd_words);
     bit [TL_DW-1:0] rxdata;
-    
+
     while (!num_rd_words) begin
       csr_spinwait(.ptr(ral.status.rxempty), .exp_data(1'b1));
       csr_rd(.ptr(ral.rxdata), .value(rxdata));
@@ -197,7 +197,7 @@ class spi_host_base_vseq extends cip_base_vseq #(
                                        foreach (intr_clear[i]) {
                                            intr_state[i] -> intr_clear[i] == 1;
                                        })
-    
+
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_intr_dly)
     cfg.clk_rst_vif.wait_clks(clear_intr_dly);
     csr_wr(.ptr(ral.intr_state), .value(intr_clear));
@@ -215,9 +215,9 @@ class spi_host_base_vseq extends cip_base_vseq #(
     join
   endtask
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.clk_rst_core_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.clk_rst_core_vif.clk_period_ps);
     cfg.clk_rst_core_vif.drive_rst_pin(1);
   endtask
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -30,9 +30,9 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
     end
   endtask
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.otp_clk_rst_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.otp_clk_rst_vif.clk_period_ps);
     cfg.otp_clk_rst_vif.drive_rst_pin(1);
   endtask
 

--- a/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
+++ b/hw/ip/usbdev/dv/env/seq_lib/usbdev_base_vseq.sv
@@ -31,9 +31,9 @@ class usbdev_base_vseq extends cip_base_vseq #(
     do_apply_post_reset_delays_for_sync();
   endtask
 
-  virtual task apply_resets_concurrently();
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.usb_clk_rst_vif.drive_rst_pin(0);
-    super.apply_resets_concurrently();
+    super.apply_resets_concurrently(cfg.usb_clk_rst_vif.clk_period_ps);
     cfg.usb_clk_rst_vif.drive_rst_pin(1);
   endtask
 


### PR DESCRIPTION
According to the comment in PR #6936, this PR asserts all resets until
at least the slowest clock finishes two periods.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>