### PR TITLE
[pwm, dv] Add pwm_smoke test for PWM IP

### DIFF
--- a/hw/ip/pwm/dv/cov/pwm_cov.core
+++ b/hw/ip/pwm/dv/cov/pwm_cov.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:pwm_cov:0.1"
+description: "PWM functional coverage interface & bind."
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+    files:
+      - pwm_cov_if.sv
+      - pwm_cov_bind.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/pwm/dv/cov/pwm_cov_bind.sv
+++ b/hw/ip/pwm/dv/cov/pwm_cov_bind.sv
@@ -1,8 +1,10 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Binds PWM functional coverage interaface to the top level PWM module.
+module pwm_cov_bind;
 
-`include "pwm_base_vseq.sv"
-`include "pwm_rx_tx_vseq.sv"
-`include "pwm_smoke_vseq.sv"
-`include "pwm_common_vseq.sv"
+  bind pwm pwm_cov_if u_pwm_cov_if (.*);
+
+endmodule

--- a/hw/ip/pwm/dv/cov/pwm_cov_if.sv
+++ b/hw/ip/pwm/dv/cov/pwm_cov_if.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implements functional coverage for PWM.
+interface pwm_cov_if (
+  input logic clk_i
+);
+
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  `include "dv_fcov_macros.svh"
+
+  // TODO Add coverage points if needed
+
+endinterface : pwm_cov_if

--- a/hw/ip/pwm/dv/env/pwm_env.core
+++ b/hw/ip/pwm/dv/env/pwm_env.core
@@ -9,7 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
-      - lowrisc:dv:pwm_agent
+      - lowrisc:dv:pwm_monitor
       - lowrisc:ip:pwm
     files:
       - pwm_env_pkg.sv
@@ -21,6 +21,7 @@ filesets:
       - pwm_env.sv: {is_include_file: true}
       - seq_lib/pwm_vseq_list.sv: {is_include_file: true}
       - seq_lib/pwm_base_vseq.sv: {is_include_file: true}
+      - seq_lib/pwm_rx_tx_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_common_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/pwm/dv/env/pwm_env.sv
+++ b/hw/ip/pwm/dv/env/pwm_env.sv
@@ -11,32 +11,33 @@ class pwm_env extends cip_base_env #(
   `uvm_component_utils(pwm_env)
   `uvm_component_new
 
-  pwm_agent m_pwm_agent;
+  pwm_monitor#(PWM_NUM_CHANNELS) m_pwm_monitor;
 
   function void build_phase(uvm_phase phase);
-    int core_clk_freq_mhz;
-
     super.build_phase(phase);
-    m_pwm_agent = pwm_agent::type_id::create("m_pwm_agent", this);
-    uvm_config_db#(pwm_agent_cfg)::set(this, "m_pwm_agent*", "cfg", cfg.m_pwm_agent_cfg);
-    cfg.m_pwm_agent_cfg.en_cov = cfg.en_cov;
+
+    // instantiate pwm_monitor
+    m_pwm_monitor = pwm_monitor#(PWM_NUM_CHANNELS)::type_id::create("m_pwm_monitor", this);
+    m_pwm_monitor.cfg = cfg.m_pwm_monitor_cfg;
 
     // generate core clock (must slower than bus clock)
-    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_rst_core_vif",
-        cfg.clk_rst_core_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get clk_rst_core_vif from uvm_config_db")
+    if (!uvm_config_db#(virtual clk_rst_if)
+        ::get(this, "", "clk_rst_core_vif", cfg.clk_rst_core_vif)) begin
+      `uvm_fatal(`gfn, "\n  pwm_env: failed to get clk_rst_core_vif from uvm_config_db")
     end
-    core_clk_freq_mhz = cfg.get_clk_core_freq(cfg.seq_cfg.pwm_core_clk_ratio);
-    cfg.clk_rst_core_vif.set_freq_mhz(core_clk_freq_mhz);
+    cfg.core_clk_freq_mhz = cfg.get_clk_core_freq();
+    cfg.clk_rst_core_vif.set_freq_mhz(cfg.core_clk_freq_mhz);
+    `uvm_info(`gfn, $sformatf("\n  env_cfg: bus_clk %0d Mhz, core_clk %0d Mhz",
+        cfg.clk_rst_vif.clk_freq_mhz, cfg.clk_rst_core_vif.clk_freq_mhz), UVM_DEBUG)
   endfunction : build_phase
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
     if (cfg.en_scb) begin
-      for (uint i = 0; i < NUM_PWM_CHANNELS; i++) begin
-        m_pwm_agent.monitor.item_port[i].connect(scoreboard.item_fifo[i].analysis_export);
+      for (int i = 0; i < PWM_NUM_CHANNELS; i++) begin
+        m_pwm_monitor.item_port[i].connect(scoreboard.item_fifo[i].analysis_export);
       end
     end
-  endfunction
+  endfunction : connect_phase
 
 endclass : pwm_env

--- a/hw/ip/pwm/dv/env/pwm_env_cfg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_cfg.sv
@@ -3,30 +3,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class pwm_env_cfg extends cip_base_env_cfg #(.RAL_T(pwm_reg_block));
-
-  // pwm_agent_cfg
-  rand pwm_agent_cfg m_pwm_agent_cfg;
-
-  // seq_cfg
-  pwm_seq_cfg seq_cfg;
-
-  // clk_rst_core_if
-  virtual clk_rst_if clk_rst_core_vif;
-
   `uvm_object_utils_begin(pwm_env_cfg)
-    `uvm_field_object(m_pwm_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
+
+  // configs
+  pwm_monitor_cfg#(PWM_NUM_CHANNELS) m_pwm_monitor_cfg;
+  pwm_seq_cfg seq_cfg;
+  // virtual ifs
+  virtual clk_rst_if clk_rst_core_vif;
+  // variables
+  uint ok_to_end_delay_ns = 3000;    // drained time of phase_ready_to_end
+  int num_pulses;                    // number of generated pulse
+  int core_clk_freq_mhz;             // core clock freq
+  
+  // ratio between bus_clk and core_clk (must be >= 1)
+  rand int clk_ratio;
+  constraint clk_ratio_c { clk_ratio inside {[1: 4]}; }
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = pwm_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
 
-    // create m_pwm_agent_cfg
-    m_pwm_agent_cfg = pwm_agent_cfg::type_id::create("m_pwm_agent_cfg");
-    m_pwm_agent_cfg.if_mode = Device; // setup agent in Device mode
-    m_pwm_agent_cfg.ok_to_end_delay_ns = 8000; // drained time of phase_ready_to_end
+    // create pwm_agent_cfg
+    m_pwm_monitor_cfg = pwm_monitor_cfg#(PWM_NUM_CHANNELS)::type_id::create("m_pwm_monitor_cfg");
+    m_pwm_monitor_cfg.if_mode = Device;
 
     // create seq_cfg
     seq_cfg = pwm_seq_cfg::type_id::create("seq_cfg");
@@ -35,22 +37,55 @@ class pwm_env_cfg extends cip_base_env_cfg #(.RAL_T(pwm_reg_block));
   // clk_core_freq_mhz is assigned by
   // - a slower frequency in range [bus_clock*scale : bus_clock] if en_random is set (scale <= 1)
   // - bus_clock frequency otherwise
-  virtual function int get_clk_core_freq(real core_clk_ratio, uint en_random = 1);
+  virtual function int get_clk_core_freq(uint en_random = 1);
     int clk_core_min, clk_core_max, clk_core_mhz;
 
     if (en_random) begin
-      `DV_CHECK_LE(core_clk_ratio, 1)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clk_ratio)
+      `DV_CHECK_GE(clk_ratio, 1)
       clk_core_max = clk_rst_vif.clk_freq_mhz;
-      clk_core_min = int'(core_clk_ratio * real'(clk_rst_vif.clk_freq_mhz));
+      clk_core_min = int'(clk_rst_vif.clk_freq_mhz / clk_ratio);
       clk_core_mhz = $urandom_range(clk_core_min, clk_core_max);
     end else begin
       clk_core_mhz = clk_rst_vif.clk_freq_mhz;
     end
-    `uvm_info(`gfn, $sformatf("clk_bus %0d Mhz, clk_core %0d Mhz",
-        clk_rst_vif.clk_freq_mhz, clk_core_mhz), UVM_DEBUG)
-    `DV_CHECK_LE(clk_core_mhz, clk_rst_vif.clk_freq_mhz)
-
     return clk_core_mhz;
   endfunction : get_clk_core_freq
 
+  virtual function void print_channel_cfg(string     msg,
+                                          pwm_regs_t regs,
+                                          int        channel,
+                                          bit        en_print = 1'b1);
+    if (regs.pwm_en[channel] && en_print) begin
+      string str = $sformatf("\n>>> %s: channel %0d configuration", msg, channel);
+      str = {str, $sformatf("\n  pwm_mode        %s",  regs.pwm_mode[channel].name())};
+      str = {str, $sformatf("\n  pwm_en          %s",
+          regs.pwm_en[channel] ? "Enable" : "Disable")};
+      str = {str, $sformatf("\n  clk_div         %0d", regs.clk_div)};
+      str = {str, $sformatf("\n  dc_resn         %0d", regs.dc_resn)};
+      str = {str, $sformatf("\n  cntr_en         %b",  regs.cntr_en)};
+      str = {str, $sformatf("\n  num_pulses      %0d", num_pulses)};
+      str = {str, $sformatf("\n  beat_cycle      %0d", regs.beat_cycle)};
+      str = {str, $sformatf("\n  pulse_cycle     %0d", regs.pulse_cycle)};
+      str = {str, $sformatf("\n  invert          %b",  regs.invert[channel])};
+      str = {str, $sformatf("\n  blink_en        %b",  regs.blink_en[channel])};
+      str = {str, $sformatf("\n  htbt_en         %b",  regs.htbt_en[channel])};
+      str = {str, $sformatf("\n  phase_delay     %0d", regs.phase_delay[channel])};
+      str = {str, $sformatf("\n  duty_cycle_a    %0d", regs.duty_cycle_a[channel])};
+      str = {str, $sformatf("\n  duty_cycle_b    %0d", regs.duty_cycle_b[channel])};
+      str = {str, $sformatf("\n  blink_param_x   %0d", regs.blink_param_x[channel])};
+      str = {str, $sformatf("\n  blink_param_y   %0d", regs.blink_param_y[channel])};
+      `uvm_info(`gfn, $sformatf("%s", str), UVM_LOW)
+    end
+  endfunction : print_channel_cfg
+
+  virtual function void print_all_channel_cfg(string msg,
+                                              pwm_regs_t regs,
+                                              int num_channels = PWM_NUM_CHANNELS,
+                                              bit en_print = 1'b1);
+    for (int channel = 0; channel < num_channels; channel++) begin
+      print_channel_cfg(msg, regs, channel, en_print);
+    end
+  endfunction : print_all_channel_cfg
+  
 endclass : pwm_env_cfg

--- a/hw/ip/pwm/dv/env/pwm_env_pkg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_pkg.sv
@@ -9,12 +9,14 @@ package pwm_env_pkg;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
   import tl_agent_pkg::*;
-  import pwm_agent_pkg::*;
   import cip_base_pkg::*;
   import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
+  import pwm_monitor_pkg::*;
   import pwm_reg_pkg::*;
   import pwm_ral_pkg::*;
+
+  parameter uint PWM_NUM_CHANNELS = pwm_reg_pkg::NOutputs;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -25,9 +27,52 @@ package pwm_env_pkg;
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
 
-  // types
+  // datatype
+  typedef enum bit [1:0] {
+    Standard   = 2'b00,
+    Blinking   = 2'b01,
+    Heartbeat  = 2'b11,
+    Allmodes   = 2'b10
+  } pwm_mode_e;
 
-  // functions
+  typedef enum bit {
+    Enable     = 1'b1,
+    Disable    = 1'b0
+  } pwm_status_e;
+
+  typedef struct {
+    // cfg reg
+    rand bit [3:0]    dc_resn;
+    rand bit [26:0]   clk_div;
+    bit               cntr_en;
+    // en reg
+    rand bit [PWM_NUM_CHANNELS-1:0]         pwm_en;
+    // invert multireg
+    rand bit [PWM_NUM_CHANNELS-1:0]         invert;
+    // param multireg
+    rand bit [PWM_NUM_CHANNELS-1:0]         blink_en;
+    rand bit [PWM_NUM_CHANNELS-1:0]         htbt_en;
+    rand bit [PWM_NUM_CHANNELS-1:0][15:0]   phase_delay;
+    // duty_cycle multireg
+    rand bit [PWM_NUM_CHANNELS-1:0][15:0]   duty_cycle_a;
+    rand bit [PWM_NUM_CHANNELS-1:0][15:0]   duty_cycle_b;
+    // blink_param multireg
+    rand bit [PWM_NUM_CHANNELS-1:0][15:0]   blink_param_x;
+    rand bit [PWM_NUM_CHANNELS-1:0][15:0]   blink_param_y;
+    // mode multireg
+    rand pwm_mode_e [PWM_NUM_CHANNELS-1:0]  pwm_mode;
+    // derived params
+    bit  [27:0] beat_cycle;   // 2**(clk_div+1) core cycles
+    bit  [16:0] pulse_cycle;  // 2**(dc_resn+1) beat cycles
+  } pwm_regs_t;
+
+  // function
+  function automatic pwm_mode_e get_pwm_mode(bit [1:0] mode);
+    return (mode == 2'b10) ? Blinking  :
+           (mode == 2'b11) ? Heartbeat :
+           (mode == 2'b00) ? Standard  :
+                             Allmodes;
+  endfunction : get_pwm_mode
 
   // package sources
   `include "pwm_seq_cfg.sv"
@@ -35,7 +80,8 @@ package pwm_env_pkg;
   `include "pwm_env_cov.sv"
   `include "pwm_virtual_sequencer.sv"
   `include "pwm_scoreboard.sv"
+  `include "pwm_monitor.sv"
   `include "pwm_env.sv"
   `include "pwm_vseq_list.sv"
 
-endpackage
+endpackage : pwm_env_pkg

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -10,40 +10,44 @@ class pwm_scoreboard extends cip_base_scoreboard #(
   `uvm_component_utils(pwm_scoreboard)
   `uvm_component_new
 
-  //****************************************************
-  // TODO: This is still WIP (cleaned up later)
-  //****************************************************
-  // TLM fifos hold the transactions sent by monitor
-  uvm_tlm_analysis_fifo #(pwm_item) item_fifo[NUM_PWM_CHANNELS];
+  // TLM agent fifos
+  uvm_tlm_analysis_fifo #(pwm_item) item_fifo[PWM_NUM_CHANNELS];
+
+  local pwm_regs_t pwm_regs;
+  local pwm_item   exp_item_q[PWM_NUM_CHANNELS][$];
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    for (uint i = 0; i < NUM_PWM_CHANNELS; i++) begin
+    for (int i = 0; i < PWM_NUM_CHANNELS; i++) begin
       item_fifo[i] = new($sformatf("item_fifo[%0d]", i), this);
     end
   endfunction
 
-  function void connect_phase(uvm_phase phase);
-    super.connect_phase(phase);
-  endfunction
-
   task run_phase(uvm_phase phase);
     super.run_phase(phase);
-    fork
-      // TODO
-    join_none
-  endtask
+    forever begin
+      `DV_SPINWAIT_EXIT(
+        for (int i = 0; i < PWM_NUM_CHANNELS; i++) begin
+          fork
+            automatic int channel = i;
+            compare_trans(channel);
+          join_none
+        end
+        wait fork;,
+        @(negedge cfg.clk_rst_vif.rst_n),
+      )
+    end
+  endtask : run_phase
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
     uvm_reg csr;
-    bit     do_read_check   = 1'b1;
-    bit     write           = item.is_write();
+    bit [TL_DW-1:0] reg_value;
+    bit do_read_check = 1'b1;
+    bit write = item.is_write();
     uvm_reg_addr_t csr_addr = ral.get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit addr_phase_write = (write && channel  == AddrChannel);
+    bit data_phase_read  = (!write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -54,19 +58,68 @@ class pwm_scoreboard extends cip_base_scoreboard #(
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
-    // if incoming access is a write to a valid csr, then make updates right away
     if (addr_phase_write) begin
-      void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
-    end
+      string csr_name = csr.get_name();
 
-    // process the csr req
-    // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
-    case (csr.get_name())
-      default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
-      end
-    endcase
+      // if incoming access is a write to a valid csr, then make updates right away
+      void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
+
+      // process the csr req
+      // for write, update local variable and fifo at address phase
+      // for read, update predication at address phase and compare at data phase
+      case (csr_name)
+        "pwm_en": begin
+          pwm_regs.pwm_en = ral.pwm_en.get_mirrored_value();
+          `uvm_info(`gfn, $sformatf("\n  scb: pwm_en %b", pwm_regs.pwm_en), UVM_DEBUG)
+        end
+        "cfg": begin
+          reg_value = ral.cfg.get_mirrored_value();
+          pwm_regs.clk_div = get_field_val(ral.cfg.clk_div, reg_value);
+          pwm_regs.dc_resn = get_field_val(ral.cfg.dc_resn, reg_value);
+          pwm_regs.cntr_en = get_field_val(ral.cfg.cntr_en, reg_value);
+          pwm_regs.beat_cycle  = pwm_regs.clk_div + 1;
+          pwm_regs.pulse_cycle = 2**(pwm_regs.dc_resn + 1);
+          for (int channel = 0; channel < PWM_NUM_CHANNELS; channel++) begin
+            cfg.print_channel_cfg("scb", pwm_regs, channel, 1'b0);
+            generate_exp_items(channel);
+          end
+        end
+        "invert": begin
+          pwm_regs.invert = ral.invert.get_mirrored_value();
+          `uvm_info(`gfn, $sformatf("\n  scb: channels invert %b", pwm_regs.invert), UVM_DEBUG)
+        end
+        "pwm_param_0", "pwm_param_1", "pwm_param_2",
+        "pwm_param_3", "pwm_param_4", "pwm_param_5": begin
+          int channel = get_reg_index(csr_name, 10);
+          pwm_regs.blink_en[channel] = bit'(get_field_val(ral.pwm_param_0.blink_en_0, item.a_data));
+          pwm_regs.htbt_en[channel] = bit'(get_field_val(ral.pwm_param_0.htbt_en_0, item.a_data));
+          pwm_regs.phase_delay[channel] = get_field_val(ral.pwm_param_0.phase_delay_0, item.a_data);
+          pwm_regs.pwm_mode[channel] = get_pwm_mode({pwm_regs.blink_en[channel],
+                                                     pwm_regs.htbt_en[channel]});
+          `uvm_info(`gfn, $sformatf("\n  scb: channel %0d, data %b, pwm_mode %s, phase_delay %0d",
+              channel, item.a_data, pwm_regs.pwm_mode[channel].name(),
+              pwm_regs.phase_delay[channel]), UVM_DEBUG)
+        end
+        "duty_cycle_0", "duty_cycle_1", "duty_cycle_2",
+        "duty_cycle_3", "duty_cycle_4", "duty_cycle_5": begin
+          int channel = get_reg_index(csr_name, 11);
+          {pwm_regs.duty_cycle_b[channel], pwm_regs.duty_cycle_a[channel]} = item.a_data;
+          `uvm_info(`gfn, $sformatf("\n  scb: channel %0d, duty_cycle_b %0d, duty_cycle_a %0d",
+              channel, pwm_regs.duty_cycle_b[channel], pwm_regs.duty_cycle_a[channel]), UVM_DEBUG)
+        end
+        "blink_param_0", "blink_param_1", "blink_param_2",
+        "blink_param_3", "blink_param_4", "blink_param_5": begin
+          int channel = get_reg_index(csr_name, 12);
+          {pwm_regs.blink_param_y[channel], pwm_regs.blink_param_x[channel]} = item.a_data;
+          `uvm_info(`gfn, $sformatf("\n  scb: channel %0d, blink_param_y %0d, blink_param_x %0d",
+              channel, pwm_regs.blink_param_y[channel],
+              pwm_regs.blink_param_x[channel]), UVM_DEBUG)
+        end
+        default: begin
+          `uvm_fatal(`gfn, $sformatf("\n  scb: invalid csr: %0s", csr.get_full_name()))
+        end
+      endcase
+    end
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read) begin
@@ -78,14 +131,87 @@ class pwm_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
+  virtual task compare_trans(int channel);
+    pwm_item exp_item;
+    pwm_item dut_item;
+
+    forever begin
+      item_fifo[channel].get(dut_item);
+      wait(exp_item_q[channel].size() > 0);
+      exp_item = exp_item_q[channel].pop_front();
+
+      if (!dut_item.compare(exp_item)) begin
+        //cfg.print_channel_regs("scb", pwm_regs, channel);
+        `uvm_error(`gfn, $sformatf("\n--> channel %0d item mismatch!\n--> EXP:\n%s\--> DUT:\n%s",
+            channel, exp_item.sprint(), dut_item.sprint()))
+      end else begin
+        `uvm_info(`gfn, $sformatf("\n--> channel %0d item match!\n--> EXP:\n%s\--> DUT:\n%s",
+            channel, exp_item.sprint(), dut_item.sprint()), UVM_DEBUG)
+      end
+    end
+  endtask : compare_trans
+
+  virtual function void generate_exp_items(uint channel);
+    uint beat_cycle  = uint'(pwm_regs.beat_cycle);
+    uint pulse_cycle = uint'(pwm_regs.pulse_cycle);
+
+    if (pwm_regs.pwm_en[channel] && pwm_regs.cntr_en) begin
+      for (int pulse_index = 1; pulse_index <= cfg.num_pulses; pulse_index++) begin
+        bit get_exp_item = 1'b0;
+        pwm_item exp_item = pwm_item::type_id::create("exp_item");
+
+        exp_item.index = pulse_index;
+        unique case (pwm_regs.pwm_mode[channel])
+          Heartbeat: begin
+            // TODO: get the duty_cycle for the Heartbeat mode
+          end
+          Blinking: begin
+            // TODO: get the duty_cycle for the Blinking mode
+          end
+          Standard: begin  // Standard mode
+            // pulse_duty depends on duty_cycle_a is only
+            exp_item.duty_high = pwm_regs.beat_cycle *
+                                 (pwm_regs.duty_cycle_a[channel] % pwm_regs.pulse_cycle);
+            exp_item.duty_low  = pwm_regs.beat_cycle * pwm_regs.pulse_cycle - exp_item.duty_high;
+
+            `uvm_info(`gfn, $sformatf("\n  scb: channel %0d duty_a %0d, pulse_cyc %0d, duty_high %0d",
+                channel, pwm_regs.duty_cycle_a[channel], pwm_regs.pulse_cycle, exp_item.duty_high), UVM_DEBUG)
+            // if invert bit is set, swap duty_high and duty_low since pulses are inverted
+            if (pwm_regs.invert[channel]) begin
+              int temp = exp_item.duty_high;
+              exp_item.duty_high = exp_item.duty_low;
+              exp_item.duty_low = temp;
+            end
+            get_exp_item = (exp_item.index < cfg.num_pulses);
+          end
+        endcase
+        if (get_exp_item) begin
+          exp_item_q[channel].push_back(exp_item);
+          `uvm_info(`gfn, $sformatf("\n--> scb: get exp_item for channel %0d\n%s",
+              channel, exp_item.sprint()), UVM_DEBUG)
+        end
+      end
+    end
+  endfunction : generate_exp_items
+
+  virtual function int get_reg_index(string csr_name, int pos);
+    return csr_name.substr(pos, pos).atoi();
+  endfunction : get_reg_index
+
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
-    // reset local fifos queues and variables
+    for (int i = 0; i < PWM_NUM_CHANNELS; i++) begin
+      item_fifo[i].flush();
+      exp_item_q[i].delete();
+    end
   endfunction
 
