### PR TITLE
Add libftdi-devel as a required package

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -28,6 +28,7 @@ libelf1
 libelf-dev
 libftdi1-2
 libftdi1-dev
+libftdi-devel
 # A requirement of the prebuilt clang toolchain.
 libncurses5
 libssl-dev

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -24,6 +24,7 @@ libelf1
 libelf-dev
 libftdi1-2
 libftdi1-dev
+libftdi-devel
 libssl-dev
 libusb-1.0-0
 lsb-release


### PR DESCRIPTION
Will Chen from Synopsys found this package is needed on their side,
in order to run chip-level simulation

Signed-off-by: Weicai Yang <weicai@google.com>