### PR TITLE
[csrng/rtl] fix for app cmd with clen less than 12

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -895,7 +895,7 @@ module csrng_core import csrng_pkg::*; #(
   ) u_prim_packer_fifo_adata (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
-    .clr_i      (!cs_enable),
+    .clr_i      (!cs_enable || packer_adata_pop_q),
     .wvalid_i   (acmd_mop),
     .wdata_i    (acmd_bus),
     .wready_o   (),


### PR DESCRIPTION
Fix for when an application command is sent to csrng with a clen of less than 12.
The additional data packer must be cleared after each command.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>