### PR TITLE
[dv/otp_ctrl_if] enabled setting PRIM_GENERIC_OTP_CMD_I_PATH macro vi…

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -13,8 +13,10 @@
 `define LC_PART_OTP_CMD_PATH \
     tb.dut.gen_partitions[6].gen_lifecycle.u_part_buf.otp_cmd_o
 
-`define PRIM_GENERIC_OTP_CMD_I_PATH \
-    tb.dut.u_otp.gen_generic.u_impl_generic.cmd_i
+`ifndef PRIM_GENERIC_OTP_CMD_I_PATH
+  `define PRIM_GENERIC_OTP_CMD_I_PATH \
+      tb.dut.u_otp.gen_generic.u_impl_generic.cmd_i
+`endif
 
 interface otp_ctrl_if(input clk_i, input rst_ni);
   import otp_ctrl_env_pkg::*;


### PR DESCRIPTION
…a build options

Signed-off-by: Dror Kabely <dror.kabely@nuvoton.com>

Currently the PRIM_GENERIC_OTP_CMD_I_PATH is set to an RTL path which is unique to the prim_pkg::ImplGeneric implementation, and cannot be changed outside the code.
![image](https://user-images.githubusercontent.com/83413366/122672615-242b7880-d1d5-11eb-8145-e69074cf46a8.png)
Once a vendor uses a different implementation this RTL path no longer exists and the compilation fails.

Since this path cannot be changed, the `ifndef guard is added to allow the user to set the PRIM_GENERIC_OTP_CMD_I_PATH using **'+define+PRIM_GENERIC_OTP_CMD_I_PATH=path-to-ip-cmd-i'**, which will define the macro outside the code, from the sim config hjson file or via arguments passed to dvsim.

