### PR TITLE
[dv/cip_lib] Condition check on num_interrupts

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -413,6 +413,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   // Task to clear register intr status bits
   virtual task clear_all_interrupts();
+    if (cfg.num_interrupts == 0) return;
     foreach (intr_state_csrs[i]) begin
       bit [BUS_DW-1:0] data;
       csr_rd(.ptr(intr_state_csrs[i]), .value(data));


### PR DESCRIPTION
clear_all_interrupts should not perform the interrupt check if
num_interrupts == 0 since the vif_intr handle can be uninitialized.

Signed-off-by: Guillermo Maturana <maturana@google.com>