### PR TITLE
[dv] Use array for multi-reg in RAL model

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -91,11 +91,11 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
               process_alert_sig(index, 0);
             // alert integrity fail
             end else if (act_item.alert_esc_type == AlertEscIntFail) begin
-              bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_2.get_mirrored_value();
+              bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en[2].get_mirrored_value();
               if (loc_alert_en[LocalAlertIntFail]) process_alert_sig(index, 1, LocalAlertIntFail);
             end else if (act_item.alert_esc_type == AlertEscPingTrans &&
                          act_item.ping_timeout) begin
-              bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_0.get_mirrored_value();
+              bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en[0].get_mirrored_value();
               if (loc_alert_en[LocalAlertPingFail]) begin
                 process_alert_sig(index, 1, LocalAlertPingFail);
                 `uvm_info(`gfn, $sformatf("alert %0d ping timeout, timeout_cyc reg is %0d",
@@ -122,11 +122,11 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           // escalation integrity fail
           end else if (act_item.alert_esc_type == AlertEscIntFail ||
                (act_item.esc_handshake_sta == EscIntFail && !act_item.ping_timeout)) begin
-            bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_3.get_mirrored_value();
+            bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en[3].get_mirrored_value();
             if (loc_alert_en[LocalEscIntFail]) process_alert_sig(index, 1, LocalEscIntFail);
           // escalation ping timeout
           end else if (act_item.alert_esc_type == AlertEscPingTrans && act_item.ping_timeout) begin
-            bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_1.get_mirrored_value();
+            bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en[1].get_mirrored_value();
             if (loc_alert_en[LocalEscPingFail]) begin
               process_alert_sig(index, 1, LocalEscPingFail);
               `uvm_info(`gfn, $sformatf("esc %0d ping timeout, timeout_cyc reg is %0d",

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -61,8 +61,8 @@ class alert_handler_base_vseq extends cip_base_vseq #(
       csr_wr(.ptr(loc_alert_en_reg), .value(loc_alert_en[i]));
     end
     // TODO: not use fixed postfix "_0" but randomize it.
-    csr_wr(.ptr(ral.loc_alert_class_0), .value(loc_alert_class));
-    csr_wr(.ptr(ral.alert_class_0), .value(alert_class));
+    csr_wr(.ptr(ral.loc_alert_class[0]), .value(loc_alert_class));
+    csr_wr(.ptr(ral.alert_class[0]), .value(alert_class));
   endtask
 
   virtual task alert_handler_rand_wr_class_ctrl(bit [NUM_ALERT_HANDLER_CLASSES-1:0] lock_bit);
@@ -151,8 +151,8 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   // checking for csr_rd is done in scb
   virtual task read_alert_cause();
     bit [TL_DW-1:0] alert_cause;
-    csr_rd(.ptr(ral.alert_cause_0), .value(alert_cause));
-    csr_rd(.ptr(ral.loc_alert_cause_0), .value(alert_cause));
+    csr_rd(.ptr(ral.alert_cause[0]), .value(alert_cause));
+    csr_rd(.ptr(ral.loc_alert_cause[0]), .value(alert_cause));
   endtask
 
   virtual task read_esc_status();

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -51,14 +51,16 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     uvm_reg_data_t data;
     uvm_reg csr;
     data =
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.en_0, data, region_cfg.en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.rd_en_0, data, region_cfg.read_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.prog_en_0, data, region_cfg.program_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.erase_en_0, data, region_cfg.erase_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.base_0, data, region_cfg.start_page) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_0.size_0, data, region_cfg.num_pages);
-    csr = ral.get_reg_by_name($sformatf("mp_region_cfg_%0d", index));
-    csr_wr(.ptr(csr), .value(data));
+        get_csr_val_with_updated_field(ral.mp_region_cfg[index].en_0, data, region_cfg.en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg[index].rd_en_0, data, region_cfg.read_en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg[index].prog_en_0, data,
+                                       region_cfg.program_en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg[index].erase_en_0, data,
+                                       region_cfg.erase_en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg[index].base_0, data,
+                                       region_cfg.start_page) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg[index].size_0, data, region_cfg.num_pages);
+    csr_wr(.ptr(ral.mp_region_cfg[index]), .value(data));
   endtask
 
   // Configure the protection for the "default" region (all pages that do not fall into one

