### PR TITLE
Fix tl_intg_err test for rom_ctrl and i2c

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -261,9 +261,10 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
     `uvm_info(`gfn, $sformatf("Running run_tl_intg_err_vseq %0d/%0d", trans, num_times),
               UVM_LOW)
     fork
-      // run csr_rw seq to send some normal CSR accesses in the parallel
+      // run csr_rw seq to send some normal CSR accesses in parallel
       begin
         `uvm_info(`gfn, "Run csr_rw seq", UVM_HIGH)
+        apply_extra_excl_for_tl_intg_vseq();
         run_csr_vseq("rw");
       end
       begin
@@ -297,4 +298,13 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
     dut_init("HARD");
   end
 endtask
+
+// in run_tl_intg_err_vseq, csr_rw seq is running in the parallel. And intg error will be injected
+// which may affect some CSR values. Use this function to add additional exclusion
+// TODO, as discussed at #7082, best approach is to standardize alert cause in all IPs, so that
+// we can check it in the automatic test. Let's wait until designers finalize the alert cause
+// keep this approach in case we still want it
+virtual function void apply_extra_excl_for_tl_intg_vseq();
+endfunction
+
 `undef create_tl_access_error_case

--- a/hw/ip/i2c/dv/tb/tb.sv
+++ b/hw/ip/i2c/dv/tb/tb.sv
@@ -13,7 +13,7 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  wire clk_i, rst_ni;
+  wire clk, rst_n;
   wire devmode;
   wire intr_fmt_watermark;
   wire intr_rx_watermark;
@@ -41,19 +41,20 @@ module tb;
   wire cio_sda_en_o;
 
   // interfaces
-  clk_rst_if clk_rst_if(.clk(clk_i), .rst_n(rst_ni));
+  clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
   pins_if #(1) devmode_if(devmode);
 
-  tl_if tl_if(.clk(clk_i), .rst_n(rst_ni));
+  tl_if tl_if(.clk(clk), .rst_n(rst_n));
   i2c_if i2c_if();
 
+  // clk and rst_n is used for alert_if in `DV_ALERT_IF_CONNECT
   `DV_ALERT_IF_CONNECT
 
   // dut
   i2c dut (
-    .clk_i                   (clk_i      ),
-    .rst_ni                  (rst_ni     ),
+    .clk_i                   (clk        ),
+    .rst_ni                  (rst_n      ),
 
     .tl_i                    (tl_if.h2d  ),
     .tl_o                    (tl_if.d2h  ),
@@ -93,8 +94,8 @@ module tb;
   assign cio_sda_i = i2c_if.sda_o;
 
   // host -> device if
-  assign i2c_if.clk_i  = clk_i;
-  assign i2c_if.rst_ni = rst_ni;
+  assign i2c_if.clk_i  = clk;
+  assign i2c_if.rst_ni = rst_n;
 
   // interrupt
   assign interrupts[FmtWatermark]   = intr_fmt_watermark;

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -20,7 +20,10 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = rom_ctrl_env_pkg::LIST_OF_ALERTS;
+    tl_intg_alert_name = "fatal";
+
     ral_model_names.push_back("rom_ctrl_rom_reg_block");
+
     super.initialize(csr_base_addr);
     num_interrupts = 0;
 

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -14,4 +14,11 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  // in run_tl_intg_err_vseq, csr_rw seq is running in the parallel. And intg error will be injected
+  // which may affect fatal_alert_cause.integrity_error. Exclude checking it
+  virtual function void apply_extra_excl_for_tl_intg_vseq();
+    cfg.ral.csr_excl.add_excl(ral.fatal_alert_cause.integrity_error.`gfn,
+                              CsrExclCheck, CsrNonInitTests);
+  endfunction
+
 endclass


### PR DESCRIPTION
For I2C, fix alert reset and clock

For rom_ctrl:
Tl_intg_err seq calls csr_rw seq.
Some blocks like rom_ctrl have a CSR FATAL_ALERT_CAUSE, which is
affected by sending TL item with intg error, need to exclude checking the
CSR in the csr_rw seq
add the function and apply an exclusion in rom_ctrl to fix the failure