### PR TITLE
Tool cover

### DIFF
--- a/hw/dv/tools/xcelium/cov_merge.tcl
+++ b/hw/dv/tools/xcelium/cov_merge.tcl
@@ -19,3 +19,8 @@ set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
 
 # Run the merge command.
 merge $cov_db_dirs -out $cov_merge_db_dir -overwrite
+
+# Create a file with the path to the cover dirs
+set filepointer [open "$cov_merge_db_dir/runs.txt" w]
+puts $filepointer "$cov_db_dirs"
+close $filepointer

--- a/hw/dv/tools/xcelium/cov_report.tcl
+++ b/hw/dv/tools/xcelium/cov_report.tcl
@@ -47,3 +47,6 @@ report_metrics \
   -assertionStatus \
   -allAssertionCounters \
   -all
+
+# rank the test runs
+rank -runfile $cov_merge_db_dir/runs.txt -html -out $cov_report_dir/grading


### PR DESCRIPTION
Updating xcelium coverage scripts to support test case ranking.
Unfortunately xcelium does not support the same granularity as VCS when using IMC at command line.

the script has been updated to create a file with a path to the coverage output directory.
this file is read when raking the tests cases.

the resulting output can be found under cov_report/grading/rank_sub_dir/rank.html
a link to this file can be added to our run summary pages.

