### PR TITLE
[otp_ctrl] Add bit remapping option to OTP image generation script

### DIFF
--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 r"""Shared subfunctions.
 """
-import logging as log
 import random
 import textwrap
 from math import ceil, log2
@@ -201,6 +200,16 @@ def scatter_bits(mask, bits):
             j += 1
 
     return scatterword
+
+
+def permute_bits(bits, permutation):
+    '''Permute the bits in a bitstring'''
+    bitlen = len(bits)
+    assert bitlen == len(permutation)
+    permword = ''
+    for k in permutation:
+        permword = bits[bitlen - k - 1] + permword
+    return permword
 
 
 def random_or_hexvalue(dict_obj, key, num_bits):


### PR DESCRIPTION
The ECC + data mapping within a word in the technology-specifc OTP macros may be different from the mapping employed in the generic model.

This adds a command line option that allows to specify a permutation that is applied to the generated OTP image before writing the hexfile.

For example, the following command reverses the byte order for a word width of 24bit:
```
util/design/gen-otp-img.py -o test.vmem --data-perm '[7:0],[15:8],[23:16]'
```
Signed-off-by: Michael Schaffner <msf@opentitan.org>