### PR TITLE
[dv/common] fix xcelium compile error

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -80,49 +80,84 @@ covergroup resets_cg (string name) with function sample(logic [1:0] resets);
   }
 endgroup
 
-// This covergroup sampled all kinds of TL error cases.
-covergroup tl_errors_cg (string ral_name)
-    with function sample(bit unmapped_err,
-                         bit csr_aligned_err,
-                         bit csr_size_err,
-                         bit mem_byte_access_err,
-                         bit mem_wo_err,
-                         bit mem_ro_err,
-                         bit tl_protocol_err);
-  option.per_instance = 1;
-  option.name = ral_name;
+class tl_errors_cg_wrap;
+  // This covergroup sampled all kinds of TL error cases.
+  covergroup tl_errors_cg (string ral_name)
+      with function sample(bit unmapped_err,
+                           bit csr_aligned_err,
+                           bit csr_size_err,
+                           bit mem_byte_access_err,
+                           bit mem_wo_err,
+                           bit mem_ro_err,
+                           bit tl_protocol_err);
+    option.per_instance = 1;
+    option.name = ral_name;
 
-  // these cp should be disabled (set weight to 0), when they're not applicable for the block
-  cp_unmapped_err: coverpoint unmapped_err;
-  cp_csr_aligned_err: coverpoint csr_aligned_err;
-  cp_csr_size_err: coverpoint csr_size_err;
-  cp_mem_byte_access_err: coverpoint mem_byte_access_err;
-  cp_mem_wo_err: coverpoint mem_wo_err;
-  cp_mem_ro_err: coverpoint mem_ro_err;
+    // these cp should be disabled (set weight to 0), when they're not applicable for the block
+    cp_unmapped_err: coverpoint unmapped_err;
+    cp_csr_aligned_err: coverpoint csr_aligned_err;
+    cp_csr_size_err: coverpoint csr_size_err;
+    cp_mem_byte_access_err: coverpoint mem_byte_access_err;
+    cp_mem_wo_err: coverpoint mem_wo_err;
+    cp_mem_ro_err: coverpoint mem_ro_err;
 
-  // we don't enumerate the various kinds of TL protocol errors here because there is a covergroup
-  // in tl_agent, which covers those
-  cp_tl_protocol_err: coverpoint tl_protocol_err;
-endgroup
+    // we don't enumerate the various kinds of TL protocol errors here because there is a covergroup
+    // in tl_agent, which covers those
+    cp_tl_protocol_err: coverpoint tl_protocol_err;
+  endgroup
 
-// This covergroup sampled all kinds of TL integrity error and numbers of error bits.
-covergroup tl_intg_err_cg (string ral_name) with function sample(tl_intg_err_e tl_intg_err_type,
-                                                                 uint          num_cmd_err_bits,
-                                                                 uint          num_data_err_bits,
-                                                                 bit           is_mem);
-  option.per_instance = 1;
-  option.name = ral_name;
+  // Function: new
+  function new(string ral_name);
+    tl_errors_cg = new(ral_name);
+  endfunction : new
 
-  cp_tl_intg_err_type: coverpoint tl_intg_err_type;
+  // Function: sample
+  function void sample(bit unmapped_err,
+                       bit csr_aligned_err,
+                       bit csr_size_err,
+                       bit mem_byte_access_err,
+                       bit mem_wo_err,
+                       bit mem_ro_err,
+                       bit tl_protocol_err);
+    tl_errors_cg.sample(unmapped_err, csr_aligned_err, csr_size_err, mem_byte_access_err,
+                        mem_wo_err, mem_ro_err, tl_protocol_err);
+  endfunction : sample
 
