### PR TITLE
[spi*/uart] Make sure integ alert is fatal

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -981,7 +981,7 @@ module spi_device
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
-      .IsFatal(i)
+      .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -77,7 +77,7 @@ module spi_host
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
-      .IsFatal(i)
+      .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,

--- a/hw/ip/uart/rtl/uart.sv
+++ b/hw/ip/uart/rtl/uart.sv
@@ -83,7 +83,7 @@ module uart
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
-      .IsFatal(i)
+      .IsFatal(1'b1)
     ) u_prim_alert_sender (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
This slipped through the cracks. These alerts should be set to fatal.

Signed-off-by: Michael Schaffner <msf@opentitan.org>