### PR TITLE
[dv/otp_ctrl] Align the otbn nonce width

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -88,7 +88,7 @@ package otp_ctrl_env_pkg;
   parameter uint NUM_ROUND          = 31;
 
   parameter uint NUM_SRAM_EDN_REQ = 12;
-  parameter uint NUM_OTBN_EDN_REQ = 16;
+  parameter uint NUM_OTBN_EDN_REQ = 10;
 
   parameter uint NUM_UNBUFF_PARTS = 2;
   parameter uint NUM_BUFF_PARTS   = 5;


### PR DESCRIPTION
This PR aligns with design change with PR #7144.
Now the otbn requires 10 edn fetch instead of 16 fetches.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>