### PR TITLE
[clkmgr] Finish de-duplicating clocks

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -130,7 +130,7 @@ num_grps = len(grps)
       name:    "idle",
       act:     "rcv",
       package: "",
-      width:   "${len(hint_clks)}"
+      width:   "${len(hint_blocks)}"
     },
   ],
 
@@ -228,14 +228,14 @@ num_grps = len(grps)
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-% for clk in hint_clks:
+% for block in hint_blocks:
         {
           bits: "${loop.index}",
-          name: "${clk.upper()}_HINT",
+          name: "${block.upper()}_HINT",
           resval: 1,
           desc: '''
-            0 ${clk.upper()} can be disabled.
-            1 ${clk.upper()} is enabled.
+            0: ${block.upper()} can be disabled.
+            1: ${block.upper()} is enabled.
           '''
         }
 % endfor
@@ -254,14 +254,14 @@ num_grps = len(grps)
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [
-% for clk in hint_clks.keys():
+% for block in hint_blocks:
         {
           bits: "${loop.index}",
-          name: "${clk.upper()}_VAL",
+          name: "${block.upper()}_VAL",
           resval: 1,
           desc: '''
-            0 ${clk.upper()} is disabled.
-            1 ${clk.upper()} is enabled.
+            0: ${block.upper()} is disabled.
+            1: ${block.upper()} is enabled.
           '''
         }
 % endfor

--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 clks_attr = cfg['clocks']
 grps = clks_attr['groups']
-num_hints = len(hint_clks)
+num_hints = len(hint_blocks)
 %>
 
 package clkmgr_pkg;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -44,10 +44,10 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
       uvm_reg_field value_bit;
     } trans_descriptor_t;
     trans_descriptor_t trans_descriptors[NUM_TRANS] = '{
-        '{TransAes, ral.clk_hints.clk_main_aes_hint, ral.clk_hints_status.clk_main_aes_val},
-        '{TransHmac, ral.clk_hints.clk_main_hmac_hint, ral.clk_hints_status.clk_main_hmac_val},
-        '{TransKmac, ral.clk_hints.clk_main_kmac_hint, ral.clk_hints_status.clk_main_kmac_val},
-        '{TransAes, ral.clk_hints.clk_main_otbn_hint, ral.clk_hints_status.clk_main_otbn_val}
+        '{TransAes, ral.clk_hints.aes_hint, ral.clk_hints_status.aes_val},
+        '{TransHmac, ral.clk_hints.hmac_hint, ral.clk_hints_status.hmac_val},
+        '{TransKmac, ral.clk_hints.kmac_hint, ral.clk_hints_status.kmac_val},
+        '{TransAes, ral.clk_hints.otbn_hint, ral.clk_hints_status.otbn_val}
     };
     idle = 0;
     cfg.clkmgr_vif.update_idle(idle);

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2644,12 +2644,12 @@
           struct: logic
           type: uni
           act: rcv
-          width: 5
+          width: 4
           inst_name: clkmgr_aon
           default: ""
           package: ""
-          end_idx: 4
-          top_type: partial-one-to-N
+          end_idx: -1
+          top_type: one-to-N
           top_signame: clkmgr_aon_idle
           index: -1
         }
@@ -13633,12 +13633,12 @@
         struct: logic
         type: uni
         act: rcv
-        width: 5
+        width: 4
         inst_name: clkmgr_aon
         default: ""
         package: ""
-        end_idx: 4
-        top_type: partial-one-to-N
+        end_idx: -1
+        top_type: one-to-N
         top_signame: clkmgr_aon_idle
         index: -1
       }
@@ -17434,9 +17434,9 @@
         package: ""
         struct: logic
         signame: clkmgr_aon_idle
-        width: 5
+        width: 4
         type: uni
-        end_idx: 4
+        end_idx: -1
         act: rcv
         suffix: ""
         default: "'0"

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -142,7 +142,7 @@
       name:    "idle",
       act:     "rcv",
       package: "",
-      width:   "5"
+      width:   "4"
     },
   ],
 
