### PR TITLE
[otbn] Fix insn_cnt_o reset on start

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -123,6 +123,7 @@ module otbn_controller
   output logic rnd_prefetch_req_o,
   input  logic rnd_valid_i,
 
+  input  logic        insn_cnt_reset_i,
   output logic [31:0] insn_cnt_o
 );
   otbn_state_e state_q, state_d, state_raw;
@@ -350,8 +351,8 @@ module otbn_controller
     end
   end
 
-  assign insn_cnt_d = start_i ? 32'd0 : (insn_cnt_q + 32'd1);
-  assign insn_cnt_en = (insn_executing & ~stall & (insn_cnt_q != 32'hffffffff)) | start_i;
+  assign insn_cnt_d = insn_cnt_reset_i ? 32'd0 : (insn_cnt_q + 32'd1);
+  assign insn_cnt_en = (insn_executing & ~stall & (insn_cnt_q != 32'hffffffff)) | insn_cnt_reset_i;
   assign insn_cnt_o = insn_cnt_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -166,6 +166,7 @@ module otbn_core
   logic                     controller_start;
   logic [ImemAddrWidth-1:0] controller_start_addr;
 
+  logic        insn_cnt_reset;
   logic [31:0] insn_cnt;
 
   // Start stop control start OTBN execution when requested and deals with any pre start or post
@@ -187,7 +188,8 @@ module otbn_core
     .urnd_reseed_busy_i (urnd_reseed_busy),
     .urnd_advance_o     (urnd_advance),
 
-    .ispr_init_o (ispr_init)
+    .ispr_init_o      (ispr_init),
+    .insn_cnt_reset_o (insn_cnt_reset)
   );
 
   // Depending on its usage, the instruction address (program counter) is qualified by two valid
@@ -345,6 +347,7 @@ module otbn_core
     .rnd_prefetch_req_o (rnd_prefetch_req),
     .rnd_valid_i        (rnd_valid),
 
+    .insn_cnt_reset_i   (insn_cnt_reset),
     .insn_cnt_o         (insn_cnt)
   );
 

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -36,7 +36,8 @@ module otbn_start_stop_control
   input  logic urnd_reseed_busy_i,
   output logic urnd_advance_o,
 
-  output logic ispr_init_o
+  output logic ispr_init_o,
+  output logic insn_cnt_reset_o
 );
   otbn_start_stop_state_e state_q, state_d;
 
@@ -63,6 +64,7 @@ module otbn_start_stop_control
     start_addr_en      = 1'b0;
     state_d            = state_q;
     ispr_init_o        = 1'b0;
+    insn_cnt_reset_o   = 1'b0;
 
     unique case(state_q)
       OtbnStartStopStateHalt: begin
@@ -70,6 +72,7 @@ module otbn_start_stop_control
           start_addr_en     = 1'b1;
           urnd_reseed_req_o = 1'b1;
           ispr_init_o       = 1'b1;
+          insn_cnt_reset_o  = 1'b1;
           state_d           = OtbnStartStopStateUrndRefresh;
         end
       end


### PR DESCRIPTION
The instruction count visibile on insn_cnt_o must reset as soon as OTBN
starts. Previously it would only reset after the initial start state
machine (which reseeds the URND LFSR) had completed.

Fixes #7052

Signed-off-by: Greg Chadwick <gac@lowrisc.org>