-  cp_num_cmd_err_bits: coverpoint num_cmd_err_bits {
-    bins values[] = {[0:MAX_TL_ECC_ERRORS]};
-  }
-  cp_num_data_err_bits: coverpoint num_data_err_bits {
-    bins values[] = {[0:MAX_TL_ECC_ERRORS]};
-  }
-  cp_is_mem: coverpoint is_mem;
-endgroup
+endclass
+
+class tl_intg_err_cg_wrap;
+  // This covergroup sampled all kinds of TL integrity error and numbers of error bits.
+  covergroup tl_intg_err_cg (string ral_name) with function sample(tl_intg_err_e tl_intg_err_type,
+                                                                   uint          num_cmd_err_bits,
+                                                                   uint          num_data_err_bits,
+                                                                   bit           is_mem);
+    option.per_instance = 1;
+    option.name = ral_name;
+
+    cp_tl_intg_err_type: coverpoint tl_intg_err_type;
+
+    cp_num_cmd_err_bits: coverpoint num_cmd_err_bits {
+      bins values[] = {[0:MAX_TL_ECC_ERRORS]};
+    }
+    cp_num_data_err_bits: coverpoint num_data_err_bits {
+      bins values[] = {[0:MAX_TL_ECC_ERRORS]};
+    }
+    cp_is_mem: coverpoint is_mem;
+  endgroup
+
+  // Function: new
+  function new(string ral_name);
+    tl_intg_err_cg = new(ral_name);
+  endfunction : new
+
+  // Function: sample
+  function void sample(tl_intg_err_e tl_intg_err_type,
+                       uint          num_cmd_err_bits,
+                       uint          num_data_err_bits,
+                       bit           is_mem);
+    tl_intg_err_cg.sample(tl_intg_err_type, num_cmd_err_bits, num_data_err_bits, is_mem);
+  endfunction : sample
+endclass
 
 class cip_base_env_cov #(type CFG_T = cip_base_env_cfg) extends dv_base_env_cov #(CFG_T);
   `uvm_component_param_utils(cip_base_env_cov #(CFG_T))

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -28,8 +28,8 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   local int alert_chk_max_delay[string];
 
   // covergroups
-  tl_errors_cg   tl_errors_cgs[string];
-  tl_intg_err_cg tl_intg_err_cgs[string];
+  tl_errors_cg_wrap   tl_errors_cgs_wrap[string];
+  tl_intg_err_cg_wrap tl_intg_err_cgs_wrap[string];
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
@@ -59,19 +59,27 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         get_all_mem_attrs(cfg.ral_models[ral_name], has_mem_byte_access, has_wo_mem, has_ro_mem);
       end
 
-      tl_errors_cgs[ral_name] = new(ral_name);
+      tl_errors_cgs_wrap[ral_name] = new(ral_name);
       if (!has_csr) begin
-        tl_errors_cgs[ral_name].cp_csr_aligned_err.option.weight = 0;
-        tl_errors_cgs[ral_name].cp_csr_size_err.option.weight = 0;
+        tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_csr_aligned_err.option.weight = 0;
+        tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_csr_size_err.option.weight = 0;
       end
-      if (!has_unmapped)        tl_errors_cgs[ral_name].cp_unmapped_err.option.weight = 0;
-      if (!has_mem_byte_access) tl_errors_cgs[ral_name].cp_mem_byte_access_err.option.weight = 0;
-      if (!has_wo_mem)          tl_errors_cgs[ral_name].cp_mem_wo_err.option.weight = 0;
-      if (!has_ro_mem)          tl_errors_cgs[ral_name].cp_mem_ro_err.option.weight = 0;
+      if (!has_unmapped) begin
+        tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_unmapped_err.option.weight = 0;
+      end
+      if (!has_mem_byte_access) begin
+        tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_byte_access_err. option.weight = 0;
+      end
+      if (!has_wo_mem) begin
+        tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_wo_err.option.weight = 0;
+      end
+      if (!has_ro_mem) begin
+        tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_ro_err.option.weight = 0;
+      end
 
       if (cfg.en_tl_intg_gen) begin
-        tl_intg_err_cgs[ral_name] = new(ral_name);
-        if (!has_mem) tl_intg_err_cgs[ral_name].cp_is_mem.option.weight = 0;
+        tl_intg_err_cgs_wrap[ral_name] = new(ral_name);
+        if (!has_mem) tl_intg_err_cgs_wrap[ral_name].tl_intg_err_cg.cp_is_mem.option.weight = 0;
       end
     end
   endfunction
@@ -316,7 +324,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
         // sample covergroup
         `downcast(cip_item, item)
         cip_item.get_a_chan_err_info(tl_intg_err_type, num_cmd_err_bits, num_data_err_bits);
-        tl_intg_err_cgs[ral_name].sample(tl_intg_err_type, num_cmd_err_bits, num_data_err_bits,
+        tl_intg_err_cgs_wrap[ral_name].sample(tl_intg_err_type, num_cmd_err_bits, num_data_err_bits,
                                          is_mem_addr(item, ral_name));
       end
     end
@@ -335,7 +343,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       // error, so that we know the error actually triggers the outcome
       if (is_tl_unmapped_addr + csr_aligned_err + csr_size_err + mem_byte_access_err + mem_wo_err +
           mem_ro_err + tl_item_err == 1) begin
-        tl_errors_cgs[ral_name].sample(.unmapped_err(is_tl_unmapped_addr),
+        tl_errors_cgs_wrap[ral_name].sample(.unmapped_err(is_tl_unmapped_addr),
                                        .csr_aligned_err(csr_aligned_err),
                                        .csr_size_err(csr_size_err),
                                        .mem_byte_access_err(mem_byte_access_err),


### PR DESCRIPTION
Because xcelium does not support array of covergroups, this PR wrap it
around with a class.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>