### PR TITLE
[dv/otp_ctrl] modified otp_ctrl_sim.core targets to fit partner envir…

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim.core
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim.core
@@ -20,12 +20,15 @@ filesets:
     file_type: systemVerilogSource
 
 targets:
-  sim: &sim_target
+  default: &default_target
     toplevel: tb
     filesets:
       - files_rtl
       - files_dv
+
+  sim:
+    <<: *default_target
     default_tool: vcs
 
   lint:
-    <<: *sim_target
+    <<: *default_target


### PR DESCRIPTION
…onment

Signed-off-by: Dror Kabely <dror.kabely@nuvoton.com>

Made some small modifications to the targets of the otp_ctrl_sim.core in order for the partner OTP environment to be able to include otp_ctrl_sim.core as a dependent core package.

This modifications are similar to the changes made in https://github.com/lowRISC/opentitan/blob/master/hw/ip/flash_ctrl/dv/flash_ctrl_sim.core 