### PR TITLE
Synchronise D and A channels in cip_base_scoreboard.sv

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -91,6 +91,11 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
       end
       if (cfg.has_edn) cfg.m_edn_pull_agent_cfg.zero_delays = 1;
     end
+
+    // Set the synchronise_ports flag on each of the TL agents configs
+    foreach (cfg.m_tl_agent_cfgs[i]) begin
+      cfg.m_tl_agent_cfgs[i].synchronise_ports = 1'b1;
+    end
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);
@@ -98,6 +103,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
     foreach (m_tl_agents[i]) begin
       m_tl_agents[i].monitor.a_chan_port.connect(scoreboard.tl_a_chan_fifos[i].analysis_export);
       m_tl_agents[i].monitor.d_chan_port.connect(scoreboard.tl_d_chan_fifos[i].analysis_export);
+      m_tl_agents[i].monitor.channel_dir_port.connect(scoreboard.tl_dir_fifos[i].analysis_export);
     end
     foreach (cfg.list_of_alerts[i]) begin
       string alert_name = cfg.list_of_alerts[i];

--- a/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
+++ b/hw/dv/sv/tl_agent/dv/env/tl_agent_env_cfg.sv
@@ -26,6 +26,7 @@ class tl_agent_env_cfg extends dv_base_env_cfg;
     host_agent_cfg = tl_agent_cfg::type_id::create("host_agent_cfg");
     host_agent_cfg.max_outstanding_req = 1 << SourceWidth;
     host_agent_cfg.if_mode = dv_utils_pkg::Host;
+    host_agent_cfg.device_can_rsp_on_same_cycle = 1;
 
     device_agent_cfg = tl_agent_cfg::type_id::create("device_agent_cfg");
     device_agent_cfg.if_mode = dv_utils_pkg::Device;

--- a/hw/dv/sv/tl_agent/tl_agent_cfg.sv
+++ b/hw/dv/sv/tl_agent/tl_agent_cfg.sv
@@ -74,6 +74,11 @@ class tl_agent_cfg extends dv_base_agent_cfg;
   // knob for device to enable/disable same cycle response
   bit device_can_rsp_on_same_cycle = 0;
 
+  // A configuration flag for the monitor that configures whether it should synchronise concurrent A
+  // and D transactions or not. See note above the definition of channel_dir_port in tl_monitor.sv
+  // for details.
+  bit synchronise_ports = 1'b0;
+
   // for same cycle response, need to know when a_valid and other data/control are available, so
   // that monitor can sample it, then send to sequence to get data for response in the same cycle
   // 10 means 10% of TL clock period. This var is only use when device_can_rsp_on_same_cycle = 1

--- a/hw/dv/sv/tl_agent/tl_monitor.sv
+++ b/hw/dv/sv/tl_agent/tl_monitor.sv
@@ -18,9 +18,24 @@ class tl_monitor extends dv_base_monitor#(
   string         agent_name;
   uvm_phase      run_phase_h;
 
