### PR TITLE
[dv/otp] Update tl integrity alert name

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -35,6 +35,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_reg_block));
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
     has_edn = 1;
+    tl_intg_alert_name = "fatal_bus_integ_error";
     super.initialize(csr_base_addr);
 
     // create push_pull agent config obj


### PR DESCRIPTION
OTP_CTRL integrity alert name is `fatal_bus_integ_error` instead of the
default name. This PR updates it in otp dv environment.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>