### PR TITLE
[tlul] Correct width for secded encoder in tlul_adapter_reg.sv

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_reg.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_reg.sv
@@ -100,7 +100,7 @@ module tlul_adapter_reg import tlul_pkg::*; #(
   if (EnableDataIntgGen) begin : gen_data_intg
     logic [DataMaxWidth-1:0] unused_data;
 
-    prim_secded_64_57_enc u_data_gen (
+    prim_secded_39_32_enc u_data_gen (
       .data_i(DataMaxWidth'(rdata)),
       .data_o({data_intg, unused_data})
     );


### PR DESCRIPTION
I think this was missed from commit 4a7399f (and causes lint errors).
