### PR TITLE
[sw/silicon_creator] Add driver for retention SRAM scrambling

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -332,6 +332,24 @@ sw_silicon_creator_lib_driver_retention_sram = declare_dependency(
   ),
 )
 
+test('sw_silicon_creator_lib_driver_retention_sram_unittest', executable(
+    'sw_silicon_creator_lib_driver_retention_sram_unittest',
+    sources: [
+      'retention_sram_unittest.cc',
+      hw_ip_sram_ctrl_reg_h,
+      'retention_sram.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+  ),
+  suite: 'mask_rom',
+)
+
 sw_silicon_creator_lib_driver_retention_sram_functest = declare_dependency(
   link_with: static_library(
     'sw_silicon_creator_lib_driver_retention_sram_functest',

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -6,7 +6,17 @@
 
 #include <assert.h>
 
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sram_ctrl_regs.h"  // Generated.
+
+enum {
+  /**
+   * Base address of retention SRAM controller.
+   */
+  kBase = TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR,
+};
 
 volatile retention_sram_t *retention_sram_get(void) {
   static_assert(sizeof(retention_sram_t) == TOP_EARLGREY_RAM_RET_AON_SIZE_BYTES,
@@ -16,4 +26,22 @@ volatile retention_sram_t *retention_sram_get(void) {
 
 void retention_sram_clear(void) {
   *retention_sram_get() = (retention_sram_t){0};
+}
+
+rom_error_t retention_sram_scramble(void) {
+  // Check that control register writes are enabled.
+  if (!bitfield_bit32_read(
+          abs_mmio_read32(kBase + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET),
+          SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT)) {
+    return kErrorRetSramLocked;
+  }
+
+  // Request the renewal of the scrambling key and initialization to random
+  // values.
+  uint32_t ctrl = 0;
+  ctrl = bitfield_bit32_write(ctrl, SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, true);
+  ctrl = bitfield_bit32_write(ctrl, SRAM_CTRL_CTRL_INIT_BIT, true);
+  abs_mmio_write32(kBase + SRAM_CTRL_CTRL_REG_OFFSET, ctrl);
+
+  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_RETENTION_SRAM_H_
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/error.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,20 @@ volatile retention_sram_t *retention_sram_get(void);
  * Clear the retention SRAM by setting every word to 0.
  */
 void retention_sram_clear(void);
+
+/**
+ * Start scrambling the retention SRAM.
+ *
+ * Requests a new scrambling key for the retention SRAM. This operation
+ * will wipe all of the data in the retention SRAM. The retention SRAM
+ * will then be initialized to undefined values.
+ *
+ * The scrambling operation takes time and accesses to retention SRAM
+ * will stall until it completes.
+ *
+ * @return An error if a new key cannot be requested.
+ */
+rom_error_t retention_sram_scramble(void);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sram_ctrl_regs.h"  // Generated.
+
+namespace retention_sram_unittest {
+namespace {
+class RetentionSramTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_PINMUX_AON_BASE_ADDR;
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+class ScrambleTest : public RetentionSramTest {};
+
+TEST_F(ScrambleTest, Ok) {
+  uint32_t write_enabled =
+      bitfield_bit32_write(0, SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT, true);
+  EXPECT_ABS_READ32(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR +
+                        SRAM_CTRL_CTRL_REGWEN_REG_OFFSET,
+                    write_enabled);
+
+  uint32_t ctrl = 0;
+  ctrl = bitfield_bit32_write(ctrl, SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, true);
+  ctrl = bitfield_bit32_write(ctrl, SRAM_CTRL_CTRL_INIT_BIT, true);
+  EXPECT_ABS_WRITE32(
+      TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR + SRAM_CTRL_CTRL_REG_OFFSET,
+      ctrl);
+
+  EXPECT_EQ(retention_sram_scramble(), kErrorOk);
+}
+
+TEST_F(ScrambleTest, Locked) {
+  uint32_t write_enabled =
+      bitfield_bit32_write(0, SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT, false);
+  EXPECT_ABS_READ32(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR +
+                        SRAM_CTRL_CTRL_REGWEN_REG_OFFSET,
+                    write_enabled);
+
+  EXPECT_EQ(retention_sram_scramble(), kErrorRetSramLocked);
+}
+
+}  // namespace
+}  // namespace retention_sram_unittest

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -39,6 +39,7 @@ enum module_ {
   kModuleFlashCtrl =    MODULE_CODE('F', 'C'),
   kModuleSecMmio =      MODULE_CODE('I', 'O'),
   kModuleBootPolicy =   MODULE_CODE('B', 'P'),
+  kModuleRetSram =      MODULE_CODE('R', 'S'),
   // clang-format on
 };
 
@@ -102,6 +103,7 @@ enum module_ {
   X(kErrorSecMmioCheckCountFault,     ERROR_(6, kModuleSecMmio, kInternal)), \
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyRollback,         ERROR_(2, kModuleBootPolicy, kInternal)), \
+  X(kErrorRetSramLocked,              ERROR_(1, kModuleRetSram, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 


### PR DESCRIPTION
Adds a simple API to allow silicon creator code to request a new scrambling key for the retention SRAM and initialize it.

Signed-off-by: Michael Munday <mike.munday@lowrisc.org>