### PR TITLE
[dv/otp_ctrl] alignment on OTP LC partition status

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -96,8 +96,8 @@ package otp_ctrl_env_pkg;
   parameter uint CHK_TIMEOUT_CYC = 40;
 
   // When fatal alert triggered, all partitions go to error state and status will be
-  // set to 1, except LC partition index.
-  parameter bit [8:0] FATAL_EXP_STATUS = 9'b1_1011_1111;
+  // set to 1.
+  parameter bit [8:0] FATAL_EXP_STATUS = '1;
 
   // lc does not have dai access
   parameter int PART_BASE_ADDRS [NumPart-1] = {

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -187,16 +187,7 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
         if (err_code == exp_err_code) begin
           error_cnt++;
         end else if (err_code != OtpFsmStateError) begin
-          // If error code is not `exp_err_code`, then it has to be `FsmStateError` expect this
-          // corner case where sequence inject ECC correctable error on LC partition.
-          // Design has not processed the LC partition, then other uncorrectable error triggered
-          // fatal alert. Because fatal alert triggered by other FSMs won't affect LC partition,
-          // LC partition status stays as no error.
-          if (i != OtpLifeCycleErrIdx) begin
-            `uvm_error(`gfn, $sformatf("Unexpected error code_%0d: %0s", i, err_code.name))
-          end else if (err_code == OtpNoError) begin
-            exp_status[OtpLifeCycleErrIdx] = 0;
-          end
+          `uvm_error(`gfn, $sformatf("Unexpected error code_%0d: %0s", i, err_code.name))
         end
         if (cfg.en_cov) cov.collect_err_code_field_cov(i, err_code);
       end


### PR DESCRIPTION
This PR aligns the design behavior on PT #7014. We are merging two
escalation behaviors and revert back the changes about lc_partition
status in fatal alert.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>