@@ -267,47 +267,38 @@
       fields: [
         {
           bits: "0",
-          name: "CLK_MAIN_AES_HINT",
+          name: "AES_HINT",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_AES can be disabled.
-            1 CLK_MAIN_AES is enabled.
+            0: AES can be disabled.
+            1: AES is enabled.
           '''
         }
         {
           bits: "1",
-          name: "CLK_MAIN_HMAC_HINT",
+          name: "HMAC_HINT",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_HMAC can be disabled.
-            1 CLK_MAIN_HMAC is enabled.
+            0: HMAC can be disabled.
+            1: HMAC is enabled.
           '''
         }
         {
           bits: "2",
-          name: "CLK_MAIN_KMAC_HINT",
+          name: "KMAC_HINT",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_KMAC can be disabled.
-            1 CLK_MAIN_KMAC is enabled.
+            0: KMAC can be disabled.
+            1: KMAC is enabled.
           '''
         }
         {
           bits: "3",
-          name: "CLK_MAIN_OTBN_HINT",
+          name: "OTBN_HINT",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_OTBN can be disabled.
-            1 CLK_MAIN_OTBN is enabled.
-          '''
-        }
-        {
-          bits: "4",
-          name: "CLK_IO_DIV4_OTBN_HINT",
-          resval: 1,
-          desc: '''
-            0 CLK_IO_DIV4_OTBN can be disabled.
-            1 CLK_IO_DIV4_OTBN is enabled.
+            0: OTBN can be disabled.
+            1: OTBN is enabled.
           '''
         }
       ]