--- a/hw/ip/hmac/dv/env/hmac_scoreboard.sv
+++ b/hw/ip/hmac/dv/env/hmac_scoreboard.sv
@@ -386,14 +386,7 @@ class hmac_scoreboard extends cip_base_scoreboard #(.CFG_T (hmac_env_cfg),
         exp_digest = '{default:0};
       end
     endcase
-    void'(ral.digest_0.predict(exp_digest[0]));
-    void'(ral.digest_1.predict(exp_digest[1]));
-    void'(ral.digest_2.predict(exp_digest[2]));
-    void'(ral.digest_3.predict(exp_digest[3]));
-    void'(ral.digest_4.predict(exp_digest[4]));
-    void'(ral.digest_5.predict(exp_digest[5]));
-    void'(ral.digest_6.predict(exp_digest[6]));
-    void'(ral.digest_7.predict(exp_digest[7]));
+    foreach (exp_digest[i]) void'(ral.digest[i].predict(exp_digest[i]));
   endfunction
 
   virtual function void update_wr_msg_length(int size_bytes);

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -84,16 +84,8 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
   virtual task write_discard_key();
     bit [TL_DW-1:0] rand_key_value = $urandom();
-    randcase
-      1:  csr_wr(ral.key_0, rand_key_value);
-      1:  csr_wr(ral.key_1, rand_key_value);
-      1:  csr_wr(ral.key_2, rand_key_value);
-      1:  csr_wr(ral.key_3, rand_key_value);
-      1:  csr_wr(ral.key_4, rand_key_value);
-      1:  csr_wr(ral.key_5, rand_key_value);
-      1:  csr_wr(ral.key_6, rand_key_value);
-      1:  csr_wr(ral.key_7, rand_key_value);
-    endcase
+    int key_idx = $urandom_range(0, 7);
+    csr_wr(ral.key[key_idx], rand_key_value);
   endtask
 
   // trigger hash computation to start
@@ -120,14 +112,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
     // read digest value and output read value
   virtual task csr_rd_digest(output bit [TL_DW-1:0] digest[8]);
-    csr_rd(.ptr(ral.digest_0), .value(digest[0]));
-    csr_rd(.ptr(ral.digest_1), .value(digest[1]));
-    csr_rd(.ptr(ral.digest_2), .value(digest[2]));
-    csr_rd(.ptr(ral.digest_3), .value(digest[3]));
-    csr_rd(.ptr(ral.digest_4), .value(digest[4]));
-    csr_rd(.ptr(ral.digest_5), .value(digest[5]));
-    csr_rd(.ptr(ral.digest_6), .value(digest[6]));
-    csr_rd(.ptr(ral.digest_7), .value(digest[7]));
+    foreach (digest[i]) csr_rd(.ptr(ral.digest[i]), .value(digest[i]));
   endtask
 
   // write 256-bit hashed key
@@ -136,23 +121,9 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   // since HMAC key size is always 256 bits
   virtual task wr_key(bit [TL_DW-1:0] key[]);
     // pity we cant loop here
-    ral.key_0.set(key[0]);
-    ral.key_1.set(key[1]);
-    ral.key_2.set(key[2]);
-    ral.key_3.set(key[3]);
-    ral.key_4.set(key[4]);
-    ral.key_5.set(key[5]);
-    ral.key_6.set(key[6]);
-    ral.key_7.set(key[7]);
-    csr_update(.csr(ral.key_0));
-    csr_update(.csr(ral.key_1));
-    csr_update(.csr(ral.key_2));
-    csr_update(.csr(ral.key_3));
-    csr_update(.csr(ral.key_4));
-    csr_update(.csr(ral.key_5));
-    csr_update(.csr(ral.key_6));
-    csr_update(.csr(ral.key_7));
     foreach (key[i]) begin
+      ral.key[i].set(key[7]);
+      csr_update(.csr(ral.key[i]));
       `uvm_info(`gfn, $sformatf("key[%0d] = 0x%0h", i, key[i]), UVM_HIGH)
     end
   endtask

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2088,8 +2088,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                   // msgfifo will now be written
                   unchecked_kmac_cmd = CmdStart;
 
-                  function_name_6B[31:0]  = `gmv(ral.prefix_0);
-                  prefix_val = `gmv(ral.prefix_1);
+                  function_name_6B[31:0]  = `gmv(ral.prefix[0]);
+                  prefix_val = `gmv(ral.prefix[1]);
                   function_name_6B[47:32] = prefix_val[15:0];
 
                   if (kmac_en && function_name_6B != kmac_pkg::EncodedStringKMAC) begin

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -88,8 +88,10 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
       push_pull_item#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)) item_rcv;
       otp_token_fifo.get(item_rcv);
       if (cfg.en_scb) begin
