### PR TITLE
Add hardened_byte_bool_t for OTP entries and update rma and dev OTP images

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -19,6 +19,14 @@
                 {
                     name:  "CREATOR_SW_CFG_DIGEST",
                     value: "0x0",
+                },
+                {
+                    name: "CREATOR_SW_CFG_KEY_IS_VALID",
+                    // Mark the first two keys as valid and remaining as
+                    // invalid since we have currently only two keys. See the
+                    // definition of `hardened_byte_bool_t` in
+                    // sw/device/lib/base/hardened.h.
+                    value: "0x4b4b4b4b4b4ba5a5",
                 }
             ],
         }

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -19,6 +19,14 @@
                 {
                     name:  "CREATOR_SW_CFG_DIGEST",
                     value: "0x0",
+                },
+                {
+                    name: "CREATOR_SW_CFG_KEY_IS_VALID",
+                    // Mark the first two keys as valid and remaining as
+                    // invalid since we have currently only two keys. See the
+                    // definition of `hardened_byte_bool_t` in
+                    // sw/device/lib/base/hardened.h.
+                    value: "0x4b4b4b4b4b4ba5a5",
                 }
             ],
         }

--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -32,4 +32,24 @@ typedef enum hardened_bool {
   kHardenedBoolFalse = 0x1d4u,
 } hardened_bool_t;
 
+/**
+ * A byte-sized hardened boolean.
+ *
+ * This type is intended for cases where a byte-sized hardened boolean is
+ * required, e.g. for the entries of the `CREATOR_SW_CFG_KEY_IS_VALID` OTP item.
+ *
+ * The values below were chosen to ensure that the hamming difference between
+ * them is greater than 5 and they are not bitwise complements of each other.
+ */
+typedef enum hardened_byte_bool {
+  /**
+   * The truthy value.
+   */
+  kHardenedByteBoolTrue = 0xa5,
+  /**
+   * The falsy value.
+   */
+  kHardenedByteBoolFalse = 0x4b,
+} hardened_byte_bool_t;
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_H_


### PR DESCRIPTION
This change adds a byte-sized hardened bool type that can be used for the entries of `CREATOR_SW_CFG_KEY_IS_VALID` and updates rma and dev OTP images. It looks like we use only the rma image but since the docs also mention the dev image, I updated that too to avoid any surprises. Only the first keys are marked as valid since we have currently only two keys.