-  function void check_phase(uvm_phase phase);
+  virtual function void check_phase(uvm_phase phase);
     super.check_phase(phase);
-    // post test checks - ensure that all local fifos and queues are empty
+    for (int i = 0; i < PWM_NUM_CHANNELS; i++) begin
+      `DV_EOT_PRINT_Q_CONTENTS(pwm_item, exp_item_q[i])
+      `DV_EOT_PRINT_TLM_FIFO_CONTENTS(pwm_item, item_fifo[i])
+    end
   endfunction
 
 endclass : pwm_scoreboard

--- a/hw/ip/pwm/dv/env/pwm_seq_cfg.sv
+++ b/hw/ip/pwm/dv/env/pwm_seq_cfg.sv
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This clas provides knobs to set the weights for various seq random variables.
+
+class pwm_seq_cfg extends uvm_object;
+
+  `uvm_object_utils(pwm_seq_cfg)
+  `uvm_object_new
+
+  // knobs for number of requests sent to dut
+  uint pwm_min_num_trans         = 10;
+  uint pwm_max_num_trans         = 15;
+
+  // knobs for number of retry after reset
+  // for stress_all, stress_all_with_rand_reset
+  uint pwm_min_num_runs          = 1;
+  uint pwm_max_num_runs          = 5;
+
+  // knobs for pwm channels
+  uint pwm_min_clk_div           = 1;
+  uint pwm_max_clk_div           = 5;
+  uint pwm_min_dc_resn           = 1;
+  uint pwm_max_dc_resn           = 8;
+  uint pwm_min_param             = 4;
+  uint pwm_max_param             = 10;
+  // derive params
+  uint pwm_min_num_pulses        = 2 * pwm_min_param;
+  uint pwm_max_num_pulses        = 4 * pwm_max_param;
+
+  // test knobs
+  pwm_mode_e pwm_run_mode        = Allmodes;
+  int        pwm_run_channel     = PWM_NUM_CHANNELS;
+
+endclass : pwm_seq_cfg

