### PR TITLE
[sw] Add option to configure sideload in kmac dif

### DIFF
--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -187,6 +187,8 @@ dif_kmac_result_t dif_kmac_configure(dif_kmac_t *kmac,
   cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_ENTROPY_FAST_PROCESS_BIT,
                                  config.entropy_fast_process);
   cfg_reg =
+      bitfield_bit32_write(cfg_reg, KMAC_CFG_SIDELOAD_BIT, config.sideload);
+  cfg_reg =
       bitfield_bit32_write(cfg_reg, KMAC_CFG_ENTROPY_READY_BIT, entropy_ready);
   mmio_region_write32(kmac->params.base_addr, KMAC_CFG_REG_OFFSET, cfg_reg);
 

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -155,6 +155,12 @@ typedef struct dif_kmac_config {
    * granularity.
    */
   bool output_big_endian;
+
+  /**
+   * Place kmac inside key sideload mode
+   */
+  bool sideload;
+
 } dif_kmac_config_t;
 
 /**


### PR DESCRIPTION
This is required for keymgr usage of KMAC. 
Without setting the sideload bit, the KMAC uses incorrect key length for keymgr. 