### PR TITLE
[otbn,dv] Teach the RIG about the 'wrd' operand of bn.mulqacc.so

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -219,7 +219,9 @@
   synopsis: Quarter-word Multiply and Accumulate with half-word writeback
   operands:
     - *mulqacc-zero-acc
-    - *mulqacc-wrd
+    - name: wrd
+      doc: Updated WDR.
+      type: wrb
     - name: wrd_hwsel
       abbrev: dh
       type: enum(L,U)

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -113,7 +113,8 @@ encoding-schemes: enc-schemes.yml
 #             source; "grd" for a destination.
 #
 #  wdr:       The name of a wide register. Syntax "wrs" for a source;
-#             "wrd" for a destination.
+#             "wrd" for a destination; "wrb" for a register that is both a
+#             source and a destination.
 #
 #  csr:       The name of a CSR. Syntax "csr" (always considered a destination)
 #

--- a/hw/ip/otbn/util/otbn-as
+++ b/hw/ip/otbn/util/otbn-as
@@ -479,7 +479,7 @@ def _unpack_lx(where: str,
                            'insns.yml?')
 
     try:
-        gpr_type = RegOperandType('gpr', True)
+        gpr_type = RegOperandType('gpr', False, True)
         grd_op_val = gpr_type.str_to_op_val(grd)
         assert grd_op_val is not None
     except ValueError as err:


### PR DESCRIPTION
This is both a source and a destination (we update just half of the
word). So we need to teach the tooling about updated wide registers (I
used the mnemonic `wru`) and update `bignum-insns.yml` to say that
bn.mulqacc.so's `wrd` operand is actually updated.

This fixes a failing test (`otbn_reset` with seed 531773529) caused by
the fact that one of the WDRs comes up with a nonzero initial value.
The RIG is quite careful to avoid reading registers with unknown
values, but didn't realise that a `bn.mulqacc.so` wasn't safe (because
the destination register didn't have a determined value).
