### PR TITLE
[i2c, dv] Fix fifo test for i2c host rtl

### DIFF
--- a/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
+++ b/hw/dv/sv/i2c_agent/i2c_agent_cfg.sv
@@ -6,6 +6,10 @@ class i2c_agent_cfg extends dv_base_agent_cfg;
 
   bit en_monitor = 1'b1; // enable monitor
 
+  // this parameters can be set by test to slow down the agent's responses
+  int host_latency_cycles = 0;
+  int device_latency_cycles = 0;
+
   i2c_target_addr_mode_e target_addr_mode = Addr7BitMode;
 
   timing_cfg_t    timing_cfg;

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -45,8 +45,10 @@ package i2c_env_pkg;
     ReadWrite = 2
   } tran_type_e;
 
-  parameter uint I2C_FMT_FIFO_DEPTH = 32;
-  parameter uint I2C_RX_FIFO_DEPTH  = 32;
+  parameter uint I2C_FMT_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
+  parameter uint I2C_RX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
+  parameter uint I2C_TX_FIFO_DEPTH  = i2c_reg_pkg::FifoDepth;
+  parameter uint I2C_ACQ_FIFO_DEPTH = i2c_reg_pkg::FifoDepth;
 
   // alerts
   parameter uint NUM_ALERTS = 1;

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_base_vseq.sv
@@ -197,7 +197,8 @@ class i2c_base_vseq extends cip_base_vseq #(
       i2c_init(Device);
       agent_init(Host);
     end
-    `uvm_info(`gfn, "\n  initialization is done", UVM_DEBUG)
+    `uvm_info(`gfn, $sformatf("\n  initialization is done, DUT/AGENT = %s",
+        (mode == Host) ? "Host/Target" : "Target/Host"), UVM_LOW)
   endtask : initialization
 
   virtual task agent_init(if_mode_e mode = Device);

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_full_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_full_vseq.sv
@@ -66,9 +66,17 @@ class i2c_fifo_full_vseq extends i2c_rx_tx_vseq;
     csr_rd(.ptr(ral.fifo_status.fmtlvl), .value(fmt_lvl), .backdoor(1'b1));
     csr_rd(.ptr(ral.fifo_status.rxlvl), .value(rx_lvl), .backdoor(1'b1));
     if (!cfg.under_reset) begin
-      if (fmt_full)  `DV_CHECK_EQ(fmt_lvl, I2C_FMT_FIFO_DEPTH);
+      if (fmt_full)  begin
+        `DV_CHECK_EQ(fmt_lvl, I2C_FMT_FIFO_DEPTH);
+      end else begin
+        `DV_CHECK_LT(fmt_lvl, I2C_FMT_FIFO_DEPTH);
+      end
+      if (rx_full)   begin
+        `DV_CHECK_EQ(rx_lvl, I2C_RX_FIFO_DEPTH);
+      end else begin
+        `DV_CHECK_LT(rx_lvl, I2C_RX_FIFO_DEPTH);
+      end
       if (fmt_empty) `DV_CHECK_EQ(fmt_lvl, 0);
-      if (rx_full)   `DV_CHECK_EQ(rx_lvl, I2C_RX_FIFO_DEPTH);
       if (rx_empty)  `DV_CHECK_EQ(rx_lvl, 0);
     end
   endtask : process_fifo_full_status

--- a/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_watermark_vseq.sv
+++ b/hw/ip/i2c/dv/env/seq_lib/i2c_fifo_watermark_vseq.sv
@@ -11,15 +11,10 @@ class i2c_fifo_watermark_vseq extends i2c_rx_tx_vseq;
 
   // fast write data to fmt_fifo to quickly trigger fmt_watermark interrupt
   constraint fmt_fifo_access_dly_c { fmt_fifo_access_dly == 0;}
-
   // fast read data from rd_fifo after crossing watermark level to quickly finish simulation
   constraint rx_fifo_access_dly_c { rx_fifo_access_dly == 0;}
-
-  // write transaction length is more than fmt_fifo depth to cross fmtilvl
-  constraint num_wr_bytes_c {
-    solve num_data_ovf before num_wr_bytes;
-    num_wr_bytes == I2C_FMT_FIFO_DEPTH + num_data_ovf;
-  }
+  // set write transaction size to fmt_fifo depth is enough to cross the highest fmtilvl value
+  constraint num_wr_bytes_c { num_wr_bytes == I2C_FMT_FIFO_DEPTH; }
   // read transaction length is equal to rx_fifo depth to cross rxilvl
   constraint num_rd_bytes_c { num_rd_bytes == I2C_RX_FIFO_DEPTH; }
 
@@ -29,7 +24,7 @@ class i2c_fifo_watermark_vseq extends i2c_rx_tx_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    // config rx_watermark test (fmt_watermark test is auto configured)
+    // config rx_watermark test (fmt_watermark test is configured by default)
     cfg.seq_cfg.en_rx_watermark = 1'b1;
     print_seq_cfg_vars("pre-start");
   endtask : pre_start
@@ -75,7 +70,7 @@ class i2c_fifo_watermark_vseq extends i2c_rx_tx_vseq;
             // until rx_fifo becomes full, en_rx_watermark is set to start reading rx_fifo
             host_send_trans(1, ReadOnly);
             check_rx_watermark = 1'b0; // gracefully stop process_rx_watermark_intr
-            // for fmtilvl > 4, rx_watermark is disable (cnt_rx_watermark = 0)
+            // for fmtilvl > 4, rx_watermark is disabled (cnt_rx_watermark = 0)
             // otherwise, cnt_rx_watermark must be 1
             if (!cfg.under_reset) begin
               if ( rxilvl <= 4) begin


### PR DESCRIPTION
 This PR includes

  - Use fifo_depth parameters from i2c_reg_pkg.sv instead of hardcoding (refer #7081)
  - Fix corner case in which target only stretches host clock within data cycle
  - Reduce reseed values for fifo tests since the fifo depth is increased 32->64
  - Clean up code

Signed-off-by: Tung Hoang <hoang.tung@wdc.com>