-  uvm_analysis_port #(tl_seq_item) d_chan_port;
-  uvm_analysis_port #(tl_seq_item) a_chan_port;
-  // send back a chan info ASAP for device to support same cycle response
+  // Sequence items for transactions on the A and D channels. Sampled on the positive clock edge.
+  //
+  // If cfg.synchronise_ports (disabled by default), use these by waiting on channel_dir_port. This
+  // gets updated just after we push to a_chan_port or d_chan_port, telling the reader which channel
+  // to read. That way, the reader can guarantee a sample order if an A and D transaction both
+  // appear at the same time.
+  //
+  // Otherwise, wait on a_chan_port and d_chan_port with two concurrent processes. A and D
+  // transactions that happen at the same time will be popped from the fifos in an indeterminate
+  // order.
+  uvm_analysis_port #(tl_channels_e) channel_dir_port;
+  uvm_analysis_port #(tl_seq_item)   a_chan_port;
+  uvm_analysis_port #(tl_seq_item)   d_chan_port;
+
+  // Sequence items for transactions on the A channel, sampled shortly after the positive clock
+  // edge. This is only used if cfg.device_can_rsp_on_same_cycle, in which case a sequence item for
+  // a transaction will appear on this port when sampled and on a_chan_port on the following clock
+  // edge.
   uvm_analysis_port #(tl_seq_item) a_chan_same_cycle_rsp_port;
 
   `uvm_component_utils(tl_monitor)
@@ -29,17 +44,23 @@ class tl_monitor extends dv_base_monitor#(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    d_chan_port = new("d_chan_port", this);
+    if (cfg.synchronise_ports) begin
+      channel_dir_port = new("channel_dir_port", this);
+    end
+
     a_chan_port = new("a_chan_port", this);
-    a_chan_same_cycle_rsp_port = new("a_chan_same_cycle_rsp_port", this);
+    d_chan_port = new("d_chan_port", this);
+
+    if (cfg.device_can_rsp_on_same_cycle) begin
+      a_chan_same_cycle_rsp_port = new("a_chan_same_cycle_rsp_port", this);
+    end
   endfunction : build_phase
 
   virtual task run_phase(uvm_phase phase);
     run_phase_h = phase;
     wait_for_reset_done();
     fork
-      a_channel_thread();
-      d_channel_thread();
+      ad_channels_thread();
       reset_thread();
     join_none
   endtask : run_phase
@@ -61,105 +82,145 @@ class tl_monitor extends dv_base_monitor#(
     end
   endtask : reset_thread
 
-  virtual task a_channel_thread();
-    tl_seq_item req, cloned_req;
-    bit item_done = 0;
+  // Check the A and D channels for transactions. When a transaction is seen, push it to a_chan_port
+  // or d_chan_port, respectively. If cfg.synchronise_ports, also push the channel to
+  // channel_dir_port. If transactions are seen for both channels on a clock edge, push D then A.
+  //
+  // If the device isn't expected to respond combinatorially (cfg.device_can_rsp_on_same_cycle = 0),
+  // then both channels are sampled on the posedge of the clock. If the device *can* respond
+  // combinatorially, we delay sampling on the A side by a short time. The idea is that the A
+  // transaction will be asserted just after a clock edge and then D will be asserted some time
+  // afterwards. Sampling A in the middle of the cycle and then D at the following clock ensures
+  // that we see A before D (the order in which the events happened).
+  task ad_channels_thread();
+
+    // The most recently seen request on the A channel. Set to something non-null by successful
+    // calls to check_a_channel. Cleared back to null when the item is written to a_chan_port.
+    tl_seq_item a_chan_req_item;
+
     forever begin
-      bit valid_req_with_same_cycle_rsp;
-      bit valid_req_with_diff_cycle_rsp;
-      // Qualify req with same cycle rsp from device enabled.
-      valid_req_with_same_cycle_rsp = cfg.device_can_rsp_on_same_cycle &&
-                                      cfg.vif.h2d.a_valid && cfg.vif.d2h.a_ready;
-
-      // Qualify req with same cycle rsp from device disabled.
-      valid_req_with_diff_cycle_rsp = !cfg.device_can_rsp_on_same_cycle &&
-                                      cfg.vif.mon_cb.h2d.a_valid && cfg.vif.mon_cb.d2h.a_ready;
-
-      if (valid_req_with_same_cycle_rsp || valid_req_with_diff_cycle_rsp) begin
-        tlul_pkg::tl_h2d_t h2d = valid_req_with_same_cycle_rsp ? cfg.vif.h2d : cfg.vif.mon_cb.h2d;
-
-        req = tl_seq_item::type_id::create("req");
-        req.a_addr   = h2d.a_address;
-        req.a_opcode = h2d.a_opcode;
-        req.a_size   = h2d.a_size;
-        req.a_param  = h2d.a_param;
-        req.a_data   = h2d.a_data;
-        req.a_mask   = h2d.a_mask;
-        req.a_source = h2d.a_source;
-        req.a_user   = h2d.a_user;
-        `uvm_info("tl_logging", $sformatf("[%0s][a_chan] : %0s",
-                   agent_name, req.convert2string()), UVM_HIGH)
-
-        `downcast(cloned_req, req.clone());
-        `DV_CHECK_EQ_FATAL(cloned_req.a_source >> cfg.valid_a_source_width, 0)
-        `DV_CHECK_EQ_FATAL(pending_a_req.exists(cloned_req.a_source), 0)
-
-        if (cfg.en_cov) sample_outstanding_cov(req);
-        pending_a_req[cloned_req.a_source] = cloned_req;
-
-        if (cfg.max_outstanding_req > 0 && cfg.vif.rst_n === 1) begin
-          if (pending_a_req.size() > cfg.max_outstanding_req) begin
-            `uvm_error(get_full_name(), $sformatf("Number of pending a_req exceeds limit %0d",
-                                        pending_a_req.size()))
-          end
-          if (cfg.en_cov) cov.m_max_outstanding_cg.sample(pending_a_req.size());
-        end
-
-        // when device_can_rsp_on_same_cycle=1, write item to a_chan_same_cycle_rsp_port in the same
-        // cycle a_valid & a_ready is high, then write to a_chan_port at the sample edge
-        // when !device_can_rsp_on_same_cycle, only write to a_chan_port at the sample edge
-        if (cfg.device_can_rsp_on_same_cycle) begin
-          a_chan_same_cycle_rsp_port.write(req);
-          // write to a_chan_port at the sample edge
-          item_done = 1;
-        end else begin
-          a_chan_port.write(req);
-        end
-      end
       @(cfg.vif.mon_cb);
