### PR TITLE
[sw/silicon_creator, mask_rom] Implement the mask ROM Memory Protection module

### DIFF
--- a/sw/device/silicon_creator/lib/epmp.c
+++ b/sw/device/silicon_creator/lib/epmp.c
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/epmp.h"
+
+#include "sw/device/lib/base/csr.h"
+
+/**
+ * Extern declarations of inline functions.
+ */
+extern void epmp_state_configure_tor(epmp_state_t *state, uint32_t entry,
+                                     epmp_region_t region, epmp_perm_t perm);
+extern void epmp_state_configure_na4(epmp_state_t *state, uint32_t entry,
+                                     epmp_region_t region, epmp_perm_t perm);
+extern void epmp_state_configure_napot(epmp_state_t *state, uint32_t entry,
+                                       epmp_region_t region, epmp_perm_t perm);
+
+rom_error_t epmp_state_check(const epmp_state_t *s) {
+  bool result = true;
+#define CHECK_CSR(reg, value) \
+  do {                        \
+    uint32_t csr;             \
+    CSR_READ(reg, &csr);      \
+    result &= csr == (value); \
+  } while (false)
+
+  // Check address registers.
+  CHECK_CSR(CSR_REG_PMPADDR0, s->pmpaddr[0]);
+  CHECK_CSR(CSR_REG_PMPADDR1, s->pmpaddr[1]);
+  CHECK_CSR(CSR_REG_PMPADDR2, s->pmpaddr[2]);
+  CHECK_CSR(CSR_REG_PMPADDR3, s->pmpaddr[3]);
+  CHECK_CSR(CSR_REG_PMPADDR4, s->pmpaddr[4]);
+  CHECK_CSR(CSR_REG_PMPADDR5, s->pmpaddr[5]);
+  CHECK_CSR(CSR_REG_PMPADDR6, s->pmpaddr[6]);
+  CHECK_CSR(CSR_REG_PMPADDR7, s->pmpaddr[7]);
+  CHECK_CSR(CSR_REG_PMPADDR8, s->pmpaddr[8]);
+  CHECK_CSR(CSR_REG_PMPADDR9, s->pmpaddr[9]);
+  CHECK_CSR(CSR_REG_PMPADDR10, s->pmpaddr[10]);
+  CHECK_CSR(CSR_REG_PMPADDR11, s->pmpaddr[11]);
+  CHECK_CSR(CSR_REG_PMPADDR12, s->pmpaddr[12]);
+  CHECK_CSR(CSR_REG_PMPADDR13, s->pmpaddr[13]);
+  CHECK_CSR(CSR_REG_PMPADDR14, s->pmpaddr[14]);
+  CHECK_CSR(CSR_REG_PMPADDR15, s->pmpaddr[15]);
+
+  // Check configuration registers.
+  CHECK_CSR(CSR_REG_PMPCFG0, s->pmpcfg[0]);
+  CHECK_CSR(CSR_REG_PMPCFG1, s->pmpcfg[1]);
+  CHECK_CSR(CSR_REG_PMPCFG2, s->pmpcfg[2]);
+  CHECK_CSR(CSR_REG_PMPCFG3, s->pmpcfg[3]);
+
+  // Check Machine Security Configuration (MSECCFG) register.
+  // High bits are hardcoded to 0.
+  CHECK_CSR(CSR_REG_MSECCFG, s->mseccfg);
+  CHECK_CSR(CSR_REG_MSECCFGH, 0);
+
+#undef CHECK_CSR
+
+  return result ? kErrorOk : kErrorEpmpBadCheck;
+}

--- a/sw/device/silicon_creator/lib/epmp.h
+++ b/sw/device/silicon_creator/lib/epmp.h
@@ -1,0 +1,221 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/epmp_defs.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Silicon creator ePMP library.
+ *
+ * This library provides functions to create and manage an in-memory copy of the
+ * ePMP configuration. To update the hardware configuration please use either
+ * assembly or the CSR library directly as needed.
+ */
+
+enum {
+  /**
+   * The number of PMP entries supported by the hardware.
+   */
+  kEpmpNumRegions = 16,
+};
+
+/**
+ * PMP configuration permission settings.
+ *
+ * May be combined with `epmp_mode_t` values to form complete configurations.
+ *
+ *   Bit | Index
+ *   ----+------
+ *    L  |  7
+ *    R  |  0
+ *    W  |  1
+ *    X  |  2
+ *
+ * Combinations not exposed by this enum should not be used. The 'unlocked'
+ * zero value should only be used for entries that are configured as OFF.
+ */
+typedef enum epmp_perm {
+  kEpmpPermUnlocked = 0,
+  kEpmpPermLockedNoAccess = EPMP_CFG_L,
+  kEpmpPermLockedReadOnly = EPMP_CFG_LR,
+  kEpmpPermLockedReadWrite = EPMP_CFG_LRW,
+  kEpmpPermLockedReadExecute = EPMP_CFG_LRX,
+} epmp_perm_t;
+
+/**
+ * PMP configuration addressing mode fields.
+ *
+ * May be combined with `epmp_perm_t` values to form complete configurations.
+ */
+typedef enum epmp_mode {
+  kEpmpModeOff = EPMP_CFG_A_OFF,
+  kEpmpModeTor = EPMP_CFG_A_TOR,
+  kEpmpModeNa4 = EPMP_CFG_A_NA4,
+  kEpmpModeNapot = EPMP_CFG_A_NAPOT,
+} epmp_mode_t;
+
+/**
+ * ePMP region specification.
+ *
+ * Provides the unencoded start and end addresses of a particular region.
+ *
+ * The `start` address is inclusive and the `end` address is exclusive.
+ */
+typedef struct epmp_region {
+  uintptr_t start;
+  uintptr_t end;
+} epmp_region_t;
+
+/**
+ * In-memory copy of the ePMP register state.
+ */
+typedef struct epmp_state {
+  /**
+   * PMP configuration values (pmpcfg0 - pmpcfg3).
+   *
+   * The 8-bit configuration values (pmp0cfg - pmp15cfg) are packed into these
+   * registers in little-endian byte order.
+   *
+   * Each 8-bit configuration value is encoded as follows:
+   *
+   * Layout:
+   *
+   *   +---+-------+-------+---+---+---+
+   *   | L |   0   |   A   | X | W | R |
+   *   +---+-------+-------+---+---+---+
+   *   8   7   6   5   4   3   2   1   0
+   *
+   * Key:
+   *
+   *   L = Locked
+   *   A = Address-matching Mode (OFF=0, TOR=1, NA4=2, NAPOT=3)
+   *   X = Executable
+   *   W = Writeable
+   *   R = Readable
+   *
+   * Note: the interpretation of these configuration bits depends on
+   * whether Machine Mode Lockdown (mseccfg.MML) is enabled or not.
+   * See the PMP Enhancements specification for more details.
+   */
+  uint32_t pmpcfg[kEpmpNumRegions / 4];
+
+  /**
+   * PMP address registers (pmpaddr0 - pmpaddr15).
+   *
+   * The way that address register values are interpreted differs
+   * depending on the address-matching mode (A) in the relevant pmpcfg
+   * register(s).
+   */
+  uint32_t pmpaddr[kEpmpNumRegions];
+
+  /**
+   * Machine Security Configuration register (mseccfg).
+   *
+   *   +---...---+------+------+------+
+   *   |    0    |  RLB | MMWP |  MML |
+   *   +---...---+------+------+------+
+   *  63         3      2      1     0
+   *
+   *  Key:
+   *
+   *    RLB  = Rule Locking Bypass
+   *    MMWP = Machine Mode Whitelist Policy
+   *    MML  = Machine Mode Lockdown
+   *
+   * See the PMP Enhancements specification for more details.
+   *
+   * Note: these are the low 32 bits of mseccfg only. The high 32 bits
+   * are set to 0.
+   */
+  uint32_t mseccfg;
+} epmp_state_t;
+
+/**
+ * Configure the given PMP entry in state using the Top-Of-Range addressing
+ * mode.
+ *
+ * @param state The ePMP state to update.
+ * @param entry The index of the entry to update.
+ * @param region The memory region to encode in the address registers.
+ * @param perm The permissions to set for the entry.
+ */
+inline void epmp_state_configure_tor(epmp_state_t *state, uint32_t entry,
+                                     epmp_region_t region, epmp_perm_t perm) {
+  // Set address registers.
+  if (entry > 0) {
+    state->pmpaddr[entry - 1] = region.start >> 2;
+  }
+  state->pmpaddr[entry] = region.end >> 2;
+
+  // Set configuration register.
+  bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
+  state->pmpcfg[entry / 4] = bitfield_field32_write(state->pmpcfg[entry / 4],
+                                                    field, kEpmpModeTor | perm);
+}
+
+/**
+ * Configure the given PMP entry in state using the Naturally-Aligned-4-byte
+ * addressing mode.
+ *
+ * @param state The ePMP state to update.
+ * @param entry The index of the entry to update.
+ * @param region The memory region to encode in the address registers.
+ * @param perm The permissions to set for the entry.
+ */
+inline void epmp_state_configure_na4(epmp_state_t *state, uint32_t entry,
+                                     epmp_region_t region, epmp_perm_t perm) {
+  // Set address register.
+  state->pmpaddr[entry] = region.start >> 2;
+
+  // Set configuration register.
+  bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
+  state->pmpcfg[entry / 4] = bitfield_field32_write(state->pmpcfg[entry / 4],
+                                                    field, kEpmpModeNa4 | perm);
+}
+
+/**
+ * Configure the given PMP entry in state using the
+ * Naturally-Aligned-Power-Of-Two addressing mode.
+ *
+ * @param state The ePMP state to update.
+ * @param entry The index of the entry to update.
+ * @param region The memory region to encode in the address registers.
+ * @param perm The permissions to set for the entry.
+ */
+inline void epmp_state_configure_napot(epmp_state_t *state, uint32_t entry,
+                                       epmp_region_t region, epmp_perm_t perm) {
+  // Set address register.
+  uint32_t len = (region.end - region.start - 1) >> 3;
+  state->pmpaddr[entry] = (region.start >> 2) | len;
+
+  // Set configuration register.
+  bitfield_field32_t field = {.mask = 0xff, .index = (entry % 4) * 8};
+  state->pmpcfg[entry / 4] = bitfield_field32_write(
+      state->pmpcfg[entry / 4], field, kEpmpModeNapot | perm);
+}
+
+/**
+ * Report whether the given state matches the current hardware ePMP
+ * configuration.
+ *
+ * @param state Expected values of the ePMP CSRs.
+ * @return Whether the check succeeded.
+ */
+rom_error_t epmp_state_check(const epmp_state_t *state);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_H_

