### PR TITLE
[entropy_src] Fix width mismatch in entropy_src_core.sv

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1866,8 +1866,10 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   assign sfifo_observe_wdata = pfifo_postht_rdata;
 
-  assign sfifo_observe_pop = fw_ov_mode &&
-         (fw_ov_fifo_rd_pulse || ((ObserveFifoDepth-1) == sfifo_observe_depth));
+  assign sfifo_observe_pop =
+         (fw_ov_mode &&
+          (fw_ov_fifo_rd_pulse ||
+           ((Clog2ObserveFifoDepth+1)'(ObserveFifoDepth-1) == sfifo_observe_depth)));
 
   // fifo err
   assign sfifo_observe_err =


### PR DESCRIPTION
Verilator complains that `ObserveFifoDepth-1` is a 32-bit integer and
`sfifo_observe_depth` is 7 bits. Explicitly cast the integer
literal (which is "obviously safe": `Clog2ObserveFifoDepth` is indeed
`$clog2(ObserveFifoDepth)`, so everything will definitely fit).
