### PR TITLE
[dv/otp_ctrl] tie otp_test_ctrl pin to 0

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -37,6 +37,9 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
                        lc_creator_seed_sw_rw_en_i, lc_seed_hw_rd_en_i, scanmode_i;
   otp_ast_rsp_t        otp_ast_pwr_seq_h_i;
 
+  // Unused in prim_generic_otp memory.
+  logic [otp_ctrl_pkg::OtpTestCtrlWidth-1:0] otp_test_ctrl_i;
+
   // Connect with lc_prog push_pull interface.
   logic lc_prog_req, lc_prog_err;
   logic lc_prog_err_dly1, lc_prog_no_sta_check;
@@ -96,6 +99,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     scan_en_i                  = $urandom();
     scan_rst_ni                = $urandom();
     scanmode_i                 = $urandom();
+    otp_test_ctrl_i            = 0;
   endtask
 
   task automatic drive_pwr_otp_init(logic val);

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -24,9 +24,6 @@ module tb;
   wire otp_ctrl_pkg::sram_otp_key_req_t[NumSramKeyReqSlots-1:0] sram_req;
   wire otp_ctrl_pkg::sram_otp_key_rsp_t[NumSramKeyReqSlots-1:0] sram_rsp;
 
-  // TODO: need to connect this properly
-  wire [otp_ctrl_pkg::OtpTestCtrlWidth-1:0] otp_test_ctrl;
-
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire intr_otp_operation_done, intr_otp_error;
 
@@ -92,7 +89,7 @@ module tb;
     .pwr_otp_i                  (otp_ctrl_if.pwr_otp_init_i),
     .pwr_otp_o                  ({otp_ctrl_if.pwr_otp_done_o, otp_ctrl_if.pwr_otp_idle_o}),
     // lc
-    .lc_otp_program_i           ({lc_prog_if.req, lc_prog_if.h_data, otp_test_ctrl}),
+    .lc_otp_program_i           ({lc_prog_if.req, lc_prog_if.h_data, otp_ctrl_if.otp_test_ctrl_i}),
     .lc_otp_program_o           ({lc_prog_if.d_data, lc_prog_if.ack}),
     .lc_creator_seed_sw_rw_en_i (otp_ctrl_if.lc_creator_seed_sw_rw_en_i),
     .lc_seed_hw_rd_en_i         (otp_ctrl_if.lc_seed_hw_rd_en_i),


### PR DESCRIPTION
This PR ties the otp_test_ctrl pin to 0 as requested in the proprietary
repo.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>