### PR TITLE
[lc_ctrl] Move to D2

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.prj.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "../doc/checklist",
     version:            "0.1",
     life_stage:         "L1",
-    design_stage:       "D1",
+    design_stage:       "D2",
     verification_stage: "V1",
     notes:              "",
 }

--- a/hw/ip/lc_ctrl/doc/checklist.md
+++ b/hw/ip/lc_ctrl/doc/checklist.md
@@ -48,7 +48,7 @@ Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
 RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
-RTL           | [ARCHITECTURE_FROZEN][] | Done        | Note that the KMAC token hashing interface change is deferred to after D2 (this is a security hardening task).
+RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        |
 RTL           | [STYLE_X][]             | Done        |
 Code Quality  | [LINT_PASS][]           | Done        |


### PR DESCRIPTION
This finally moves `lc_ctrl` into D2, now that additional features like the KMAC interface have been implemented.

Note that this needs https://github.com/lowRISC/opentitan/pull/7014 and https://github.com/lowRISC/opentitan/pull/7075 to go in first.

Signed-off-by: Michael Schaffner <msf@opentitan.org>