### PR TITLE
[integ alerts] Align description of integ alerts

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -35,7 +35,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the ADC_CTRL unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -27,7 +27,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the AON_TIMER unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -22,7 +22,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the GPIO unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -20,7 +20,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the HMAC unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -66,7 +66,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the I2C unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -25,7 +25,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the KMAC unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -30,7 +30,7 @@
       desc: "This alert triggers if an error in the life cycle state or life cycle controller FSM is detected.",
     }
     { name: "fatal_bus_integ_error",
-      desc: "This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the LC_CTRL unit."
+      desc: "This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected."
     }
   ],
 

--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -27,7 +27,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the PATTGEN unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -22,7 +22,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the PINMUX unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -34,7 +34,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the PINMUX unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -26,7 +26,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the PWM unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/rv_plic/data/rv_plic.hjson
+++ b/hw/ip/rv_plic/data/rv_plic.hjson
@@ -42,7 +42,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the RV_PLIC unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip/rv_plic/data/rv_plic.hjson.tpl
@@ -43,7 +43,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the RV_PLIC unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -32,7 +32,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the SPI_DEVICE unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -18,13 +18,6 @@
       width:   "1"
     }
   ]
-  alert_list: [
-    { name: "fatal_fault",
-      desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the KMAC unit.
-      '''
-    }
-  ],
   regwidth: "32",
   scan: "true",
   param_list: [
@@ -82,7 +75,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the HMAC unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -21,7 +21,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the SYSRST_CTRL unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -37,7 +37,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the UART unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -30,7 +30,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the PINMUX unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],

--- a/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
+++ b/hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson
@@ -50,7 +50,7 @@
   alert_list: [
     { name: "fatal_fault",
       desc: '''
-      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected inside the RV_PLIC unit.
+      This fatal alert is triggered when a fatal TL-UL bus integrity fault is detected.
       '''
     }
   ],


### PR DESCRIPTION
This shortens the description of the integ alerts and makes it a bit more generic.

Signed-off-by: Michael Schaffner <msf@opentitan.org>