### PR TITLE
[flah_ctrl/dv] Small 2 changes regarding flash_ctrl ral.set_hdl_path

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -16,6 +16,8 @@ class flash_ctrl_env #(type CFG_T = flash_ctrl_env_cfg,
   tl_agent        m_eflash_tl_agent;
   tl_reg_adapter  m_eflash_tl_reg_adapter;
 
+  string hdl_path_root;
+
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
@@ -29,6 +31,10 @@ class flash_ctrl_env #(type CFG_T = flash_ctrl_env_cfg,
       cfg.m_eflash_tl_agent_cfg.a_ready_delay_max = 0;
       cfg.m_eflash_tl_agent_cfg.d_ready_delay_min = 0;
       cfg.m_eflash_tl_agent_cfg.d_ready_delay_max = 0;
+    end
+    // Retrieve hdl_path_root from tb for ral.
+    if (!uvm_config_db#(string)::get(this, "", "hdl_path_root", hdl_path_root)) begin
+      `uvm_fatal(`gfn, $sformatf("failed to get hdl_path_root from uvm_config_db"))
     end
 
     // Retrieve the mem backdoor util instances.
@@ -67,9 +73,7 @@ class flash_ctrl_env #(type CFG_T = flash_ctrl_env_cfg,
   virtual function void end_of_elaboration_phase(uvm_phase phase);
     // We have a custom design wrapper around the flash controller, so we need to fix the
     // HDL path root.
-    if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin // If using open-source flash
-      cfg.ral.set_hdl_path_root("tb.dut.u_flash_ctrl", "BkdrRegPathRtl");
-    end
+    cfg.ral.set_hdl_path_root(hdl_path_root, "BkdrRegPathRtl");
     super.end_of_elaboration_phase(phase);
   endfunction : end_of_elaboration_phase
 

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -183,6 +183,8 @@ module tb;
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_flash_ctrl_core_reg_block*", "vif",
                                        tl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_eflash_tl_agent*", "vif", eflash_tl_if);
+    // Define flash_ctrl path as string to pass to flash_ctrl_env for ral hdl_path.
+    uvm_config_db#(string)::set(null, "*.env", "hdl_path_root", "tb.dut.u_flash_ctrl");
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Hi,

In this PR I added 2 small changes:
* Return **ral.set_hdl_path** in **flash_ctrl_env** to be independent of implementation, assuming extending envs will just use the same paths.
* Move flash_ctrl path in **ral.set_hdl_path** to come from **tb** through **uvm_config_db** rather then to be set specifically in **flash_ctrl_env**.

Thanks!

Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>