@@ -327,47 +318,38 @@
       fields: [
         {
           bits: "0",
-          name: "CLK_MAIN_AES_VAL",
+          name: "AES_VAL",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_AES is disabled.
-            1 CLK_MAIN_AES is enabled.
+            0: AES is disabled.
+            1: AES is enabled.
           '''
         }
         {
           bits: "1",
-          name: "CLK_MAIN_HMAC_VAL",
+          name: "HMAC_VAL",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_HMAC is disabled.
-            1 CLK_MAIN_HMAC is enabled.
+            0: HMAC is disabled.
+            1: HMAC is enabled.
           '''
         }
         {
           bits: "2",
-          name: "CLK_MAIN_KMAC_VAL",
+          name: "KMAC_VAL",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_KMAC is disabled.
-            1 CLK_MAIN_KMAC is enabled.
+            0: KMAC is disabled.
+            1: KMAC is enabled.
           '''
         }
         {
           bits: "3",
-          name: "CLK_MAIN_OTBN_VAL",
+          name: "OTBN_VAL",
           resval: 1,
           desc: '''
-            0 CLK_MAIN_OTBN is disabled.
-            1 CLK_MAIN_OTBN is enabled.
-          '''
-        }
-        {
-          bits: "4",
-          name: "CLK_IO_DIV4_OTBN_VAL",
-          resval: 1,
-          desc: '''
-            0 CLK_IO_DIV4_OTBN is disabled.
-            1 CLK_IO_DIV4_OTBN is enabled.
+            0: OTBN is disabled.
+            1: OTBN is enabled.
           '''
         }
       ]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -57,7 +57,7 @@
   input lc_tx_t scanmode_i,
 
   // idle hints
-  input [4:0] idle_i,
+  input [3:0] idle_i,
 
   // life cycle state output
   input lc_tx_t lc_dft_en_i,
@@ -561,26 +561,27 @@
   // clock target
   ////////////////////////////////////////////////////
 
-  logic clk_main_aes_hint;
-  logic clk_main_aes_en;
-  logic clk_main_hmac_hint;
-  logic clk_main_hmac_en;
-  logic clk_main_kmac_hint;
-  logic clk_main_kmac_en;
-  logic clk_main_otbn_hint;
-  logic clk_main_otbn_en;
-  logic clk_io_div4_otbn_hint;
-  logic clk_io_div4_otbn_en;
+  logic aes_hint;
+  logic aes_en;
+  logic hmac_hint;
+  logic hmac_en;
+  logic kmac_hint;
+  logic kmac_en;
+  logic otbn_hint;
+  logic otbn_en;
 
-  assign clk_main_aes_en = clk_main_aes_hint | ~idle_i[Aes];
+  assign aes_en = aes_hint | ~idle_i[Aes];
+  assign hmac_en = hmac_hint | ~idle_i[Hmac];
+  assign kmac_en = kmac_hint | ~idle_i[Kmac];
+  assign otbn_en = otbn_hint | ~idle_i[Otbn];
 
   prim_flop_2sync #(
     .Width(1)
   ) u_clk_main_aes_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d_i(reg2hw.clk_hints.clk_main_aes_hint.q),
-    .q_o(clk_main_aes_hint)
+    .d_i(reg2hw.clk_hints.aes_hint.q),
+    .q_o(aes_hint)
   );
 
   lc_tx_t clk_main_aes_scanmode;
@@ -598,20 +599,18 @@
     .NoFpgaGate(1'b1)
   ) u_clk_main_aes_cg (
     .clk_i(clk_main_root),
-    .en_i(clk_main_aes_en & clk_main_en),
+    .en_i(aes_en & clk_main_en),
     .test_en_i(clk_main_aes_scanmode == lc_ctrl_pkg::On),
     .clk_o(clocks_o.clk_main_aes)
   );
-
-  assign clk_main_hmac_en = clk_main_hmac_hint | ~idle_i[Hmac];
 
   prim_flop_2sync #(
     .Width(1)
   ) u_clk_main_hmac_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d_i(reg2hw.clk_hints.clk_main_hmac_hint.q),
-    .q_o(clk_main_hmac_hint)
+    .d_i(reg2hw.clk_hints.hmac_hint.q),
+    .q_o(hmac_hint)
   );
 
   lc_tx_t clk_main_hmac_scanmode;
@@ -629,20 +628,18 @@
     .NoFpgaGate(1'b1)
   ) u_clk_main_hmac_cg (
     .clk_i(clk_main_root),
-    .en_i(clk_main_hmac_en & clk_main_en),
+    .en_i(hmac_en & clk_main_en),
     .test_en_i(clk_main_hmac_scanmode == lc_ctrl_pkg::On),
     .clk_o(clocks_o.clk_main_hmac)
   );
-
-  assign clk_main_kmac_en = clk_main_kmac_hint | ~idle_i[Kmac];
 
   prim_flop_2sync #(
     .Width(1)
   ) u_clk_main_kmac_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d_i(reg2hw.clk_hints.clk_main_kmac_hint.q),
-    .q_o(clk_main_kmac_hint)
+    .d_i(reg2hw.clk_hints.kmac_hint.q),
+    .q_o(kmac_hint)
   );
 
   lc_tx_t clk_main_kmac_scanmode;
@@ -660,20 +657,18 @@
     .NoFpgaGate(1'b1)
   ) u_clk_main_kmac_cg (
     .clk_i(clk_main_root),
-    .en_i(clk_main_kmac_en & clk_main_en),
+    .en_i(kmac_en & clk_main_en),
     .test_en_i(clk_main_kmac_scanmode == lc_ctrl_pkg::On),
     .clk_o(clocks_o.clk_main_kmac)
   );
-
-  assign clk_main_otbn_en = clk_main_otbn_hint | ~idle_i[Otbn];
 
   prim_flop_2sync #(
     .Width(1)
   ) u_clk_main_otbn_hint_sync (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
-    .d_i(reg2hw.clk_hints.clk_main_otbn_hint.q),
-    .q_o(clk_main_otbn_hint)
+    .d_i(reg2hw.clk_hints.otbn_hint.q),
+    .q_o(otbn_hint)
   );
 
   lc_tx_t clk_main_otbn_scanmode;
@@ -691,20 +686,18 @@
     .NoFpgaGate(1'b1)
   ) u_clk_main_otbn_cg (
     .clk_i(clk_main_root),
-    .en_i(clk_main_otbn_en & clk_main_en),
+    .en_i(otbn_en & clk_main_en),
     .test_en_i(clk_main_otbn_scanmode == lc_ctrl_pkg::On),
     .clk_o(clocks_o.clk_main_otbn)
   );
-
-  assign clk_io_div4_otbn_en = clk_io_div4_otbn_hint | ~idle_i[Otbn];
 
   prim_flop_2sync #(
     .Width(1)
   ) u_clk_io_div4_otbn_hint_sync (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_io_div4_ni),
-    .d_i(reg2hw.clk_hints.clk_io_div4_otbn_hint.q),
-    .q_o(clk_io_div4_otbn_hint)
+    .d_i(reg2hw.clk_hints.otbn_hint.q),
+    .q_o(otbn_hint)
   );
 
   lc_tx_t clk_io_div4_otbn_scanmode;
@@ -722,23 +715,21 @@
     .NoFpgaGate(1'b1)
   ) u_clk_io_div4_otbn_cg (
     .clk_i(clk_io_div4_root),
-    .en_i(clk_io_div4_otbn_en & clk_io_div4_en),
+    .en_i(otbn_en & clk_io_div4_en),
     .test_en_i(clk_io_div4_otbn_scanmode == lc_ctrl_pkg::On),
     .clk_o(clocks_o.clk_io_div4_otbn)
   );
 
 
   // state readback
-  assign hw2reg.clk_hints_status.clk_main_aes_val.de = 1'b1;
-  assign hw2reg.clk_hints_status.clk_main_aes_val.d = clk_main_aes_en;
-  assign hw2reg.clk_hints_status.clk_main_hmac_val.de = 1'b1;
-  assign hw2reg.clk_hints_status.clk_main_hmac_val.d = clk_main_hmac_en;
-  assign hw2reg.clk_hints_status.clk_main_kmac_val.de = 1'b1;
-  assign hw2reg.clk_hints_status.clk_main_kmac_val.d = clk_main_kmac_en;
-  assign hw2reg.clk_hints_status.clk_main_otbn_val.de = 1'b1;
-  assign hw2reg.clk_hints_status.clk_main_otbn_val.d = clk_main_otbn_en;
-  assign hw2reg.clk_hints_status.clk_io_div4_otbn_val.de = 1'b1;
-  assign hw2reg.clk_hints_status.clk_io_div4_otbn_val.d = clk_io_div4_otbn_en;
+  assign hw2reg.clk_hints_status.aes_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.aes_val.d = aes_en;
+  assign hw2reg.clk_hints_status.hmac_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.hmac_val.d = hmac_en;
+  assign hw2reg.clk_hints_status.kmac_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.kmac_val.d = kmac_en;
+  assign hw2reg.clk_hints_status.otbn_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.otbn_val.d = otbn_en;
 
   assign jitter_en_o = reg2hw.jitter_enable.q;
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -61,11 +61,11 @@ package clkmgr_pkg;
   } clkmgr_ast_out_t;
 
   typedef struct packed {
-    logic [5-1:0] idle;
+    logic [4-1:0] idle;
   } clk_hint_status_t;
 
   parameter clk_hint_status_t CLK_HINT_STATUS_DEFAULT = '{
-    idle: {5{1'b1}}
+    idle: {4{1'b1}}
   };
 
 endpackage // clkmgr_pkg

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -48,56 +48,49 @@ package clkmgr_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-    } clk_main_aes_hint;
+    } aes_hint;
     struct packed {
       logic        q;
-    } clk_main_hmac_hint;
+    } hmac_hint;
     struct packed {
       logic        q;
-    } clk_main_kmac_hint;
+    } kmac_hint;
     struct packed {
       logic        q;
-    } clk_main_otbn_hint;
-    struct packed {
-      logic        q;
-    } clk_io_div4_otbn_hint;
+    } otbn_hint;
   } clkmgr_reg2hw_clk_hints_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_aes_val;
+    } aes_val;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_hmac_val;
+    } hmac_val;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_kmac_val;
+    } kmac_val;
     struct packed {
       logic        d;
       logic        de;
-    } clk_main_otbn_val;
-    struct packed {
-      logic        d;
-      logic        de;
-    } clk_io_div4_otbn_val;
+    } otbn_val;
   } clkmgr_hw2reg_clk_hints_status_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_alert_test_reg_t alert_test; // [15:14]
-    clkmgr_reg2hw_extclk_sel_reg_t extclk_sel; // [13:10]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [9:9]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [8:5]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [4:0]
+    clkmgr_reg2hw_alert_test_reg_t alert_test; // [14:13]
+    clkmgr_reg2hw_extclk_sel_reg_t extclk_sel; // [12:9]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [8:8]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [7:4]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [3:0]
   } clkmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [9:0]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [7:0]
   } clkmgr_hw2reg_t;
 
   // Register offsets

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -125,21 +125,18 @@ module clkmgr_reg_top (
   logic clk_enables_clk_usb_peri_en_qs;
   logic clk_enables_clk_usb_peri_en_wd;
   logic clk_hints_we;
-  logic clk_hints_clk_main_aes_hint_qs;
-  logic clk_hints_clk_main_aes_hint_wd;
-  logic clk_hints_clk_main_hmac_hint_qs;
-  logic clk_hints_clk_main_hmac_hint_wd;
-  logic clk_hints_clk_main_kmac_hint_qs;
-  logic clk_hints_clk_main_kmac_hint_wd;
-  logic clk_hints_clk_main_otbn_hint_qs;
-  logic clk_hints_clk_main_otbn_hint_wd;
-  logic clk_hints_clk_io_div4_otbn_hint_qs;
-  logic clk_hints_clk_io_div4_otbn_hint_wd;
-  logic clk_hints_status_clk_main_aes_val_qs;
-  logic clk_hints_status_clk_main_hmac_val_qs;
-  logic clk_hints_status_clk_main_kmac_val_qs;
-  logic clk_hints_status_clk_main_otbn_val_qs;
-  logic clk_hints_status_clk_io_div4_otbn_val_qs;
+  logic clk_hints_aes_hint_qs;
+  logic clk_hints_aes_hint_wd;
+  logic clk_hints_hmac_hint_qs;
+  logic clk_hints_hmac_hint_wd;
+  logic clk_hints_kmac_hint_qs;
+  logic clk_hints_kmac_hint_wd;
+  logic clk_hints_otbn_hint_qs;
+  logic clk_hints_otbn_hint_wd;
+  logic clk_hints_status_aes_val_qs;
+  logic clk_hints_status_hmac_val_qs;
+  logic clk_hints_status_kmac_val_qs;
+  logic clk_hints_status_otbn_val_qs;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -347,18 +344,18 @@ module clkmgr_reg_top (
 
   // R[clk_hints]: V(False)
 
-  //   F[clk_main_aes_hint]: 0:0
+  //   F[aes_hint]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_clk_main_aes_hint (
+  ) u_clk_hints_aes_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (clk_hints_we),
-    .wd     (clk_hints_clk_main_aes_hint_wd),
+    .wd     (clk_hints_aes_hint_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -366,25 +363,25 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clk_hints.clk_main_aes_hint.q),
+    .q      (reg2hw.clk_hints.aes_hint.q),
 
     // to register interface (read)
-    .qs     (clk_hints_clk_main_aes_hint_qs)
+    .qs     (clk_hints_aes_hint_qs)
   );
 
 
-  //   F[clk_main_hmac_hint]: 1:1
+  //   F[hmac_hint]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_clk_main_hmac_hint (
+  ) u_clk_hints_hmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (clk_hints_we),
-    .wd     (clk_hints_clk_main_hmac_hint_wd),
+    .wd     (clk_hints_hmac_hint_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -392,25 +389,25 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clk_hints.clk_main_hmac_hint.q),
+    .q      (reg2hw.clk_hints.hmac_hint.q),
 
     // to register interface (read)
-    .qs     (clk_hints_clk_main_hmac_hint_qs)
+    .qs     (clk_hints_hmac_hint_qs)
   );
 
 
-  //   F[clk_main_kmac_hint]: 2:2
+  //   F[kmac_hint]: 2:2
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_clk_main_kmac_hint (
+  ) u_clk_hints_kmac_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (clk_hints_we),
-    .wd     (clk_hints_clk_main_kmac_hint_wd),
+    .wd     (clk_hints_kmac_hint_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -418,25 +415,25 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clk_hints.clk_main_kmac_hint.q),
+    .q      (reg2hw.clk_hints.kmac_hint.q),
 
     // to register interface (read)
-    .qs     (clk_hints_clk_main_kmac_hint_qs)
+    .qs     (clk_hints_kmac_hint_qs)
   );
 
 
-  //   F[clk_main_otbn_hint]: 3:3
+  //   F[otbn_hint]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_clk_main_otbn_hint (
+  ) u_clk_hints_otbn_hint (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (clk_hints_we),
-    .wd     (clk_hints_clk_main_otbn_hint_wd),
+    .wd     (clk_hints_otbn_hint_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -444,47 +441,21 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.clk_hints.clk_main_otbn_hint.q),
+    .q      (reg2hw.clk_hints.otbn_hint.q),
 
     // to register interface (read)
-    .qs     (clk_hints_clk_main_otbn_hint_qs)
-  );
-
-
-  //   F[clk_io_div4_otbn_hint]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h1)
-  ) u_clk_hints_clk_io_div4_otbn_hint (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (clk_hints_we),
-    .wd     (clk_hints_clk_io_div4_otbn_hint_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.clk_hints.clk_io_div4_otbn_hint.q),
-
-    // to register interface (read)
-    .qs     (clk_hints_clk_io_div4_otbn_hint_qs)
+    .qs     (clk_hints_otbn_hint_qs)
   );
 
 
   // R[clk_hints_status]: V(False)
 
-  //   F[clk_main_aes_val]: 0:0
+  //   F[aes_val]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_status_clk_main_aes_val (
+  ) u_clk_hints_status_aes_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -493,24 +464,24 @@ module clkmgr_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.clk_hints_status.clk_main_aes_val.de),
-    .d      (hw2reg.clk_hints_status.clk_main_aes_val.d),
+    .de     (hw2reg.clk_hints_status.aes_val.de),
+    .d      (hw2reg.clk_hints_status.aes_val.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (clk_hints_status_clk_main_aes_val_qs)
+    .qs     (clk_hints_status_aes_val_qs)
   );
 
 
-  //   F[clk_main_hmac_val]: 1:1
+  //   F[hmac_val]: 1:1
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_status_clk_main_hmac_val (
+  ) u_clk_hints_status_hmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -519,24 +490,24 @@ module clkmgr_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.clk_hints_status.clk_main_hmac_val.de),
-    .d      (hw2reg.clk_hints_status.clk_main_hmac_val.d),
+    .de     (hw2reg.clk_hints_status.hmac_val.de),
+    .d      (hw2reg.clk_hints_status.hmac_val.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (clk_hints_status_clk_main_hmac_val_qs)
+    .qs     (clk_hints_status_hmac_val_qs)
   );
 
 
-  //   F[clk_main_kmac_val]: 2:2
+  //   F[kmac_val]: 2:2
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_status_clk_main_kmac_val (
+  ) u_clk_hints_status_kmac_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -545,24 +516,24 @@ module clkmgr_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.clk_hints_status.clk_main_kmac_val.de),
-    .d      (hw2reg.clk_hints_status.clk_main_kmac_val.d),
+    .de     (hw2reg.clk_hints_status.kmac_val.de),
+    .d      (hw2reg.clk_hints_status.kmac_val.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (clk_hints_status_clk_main_kmac_val_qs)
+    .qs     (clk_hints_status_kmac_val_qs)
   );
 
 
-  //   F[clk_main_otbn_val]: 3:3
+  //   F[otbn_val]: 3:3
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RO"),
     .RESVAL  (1'h1)
-  ) u_clk_hints_status_clk_main_otbn_val (
+  ) u_clk_hints_status_otbn_val (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -571,41 +542,15 @@ module clkmgr_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.clk_hints_status.clk_main_otbn_val.de),
-    .d      (hw2reg.clk_hints_status.clk_main_otbn_val.d),
+    .de     (hw2reg.clk_hints_status.otbn_val.de),
+    .d      (hw2reg.clk_hints_status.otbn_val.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (clk_hints_status_clk_main_otbn_val_qs)
-  );
-
-
-  //   F[clk_io_div4_otbn_val]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h1)
-  ) u_clk_hints_status_clk_io_div4_otbn_val (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.clk_hints_status.clk_io_div4_otbn_val.de),
-    .d      (hw2reg.clk_hints_status.clk_io_div4_otbn_val.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (clk_hints_status_clk_io_div4_otbn_val_qs)
+    .qs     (clk_hints_status_otbn_val_qs)
   );
 
 
@@ -659,15 +604,13 @@ module clkmgr_reg_top (
   assign clk_enables_clk_usb_peri_en_wd = reg_wdata[3];
   assign clk_hints_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign clk_hints_clk_main_aes_hint_wd = reg_wdata[0];
+  assign clk_hints_aes_hint_wd = reg_wdata[0];
 
-  assign clk_hints_clk_main_hmac_hint_wd = reg_wdata[1];
+  assign clk_hints_hmac_hint_wd = reg_wdata[1];
 
-  assign clk_hints_clk_main_kmac_hint_wd = reg_wdata[2];
+  assign clk_hints_kmac_hint_wd = reg_wdata[2];
 
-  assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[3];
-
-  assign clk_hints_clk_io_div4_otbn_hint_wd = reg_wdata[4];
+  assign clk_hints_otbn_hint_wd = reg_wdata[3];
 
   // Read data return
   always_comb begin
@@ -697,19 +640,17 @@ module clkmgr_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[0] = clk_hints_clk_main_aes_hint_qs;
-        reg_rdata_next[1] = clk_hints_clk_main_hmac_hint_qs;
-        reg_rdata_next[2] = clk_hints_clk_main_kmac_hint_qs;
-        reg_rdata_next[3] = clk_hints_clk_main_otbn_hint_qs;
-        reg_rdata_next[4] = clk_hints_clk_io_div4_otbn_hint_qs;
+        reg_rdata_next[0] = clk_hints_aes_hint_qs;
+        reg_rdata_next[1] = clk_hints_hmac_hint_qs;
+        reg_rdata_next[2] = clk_hints_kmac_hint_qs;
+        reg_rdata_next[3] = clk_hints_otbn_hint_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[0] = clk_hints_status_clk_main_aes_val_qs;
-        reg_rdata_next[1] = clk_hints_status_clk_main_hmac_val_qs;
-        reg_rdata_next[2] = clk_hints_status_clk_main_kmac_val_qs;
-        reg_rdata_next[3] = clk_hints_status_clk_main_otbn_val_qs;
-        reg_rdata_next[4] = clk_hints_status_clk_io_div4_otbn_val_qs;
+        reg_rdata_next[0] = clk_hints_status_aes_val_qs;
+        reg_rdata_next[1] = clk_hints_status_hmac_val_qs;
+        reg_rdata_next[2] = clk_hints_status_kmac_val_qs;
+        reg_rdata_next[3] = clk_hints_status_otbn_val_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -515,7 +515,7 @@ module top_earlgrey #(
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   kmac_pkg::app_req_t [2:0] kmac_app_req;
   kmac_pkg::app_rsp_t [2:0] kmac_app_rsp;
-  logic [4:0] clkmgr_aon_idle;
+  logic [3:0] clkmgr_aon_idle;
   jtag_pkg::jtag_req_t       pinmux_aon_lc_jtag_req;
   jtag_pkg::jtag_rsp_t       pinmux_aon_lc_jtag_rsp;
   jtag_pkg::jtag_req_t       pinmux_aon_rv_jtag_req;


### PR DESCRIPTION
*There are some design questions open here: I'll keep this in draft until they're resolved*

This is a follow-on from 56544b0. The background is that OTBN now has
two different "hint" clocks. That is, its `idle_o` signal is connected
to the clock manager and gates two different clocks.

The previous commit sorted out the generation of clock hint names so
that they were indexed by "blocks that have at least one relevant
clock" instead of by the clocks themselves.

This commit finishes the job. Now, there's one `FOO_hint` and `FOO_en`
signal in `clkmgr.sv` for each relevant block, rather than each relevant
clock. The names of the generated register fields have got a bit
simpler (instead of e.g. "`CLK_IO_DIV4_OTBN_HINT`", there's now
"`OTBN_HINT`") and been de-duplicated too.

(Note that this probably fixes a bug: before this patch, the hint signal corresponding to the OTBN IO/4 clock was hard-wired to 1, which I think means we could have accidentally turned off half of the clocks to OTBN: oops!)