### PR TITLE
[dv] Fix tl_error

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -54,7 +54,7 @@ package cip_base_pkg;
 
   // get mem attributes to know what error cases can be triggered
   function automatic void get_all_mem_attrs(input dv_base_reg_block reg_block,
-                                            output bit has_mem_byte_access,
+                                            output bit has_mem_byte_access_err,
                                             output bit has_wo_mem,
                                             output bit has_ro_mem);
     uvm_mem mems[$];
@@ -63,7 +63,7 @@ package cip_base_pkg;
     foreach (mems[i]) begin
       dv_base_mem dv_mem;
       `downcast(dv_mem, mems[i], , , msg_id)
-      if (dv_mem.get_mem_partial_write_support()) has_mem_byte_access = 1;
+      if (!dv_mem.get_mem_partial_write_support()) has_mem_byte_access_err = 1;
       if (dv_mem.get_access() == "WO") has_wo_mem = 1;
       if (dv_mem.get_access() == "RO") has_ro_mem = 1;
     end

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -51,12 +51,12 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       bit has_unmapped  = (cfg.ral_models[ral_name].unmapped_addr_ranges.size > 0);
       bit has_csr       = (cfg.ral_models[ral_name].csr_addrs.size > 0);
       bit has_mem       = (cfg.ral_models[ral_name].mem_ranges.size > 0);
-      bit has_mem_byte_access;
+      bit has_mem_byte_access_err;
       bit has_wo_mem;
       bit has_ro_mem;
 
       if (has_mem) begin
-        get_all_mem_attrs(cfg.ral_models[ral_name], has_mem_byte_access, has_wo_mem, has_ro_mem);
+        get_all_mem_attrs(cfg.ral_models[ral_name], has_mem_byte_access_err, has_wo_mem, has_ro_mem);
       end
 
       tl_errors_cgs_wrap[ral_name] = new($sformatf("tl_errors_cgs_wrap[%0s]", ral_name));
@@ -67,7 +67,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       if (!has_unmapped) begin
         tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_unmapped_err.option.weight = 0;
       end
-      if (!has_mem_byte_access) begin
+      if (!has_mem_byte_access_err) begin
         tl_errors_cgs_wrap[ral_name].tl_errors_cg.cp_mem_byte_access_err.option.weight = 0;
       end
       if (!has_wo_mem) begin

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -193,7 +193,7 @@ virtual task run_tl_errors_vseq_sub(int num_times = 1, bit do_wait_clk = 0, stri
   addr_range_t loc_mem_range[$] = cfg.ral_models[ral_name].mem_ranges;
   bit has_mem = (loc_mem_range.size > 0);
   bit [BUS_AW-1:0] csr_base_addr = cfg.ral_models[ral_name].default_map.get_base_addr();
-  bit has_mem_byte_access;
+  bit has_mem_byte_access_err;
   bit has_wo_mem;
   bit has_ro_mem;
 
@@ -223,7 +223,7 @@ virtual task run_tl_errors_vseq_sub(int num_times = 1, bit do_wait_clk = 0, stri
     end
   end
 
-  get_all_mem_attrs(cfg.ral_models[ral_name], has_mem_byte_access, has_wo_mem, has_ro_mem);
+  get_all_mem_attrs(cfg.ral_models[ral_name], has_mem_byte_access_err, has_wo_mem, has_ro_mem);
 
   for (int trans = 1; trans <= num_times; trans++) begin
     `uvm_info(`gfn, $sformatf("Running run_tl_errors_vseq %0d/%0d", trans, num_times), UVM_LOW)
@@ -248,7 +248,7 @@ virtual task run_tl_errors_vseq_sub(int num_times = 1, bit do_wait_clk = 0, stri
                 cfg.ral_models[ral_name].has_unmapped_addrs: tl_access_unmapped_addr(ral_name);
 
                 // only run this task when the error can be triggered
-                !has_mem_byte_access: tl_write_mem_less_than_word(ral_name);
+                has_mem_byte_access_err: tl_write_mem_less_than_word(ral_name);
                 has_wo_mem: tl_read_wo_mem_err(ral_name);
                 has_ro_mem: tl_write_ro_mem_err(ral_name);
               endcase


### PR DESCRIPTION
Fix the follow error due to wrong condition of testing mem byte access
error
>UVM_FATAL @    917818 ps: (csr_utils_pkg.sv:68) [csr_utils] Check failed mem != null (0 [0x0] vs 0 [0x0]) Can't find any mem with addr 0x0

Detailed reason:
some of our mem supports byte access, some doesn't. For those that doesn't support, we test that it returns an error for byte access. In my previous update, I use `if (!has_mem_byte_access) tl_write_mem_less_than_word(ral_name)`, but I forgot to exclude the case that the block doesn't contain mem. now I use `if (has_mem_byte_access_err) tl_write_mem_less_than_word(ral_name)`. `has_mem_byte_access_err` means that the block contain mem and the mem doesn't support byte access.

Signed-off-by: Weicai Yang <weicai@google.com>