### PR TITLE
[top/alerts] Add a C enum for local alert IDs

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -106,6 +106,36 @@
       default: "2",
       local: "true"
     },
+    { name: "LOCAL_ALERT_ID_ALERT_PINGFAIL",
+      desc: "Local alert ID",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ESC_PINGFAIL",
+      desc: "Local alert ID",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ALERT_INTEGFAIL",
+      desc: "Local alert ID",
+      type: "int",
+      default: "2",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ESC_INTEGFAIL",
+      desc: "Local alert ID",
+      type: "int",
+      default: "3",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_BUS_INTEGFAIL",
+      desc: "Local alert ID",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
   ],
 
   inter_signal_list: [

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -110,6 +110,42 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       default: "${int(math.ceil(math.log2(n_classes)))}",
       local: "true"
     },
+    { name: "LOCAL_ALERT_ID_ALERT_PINGFAIL",
+      desc: "Local alert ID for alert ping failure.",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ESC_PINGFAIL",
+      desc: "Local alert ID for escalation ping failure.",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ALERT_INTEGFAIL",
+      desc: "Local alert ID for alert integrity failure.",
+      type: "int",
+      default: "2",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ESC_INTEGFAIL",
+      desc: "Local alert ID for escalation integrity failure.",
+      type: "int",
+      default: "3",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_BUS_INTEGFAIL",
+      desc: "Local alert ID for bus integrity failure.",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_LAST",
+      desc: "Last local alert ID.",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
   ],
 
   inter_signal_list: [

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -18,6 +18,11 @@ package alert_handler_reg_pkg;
   parameter int PING_CNT_DW = 16;
   parameter int PHASE_DW = 2;
   parameter int CLASS_DW = 2;
+  parameter int LOCAL_ALERT_ID_ALERT_PINGFAIL = 0;
+  parameter int LOCAL_ALERT_ID_ESC_PINGFAIL = 1;
+  parameter int LOCAL_ALERT_ID_ALERT_INTEGFAIL = 2;
+  parameter int LOCAL_ALERT_ID_ESC_INTEGFAIL = 3;
+  parameter int LOCAL_ALERT_ID_BUS_INTEGFAIL = 4;
 
   // Address widths within the block
   parameter int BlockAw = 9;

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -114,6 +114,42 @@
       default: "2",
       local: "true"
     },
+    { name: "LOCAL_ALERT_ID_ALERT_PINGFAIL",
+      desc: "Local alert ID for alert ping failure.",
+      type: "int",
+      default: "0",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ESC_PINGFAIL",
+      desc: "Local alert ID for escalation ping failure.",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ALERT_INTEGFAIL",
+      desc: "Local alert ID for alert integrity failure.",
+      type: "int",
+      default: "2",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_ESC_INTEGFAIL",
+      desc: "Local alert ID for escalation integrity failure.",
+      type: "int",
+      default: "3",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_BUS_INTEGFAIL",
+      desc: "Local alert ID for bus integrity failure.",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
+    { name: "LOCAL_ALERT_ID_LAST",
+      desc: "Last local alert ID.",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
   ],
 
   inter_signal_list: [

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -18,6 +18,12 @@ package alert_handler_reg_pkg;
   parameter int PING_CNT_DW = 16;
   parameter int PHASE_DW = 2;
   parameter int CLASS_DW = 2;
+  parameter int LOCAL_ALERT_ID_ALERT_PINGFAIL = 0;
+  parameter int LOCAL_ALERT_ID_ESC_PINGFAIL = 1;
+  parameter int LOCAL_ALERT_ID_ALERT_INTEGFAIL = 2;
+  parameter int LOCAL_ALERT_ID_ESC_INTEGFAIL = 3;
+  parameter int LOCAL_ALERT_ID_BUS_INTEGFAIL = 4;
+  parameter int LOCAL_ALERT_ID_LAST = 4;
 
   // Address widths within the block
   parameter int BlockAw = 11;


### PR DESCRIPTION
@cfrantz there is currently no Hjson entry where we could read this definition from, hence I had to hardcode it. I placed the enum definition into the function that parses out the alert names from the top-level design, since this makes it a bit more straightforward to reuse the automatic C-enum generation function (with proper formatting and top-level name prefixing).

Does this achieve what you had in mind?

Signed-off-by: Michael Schaffner <msf@opentitan.org>