-      if (cfg.device_can_rsp_on_same_cycle) begin
-        if (item_done) begin
-          a_chan_port.write(req);
-          item_done = 0;
-        end
+      // This is just after the clock edge, so time to sample D and A channels.
 
-        // sample within a cycle to allow device to respond in same cycle
+      // Handle the D side.
+      check_d_channel();
+
+      // Handle the A side. If cfg.device_can_rsp_on_same_cycle then we've actually done the
+      // sampling already. Otherwise, we should check now.
+      if (!cfg.device_can_rsp_on_same_cycle) begin
+        a_chan_req_item = check_a_channel(.immediate(1'b0));
+      end
+      if (a_chan_req_item != null) begin
+        a_chan_port.write(a_chan_req_item);
+        if (cfg.synchronise_ports) channel_dir_port.write(AddrChannel);
+        a_chan_req_item = null;
+      end
+
+      // We're done with this clock edge. If cfg.device_can_rsp_on_same_cycle, we now wait a short
+      // time afterwards and sample a little after the clockedge.
+      if (cfg.device_can_rsp_on_same_cycle) begin
         `DV_SPINWAIT_EXIT(
             #(cfg.time_a_valid_avail_after_sample_edge);,
             @(cfg.vif.mon_cb) `uvm_fatal(`gfn, $sformatf(
                 "time_a_valid_avail_after_sample_edge (%0t) is over one cycle",
                 cfg.time_a_valid_avail_after_sample_edge)))
+
+        // It's a short time afterwards. Do the sampling!
+        a_chan_req_item = check_a_channel(.immediate(1'b1));
+        if (a_chan_req_item != null) begin
+          a_chan_same_cycle_rsp_port.write(a_chan_req_item);
+        end
       end
     end
-  endtask : a_channel_thread
+  endtask
 
-  // Collect ack from D channel
-  virtual task d_channel_thread();
-    tl_seq_item rsp;
-    forever begin
-      @(cfg.vif.mon_cb);
-      if (cfg.vif.mon_cb.d2h.d_valid && cfg.vif.mon_cb.h2d.d_ready) begin
-        // A matching request must exist
-        `DV_CHECK_EQ_FATAL(pending_a_req.exists(cfg.vif.mon_cb.d2h.d_source), 1, $sformatf(
-             "Cannot find request matching d_source 0x%0x", cfg.vif.mon_cb.d2h.d_source))
-        rsp = pending_a_req[cfg.vif.mon_cb.d2h.d_source];
-        rsp.d_opcode = cfg.vif.mon_cb.d2h.d_opcode;
-        rsp.d_data   = cfg.vif.mon_cb.d2h.d_data;
-        rsp.d_source = cfg.vif.mon_cb.d2h.d_source;
-        rsp.d_param  = cfg.vif.mon_cb.d2h.d_param;
-        rsp.d_error  = cfg.vif.mon_cb.d2h.d_error;
-        rsp.d_sink   = cfg.vif.mon_cb.d2h.d_sink;
-        rsp.d_size   = cfg.vif.mon_cb.d2h.d_size;
-        rsp.d_user   = cfg.vif.mon_cb.d2h.d_user;
+  // Check the A channel for a transaction
+  //
+  // If immediate is true, this is running just after a posedge of the clock, to allow us to capture
+  // same-cycle responses. In this case, it samples the immediate values of the signals.
+  //
+  // Otherwise, this is running on the posedge. It samples signals through the mon_cb clocking
+  // block.
+  //
+  // In either case, if a transaction is found then it returns a sequence item. Otherwise, it
+  // returns null.
+  function tl_seq_item check_a_channel(bit immediate);
+    logic a_valid = immediate ? cfg.vif.h2d.a_valid : cfg.vif.mon_cb.h2d.a_valid;
+    logic a_ready = immediate ? cfg.vif.d2h.a_ready : cfg.vif.mon_cb.d2h.a_ready;
 
-        `uvm_info("tl_logging", $sformatf("[%0s][d_chan] : %0s",
-                  agent_name, rsp.convert2string()), UVM_HIGH)
-        d_chan_port.write(rsp);
-        pending_a_req.delete(cfg.vif.mon_cb.d2h.d_source);
-        if (cfg.en_cov) cov.sample(rsp);
+    if (a_valid && a_ready) begin
+      tl_seq_item req = tl_seq_item::type_id::create("req");
+      tl_seq_item cloned_req;
+      tlul_pkg::tl_h2d_t h2d = immediate ? cfg.vif.h2d : cfg.vif.mon_cb.h2d;
+
+      // Create a sequence item. Note: this is a field in the class, which ad_channels_thread() uses
+      // to pass the transaction to the relevant analysis port/ports.
+      req.a_addr   = h2d.a_address;
+      req.a_opcode = h2d.a_opcode;
+      req.a_size   = h2d.a_size;
+      req.a_param  = h2d.a_param;
+      req.a_data   = h2d.a_data;
+      req.a_mask   = h2d.a_mask;
+      req.a_source = h2d.a_source;
+      req.a_user   = h2d.a_user;
+      `uvm_info("tl_logging",
+                $sformatf("[%0s][a_chan] : %0s", agent_name, req.convert2string()),
+                UVM_HIGH)
+
+      if (cfg.en_cov) sample_outstanding_cov(req);
+
+      `downcast(cloned_req, req.clone());
+      `DV_CHECK_EQ_FATAL(cloned_req.a_source >> cfg.valid_a_source_width, 0)
+      `DV_CHECK_EQ_FATAL(pending_a_req.exists(cloned_req.a_source), 0)
+      pending_a_req[cloned_req.a_source] = cloned_req;
+
+      if (cfg.max_outstanding_req > 0 && cfg.vif.rst_n === 1) begin
+        if (pending_a_req.size() > cfg.max_outstanding_req) begin
+          `uvm_error(`gfn,
+                     $sformatf("Number of pending a_req exceeds limit %0d", pending_a_req.size()))
+        end
+        if (cfg.en_cov) cov.m_max_outstanding_cg.sample(pending_a_req.size());
       end
+      return req;
     end
-  endtask : d_channel_thread
+
+    return null;
+  endfunction
+
+  // Checks the D channel for a transaction
+  //
+  // If a transaction is found, writes it to d_chan_port and clears the corresponding pending
+  // request.
+  function void check_d_channel();
+    if (cfg.vif.mon_cb.d2h.d_valid && cfg.vif.mon_cb.h2d.d_ready) begin
+      tl_seq_item rsp;
+
+      // A matching request must exist
+      `DV_CHECK_FATAL(pending_a_req.exists(cfg.vif.mon_cb.d2h.d_source),
+                      $sformatf("Cannot find request matching d_source 0x%0x",
+                                cfg.vif.mon_cb.d2h.d_source))
+
+      rsp = pending_a_req[cfg.vif.mon_cb.d2h.d_source];
+      pending_a_req.delete(cfg.vif.mon_cb.d2h.d_source);
+
+      rsp.d_opcode = cfg.vif.mon_cb.d2h.d_opcode;
+      rsp.d_data   = cfg.vif.mon_cb.d2h.d_data;
+      rsp.d_source = cfg.vif.mon_cb.d2h.d_source;
+      rsp.d_param  = cfg.vif.mon_cb.d2h.d_param;
+      rsp.d_error  = cfg.vif.mon_cb.d2h.d_error;
+      rsp.d_sink   = cfg.vif.mon_cb.d2h.d_sink;
+      rsp.d_size   = cfg.vif.mon_cb.d2h.d_size;
+      rsp.d_user   = cfg.vif.mon_cb.d2h.d_user;
+
+      `uvm_info("tl_logging",
+                $sformatf("[%0s][d_chan] : %0s", agent_name, rsp.convert2string()), UVM_HIGH)
+
+      d_chan_port.write(rsp);
+      if (cfg.synchronise_ports) channel_dir_port.write(DataChannel);
+
+      if (cfg.en_cov) cov.sample(rsp);
+    end
+  endfunction
 
   // update ok_to_end to prevent sim finish when there is any pending item
   virtual task monitor_ready_to_end();


### PR DESCRIPTION
There are 2 commits in this PR. The first restructures the monitor a little so that it's possible to use it "synchronously". Here's the commit message:

> **[dv,tl] Add code to allow synchronisation between A and D channels**
> 
> This is disabled by default and not enabled for any configuration in
> this commit, so there should be no change to behaviour.
> 
> The main change in this patch is to the monitor. Rather than running
> two processes to sample the A and D channels in parallel, we now have
> a single process that samples both. This makes it possible to control
> which of two simultaneous transactions is seen first.
> 
> If `cfg.device_can_rsp_on_same_cycle` is false, the `ad_channels_thread()`
> task samples D then A on each clock edge. If it is true, the task
> samples A just after a clock edge, writing `a_chan_same_cycle_rsp_port`,
> then samples D and repeats any A item on the following edge. The end
> result should be equivalent but (I hope) a bit easier to understand.
> 
> If `cfg.synchronise_ports` is true, the monitor writes to a new analysis
> port called `channel_dir_port` just after it pushes to `a_chan_port` or
> `d_chan_port`. The idea is that a client can then block on
> `channel_dir_port` and then do a non-blocking read from the channel port
> indicated. That way, the client can guarantee to get "D then A" if
> both happen simultaneously.

The second commit tells the `cip_base_*` code to use the result:

> **[dv,tl] Read synchronously from TL agents in cip_base_env**
> 
> This means that any scoreboard that derives from the cip_base_scoreboard
> knows that its `process_tl_access()` task will be called in a
> "synchronous manner". Specifically, if there are transactions on both
> the A and D channels at the same time, it will see the D side and then
> the A side.