--- a/sw/device/silicon_creator/lib/epmp_defs.h
+++ b/sw/device/silicon_creator/lib/epmp_defs.h
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_DEFS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_DEFS_H_
+
+/**
+ * Constants for use when interacting with the enhanced Physical Memory
+ * Protection control registers.
+ *
+ * See the Ibex Physical Memory Protection documentation for more
+ * details:
+ *
+ * https://ibex-core.readthedocs.io/en/latest/03_reference/pmp.html
+ *
+ * Note: this file must be usable from assembly, C and C++ files and
+ * should therefore only contain constant definitions.
+ */
+
+/**
+ * Address of the Machine Security Configuration control register.
+ *
+ * For use with CSR operations such as read, write, set and clear.
+ */
+#define EPMP_MSECCFG 0x390
+
+/**
+ * Machine Security Configuration bits.
+ *
+ *   MML = Machine Mode Lockdown
+ *   MMWP = Machine Mode Whitelist Policy
+ *   RLB = Rule Locking Bypass
+ */
+#define EPMP_MSECCFG_MML (1 << 0)
+#define EPMP_MSECCFG_MMWP (1 << 1)
+#define EPMP_MSECCFG_RLB (1 << 2)
+
+/**
+ * PMP configuration (`pmpNcfg`) register fields.
+ *
+ *   8   7       5       3   2   1   0
+ *   +---+-------+-------+---+---+---+
+ *   | L |   0   |   A   | X | W | R |
+ *   +---+-------+-------+---+---+---+
+ *
+ * Key:
+ *
+ *   L - lock
+ *   A - addressing mode (OFF=0, TOR=1, NA4=2, NAPOT=3)
+ *   X - execute
+ *   W - write
+ *   R - read
+ *
+ * Note that there are four 8-bit configuration fields (`pmpNcfg`)
+ * packed into each hardware configuration register (`pmpcfgN`).
+ */
+#define EPMP_CFG_L (1 << 7)
+#define EPMP_CFG_A_OFF (0 << 3)
+#define EPMP_CFG_A_TOR (1 << 3)
+#define EPMP_CFG_A_NA4 (2 << 3)
+#define EPMP_CFG_A_NAPOT (3 << 3)
+#define EPMP_CFG_X (1 << 2)
+#define EPMP_CFG_W (1 << 1)
+#define EPMP_CFG_R (1 << 0)
+
+/**
+ * Common PMP configuration (`pmpNcfg`) permission combinations.
+ */
+#define EPMP_CFG_LR (EPMP_CFG_L | EPMP_CFG_R)
+#define EPMP_CFG_LRX (EPMP_CFG_L | EPMP_CFG_R | EPMP_CFG_X)
+#define EPMP_CFG_LRW (EPMP_CFG_L | EPMP_CFG_R | EPMP_CFG_W)
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_DEFS_H_

--- a/sw/device/silicon_creator/lib/epmp_test_unlock.c
+++ b/sw/device/silicon_creator/lib/epmp_test_unlock.c
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/epmp_test_unlock.h"
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/csr.h"
+
+bool epmp_unlock_test_status(epmp_state_t *state) {
+  // PMP entry dedicated to test status (DV).
+  enum {
+    kEntry = 6,
+  };
+
+  // Permissions to apply to test status address space.
+  const epmp_perm_t kPerm = kEpmpPermLockedReadWrite;
+
+  // Check that address space is word aligned.
+  if (kDeviceTestStatusAddress % sizeof(uint32_t) != 0) {
+    return false;
+  }
+
+  // Update the shadow register values (if provided).
+  if (state != NULL) {
+    epmp_region_t region = {.start = kDeviceTestStatusAddress,
+                            .end = kDeviceTestStatusAddress + sizeof(uint32_t)};
+    epmp_state_configure_na4(state, kEntry, region, kPerm);
+  }
+
+  // Update the hardware registers.
+  static_assert(kEntry == 6, "PMP entry has changed, update CSR operations.");
+  CSR_WRITE(CSR_REG_PMPADDR6, kDeviceTestStatusAddress / sizeof(uint32_t));
+  CSR_SET_BITS(CSR_REG_PMPCFG1, (kEpmpModeNa4 | kPerm)
+                                    << ((kEntry % sizeof(uint32_t)) * 8));
+
+  // Double check that the shadow registers match.
+  if (state != NULL && !epmp_state_check(state)) {
+    return false;
+  }
+
+  return true;
+}

--- a/sw/device/silicon_creator/lib/epmp_test_unlock.h
+++ b/sw/device/silicon_creator/lib/epmp_test_unlock.h
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_TEST_UNLOCK_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_TEST_UNLOCK_H_
+
+#include <stdbool.h>
+
+#include "sw/device/silicon_creator/lib/epmp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Unlock the test status address space for read/write access.
+ *
+ * The production ePMP schema used by the mask ROM blocks all accesses to the
+ * 4 byte test status address space. This address space is used by tests to
+ * report test progress and results and so must be made accessible before tests
+ * can be run.
+ *
+ * Utilizes a dedicated PMP entry reserved for this usage.
+ *
+ * @param state Shadow register state to update and check against (optional).
+ * @returns The result of the operation (`true` if address space unlocked
+ * successfully).
+ */
+bool epmp_unlock_test_status(epmp_state_t *state);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_EPMP_TEST_UNLOCK_H_

