### PR TITLE
[sw/rom] Skip keymgr initialization in mask ROM.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -4,11 +4,23 @@
 
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 
+#include "sw/device/lib/base/freestanding/assert.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "keymgr_regs.h"  // Generated.
+
+#define KEYMGR_ASSERT(a, b) static_assert(a == b, "Bad value for " #a)
+KEYMGR_ASSERT(kKeymgrStateReset, KEYMGR_WORKING_STATE_STATE_VALUE_RESET);
+KEYMGR_ASSERT(kKeymgrStateInit, KEYMGR_WORKING_STATE_STATE_VALUE_INIT);
+KEYMGR_ASSERT(kKeymgrStateCreatorRootKey,
+              KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY);
+KEYMGR_ASSERT(kKeymgrStateOwnerIntermediateKey,
+              KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY);
+KEYMGR_ASSERT(kKeymgrStateOwnerKey, KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY);
+KEYMGR_ASSERT(kKeymgrStateDisabled, KEYMGR_WORKING_STATE_STATE_VALUE_DISABLED);
+KEYMGR_ASSERT(kKeymgrStateInvalid, KEYMGR_WORKING_STATE_STATE_VALUE_INVALID);
 
 enum {
   kBase = TOP_EARLGREY_KEYMGR_BASE_ADDR,
@@ -22,8 +34,7 @@ enum {
  * @return `kErrorOk` if the key manager is at the `expected_state` and the
  * status is idle or success.
  */
-static rom_error_t check_expected_state(uint32_t expected_state,
-                                        uint32_t expected_status) {
+static rom_error_t check_expected_state(uint32_t expected_state) {
   // Read and clear the status register by writing back the read value,
   // polling until the status is non-WIP.
   uint32_t op_status;
@@ -33,54 +44,31 @@ static rom_error_t check_expected_state(uint32_t expected_state,
     abs_mmio_write32(kBase + KEYMGR_OP_STATUS_REG_OFFSET, op_status);
     op_status_field =
         bitfield_field32_read(op_status, KEYMGR_OP_STATUS_STATUS_FIELD);
-  } while (op_status_field == KEYMGR_OP_STATUS_STATUS_VALUE_WIP);
+  } while (op_status_field == KEYMGR_OP_STATUS_STATUS_VALUE_WIP ||
+           op_status_field == KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
 
   // Read and clear the error register by writing back the read value.
   uint32_t error_code = abs_mmio_read32(kBase + KEYMGR_ERR_CODE_REG_OFFSET);
   abs_mmio_write32(kBase + KEYMGR_ERR_CODE_REG_OFFSET, error_code);
 
   uint32_t got_state = abs_mmio_read32(kBase + KEYMGR_WORKING_STATE_REG_OFFSET);
-  if (op_status_field == expected_status && error_code == 0u &&
-      got_state == expected_state) {
+  if (op_status_field == KEYMGR_OP_STATUS_STATUS_VALUE_IDLE &&
+      error_code == 0u && got_state == expected_state) {
     return kErrorOk;
   }
   return kErrorKeymgrInternal;
 }
 
-/**
- * Advances the sate of the key manager.
- *
- * The `check_expected_state()` function must be called before this function
- * no ensure the key manager is ready to receive op commands.
- */
-static void advance_state(void) {
-  uint32_t reg = bitfield_bit32_write(0, KEYMGR_CONTROL_START_BIT, true);
-  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_DEST_SEL_FIELD,
-                               KEYMGR_CONTROL_DEST_SEL_VALUE_NONE);
-  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_OPERATION_FIELD,
-                               KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE);
-  abs_mmio_write32(kBase + KEYMGR_CONTROL_REG_OFFSET, reg);
-}
-
 rom_error_t keymgr_init(uint16_t entropy_reseed_interval) {
-  RETURN_IF_ERROR(check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
-                                       KEYMGR_OP_STATUS_STATUS_VALUE_IDLE));
-
+  RETURN_IF_ERROR(check_expected_state(kKeymgrStateReset));
   uint32_t reg = bitfield_field32_write(0, KEYMGR_RESEED_INTERVAL_VAL_FIELD,
                                         entropy_reseed_interval);
   abs_mmio_write32(kBase + KEYMGR_RESEED_INTERVAL_REG_OFFSET, reg);
-
-  // Advance to INIT state.
-  advance_state();
   return kErrorOk;
 }
 
-rom_error_t keymgr_state_advance_to_creator(
-    const keymgr_binding_value_t *binding_value, uint32_t max_key_ver) {
-  RETURN_IF_ERROR(
-      check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_INIT,
-                           KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS));
-
+void keymgr_set_next_stage_inputs(const keymgr_binding_value_t *binding_value,
+                                  uint32_t max_key_ver) {
   // Write and lock (rw0c) the software binding value. This register is unlocked
   // by hardware upon a successful state transition.
   // FIXME: Consider using sec_mmio module for the following register writes.
@@ -94,13 +82,17 @@ rom_error_t keymgr_state_advance_to_creator(
   // Write and lock (rw0c) the max key version.
   abs_mmio_write32(kBase + KEYMGR_MAX_CREATOR_KEY_VER_REG_OFFSET, max_key_ver);
   abs_mmio_write32(kBase + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
-
-  // Advance to CREATOR_ROOT_KEY state.
-  advance_state();
-  return kErrorOk;
 }
 
-rom_error_t keymgr_state_creator_check() {
-  return check_expected_state(KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
-                              KEYMGR_OP_STATUS_STATUS_VALUE_DONE_SUCCESS);
+void keymgr_advance_state(void) {
+  uint32_t reg = bitfield_bit32_write(0, KEYMGR_CONTROL_START_BIT, true);
+  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_DEST_SEL_FIELD,
+                               KEYMGR_CONTROL_DEST_SEL_VALUE_NONE);
+  reg = bitfield_field32_write(reg, KEYMGR_CONTROL_OPERATION_FIELD,
+                               KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE);
+  abs_mmio_write32(kBase + KEYMGR_CONTROL_REG_OFFSET, reg);
+}
+
+rom_error_t keymgr_check_state(keymgr_state_t expected_state) {
+  return check_expected_state(expected_state);
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -16,6 +16,59 @@ extern "C" {
 #endif
 
 /**
+ * Key Manager states.
+ */
+typedef enum keymgr_state {
+  /**
+   * Key manager control is still in reset. Please wait for initialization
+   * complete before issuing operations
+   */
+  kKeymgrStateReset,
+  /**
+   * Key manager control has finished initialization and will now accept
+   * software commands.
+   */
+  kKeymgrStateInit,
+  /**
+   * Key manager control currently contains the creator root key.
+   */
+  kKeymgrStateCreatorRootKey,
+  /**
+   * Key manager control currently contains the owner intermediate key.
+   */
+  kKeymgrStateOwnerIntermediateKey,
+  /**
+   * Key manager control currently contains the owner key.
+   */
+  kKeymgrStateOwnerKey,
+  /**
+   * Key manager currently disabled. Please reset the key manager. Sideload keys
+   * are still valid.
+   */
+  kKeymgrStateDisabled,
+  /**
+   * Key manager currently invalid. Please reset the key manager. Sideload keys
+   * are no longer valid.
+   */
+  kKeymgrStateInvalid,
+  /**
+   * This is not a state - it is the total number of states.
+   */
+  kKeymgrStateNumStates,
+} keymgr_state_t;
+
+/**
+ * Sets the key manager inputs.
+ *
+ * @param binding_value Software binding value from the manifest of the next
+ * stage.
+ * @param max_key_version Maximum key version from the manifest of the next
+ * stage.
+ */
+void keymgr_set_next_stage_inputs(const keymgr_binding_value_t *binding_value,
+                                  uint32_t max_key_version);
+
+/**
  * Initializes the key manager.
  *
  * Initializes the key manager `entropy_reseed_interval` and advances the state
@@ -31,29 +84,25 @@ extern "C" {
 rom_error_t keymgr_init(uint16_t entropy_reseed_interval);
 
 /**
- * Advances the state of the key manager to Creator Root Key state.
+ * Advances the state of the key manager.
  *
- * This operation is non-blocking to allow the software to continue with other
- * operations while the key manager is advancing its state. The caller is
- * responsible for calling the `keymgr_state_creator_check()` at a later time
- * to ensure the advance transition completed without errors.
+ * The `keymgr_check_state()` function must be called before this function to
+ * ensure the key manager is in the expected state and ready to receive op
+ * commands.
  *
- * @param binding_value Software binding value extracted from the ROM_EXT
- * manifest.
- * @param max_key_version Maximum key version extracted from the ROM_EXT
- * manifest.
- * @return The result of the operation.
+ * The caller is responsible for calling the `keymgr_check_state()` at a later
+ * time to ensure the advance transition completed without errors.
  */
-rom_error_t keymgr_state_advance_to_creator(
-    const keymgr_binding_value_t *binding_value, uint32_t max_key_version);
+void keymgr_advance_state(void);
 
 /**
  * Checks the state of the key manager.
  *
- * @return `kErrorOk` if the key manager is in Creator Root Key state and the
- * status is idle of success; otherwise retuns `kErrorKeymgrInternal`.
+ * @param expected_state Expected key manager state.
+ * @return `kErrorOk` if the key manager is in `expected_state` and the status
+ * is idle or success; otherwise returns `kErrorKeymgrInternal`.
  */
-rom_error_t keymgr_state_creator_check(void);
+rom_error_t keymgr_check_state(keymgr_state_t expected_state);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -1,0 +1,177 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/flash_ctrl.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/keymgr.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
+#include "sw/device/silicon_creator/lib/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "keymgr_regs.h"
+
+#define ASSERT_OK(expr_)                        \
+  do {                                          \
+    rom_error_t local_error_ = expr_;           \
+    if (local_error_ != kErrorOk) {             \
+      LOG_ERROR("Error at line: %d", __LINE__); \
+      return local_error_;                      \
+    }                                           \
+  } while (0)
+
+#define ASSERT_EQZ(x) CHECK((x) == 0)
+
+enum {
+  /** Creator Secret flash info page ID. */
+  kFlashInfoPageIdCreatorSecret = 1,
+
+  /** Owner Secret flash info page ID. */
+  kFlashInfoPageIdOwnerSecret = 2,
+
+  /** Key manager secret word size. */
+  kSecretWordSize = 16,
+};
+
+/**
+ * Software binding value associated with the ROM_EXT. Programmed by
+ * mask ROM.
+ */
+const keymgr_binding_value_t kBindingValueRomExt = {
+    .data = {0xdc96c23d, 0xaf36e268, 0xcb68ff71, 0xe92f76e2, 0xb8a8379d,
+             0x426dc745, 0x19f5cff7, 0x4ec9c6d6},
+};
+
+/**
+ * Software binding value associated with BL0. Programmed by ROM_EXT.
+ */
+const keymgr_binding_value_t kBindingValueBl0 = {
+    .data = {0xe4987b39, 0x3f83d390, 0xc2f3bbaf, 0x3195dbfa, 0x23fb480c,
+             0xb012ae5e, 0xf1394d28, 0x1940ceeb},
+};
+
+/**
+ * Key manager Creator Secret stored in info flash page.
+ */
+const uint32_t kCreatorSecret[kSecretWordSize] = {
+    0x4e919d54, 0x322288d8, 0x4bd127c7, 0x9f89bc56, 0xb4fb0fdf, 0x1ca1567b,
+    0x13a0e876, 0xa6521d8f, 0xbebf6301, 0xd10879a1, 0x69797afb, 0x5f295405,
+    0x444a8511, 0xe7bb2fa5, 0xd570c0a3, 0xf15f82e5,
+};
+
+/**
+ * Key manager Owner Secret stored in info flash page.
+ */
+const uint32_t kOwnerSecret[kSecretWordSize] = {
+    0xf15f82e5, 0xd570c0a3, 0xe7bb2fa5, 0x444a8511, 0x5f295405, 0x69797afb,
+    0xd10879a1, 0xbebf6301, 0xa6521d8f, 0x13a0e876, 0x1ca1567b, 0xb4fb0fdf,
+    0x9f89bc56, 0x4bd127c7, 0x322288d8, 0x4e919d54,
+};
+
+/** ROM_EXT key manager maximum version. */
+const uint32_t kMaxVerRomExt = 1;
+
+/** BL0 key manager maximum version. */
+const uint32_t kMaxVerBl0 = 2;
+
+const test_config_t kTestConfig;
+
+/**
+ * Writes `size` words of `data` into flash info page.
+ *
+ * @param page_id Info page ID to write to.
+ * @param data Data to write.
+ * @param size Number of 4B words to write from `data` buffer.
+ */
+static void write_info_page(uint32_t page_id, const uint32_t *data,
+                            size_t size) {
+  mp_region_t info_region = {.num = page_id,
+                             .base = 0x0,  // only used to calculate bank id.
+                             .size = 0x1,  // unused for info pages.
+                             .part = kInfoPartition,
+                             .rd_en = true,
+                             .prog_en = true,
+                             .erase_en = true,
+                             .scramble_en = false};
+  flash_cfg_region(&info_region);
+
+  uint32_t address = FLASH_MEM_BASE_ADDR + page_id * flash_get_page_size();
+
+  ASSERT_EQZ(flash_page_erase(address, kInfoPartition));
+  ASSERT_EQZ(flash_write(address, kInfoPartition, data, size));
+
+  for (size_t i = 0; i < size; ++i) {
+    uint32_t got_data;
+    ASSERT_EQZ(flash_read(address + i * sizeof(uint32_t), kInfoPartition,
+                          /*size=*/1, &got_data));
+    CHECK(got_data == data[i]);
+  }
+  info_region.rd_en = false;
+  info_region.prog_en = false;
+  info_region.erase_en = false;
+  flash_cfg_region(&info_region);
+}
+
+static void init_flash(void) {
+  // setup default access for data partition
+  flash_default_region_access(/*rd_en=*/true, /*prog_en=*/true,
+                              /*erase_en=*/true);
+  // Initialize flash secrets.
+  write_info_page(kFlashInfoPageIdCreatorSecret, kCreatorSecret,
+                  ARRAYSIZE(kCreatorSecret));
+  write_info_page(kFlashInfoPageIdOwnerSecret, kOwnerSecret,
+                  ARRAYSIZE(kOwnerSecret));
+}
+
+/** Key manager configuration steps performed in mask ROM. */
+rom_error_t keymgr_rom_test(void) {
+  ASSERT_OK(keymgr_check_state(kKeymgrStateReset));
+  keymgr_set_next_stage_inputs(&kBindingValueRomExt, kMaxVerRomExt);
+  return kErrorOk;
+}
+
+/** Key manager configuration steps performed in ROM_EXT. */
+rom_error_t keymgr_rom_ext_test(void) {
+  ASSERT_OK(keymgr_check_state(kKeymgrStateReset));
+
+  const uint16_t kEntropyReseedInterval = 0x1234;
+  ASSERT_OK(keymgr_init(kEntropyReseedInterval));
+  keymgr_advance_state();
+  ASSERT_OK(keymgr_check_state(kKeymgrStateInit));
+
+  // FIXME: Check `kBindingValueRomExt` before advancing state.
+  keymgr_advance_state();
+  ASSERT_OK(keymgr_check_state(kKeymgrStateCreatorRootKey));
+
+  keymgr_set_next_stage_inputs(&kBindingValueBl0, kMaxVerBl0);
+
+  // FIXME: Check `kBindingValueBl0` before advancing state.
+  keymgr_advance_state();
+  ASSERT_OK(keymgr_check_state(kKeymgrStateOwnerIntermediateKey));
+  return kErrorOk;
+}
+
+bool test_main(void) {
+  rom_error_t result = kErrorOk;
+
+  // This test is expected to run in DEV, PROD or PROD_END states.
+  lifecycle_state_t lc_state = lifecycle_state_get();
+  LOG_INFO("lifecycle state: %s", lifecycle_state_name[lc_state]);
+
+  init_flash();
+
+  EXECUTE_TEST(result, keymgr_rom_test);
+  EXECUTE_TEST(result, keymgr_rom_ext_test);
+  return result == kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -2,6 +2,21 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Mask ROM lifecycle driver
+sw_silicon_creator_lib_driver_lifecycle = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_lifecycle',
+    sources: [
+      hw_ip_lc_ctrl_reg_h,
+      'lifecycle.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_base_abs_mmio,
+      sw_lib_bitfield,
+    ],
+  ),
+)
+
 # Mask ROM hmac driver
 sw_silicon_creator_lib_driver_hmac = declare_dependency(
   link_with: static_library(
@@ -80,6 +95,26 @@ test('sw_silicon_creator_lib_driver_keymgr_unittest', executable(
     ),
   suite: 'mask_rom',
 )
+
+sw_silicon_creator_lib_driver_keymgr_functest = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_keymgr_functest',
+    sources: [
+      hw_ip_keymgr_reg_h,
+      'keymgr_functest.c',
+    ],
+    dependencies: [
+      sw_lib_flash_ctrl,
+      sw_silicon_creator_lib_driver_keymgr,
+      sw_silicon_creator_lib_driver_lifecycle,
+    ],
+  ),
+)
+mask_rom_tests += {
+  'sw_silicon_creator_lib_driver_keymgr_functest': {
+    'library': sw_silicon_creator_lib_driver_keymgr_functest,
+  }
+}
 
 # Mask ROM uart driver
 sw_silicon_creator_lib_driver_uart = declare_dependency(
@@ -246,18 +281,3 @@ mask_rom_tests += {
     'library': sw_silicon_creator_lib_driver_alert_functest,
   }
 }
-
-# Mask ROM lifecycle driver
-sw_silicon_creator_lib_driver_lifecycle = declare_dependency(
-  link_with: static_library(
-    'sw_silicon_creator_lib_driver_lifecycle',
-    sources: [
-      hw_ip_lc_ctrl_reg_h,
-      'lifecycle.c',
-    ],
-    dependencies: [
-      sw_silicon_creator_lib_base_abs_mmio,
-      sw_lib_bitfield,
-    ],
-  ),
-)


### PR DESCRIPTION
This change removes key manager initialization from the mask ROM. The
only steps performed now are sofware binding and max key version
configuration. This is done to avoid having to depend on entropy
settings for the key manager in the mask ROM.

This change relies on the key manager's write lockable registers to
prevent the ROM_EXT from overriding the values set by the mask ROM.

Other changes:

* Add key manager driver functional test with ROM and ROM_EXT expected flows.