### PR TITLE
[sysrst_ctrl] Give an explicit size to the EDGE_TYPE param

### DIFF
--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_ulpfsm.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_ulpfsm.sv
@@ -5,7 +5,7 @@
 // Description sysrst_ctrl ULP FSM module
 
 module sysrst_ctrl_ulpfsm #(
-  parameter EDGE_TYPE = "H", // can be LH, HL and H
+  parameter bit [15:0] EDGE_TYPE = "H", // can be LH, HL and H
   parameter int unsigned TIMERBIT = 16
   ) (
   input                clk_aon_i,


### PR DESCRIPTION
If this module is instantiated with `EDGE_TYPE = "H"` (the default), the
`EDGE_TYPE` parameter ends up with inferred type "bit [7:0]", which then
causes a lint warning about width mismatches when compared against `LH`
or `HL`.