--- a/sw/device/silicon_creator/lib/epmp_unittest.cc
+++ b/sw/device/silicon_creator/lib/epmp_unittest.cc
@@ -1,0 +1,372 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/epmp.h"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/testing/mock_csr.h"
+
+namespace epmp_unittest {
+using ::mock_csr::CsrTest;
+using ::testing::Test;
+
+/**
+ * Representation of the hardware PMP control register state.
+ */
+struct PmpCsrs {
+  /**
+   * The unpacked PMP configuration (`pmpNcfg`) registers, one entry for each
+   * PMP entry.
+   */
+  std::array<uint8_t, kEpmpNumRegions> pmpcfg{};
+
+  /**
+   * The PMP address registers, one for each PMP entry.
+   */
+  std::array<uint32_t, kEpmpNumRegions> pmpaddr{};
+
+  /**
+   * The Machine Security Configuration register.
+   */
+  uint64_t mseccfg = 0;
+
+  /**
+   * Pack the individual (`pmpNcfg`) PMP entry configuration register
+   * values into hardware register (`pmpcfgN`) values.
+   *
+   * @returns An array representing the packed `pmpcfgN` values.
+   */
+  std::array<uint32_t, kEpmpNumRegions / 4> PackCfg() const {
+    // There are four 8-bit `pmpNcfg` values packed into each `pmpcfgN`
+    // register.
+    std::array<uint32_t, kEpmpNumRegions / 4> packed{};
+    for (int i = 0; i < pmpcfg.size(); ++i) {
+      bitfield_field32_t field = {.mask = 0xff,
+                                  .index = (static_cast<uint32_t>(i) % 4) * 8};
+      packed.at(i / 4) = bitfield_field32_write(
+          packed.at(i / 4), field, static_cast<uint32_t>(pmpcfg.at(i)));
+    }
+    return packed;
+  }
+
+  /**
+   * Generate a state that is a snapshot of the current PMP control register
+   * values.
+   *
+   * @returns An `epmp_state_t` value.
+   */
+  epmp_state_t State() const {
+    epmp_state_t state;
+    auto packed = PackCfg();
+    for (int i = 0; i < packed.size(); ++i) {
+      state.pmpcfg[i] = packed.at(i);
+    }
+    for (int i = 0; i < pmpaddr.size(); ++i) {
+      state.pmpaddr[i] = pmpaddr.at(i);
+    }
+    state.mseccfg = static_cast<uint32_t>(mseccfg);
+    return state;
+  }
+};
+
+/**
+ * Map from PMP config register index to CSR_REG_PMPCFGN value.
+ */
+const std::vector<uint32_t> kPmpcfgMap = {
+    CSR_REG_PMPCFG0,
+    CSR_REG_PMPCFG1,
+    CSR_REG_PMPCFG2,
+    CSR_REG_PMPCFG3,
+};
+
+/**
+ * Map from PMP address register index to CSR_REG_PMPADDRN value.
+ */
+const std::vector<uint32_t> kPmpaddrMap = {
+    CSR_REG_PMPADDR0,  CSR_REG_PMPADDR1,  CSR_REG_PMPADDR2,  CSR_REG_PMPADDR3,
+    CSR_REG_PMPADDR4,  CSR_REG_PMPADDR5,  CSR_REG_PMPADDR6,  CSR_REG_PMPADDR7,
+    CSR_REG_PMPADDR8,  CSR_REG_PMPADDR9,  CSR_REG_PMPADDR10, CSR_REG_PMPADDR11,
+    CSR_REG_PMPADDR12, CSR_REG_PMPADDR13, CSR_REG_PMPADDR14, CSR_REG_PMPADDR15,
+};
+
+/**
+ * Helper function to call EXPECT_CSR_READ on all pmpcfg registers
+ * returning the values provided.
+ */
+static void ExpectPmpcfgRead(const PmpCsrs &expect) {
+  auto packed = expect.PackCfg();
+  for (int i = 0; i < packed.size(); ++i) {
+    EXPECT_CSR_READ(kPmpcfgMap.at(i), packed.at(i));
+  }
+}
+
+/**
+ * Helper function to call EXPECT_CSR_READ on all pmpaddr registers
+ * returning the values provided.
+ */
+static void ExpectPmpaddrRead(const PmpCsrs &expect) {
+  for (int i = 0; i < expect.pmpaddr.size(); ++i) {
+    EXPECT_CSR_READ(kPmpaddrMap.at(i), expect.pmpaddr.at(i));
+  }
+}
+
+/**
+ * Helper function to call EXPECT_CSR_READ on the mseccfg register
+ * returning the value provided.
+ */
+static void ExpectMseccfgRead(const PmpCsrs &expect) {
+  EXPECT_CSR_READ(CSR_REG_MSECCFG, static_cast<uint32_t>(expect.mseccfg));
+  EXPECT_CSR_READ(CSR_REG_MSECCFGH,
+                  static_cast<uint32_t>(expect.mseccfg >> 32));
+}
+
+/**
+ * Helper function to call EXPECT_CSR_READ as necessary for an
+ * internal `read_state` call with the expected values provided.
+ */
+static void ExpectReadState(const PmpCsrs &expect) {
+  ExpectPmpaddrRead(expect);
+  ExpectPmpcfgRead(expect);
+  ExpectMseccfgRead(expect);
+}
+
+/**
+ * Encode a region using the NAPOT address mode. This does not
+ * do any validation of the values provided.
+ *
+ * Note: other address modes just require the address to be right
+ * shifted by 2.
+ */
+static uint32_t napot(epmp_region_t region) {
+  return (region.start >> 2) | ((region.end - region.start - 1) >> 3);
+}
+
+class EpmpTest : public CsrTest {
+ protected:
+  /**
+   * Default reset value for the PMP CSRs.
+   */
+  const PmpCsrs reset_ = PmpCsrs{};
+  epmp_state_t state_ = reset_.State();
+};
+
+class EpmpCheckTest : public Test, public EpmpTest {};
+
+TEST_F(EpmpCheckTest, Default) {
+  // Check CSRs are set as expected.
+  ExpectReadState(reset_);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+TEST_F(EpmpCheckTest, ErrorPmpaddr) {
+  // Inject an error.
+  PmpCsrs bad = reset_;
+  bad.pmpaddr.at(15) ^= 1 << 31;
+
+  // Check should fail.
+  ExpectReadState(bad);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorEpmpBadCheck);
+}
+
+TEST_F(EpmpCheckTest, ErrorPmpcfg) {
+  // Inject an error.
+  PmpCsrs bad = reset_;
+  bad.pmpcfg.at(0) ^= 1;
+
+  // Check should fail.
+  ExpectReadState(bad);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorEpmpBadCheck);
+}
+
+TEST_F(EpmpCheckTest, ErrorMseccfg) {
+  // Inject an error.
+  PmpCsrs bad = reset_;
+  bad.mseccfg ^= 1;
+
+  // Check should fail.
+  ExpectReadState(bad);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorEpmpBadCheck);
+}
+
+class EpmpTorTest : public Test, public EpmpTest {};
+
+TEST_F(EpmpTorTest, Entry0) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0,
+      .end = 0,
+  };
+
+  // Configure registers for entry 0 (base address implicitly 0).
+  PmpCsrs csrs = reset_;
+  csrs.pmpcfg[0] = EPMP_CFG_L | EPMP_CFG_A_TOR | EPMP_CFG_R;
+  csrs.pmpaddr[0] = region.end >> 2;
+
+  // Configure same entry in state.
+  epmp_state_configure_tor(&state_, 0, region, kEpmpPermLockedReadOnly);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+TEST_F(EpmpTorTest, Entry1) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0x120,
+      .end = 0x140,
+  };
+
+  // Configure registers for entry 1, with base address in entry 0.
+  PmpCsrs csrs = reset_;
+  csrs.pmpaddr[0] = region.start >> 2;
+  csrs.pmpcfg[1] = EPMP_CFG_L | EPMP_CFG_A_TOR | EPMP_CFG_R;
+  csrs.pmpaddr[1] = region.end >> 2;
+
+  // Configure same entry in state.
+  epmp_state_configure_tor(&state_, 1, region, kEpmpPermLockedReadOnly);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+TEST_F(EpmpTorTest, Entry15) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0x120,
+      .end = 0x140,
+  };
+
+  // Configure registers for entry 15, with base address in entry 14.
+  PmpCsrs csrs = reset_;
+  csrs.pmpaddr[14] = region.start >> 2;
+  csrs.pmpcfg[15] = EPMP_CFG_L | EPMP_CFG_A_TOR | EPMP_CFG_R;
+  csrs.pmpaddr[15] = region.end >> 2;
+
+  // Configure same entry in state.
+  epmp_state_configure_tor(&state_, 15, region, kEpmpPermLockedReadOnly);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+TEST_F(EpmpTorTest, SharedAddress) {
+  // Adjacent regions for entries.
+  epmp_region_t region1 = {
+      .start = 0x120,
+      .end = 0x140,
+  };
+  epmp_region_t region2 = {
+      .start = 0x140,
+      .end = 0x180,
+  };
+
+  // Configure registers for entries 1 and 2, with base address in entry 0.
+  PmpCsrs csrs = reset_;
+  csrs.pmpaddr[0] = region1.start >> 2;
+  csrs.pmpcfg[1] = EPMP_CFG_L | EPMP_CFG_A_TOR | EPMP_CFG_R | EPMP_CFG_X;
+  csrs.pmpaddr[1] = region1.end >> 2;
+  csrs.pmpcfg[2] = EPMP_CFG_L | EPMP_CFG_A_TOR | EPMP_CFG_R;
+  csrs.pmpaddr[2] = region2.end >> 2;
+
+  // Configure same entry in state.
+  epmp_state_configure_tor(&state_, 1, region1, kEpmpPermLockedReadExecute);
+  epmp_state_configure_tor(&state_, 2, region2, kEpmpPermLockedReadOnly);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+class EpmpNa4Test : public Test, public EpmpTest {};
+
+TEST_F(EpmpNa4Test, Entry0) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0xF4,
+      .end = 0xF8,
+  };
+
+  // Configure registers for entry 0.
+  PmpCsrs csrs = reset_;
+  csrs.pmpcfg[0] = EPMP_CFG_L | EPMP_CFG_A_NA4 | EPMP_CFG_R | EPMP_CFG_X;
+  csrs.pmpaddr[0] = region.start >> 2;
+
+  // Configure same entry in state.
+  epmp_state_configure_na4(&state_, 0, region, kEpmpPermLockedReadExecute);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+TEST_F(EpmpNa4Test, Entry15) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0x0,
+      .end = 0x4,
+  };
+
+  // Configure registers for entry 15.
+  PmpCsrs csrs = reset_;
+  csrs.pmpcfg[15] = EPMP_CFG_L | EPMP_CFG_A_NA4 | EPMP_CFG_R | EPMP_CFG_W;
+  csrs.pmpaddr[15] = region.start >> 2;
+
+  // Configure same entry in state.
+  epmp_state_configure_na4(&state_, 15, region, kEpmpPermLockedReadWrite);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+class EpmpNapotTest : public Test, public EpmpTest {};
+
+TEST_F(EpmpNapotTest, Entry0) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0xFF00,
+      .end = 0xFF10,
+  };
+
+  // Configure registers for entry 0.
+  PmpCsrs csrs = reset_;
+  csrs.pmpcfg[0] = EPMP_CFG_L | EPMP_CFG_A_NAPOT | EPMP_CFG_R | EPMP_CFG_X;
+  csrs.pmpaddr[0] = napot(region);
+
+  // Configure same entry in state.
+  epmp_state_configure_napot(&state_, 0, region, kEpmpPermLockedReadExecute);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+TEST_F(EpmpNapotTest, Entry15) {
+  // Region for entry.
+  epmp_region_t region = {
+      .start = 0x0,
+      .end = 0x8,
+  };
+
+  // Configure registers for entry 15.
+  PmpCsrs csrs = reset_;
+  csrs.pmpcfg[15] = EPMP_CFG_L | EPMP_CFG_A_NAPOT | EPMP_CFG_R | EPMP_CFG_W;
+  csrs.pmpaddr[15] = napot(region);
+
+  // Configure same entry in state.
+  epmp_state_configure_napot(&state_, 15, region, kEpmpPermLockedReadWrite);
+
+  // Check CSRs match.
+  ExpectReadState(csrs);
+  EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
+}
+
+}  // namespace epmp_unittest

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -32,6 +32,7 @@ enum module_ {
   kModuleMaskRom = 0x524d,       // ASCII "MR".
   kModuleRomextimage = 0x4552,   // ASCII "RE".
   kModuleInterrupt = 0x5249,     // ASCII "IR".
+  kModuleEpmp = 0x5045,          // ASCII "EP",
 };
 
 /**
@@ -77,6 +78,7 @@ enum module_ {
   X(kErrorMaskRomBootFailed,          ERROR_(1, kModuleMaskRom, kFailedPrecondition)), \
   /* The high-byte of kErrorInterrupt is modified with the interrupt cause */ \
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
+  X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 
 #include "sw/device/lib/base/macros.h"
