### PR TITLE
[prim] Do remove prim_esc.core from the dependencies

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
@@ -9,6 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:prim:all:0.1
+      - lowrisc:prim:esc
       - lowrisc:dv:dv_lib
     files:
       - alert_esc_if.sv

--- a/hw/ip/nmi_gen/nmi_gen.core
+++ b/hw/ip/nmi_gen/nmi_gen.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:esc
     files:
       - rtl/nmi_gen_reg_pkg.sv
       - rtl/nmi_gen_reg_top.sv

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -22,7 +22,6 @@ filesets:
       - lowrisc:prim:arbiter
       - lowrisc:prim:fifo
       - lowrisc:prim:alert
-      - lowrisc:prim:esc
       - lowrisc:prim:subreg
       - lowrisc:prim:cipher
       - lowrisc:prim:xor2


### PR DESCRIPTION
`prim_esc` is in general not needed in most IPs, hence we remove it from the `prim.core` file and make the dependency explicit in the IPs that use `prim_esc`.

This fixes https://github.com/lowRISC/opentitan/issues/7073

Signed-off-by: Michael Schaffner <msf@opentitan.org>