--- a/hw/ip/pwm/dv/env/pwm_virtual_sequencer.sv
+++ b/hw/ip/pwm/dv/env/pwm_virtual_sequencer.sv
@@ -6,9 +6,8 @@ class pwm_virtual_sequencer extends cip_base_virtual_sequencer #(
   .CFG_T(pwm_env_cfg),
   .COV_T(pwm_env_cov)
 );
+
   `uvm_component_utils(pwm_virtual_sequencer)
-
-
   `uvm_component_new
 
-endclass
+endclass : pwm_virtual_sequencer

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_base_vseq.sv
@@ -11,8 +11,12 @@ class pwm_base_vseq extends cip_base_vseq #(
   `uvm_object_utils(pwm_base_vseq)
   `uvm_object_new
 
-  // random variables
+  // number of runs
   rand uint num_runs;
+  // pwm registers
+  rand pwm_regs_t pwm_regs;
+  // number of generated pulses
+  rand int num_pulses;
 
   // constraints
   constraint num_trans_c {
@@ -21,29 +25,182 @@ class pwm_base_vseq extends cip_base_vseq #(
   constraint num_runs_c {
     num_runs inside {[cfg.seq_cfg.pwm_min_num_runs : cfg.seq_cfg.pwm_max_num_runs]};
   }
+  constraint num_pulses_c {
+    num_pulses inside {[cfg.seq_cfg.pwm_min_num_pulses : cfg.seq_cfg.pwm_max_num_pulses]};
+  }
 
+  constraint pwm_regs_c {
+    // constraints for single regs
+    pwm_regs.dc_resn inside {[cfg.seq_cfg.pwm_min_dc_resn : cfg.seq_cfg.pwm_max_dc_resn]};
+    pwm_regs.clk_div inside {[cfg.seq_cfg.pwm_min_clk_div : cfg.seq_cfg.pwm_max_clk_div]};
+
+    // constraints for multi regs
+    foreach (pwm_regs.pwm_mode[i]) {
+      if (cfg.seq_cfg.pwm_run_mode == Allmodes) {
+        pwm_regs.pwm_mode[i] dist { Standard  :/ 1, Blinking  :/ 1, Heartbeat :/ 0 };
+      } else {
+        pwm_regs.pwm_mode[i] == cfg.seq_cfg.pwm_run_mode;
+      }
+    }
+    foreach (pwm_regs.blink_en[i]) {pwm_regs.blink_en[i] == (pwm_regs.pwm_mode[i] != Standard);}
+    foreach (pwm_regs.htbt_en[i])  {pwm_regs.htbt_en[i]  == (pwm_regs.pwm_mode[i] == Heartbeat);}
+    pwm_regs.pwm_en inside {[1 : (1 << cfg.seq_cfg.pwm_run_channel) - 1]};
+    foreach (pwm_regs.invert[i]) {
+      if (pwm_regs.pwm_en[i]) {
+        pwm_regs.invert[i] dist {1'b1 :/ 1, 1'b0 :/ 1};
+      } else {
+        pwm_regs.invert[i] == 1'b0;
+      }
+    }
+    foreach (pwm_regs.phase_delay[i]) {
+      pwm_regs.phase_delay[i] inside {[0 : 2**(pwm_regs.dc_resn + 1)]};
+    }
+    foreach (pwm_regs.blink_param_x[i]) {
+      pwm_regs.blink_param_x[i] inside {[cfg.seq_cfg.pwm_min_param : cfg.seq_cfg.pwm_max_param]};
+    }
+    foreach (pwm_regs.blink_param_y[i]) {
+      pwm_regs.blink_param_y[i] inside {[cfg.seq_cfg.pwm_min_param : cfg.seq_cfg.pwm_max_param]};
+    }
+    foreach (pwm_regs.duty_cycle_a[i]) {
+      pwm_regs.duty_cycle_a[i] inside {[1 : 2**(pwm_regs.dc_resn + 1) - 1]};
+    }
+    foreach (pwm_regs.duty_cycle_b[i]) {
+      pwm_regs.duty_cycle_b[i] inside {[1 : 2**(pwm_regs.dc_resn + 1) - 1]};
+    }
+  }
+
+  //================================
   virtual task pre_start();
-    cfg.m_pwm_agent_cfg.en_monitor = cfg.en_scb;
-    `uvm_info(`gfn, $sformatf("\n--> %s monitor and scoreboard", cfg.en_scb ? "enable" : "disable"),
-              UVM_DEBUG)
     num_runs.rand_mode(0);
     // unset to disable intr test because pwm does not have intr pins
     do_clear_all_interrupts = 1'b0;
     super.pre_start();
   endtask : pre_start
 