-#include "sw/device/lib/runtime/epmp.h"
+#include "sw/device/silicon_creator/lib/epmp.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/keymgr_binding_value.h"
 #include "sw/device/silicon_creator/lib/manifest_size.h"

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -5,7 +5,7 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 #include "gtest/gtest.h"
-#include "sw/device/lib/runtime/epmp.h"
+#include "sw/device/silicon_creator/lib/epmp.h"
 
 namespace manifest_unittest {
 namespace {

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -77,6 +77,29 @@ sw_silicon_creator_lib_shutdown = declare_dependency(
   ),
 )
 
+# Silicon creator ePMP library.
+sw_silicon_creator_lib_epmp = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_epmp',
+    sources: [
+      'epmp.c',
+    ],
+  ),
+)
+
+# Silicon creator ePMP test utilities.
+sw_silicon_creator_lib_epmp_test_unlock = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_epmp_test_unlock',
+    sources: [
+      'epmp_test_unlock.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_epmp,
+    ],
+  ),
+)
+
 test('sw_silicon_creator_lib_shutdown_unittest', executable(
     'sw_silicon_creator_lib_shutdown_unittest',
     sources: [

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -176,6 +176,24 @@ test('sw_silicon_creator_lib_sigverify_unittest', executable(
   suite: 'mask_rom',
 )
 
+test('sw_silicon_creator_lib_epmp_unittest', executable(
+    'sw_silicon_creator_lib_epmp_unittest',
+    sources: [
+      'epmp_unittest.cc',
+      'epmp.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_csr,
+      sw_lib_testing_bitfield,
+    ],
+    native: true,
+    c_args: ['-DMOCK_CSR'],
+    cpp_args: ['-DMOCK_CSR'],
+    ),
+  suite: 'mask_rom',
+)
+
 sw_silicon_creator_lib_sigverify_functest = declare_dependency(
   link_with: static_library(
     'sw_silicon_creator_lib_sigverify_functest',

--- a/sw/device/silicon_creator/mask_rom/mask_rom.ld
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.ld
@@ -37,6 +37,19 @@ _chip_info_start = _chip_info_end - _chip_info_size;
 /* DV Log offset (has to be different to other boot stages). */
 _dv_log_offset = 0x0;
 
+/**
+ * Physical Memory Protection (PMP) encoded address register values.
+ *
+ * Some addresses required for PMP entries are known only at link time.
+ * These addresses are encoded here so that no calculations need to be
+ * performed at runtime.
+ *
+ * See The RISC-V Instruction Set Manual Volume II: Privileged Architecture
+ * for more information about PMP address register encodings.
+ */
+_epmp_text_tor_lo = _text_start / 4;
+_epmp_text_tor_hi = _text_end / 4;
+_epmp_stack_guard_na4 = _stack_start / 4;
 
 ENTRY(_mask_rom_start_boot);
 
@@ -52,6 +65,7 @@ SECTIONS {
    * reset handler correctly.
    */
   .vectors _mask_rom_boot_address : ALIGN(256) {
+    _text_start = .;
     KEEP(*(.vectors))
   } > rom
 
@@ -71,6 +85,10 @@ SECTIONS {
   .text : ALIGN(4) {
     *(.text)
     *(.text.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+    _text_end = .;
   } > rom
 
   /**

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
@@ -1,0 +1,155 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/epmp_defs.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+
+/**
+ * Helper macro to move v into the correct position to set the pmp{N*4+i}cfg
+ * field in the pmpcfg{N} register.
+ *
+ * Example: set value for pmp5cfg which is a field of pmpcfg1.
+ *
+ *   li   t0, CFG_INDEX(5 % 4, v)
+ *   csrw pmpcfg1, t0
+ */
+#define CFG_INDEX(i, v) ((v) << (i*8))
+
+/**
+ * Encode address for Top-Of-Range addressing mode.
+ */
+#define TOR(addr) ((addr) >> 2)
+
+/**
+ * Encode address and length for Naturally-Aligned-Power-Of-Two addressing
+ * mode.
+ */
+#define NAPOT(addr, len) (((addr) >> 2) | (((len) - 1) >> 3))
+
+/**
+ * The "ax" flag below is necessary to ensure that this section
+ * is allocated space in ROM by the linker.
+ */
+.section .crt, "ax", @progbits
+
+/**
+ * Configure the CPU's Enhanced Physical Memory Protection (ePMP) feature.
+ *
+ * The steps are:
+ *
+ *   1. Enable Rule Locking Bypass (RLB). RLB allows later boot stages to
+ *      modify locked PMP entries.
+ *   2. Configure access permissions for each address space of interest.
+ *   3. Enable Machine Mode Whitelist Policy (MMWP). MMWP stops any access
+ *      that does not match a PMP entry.
+ *
+ * This function follows the standard ILP32 calling convention but does not
+ * require a valid stack pointer, thread pointer or global pointer.
+ *
+ * May clobber temporary registers (t0-t6).
+ */
+mask_rom_epmp_init:
+  .globl mask_rom_epmp_init
+  .type mask_rom_epmp_init, @function
+
+  // Enable Rule Locking Bypass (RLB).
+  csrsi EPMP_MSECCFG, EPMP_MSECCFG_RLB
+
+  // Clear all PMP configuration registers.
+  csrw pmpcfg0, zero
+  csrw pmpcfg1, zero
+  csrw pmpcfg2, zero
+  csrw pmpcfg3, zero
+
+  // Pre-encoded addresses defined in linker script.
+  .extern _epmp_text_tor_lo
+  .extern _epmp_text_tor_hi
+  .extern _epmp_stack_guard_na4
+
+  // Setup PMP address registers.
+
+  // ROM TEXT
+  la   t0, _epmp_text_tor_lo
+  csrw pmpaddr0, t0
+  la   t0, _epmp_text_tor_hi
+  csrw pmpaddr1, t0
+
+  // ROM
+  li   t0, NAPOT(TOP_EARLGREY_ROM_BASE_ADDR, TOP_EARLGREY_ROM_SIZE_BYTES)
+  csrw pmpaddr2, t0
+
+  // ROM_EXT TEXT (configured after signature verification)
+  csrw pmpaddr3, zero // ROM_EXT TEXT low
+  csrw pmpaddr4, zero // ROM_EXT TEXT high
+
+  // eFLASH
+  li   t0, NAPOT(TOP_EARLGREY_EFLASH_BASE_ADDR, TOP_EARLGREY_EFLASH_SIZE_BYTES)
+  csrw pmpaddr5, t0
+
+  // Free entries
+  csrw pmpaddr6, zero
+  csrw pmpaddr7, zero
+  csrw pmpaddr8, zero
+  csrw pmpaddr9, zero
+
+  // MMIO
+  li   t0, TOR(0x40000000) // TODO(#7117): generate MMIO start address.
+  csrw pmpaddr10, t0
+  li   t0, TOR(0x50000000) // TODO(#7117): generate MMIO end address.
+  csrw pmpaddr11, t0
+
+  // Free entries
+  csrw pmpaddr12, zero
+  csrw pmpaddr13, zero
+
+  // Stack guard
+  la   t0, _epmp_stack_guard_na4
+  csrw pmpaddr14, t0
+
+  // RAM
+  li   t0, NAPOT(TOP_EARLGREY_RAM_MAIN_BASE_ADDR, TOP_EARLGREY_RAM_MAIN_SIZE_BYTES)
+  csrw pmpaddr15, t0
+
+  // Set PMP configuration registers.
+  li   t0, CFG_INDEX(1  % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRX) | /* ROM TEXT    */ \
+           CFG_INDEX(2  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* ROM         */
+  li   t1, CFG_INDEX(5  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* eFLASH      */
+  li   t2, CFG_INDEX(11 % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRW)   /* MMIO        */
+  li   t3, CFG_INDEX(14 % 4, EPMP_CFG_A_NA4   | EPMP_CFG_LRW) | /* Stack Guard */ \
+           CFG_INDEX(15 % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LRW)   /* RAM         */
+  csrw pmpcfg0, t0
+  csrw pmpcfg1, t1
+  csrw pmpcfg2, t2
+  csrw pmpcfg3, t3
+
+  // Enable Machine Mode Whitelist Policy (MMWP).
+  // TODO(#5653): Enable Machine Mode Lockdown (MML)?
+  csrsi EPMP_MSECCFG, EPMP_MSECCFG_MMWP
+
+  ret
+
+  // Set function size to allow disassembly.
+  .size mask_rom_epmp_init, .-mask_rom_epmp_init
+
+/**
+ * Disable all accesses to the stack guard word.
+ *
+ * This function follows the standard ILP32 calling convention but does not
+ * require a valid stack pointer, thread pointer or global pointer.
+ *
+ * Clobbers t0.
+ */
+mask_rom_epmp_stack_guard_init:
+  .globl mask_rom_epmp_stack_guard_init
+  .type mask_rom_epmp_stack_guard_init, @function
+
+  // Remove all permissions from entry 14 (the stack guard).
+  li   t0, CFG_INDEX(14 % 4, EPMP_CFG_R | EPMP_CFG_W | EPMP_CFG_X)
+  csrc pmpcfg3, t0
+
+  ret
+
+  // Set function size to allow disassembly.
+  .size mask_rom_epmp_stack_guard_init, .-mask_rom_epmp_stack_guard_init

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.c
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/mask_rom/mask_rom_epmp.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Symbols defined in linker script.
+extern char _stack_start[];  // Lowest stack address.
+extern char _text_start[];   // Start of executable code.
+extern char _text_end[];     // End of executable code.
+
+void mask_rom_epmp_state_init(epmp_state_t *state) {
+  // Address space definitions.
+  //
+  // Note that the stack guard is placed at _stack_start because the stack
+  // grows downward from _stack_end.
+  const epmp_region_t rom_text = {.start = (uintptr_t)_text_start,
+                                  .end = (uintptr_t)_text_end};
+  const epmp_region_t rom = {.start = TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR,
+                             .end = TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR +
+                                    TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES};
+  const epmp_region_t eflash = {
+      .start = TOP_EARLGREY_EFLASH_BASE_ADDR,
+      .end = TOP_EARLGREY_EFLASH_BASE_ADDR + TOP_EARLGREY_EFLASH_SIZE_BYTES};
+  // TODO(#7117): generate MMIO addresses.
+  const epmp_region_t mmio = {.start = 0x40000000, .end = 0x50000000};
+  const epmp_region_t stack_guard = {.start = (uintptr_t)_stack_start,
+                                     .end = (uintptr_t)_stack_start + 4};
+  const epmp_region_t ram = {.start = TOP_EARLGREY_RAM_MAIN_BASE_ADDR,
+                             .end = TOP_EARLGREY_RAM_MAIN_BASE_ADDR +
+                                    TOP_EARLGREY_RAM_MAIN_SIZE_BYTES};
+
+  // Initialize in-memory copy of ePMP register state.
+  //
+  // The actual hardware configuration is performed separately, either by reset
+  // logic or in assembly. This code must be kept in sync with any changes
+  // to the hardware configuration.
+  *state = (epmp_state_t){0};
+  epmp_state_configure_tor(state, 1, rom_text, kEpmpPermLockedReadExecute);
+  epmp_state_configure_napot(state, 2, rom, kEpmpPermLockedReadOnly);
+  epmp_state_configure_napot(state, 5, eflash, kEpmpPermLockedReadOnly);
+  epmp_state_configure_tor(state, 11, mmio, kEpmpPermLockedReadWrite);
+  epmp_state_configure_na4(state, 14, stack_guard, kEpmpPermLockedNoAccess);
+  epmp_state_configure_napot(state, 15, ram, kEpmpPermLockedReadWrite);
+  state->mseccfg = EPMP_MSECCFG_MMWP | EPMP_MSECCFG_RLB;
+}
+
+void mask_rom_epmp_unlock_rom_ext_rx(epmp_state_t *state, epmp_region_t image) {
+  // Update the in-memory copy of ePMP register state.
+  const int kEntry = 4;
+  epmp_state_configure_tor(state, kEntry, image, kEpmpPermLockedReadExecute);
+
+  // Update the hardware configuration (CSRs).
+  //
+  // Entry is hardcoded as 4. Make sure to modify hardcoded values if changing
+  // kEntry.
+  //
+  // The `pmp4cfg` configuration is the first field in `pmpcfg1`.
+  //
+  //            32          24          16           8           0
+  //             +-----------+-----------+-----------+-----------+
+  // `pmpcfg1` = | `pmp7cfg` | `pmp6cfg` | `pmp5cfg` | `pmp4cfg` |
+  //             +-----------+-----------+-----------+-----------+
+  CSR_WRITE(CSR_REG_PMPADDR3, image.start >> 2);
+  CSR_WRITE(CSR_REG_PMPADDR4, image.end >> 2);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG1, 0xff);
+  CSR_SET_BITS(CSR_REG_PMPCFG1, kEpmpModeTor | kEpmpPermLockedReadExecute);
+}

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.h
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.h
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MASK_ROM_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MASK_ROM_EPMP_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/epmp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Mask ROM enhanced Physical Memory Protection (ePMP) library.
+ *
+ * The ePMP configuration is managed in two parts:
+ *
+ *   1. The actual hardware configuration held in CSRs
+ *   2. The in-memory copy of register values in `epmp_state_t` that is used
+ *      to verify the CSRs
+ *
+ * Every time the hardware configuration is updated the in-memory copy
+ * must also be updated. The hardware configuration is usually interacted
+ * with directly using the CSR library or assembly whereas the in-memory
+ * copy of the state should normally be modified using configuration functions
+ * from the silicon creator ePMP library.
+ *
+ * This separation of concerns allows the hardware configuration to be
+ * updated efficiently as needed (including before the C runtime is
+ * initialized) with the in-memory copy of the state used to double check the
+ * configuration as required.
+ */
+
+/**
+ * Initialise the ePMP in-memory copy of the register state to reflect the
+ * hardware configuration expected at entry to the mask ROM C code.
+ *
+ * The actual hardware configuration is performed separately, either by reset
+ * logic or in assembly. This code must be kept in sync with any changes
+ * to the hardware configuration.
+ *
+ * @param[out] state The shadow registers to configure with initial values.
+ */
+void mask_rom_epmp_state_init(epmp_state_t *state);
+
+/**
+ * Unlocks the provided ROM_EXT image region with read-execute permissions.
+ *
+ * The provided ePMP state is also updated to reflect the changes made to the
+ * hardware configuration.
+ *
+ * @param state The ePMP state to update.
+ * @param image Region for executable sections in ROM_EXT image.
+ */
+void mask_rom_epmp_unlock_rom_ext_rx(epmp_state_t *state, epmp_region_t image);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MASK_ROM_EPMP_H_

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
@@ -1,0 +1,403 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/mask_rom/mask_rom_epmp.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/pinmux.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/test_status.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+#include "sw/device/silicon_creator/lib/epmp_test_unlock.h"
+#include "sw/device/silicon_creator/mask_rom/mask_rom_epmp.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sram_ctrl_regs.h"  // Generated.
+
+/**
+ * Mask ROM ePMP test.
+ *
+ * This test uses the mask ROM linker script and ePMP setup code to initialize
+ * its own ePMP configuration and then attempts to execute instructions in
+ * various address spaces. Typically execution in these address spaces should be
+ * blocked unless the unlock function has been called with a region containing
+ * the address of the access.
+ */
+
+/**
+ * Exception types that may be encountered.
+ *
+ * TODO(#7190): use global definitions instead.
+ */
+typedef enum exception {
+  kExceptionNone = -1,
+  kExceptionInstructionAccessFault = 1,
+  kExceptionIllegalInstruction = 2,
+  kExceptionBreakpoint = 3,
+  kExceptionLoadAccessFault = 5,
+  kExceptionStoreAccessFault = 7,
+  kExceptionECallFromUMode = 8,
+  kExceptionECallFromMMode = 11,
+} exception_t;
+
+/**
+ * Get the value of the `mcause` register.
+ *
+ * @returns The encoded interrupt or exception cause.
+ */
+static uint32_t get_mcause(void) {
+  uint32_t mcause;
+  CSR_READ(CSR_REG_MCAUSE, &mcause);
+  return mcause;
+}
+
+/**
+ * Get the value of the `mepc` register.
+ *
+ * @returns The value of the machine exception program counter.
+ */
+static uint32_t get_mepc(void) {
+  uint32_t mepc;
+  CSR_READ(CSR_REG_MEPC, &mepc);
+  return mepc;
+}
+
+/**
+ * Set the value of the `mepc` register.
+ *
+ * After an exception has been handled execution will be resumed at the address
+ * contained within `mepc`.
+ *
+ * @param pc The value to set the machine exception program counter to.
+ */
+static void set_mepc(uint32_t pc) { CSR_WRITE(CSR_REG_MEPC, pc); }
+
+/**
+ * Interrupt handlers.
+ *
+ * If operating correctly this test should only trigger exceptions. Interrupts
+ * are therefore not recovered.
+ */
+void mask_rom_nmi_handler(void) { wait_for_interrupt(); }
+void mask_rom_interrupt_handler(void) { wait_for_interrupt(); }
+
+/**
+ * The type of last exception (if any) received.
+ *
+ * Set by the exception handler.
+ */
+volatile exception_t exception_received = kExceptionNone;
+
+/**
+ * The `mepc` value for the last exception (if any) received.
+ *
+ * Set by the exception handler.
+ */
+volatile uintptr_t exception_pc = 0;
+
+/**
+ * Exception handler.
+ *
+ * Handle instruction access faults and illegal instructions by setting
+ * `exception_received` and `exception_pc` and then returning to the code
+ * that jumped (via a call) to the offending instruction.
+ *
+ * This will likely only work correctly if the instruction exception was
+ * caused by a jump from `execute` to an invalid instruction (whether illegal
+ * or inaccessible).
+ *
+ * For all other exceptions hang (could also shutdown) so as not to hide them.
+ */
+void mask_rom_exception_handler(void) {
+  uint32_t mcause = get_mcause();
+  if (mcause == kExceptionInstructionAccessFault ||
+      mcause == kExceptionIllegalInstruction) {
+    exception_received = (exception_t)mcause;
+    exception_pc = get_mepc();
+
+    // Return to caller.
+    uintptr_t ret = (uintptr_t)__builtin_return_address(0);
+    set_mepc((uint32_t)ret);
+    return;
+  }
+
+  // Wait forever if an unexpected exception is encountered.
+  wait_for_interrupt();
+}
+
+/**
+ * Attempt to execute the code at `pc` by calling it like a function.
+ *
+ * Typically the contents of `pc` should be an invalid instruction such
+ * as an all zero value. In this case if execution was blocked by PMP an
+ * instruction fault exception will be raised. If however execution was
+ * allowed then an illegal instruction exception will be raised instead.
+ *
+ * The interrupt handler will arrange for control to be returned to the
+ * caller on encountering either an instruction fault or illegal
+ * instruction error so this function will report a result in either
+ * case.
+ *
+ * @param pc The address of the instruction to try and execute.
+ * @param expect The expected exception that will be raised.
+ * @returns Whether the expected exception was raised at the correct PC.
+ */
+static bool execute(const void *pc, exception_t expect) {
+  exception_pc = 0;
+  exception_received = kExceptionNone;
+
+  // Jump to the target PC.
+  //
+  // Using a `call` here (`jal` or `jalr`) sets the return address (`ra`)
+  // register. When an exception is raised the interrupt handler will recover
+  // by restarting execution at the address in `ra` thereby making it appear
+  // as if the call returned normally.
+  //
+  //   ...
+  //   jal ra, pc # <- Set return address and jump to pc.
+  //   ...        # <- Interrupt handler restarts execution at the next
+  //              #    instruction in the caller, here.
+  //
+  // pc:
+  //   unimp      # <- Illegal instruction or access fault. Enter interrupt
+  //                   handler.
+  //
+  ((void (*)(void))pc)();
+
+  // Be careful to ensure that the exception was raised when trying to
+  // execute `pc` just in case a valid instruction is actually executed
+  // and then execution continued to a point where an exception is
+  // raised.
+  if (exception_received != kExceptionNone && exception_pc != (uintptr_t)pc) {
+    return false;
+  }
+  return exception_received == expect;
+}
+
+/**
+ * An instruction that has no bits set.
+ *
+ * Attempts to execute this instruction, `unimp`, will result in an illegal
+ * instruction exception.
+ *
+ * Note that if compressed instructions are enabled only the first two bytes
+ * will be decoded (as `c.unimp`).
+ */
+static const uint32_t kUnimpInstruction = 0;
+
+/**
+ * Illegal instruction residing in .rodata.
+ */
+static const uint32_t illegal_ins_ro[] = {
+    kUnimpInstruction,
+};
+
+/**
+ * Illegal instruction residing in .data.
+ */
+static uint32_t illegal_ins_rw[] = {
+    kUnimpInstruction,
+};
+
+/**
+ * Report whether the given pointer points to a location with the provided
+ * address space.
+ *
+ * @param ptr Pointer to test.
+ * @param start Address of the start of the address space.
+ * @param size The size of the address space in bytes.
+ * @returns Whether the pointer is in the address space.
+ */
+static bool is_in_address_space(const void *ptr, uintptr_t start,
+                                uintptr_t size) {
+  return (uintptr_t)ptr >= start && (uintptr_t)ptr < (start + size);
+}
+
+/**
+ * Enable execution of SRAM for the given controller.
+ *
+ * @param ctrl_addr Base address for SRAM controller.
+ * @returns Whether execution was enabled successfully or not.
+ */
+static bool sram_exec_enable(uint32_t ctrl_addr) {
+  // TODO: use the SRAM driver or DIF when available.
+  const uint32_t kEnableExecution = 5;
+  abs_mmio_write32(ctrl_addr + SRAM_CTRL_EXEC_REG_OFFSET, kEnableExecution);
+  return abs_mmio_read32(ctrl_addr + SRAM_CTRL_EXEC_REG_OFFSET) ==
+         kEnableExecution;
+}
+
+/**
+ * Set to false if a test fails.
+ */
+static bool passed = true;
+
+/**
+ * Custom CHECK macro to assert a condition that if false should cause the
+ * test to fail. Note: we can't use the normal CHECK macro because it tries to
+ * write to the DV address space but that is locked by the ePMP configuration.
+ */
+#define CHECK(condition)                  \
+  if (!(condition)) {                     \
+    LOG_ERROR("CHECK-fail: " #condition); \
+    passed = false;                       \
+  }
+
+/**
+ * Test that .rodata in the ROM is not executable.
+ */
+static void test_noexec_rodata(void) {
+  CHECK(is_in_address_space(illegal_ins_ro, TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR,
+                            TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES));
+  CHECK(execute(illegal_ins_ro, kExceptionInstructionAccessFault));
+}
+
+/**
+ * Test that the .data section in RAM is not executable.
+ */
+static void test_noexec_rwdata(void) {
+  if (!sram_exec_enable(TOP_EARLGREY_SRAM_CTRL_MAIN_BASE_ADDR)) {
+    base_printf("failed to enable main RAM execution\n");
+  }
+  CHECK(is_in_address_space(illegal_ins_rw, TOP_EARLGREY_RAM_MAIN_BASE_ADDR,
+                            TOP_EARLGREY_RAM_MAIN_SIZE_BYTES));
+  CHECK(execute(illegal_ins_rw, kExceptionInstructionAccessFault));
+}
+
+/**
+ * Test that eFlash is not executable.
+ */
+static void test_noexec_eflash(void) {
+  // Ideally we'd check all of eFlash but that takes a very long time in
+  // simulation. Instead, check the first and last words are not executable and
+  // check a sample of other addresses.
+  uint32_t *eflash = (uint32_t *)TOP_EARLGREY_EFLASH_BASE_ADDR;
+  size_t eflash_len = TOP_EARLGREY_EFLASH_SIZE_BYTES / sizeof(eflash[0]);
+  CHECK(execute(&eflash[0], kExceptionInstructionAccessFault));
+  CHECK(execute(&eflash[eflash_len - 1], kExceptionInstructionAccessFault));
+
+  // Step size is picked arbitrarily but should provide a reasonable sample of
+  // addresses.
+  size_t step = eflash_len / 999;
+  for (size_t i = step; i < eflash_len; i += step) {
+    if (!execute(&eflash[i], kExceptionInstructionAccessFault)) {
+      LOG_ERROR("eflash execution not blocked @ %p", &eflash[i]);
+      passed = false;
+      break;
+    }
+  }
+}
+
+/**
+ * Test that the MMIO address space (specifically the retention RAM) is not
+ * executable.
+ */
+static void test_noexec_mmio(void) {
+  // Note: execution of retention RAM always fails regardless of controller or
+  // ePMP configurations however it doesn't hurt to check it anyway.
+  if (!sram_exec_enable(TOP_EARLGREY_SRAM_CTRL_RET_AON_BASE_ADDR)) {
+    base_printf("failed to enable retention RAM execution\n");
+  }
+  uint32_t *ret_ram = (uint32_t *)TOP_EARLGREY_RAM_RET_AON_BASE_ADDR;
+  size_t ret_ram_len = TOP_EARLGREY_RAM_RET_AON_SIZE_BYTES / sizeof(ret_ram[0]);
+  ret_ram[0] = kUnimpInstruction;
+  CHECK(execute(&ret_ram[0], kExceptionInstructionAccessFault));
+  ret_ram[ret_ram_len - 1] = kUnimpInstruction;
+  CHECK(execute(&ret_ram[ret_ram_len - 1], kExceptionInstructionAccessFault));
+}
+
+/**
+ * Test the function used to unlock execution of the ROM extension.
+ *
+ * Unlock a section of eFlash to simulate the unlocking of the ROM_EXT text.
+ * Accesses within the unlocked region should execute (and generate an illegal
+ * instruction exception in this case) while accesses outside the unlocked
+ * region should still fail with an instruction access fault exception.
+ *
+ * @param epmp The ePMP state to update.
+ */
+static void test_unlock_exec_eflash(epmp_state_t *epmp) {
+  // Define a region to unlock (this is somewhat arbitrary but must be word-
+  // aligned).
+  uint32_t *eflash = (uint32_t *)TOP_EARLGREY_EFLASH_BASE_ADDR;
+  size_t eflash_len = TOP_EARLGREY_EFLASH_SIZE_BYTES / sizeof(eflash[0]);
+  uint32_t *image = &eflash[eflash_len / 5];
+  size_t image_len = eflash_len / 7;
+  epmp_region_t region = {.start = (uintptr_t)&image[0],
+                          .end = (uintptr_t)&image[image_len]};
+
+  // Unlock execution of the region and check that the same changes are made
+  // to the ePMP state.
+  mask_rom_epmp_unlock_rom_ext_rx(epmp, region);
+  CHECK(epmp_state_check(epmp) == kErrorOk);
+
+  // Verify that execution within the region succeeds.
+  // The image must consist of `unimp` instructions so that an illegal
+  // instruction exception is generated.
+  CHECK(image[0] == kUnimpInstruction);
+  CHECK(execute(&image[0], kExceptionIllegalInstruction));
+  CHECK(image[image_len - 1] == kUnimpInstruction);
+  CHECK(execute(&image[image_len - 1], kExceptionIllegalInstruction));
+
+  // Verify that execution just outside the region still fails.
+  CHECK(execute(&image[-1], kExceptionInstructionAccessFault));
+  CHECK(execute(&image[image_len], kExceptionInstructionAccessFault));
+}
+
+void mask_rom_main(void) {
+  // Initialize pinmux configuration so we can use the UART.
+  pinmux_init();
+
+  // Configure UART0 as stdout.
+  uart_init(kUartNCOValue);
+  base_set_stdout((buffer_sink_t){
+      .data = NULL,
+      .sink = uart_sink,
+  });
+
+  // Start the tests.
+  LOG_INFO("Starting MaskROM ePMP functional test.");
+
+  // Initialize shadow copy of the ePMP register configuration.
+  epmp_state_t epmp;
+  mask_rom_epmp_state_init(&epmp);
+  CHECK(epmp_state_check(&epmp) == kErrorOk);
+
+  // Test that execution outside the ROM text is blocked by default.
+  test_noexec_rodata();
+  test_noexec_rwdata();
+  test_noexec_eflash();
+  test_noexec_mmio();
+
+  // Test that execution is unlocked for a sub-region of eFlash correctly.
+  // Simulates the unlocking of the ROM extension text.
+  test_unlock_exec_eflash(&epmp);
+
+  // The test of the mask ROM's ePMP configuration is now complete. Unlock the
+  // DV address space so that the test result can be reported. Assumes that PMP
+  // entry 6 is allocated for this purpose.
+  CHECK(epmp_unlock_test_status(&epmp));
+
+  // Report the test status.
+  //
+  // Note that it is only now, after the DV address space has been unlocked that
+  // we can signal that the test has started unfortunately.
+  test_status_set(kTestStatusInTest);
+  test_status_set(passed ? kTestStatusPassed : kTestStatusFailed);
+
+  // Unreachable if reporting the test status correctly caused the
+  // test to stop.
+  while (true) {
+    wait_for_interrupt();
+  }
+}

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -224,12 +224,21 @@ _mask_rom_start_boot:
 
   .extern crt_section_clear
   .extern crt_section_copy
+  .extern mask_rom_epmp_init
+  .extern mask_rom_epmp_stack_guard_init
+
+  // Must be called prior to any Main RAM access.
+  call mask_rom_epmp_init
 
   // TODO: Setup SRAM Scrambling
   // Temporarily: Zero out ram_main
   li   a0, TOP_EARLGREY_RAM_MAIN_BASE_ADDR
   li   a1, (TOP_EARLGREY_RAM_MAIN_BASE_ADDR + TOP_EARLGREY_RAM_MAIN_SIZE_BYTES)
   call crt_section_clear
+
+  // Must be called after RAM zeroing to avoid triggering stack overflow fault
+  // as it will write into the `_stack_start` address.
+  call mask_rom_epmp_stack_guard_init
 
   /**
    * Setup C Runtime

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -6,6 +6,7 @@
 #
 # See sw/device/exts/common/flash_link.ld for additional info about these
 # parameters.
+
 rom_linkfile = files(['mask_rom.ld'])
 rom_link_args = [
   '-Wl,-L,@0@'.format(meson.source_root()),
@@ -36,6 +37,20 @@ sw_silicon_creator_mask_rom_romextimage = declare_dependency(
   ),
 )
 
+# Mask ROM ePMP library
+sw_silicon_creator_mask_rom_epmp = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_mask_rom_epmp',
+    sources: [
+      'mask_rom_epmp.S',
+      'mask_rom_epmp.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_epmp,
+    ],
+  )
+)
+
 # MaskROM library.
 mask_rom_lib = declare_dependency(
   sources: [
@@ -54,6 +69,7 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_fake_deps,
       sw_silicon_creator_lib_manifest,
       sw_silicon_creator_lib_shutdown,
+      sw_silicon_creator_mask_rom_epmp,
       sw_silicon_creator_mask_rom_sigverify,
       sw_silicon_creator_mask_rom_romextimage,
       sw_lib_crt,
@@ -63,7 +79,7 @@ mask_rom_lib = declare_dependency(
     link_with: static_library(
       'mask_rom_lib',
       sources: [
-        'mask_rom.c'
+        'mask_rom.c',
       ],
       link_depends: [rom_linkfile],
   )

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -51,6 +51,104 @@ sw_silicon_creator_mask_rom_epmp = declare_dependency(
   )
 )
 
+# Mask ROM ePMP test library.
+mask_rom_epmp_test_lib = declare_dependency(
+  sources: [
+    hw_ip_entropy_src_reg_h,
+    hw_ip_csrng_reg_h,
+    hw_ip_edn_reg_h,
+    'mask_rom_start.S',
+  ],
+  link_args: rom_link_args,
+  dependencies: [
+    freestanding_headers,
+    sw_silicon_creator_lib_driver_uart,
+    sw_silicon_creator_lib_epmp_test_unlock,
+    sw_silicon_creator_lib_fake_deps,
+    sw_silicon_creator_mask_rom_epmp,
+    sw_lib_crt,
+    sw_lib_pinmux,
+    sw_lib_runtime_print,
+    sw_lib_testing_test_status,
+  ],
+  link_with: static_library(
+    'mask_rom_epmp_test_lib',
+    sources: [
+      hw_ip_sram_ctrl_reg_h,
+      'mask_rom_epmp_test.c',
+    ],
+    link_depends: [rom_linkfile],
+  )
+)
+
+# Mask ROM ePMP test images
+foreach device_name, device_lib : sw_lib_arch_core_devices
+  mask_rom_epmp_test_elf = executable(
+    'mask_rom_epmp_test_' + device_name,
+    name_suffix: 'elf',
+    link_depends: rom_link_deps,
+    link_args: [
+      '-Wl,-Map=@0@/mask_rom_@1@.map'.format(meson.current_build_dir(), device_name),
+    ],
+    dependencies: [
+      device_lib,
+      mask_rom_epmp_test_lib,
+    ],
+  )
+
+  target_name = 'mask_rom_epmp_test_@0@_' + device_name
+
+  mask_rom_epmp_test_dis = custom_target(
+    target_name.format('dis'),
+    input: mask_rom_epmp_test_elf,
+    kwargs: elf_to_dis_custom_target_args,
+  )
+
+  mask_rom_epmp_test_bin = custom_target(
+    target_name.format('bin'),
+    input: mask_rom_epmp_test_elf,
+    kwargs: elf_to_bin_custom_target_args,
+  )
+
+  mask_rom_epmp_test_vmem32 = custom_target(
+    target_name.format('vmem32'),
+    input: mask_rom_epmp_test_bin,
+    kwargs: bin_to_vmem32_custom_target_args,
+  )
+
+  mask_rom_epmp_test_vmem64 = custom_target(
+    target_name.format('vmem64'),
+    input: mask_rom_epmp_test_bin,
+    kwargs: bin_to_vmem64_custom_target_args,
+  )
+
+  mask_rom_epmp_test_scrambled = custom_target(
+    target_name.format('scrambled'),
+    command: scramble_image_command,
+    depend_files: scramble_image_depend_files,
+    input: mask_rom_epmp_test_elf,
+    output: scramble_image_outputs,
+    build_by_default: true,
+  )
+
+  custom_target(
+    target_name.format('export'),
+    command: export_target_command,
+    depend_files: [export_target_depend_files,],
+    input: [
+      mask_rom_epmp_test_elf,
+      mask_rom_epmp_test_dis,
+      mask_rom_epmp_test_bin,
+      mask_rom_epmp_test_vmem32,
+      mask_rom_epmp_test_vmem64,
+      mask_rom_epmp_test_scrambled,
+    ],
+    output: target_name.format('export'),
+    build_always_stale: true,
+    build_by_default: true,
+  )
+endforeach
+
 # MaskROM library.
 mask_rom_lib = declare_dependency(
   sources: [

--- a/sw/device/silicon_creator/rom_exts/meson.build
+++ b/sw/device/silicon_creator/rom_exts/meson.build
@@ -52,10 +52,17 @@ foreach slot, slot_link_args : rom_ext_link_info
         sw_lib_runtime_hart,
         sw_lib_runtime_print,
         sw_silicon_creator_lib_manifest_section,
+
+        # TODO: ePMP test status dependency should be removed from
+        # production ROM_EXT. Tests should unlock the test status
+        # address themselves (via a library or similar).
+        sw_silicon_creator_lib_epmp_test_unlock,
       ],
       link_with: static_library(
         slot + '_rom_ext_lib',
-        sources: ['rom_ext.c'],
+        sources: [
+          'rom_ext.c',
+        ],
         link_depends: [slot_link_args[1]],
     )
   )

--- a/sw/device/silicon_creator/rom_exts/rom_ext.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext.c
@@ -9,6 +9,7 @@
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/silicon_creator/lib/epmp_test_unlock.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
@@ -22,6 +23,12 @@ int main(int argc, char *argv[]);
 //        this function will change to pass the relevant information from
 //        the Mask ROM.
 void rom_ext_boot(void) {
+  // Unlock the DV address space so that test results can be written out.
+  // TODO: move to a test library.
+  if (!epmp_unlock_test_status(NULL)) {
+    abort();
+  }
+
   dif_uart_result_t init_result = dif_uart_init(
       (dif_uart_params_t){
           .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),

--- a/sw/device/silicon_creator/rom_exts/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_common.ld
@@ -62,6 +62,9 @@ SECTIONS {
   .text : ALIGN(4) {
     *(.text)
     *(.text.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
   } > eflash
 
   /**

--- a/test/systemtest/roms_config.py
+++ b/test/systemtest/roms_config.py
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# List of self-checking test ROM images, which return PASS or FAIL after
+# completion.
+#
+# Each list entry is a dict with the following keys:
+#
+# name:
+#   Name of the test (required)
+# verilator_extra_args:
+#   A list of additional command-line arguments passed to the Verilator
+#   simulation (optional).
+# targets:
+#   List of targets for which the test is executed. The test will be executed
+#   on all targets if not given (optional).
+TEST_ROMS_SELFCHECKING = [
+    {
+        "name": "mask_rom_epmp_test",
+        "targets": ["sim_verilator"],
+        "test_dir": "sw/device/silicon_creator/mask_rom",
+    },
+]


### PR DESCRIPTION
An implementation of the mask ROM memory protection module as detailed in https://github.com/lowRISC/opentitan/pull/6959.

Apologies for the size of this PR. I've split the functionality into multiple commits which I hope will make it a little bit easier to review.