-        `DV_CHECK_EQ(item_rcv.h_data, {`gmv(ral.transition_token_3), `gmv(ral.transition_token_2),
-                                       `gmv(ral.transition_token_1), `gmv(ral.transition_token_0)})
+        `DV_CHECK_EQ(item_rcv.h_data, {`gmv(ral.transition_token[3]),
+                                       `gmv(ral.transition_token[2]),
+                                       `gmv(ral.transition_token[1]),
+                                       `gmv(ral.transition_token[0])})
       end
     end
   endtask

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -105,10 +105,10 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     bit [TL_DW-1:0] status_val;
     csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
     csr_wr(ral.transition_target, next_lc_state);
-    csr_wr(ral.transition_token_0, token_val[TL_DW-1:0]);
-    csr_wr(ral.transition_token_1, token_val[TL_DW*2-1-:TL_DW]);
-    csr_wr(ral.transition_token_2, token_val[TL_DW*3-1-:TL_DW]);
-    csr_wr(ral.transition_token_3, token_val[TL_DW*4-1-:TL_DW]);
+    foreach (ral.transition_token[i]) begin
+      csr_wr(ral.transition_token[i], token_val[TL_DW-1:0]);
+      token_val = token_val >> TL_DW;
+    end
     csr_wr(ral.transition_cmd, 'h01);
 
     // Wait for status done or terminal errors

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -58,20 +58,20 @@ class otp_ctrl_csr_rd_after_alert_cg_wrap;
   // This covergroup samples CSRs being checked (via CSR read) after fatal alert is issued.
   covergroup csr_rd_after_alert_cg(otp_ctrl_reg_block ral) with function sample(bit[TL_DW-1:0] csr_offset);
     read_csr_after_alert_issued: coverpoint csr_offset {
-      bins unbuffered_digests  = {ral.creator_sw_cfg_digest_0.get_offset(),
-                                  ral.creator_sw_cfg_digest_1.get_offset(),
-                                  ral.owner_sw_cfg_digest_0.get_offset(),
-                                  ral.owner_sw_cfg_digest_1.get_offset()};
-      bins hw_digests          = {ral.hw_cfg_digest_0.get_offset(),
-                                  ral.hw_cfg_digest_1.get_offset()};
-      bins secret_digests      = {ral.secret0_digest_0.get_offset(),
-                                  ral.secret0_digest_1.get_offset(),
-                                  ral.secret1_digest_0.get_offset(),
-                                  ral.secret1_digest_1.get_offset(),
-                                  ral.secret2_digest_0.get_offset(),
-                                  ral.secret2_digest_1.get_offset()};
-      bins direct_access_rdata = {ral.direct_access_rdata_0.get_offset(),
-                                  ral.direct_access_rdata_1.get_offset()};
+      bins unbuffered_digests  = {ral.creator_sw_cfg_digest[0].get_offset(),
+                                  ral.creator_sw_cfg_digest[1].get_offset(),
+                                  ral.owner_sw_cfg_digest[0].get_offset(),
+                                  ral.owner_sw_cfg_digest[1].get_offset()};
+      bins hw_digests          = {ral.hw_cfg_digest[0].get_offset(),
+                                  ral.hw_cfg_digest[1].get_offset()};
+      bins secret_digests      = {ral.secret0_digest[0].get_offset(),
+                                  ral.secret0_digest[1].get_offset(),
+                                  ral.secret1_digest[0].get_offset(),
+                                  ral.secret1_digest[1].get_offset(),
+                                  ral.secret2_digest[0].get_offset(),
+                                  ral.secret2_digest[1].get_offset()};
+      bins direct_access_rdata = {ral.direct_access_rdata[0].get_offset(),
+                                  ral.direct_access_rdata[1].get_offset()};
       bins status              = {ral.status.get_offset()};
       bins error_code          = {ral.err_code.get_offset()};
     }

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -105,8 +105,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     addr = randomize_dai_addr(addr);
     `uvm_info(`gfn, $sformatf("dai write addr %0h, data %0h", addr, wdata0), UVM_HIGH)
     csr_wr(ral.direct_access_address, addr);
