### PR TITLE
[dv,cip] Mirror FATAL_ALERT_CAUSE-style registers in scoreboard

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -13,6 +13,10 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
 
   // Override this alert name at `initialize` if it's not as below
   string              tl_intg_alert_name = "fatal_fault";
+  // If there is a bit in an "alert cause" register that will be set by a corrupt bus access, this
+  // should be the name of that field (with syntax "reg.field"). Used by cip_base_scoreboard to
+  // update the relevant field in the RAL model if it sees an error.
+  string              tl_intg_alert_field = "";
   // Enables TL integrity generation & checking with *_user bits.
   // Assume ALL TL agents have integrity check enabled or disabled altogether.
   bit                 en_tl_intg_gen = 1;

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -288,7 +288,6 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
       // run csr_rw seq to send some normal CSR accesses in parallel
       begin
         `uvm_info(`gfn, "Run csr_rw seq", UVM_HIGH)
-        apply_extra_excl_for_tl_intg_vseq();
         run_csr_vseq("rw");
       end
       begin
@@ -335,13 +334,5 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
     dut_init("HARD");
   end
 endtask
-
-// in run_tl_intg_err_vseq, csr_rw seq is running in the parallel. And intg error will be injected
-// which may affect some CSR values. Use this function to add additional exclusion
-// TODO, as discussed at #7082, best approach is to standardize alert cause in all IPs, so that
-// we can check it in the automatic test. Let's wait until designers finalize the alert cause
-// keep this approach in case we still want it
-virtual function void apply_extra_excl_for_tl_intg_vseq();
-endfunction
 
 `undef create_tl_access_error_case

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -50,8 +50,10 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     // Tell the CIP base code how many interrupts we have (defaults to zero)
     num_interrupts = 1;
 
-    // Tell the CIP base code what alert we generate if we see a TL fault
+    // Tell the CIP base code what alert we generate if we see a TL fault and the field in the
+    // FATAL_ALERT_CAUSE register that it should expect to see get set.
     tl_intg_alert_name = "fatal";
+    tl_intg_alert_field = "fatal_alert_cause.bus_integrity_error";
 
     model_agent_cfg = otbn_model_agent_cfg::type_id::create("model_agent_cfg");
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -31,6 +31,8 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
     m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_kmac_agent_cfg.start_default_device_seq = 1'b1;
 
+    // Tell the CIP base code what bit gets set if we see a TL fault.
+    tl_intg_alert_field = "fatal_alert_cause.integrity_error";
   endfunction
 
 endclass

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -14,11 +14,4 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
-  // in run_tl_intg_err_vseq, csr_rw seq is running in the parallel. And intg error will be injected
-  // which may affect fatal_alert_cause.integrity_error. Exclude checking it
-  virtual function void apply_extra_excl_for_tl_intg_vseq();
-    cfg.ral.csr_excl.add_excl(ral.fatal_alert_cause.integrity_error.`gfn,
-                              CsrExclCheck, CsrNonInitTests);
-  endfunction
-
 endclass


### PR DESCRIPTION
When running the TL error sequence run by `run_tl_intg_err_vseq_sub`, we
inject an integrity error into one or more TL accesses, which would
confuse the scoreboard for some blocks. To avoid chaos, we disable the
scoreboard when running this sequence with a runtime plusarg.

Some blocks' environments do prediction of hardware-updated CSRs, and
this is done in the scoreboard. Unfortunately, disabling the
scoreboard means that this won't happen which, in turn, causes
`csr_utils::csr_rd_check` to spot an "error" when reading a
hardware-updated CSR that changes on an alert (an "ALERT_CAUSE"
register).

This patch allows a block to configure the (single-bit) field that
will be set when there is a TL error. Assuming there's such a field
configured, `cip_base_scoreboard.sv` notices any error response and
updates the mirrored value of that field accordingly.

This allows us to get rid of the special-case code at the bottom of
`cip_base_vseq__tl_errors.svh`: rather than avoiding looking at a
particular behaviour, we can just predict it properly.
