### PR TITLE
[dv/mem_util] Remove data width constraints

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -181,9 +181,8 @@ class mem_bkdr_util extends uvm_object;
     return data;
   endfunction
 
-  // Convenience macro to check the addr and data width for each flavor of read and write functions.
-  `define _ADDR_DW_CHECKS(_ADDR, _DW) \
-    `DV_CHECK_GE_FATAL(data_width, _DW, $sformatf("data_width %0d is < ``_DW``!", data_width)) \
+  // Convenience macro to check the addr for each flavor of read and write functions.
+  `define _ACCESS_CHECKS(_ADDR, _DW) \
     `DV_CHECK_EQ_FATAL(_ADDR % (_DW / 8), 0, $sformatf("addr 0x%0h not ``_DW``-bit aligned", _ADDR))
 
   // Read a single byte at specified address.
@@ -196,22 +195,22 @@ class mem_bkdr_util extends uvm_object;
   endfunction
 
   virtual function logic [15:0] read16(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `_ADDR_DW_CHECKS(addr, 16)
+    `_ACCESS_CHECKS(addr, 16)
     return {read8(addr + 1), read8(addr)};
   endfunction
 
   virtual function logic [31:0] read32(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `_ADDR_DW_CHECKS(addr, 32)
+    `_ACCESS_CHECKS(addr, 32)
     return {read16(addr + 2), read16(addr)};
   endfunction
 
   virtual function logic [63:0] read64(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `_ADDR_DW_CHECKS(addr, 64)
+    `_ACCESS_CHECKS(addr, 64)
     return {read32(addr + 4), read32(addr)};
   endfunction
 
   virtual function logic [127:0] read128(bit [bus_params_pkg::BUS_AW-1:0] addr);
-    `_ADDR_DW_CHECKS(addr, 128)
+    `_ACCESS_CHECKS(addr, 128)
     return {read64(addr + 8), read64(addr)};
   endfunction
 
@@ -281,34 +280,34 @@ class mem_bkdr_util extends uvm_object;
   endfunction
 
   virtual function void write16(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [15:0] data);
-    `_ADDR_DW_CHECKS(addr, 16)
+    `_ACCESS_CHECKS(addr, 16)
     if (!check_addr_valid(addr)) return;
     write8(addr, data[7:0]);
     write8(addr + 1, data[15:8]);
   endfunction
 
   virtual function void write32(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [31:0] data);
-    `_ADDR_DW_CHECKS(addr, 32)
+    `_ACCESS_CHECKS(addr, 32)
     if (!check_addr_valid(addr)) return;
     write16(addr, data[15:0]);
     write16(addr + 2, data[31:16]);
   endfunction
 
   virtual function void write64(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [63:0] data);
-    `_ADDR_DW_CHECKS(addr, 64)
+    `_ACCESS_CHECKS(addr, 64)
     if (!check_addr_valid(addr)) return;
     write32(addr, data[31:0]);
     write32(addr + 4, data[63:32]);
   endfunction
 
   virtual function void write128(bit [bus_params_pkg::BUS_AW-1:0] addr, logic [127:0] data);
-    `_ADDR_DW_CHECKS(addr, 128)
+    `_ACCESS_CHECKS(addr, 128)
     if (!check_addr_valid(addr)) return;
     write64(addr, data[63:0]);
     write64(addr + 4, data[127:63]);
   endfunction
 
-  `undef _ADDR_DW_CHECKS
+  `undef _ACCESS_CHECKS
 
   /////////////////////////////////////////////////////////
   // Wrapper functions for memory reads with ECC enabled //

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -72,14 +72,4 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
     m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
-  // OTP memory width is 16 bits while OTP word is 32 bits.
-  virtual function void backdoor_write32(bit [TL_DW-1:0] addr, bit [31:0] val);
-    mem_bkdr_util_h.write16(addr,     val[15:0]);
-    mem_bkdr_util_h.write16(addr + 2, val[31:16]);
-  endfunction
-
-  virtual function bit[31:0] backdoor_read32(bit [TL_DW-1:0] addr);
-    return {mem_bkdr_util_h.read16(addr + 2), mem_bkdr_util_h.read16(addr)};
-  endfunction
-
 endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -121,8 +121,8 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
 
             if (dai_digest_ip != LifeCycleIdx) begin
               bit [TL_DW-1:0] otp_addr = PART_OTP_DIGEST_ADDRS[dai_digest_ip];
-              otp_a[otp_addr]   = cfg.backdoor_read32(otp_addr << 2);
-              otp_a[otp_addr+1] = cfg.backdoor_read32((otp_addr << 2) + 4);
+              otp_a[otp_addr]   = cfg.mem_bkdr_util_h.read32(otp_addr << 2);
+              otp_a[otp_addr+1] = cfg.mem_bkdr_util_h.read32((otp_addr << 2) + 4);
               dai_digest_ip = LifeCycleIdx;
             end
             predict_digest_csrs();
@@ -237,7 +237,7 @@ class otp_ctrl_scoreboard extends cip_base_scoreboard #(
       #1ps;
       if (cfg.otp_ctrl_vif.rst_ni == 0) begin
         for (int i = 0; i < LC_PROG_DATA_SIZE/32; i++) begin
-          otp_lc_data[i*32+:32] = cfg.backdoor_read32(LifeCycleOffset + i * 4);
+          otp_lc_data[i*32+:32] = cfg.mem_bkdr_util_h.read32(LifeCycleOffset + i * 4);
         end
       end
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -164,7 +164,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     // If has ecc_err, backdoor write back original value
     // TODO: remove this once we can detect ECC error from men_bkdr_if
     if (backdoor_wr) begin
-      cfg.backdoor_write32({addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
+      cfg.mem_bkdr_util_h.write32({addr[TL_DW-3:2], 2'b00}, backdoor_rd_val);
     end
   endtask : dai_rd
 
@@ -248,7 +248,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
                                                            otp_ecc_err_e   ecc_err);
     bit [TL_DW-1:0] val;
     addr = {addr[TL_DW-1:2], 2'b00};
-    val = cfg.backdoor_read32(addr);
+    val = cfg.mem_bkdr_util_h.read32(addr);
     if (ecc_err == OtpNoEccErr || addr >= (LifeCycleOffset + LifeCycleSize)) return val;
 
     // Backdoor read and write back with error bits
@@ -282,7 +282,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     if (wait_done && val) csr_spinwait(ral.status.check_pending, 0);
 
     if (ecc_err != OtpNoEccErr) begin
-      cfg.backdoor_write32(addr, backdoor_rd_val);
+      cfg.mem_bkdr_util_h.write32(addr, backdoor_rd_val);
       cfg.ecc_chk_err = '{default: OtpNoEccErr};
     end
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_low_freq_read_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_low_freq_read_vseq.sv
@@ -19,7 +19,7 @@ class otp_ctrl_low_freq_read_vseq extends otp_ctrl_base_vseq;
     // Backdoor write all partitions.
     for (int addr = CreatorSwCfgOffset / 4; addr < LifeCycleOffset / 4; addr++) begin
       int dai_addr = addr * 4;
-        cfg.backdoor_write32(dai_addr, dai_addr);
+        cfg.mem_bkdr_util_h.write32(dai_addr, dai_addr);
         `uvm_info(`gfn, $sformatf("backdoor write dai addr %0h", dai_addr), UVM_HIGH)
     end
 


### PR DESCRIPTION
This PR removes data_width constraints for the mem_bkdr_util to
read/write memories.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>