### PR TITLE
[sw, dif_spi_device] Proper naming of polarity and phase

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -203,8 +203,8 @@ int bootstrap(void) {
   CHECK(
       dif_spi_device_configure(&spi,
                                (dif_spi_device_config_t){
-                                   .clock_polarity = kDifSpiDeviceEdgePositive,
-                                   .data_phase = kDifSpiDeviceEdgeNegative,
+                                   .clock_polarity = kDifSpiDeviceClockPositive,
+                                   .clock_phase = kDifSpiDevicePhaseSampleLeading,
                                    .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
                                    .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
                                    .rx_fifo_timeout = 63,

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -129,8 +129,8 @@ int main(int argc, char **argv) {
             &spi) == kDifSpiDeviceOk);
   CHECK(dif_spi_device_configure(
             &spi, (dif_spi_device_config_t){
-                      .clock_polarity = kDifSpiDeviceEdgePositive,
-                      .data_phase = kDifSpiDeviceEdgeNegative,
+                      .clock_polarity = kDifSpiDeviceClockPositive,
+                      .clock_phase = kDifSpiDevicePhaseSampleLeading,
                       .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
                       .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
                       .rx_fifo_timeout = 63,

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -45,8 +45,8 @@ int main(int argc, char **argv) {
             &spi) == kDifSpiDeviceOk);
   CHECK(dif_spi_device_configure(
             &spi, (dif_spi_device_config_t){
-                      .clock_polarity = kDifSpiDeviceEdgePositive,
-                      .data_phase = kDifSpiDeviceEdgeNegative,
+                      .clock_polarity = kDifSpiDeviceClockPositive,
+                      .clock_phase = kDifSpiDevicePhaseSampleLeading,
                       .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
                       .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
                       .rx_fifo_timeout = 63,

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -31,9 +31,9 @@ static uint32_t build_control_word(dif_spi_device_config_t config) {
 
   val =
       bitfield_bit32_write(val, SPI_DEVICE_CFG_CPOL_BIT,
-                           config.clock_polarity == kDifSpiDeviceEdgeNegative);
+                           config.clock_polarity == kDifSpiDeviceClockNegative);
   val = bitfield_bit32_write(val, SPI_DEVICE_CFG_CPHA_BIT,
-                             config.data_phase == kDifSpiDeviceEdgePositive);
+                             config.clock_phase == kDifSpiDevicePhaseSampleTrailing);
   val = bitfield_bit32_write(val, SPI_DEVICE_CFG_TX_ORDER_BIT,
                              config.tx_order == kDifSpiDeviceBitOrderLsbToMsb);
   val = bitfield_bit32_write(val, SPI_DEVICE_CFG_RX_ORDER_BIT,

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -22,18 +22,32 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * A signal edge type: positive or negative.
+ * Clock polarity type
  */
-typedef enum dif_spi_device_edge {
+typedef enum dif_spi_device_clock_polarity {
   /**
-   * Represents a positive edge (i.e., from low to high).
+   * Positive polarity (CPOL=0)
    */
-  kDifSpiDeviceEdgePositive,
+  kDifSpiDeviceClockPositive,
   /**
-   * Represents a negative edge (i.e., from high to low).
+   * Negative polarity (CPOL=1)
    */
-  kDifSpiDeviceEdgeNegative,
-} dif_spi_device_edge_t;
+  kDifSpiDeviceClockNegative,
+} dif_spi_device_clock_polarity_t;
+
+/**
+ * Clock phase
+ */
+typedef enum dif_spi_device_clock_phase {
+  /**
+   * Sample data on leading edge (CPHA=0)
+   */
+  kDifSpiDevicePhaseSampleLeading,
+  /**
+   * Sample data on trailing edge (CPHA=1)
+   */
+  kDifSpiDevicePhaseSampleTrailing,
+} dif_spi_device_clock_phase_t;
 
 /**
  * A bit ordering within a byte.
@@ -87,8 +101,8 @@ typedef struct dif_spi_device_params {
  * hardware.
  */
 typedef struct dif_spi_device_config {
-  dif_spi_device_edge_t clock_polarity;
-  dif_spi_device_edge_t data_phase;
+  dif_spi_device_clock_polarity_t clock_polarity;
+  dif_spi_device_clock_phase_t clock_phase;
   dif_spi_device_bit_order_t tx_order;
   dif_spi_device_bit_order_t rx_order;
   uint8_t rx_fifo_timeout;

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -46,8 +46,8 @@ class SpiTest : public testing::Test, public MmioTest {
   };
 
   dif_spi_device_config_t config_ = {
-      .clock_polarity = kDifSpiDeviceEdgePositive,
-      .data_phase = kDifSpiDeviceEdgeNegative,
+      .clock_polarity = kDifSpiDeviceClockPositive,
+      .clock_phase = kDifSpiDevicePhaseSampleLeading,
       .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .rx_fifo_timeout = 63,
@@ -113,8 +113,8 @@ TEST_F(ConfigTest, BasicInit) {
 
 TEST_F(ConfigTest, ComplexInit) {
   config_ = {
-      .clock_polarity = kDifSpiDeviceEdgeNegative,
-      .data_phase = kDifSpiDeviceEdgePositive,
+      .clock_polarity = kDifSpiDeviceClockNegative,
+      .clock_phase = kDifSpiDevicePhaseSampleTrailing,
       .tx_order = kDifSpiDeviceBitOrderLsbToMsb,
       .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .rx_fifo_timeout = 42,

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -141,8 +141,8 @@ static void spi_device_init_with_irqs(mmio_region_t base_addr,
                                       dif_spi_device_t *spi_device) {
   LOG_INFO("Initializing the SPI_DEVICE.");
   dif_spi_device_config_t spi_device_config = {
-      .clock_polarity = kDifSpiDeviceEdgePositive,
-      .data_phase = kDifSpiDeviceEdgeNegative,
+      .clock_polarity = kDifSpiDeviceClockPositive,
+      .clock_phase = kDifSpiDevicePhaseSampleLeading,
       .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
       .rx_fifo_timeout = 63,


### PR DESCRIPTION
The naming of clock polarity and clock phase is not really precise. Change the naming to reflect the underlying options.

This relates to #7136, naming should match the underlying options. The "sampling" notion for the phase makes probably most sense, alternative is probably "shifted/aligned" I think.