### PR TITLE
[dv/otp_ctrl] parameterized otp_ctrl_base_test

### DIFF
--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -15,6 +15,21 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // TB base test ENV_T & CFG_T specification
+  //
+  // Specify the parameters for the otp_ctrl_base_test
+  // This will invoke the UVM registry and link this test type to
+  // the name 'otp_ctrl_base_test' as a test name passed by UVM_TESTNAME
+  //
+  // This is done explicitly only for the prim_pkg::ImplGeneric implementation
+  // since partner base tests inherit from otp_ctrl_base_test#(CFG_T, ENV_T) and
+  // specify directly (CFG_T, ENV_T) via the class extension and use a different
+  // UVM_TESTNAME
+  if (`PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric) begin : gen_spec_base_test_params
+    typedef otp_ctrl_base_test #(.CFG_T(otp_ctrl_env_cfg),
+                                 .ENV_T(otp_ctrl_env)) otp_ctrl_base_test_t;
+  end
+
   wire clk, rst_n;
   wire devmode;
   wire otp_ctrl_pkg::flash_otp_key_req_t flash_req;

--- a/hw/ip/otp_ctrl/dv/tests/otp_ctrl_base_test.sv
+++ b/hw/ip/otp_ctrl/dv/tests/otp_ctrl_base_test.sv
@@ -2,12 +2,43 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class otp_ctrl_base_test extends cip_base_test #(
-    .CFG_T(otp_ctrl_env_cfg),
-    .ENV_T(otp_ctrl_env)
+class otp_ctrl_base_test #(
+    type CFG_T = otp_ctrl_env_cfg,
+    type ENV_T = otp_ctrl_env
+  ) extends cip_base_test #(
+    .CFG_T(CFG_T),
+    .ENV_T(ENV_T)
   );
 
-  `uvm_component_utils(otp_ctrl_base_test)
+  // A prototype for the registry to associate the parameterized base test
+  // with the name 'otp_ctrl_base_test'
+  //
+  // Register the name 'otp_ctrl_base_test' with the UVM factory to be associated
+  // with the template base test class parameterized with the default types (see
+  // declaration. We cannot invoke the standard UVM factory automation macro t
+  // (uvm_component_param_utils) to register a parameterized test class with the
+  // factory because the creation of the test by name (via the UVM_TESTNAME
+  // plusarg) does not work. We expand the contents of the automation macro
+  // here instead. See the following paper for details:
+  // https://verificationacademy-news.s3.amazonaws.com/DVCon2016/Papers/
+  // dvcon-2016_paramaters-uvm-coverage-and-emulation-take-two-and-call-me-in-the-morning_paper.pdf
+  typedef uvm_component_registry#(otp_ctrl_base_test#(CFG_T, ENV_T), "otp_ctrl_base_test") type_id;
+
+  // functions to support the component registry above
+  static function type_id get_type();
+    return type_id::get();
+  endfunction : get_type
+
+  virtual function uvm_object_wrapper get_object_type();
+    return type_id::get();
+  endfunction : get_object_type
+
+  const static string type_name = "otp_ctrl_base_test";
+
+  virtual function string get_type_name();
+    return type_name;
+  endfunction : get_type_name
+
   `uvm_component_new
 
   // the base class dv_base_test creates the following instances:


### PR DESCRIPTION
Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

Partner DV environment use a different env_cfg and env class types than the prim_pkg::ImplGeneric implementation, which requires the base test to specify different type parameters for ENV_T and CFG_T.
Since otp_ctrl_base_test is not parameterized, currently the partner DV base_test class inherits from cip_base_test and specifies its (ENV_T,CFG_T) directly, and not via inheritance from otp_ctrl_base_test.

Parametrization of otp_ctrl_base_test led to a problem since UVM_TESTNAME doesn't allow passing a test name with parameters as the UVM registry doesn't recognize 'otp_ctrl_base_test' as a name in the registry once the class has been parameterized.
Neither `uvm_component_utils` nor `uvm_component_param_utils` work.

The following solution to that problem is based on this article from DVCon-2016. 
Pages #2-3 discuss the solution for parameterized tests in UVM.
https://verificationacademy-news.s3.amazonaws.com/DVCon2016/Papers/dvcon-2016_paramaters-uvm-coverage-and-emulation-take-two-and-call-me-in-the-morning_paper.pdf 