### PR TITLE
[lc_ctrl] Add CSR for switching to an external clock source

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -592,6 +592,13 @@
               // CLAIM_TRANSITION_IF, so can not auto predict its value.
               "excl:CsrNonInitTests:CsrExclCheck"],
       fields: [
+        { bits: "16",
+          name: "EXT_CLOCK",
+          desc: '''
+          Switch to an externally supplied clock when initiating a life cycle state transition.
+          The clock mux will remain switched until the next system reset.
+          ''',
+        }
         { bits: "CsrOtpTestCtrlWidth-1:0",
           name: "VAL",
           desc: '''

--- a/hw/ip/lc_ctrl/doc/_index.md
+++ b/hw/ip/lc_ctrl/doc/_index.md
@@ -219,9 +219,10 @@ The CHECK_BYP_EN signal is only asserted when a transition command is issued.
 
 #### CLK_BYP_REQ
 
-The CLK_BYP_REQ signal switches the main system clock to an external clock signal in RAW and TEST_LOCKED states when initiating a life cycle transition.
-This is needed since the internal clock source may not be fully calibrated yet in those states, and the OTP macro requires a stable clock frequency in order to reliably program the fuse array.
+If the life cycle state is in RAW, TEST* or RMA, and if {{< regref OTP_TEST_CTRL.EXT_CLOCK >}} is set to one, the CLK_BYP_REQ signal is asserted in order to switch the main system clock to an external clock signal.
+This functionality is needed in certain life cycle states where the internal clock source may not be fully calibrated yet, since the OTP macro requires a stable clock frequency in order to reliably program the fuse array.
 The CLK_BYP_REQ signal is only asserted when a transition command is issued.
+This function is not available in production life cycle states.
 
 
 ### Life Cycle Access Control Signals
@@ -609,7 +610,7 @@ This resets the mux to select no one and also holds the request interface in res
 #### Vendor-specific Test Control Register
 
 Certain OTP macros require special configuration bits to be set during the test phases.
-Hence, the life cycle CSRs include register {{< regref "OTP_TEST_CTRL" >}}, which is reserved for vendor-specific test control bits.
+Hence, the life cycle CSRs include register {{< regref OTP_TEST_CTRL.VAL >}}, which is reserved for vendor-specific test control bits.
 Its value is only forwarded to the OTP macro in RAW, TEST_* and RMA life cycle states.
 In all other life cycle states, a value of 0 will be sent to the OTP macro.
 
@@ -646,11 +647,17 @@ Hence the following programming sequence applies to both SW running on the devic
 
 3. Claim exclusive access to the transition interface by writing 0xA5 to the {{< regref "CLAIM_TRANSITION_IF" >}} register, and reading it back. If the value read back equals to 0xA5, the hardware mutex has successfully been claimed and SW can proceed to step 4. If the value read back equals to 0, the mutex has already been claimed by the other interface (either CSR or TAP), and SW should try claiming the mutex again.
 
-4. Write the desired target state to {{< regref "TRANSITION_TARGET" >}}. For conditional transitions, the corresponding token has to be written to {{< regref "TRANSITION_TOKEN_0" >}}. For all unconditional transitions, the token registers have to be set to zero. An optional, but recommended step is to read back and verify the values written to these registers before proceeding with step 5.
+4. Write the desired target state to {{< regref "TRANSITION_TARGET" >}}. For conditional transitions, the corresponding token has to be written to {{< regref "TRANSITION_TOKEN_0" >}}. For all unconditional transitions, the token registers have to be set to zero.
 
-5. Write 1 to the {{< regref "TRANSITION_CMD.START" >}} register to initiate the life cycle transition.
+5. If required, enable the external clock and other vendor-specific OTP settings in the {{< regref "OTP_TEST_CTRL" >}} register.
+Note that these settings only take effect in RAW, TEST* and RMA life cycle states.
+They are ignored in the PROD* and DEV states.
 
-6. Poll the {{< regref "STATUS" >}} register and wait until either {{< regref "STATUS.TRANSITION_SUCCESSFUL" >}} or any of the error bits is asserted.
+6. An optional, but recommended step is to read back and verify the values written in steps 4. and 5. before proceeding with step 6.
+
+7. Write 1 to the {{< regref "TRANSITION_CMD.START" >}} register to initiate the life cycle transition.
+
+8. Poll the {{< regref "STATUS" >}} register and wait until either {{< regref "STATUS.TRANSITION_SUCCESSFUL" >}} or any of the error bits is asserted.
 
 Note that any life cycle state transition - no matter whether successful or not - increments the LC_TRANSITION_CNT and moves the life cycle state into the temporary POST_TRANSITION state.
 Hence, step 6. cannot be carried out in case device SW is used to implement the programming sequence above, since the processor is disabled in the POST_TRANSITION life cycle state.

--- a/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_otp_accessibility.md
@@ -36,7 +36,7 @@
 </tr>
 <tr>
 <td>RMA_UNLOCK_TOKEN</td>
-<td rowspan="3" colspan="2" style="text-align:center;vertical-align:middle">SECRET0_DIGEST == 0 && CREATOR_SEED_SW_RW_EN == ON</td>
+<td rowspan="3" colspan="2" style="text-align:center;vertical-align:middle">SECRET2_DIGEST == 0 && CREATOR_SEED_SW_RW_EN == ON</td>
 <td rowspan="3" style="text-align:center;vertical-align:middle">SEED_HW_RD_EN == ON</td>
 <td></td>
 </tr>

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -58,8 +58,14 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_reg2hw_transition_target_reg_t;
 
   typedef struct packed {
-    logic [7:0]  q;
-    logic        qe;
+    struct packed {
+      logic [7:0]  q;
+      logic        qe;
+    } val;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } ext_clock;
   } lc_ctrl_reg2hw_otp_test_ctrl_reg_t;
 
   typedef struct packed {
@@ -112,7 +118,12 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_transition_target_reg_t;
 
   typedef struct packed {
-    logic [7:0]  d;
+    struct packed {
+      logic [7:0]  d;
+    } val;
+    struct packed {
+      logic        d;
+    } ext_clock;
   } lc_ctrl_hw2reg_otp_test_ctrl_reg_t;
 
   typedef struct packed {
@@ -133,22 +144,22 @@ package lc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [162:157]
-    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [156:148]
-    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [147:146]
-    lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [145:14]
-    lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [13:9]
-    lc_ctrl_reg2hw_otp_test_ctrl_reg_t otp_test_ctrl; // [8:0]
+    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [164:159]
+    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [158:150]
+    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [149:148]
+    lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [147:16]
+    lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [15:11]
+    lc_ctrl_reg2hw_otp_test_ctrl_reg_t otp_test_ctrl; // [10:0]
   } lc_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [425:416]
-    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [415:408]
-    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [407:407]
-    lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [406:279]
-    lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [278:275]
-    lc_ctrl_hw2reg_otp_test_ctrl_reg_t otp_test_ctrl; // [274:267]
+    lc_ctrl_hw2reg_status_reg_t status; // [426:417]
+    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [416:409]
+    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [408:408]
+    lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [407:280]
+    lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [279:276]
+    lc_ctrl_hw2reg_otp_test_ctrl_reg_t otp_test_ctrl; // [275:267]
     lc_ctrl_hw2reg_lc_state_reg_t lc_state; // [266:263]
     lc_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [262:258]
     lc_ctrl_hw2reg_lc_id_state_reg_t lc_id_state; // [257:256]
@@ -194,7 +205,7 @@ package lc_ctrl_reg_pkg;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_2_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_3_RESVAL = 32'h 0;
   parameter logic [3:0] LC_CTRL_TRANSITION_TARGET_RESVAL = 4'h 0;
-  parameter logic [7:0] LC_CTRL_OTP_TEST_CTRL_RESVAL = 8'h 0;
+  parameter logic [16:0] LC_CTRL_OTP_TEST_CTRL_RESVAL = 17'h 0;
   parameter logic [3:0] LC_CTRL_LC_STATE_RESVAL = 4'h 0;
   parameter logic [4:0] LC_CTRL_LC_TRANSITION_CNT_RESVAL = 5'h 0;
   parameter logic [1:0] LC_CTRL_LC_ID_STATE_RESVAL = 2'h 0;
@@ -245,7 +256,7 @@ package lc_ctrl_reg_pkg;
     4'b 1111, // index[ 7] LC_CTRL_TRANSITION_TOKEN_2
     4'b 1111, // index[ 8] LC_CTRL_TRANSITION_TOKEN_3
     4'b 0001, // index[ 9] LC_CTRL_TRANSITION_TARGET
-    4'b 0001, // index[10] LC_CTRL_OTP_TEST_CTRL
+    4'b 0111, // index[10] LC_CTRL_OTP_TEST_CTRL
     4'b 0001, // index[11] LC_CTRL_LC_STATE
     4'b 0001, // index[12] LC_CTRL_LC_TRANSITION_CNT
     4'b 0001, // index[13] LC_CTRL_LC_ID_STATE

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -149,8 +149,10 @@ module lc_ctrl_reg_top (
   logic [3:0] transition_target_wd;
   logic otp_test_ctrl_re;
   logic otp_test_ctrl_we;
-  logic [7:0] otp_test_ctrl_qs;
-  logic [7:0] otp_test_ctrl_wd;
+  logic [7:0] otp_test_ctrl_val_qs;
+  logic [7:0] otp_test_ctrl_val_wd;
+  logic otp_test_ctrl_ext_clock_qs;
+  logic otp_test_ctrl_ext_clock_wd;
   logic lc_state_re;
   logic [3:0] lc_state_qs;
   logic lc_transition_cnt_re;
@@ -506,17 +508,33 @@ module lc_ctrl_reg_top (
 
   // R[otp_test_ctrl]: V(True)
 
+  //   F[val]: 7:0
   prim_subreg_ext #(
     .DW    (8)
-  ) u_otp_test_ctrl (
+  ) u_otp_test_ctrl_val (
     .re     (otp_test_ctrl_re),
     .we     (otp_test_ctrl_we & transition_regwen_qs),
-    .wd     (otp_test_ctrl_wd),
-    .d      (hw2reg.otp_test_ctrl.d),
+    .wd     (otp_test_ctrl_val_wd),
+    .d      (hw2reg.otp_test_ctrl.val.d),
     .qre    (),
-    .qe     (reg2hw.otp_test_ctrl.qe),
-    .q      (reg2hw.otp_test_ctrl.q),
-    .qs     (otp_test_ctrl_qs)
+    .qe     (reg2hw.otp_test_ctrl.val.qe),
+    .q      (reg2hw.otp_test_ctrl.val.q),
+    .qs     (otp_test_ctrl_val_qs)
+  );
+
+
+  //   F[ext_clock]: 16:16
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_otp_test_ctrl_ext_clock (
+    .re     (otp_test_ctrl_re),
+    .we     (otp_test_ctrl_we & transition_regwen_qs),
+    .wd     (otp_test_ctrl_ext_clock_wd),
+    .d      (hw2reg.otp_test_ctrl.ext_clock.d),
+    .qre    (),
+    .qe     (reg2hw.otp_test_ctrl.ext_clock.qe),
+    .q      (reg2hw.otp_test_ctrl.ext_clock.q),
+    .qs     (otp_test_ctrl_ext_clock_qs)
   );
 
 
@@ -794,7 +812,9 @@ module lc_ctrl_reg_top (
   assign otp_test_ctrl_re = addr_hit[10] & reg_re & !reg_error;
   assign otp_test_ctrl_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign otp_test_ctrl_wd = reg_wdata[7:0];
+  assign otp_test_ctrl_val_wd = reg_wdata[7:0];
+
+  assign otp_test_ctrl_ext_clock_wd = reg_wdata[16];
   assign lc_state_re = addr_hit[11] & reg_re & !reg_error;
   assign lc_transition_cnt_re = addr_hit[12] & reg_re & !reg_error;
   assign lc_id_state_re = addr_hit[13] & reg_re & !reg_error;
@@ -863,7 +883,8 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[7:0] = otp_test_ctrl_qs;
+        reg_rdata_next[7:0] = otp_test_ctrl_val_qs;
+        reg_rdata_next[16] = otp_test_ctrl_ext_clock_qs;
       end
 
       addr_hit[11]: begin


### PR DESCRIPTION
This makes the switch to an external clock source configurable through the CSRs and LC TAP. It is similar to the additional vendor-specific OTP test CSR that can be used to switch to external VPP in certain life cycle states.

Note that the external clock option is only available in RAW, TEST* and RMA, but not in the production states PROD* and DEV.