### PR TITLE
[otbn/otp_ctrl] Replicate dmem scrambling keystream

### DIFF
--- a/hw/dv/verilator/cpp/scrambled_ecc32_mem_area.h
+++ b/hw/dv/verilator/cpp/scrambled_ecc32_mem_area.h
@@ -5,9 +5,9 @@
 #ifndef OPENTITAN_HW_DV_VERILATOR_CPP_SCRAMBLED_ECC32_MEM_AREA_H_
 #define OPENTITAN_HW_DV_VERILATOR_CPP_SCRAMBLED_ECC32_MEM_AREA_H_
 
-#include "ecc32_mem_area.h"
-
 #include <vector>
+
+#include "ecc32_mem_area.h"
 
 /**
  * A memory that implements scrambling over a 32-bit ECC integrity protection
@@ -23,9 +23,14 @@ class ScrambledEcc32MemArea : public Ecc32MemArea {
    * at scope. It is size words long. Each memory word is 4 * width_32 bytes
    * wide in the address space and 39 * width_32 bits wide in the physical
    * memory.
+   *
+   * If the keystream of one single PRINCE instance should be repeated,
+   * set "repeat_keystream" to true. If this is set to false, multiple
+   * PRINCE instances are employed to produce the keystream.
+   *
    */
   ScrambledEcc32MemArea(const std::string &scope, uint32_t size,
-                        uint32_t width_32);
+                        uint32_t width_32, bool repeat_keystream = true);
 
  private:
   void WriteBuffer(uint8_t buf[SV_MEM_WIDTH_BYTES],
@@ -49,6 +54,7 @@ class ScrambledEcc32MemArea : public Ecc32MemArea {
 
   std::string scr_scope_;
   uint32_t addr_width_;
+  bool repeat_keystream_;
 };
 
 #endif  // OPENTITAN_HW_DV_VERILATOR_CPP_SCRAMBLED_ECC32_MEM_AREA_H_

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -68,9 +68,7 @@ module tb;
   end
 
   localparam logic [127:0] TestScrambleKey = 128'h48ecf6c738f0f108a5b08620695ffd4d;
-  // Full nonce is 320 bits but OTP only provides 256-bits for now
-  localparam logic [255:0] TestScrambleNonce =
-    256'h19286173144131c12c2607f5e72aca1fb72adea0a4ff82b9f88c2578fa4cd123;
+  localparam logic [63:0]  TestScrambleNonce = 64'hf88c2578fa4cd123;
 
   assign otp_key_rsp.ack = otp_key_ack_q;
   assign otp_key_rsp.key = TestScrambleKey;

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -19,9 +19,8 @@ module otbn_top_sim (
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte);
 
   // Fixed key and nonce for scrambling in verilator environment
-  localparam logic [127:0] TestScrambleKey = 128'h48ecf6c738f0f108a5b08620695ffd4d;
-  // 320-bit nonce has 0s in top bits as nonce from OTP is only 256-bit for now
-  localparam logic [319:0] TestScrambleNonce = 320'h19286173144131c12c2607f5e72aca1fb72adea0a4ff82b9f88c2578fa4cd123;
+  localparam logic [127:0] TestScrambleKey   = 128'h48ecf6c738f0f108a5b08620695ffd4d;
+  localparam logic [63:0]  TestScrambleNonce = 64'hf88c2578fa4cd123;
 
   logic      otbn_done_d, otbn_done_q;
   err_bits_t otbn_err_bits_d, otbn_err_bits_q;
@@ -169,10 +168,11 @@ module otbn_top_sim (
   assign unused_dmem_addr = dmem_addr[DmemAddrWidth-DmemIndexWidth-1:0];
 
   prim_ram_1p_scr #(
-    .Width           ( ExtWLEN       ),
-    .Depth           ( DmemSizeWords ),
-    .DataBitsPerMask ( 39            ),
-    .EnableParity    ( 0             )
+    .Width              ( ExtWLEN       ),
+    .Depth              ( DmemSizeWords ),
+    .DataBitsPerMask    ( 39            ),
+    .EnableParity       ( 0             ),
+    .ReplicateKeyStream ( 1             )
   ) u_dmem (
     .clk_i        ( IO_CLK            ),
     .rst_ni       ( IO_RST_N          ),
@@ -224,7 +224,7 @@ module otbn_top_sim (
 
     .key_valid_i  ( 1'b1                    ),
     .key_i        ( TestScrambleKey         ),
-    .nonce_i      ( TestScrambleNonce[63:0] ),
+    .nonce_i      ( TestScrambleNonce       ),
 
     .init_seed_i  ( '0                      ),
     .init_req_i   ( 1'b0                    ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -375,11 +375,12 @@ module otbn
   assign unused_dmem_addr_core_wordbits = ^dmem_addr_core[DmemAddrWidth-DmemIndexWidth-1:0];
 
   prim_ram_1p_scr #(
-    .Width           (ExtWLEN),
-    .Depth           (DmemSizeWords),
-    .DataBitsPerMask (39),
-    .EnableParity    (0),
-    .DiffWidth       (39)
+    .Width              (ExtWLEN),
+    .Depth              (DmemSizeWords),
+    .DataBitsPerMask    (39),
+    .EnableParity       (0),
+    .DiffWidth          (39),
+    .ReplicateKeyStream (1)
   ) u_dmem (
     .clk_i,
     .rst_ni      (rst_n),

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -390,10 +390,10 @@ package otbn_pkg;
   };
 
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnKeyDefault =
-    128'h14e8cecae3040d5e12286bb3cc113298;
+      128'h14e8cecae3040d5e12286bb3cc113298;
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnNonceDefault =
-    256'hf79780bc735f38434f47570613cabf6490f795a48be7a10d930e0fdd326df627;
+      64'hf79780bc735f3843;
 
-  typedef logic [319:0] otbn_dmem_nonce_t;
-  typedef logic [63:0]  otbn_imem_nonce_t;
+  typedef logic [63:0] otbn_dmem_nonce_t;
+  typedef logic [63:0] otbn_imem_nonce_t;
 endpackage

--- a/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
+++ b/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
@@ -71,26 +71,23 @@ module otbn_scramble_ctrl
   otp_ctrl_pkg::otbn_nonce_t otp_nonce;
   logic                      otp_key_seed_valid;
 
-  // TODO: Sort out nonce widths. OTP provides us with 256-bit nonce, we need 320-bit for dmem. We
-  // could reuse nonce bits or use a replicated PRINCE keystream so only 64 bits of nonce would be
-  // required. https://github.com/lowRISC/opentitan/issues/7054
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       dmem_key_q   <= RndCnstOtbnKey;
-      dmem_nonce_q <= {64'b0, RndCnstOtbnNonce};
+      dmem_nonce_q <= RndCnstOtbnNonce;
     end else if (dmem_key_nonce_en) begin
       dmem_key_q   <= otp_key;
-      dmem_nonce_q <= {64'b0, otp_nonce};
+      dmem_nonce_q <= otp_nonce;
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       imem_key_q   <= RndCnstOtbnKey;
-      imem_nonce_q <= RndCnstOtbnNonce[63:0];
+      imem_nonce_q <= RndCnstOtbnNonce;
     end else if (imem_key_nonce_en) begin
       imem_key_q   <= otp_key;
-      imem_nonce_q <= otp_nonce[63:0];
+      imem_nonce_q <= otp_nonce;
     end
   end
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -88,7 +88,7 @@ package otp_ctrl_env_pkg;
   parameter uint NUM_ROUND          = 31;
 
   parameter uint NUM_SRAM_EDN_REQ = 12;
-  parameter uint NUM_OTBN_EDN_REQ = 16;
+  parameter uint NUM_OTBN_EDN_REQ = 10;
 
   parameter uint NUM_UNBUFF_PARTS = 2;
   parameter uint NUM_BUFF_PARTS   = 5;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -161,12 +161,12 @@ package otp_ctrl_pkg;
 
   parameter int FlashKeySeedWidth = 256;
   parameter int SramKeySeedWidth  = 128;
-  parameter int KeyMgrKeyWidth   = 256;
-  parameter int FlashKeyWidth    = 128;
-  parameter int SramKeyWidth     = 128;
-  parameter int SramNonceWidth   = 128;
-  parameter int OtbnKeyWidth     = 128;
-  parameter int OtbnNonceWidth   = 256;
+  parameter int KeyMgrKeyWidth    = 256;
+  parameter int FlashKeyWidth     = 128;
+  parameter int SramKeyWidth      = 128;
+  parameter int SramNonceWidth    = 128;
+  parameter int OtbnKeyWidth      = 128;
+  parameter int OtbnNonceWidth    = 64;
 
   typedef logic [SramKeyWidth-1:0]   sram_key_t;
   typedef logic [SramNonceWidth-1:0] sram_nonce_t;

--- a/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.h
+++ b/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.h
@@ -37,15 +37,16 @@ std::vector<uint8_t> scramble_addr(const std::vector<uint8_t> &addr_in,
  * @param addr_width       Width of the address in bits
  * @param nonce            Byte vector of scrambling nonce
  * @param key              Byte vector of scrambling key
+ * @param repeat_keystream Repeat the keystream of one single PRINCE instance if
+ *                         set to true. Otherwise multiple PRINCE instances are
+ *                         used.
  * @return Byte vector with decrypted data
  */
-std::vector<uint8_t> scramble_decrypt_data(const std::vector<uint8_t> &data_in,
-                                           uint32_t data_width,
-                                           uint32_t subst_perm_width,
-                                           const std::vector<uint8_t> &addr,
-                                           uint32_t addr_width,
-                                           const std::vector<uint8_t> &nonce,
-                                           const std::vector<uint8_t> &key);
+std::vector<uint8_t> scramble_decrypt_data(
+    const std::vector<uint8_t> &data_in, uint32_t data_width,
+    uint32_t subst_perm_width, const std::vector<uint8_t> &addr,
+    uint32_t addr_width, const std::vector<uint8_t> &nonce,
+    const std::vector<uint8_t> &key, bool repeat_keystream);
 
 /** Encrypt scrambled data
  * @param data_in          Byte vector of data to encrypt
@@ -56,14 +57,15 @@ std::vector<uint8_t> scramble_decrypt_data(const std::vector<uint8_t> &data_in,
  * @param addr_width       Width of the address in bits
  * @param nonce            Byte vector of scrambling nonce
  * @param key              Byte vector of scrambling key
+ * @param repeat_keystream Repeat the keystream of one single PRINCE instance if
+ *                         set to true. Otherwise multiple PRINCE instances are
+ *                         used.
  * @return Byte vector with encrypted data
  */
-std::vector<uint8_t> scramble_encrypt_data(const std::vector<uint8_t> &data_in,
-                                           uint32_t data_width,
-                                           uint32_t subst_perm_width,
-                                           const std::vector<uint8_t> &addr,
-                                           uint32_t addr_width,
-                                           const std::vector<uint8_t> &nonce,
-                                           const std::vector<uint8_t> &key);
+std::vector<uint8_t> scramble_encrypt_data(
+    const std::vector<uint8_t> &data_in, uint32_t data_width,
+    uint32_t subst_perm_width, const std::vector<uint8_t> &addr,
+    uint32_t addr_width, const std::vector<uint8_t> &nonce,
+    const std::vector<uint8_t> &key, bool repeat_keystream);
 
 #endif  // OPENTITAN_HW_IP_PRIM_DV_PRIM_RAM_SCR_CPP_SCRAMBLE_MODEL_H_


### PR DESCRIPTION
This replicates the keystream instead of instantiating multiple PRINCE primitives, as discussed in detail in #7054. This effectively means that the OTBN nonce is now only 64bit wide, and this patch changes the widths throughout the `otp_ctrl` and `otbn` designs.

Signed-off-by: Michael Schaffner <msf@opentitan.org>