-    csr_wr(ral.direct_access_wdata_0, wdata0);
-    if (is_secret(addr) || is_sw_digest(addr)) csr_wr(ral.direct_access_wdata_1, wdata1);
+    csr_wr(ral.direct_access_wdata[0], wdata0);
+    if (is_secret(addr) || is_sw_digest(addr)) csr_wr(ral.direct_access_wdata[1], wdata1);
 
     csr_wr(ral.direct_access_cmd, int'(otp_ctrl_pkg::DaiWrite));
     `uvm_info(`gfn, $sformatf("DAI write, address %0h, data0 %0h data1 %0h, is_secret = %0b",
@@ -159,8 +159,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     end
 
     wait_dai_op_done();
-    csr_rd(ral.direct_access_rdata_0, rdata0);
-    if (is_secret(addr) || is_digest(addr)) csr_rd(ral.direct_access_rdata_1, rdata1);
+    csr_rd(ral.direct_access_rdata[0], rdata0);
+    if (is_secret(addr) || is_digest(addr)) csr_rd(ral.direct_access_rdata[1], rdata1);
     rd_and_clear_intrs();
 
     // If has ecc_err, backdoor write back original value
@@ -229,18 +229,18 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // The digest CSR values are verified in otp_ctrl_scoreboard
   virtual task rd_digests();
     bit [TL_DW-1:0] val;
-    csr_rd(.ptr(ral.creator_sw_cfg_digest_0), .value(val));
-    csr_rd(.ptr(ral.creator_sw_cfg_digest_1), .value(val));
-    csr_rd(.ptr(ral.owner_sw_cfg_digest_0),   .value(val));
-    csr_rd(.ptr(ral.owner_sw_cfg_digest_1),   .value(val));
-    csr_rd(.ptr(ral.hw_cfg_digest_0),         .value(val));
-    csr_rd(.ptr(ral.hw_cfg_digest_1),         .value(val));
-    csr_rd(.ptr(ral.secret0_digest_0),        .value(val));
-    csr_rd(.ptr(ral.secret0_digest_1),        .value(val));
-    csr_rd(.ptr(ral.secret1_digest_0),        .value(val));
-    csr_rd(.ptr(ral.secret1_digest_1),        .value(val));
-    csr_rd(.ptr(ral.secret2_digest_0),        .value(val));
-    csr_rd(.ptr(ral.secret2_digest_1),        .value(val));
+    csr_rd(.ptr(ral.creator_sw_cfg_digest[0]), .value(val));
+    csr_rd(.ptr(ral.creator_sw_cfg_digest[1]), .value(val));
+    csr_rd(.ptr(ral.owner_sw_cfg_digest[0]),   .value(val));
+    csr_rd(.ptr(ral.owner_sw_cfg_digest[1]),   .value(val));
+    csr_rd(.ptr(ral.hw_cfg_digest[0]),         .value(val));
+    csr_rd(.ptr(ral.hw_cfg_digest[1]),         .value(val));
+    csr_rd(.ptr(ral.secret0_digest[0]),        .value(val));
+    csr_rd(.ptr(ral.secret0_digest[1]),        .value(val));
+    csr_rd(.ptr(ral.secret1_digest[0]),        .value(val));
+    csr_rd(.ptr(ral.secret1_digest[1]),        .value(val));
+    csr_rd(.ptr(ral.secret2_digest[0]),        .value(val));
+    csr_rd(.ptr(ral.secret2_digest[1]),        .value(val));
   endtask
 
   // This function backdoor inject error according to ecc_err.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -27,7 +27,7 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
 
     // write seq
     csr_wr(ral.direct_access_address, rand_addr);
-    csr_wr(ral.direct_access_wdata_0, '1);
+    csr_wr(ral.direct_access_wdata[0], '1);
     csr_wr(ral.direct_access_cmd, 2);
     wait(cfg.intr_vif.pins[OtpOperationDone] == 1);
     csr_wr(ral.intr_state, (1'b1 << NumOtpCtrlIntr) - 1);
@@ -36,7 +36,7 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
     csr_wr(ral.direct_access_address, rand_addr);
     csr_wr(ral.direct_access_cmd, 1);
     wait(cfg.intr_vif.pins[OtpOperationDone] == 1);
-    csr_rd_check(.ptr(ral.direct_access_rdata_0), .compare_value('1));
+    csr_rd_check(.ptr(ral.direct_access_rdata[0]), .compare_value('1));
     csr_wr(ral.intr_state, (1'b1 << NumOtpCtrlIntr) - 1);
 
     // digest sw error seq

--- a/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_scoreboard.sv
@@ -86,19 +86,19 @@ class pattgen_scoreboard extends cip_base_scoreboard #(
           channel_cfg[0].prediv = ral.prediv_ch0.get_mirrored_value();
         end
         "data_ch0_0": begin
-          channel_cfg[0].data[31:0] = ral.data_ch0_0.get_mirrored_value();
+          channel_cfg[0].data[31:0] = ral.data_ch0[0].get_mirrored_value();
         end
         "data_ch0_1": begin
-          channel_cfg[0].data[63:32] = ral.data_ch0_1.get_mirrored_value();
+          channel_cfg[0].data[63:32] = ral.data_ch0[1].get_mirrored_value();
         end
         "prediv_ch1": begin
           channel_cfg[1].prediv = ral.prediv_ch1.get_mirrored_value();
         end
         "data_ch1_0": begin
-          channel_cfg[1].data[31:0] = ral.data_ch1_0.get_mirrored_value();
+          channel_cfg[1].data[31:0] = ral.data_ch1[0].get_mirrored_value();
         end
         "data_ch1_1": begin
-          channel_cfg[1].data[63:32] = ral.data_ch1_1.get_mirrored_value();
+          channel_cfg[1].data[63:32] = ral.data_ch1[1].get_mirrored_value();
         end
         "ctrl": begin
           reg_value = ral.ctrl.get_mirrored_value();

--- a/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
+++ b/hw/ip/pattgen/dv/env/seq_lib/pattgen_base_vseq.sv
@@ -110,8 +110,8 @@ class pattgen_base_vseq extends cip_base_vseq #(
       ral.size.reps_ch0.set(channel_cfg[0].reps);
       csr_update(ral.size);
       csr_wr(.ptr(ral.prediv_ch0), .value(channel_cfg[0].prediv));
-      csr_wr(.ptr(ral.data_ch0_0), .value(channel_cfg[0].data[31:0]));
-      csr_wr(.ptr(ral.data_ch0_1), .value(channel_cfg[0].data[63:32]));
+      csr_wr(.ptr(ral.data_ch0[0]), .value(channel_cfg[0].data[31:0]));
+      csr_wr(.ptr(ral.data_ch0[1]), .value(channel_cfg[0].data[63:32]));
       ral.ctrl.polarity_ch0.set(channel_cfg[0].polarity);
       update_pattgen_agent_cfg(.channel(0));
       csr_update(ral.ctrl);
@@ -132,8 +132,8 @@ class pattgen_base_vseq extends cip_base_vseq #(
       ral.size.reps_ch1.set(channel_cfg[1].reps);
       csr_update(ral.size);
       csr_wr(.ptr(ral.prediv_ch1), .value(channel_cfg[1].prediv));
-      csr_wr(.ptr(ral.data_ch1_0), .value(channel_cfg[1].data[31:0]));
-      csr_wr(.ptr(ral.data_ch1_1), .value(channel_cfg[1].data[63:32]));
+      csr_wr(.ptr(ral.data_ch1[0]), .value(channel_cfg[1].data[31:0]));
+      csr_wr(.ptr(ral.data_ch1[1]), .value(channel_cfg[1].data[63:32]));
       ral.ctrl.polarity_ch1.set(channel_cfg[1].polarity);
       update_pattgen_agent_cfg(.channel(1));
       csr_update(ral.ctrl);

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -5,7 +5,7 @@
 
 import logging as log
 import os
-from typing import List
+from typing import List, Union
 
 import yaml
 
@@ -14,6 +14,7 @@ from mako.lookup import TemplateLookup  # type: ignore
 from pkg_resources import resource_filename
 
 from .ip_block import IpBlock
+from .multi_register import MultiRegister
 from .register import Register
 from .window import Window
 
@@ -23,7 +24,7 @@ def bcname(esc_if_name: str) -> str:
     return esc_if_name + "_reg_block"
 
 
-def rcname(esc_if_name: str, r: Register) -> str:
+def rcname(esc_if_name: str, r: Union[Register, MultiRegister]) -> str:
     '''Get the name of the dv_base_reg subclass for this register'''
     return '{}_reg_{}'.format(esc_if_name, r.name.lower())
 

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -69,7 +69,7 @@ class MultiRegister(RegBase):
         self.cname = check_name(rd['cname'],
                                 'cname field of multireg {}'
                                 .format(self.reg.name))
-        self.name = self.cname
+        self.name = self.reg.name
 
         self.regwen_multi = check_bool(rd.get('regwen_multi', False),
                                        'regwen_multi field of multireg {}'
@@ -117,6 +117,13 @@ class MultiRegister(RegBase):
                                       self.regwen_multi, self.compact,
                                       min_reg_idx, max_reg_idx, self.cname)
             self.regs.append(reg)
+
+        # dv_compact is true if the multireg can be equally divided, and we can
+        # pack them as an array
+        if self.count < regs_per_creg or (self.count % regs_per_creg) == 0:
+            self.dv_compact = True
+        else:
+            self.dv_compact = False
 
     def next_offset(self, addrsep: int) -> int:
         return self.offset + len(self.regs) * addrsep

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -69,6 +69,7 @@ class MultiRegister(RegBase):
         self.cname = check_name(rd['cname'],
                                 'cname field of multireg {}'
                                 .format(self.reg.name))
+        self.name = self.cname
 
         self.regwen_multi = check_bool(rd.get('regwen_multi', False),
                                        'regwen_multi field of multireg {}'

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -205,11 +205,14 @@ class RegBlock:
                                          reg.name, reg.offset,
                                          self.name_to_offset[lname]))
             self._add_flat_reg(reg)
+            if mr.dv_compact is False:
+                self.type_regs.append(reg)
             self.name_to_offset[lname] = reg.offset
 
         self.multiregs.append(mr)
         self.all_regs.append(mr)
-        self.type_regs.append(mr.reg)
+        if mr.dv_compact is True:
+            self.type_regs.append(mr.reg)
         self.entries.append(mr)
         self.offset = mr.next_offset(self._addrsep)
 

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -39,6 +39,11 @@ class RegBlock:
         # A list of registers and multiregisters (unexpanded)
         self.all_regs = []  # type: List[Union[Register, MultiRegister]]
 
+        # A list of all the underlying register types used in the block. This
+        # has one entry for each actual Register, plus a single entry giving
+        # the underlying register for each MultiRegister.
+        self.type_regs = []  # type: List[Register]
+
         # A list with everything in order
         self.entries = []  # type: List[object]
 
@@ -204,6 +209,7 @@ class RegBlock:
 
         self.multiregs.append(mr)
         self.all_regs.append(mr)
+        self.type_regs.append(mr.reg)
         self.entries.append(mr)
         self.offset = mr.next_offset(self._addrsep)
 
@@ -221,6 +227,7 @@ class RegBlock:
 
         self.registers.append(reg)
         self.all_regs.append(reg)
+        self.type_regs.append(reg)
         self.entries.append(reg)
         self.offset = reg.next_offset(self._addrsep)
 


### PR DESCRIPTION
Address #5852 item 1

Change to generate multi-reg as below. User can access the reg by using
the index, e.g. ral.sw_binding[0]
```
 class keymgr_reg_block extends dv_base_reg_block;
    rand keymgr_reg_sw_binding sw_binding[8];
    rand keymgr_reg_salt salt[8];
```

before this change, it generates the multi-reg like this
```
 class keymgr_reg_block extends dv_base_reg_block;
    rand keymgr_reg_sw_binding_0 sw_binding_0;
    rand keymgr_reg_sw_binding_1 sw_binding_1;
    rand keymgr_reg_sw_binding_2 sw_binding_2;
    rand keymgr_reg_sw_binding_3 sw_binding_3;
    rand keymgr_reg_sw_binding_4 sw_binding_4;
    rand keymgr_reg_sw_binding_5 sw_binding_5;
    rand keymgr_reg_sw_binding_6 sw_binding_6;
    rand keymgr_reg_sw_binding_7 sw_binding_7;
    rand keymgr_reg_salt_0 salt_0;
    rand keymgr_reg_salt_1 salt_1;
    rand keymgr_reg_salt_2 salt_2;
    rand keymgr_reg_salt_3 salt_3;
    rand keymgr_reg_salt_4 salt_4;
    rand keymgr_reg_salt_5 salt_5;
    rand keymgr_reg_salt_6 salt_6;
    rand keymgr_reg_salt_7 salt_7;
```

multi-fields will be handled in next PR

Signed-off-by: Weicai Yang <weicai@google.com>