### PR TITLE
[tlul] Add some missing dependencies

### DIFF
--- a/hw/ip/prim/prim_fifo.core
+++ b/hw/ip/prim/prim_fifo.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:util
       - lowrisc:prim:flop_2sync
     files:
       - rtl/prim_fifo_async.sv

--- a/hw/ip/tlul/common.core
+++ b/hw/ip/tlul/common.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:fifo
       - lowrisc:tlul:headers
+      - lowrisc:tlul:trans_intg
     files:
       - rtl/tlul_fifo_sync.sv
       - rtl/tlul_fifo_async.sv

--- a/hw/ip/tlul/trans_intg.core
+++ b/hw/ip/tlul/trans_intg.core
@@ -10,7 +10,7 @@ filesets:
     depend:
       - lowrisc:prim:assert
       - lowrisc:prim:secded
-      - lowrisc:tlul:common
+      - lowrisc:tlul:headers
     files:
       - rtl/tlul_cmd_intg_gen.sv
       - rtl/tlul_cmd_intg_chk.sv


### PR DESCRIPTION
These missing dependencies currently lead to lint errors in the tlul modules (when they are linted separately).

Signed-off-by: Michael Schaffner <msf@opentitan.org>