### PR TITLE
[dvsim] GUI mode and launcher creation fixes

### DIFF
--- a/util/dvsim/Scheduler.py
+++ b/util/dvsim/Scheduler.py
@@ -108,6 +108,10 @@ class Scheduler:
         # per-target.
         self.item_to_status = {}
 
+        # Create the launcher instance for all items.
+        for item in self.items:
+            item.create_launcher()
+
         # The chosen launcher class. This allows us to access launcher
         # variant-specific settings such as max parallel jobs & poll rate.
         self.launcher_cls = launcher_cls


### PR DESCRIPTION
There are 2 fixes in this commit.

- GUI mode
  set this as a Deploy class property rather than sim cfg property.
  For the cloud launcher, the `--gui` switch is also used to
  translate to VNC session invocation command which is not required
  for the build step. By making it a Deploy class property, we can
  turn off the VNC invocation just for the CompileSim object.

- Create launcher ONLY if the job is run.
  Previously, the launcher class instance was created in Deploy::init().
  In SimCfg, there is a piece of code that prunes the builds / runs
  based on external switches such as `--build-only` and `--run-only`.
  The runs are pruned further when enabling GUI mode. Hence, rather than
  creating the launcher instance in Deploy::init() we create it in
  `create_launcher()` method which is invoked for all items in Scheduler
  class's init() when the final list of exactly what we want to run is
  known.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>