### PR TITLE
[tools/dsim] Fix non-LRM compliant code

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -212,7 +212,11 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
 
       // run write-only sequence to randomize the csr values
       m_csr_write_seq = csr_write_seq::type_id::create("m_csr_write_seq");
-      m_csr_write_seq.models = cfg.ral_models;
+      // We have to assign this array in a loop because the element types aren't equivalent, so
+      // the array types aren't assignment compatible.
+      foreach (cfg.ral_models[i]) begin
+        m_csr_write_seq.models[i] = cfg.ral_models[i];
+      end
       m_csr_write_seq.external_checker = cfg.en_scb;
       m_csr_write_seq.en_rand_backdoor_write = 1'b1;
       m_csr_write_seq.start(null);
@@ -229,7 +233,11 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
 
     // create base csr seq and pass our ral
     m_csr_seq = csr_base_seq::type_id::create("m_csr_seq");
-    m_csr_seq.models = cfg.ral_models;
+    // We have to assign this array in a loop because the element types aren't equivalent, so
+    // the array types aren't assignment compatible.
+    foreach (cfg.ral_models[i])  begin
+      m_csr_seq.models[i] = cfg.ral_models[i];
+    end
     m_csr_seq.external_checker = cfg.en_scb;
     m_csr_seq.num_test_csrs = num_test_csrs;
     m_csr_seq.start(null);

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -237,7 +237,9 @@ class tl_host_driver extends tl_base_driver;
     cfg.vif.h2d_int.a_address <= '{default:'x};
     cfg.vif.h2d_int.a_mask <= '{default:'x};
     cfg.vif.h2d_int.a_data <= '{default:'x};
-    cfg.vif.h2d_int.a_user <= '{default:'x};
+    // The assignment to tl_type must have a cast since the LRM doesn't allow enum assignment of
+    // values not belonging to the enumeration set.
+    cfg.vif.h2d_int.a_user <= '{tl_type:tlul_pkg::tl_type_e'('x), default:'x};
     cfg.vif.h2d_int.a_valid <= 1'b0;
   endfunction : invalidate_a_channel
 


### PR DESCRIPTION
Fix errors dsim flags for non LRM compliant code other tools accept.
- Initializing a struct containing an enum with default:'x is
  non-compliant if the enum doesn't have an explicit member with
  value 'x. Initialize the value with a cast 'x instead.
- Assigning an array of a base class to an array of a derived
  class is non-compliant. Make the assignments in a foreach loop.

Signed-off-by: Guillermo Maturana <maturana@google.com>