-  // setup basic pwm features
-  virtual task pwm_init();
-    // TODO
-  endtask : pwm_init
+  virtual task initialize_pwm();
+    wait(cfg.clk_rst_vif.rst_n && cfg.clk_rst_core_vif.rst_n);
+    `uvm_info(`gfn, "\n  base_vseq: out of reset", UVM_DEBUG)
+    csr_spinwait(.ptr(ral.regen), .exp_data(1'b1));
+    program_pwm_enb_regs(Disable);
+    program_pwm_cnt_regs(Disable);
+    `uvm_info(`gfn, "\n  base_vseq: clear regen to enable register program", UVM_DEBUG)
+    `uvm_info(`gfn, "\n--> INITIALIZATION is finished", UVM_LOW)
+  endtask : initialize_pwm
 
-  virtual task body();
-    `uvm_info(`gfn, "\n--> start of sequence", UVM_DEBUG)
-    `uvm_info(`gfn, $sformatf("\n--> total required pulses %0d", num_trans), UVM_DEBUG)
-    // TODO
-  endtask : body
+  virtual task start_pwm_channels();
+    update_pwm_monitor_cfg();
+    cfg.num_pulses = num_pulses;
+    program_pwm_enb_regs(Enable);
+    program_pwm_inv_regs(Enable);
+    program_pwm_cnt_regs(Enable);
+    cfg.m_pwm_monitor_cfg.print_pwm_monitor_cfg(.en_print(1'b0));
+    `uvm_info(`gfn, $sformatf("\n  base_vseq: start channels (%b)", pwm_regs.pwm_en), UVM_DEBUG)
+  endtask : start_pwm_channels
 
-  // override apply_reset to handle core_reset domain
+  virtual task run_pwm_channels();
+    int runtime = cfg.num_pulses * pwm_regs.pulse_cycle * pwm_regs.beat_cycle;
+    `DV_CHECK_NE(runtime, 0)
+    cfg.clk_rst_core_vif.wait_clks(runtime);
+    foreach (pwm_regs.pwm_en[i]) begin
+      if (pwm_regs.pwm_en[i]) begin
+        `uvm_info(`gfn, $sformatf("\n  base_vseq: generate %0d pulse in channel %0d",
+            cfg.num_pulses, i), UVM_DEBUG)
+      end
+    end
+    // disable channels and clear phase counter
+    program_pwm_cnt_regs(Disable);
+    program_pwm_enb_regs(Disable);
+    program_pwm_inv_regs(Disable);
+  endtask : run_pwm_channels
+
+  // clear regen after initialization to allow programming registers
+  virtual task program_pwm_regen_reg(pwm_status_e status = Enable);
+    csr_wr(.ptr(ral.regen), .value(status));
+    `uvm_info(`gfn, $sformatf("\n  base_vseq: program regen %s", status.name()), UVM_DEBUG)
+  endtask : program_pwm_regen_reg
+
+  virtual task program_pwm_cfg_regs();
+    // derived params
+    `uvm_info(`gfn, $sformatf("\n  base_vseq: clk_div %0d and dc_resn %0d ",
+        pwm_regs.clk_div, pwm_regs.dc_resn), UVM_DEBUG)
+    pwm_regs.beat_cycle  = pwm_regs.clk_div + 1;
+    pwm_regs.pulse_cycle = 2**(pwm_regs.dc_resn + 1);
+    ral.cfg.clk_div.set(pwm_regs.clk_div);
+    ral.cfg.dc_resn.set(pwm_regs.dc_resn);
+    csr_update(ral.cfg);
+  endtask : program_pwm_cfg_regs
+
+  virtual task program_pwm_cnt_regs(pwm_status_e status = Enable);
+    pwm_regs.cntr_en = (status == Enable);
+    ral.cfg.cntr_en.set(pwm_regs.cntr_en);
+    csr_update(ral.cfg);
+    csr_spinwait(.ptr(ral.cfg.cntr_en), .exp_data(pwm_regs.cntr_en));
+    cfg.m_pwm_monitor_cfg.cntr_en = pwm_regs.cntr_en;
+    `uvm_info(`gfn, $sformatf("\n  base_vseq: phase counters %s",
+        pwm_regs.cntr_en ? "enable" : "clear"), UVM_DEBUG)
+  endtask : program_pwm_cnt_regs
+
+  virtual task program_pwm_enb_regs(pwm_status_e status = Enable);
+    if (status == Enable) begin
+      csr_wr(.ptr(ral.pwm_en), .value(pwm_regs.pwm_en));
+    end else begin
+      pwm_regs.pwm_en = '0;
+      csr_wr(.ptr(ral.pwm_en), .value(pwm_regs.pwm_en));
+      // wait one cycle before disable channels to let last pulses completed
+      cfg.clk_rst_core_vif.wait_clks(1);
+    end
+    csr_spinwait(.ptr(ral.pwm_en), .exp_data(pwm_regs.pwm_en));
+    cfg.m_pwm_monitor_cfg.pwm_en = pwm_regs.pwm_en;
+    `uvm_info(`gfn, $sformatf("\n  base_vseq: %pwm_en %b", pwm_regs.pwm_en), UVM_DEBUG)
+  endtask : program_pwm_enb_regs
+
+  virtual task program_pwm_inv_regs(pwm_status_e status = Enable);
+    if (status == Disable) begin
+      pwm_regs.invert = '0;
+    end
+    csr_wr(.ptr(ral.invert), .value(pwm_regs.invert));
+    cfg.m_pwm_monitor_cfg.invert = pwm_regs.invert;
+    `uvm_info(`gfn, $sformatf("\n  base_vseq: pwm_invert %b", pwm_regs.invert), UVM_DEBUG)
+  endtask : program_pwm_inv_regs
+
+  virtual task program_pwm_duty_cycle_regs(int channel);
+    dv_base_reg base_reg = get_dv_base_reg_by_name("duty_cycle", channel);
+    // set reg fields but not update
+    set_dv_base_reg_field_by_name("duty_cycle", "a",
+      pwm_regs.duty_cycle_a[channel], channel, channel, 1'b0);
+    set_dv_base_reg_field_by_name("duty_cycle", "b",
+      pwm_regs.duty_cycle_b[channel], channel, channel, 1'b0);
+    // update fields in same cycle
+    csr_update(base_reg);
+  endtask : program_pwm_duty_cycle_regs
+
+  virtual task program_pwm_blink_param_regs(int channel);
+    dv_base_reg base_reg = get_dv_base_reg_by_name("blink_param", channel);
+    // set reg fields but not update
+    set_dv_base_reg_field_by_name("blink_param", "x",
+        pwm_regs.blink_param_x[channel], channel, channel, 1'b0);
+    set_dv_base_reg_field_by_name("blink_param", "y",
+        pwm_regs.blink_param_y[channel], channel, channel, 1'b0);
+    // update fields in same cycle
+    csr_update(base_reg);
+  endtask : program_pwm_blink_param_regs
+
+  // update pwm_monitor_config
+  virtual function void update_pwm_monitor_cfg();
+    cfg.m_pwm_monitor_cfg.num_pulses    = num_pulses;
+    cfg.m_pwm_monitor_cfg.duty_cycle_a  = pwm_regs.duty_cycle_a;
+    cfg.m_pwm_monitor_cfg.duty_cycle_b  = pwm_regs.duty_cycle_b;
+    cfg.m_pwm_monitor_cfg.blink_param_x = pwm_regs.blink_param_x;
+    cfg.m_pwm_monitor_cfg.blink_param_y = pwm_regs.blink_param_y;
+    cfg.m_pwm_monitor_cfg.phase_delay   = pwm_regs.phase_delay;
+    cfg.m_pwm_monitor_cfg.invert        = pwm_regs.invert;
+    cfg.m_pwm_monitor_cfg.pwm_mode      = pwm_regs.pwm_mode;
+    cfg.m_pwm_monitor_cfg.phase_delay   = pwm_regs.phase_delay;
+    cfg.m_pwm_monitor_cfg.pulse_cycle   = pwm_regs.pulse_cycle;
+    cfg.print_all_channel_cfg("base_vseq", pwm_regs, 1'b0);
+  endfunction : update_pwm_monitor_cfg
+
+  // override apply_reset to handle reset for bus and core domain
   virtual task apply_reset(string kind = "HARD");
     fork
       if (kind == "HARD" || kind == "TL_IF") begin
@@ -70,5 +227,37 @@ class pwm_base_vseq extends cip_base_vseq #(
       join
     end
   endtask : do_phase_align_reset
+
+  // set field of reg/mreg using name and index, need to call csr_update after setting
+  virtual task set_dv_base_reg_field_by_name(string  csr_name,
+                                             string  field_name,
+                                             uint    field_value,
+                                             int     field_idx = -1,
+                                             int     csr_idx = -1,
+                                             bit     update  = 1'b1);
+    string        reg_name;
+    uvm_reg_field reg_field;
+    dv_base_reg   base_reg;
+
+    base_reg = get_dv_base_reg_by_name(csr_name, csr_idx);
+    reg_name = (field_idx == -1) ? field_name : $sformatf("%s_%0d", field_name, field_idx);
+    reg_field = base_reg.get_field_by_name(reg_name);
+    `DV_CHECK_NE_FATAL(reg_field, null, reg_name)
+    reg_field.set(field_value);
+    if (update) csr_update(base_reg);
+    `uvm_info(`gfn, $sformatf("base_vseq: set register %s.%s", csr_name, field_name), UVM_DEBUG)
+  endtask : set_dv_base_reg_field_by_name
+
+  // set reg/mreg using name and index
+  virtual function dv_base_reg get_dv_base_reg_by_name(string csr_name,
+                                                       int    csr_idx = -1);
+    string  reg_name;
+    uvm_reg reg_uvm;
+
+    reg_name = (csr_idx == -1) ? csr_name : $sformatf("%s_%0d", csr_name, csr_idx);
+    reg_uvm  = ral.get_reg_by_name(reg_name);
+    `DV_CHECK_NE_FATAL(reg_uvm, null, reg_name)
+    `downcast(get_dv_base_reg_by_name, reg_uvm)
+  endfunction : get_dv_base_reg_by_name
 
 endclass : pwm_base_vseq

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rx_tx_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rx_tx_vseq.sv
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwm_rx_tx_vseq extends pwm_base_vseq;
+  `uvm_object_utils(pwm_rx_tx_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    `uvm_info(`gfn, "\n--> Start body task", UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("\n--> SIMULATE %0d transactions", num_trans), UVM_DEBUG)
+    initialize_pwm();
+    for (int i = 0; i < num_trans; i++) begin
+      `uvm_info(`gfn, $sformatf("\n\n--> start transaction %0d/%0d", i + 1, num_trans), UVM_LOW)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      // program single registers out of the loop
+      wait(!cfg.under_reset);
+      program_pwm_cfg_regs();
+      // program multi registers
+      program_pwm_mode_regs();
+      start_pwm_channels();   // start channels
+      run_pwm_channels();     // run then stop channels
+      `uvm_info(`gfn, $sformatf("\n--> finish transaction %0d/%0d\n", i + 1, num_trans), UVM_LOW)
+    end
+    `uvm_info(`gfn, "\n--> Finish body task", UVM_DEBUG)
+  endtask : body
+
+  // program pwm mode (including programming duty_cycle and pwm_param multiregs)
+  virtual task program_pwm_mode_regs();
+    for (int channel = 0; channel < PWM_NUM_CHANNELS; channel++) begin
+      if (pwm_regs.pwm_en[channel] == Enable) begin
+        dv_base_reg base_reg;
+
+        // program duty_cycle_a and duty_cycle_b in same cycle
+        program_pwm_duty_cycle_regs(channel);
+        // program blink_param_x and blink_param_y in same cycle
+        program_pwm_blink_param_regs(channel);
+
+        `uvm_info(`gfn, $sformatf("\n  rxtx_vseq: program pwm_param[%0d] to mode %s",
+            channel, pwm_regs.pwm_mode[channel].name()), UVM_DEBUG)
+        base_reg = get_dv_base_reg_by_name("pwm_param", channel);
+        // program pwm_mode
+        `uvm_info(`gfn, $sformatf("\n  rxtx_vseq: programm channel %0d to mode %s",
+            channel, pwm_regs.pwm_mode[channel].name()), UVM_DEBUG)
+        case (pwm_regs.pwm_mode[channel])
+          Blinking: begin
+            // enable blink_en, disable htbt_en in same cycle
+            set_dv_base_reg_field_by_name("pwm_param", "blink_en", Enable,  channel, channel, 1'b0);
+            set_dv_base_reg_field_by_name("pwm_param", "htbt_en",  Disable, channel, channel, 1'b0);
+          end
+          Heartbeat: begin
+            // enable both blink_en and htbt_en in same cycle
+            set_dv_base_reg_field_by_name("pwm_param", "blink_en", Enable, channel, channel, 1'b0);
+            set_dv_base_reg_field_by_name("pwm_param", "htbt_en",  Enable, channel, channel, 1'b0);
+            csr_update(base_reg);
+          end
+          Standard: begin
+            // disable both blink_en and htbt_en in same cycle
+            set_dv_base_reg_field_by_name("pwm_param", "blink_en", Disable, channel, channel, 1'b0);
+            set_dv_base_reg_field_by_name("pwm_param", "htbt_en",  Disable, channel, channel, 1'b0);
+          end
+        endcase
+        // program phase delay
+        cfg.num_pulses = num_pulses;
+        set_dv_base_reg_field_by_name("pwm_param", "phase_delay",
+            pwm_regs.phase_delay[channel], channel, channel, 1'b0);
+        // update pwm_param register
+        csr_update(base_reg);
+        `uvm_info(`gfn, $sformatf("\n  rxtx_vseq: update pwm_mode_regs[%0d]", channel), UVM_DEBUG)
+      end
+    end
+  endtask : program_pwm_mode_regs
+
+endclass : pwm_rx_tx_vseq

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_smoke_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_smoke_vseq.sv
@@ -3,15 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // smoke test vseq: accessing a major datapath within the pwm
-class pwm_smoke_vseq extends pwm_base_vseq;
+class pwm_smoke_vseq extends pwm_rx_tx_vseq;
   `uvm_object_utils(pwm_smoke_vseq)
-
   `uvm_object_new
 
-  task body();
-    super.body();
-    #1us;
-    // TODO
-  endtask : body
+  virtual task pre_start();
+    super.pre_start();
+    // TODO: currently, only Standard mode is verified in the smoke test for all channels
+    cfg.seq_cfg.pwm_run_mode = Standard;
+  endtask : pre_start
 
 endclass : pwm_smoke_vseq

--- a/hw/ip/pwm/dv/pwm_sim.core
+++ b/hw/ip/pwm/dv/pwm_sim.core
@@ -13,6 +13,7 @@ filesets:
     depend:
       - lowrisc:dv:pwm_test
       - lowrisc:dv:pwm_sva
+      - lowrisc:dv:pwm_cov
     files:
       - tb.sv
     file_type: systemVerilogSource

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -46,11 +46,10 @@
 
   // List of test specifications.
   tests: [
-// TODO : for V1
-//    {
-//      name: pwm_smoke
-//      uvm_test_seq: pwm_smoke_vseq
-//    }
+    {
+      name: pwm_smoke
+      uvm_test_seq: pwm_smoke_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/pwm/dv/sva/pwm_bind.sv
+++ b/hw/ip/pwm/dv/sva/pwm_bind.sv
@@ -16,7 +16,8 @@ module pwm_bind;
   bind pwm pwm_csr_assert_fpv pwm_csr_assert (
     .clk_i,
     .rst_ni,
-    .h2d    (tl_i),
-    .d2h    (tl_o)
+    .h2d  (tl_i),
+    .d2h  (tl_o)
   );
+
 endmodule

--- a/hw/ip/pwm/dv/sva/pwm_sva.core
+++ b/hw/ip/pwm/dv/sva/pwm_sva.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:tlul:headers
+      - lowrisc:fpv:csr_assert_gen
     files:
       - pwm_bind.sv
     file_type: systemVerilogSource
@@ -15,6 +16,7 @@ filesets:
   files_formal:
     depend:
       - lowrisc:ip:pwm
+
 generate:
   csr_assert_gen:
     generator: csr_assert_gen
@@ -25,6 +27,9 @@ targets:
   default: &default_target
     filesets:
       - files_dv
+    generate:
+      - csr_assert_gen
+
   formal:
     <<: *default_target
     filesets:

--- a/hw/ip/pwm/dv/tb.sv
+++ b/hw/ip/pwm/dv/tb.sv
@@ -8,23 +8,27 @@ module tb;
   import dv_utils_pkg::*;
   import pwm_env_pkg::*;
   import pwm_test_pkg::*;
+  import pwm_monitor_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  wire clk, rst_n;
-  wire devmode;
+  localparam PWM_NUM_CHANNELS = pwm_reg_pkg::NOutputs;
 
-  wire clk_core, rst_core_n;
-  wire [pwm_reg_pkg::NOutputs-1:0] pwm;
-  wire [pwm_reg_pkg::NOutputs-1:0] pwm_en;
+  wire clk;
+  wire rst_n;
+  wire devmode;
+  wire clk_core;
+  wire rst_core_n;
+  wire [PWM_NUM_CHANNELS-1:0] cio_pwm;
+  wire [PWM_NUM_CHANNELS-1:0] cio_pwm_en;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   clk_rst_if clk_rst_core_if(.clk(clk_core), .rst_n(rst_core_n));
   pins_if #(1) devmode_if(devmode);
-  pwm_if #(.NumChannels(pwm_reg_pkg::NOutputs)) pwm_if();
+  pwm_if #(PWM_NUM_CHANNELS) pwm_if();
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
@@ -43,14 +47,15 @@ module tb;
     .alert_rx_i    (alert_rx   ),
     .alert_tx_o    (alert_tx   ),
 
-    .cio_pwm_o     (pwm),
-    .cio_pwm_en_o  (pwm_en)
+    .cio_pwm_o     (cio_pwm),
+    .cio_pwm_en_o  (cio_pwm_en)
   );
 
-  assign pwm_if.clk_core   = clk_core;
-  assign pwm_if.rst_core_n = rst_core_n;
-  assign pwm_if.pwm        = pwm;
-  assign pwm_if.pwm_en     = pwm_en;
+  assign pwm_if.clk   = clk_core;
+  assign pwm_if.rst_n = rst_core_n;
+  for (genvar i = 0; i < PWM_NUM_CHANNELS; i++) begin : gen_mux
+    assign pwm_if.pwm[i] = (cio_pwm_en[i]) ? cio_pwm[i] : 1'b0;
+  end
 
   initial begin
     // drive clk and rst_n from clk_if
@@ -58,9 +63,10 @@ module tb;
     clk_rst_core_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_core_vif", clk_rst_core_if);
+    uvm_config_db#(virtual pwm_if#(PWM_NUM_CHANNELS))
+        ::set(null, "*.env.m_pwm_monitor*", "vif", pwm_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(virtual pwm_if)::set(null, "*.env.m_pwm_agent*", "vif", pwm_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Currently, the pwm_smoke test verifies only the Standard operation mode of the PWM IP

Refer PR #7093 

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>