### PR TITLE
[prim] Remove dependency of prim:esc on a hardware block

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.core
@@ -9,7 +9,6 @@ filesets:
   files_dv:
     depend:
       - lowrisc:prim:all:0.1
-      - lowrisc:prim:esc
       - lowrisc:dv:dv_lib
     files:
       - alert_esc_if.sv

--- a/hw/ip/lc_ctrl/lc_ctrl.core
+++ b/hw/ip/lc_ctrl/lc_ctrl.core
@@ -19,6 +19,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:kmac_pkg
       - lowrisc:ip:rv_dm
+      - lowrisc:ip:alert_handler_reg
     files:
       - rtl/lc_ctrl_reg_top.sv
       - rtl/lc_ctrl_state_decode.sv

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -468,7 +468,10 @@ module lc_ctrl
   // This escalation action triggers the
   // lc_escalate_en life cycle control signal.
   logic esc_wipe_secrets;
-  prim_esc_receiver u_prim_esc_receiver1 (
+  prim_esc_receiver #(
+    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
+    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+  ) u_prim_esc_receiver1 (
     .clk_i,
     .rst_ni,
     .esc_en_o (esc_wipe_secrets),
@@ -479,7 +482,10 @@ module lc_ctrl
   // This escalation action moves the life cycle
   // state into a temporary "SCRAP" state named "ESCALATE".
   logic esc_scrap_state;
-  prim_esc_receiver u_prim_esc_receiver2 (
+  prim_esc_receiver #(
+    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
+    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+  ) u_prim_esc_receiver2 (
     .clk_i,
     .rst_ni,
     .esc_en_o (esc_scrap_state),

--- a/hw/ip/nmi_gen/nmi_gen.core
+++ b/hw/ip/nmi_gen/nmi_gen.core
@@ -10,7 +10,6 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
-      - lowrisc:prim:esc
     files:
       - rtl/nmi_gen_reg_pkg.sv
       - rtl/nmi_gen_reg_top.sv

--- a/hw/ip/nmi_gen/rtl/nmi_gen.sv
+++ b/hw/ip/nmi_gen/rtl/nmi_gen.sv
@@ -103,7 +103,10 @@ module nmi_gen
   // Connect escalation signal receivers //
   /////////////////////////////////////////
   for (genvar k = 0; k < N_ESC_SEV; k++) begin : gen_esc_sev
-    prim_esc_receiver i_prim_esc_receiver (
+    prim_esc_receiver #(
+      .N_ESC_SEV   (N_ESC_SEV),
+      .PING_CNT_DW (16)
+    ) i_prim_esc_receiver (
       .clk_i,
       .rst_ni,
       .esc_en_o ( esc_en[k]   ),

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -22,6 +22,7 @@ filesets:
       - lowrisc:prim:arbiter
       - lowrisc:prim:fifo
       - lowrisc:prim:alert
+      - lowrisc:prim:esc
       - lowrisc:prim:subreg
       - lowrisc:prim:cipher
       - lowrisc:prim:xor2

--- a/hw/ip/prim/prim_esc.core
+++ b/hw/ip/prim/prim_esc.core
@@ -12,7 +12,6 @@ filesets:
       - lowrisc:prim:diff_decode
       - lowrisc:prim:buf
       - lowrisc:prim:flop
-      - lowrisc:ip:alert_handler_reg
     files:
       - rtl/prim_esc_pkg.sv
       - rtl/prim_esc_receiver.sv

--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -21,6 +21,14 @@
 module prim_esc_receiver
   import prim_esc_pkg::*;
 #(
+  // The number of escalation severities. Should be set to the Alert Handler's N_ESC_SEV when this
+  // primitive is instantiated.
+  parameter int N_ESC_SEV = 4,
+
+  // The width of the Alert Handler's ping counter. Should be set to the Alert Handler's PING_CNT_DW
+  // when this primitive is instantiated.
+  parameter int PING_CNT_DW = 16,
+
   // This counter monitors incoming ping requests and auto-escalates if the alert handler
   // ceases to send them regularly. The maximum number of cycles between subsequent ping requests
   // is N_ESC_SEV x (2 x 2 x 2**PING_CNT_DW), see also implementation of the ping timer
@@ -33,10 +41,10 @@ module prim_esc_receiver
   localparam int NumWaitCounts = 2,
   localparam int NumTimeoutCounts = 2,
   parameter int TimeoutCntDw = $clog2(MarginFactor) +
-                               $clog2(alert_handler_reg_pkg::N_ESC_SEV) +
+                               $clog2(N_ESC_SEV) +
                                $clog2(NumWaitCounts) +
                                $clog2(NumTimeoutCounts) +
-                               alert_handler_reg_pkg::PING_CNT_DW
+                               PING_CNT_DW
 ) (
   input           clk_i,
   input           rst_ni,

--- a/hw/ip/pwrmgr/pwrmgr.core
+++ b/hw/ip/pwrmgr/pwrmgr.core
@@ -9,11 +9,13 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:tlul
+      - lowrisc:prim:esc
       - lowrisc:prim:lc_sender
       - lowrisc:prim:all
       - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:ip:alert_handler_reg
     files:
       - rtl/pwrmgr.sv
       - rtl/pwrmgr_cdc.sv

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -71,7 +71,10 @@ module pwrmgr import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
 
   logic esc_rst_req;
 
-  prim_esc_receiver u_esc_rx (
+  prim_esc_receiver #(
+    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
+    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+  ) u_esc_rx (
     .clk_i,
     .rst_ni,
     .esc_en_o(esc_rst_req),

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -143,7 +143,10 @@ module rv_core_ibex #(
   // Escalation receiver that converts differential
   // protocol into single ended signal.
   logic esc_irq_nm;
-  prim_esc_receiver u_prim_esc_receiver (
+  prim_esc_receiver #(
+    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
+    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+  ) u_prim_esc_receiver (
     .clk_i    ( clk_esc_i  ),
     .rst_ni   ( rst_esc_ni ),
     .esc_en_o ( esc_irq_nm ),

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:tlul:adapter_host
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:prim:lc_sync
+      - lowrisc:ip:alert_handler_reg
     files:
       - rtl/rv_core_ibex.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
The interesting patch in this PR is the first, whose commit message is below. The follow-on patch just reverts a quick hack that we needed yesterday to fix broken CI.

> Ideally, primitives shouldn't depend on blocks (the dependency is
> supposed to go the other way around).
> 
> This is a little awkward, because the `prim_esc_receiver` module has
> signals whose width depends on the number of escalation severities and
> the width of the ping counter in the alert handler. We can work around
> this by passing the parameters explicitly. At the instantiation sites,
> we *can* point at `alert_handler_reg_pkg` without introducing a "wrong
> way" dependency.

@msfschaffner: Would you mind checking I did the right thing for the nmi_gen instance? It seems to have a different number of severity levels and I'm not quite sure how this is all wired up.