### PR TITLE
[adc_ctrl] Style updates and bug fix

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -4,7 +4,7 @@
 { name: "adc_ctrl",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
-    {clock: "clk_aon_i", reset: "rst_slow_ni"}
+    {clock: "clk_aon_i", reset: "rst_aon_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
@@ -61,6 +61,7 @@
       swaccess: "rw",
       hwaccess: "hro",
       resval: "0",
+      async: "clk_aon_i",
       fields: [
         { bits: "0",
           name: "adc_enable",
@@ -76,7 +77,7 @@
       desc: "ADC PowerDown(PD) control register",
       swaccess: "rw",
       hwaccess: "hro",
-      hwqe: "true",
+      async: "clk_aon_i",
       fields: [
         { bits: "0",
           name: "lp_mode",
@@ -99,7 +100,7 @@
       desc: "ADC Low-Power(LP) sample control register",
       swaccess: "rw",
       hwaccess: "hro",
-      hwqe: "true",
+      async: "clk_aon_i",
       fields: [
         { bits: "7:0",
           name: "lp_sample_cnt",
@@ -112,7 +113,7 @@
       desc: "ADC sample control register",
       swaccess: "rw",
       hwaccess: "hro",
-      hwqe: "true",
+      async: "clk_aon_i",
       resval: "155",
       fields: [
         { bits: "15:0",
@@ -125,6 +126,7 @@
       desc: "ADC FSM reset control",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_aon_i",
       resval: "0",
       fields: [
         { bits: "0",
@@ -147,7 +149,7 @@
         cname: "ADC_CTRL",
         swaccess: "rw",
         hwaccess: "hro",
-        hwqe: "true"
+        async: "clk_aon_i",
         resval: "0",
         fields: [
 //          { bits: "1:0",
@@ -169,10 +171,15 @@
           { bits: "27:18",
 	    name: "max_v",
 	    desc: "10-bit for chn0 filter max value ",
+	  },
+          { bits: "31",
+	    name: "EN",
+	    desc: "Enable for filter",
 	  }
         ],
       }
     }
+
     { multireg: {
         name: "adc_chn1_filter_ctl",
         desc: '''ADC channel1 filter range
@@ -187,7 +194,7 @@
         cname: "ADC_CTRL",
         swaccess: "rw",
         hwaccess: "hro",
-        hwqe: "true",
+        async: "clk_aon_i",
         resval: "0",
         fields: [
 //          { bits: "1:0",
@@ -209,10 +216,15 @@
           { bits: "27:18",
 	    name: "max_v",
 	    desc: "10-bit for chn0 filter max value ",
+	  },
+          { bits: "31",
+	    name: "EN",
+	    desc: "Enable for filter",
 	  }
         ],
       }
-    }
+    },
+
     { multireg: {
         name: "adc_chn_val",
         desc: "ADC value sampled on channel",
@@ -220,6 +232,7 @@
         cname: "ADC_CTRL",
         swaccess: "ro",
         hwaccess: "hwo",
+        async: "clk_aon_i",
         resval: "0",
         fields: [
           { bits: "1:0",
@@ -241,130 +254,61 @@
         ],
       }
     }
+
     { name: "adc_wakeup_ctl",
-      desc: "wakeup control",
+      desc: '''
+        Enable filter matches as wakeups
+      ''',
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_aon_i",
       resval: "0",
       fields: [
-        { bits: "0",
-	  name: "chn0_1_filter0_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "1",
-	  name: "chn0_1_filter1_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "2",
-	  name: "chn0_1_filter2_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "3",
-	  name: "chn0_1_filter3_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "4",
-	  name: "chn0_1_filter4_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "5",
-	  name: "chn0_1_filter5_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "6",
-	  name: "chn0_1_filter6_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "7",
-	  name: "chn0_1_filter7_en",
-          desc: "0: disable; 1: enable",
+        { bits: "NumAdcFilter-1:0",
+	  name: "EN",
+          desc: "0: filter match wil not generate wakeupe; 1: filter match will generate wakeup",
         }
       ]
     }
-    { name: "adc_wakeup_status",
-      desc: "Wakeup internal status",
+
+    { name: "filter_status",
+      desc: '''
+        Adc filter match status
+
+        Indicates whether a particular filter has matched on all channels.
+      ''',
       swaccess: "rw1c",
-      hwaccess: "hwo",
+      hwaccess: "hrw",
+      async: "clk_aon_i",
       resval: "0",
       fields: [
-        { bits: "0",
-	  name: "cc_sink_det",
-          desc: "0: filter0 condition is not met; 1: filter0 condition is met",
-        }
-	{ bits: "1",
-          name: "cc_1A5_sink_det",
-          desc: "0: filter1 condition is not met; 1: filter1 condition is met",
-        }
-	{ bits: "2",
-          name: "cc_3A0_sink_det",
-          desc: "0: filter2 condition is not met; 1: filter2 condition is met",
-        }
-	{ bits: "3",
-          name: "cc_src_det",
-          desc: "0: filter3 condition is not met; 1: filter3 condition is met",
-        }
-	{ bits: "4",
-          name: "cc_1A5_src_det",
-          desc: "0: filter4 condition is not met; 1: filter4 condition is met",
-        }
-	{ bits: "5",
-          name: "cc_src_det_flip",
-          desc: "0: filter5 condition is not met; 1: filter5 condition is met",
-        }
-	{ bits: "6",
-          name: "cc_1A5_src_det_flip",
-          desc: "0: filter6 condition is not met; 1: filter6 condition is met",
-        }
-	{ bits: "7",
-          name: "cc_discon",
-          desc: "0: filter7 condition is not met; 1: filter7 condition is met",
+        { bits: "7:0",
+	  name: "COND",
+          desc: "0: filter condition is not met; 1: filter condition is met",
         }
       ]
     }
+
     { name: "adc_intr_ctl",
-      desc: "Debug cable internal control",
+      desc: '''
+        Interrupt enable controls.
+
+        adc_ctrl sends out only 1 interrupt, so this register controls
+        which internal sources are actually registered.
+
+        This register uses the same bit enumeration as !!ADC_INTR_STATUS
+      ''',
       swaccess: "rw",
       hwaccess: "hro",
       resval: "0",
       fields: [
-        { bits: "0",
-	  name: "chn0_1_filter0_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "1",
-	  name: "chn0_1_filter1_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "2",
-	  name: "chn0_1_filter2_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "3",
-	  name: "chn0_1_filter3_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "4",
-	  name: "chn0_1_filter4_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "5",
-	  name: "chn0_1_filter5_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "6",
-	  name: "chn0_1_filter6_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "7",
-	  name: "chn0_1_filter7_en",
-          desc: "0: disable; 1: enable",
-        }
-        { bits: "8",
-	  name: "oneshot_intr_en",
-          desc: "0: disable; 1: enable",
+        { bits: "8:0",
+	  name: "EN",
+          desc: "0: interrupt source is enabled; 1: interrupt source not enabled",
         }
       ]
     }
+
     { name: "adc_intr_status",
       desc: "Debug cable internal status",
       swaccess: "rw1c",

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -41,7 +41,7 @@ module tb;
     .clk_i               (clk),
     .rst_ni              (rst_n),
     .clk_aon_i           (clk_aon),
-    .rst_slow_ni         (rst_aon_n),
+    .rst_aon_ni          (rst_aon_n),
     .tl_i                (tl_if.h2d),
     .tl_o                (tl_if.d2h),
     .alert_rx_i          (alert_rx),

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -14,7 +14,7 @@ module adc_ctrl
   input clk_i,  //regular core clock for SW config interface
   input clk_aon_i,  //always-on slow clock for internal logic
   input rst_ni,  //power-on hardware reset
-  input rst_slow_ni,  //power-on reset for the 200KHz clock(logic)
+  input rst_aon_ni,  //power-on reset for the 200KHz clock(logic)
 
   //Regster interface
   input  tlul_pkg::tl_h2d_t tl_i,
@@ -72,8 +72,10 @@ module adc_ctrl
 
   // Register module
   adc_ctrl_reg_top u_reg (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
+    .clk_i,
+    .rst_ni,
+    .clk_aon_i,
+    .rst_aon_ni,
     .tl_i(tl_i),
     .tl_o(tl_o),
     .reg2hw(reg2hw),
@@ -83,27 +85,16 @@ module adc_ctrl
   );
 
   // Instantiate DCD core module
-  adc_ctrl_core i_adc_ctrl_core (
+  adc_ctrl_core u_adc_ctrl_core (
     .clk_aon_i(clk_aon_i),
-    .rst_slow_ni(rst_slow_ni),
+    .rst_aon_ni(rst_aon_ni),
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .adc_en_ctl_i(reg2hw.adc_en_ctl),
-    .adc_pd_ctl_i(reg2hw.adc_pd_ctl),
-    .adc_lp_sample_ctl_i(reg2hw.adc_lp_sample_ctl),
-    .adc_sample_ctl_i(reg2hw.adc_sample_ctl),
-    .adc_fsm_rst_i(reg2hw.adc_fsm_rst),
-    .adc_chn0_filter_ctl_i(reg2hw.adc_chn0_filter_ctl),
-    .adc_chn1_filter_ctl_i(reg2hw.adc_chn1_filter_ctl),
-    .adc_wakeup_ctl_i(reg2hw.adc_wakeup_ctl),
-    .adc_intr_ctl_i(reg2hw.adc_intr_ctl),
-    .adc_chn_val_o(hw2reg.adc_chn_val),
-    .intr_state_i(reg2hw.intr_state),
-    .intr_enable_i(reg2hw.intr_enable),
-    .intr_test_i(reg2hw.intr_test),
+    .reg2hw_i(reg2hw),
     .intr_state_o(hw2reg.intr_state),
+    .adc_chn_val_o(hw2reg.adc_chn_val),
     .adc_intr_status_o(hw2reg.adc_intr_status),
-    .adc_wakeup_status_o(hw2reg.adc_wakeup_status),
+    .aon_filter_status_o(hw2reg.filter_status),
     .debug_cable_wakeup_o(debug_cable_wakeup_o),
     .intr_debug_cable_o(intr_debug_cable_o),
     .adc_i(adc_i),

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
@@ -6,547 +6,180 @@
 
 module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
   input  clk_aon_i,//Always-on 200KHz clock(logic)
-  input  rst_slow_ni,//power-on reset for the 200KHz clock(logic)
+  input  rst_aon_ni,//power-on reset for the 200KHz clock(logic)
   input  clk_i,//regular core clock for SW config interface
   input  rst_ni,//power-on hardware reset
 
-  input  adc_ctrl_reg2hw_adc_en_ctl_reg_t adc_en_ctl_i,
-  input  adc_ctrl_reg2hw_adc_pd_ctl_reg_t adc_pd_ctl_i,
-  input  adc_ctrl_reg2hw_adc_lp_sample_ctl_reg_t adc_lp_sample_ctl_i,
-  input  adc_ctrl_reg2hw_adc_sample_ctl_reg_t adc_sample_ctl_i,
-  input  adc_ctrl_reg2hw_adc_fsm_rst_reg_t adc_fsm_rst_i,
-  input  adc_ctrl_reg2hw_adc_chn0_filter_ctl_mreg_t [NumAdcFilter-1:0] adc_chn0_filter_ctl_i,
-  input  adc_ctrl_reg2hw_adc_chn1_filter_ctl_mreg_t [NumAdcFilter-1:0] adc_chn1_filter_ctl_i,
-  input  adc_ctrl_reg2hw_adc_wakeup_ctl_reg_t adc_wakeup_ctl_i,
-  input  adc_ctrl_reg2hw_adc_intr_ctl_reg_t adc_intr_ctl_i,
+  // register interface inputs
+  input  adc_ctrl_reg2hw_t reg2hw_i,
 
-  output adc_ctrl_hw2reg_adc_chn_val_mreg_t [NumAdcChannel-1:0] adc_chn_val_o,
-
-  input  adc_ctrl_reg2hw_intr_state_reg_t intr_state_i,
-  input  adc_ctrl_reg2hw_intr_enable_reg_t intr_enable_i,
-  input  adc_ctrl_reg2hw_intr_test_reg_t intr_test_i,
-
+  // register interface outputs
   output adc_ctrl_hw2reg_intr_state_reg_t intr_state_o,
+  output adc_ctrl_hw2reg_adc_chn_val_mreg_t [NumAdcChannel-1:0] adc_chn_val_o,
   output adc_ctrl_hw2reg_adc_intr_status_reg_t adc_intr_status_o,
-  output adc_ctrl_hw2reg_adc_wakeup_status_reg_t adc_wakeup_status_o,
+  output adc_ctrl_hw2reg_filter_status_reg_t aon_filter_status_o,
 
+  // interrupt and wakeup outputs
   output debug_cable_wakeup_o,
   output intr_debug_cable_o,
 
+  // adc interface
   input  ast_pkg::adc_ast_rsp_t adc_i,
   output ast_pkg::adc_ast_req_t adc_o
 );
 
-  logic cfg_adc_enable;
-  logic cfg_oneshot_mode;
-  logic cfg_lp_mode;
-  logic load_adc_ctl;
-  logic load_lp_sample_cnt, load_np_sample_cnt;
-  logic [3:0] cfg_pwrup_time;
-  logic [23:0] cfg_wakeup_time;
-  logic [7:0] cfg_lp_sample_cnt;
-  logic [15:0] cfg_np_sample_cnt;
-  logic cfg_fsm_rst;
-
-  //There are eight filters
-  //Each filter can have different settings
-  logic [9:0] cfg_chn0_min_v [NumAdcFilter];
-  logic [9:0] cfg_chn0_max_v [NumAdcFilter];
-  logic [9:0] cfg_chn1_min_v [NumAdcFilter];
-  logic [9:0] cfg_chn1_max_v [NumAdcFilter];
-  logic [NumAdcFilter-1:0] cfg_chn0_cond;
-  logic [NumAdcFilter-1:0] cfg_chn1_cond;
-  logic [NumAdcFilter-1:0] load_chn0_min_v;
-  logic [NumAdcFilter-1:0] load_chn1_min_v;
-  logic [NumAdcFilter-1:0] load_chn0_max_v;
-  logic [NumAdcFilter-1:0] load_chn1_max_v;
-
-  //wakeup and interrupt control registers
-  logic [NumAdcFilter-1:0] cfg_wakeup_en;
-  //[0-7] for filters, [8] is for oneshot
-  logic [NumAdcFilter-1:0] cfg_intr_en;
-  logic cfg_oneshot_intr_en;
-
   logic chn0_val_we, chn1_val_we;//write enable for the latest ADC sample
   logic [9:0] chn0_val, chn1_val;
-  logic cfg_chn0_rvalid, cfg_chn1_rvalid;
 
-  logic [NumAdcFilter-1:0] chn0_match, chn1_match, adc_ctrl_match;
-  logic [NumAdcFilter-1:0] adc_ctrl_match_pulse;
+  logic [NumAdcFilter-1:0] chn0_match, chn1_match, match;
+  logic [NumAdcFilter-1:0] match_pulse;
+
   //write enable for the ADC sample when the interrupt is triggered
   logic adc_ctrl_done, oneshot_done;
-  logic cfg_adc_ctrl_done, cfg_oneshot_done;
-  //CFG clock domain synchronized write enable when interrupt is triggered
-  logic cfg_chn_val_intr_we;//Either oneshot_done or adc_ctrl_done
 
-  // tieoff unused signals
-  logic [NumAdcFilter-1:0] unused_cond_qe;
-  logic unused_lp_mode_qe;
-  for (genvar i=0; i < NumAdcFilter; i++) begin : gen_unused_tieoff
-    assign unused_cond_qe[i] = adc_chn0_filter_ctl_i[i].cond.qe ^
-                               adc_chn1_filter_ctl_i[i].cond.qe;
-  end
+  // Pack channel 0/1 into one variable
+  typedef struct packed {
+    logic [9:0] min_v;
+    logic [9:0] max_v;
+    logic cond;
+    logic en;
+  } filter_ctl_t;
 
-  assign unused_lp_mode_qe = adc_pd_ctl_i.lp_mode.qe;
+  filter_ctl_t [NumAdcChannel-1:0][NumAdcFilter-1:0] aon_filter_ctl;
 
+  for (genvar k = 0 ; k < NumAdcFilter ; k++) begin : gen_filter_ctl_sync
 
-  //synchronize between cfg(24MHz) and always-on(200KHz)
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_adc_enable (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_en_ctl_i.adc_enable.q),
-    .q_o(cfg_adc_enable)
-  );
+    assign aon_filter_ctl[0][k] = '{
+      min_v: reg2hw_i.adc_chn0_filter_ctl[k].min_v.q,
+      max_v: reg2hw_i.adc_chn0_filter_ctl[k].max_v.q,
+      cond:  reg2hw_i.adc_chn0_filter_ctl[k].cond.q,
+      en:    reg2hw_i.adc_chn0_filter_ctl[k].en.q
+    };
 
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_oneshot_mode (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_en_ctl_i.oneshot_mode.q),
-    .q_o(cfg_oneshot_mode)
-  );
+    assign aon_filter_ctl[1][k] = '{
+      min_v: reg2hw_i.adc_chn1_filter_ctl[k].min_v.q,
+      max_v: reg2hw_i.adc_chn1_filter_ctl[k].max_v.q,
+      cond:  reg2hw_i.adc_chn1_filter_ctl[k].cond.q,
+      en:    reg2hw_i.adc_chn1_filter_ctl[k].en.q
+    };
+  end // block: gen_filter_ctl_sync
 
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_lp_mode (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_pd_ctl_i.lp_mode.q),
-    .q_o(cfg_lp_mode)
-  );
+  // Recent adc channel values
+  assign adc_chn_val_o[0].adc_chn_value.de = chn0_val_we;
+  assign adc_chn_val_o[0].adc_chn_value.d  = chn0_val;
+  assign adc_chn_val_o[1].adc_chn_value.de = chn1_val_we;
+  assign adc_chn_val_o[1].adc_chn_value.d  = chn1_val;
 
-  // all qe's for a register are the same
-  logic adc_pd_ctl_qe;
-  assign adc_pd_ctl_qe = adc_pd_ctl_i.pwrup_time.qe |
-                         adc_pd_ctl_i.wakeup_time.qe;
+  // Interrupt based adc channel values
+  // The value of the adc is captured whenever an interrupt triggers.
+  // There are two cases:
+  // completion of one shot mode
+  // match detection from the filters
+  logic chn_val_intr_we;
+  assign chn_val_intr_we = reg2hw_i.adc_en_ctl.oneshot_mode.q ? oneshot_done  :
+                           reg2hw_i.adc_en_ctl.adc_enable.q   ? adc_ctrl_done : '0;
 
-  prim_pulse_sync i_cfg_adc_pd_ctl (
-    .clk_src_i   (clk_i),
-    .rst_src_ni  (rst_ni),
-    .src_pulse_i (adc_pd_ctl_qe),
-    .clk_dst_i   (clk_aon_i),
-    .rst_dst_ni  (rst_slow_ni),
-    .dst_pulse_o (load_adc_ctl)
-  );
-
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin
-    if (!rst_slow_ni) begin
-      cfg_pwrup_time  <= '0;
-      cfg_wakeup_time <= '0;
-    end else if (load_adc_ctl) begin
-      cfg_pwrup_time  <= adc_pd_ctl_i.pwrup_time.q;
-      cfg_wakeup_time <= adc_pd_ctl_i.wakeup_time.q;
-    end
-  end
-
-  prim_pulse_sync i_cfg_lp_sample_cnt (
-    .clk_src_i   (clk_i),
-    .rst_src_ni  (rst_ni),
-    .src_pulse_i (adc_lp_sample_ctl_i.qe),
-    .clk_dst_i   (clk_aon_i),
-    .rst_dst_ni  (rst_slow_ni),
-    .dst_pulse_o (load_lp_sample_cnt)
-  );
-
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_cfg_lp_sample_cnt_reg
-    if (!rst_slow_ni) begin
-      cfg_lp_sample_cnt <= '0;
-    end else if (load_lp_sample_cnt) begin
-      cfg_lp_sample_cnt <= adc_lp_sample_ctl_i.q;
-    end
-  end
-
-  prim_pulse_sync i_cfg_np_sample_cnt (
-    .clk_src_i   (clk_i),
-    .rst_src_ni  (rst_ni),
-    .src_pulse_i (adc_sample_ctl_i.qe),
-    .clk_dst_i   (clk_aon_i),
-    .rst_dst_ni  (rst_slow_ni),
-    .dst_pulse_o (load_np_sample_cnt)
-  );
-
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_cfg_np_sample_cnt_reg
-    if (!rst_slow_ni) begin
-      cfg_np_sample_cnt <= '0;
-    end else if (load_np_sample_cnt) begin
-      cfg_np_sample_cnt <= adc_sample_ctl_i.q;
-    end
-  end
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_fsm_rst (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_fsm_rst_i.q),
-    .q_o(cfg_fsm_rst)
-  );
-
-  //synchronize between cfg(24MHz) and always-on(200KHz) for the filters
-  for (genvar k = 0 ; k < NumAdcFilter ; k++) begin : gen_filter_sync
-    prim_flop_2sync # (
-    .Width(1)
-    ) i_cfg_chn0_cond (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_chn0_filter_ctl_i[k].cond.q),
-    .q_o(cfg_chn0_cond[k])
-    );
-
-    prim_flop_2sync # (
-    .Width(1)
-    ) i_cfg_chn1_cond (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_chn1_filter_ctl_i[k].cond.q),
-    .q_o(cfg_chn1_cond[k])
-    );
-
-    prim_pulse_sync i_cfg_chn0_min_v (
-      .clk_src_i   (clk_i),
-      .rst_src_ni  (rst_ni),
-      .src_pulse_i (adc_chn0_filter_ctl_i[k].min_v.qe),
-      .clk_dst_i   (clk_aon_i),
-      .rst_dst_ni  (rst_slow_ni),
-      .dst_pulse_o (load_chn0_min_v[k])
-    );
-
-    always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_cfg_chn0_min_v_reg
-      if (!rst_slow_ni) begin
-        cfg_chn0_min_v[k]    <= '0;
-      end else if (load_chn0_min_v[k]) begin
-        cfg_chn0_min_v[k]    <= adc_chn0_filter_ctl_i[k].min_v.q;
-      end
-    end
-
-    prim_pulse_sync i_cfg_chn1_min_v (
-      .clk_src_i   (clk_i),
-      .rst_src_ni  (rst_ni),
-      .src_pulse_i (adc_chn1_filter_ctl_i[k].min_v.qe),
-      .clk_dst_i   (clk_aon_i),
-      .rst_dst_ni  (rst_slow_ni),
-      .dst_pulse_o (load_chn1_min_v[k])
-    );
-
-    always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_cfg_chn1_min_v_reg
-      if (!rst_slow_ni) begin
-        cfg_chn1_min_v[k]    <= '0;
-      end else if (load_chn1_min_v[k]) begin
-        cfg_chn1_min_v[k]    <= adc_chn1_filter_ctl_i[k].min_v.q;
-      end
-    end
-
-    prim_pulse_sync i_cfg_chn0_max_v (
-      .clk_src_i   (clk_i),
-      .rst_src_ni  (rst_ni),
-      .src_pulse_i (adc_chn0_filter_ctl_i[k].max_v.qe),
-      .clk_dst_i   (clk_aon_i),
-      .rst_dst_ni  (rst_slow_ni),
-      .dst_pulse_o (load_chn0_max_v[k])
-    );
-
-    always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_cfg_chn0_max_v_reg
-      if (!rst_slow_ni) begin
-        cfg_chn0_max_v[k]    <= '0;
-      end else if (load_chn0_max_v[k]) begin
-        cfg_chn0_max_v[k]    <= adc_chn0_filter_ctl_i[k].max_v.q;
-      end
-    end
-
-    prim_pulse_sync i_cfg_chn1_max_v (
-      .clk_src_i   (clk_i),
-      .rst_src_ni  (rst_ni),
-      .src_pulse_i (adc_chn1_filter_ctl_i[k].max_v.qe),
-      .clk_dst_i   (clk_aon_i),
-      .rst_dst_ni  (rst_slow_ni),
-      .dst_pulse_o (load_chn1_max_v[k])
-    );
-
-    always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_cfg_chn1_max_v_reg
-      if (!rst_slow_ni) begin
-        cfg_chn1_max_v[k]    <= '0;
-      end else if (load_chn1_max_v[k]) begin
-        cfg_chn1_max_v[k]    <= adc_chn1_filter_ctl_i[k].max_v.q;
-      end
-    end
-  end
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en0 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter0_en.q),
-    .q_o(cfg_wakeup_en[0])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en1 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter1_en.q),
-    .q_o(cfg_wakeup_en[1])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en2 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter2_en.q),
-    .q_o(cfg_wakeup_en[2])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en3 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter3_en.q),
-    .q_o(cfg_wakeup_en[3])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en4 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter4_en.q),
-    .q_o(cfg_wakeup_en[4])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en5 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter5_en.q),
-    .q_o(cfg_wakeup_en[5])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en6 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter6_en.q),
-    .q_o(cfg_wakeup_en[6])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_wakeup_en7 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_wakeup_ctl_i.chn0_1_filter7_en.q),
-    .q_o(cfg_wakeup_en[7])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en0 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter0_en.q),
-    .q_o(cfg_intr_en[0])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en1 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter1_en.q),
-    .q_o(cfg_intr_en[1])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en2 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter2_en.q),
-    .q_o(cfg_intr_en[2])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en3 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter3_en.q),
-    .q_o(cfg_intr_en[3])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en4 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter4_en.q),
-    .q_o(cfg_intr_en[4])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en5 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter5_en.q),
-    .q_o(cfg_intr_en[5])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en6 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter6_en.q),
-    .q_o(cfg_intr_en[6])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_intr_en7 (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.chn0_1_filter7_en.q),
-    .q_o(cfg_intr_en[7])
-  );
-
-  prim_flop_2sync # (
-    .Width(1)
-  ) i_cfg_oneshot_intr_en (
-    .clk_i(clk_aon_i),
-    .rst_ni(rst_slow_ni),
-    .d_i(adc_intr_ctl_i.oneshot_intr_en.q),
-    .q_o(cfg_oneshot_intr_en)
-  );
-
-  //Synchronize from 200KHz always-onclock to 24MHz cfg clock
-  prim_pulse_sync i_oneshot_done (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (oneshot_done),
-    .dst_pulse_o (cfg_oneshot_done)
-  );
-
-  prim_pulse_sync i_adc_ctrl_done (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_done),
-    .dst_pulse_o (cfg_adc_ctrl_done)
-  );
-
-  prim_pulse_sync i_cfg_chn0_val (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (chn0_val_we),
-    .dst_pulse_o (cfg_chn0_rvalid)
-  );
-
-  prim_pulse_sync i_cfg_chn1_val (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (chn1_val_we),
-    .dst_pulse_o (cfg_chn1_rvalid)
-  );
-
-  //To write into adc_chn_val register
-  assign adc_chn_val_o[0].adc_chn_value.de = cfg_chn0_rvalid;
-  assign adc_chn_val_o[0].adc_chn_value.d = chn0_val;
-  assign adc_chn_val_o[1].adc_chn_value.de = cfg_chn1_rvalid;
-  assign adc_chn_val_o[1].adc_chn_value.d = chn1_val;
-
-  // this signal indicates to the core clock domain one shot mode or adc mode has completed
-  // it is therefore now safe to capture the value coming from the fsm
-  assign cfg_chn_val_intr_we = cfg_oneshot_done || cfg_adc_ctrl_done;
-
-  assign adc_chn_val_o[0].adc_chn_value_intr.de = cfg_chn_val_intr_we;
-  assign adc_chn_val_o[0].adc_chn_value_intr.d = chn0_val;
-  assign adc_chn_val_o[1].adc_chn_value_intr.de = cfg_chn_val_intr_we;
-  assign adc_chn_val_o[1].adc_chn_value_intr.d = chn1_val;
+  assign adc_chn_val_o[0].adc_chn_value_intr.de = chn_val_intr_we;
+  assign adc_chn_val_o[0].adc_chn_value_intr.d  = chn0_val;
+  assign adc_chn_val_o[1].adc_chn_value_intr.de = chn_val_intr_we;
+  assign adc_chn_val_o[1].adc_chn_value_intr.d  = chn1_val;
 
   //Connect the ports for future extension
   assign adc_chn_val_o[0].adc_chn_value_ext.de = 1'b0;
-  assign adc_chn_val_o[0].adc_chn_value_ext.d = 2'b0;
+  assign adc_chn_val_o[0].adc_chn_value_ext.d  = 2'b0;
   assign adc_chn_val_o[1].adc_chn_value_ext.de = 1'b0;
-  assign adc_chn_val_o[1].adc_chn_value_ext.d = 2'b0;
+  assign adc_chn_val_o[1].adc_chn_value_ext.d  = 2'b0;
 
   assign adc_chn_val_o[0].adc_chn_value_intr_ext.de = 1'b0;
-  assign adc_chn_val_o[0].adc_chn_value_intr_ext.d = 2'b0;
+  assign adc_chn_val_o[0].adc_chn_value_intr_ext.d  = 2'b0;
   assign adc_chn_val_o[1].adc_chn_value_intr_ext.de = 1'b0;
-  assign adc_chn_val_o[1].adc_chn_value_intr_ext.d = 2'b0;
+  assign adc_chn_val_o[1].adc_chn_value_intr_ext.d  = 2'b0;
 
   //Evaluate if there is a match from chn0 and chn1 samples
   for (genvar k = 0 ; k < NumAdcFilter ; k++) begin : gen_filter_match
-    assign chn0_match[k] = (!cfg_chn0_cond[k]) ?
-            (cfg_chn0_min_v[k] <= chn0_val) && (chn0_val <= cfg_chn0_max_v[k]) :
-            (cfg_chn0_min_v[k] > chn0_val) || (chn0_val > cfg_chn0_max_v[k]);
-    assign chn1_match[k] = (!cfg_chn1_cond[k]) ?
-            (cfg_chn1_min_v[k] <= chn1_val) && (chn1_val <= cfg_chn1_max_v[k]) :
-            (cfg_chn1_min_v[k] > chn1_val) || (chn1_val > cfg_chn1_max_v[k]);
-    assign adc_ctrl_match[k] = chn0_match[k] && chn1_match[k];
-    assign adc_ctrl_match_pulse[k] = adc_ctrl_done && adc_ctrl_match[k];
+    assign chn0_match[k] = (!aon_filter_ctl[0][k].cond) ?
+            (aon_filter_ctl[0][k].min_v <= chn0_val) && (chn0_val <= aon_filter_ctl[0][k].max_v) :
+            (aon_filter_ctl[0][k].min_v >  chn0_val) || (chn0_val >  aon_filter_ctl[0][k].max_v);
+    assign chn1_match[k] = (!aon_filter_ctl[1][k].cond) ?
+            (aon_filter_ctl[1][k].min_v <= chn1_val) && (chn1_val <= aon_filter_ctl[1][k].max_v) :
+            (aon_filter_ctl[1][k].min_v >  chn1_val) || (chn1_val >  aon_filter_ctl[1][k].max_v);
+
+    assign match[k] = (chn0_match[k] & aon_filter_ctl[0][k].en) &
+                      (chn1_match[k] & aon_filter_ctl[1][k].en);
+    assign match_pulse[k] = adc_ctrl_done && match[k];
   end
 
+  // adc filter status
+  assign aon_filter_status_o.d  = match_pulse;
+  assign aon_filter_status_o.de = 1'b1;
+
+  // generate wakeup to external power manager if filter status
+  // and wakeup enable are set.
+  assign debug_cable_wakeup_o = |(reg2hw_i.filter_status.q &
+                                  reg2hw_i.adc_wakeup_ctl.q);
+
   //instantiate the main state machine
-  adc_ctrl_fsm i_adc_ctrl_fsm (
-    .clk_aon_i(clk_aon_i),
-    .rst_slow_ni(rst_slow_ni),
-    .cfg_fsm_rst(cfg_fsm_rst),
-    .cfg_adc_enable(cfg_adc_enable),
-    .cfg_oneshot_mode(cfg_oneshot_mode),
-    .cfg_lp_mode(cfg_lp_mode),
-    .cfg_pwrup_time(cfg_pwrup_time),
-    .cfg_wakeup_time(cfg_wakeup_time),
-    .cfg_lp_sample_cnt(cfg_lp_sample_cnt),
-    .cfg_np_sample_cnt(cfg_np_sample_cnt),
-    .adc_ctrl_match(adc_ctrl_match),
-    .adc_d(adc_i.data),
-    .adc_d_val(adc_i.data_valid),
-    .adc_pd(adc_o.pd),
-    .adc_chn_sel(adc_o.channel_sel),
-    .chn0_val_we(chn0_val_we),
-    .chn1_val_we(chn1_val_we),
-    .chn0_val(chn0_val),
-    .chn1_val(chn1_val),
-    .adc_ctrl_done(adc_ctrl_done),
-    .oneshot_done(oneshot_done)
+  adc_ctrl_fsm u_adc_ctrl_fsm (
+    .clk_aon_i,
+    .rst_aon_ni,
+    // configuration and settings from reg interface
+    .cfg_fsm_rst_i(reg2hw_i.adc_fsm_rst.q),
+    .cfg_adc_enable_i(reg2hw_i.adc_en_ctl.adc_enable.q),
+    .cfg_oneshot_mode_i(reg2hw_i.adc_en_ctl.oneshot_mode.q),
+    .cfg_lp_mode_i(reg2hw_i.adc_pd_ctl.lp_mode.q),
+    .cfg_pwrup_time_i(reg2hw_i.adc_pd_ctl.pwrup_time.q),
+    .cfg_wakeup_time_i(reg2hw_i.adc_pd_ctl.wakeup_time.q),
+    .cfg_lp_sample_cnt_i(reg2hw_i.adc_lp_sample_ctl.q),
+    .cfg_np_sample_cnt_i(reg2hw_i.adc_sample_ctl.q),
+    //
+    .adc_ctrl_match_i(match),
+    .adc_d_i(adc_i.data),
+    .adc_d_val_i(adc_i.data_valid),
+    .adc_pd_o(adc_o.pd),
+    .adc_chn_sel_o(adc_o.channel_sel),
+    .chn0_val_we_o(chn0_val_we),
+    .chn1_val_we_o(chn1_val_we),
+    .chn0_val_o(chn0_val),
+    .chn1_val_o(chn1_val),
+    .adc_ctrl_done_o(adc_ctrl_done),
+    .oneshot_done_o(oneshot_done)
+  );
+
+  // synchronzie from clk_aon into cfg domain
+  logic cfg_oneshot_done;
+  prim_pulse_sync u_oneshot_done_sync (
+    .clk_src_i(clk_aon_i),
+    .rst_src_ni(rst_aon_ni),
+    .src_pulse_i(oneshot_done),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(cfg_oneshot_done)
   );
 
   //Instantiate the interrupt module
-  adc_ctrl_intr i_adc_ctrl_intr (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .clk_aon_i(clk_aon_i),
-    .rst_slow_ni(rst_slow_ni),
-    .cfg_wakeup_en(cfg_wakeup_en),
-    .cfg_intr_en(cfg_intr_en),
-    .cfg_oneshot_intr_en(cfg_oneshot_intr_en),
-    .adc_ctrl_match_pulse(adc_ctrl_match_pulse),
-    .cfg_oneshot_done(cfg_oneshot_done),
-    .intr_state_i(intr_state_i),
-    .intr_enable_i(intr_enable_i),
-    .intr_test_i(intr_test_i),
-    .intr_state_o(intr_state_o),
-    .adc_intr_status_o(adc_intr_status_o),
-    .adc_wakeup_status_o(adc_wakeup_status_o),
-    .debug_cable_wakeup_o(debug_cable_wakeup_o),
-    .intr_debug_cable_o(intr_debug_cable_o)
+  adc_ctrl_intr u_adc_ctrl_intr (
+    .clk_i,
+    .rst_ni,
+    .aon_filter_status_i(reg2hw_i.filter_status.q),
+    .cfg_intr_en_i(reg2hw_i.adc_intr_ctl.q),
+    .cfg_oneshot_done_i(cfg_oneshot_done),
+    .intr_state_i(reg2hw_i.intr_state),
+    .intr_enable_i(reg2hw_i.intr_enable),
+    .intr_test_i(reg2hw_i.intr_test),
+    .intr_state_o,
+    .adc_intr_status_o,
+    .intr_debug_cable_o
   );
 
+  // unused register inputs
+  logic unused_cfgs;
+  assign unused_cfgs = ^reg2hw_i;
+
+  //////////////////////
+  // Assertions
+  //////////////////////
+
+  `ASSERT_INIT(MaxFilters_A, NumAdcFilter <= 32)
+  `ASSERT(OneHotMatch_A, adc_ctrl_done |-> $onehot0(match_pulse))
 
 endmodule

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
@@ -8,26 +8,26 @@ module adc_ctrl_fsm
   import adc_ctrl_reg_pkg::*;
 (
   input clk_aon_i,
-  input rst_slow_ni,
-  input cfg_fsm_rst,
-  input cfg_adc_enable,
-  input cfg_oneshot_mode,
-  input cfg_lp_mode,
-  input [3:0] cfg_pwrup_time,
-  input [23:0] cfg_wakeup_time,
-  input [7:0]  cfg_lp_sample_cnt,
-  input [15:0] cfg_np_sample_cnt,
-  input [NumAdcFilter-1:0] adc_ctrl_match,
-  input [9:0] adc_d,
-  input       adc_d_val,//valid bit for ADC value
-  output logic      adc_pd,
-  output logic[1:0] adc_chn_sel,
-  output logic      chn0_val_we,
-  output logic      chn1_val_we,
-  output logic [9:0] chn0_val,
-  output logic [9:0] chn1_val,
-  output logic       adc_ctrl_done,
-  output logic       oneshot_done
+  input rst_aon_ni,
+  input cfg_fsm_rst_i,
+  input cfg_adc_enable_i,
+  input cfg_oneshot_mode_i,
+  input cfg_lp_mode_i,
+  input [3:0] cfg_pwrup_time_i,
+  input [23:0] cfg_wakeup_time_i,
+  input [7:0]  cfg_lp_sample_cnt_i,
+  input [15:0] cfg_np_sample_cnt_i,
+  input [NumAdcFilter-1:0] adc_ctrl_match_i,
+  input [9:0] adc_d_i,
+  input       adc_d_val_i,//valid bit for ADC value
+  output logic      adc_pd_o,
+  output logic[1:0] adc_chn_sel_o,
+  output logic      chn0_val_we_o,
+  output logic      chn1_val_we_o,
+  output logic [9:0] chn0_val_o,
+  output logic [9:0] chn1_val_o,
+  output logic       adc_ctrl_done_o,
+  output logic       oneshot_done_o
 );
 
   logic trigger_q;
@@ -73,27 +73,27 @@ module adc_ctrl_fsm
 
   fsm_state_e fsm_state_q, fsm_state_d;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_trigger_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
       trigger_q <= 1'b0;
     end
-    else if (cfg_fsm_rst) begin
+    else if (cfg_fsm_rst_i) begin
       trigger_q <= 1'b0;
     end else begin
-      trigger_q  <= cfg_adc_enable;
+      trigger_q  <= cfg_adc_enable_i;
     end
   end
 
-  assign trigger_l2h = (trigger_q == 1'b0) && (cfg_adc_enable == 1'b1);
-  assign trigger_h2l = (trigger_q == 1'b1) && (cfg_adc_enable == 1'b0);
+  assign trigger_l2h = (trigger_q == 1'b0) && (cfg_adc_enable_i == 1'b1);
+  assign trigger_h2l = (trigger_q == 1'b1) && (cfg_adc_enable_i == 1'b0);
 
   assign pwrup_timer_cnt_d = (pwrup_timer_cnt_en) ? pwrup_timer_cnt_q + 1'b1 : pwrup_timer_cnt_q;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_pwrup_timer_cnt_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
       pwrup_timer_cnt_q    <= '0;
     end
-    else if (pwrup_timer_cnt_clr || cfg_fsm_rst) begin
+    else if (pwrup_timer_cnt_clr || cfg_fsm_rst_i) begin
        pwrup_timer_cnt_q <= '0;
     end else begin
        pwrup_timer_cnt_q <= pwrup_timer_cnt_d;
@@ -102,11 +102,11 @@ module adc_ctrl_fsm
 
   assign lp_sample_cnt_d = (lp_sample_cnt_en) ? lp_sample_cnt_q + 1'b1 : lp_sample_cnt_q;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_lp_sample_cnt_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
       lp_sample_cnt_q    <= '0;
     end
-    else if (lp_sample_cnt_clr || cfg_fsm_rst) begin
+    else if (lp_sample_cnt_clr || cfg_fsm_rst_i) begin
       lp_sample_cnt_q <= '0;
     end else begin
       lp_sample_cnt_q <= lp_sample_cnt_d;
@@ -115,11 +115,11 @@ module adc_ctrl_fsm
 
   assign np_sample_cnt_d = (np_sample_cnt_en) ? np_sample_cnt_q + 1'b1 : np_sample_cnt_q;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_np_sample_cnt_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
       np_sample_cnt_q    <= '0;
     end
-    else if (np_sample_cnt_clr || cfg_fsm_rst) begin
+    else if (np_sample_cnt_clr || cfg_fsm_rst_i) begin
       np_sample_cnt_q <= '0;
     end else begin
       np_sample_cnt_q <= np_sample_cnt_d;
@@ -129,11 +129,11 @@ module adc_ctrl_fsm
   assign wakeup_timer_cnt_d = (wakeup_timer_cnt_en) ?
            wakeup_timer_cnt_q + 1'b1 : wakeup_timer_cnt_q;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_wakeup_timer_cnt_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
       wakeup_timer_cnt_q    <= '0;
     end
-    else if (wakeup_timer_cnt_clr || cfg_fsm_rst) begin
+    else if (wakeup_timer_cnt_clr || cfg_fsm_rst_i) begin
       wakeup_timer_cnt_q <= '0;
     end else begin
       wakeup_timer_cnt_q <= wakeup_timer_cnt_d;
@@ -141,59 +141,59 @@ module adc_ctrl_fsm
   end
 
   assign fsm_chn0_sel = (fsm_state_q == ONEST_0) || (fsm_state_q == LP_0) || (fsm_state_q == NP_0);
-  assign chn0_val_we_d = fsm_chn0_sel && adc_d_val;//adc_d_val is a valid pulse
-  assign chn0_val_d = (chn0_val_we_d) ? adc_d : chn0_val;
+  assign chn0_val_we_d = fsm_chn0_sel && adc_d_val_i;//adc_d_val_i is a valid pulse
+  assign chn0_val_d = (chn0_val_we_d) ? adc_d_i : chn0_val_o;
 
   assign fsm_chn1_sel = (fsm_state_q == ONEST_1) || (fsm_state_q == LP_1) || (fsm_state_q == NP_1);
-  assign chn1_val_we_d = fsm_chn1_sel && adc_d_val;
-  assign chn1_val_d = (chn1_val_we_d) ? adc_d : chn1_val;
+  assign chn1_val_we_d = fsm_chn1_sel && adc_d_val_i;
+  assign chn1_val_d = (chn1_val_we_d) ? adc_d_i : chn1_val_o;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_chn01_val_we_reg
-    if (!rst_slow_ni) begin
-      chn0_val_we    <= '0;
-      chn1_val_we    <= '0;
-      chn0_val       <= '0;
-      chn1_val       <= '0;
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
+      chn0_val_we_o  <= '0;
+      chn1_val_we_o  <= '0;
+      chn0_val_o     <= '0;
+      chn1_val_o     <= '0;
     end
-    else if (cfg_fsm_rst) begin
-      chn0_val_we    <= '0;
-      chn1_val_we    <= '0;
-      chn0_val       <= '0;
-      chn1_val       <= '0;
+    else if (cfg_fsm_rst_i) begin
+      chn0_val_we_o  <= '0;
+      chn1_val_we_o  <= '0;
+      chn0_val_o     <= '0;
+      chn1_val_o     <= '0;
     end else begin
-      chn0_val_we    <= chn0_val_we_d;
-      chn1_val_we    <= chn1_val_we_d;
-      chn0_val       <= chn0_val_d;
-      chn1_val       <= chn1_val_d;
+      chn0_val_we_o  <= chn0_val_we_d;
+      chn1_val_we_o  <= chn1_val_we_d;
+      chn0_val_o     <= chn0_val_d;
+      chn1_val_o     <= chn1_val_d;
     end
   end
 
   for (genvar k = 0 ; k < NumAdcFilter ; k++) begin : gen_fst_lp_match
     assign fst_lp_match[k] =
-    ((lp_sample_cnt_q == 8'd1) && (fsm_state_q == LP_EVAL)) ? adc_ctrl_match[k] : 1'b0;
+    ((lp_sample_cnt_q == 8'd1) && (fsm_state_q == LP_EVAL)) ? adc_ctrl_match_i[k] : 1'b0;
   end
 
   assign any_fst_lp_match = |fst_lp_match;
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_adc_ctrl_match_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
         adc_ctrl_match_q  <= '0;
     end
-    else if (cfg_fsm_rst) begin
+    else if (cfg_fsm_rst_i) begin
         adc_ctrl_match_q  <= '0;
     end
     else if ((fsm_state_q == LP_EVAL) || (fsm_state_q == NP_EVAL)) begin
-        adc_ctrl_match_q  <= adc_ctrl_match;
+        adc_ctrl_match_q  <= adc_ctrl_match_i;
     end
   end
 
-  assign stay_match = any_fst_lp_match || (adc_ctrl_match == adc_ctrl_match_q);
+  assign stay_match = any_fst_lp_match || (adc_ctrl_match_i == adc_ctrl_match_q);
 
-  always_ff @(posedge clk_aon_i or negedge rst_slow_ni) begin: i_fsm_state_reg
-    if (!rst_slow_ni) begin
+  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin
+    if (!rst_aon_ni) begin
       fsm_state_q    <= PWRDN;
     end
-    else if (trigger_h2l || cfg_fsm_rst) begin
+    else if (trigger_h2l || cfg_fsm_rst_i) begin
       fsm_state_q    <= PWRDN;
     end else begin
       fsm_state_q    <= fsm_state_d;
@@ -203,8 +203,8 @@ module adc_ctrl_fsm
   always_comb begin: adc_fsm
     fsm_state_d = fsm_state_q;
     //outputs
-    adc_chn_sel = 2'b0;
-    adc_pd = 1'b1;//default value
+    adc_chn_sel_o = 2'b0;
+    adc_pd_o = 1'b1;//default value
     pwrup_timer_cnt_clr = 1'b0;
     pwrup_timer_cnt_en = 1'b0;
     lp_sample_cnt_clr = 1'b0;
@@ -213,8 +213,8 @@ module adc_ctrl_fsm
     wakeup_timer_cnt_en = 1'b0;
     np_sample_cnt_clr = 1'b0;
     np_sample_cnt_en = 1'b0;
-    adc_ctrl_done = 1'b0;
-    oneshot_done = 1'b0;
+    adc_ctrl_done_o = 1'b0;
+    oneshot_done_o = 1'b0;
 
     unique case (fsm_state_q)
       PWRDN: begin
@@ -224,145 +224,145 @@ module adc_ctrl_fsm
       end
 
       PWRUP: begin
-        adc_pd = 1'b0;
-        if (pwrup_timer_cnt_q != cfg_pwrup_time) begin
+        adc_pd_o = 1'b0;
+        if (pwrup_timer_cnt_q != cfg_pwrup_time_i) begin
           pwrup_timer_cnt_en = 1'b1;
         end
-        else if (pwrup_timer_cnt_q == cfg_pwrup_time) begin
+        else if (pwrup_timer_cnt_q == cfg_pwrup_time_i) begin
           pwrup_timer_cnt_clr = 1'b1;
           fsm_state_d = IDLE;
         end
       end
 
       IDLE: begin
-        adc_pd = 1'b0;
-        if (cfg_oneshot_mode) begin
+        adc_pd_o = 1'b0;
+        if (cfg_oneshot_mode_i) begin
           fsm_state_d = ONEST_0;
         end
-        else if (cfg_lp_mode) begin
+        else if (cfg_lp_mode_i) begin
           fsm_state_d = LP_0;
         end
-        else if (!cfg_lp_mode) begin
+        else if (!cfg_lp_mode_i) begin
           fsm_state_d = NP_0;
         end
       end
 
       ONEST_0: begin
-        adc_pd = 1'b0;
-        adc_chn_sel = 2'b01;
-        if (adc_d_val) begin//sample chn0 value
+        adc_pd_o = 1'b0;
+        adc_chn_sel_o = 2'b01;
+        if (adc_d_val_i) begin//sample chn0 value
           fsm_state_d = ONEST_021;
         end
       end
 
-      ONEST_021: begin//transition betwenn chn0 and chn1; adc_chn_sel=2'b0
-        adc_pd = 1'b0;
+      ONEST_021: begin//transition betwenn chn0 and chn1; adc_chn_sel_o=2'b0
+        adc_pd_o = 1'b0;
         fsm_state_d = ONEST_1;
       end
 
       ONEST_1: begin
-        adc_pd = 1'b0;
-        adc_chn_sel = 2'b10;
-        if (adc_d_val) begin//sample chn1 value
-          oneshot_done = 1'b1;
+        adc_pd_o = 1'b0;
+        adc_chn_sel_o = 2'b10;
+        if (adc_d_val_i) begin//sample chn1 value
+          oneshot_done_o = 1'b1;
           fsm_state_d = PWRDN;
         end
       end
 
       LP_0: begin
-        adc_pd = 1'b0;
-        adc_chn_sel = 2'b01;
-        if (adc_d_val) begin//sample chn0 value
+        adc_pd_o = 1'b0;
+        adc_chn_sel_o = 2'b01;
+        if (adc_d_val_i) begin//sample chn0 value
           fsm_state_d = LP_021;
         end
       end
 
-      LP_021: begin//transition betwenn chn0 and chn1; adc_chn_sel=2'b0
-        adc_pd = 1'b0;
+      LP_021: begin//transition betwenn chn0 and chn1; adc_chn_sel_o=2'b0
+        adc_pd_o = 1'b0;
         fsm_state_d = LP_1;
       end
 
       LP_1: begin
-        adc_pd = 1'b0;
-        adc_chn_sel = 2'b10;
-        if (adc_d_val) begin//sample chn1 value
+        adc_pd_o = 1'b0;
+        adc_chn_sel_o = 2'b10;
+        if (adc_d_val_i) begin//sample chn1 value
           fsm_state_d = LP_EVAL;
           lp_sample_cnt_en = 1'b1;
         end
       end
 
       LP_EVAL: begin
-        adc_pd = 1'b0;
-        if ((lp_sample_cnt_q != cfg_lp_sample_cnt) && (stay_match == 1'b1)) begin
+        adc_pd_o = 1'b0;
+        if ((lp_sample_cnt_q != cfg_lp_sample_cnt_i) && (stay_match == 1'b1)) begin
           fsm_state_d = LP_SLP;
         end
-        else if ((lp_sample_cnt_q != cfg_lp_sample_cnt) && (stay_match != 1'b1)) begin
+        else if ((lp_sample_cnt_q != cfg_lp_sample_cnt_i) && (stay_match != 1'b1)) begin
           fsm_state_d = LP_SLP;
           lp_sample_cnt_clr = 1'b1;
         end
-        else if ((lp_sample_cnt_q == cfg_lp_sample_cnt) && (stay_match == 1'b1)) begin
+        else if ((lp_sample_cnt_q == cfg_lp_sample_cnt_i) && (stay_match == 1'b1)) begin
           fsm_state_d = NP_0;
           lp_sample_cnt_clr = 1'b1;
         end
       end
 
       LP_SLP: begin
-        adc_pd = 1'b1;
-        if (wakeup_timer_cnt_q  != cfg_wakeup_time) begin
+        adc_pd_o = 1'b1;
+        if (wakeup_timer_cnt_q  != cfg_wakeup_time_i) begin
           wakeup_timer_cnt_en = 1'b1;
         end
-        else if (wakeup_timer_cnt_q == cfg_wakeup_time) begin
+        else if (wakeup_timer_cnt_q == cfg_wakeup_time_i) begin
           fsm_state_d = LP_PWRUP;
           wakeup_timer_cnt_clr = 1'b1;
         end
       end
 
       LP_PWRUP: begin
-        adc_pd = 1'b0;
-        if (pwrup_timer_cnt_q != cfg_pwrup_time) begin
+        adc_pd_o = 1'b0;
+        if (pwrup_timer_cnt_q != cfg_pwrup_time_i) begin
           pwrup_timer_cnt_en = 1'b1;
         end
-        else if (pwrup_timer_cnt_q == cfg_pwrup_time) begin
+        else if (pwrup_timer_cnt_q == cfg_pwrup_time_i) begin
           pwrup_timer_cnt_clr = 1'b1;
           fsm_state_d = LP_0;
         end
       end
 
       NP_0: begin
-        adc_pd = 1'b0;
-        adc_chn_sel = 2'b01;
-        if (adc_d_val) begin//sample chn0 value
+        adc_pd_o = 1'b0;
+        adc_chn_sel_o = 2'b01;
+        if (adc_d_val_i) begin//sample chn0 value
           fsm_state_d = NP_021;
         end
       end
 
-      NP_021: begin//transition betwenn chn0 and chn1; adc_chn_sel=2'b0
-        adc_pd = 1'b0;
+      NP_021: begin//transition betwenn chn0 and chn1; adc_chn_sel_o=2'b0
+        adc_pd_o = 1'b0;
         fsm_state_d = NP_1;
       end
 
       NP_1: begin
-        adc_pd = 1'b0;
-        adc_chn_sel = 2'b10;
-        if (adc_d_val) begin//sample chn1 value
+        adc_pd_o = 1'b0;
+        adc_chn_sel_o = 2'b10;
+        if (adc_d_val_i) begin//sample chn1 value
           fsm_state_d = NP_EVAL;
           np_sample_cnt_en = 1'b1;
         end
       end
 
       NP_EVAL: begin
-        adc_pd = 1'b0;
-        if ((np_sample_cnt_q != cfg_np_sample_cnt) && (stay_match == 1'b1)) begin
+        adc_pd_o = 1'b0;
+        if ((np_sample_cnt_q != cfg_np_sample_cnt_i) && (stay_match == 1'b1)) begin
           fsm_state_d = NP_0;
         end
-        else if ((np_sample_cnt_q != cfg_np_sample_cnt) && (stay_match != 1'b1)) begin
+        else if ((np_sample_cnt_q != cfg_np_sample_cnt_i) && (stay_match != 1'b1)) begin
           fsm_state_d = NP_0;
           np_sample_cnt_clr = 1'b1;
         end
-        else if ((np_sample_cnt_q == cfg_np_sample_cnt) && (stay_match == 1'b1)) begin
+        else if ((np_sample_cnt_q == cfg_np_sample_cnt_i) && (stay_match == 1'b1)) begin
           fsm_state_d = NP_0;
           np_sample_cnt_clr = 1'b1;
-          adc_ctrl_done = 1'b1;
+          adc_ctrl_done_o = 1'b1;
         end
       end
 

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_intr.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_intr.sv
@@ -7,14 +7,10 @@
 module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
   input  clk_i,
   input  rst_ni,
-  input  clk_aon_i,
-  input  rst_slow_ni,
 
-  input  [NumAdcFilter-1:0] cfg_wakeup_en,
-  input  [NumAdcFilter-1:0] cfg_intr_en,
-  input  cfg_oneshot_intr_en,
-  input  [NumAdcFilter-1:0] adc_ctrl_match_pulse,
-  input  cfg_oneshot_done,
+  input  [NumAdcFilter-1:0] aon_filter_status_i,
+  input  [8:0] cfg_intr_en_i,
+  input  cfg_oneshot_done_i,
 
   input  adc_ctrl_reg2hw_intr_state_reg_t intr_state_i,
   input  adc_ctrl_reg2hw_intr_enable_reg_t intr_enable_i,
@@ -22,98 +18,47 @@ module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
 
   output adc_ctrl_hw2reg_intr_state_reg_t intr_state_o,
   output adc_ctrl_hw2reg_adc_intr_status_reg_t adc_intr_status_o,
-  output adc_ctrl_hw2reg_adc_wakeup_status_reg_t adc_wakeup_status_o,
 
-  output debug_cable_wakeup_o,
   output intr_debug_cable_o
 );
 
-  logic [NumAdcFilter-1:0] cfg_adc_ctrl_match_done;
-  logic adc_ctrl_event;
+  // synchronize status into appropriate interrupts
+  logic [NumAdcFilter-1:0] cfg_filter_status;
+  logic [NumAdcFilter-1:0] filter_match_event;
+  for (genvar i = 0; i < NumAdcFilter; i++) begin : gen_filter_status_sync
+    prim_flop_2sync #(
+      .Width(1),
+      .ResetValue('0)
+    ) u_sync (
+      .clk_i,
+      .rst_ni,
+      .d_i(aon_filter_status_i[i]),
+      .q_o(cfg_filter_status[i])
+    );
 
-  //Synchronize from 200KHz always-onclock to 24MHz cfg clock
-  prim_pulse_sync i_cc_sink_det (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[0]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[0])
-  );
+    logic cfg_filter_status_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        cfg_filter_status_q <= '0;
+      end else begin
+        cfg_filter_status_q <= cfg_filter_status[i];
+      end
+    end
 
-  prim_pulse_sync i_cc_1a5_sink_det (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[1]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[1])
-  );
-
-  prim_pulse_sync i_cc_3a0_sink_det (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[2]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[2])
-  );
-
-  prim_pulse_sync i_cc_src_det (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[3]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[3])
-  );
-
-  prim_pulse_sync i_cc_1a5_src_det (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[4]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[4])
-  );
-
-  prim_pulse_sync i_cc_src_det_flip (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[5]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[5])
-  );
-
-  prim_pulse_sync i_cc_1a5_src_det_flip (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[6]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[6])
-  );
-
-  prim_pulse_sync i_cc_discon (
-    .clk_src_i   (clk_aon_i),
-    .clk_dst_i   (clk_i),
-    .rst_src_ni  (rst_slow_ni),
-    .rst_dst_ni  (rst_ni),
-    .src_pulse_i (adc_ctrl_match_pulse[7]),
-    .dst_pulse_o (cfg_adc_ctrl_match_done[7])
-  );
+    // rising detection is captured as interrupt
+    assign filter_match_event[i] = cfg_filter_status[i] & ~cfg_filter_status_q;
+  end
 
   //To write into interrupt status register
-  assign adc_intr_status_o.cc_sink_det.de = cfg_adc_ctrl_match_done[0];
-  assign adc_intr_status_o.cc_1a5_sink_det.de = cfg_adc_ctrl_match_done[1];
-  assign adc_intr_status_o.cc_3a0_sink_det.de = cfg_adc_ctrl_match_done[2];
-  assign adc_intr_status_o.cc_src_det.de = cfg_adc_ctrl_match_done[3];
-  assign adc_intr_status_o.cc_1a5_src_det.de = cfg_adc_ctrl_match_done[4];
-  assign adc_intr_status_o.cc_src_det_flip.de = cfg_adc_ctrl_match_done[5];
-  assign adc_intr_status_o.cc_1a5_src_det_flip.de = cfg_adc_ctrl_match_done[6];
-  assign adc_intr_status_o.cc_discon.de = cfg_adc_ctrl_match_done[7];
-  assign adc_intr_status_o.oneshot.de = cfg_oneshot_done;
+  assign adc_intr_status_o.cc_sink_det.de = filter_match_event[0];
+  assign adc_intr_status_o.cc_1a5_sink_det.de = filter_match_event[1];
+  assign adc_intr_status_o.cc_3a0_sink_det.de = filter_match_event[2];
+  assign adc_intr_status_o.cc_src_det.de = filter_match_event[3];
+  assign adc_intr_status_o.cc_1a5_src_det.de = filter_match_event[4];
+  assign adc_intr_status_o.cc_src_det_flip.de = filter_match_event[5];
+  assign adc_intr_status_o.cc_1a5_src_det_flip.de = filter_match_event[6];
+  assign adc_intr_status_o.cc_discon.de = filter_match_event[7];
+  assign adc_intr_status_o.oneshot.de = cfg_oneshot_done_i;
 
   assign adc_intr_status_o.cc_sink_det.d = 1'b1;
   assign adc_intr_status_o.cc_1a5_sink_det.d = 1'b1;
@@ -126,8 +71,10 @@ module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
   assign adc_intr_status_o.oneshot.d = 1'b1;
 
   //Qualify each bit with intr_en
-  assign adc_ctrl_event = (|(cfg_adc_ctrl_match_done & cfg_intr_en)) ||
-         (cfg_oneshot_done & cfg_oneshot_intr_en);
+  logic [8:0] intr_events;
+  logic adc_ctrl_event;
+  assign intr_events = {cfg_oneshot_done_i, filter_match_event};
+  assign adc_ctrl_event = |(intr_events & cfg_intr_en_i);
 
   // instantiate interrupt hardware primitive
   prim_intr_hw #(.Width(1)) i_adc_ctrl_intr_o (
@@ -142,27 +89,5 @@ module adc_ctrl_intr import adc_ctrl_reg_pkg::*; (
     .hw2reg_intr_state_d_o  (intr_state_o.d),
     .intr_o                 (intr_debug_cable_o)
   );
-
-  //To write into wakeup status register
-  assign adc_wakeup_status_o.cc_sink_det.de = cfg_adc_ctrl_match_done[0];
-  assign adc_wakeup_status_o.cc_1a5_sink_det.de = cfg_adc_ctrl_match_done[1];
-  assign adc_wakeup_status_o.cc_3a0_sink_det.de = cfg_adc_ctrl_match_done[2];
-  assign adc_wakeup_status_o.cc_src_det.de = cfg_adc_ctrl_match_done[3];
-  assign adc_wakeup_status_o.cc_1a5_src_det.de = cfg_adc_ctrl_match_done[4];
-  assign adc_wakeup_status_o.cc_src_det_flip.de = cfg_adc_ctrl_match_done[5];
-  assign adc_wakeup_status_o.cc_1a5_src_det_flip.de = cfg_adc_ctrl_match_done[6];
-  assign adc_wakeup_status_o.cc_discon.de = cfg_adc_ctrl_match_done[7];
-
-  assign adc_wakeup_status_o.cc_sink_det.d = 1'b1;
-  assign adc_wakeup_status_o.cc_1a5_sink_det.d = 1'b1;
-  assign adc_wakeup_status_o.cc_3a0_sink_det.d = 1'b1;
-  assign adc_wakeup_status_o.cc_src_det.d = 1'b1;
-  assign adc_wakeup_status_o.cc_1a5_src_det.d = 1'b1;
-  assign adc_wakeup_status_o.cc_src_det_flip.d = 1'b1;
-  assign adc_wakeup_status_o.cc_1a5_src_det_flip.d = 1'b1;
-  assign adc_wakeup_status_o.cc_discon.d = 1'b1;
-
-  //Qualify each bit with wakeup_en
-  assign debug_cable_wakeup_o = |(cfg_adc_ctrl_match_done & cfg_wakeup_en);
 
 endmodule

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_pkg.sv
@@ -48,26 +48,21 @@ package adc_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-      logic        qe;
     } lp_mode;
     struct packed {
       logic [3:0]  q;
-      logic        qe;
     } pwrup_time;
     struct packed {
       logic [23:0] q;
-      logic        qe;
     } wakeup_time;
   } adc_ctrl_reg2hw_adc_pd_ctl_reg_t;
 
   typedef struct packed {
     logic [7:0]  q;
-    logic        qe;
   } adc_ctrl_reg2hw_adc_lp_sample_ctl_reg_t;
 
   typedef struct packed {
     logic [15:0] q;
-    logic        qe;
   } adc_ctrl_reg2hw_adc_sample_ctl_reg_t;
 
   typedef struct packed {
@@ -77,88 +72,43 @@ package adc_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [9:0] q;
-      logic        qe;
     } min_v;
     struct packed {
       logic        q;
-      logic        qe;
     } cond;
     struct packed {
       logic [9:0] q;
-      logic        qe;
     } max_v;
+    struct packed {
+      logic        q;
+    } en;
   } adc_ctrl_reg2hw_adc_chn0_filter_ctl_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic [9:0] q;
-      logic        qe;
     } min_v;
     struct packed {
       logic        q;
-      logic        qe;
     } cond;
     struct packed {
       logic [9:0] q;
-      logic        qe;
     } max_v;
+    struct packed {
+      logic        q;
+    } en;
   } adc_ctrl_reg2hw_adc_chn1_filter_ctl_mreg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } chn0_1_filter0_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter1_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter2_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter3_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter4_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter5_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter6_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter7_en;
+    logic [7:0]  q;
   } adc_ctrl_reg2hw_adc_wakeup_ctl_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } chn0_1_filter0_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter1_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter2_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter3_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter4_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter5_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter6_en;
-    struct packed {
-      logic        q;
-    } chn0_1_filter7_en;
-    struct packed {
-      logic        q;
-    } oneshot_intr_en;
+    logic [7:0]  q;
+  } adc_ctrl_reg2hw_filter_status_reg_t;
+
+  typedef struct packed {
+    logic [8:0]  q;
   } adc_ctrl_reg2hw_adc_intr_ctl_reg_t;
 
   typedef struct packed {
@@ -186,39 +136,9 @@ package adc_ctrl_reg_pkg;
   } adc_ctrl_hw2reg_adc_chn_val_mreg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_sink_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_1a5_sink_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_3a0_sink_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_src_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_1a5_src_det;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_src_det_flip;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_1a5_src_det_flip;
-    struct packed {
-      logic        d;
-      logic        de;
-    } cc_discon;
-  } adc_ctrl_hw2reg_adc_wakeup_status_reg_t;
+    logic [7:0]  d;
+    logic        de;
+  } adc_ctrl_hw2reg_filter_status_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -261,26 +181,27 @@ package adc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    adc_ctrl_reg2hw_intr_state_reg_t intr_state; // [467:467]
-    adc_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [466:466]
-    adc_ctrl_reg2hw_intr_test_reg_t intr_test; // [465:464]
-    adc_ctrl_reg2hw_alert_test_reg_t alert_test; // [463:462]
-    adc_ctrl_reg2hw_adc_en_ctl_reg_t adc_en_ctl; // [461:460]
-    adc_ctrl_reg2hw_adc_pd_ctl_reg_t adc_pd_ctl; // [459:428]
-    adc_ctrl_reg2hw_adc_lp_sample_ctl_reg_t adc_lp_sample_ctl; // [427:419]
-    adc_ctrl_reg2hw_adc_sample_ctl_reg_t adc_sample_ctl; // [418:402]
-    adc_ctrl_reg2hw_adc_fsm_rst_reg_t adc_fsm_rst; // [401:401]
-    adc_ctrl_reg2hw_adc_chn0_filter_ctl_mreg_t [7:0] adc_chn0_filter_ctl; // [400:209]
-    adc_ctrl_reg2hw_adc_chn1_filter_ctl_mreg_t [7:0] adc_chn1_filter_ctl; // [208:17]
-    adc_ctrl_reg2hw_adc_wakeup_ctl_reg_t adc_wakeup_ctl; // [16:9]
+    adc_ctrl_reg2hw_intr_state_reg_t intr_state; // [438:438]
+    adc_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [437:437]
+    adc_ctrl_reg2hw_intr_test_reg_t intr_test; // [436:435]
+    adc_ctrl_reg2hw_alert_test_reg_t alert_test; // [434:433]
+    adc_ctrl_reg2hw_adc_en_ctl_reg_t adc_en_ctl; // [432:431]
+    adc_ctrl_reg2hw_adc_pd_ctl_reg_t adc_pd_ctl; // [430:402]
+    adc_ctrl_reg2hw_adc_lp_sample_ctl_reg_t adc_lp_sample_ctl; // [401:394]
+    adc_ctrl_reg2hw_adc_sample_ctl_reg_t adc_sample_ctl; // [393:378]
+    adc_ctrl_reg2hw_adc_fsm_rst_reg_t adc_fsm_rst; // [377:377]
+    adc_ctrl_reg2hw_adc_chn0_filter_ctl_mreg_t [7:0] adc_chn0_filter_ctl; // [376:201]
+    adc_ctrl_reg2hw_adc_chn1_filter_ctl_mreg_t [7:0] adc_chn1_filter_ctl; // [200:25]
+    adc_ctrl_reg2hw_adc_wakeup_ctl_reg_t adc_wakeup_ctl; // [24:17]
+    adc_ctrl_reg2hw_filter_status_reg_t filter_status; // [16:9]
     adc_ctrl_reg2hw_adc_intr_ctl_reg_t adc_intr_ctl; // [8:0]
   } adc_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    adc_ctrl_hw2reg_intr_state_reg_t intr_state; // [91:90]
-    adc_ctrl_hw2reg_adc_chn_val_mreg_t [1:0] adc_chn_val; // [89:34]
-    adc_ctrl_hw2reg_adc_wakeup_status_reg_t adc_wakeup_status; // [33:18]
+    adc_ctrl_hw2reg_intr_state_reg_t intr_state; // [84:83]
+    adc_ctrl_hw2reg_adc_chn_val_mreg_t [1:0] adc_chn_val; // [82:27]
+    adc_ctrl_hw2reg_filter_status_reg_t filter_status; // [26:18]
     adc_ctrl_hw2reg_adc_intr_status_reg_t adc_intr_status; // [17:0]
   } adc_ctrl_hw2reg_t;
 
@@ -313,7 +234,7 @@ package adc_ctrl_reg_pkg;
   parameter logic [BlockAw-1:0] ADC_CTRL_ADC_CHN_VAL_0_OFFSET = 7'h 64;
   parameter logic [BlockAw-1:0] ADC_CTRL_ADC_CHN_VAL_1_OFFSET = 7'h 68;
   parameter logic [BlockAw-1:0] ADC_CTRL_ADC_WAKEUP_CTL_OFFSET = 7'h 6c;
-  parameter logic [BlockAw-1:0] ADC_CTRL_ADC_WAKEUP_STATUS_OFFSET = 7'h 70;
+  parameter logic [BlockAw-1:0] ADC_CTRL_FILTER_STATUS_OFFSET = 7'h 70;
   parameter logic [BlockAw-1:0] ADC_CTRL_ADC_INTR_CTL_OFFSET = 7'h 74;
   parameter logic [BlockAw-1:0] ADC_CTRL_ADC_INTR_STATUS_OFFSET = 7'h 78;
 
@@ -353,7 +274,7 @@ package adc_ctrl_reg_pkg;
     ADC_CTRL_ADC_CHN_VAL_0,
     ADC_CTRL_ADC_CHN_VAL_1,
     ADC_CTRL_ADC_WAKEUP_CTL,
-    ADC_CTRL_ADC_WAKEUP_STATUS,
+    ADC_CTRL_FILTER_STATUS,
     ADC_CTRL_ADC_INTR_CTL,
     ADC_CTRL_ADC_INTR_STATUS
   } adc_ctrl_id_e;
@@ -388,7 +309,7 @@ package adc_ctrl_reg_pkg;
     4'b 1111, // index[25] ADC_CTRL_ADC_CHN_VAL_0
     4'b 1111, // index[26] ADC_CTRL_ADC_CHN_VAL_1
     4'b 0001, // index[27] ADC_CTRL_ADC_WAKEUP_CTL
-    4'b 0001, // index[28] ADC_CTRL_ADC_WAKEUP_STATUS
+    4'b 0001, // index[28] ADC_CTRL_FILTER_STATUS
     4'b 0011, // index[29] ADC_CTRL_ADC_INTR_CTL
     4'b 0011  // index[30] ADC_CTRL_ADC_INTR_STATUS
   };

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -9,6 +9,8 @@
 module adc_ctrl_reg_top (
   input clk_i,
   input rst_ni,
+  input clk_aon_i,
+  input rst_aon_ni,
 
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
@@ -102,6 +104,15 @@ module adc_ctrl_reg_top (
   );
 
   // cdc oversampling signals
+    logic sync_aon_update;
+  prim_pulse_sync u_aon_tgl (
+    .clk_src_i(clk_aon_i),
+    .rst_src_ni(rst_aon_ni),
+    .src_pulse_i(1'b1),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(sync_aon_update)
+  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -122,197 +133,267 @@ module adc_ctrl_reg_top (
   logic adc_en_ctl_we;
   logic adc_en_ctl_adc_enable_qs;
   logic adc_en_ctl_adc_enable_wd;
+  logic adc_en_ctl_adc_enable_busy;
   logic adc_en_ctl_oneshot_mode_qs;
   logic adc_en_ctl_oneshot_mode_wd;
+  logic adc_en_ctl_oneshot_mode_busy;
   logic adc_pd_ctl_we;
   logic adc_pd_ctl_lp_mode_qs;
   logic adc_pd_ctl_lp_mode_wd;
+  logic adc_pd_ctl_lp_mode_busy;
   logic [3:0] adc_pd_ctl_pwrup_time_qs;
   logic [3:0] adc_pd_ctl_pwrup_time_wd;
+  logic adc_pd_ctl_pwrup_time_busy;
   logic [23:0] adc_pd_ctl_wakeup_time_qs;
   logic [23:0] adc_pd_ctl_wakeup_time_wd;
+  logic adc_pd_ctl_wakeup_time_busy;
   logic adc_lp_sample_ctl_we;
   logic [7:0] adc_lp_sample_ctl_qs;
   logic [7:0] adc_lp_sample_ctl_wd;
+  logic adc_lp_sample_ctl_busy;
   logic adc_sample_ctl_we;
   logic [15:0] adc_sample_ctl_qs;
   logic [15:0] adc_sample_ctl_wd;
+  logic adc_sample_ctl_busy;
   logic adc_fsm_rst_we;
   logic adc_fsm_rst_qs;
   logic adc_fsm_rst_wd;
+  logic adc_fsm_rst_busy;
   logic adc_chn0_filter_ctl_0_we;
   logic [9:0] adc_chn0_filter_ctl_0_min_v_0_qs;
   logic [9:0] adc_chn0_filter_ctl_0_min_v_0_wd;
+  logic adc_chn0_filter_ctl_0_min_v_0_busy;
   logic adc_chn0_filter_ctl_0_cond_0_qs;
   logic adc_chn0_filter_ctl_0_cond_0_wd;
+  logic adc_chn0_filter_ctl_0_cond_0_busy;
   logic [9:0] adc_chn0_filter_ctl_0_max_v_0_qs;
   logic [9:0] adc_chn0_filter_ctl_0_max_v_0_wd;
+  logic adc_chn0_filter_ctl_0_max_v_0_busy;
+  logic adc_chn0_filter_ctl_0_en_0_qs;
+  logic adc_chn0_filter_ctl_0_en_0_wd;
+  logic adc_chn0_filter_ctl_0_en_0_busy;
   logic adc_chn0_filter_ctl_1_we;
   logic [9:0] adc_chn0_filter_ctl_1_min_v_1_qs;
   logic [9:0] adc_chn0_filter_ctl_1_min_v_1_wd;
+  logic adc_chn0_filter_ctl_1_min_v_1_busy;
   logic adc_chn0_filter_ctl_1_cond_1_qs;
   logic adc_chn0_filter_ctl_1_cond_1_wd;
+  logic adc_chn0_filter_ctl_1_cond_1_busy;
   logic [9:0] adc_chn0_filter_ctl_1_max_v_1_qs;
   logic [9:0] adc_chn0_filter_ctl_1_max_v_1_wd;
+  logic adc_chn0_filter_ctl_1_max_v_1_busy;
+  logic adc_chn0_filter_ctl_1_en_1_qs;
+  logic adc_chn0_filter_ctl_1_en_1_wd;
+  logic adc_chn0_filter_ctl_1_en_1_busy;
   logic adc_chn0_filter_ctl_2_we;
   logic [9:0] adc_chn0_filter_ctl_2_min_v_2_qs;
   logic [9:0] adc_chn0_filter_ctl_2_min_v_2_wd;
+  logic adc_chn0_filter_ctl_2_min_v_2_busy;
   logic adc_chn0_filter_ctl_2_cond_2_qs;
   logic adc_chn0_filter_ctl_2_cond_2_wd;
+  logic adc_chn0_filter_ctl_2_cond_2_busy;
   logic [9:0] adc_chn0_filter_ctl_2_max_v_2_qs;
   logic [9:0] adc_chn0_filter_ctl_2_max_v_2_wd;
+  logic adc_chn0_filter_ctl_2_max_v_2_busy;
+  logic adc_chn0_filter_ctl_2_en_2_qs;
+  logic adc_chn0_filter_ctl_2_en_2_wd;
+  logic adc_chn0_filter_ctl_2_en_2_busy;
   logic adc_chn0_filter_ctl_3_we;
   logic [9:0] adc_chn0_filter_ctl_3_min_v_3_qs;
   logic [9:0] adc_chn0_filter_ctl_3_min_v_3_wd;
+  logic adc_chn0_filter_ctl_3_min_v_3_busy;
   logic adc_chn0_filter_ctl_3_cond_3_qs;
   logic adc_chn0_filter_ctl_3_cond_3_wd;
+  logic adc_chn0_filter_ctl_3_cond_3_busy;
   logic [9:0] adc_chn0_filter_ctl_3_max_v_3_qs;
   logic [9:0] adc_chn0_filter_ctl_3_max_v_3_wd;
+  logic adc_chn0_filter_ctl_3_max_v_3_busy;
+  logic adc_chn0_filter_ctl_3_en_3_qs;
+  logic adc_chn0_filter_ctl_3_en_3_wd;
+  logic adc_chn0_filter_ctl_3_en_3_busy;
   logic adc_chn0_filter_ctl_4_we;
   logic [9:0] adc_chn0_filter_ctl_4_min_v_4_qs;
   logic [9:0] adc_chn0_filter_ctl_4_min_v_4_wd;
+  logic adc_chn0_filter_ctl_4_min_v_4_busy;
   logic adc_chn0_filter_ctl_4_cond_4_qs;
   logic adc_chn0_filter_ctl_4_cond_4_wd;
+  logic adc_chn0_filter_ctl_4_cond_4_busy;
   logic [9:0] adc_chn0_filter_ctl_4_max_v_4_qs;
   logic [9:0] adc_chn0_filter_ctl_4_max_v_4_wd;
+  logic adc_chn0_filter_ctl_4_max_v_4_busy;
+  logic adc_chn0_filter_ctl_4_en_4_qs;
+  logic adc_chn0_filter_ctl_4_en_4_wd;
+  logic adc_chn0_filter_ctl_4_en_4_busy;
   logic adc_chn0_filter_ctl_5_we;
   logic [9:0] adc_chn0_filter_ctl_5_min_v_5_qs;
   logic [9:0] adc_chn0_filter_ctl_5_min_v_5_wd;
+  logic adc_chn0_filter_ctl_5_min_v_5_busy;
   logic adc_chn0_filter_ctl_5_cond_5_qs;
   logic adc_chn0_filter_ctl_5_cond_5_wd;
+  logic adc_chn0_filter_ctl_5_cond_5_busy;
   logic [9:0] adc_chn0_filter_ctl_5_max_v_5_qs;
   logic [9:0] adc_chn0_filter_ctl_5_max_v_5_wd;
+  logic adc_chn0_filter_ctl_5_max_v_5_busy;
+  logic adc_chn0_filter_ctl_5_en_5_qs;
+  logic adc_chn0_filter_ctl_5_en_5_wd;
+  logic adc_chn0_filter_ctl_5_en_5_busy;
   logic adc_chn0_filter_ctl_6_we;
   logic [9:0] adc_chn0_filter_ctl_6_min_v_6_qs;
   logic [9:0] adc_chn0_filter_ctl_6_min_v_6_wd;
+  logic adc_chn0_filter_ctl_6_min_v_6_busy;
   logic adc_chn0_filter_ctl_6_cond_6_qs;
   logic adc_chn0_filter_ctl_6_cond_6_wd;
+  logic adc_chn0_filter_ctl_6_cond_6_busy;
   logic [9:0] adc_chn0_filter_ctl_6_max_v_6_qs;
   logic [9:0] adc_chn0_filter_ctl_6_max_v_6_wd;
+  logic adc_chn0_filter_ctl_6_max_v_6_busy;
+  logic adc_chn0_filter_ctl_6_en_6_qs;
+  logic adc_chn0_filter_ctl_6_en_6_wd;
+  logic adc_chn0_filter_ctl_6_en_6_busy;
   logic adc_chn0_filter_ctl_7_we;
   logic [9:0] adc_chn0_filter_ctl_7_min_v_7_qs;
   logic [9:0] adc_chn0_filter_ctl_7_min_v_7_wd;
+  logic adc_chn0_filter_ctl_7_min_v_7_busy;
   logic adc_chn0_filter_ctl_7_cond_7_qs;
   logic adc_chn0_filter_ctl_7_cond_7_wd;
+  logic adc_chn0_filter_ctl_7_cond_7_busy;
   logic [9:0] adc_chn0_filter_ctl_7_max_v_7_qs;
   logic [9:0] adc_chn0_filter_ctl_7_max_v_7_wd;
+  logic adc_chn0_filter_ctl_7_max_v_7_busy;
+  logic adc_chn0_filter_ctl_7_en_7_qs;
+  logic adc_chn0_filter_ctl_7_en_7_wd;
+  logic adc_chn0_filter_ctl_7_en_7_busy;
   logic adc_chn1_filter_ctl_0_we;
   logic [9:0] adc_chn1_filter_ctl_0_min_v_0_qs;
   logic [9:0] adc_chn1_filter_ctl_0_min_v_0_wd;
+  logic adc_chn1_filter_ctl_0_min_v_0_busy;
   logic adc_chn1_filter_ctl_0_cond_0_qs;
   logic adc_chn1_filter_ctl_0_cond_0_wd;
+  logic adc_chn1_filter_ctl_0_cond_0_busy;
   logic [9:0] adc_chn1_filter_ctl_0_max_v_0_qs;
   logic [9:0] adc_chn1_filter_ctl_0_max_v_0_wd;
+  logic adc_chn1_filter_ctl_0_max_v_0_busy;
+  logic adc_chn1_filter_ctl_0_en_0_qs;
+  logic adc_chn1_filter_ctl_0_en_0_wd;
+  logic adc_chn1_filter_ctl_0_en_0_busy;
   logic adc_chn1_filter_ctl_1_we;
   logic [9:0] adc_chn1_filter_ctl_1_min_v_1_qs;
   logic [9:0] adc_chn1_filter_ctl_1_min_v_1_wd;
+  logic adc_chn1_filter_ctl_1_min_v_1_busy;
   logic adc_chn1_filter_ctl_1_cond_1_qs;
   logic adc_chn1_filter_ctl_1_cond_1_wd;
+  logic adc_chn1_filter_ctl_1_cond_1_busy;
   logic [9:0] adc_chn1_filter_ctl_1_max_v_1_qs;
   logic [9:0] adc_chn1_filter_ctl_1_max_v_1_wd;
+  logic adc_chn1_filter_ctl_1_max_v_1_busy;
+  logic adc_chn1_filter_ctl_1_en_1_qs;
+  logic adc_chn1_filter_ctl_1_en_1_wd;
+  logic adc_chn1_filter_ctl_1_en_1_busy;
   logic adc_chn1_filter_ctl_2_we;
   logic [9:0] adc_chn1_filter_ctl_2_min_v_2_qs;
   logic [9:0] adc_chn1_filter_ctl_2_min_v_2_wd;
+  logic adc_chn1_filter_ctl_2_min_v_2_busy;
   logic adc_chn1_filter_ctl_2_cond_2_qs;
   logic adc_chn1_filter_ctl_2_cond_2_wd;
+  logic adc_chn1_filter_ctl_2_cond_2_busy;
   logic [9:0] adc_chn1_filter_ctl_2_max_v_2_qs;
   logic [9:0] adc_chn1_filter_ctl_2_max_v_2_wd;
+  logic adc_chn1_filter_ctl_2_max_v_2_busy;
+  logic adc_chn1_filter_ctl_2_en_2_qs;
+  logic adc_chn1_filter_ctl_2_en_2_wd;
+  logic adc_chn1_filter_ctl_2_en_2_busy;
   logic adc_chn1_filter_ctl_3_we;
   logic [9:0] adc_chn1_filter_ctl_3_min_v_3_qs;
   logic [9:0] adc_chn1_filter_ctl_3_min_v_3_wd;
+  logic adc_chn1_filter_ctl_3_min_v_3_busy;
   logic adc_chn1_filter_ctl_3_cond_3_qs;
   logic adc_chn1_filter_ctl_3_cond_3_wd;
+  logic adc_chn1_filter_ctl_3_cond_3_busy;
   logic [9:0] adc_chn1_filter_ctl_3_max_v_3_qs;
   logic [9:0] adc_chn1_filter_ctl_3_max_v_3_wd;
+  logic adc_chn1_filter_ctl_3_max_v_3_busy;
+  logic adc_chn1_filter_ctl_3_en_3_qs;
+  logic adc_chn1_filter_ctl_3_en_3_wd;
+  logic adc_chn1_filter_ctl_3_en_3_busy;
   logic adc_chn1_filter_ctl_4_we;
   logic [9:0] adc_chn1_filter_ctl_4_min_v_4_qs;
   logic [9:0] adc_chn1_filter_ctl_4_min_v_4_wd;
+  logic adc_chn1_filter_ctl_4_min_v_4_busy;
   logic adc_chn1_filter_ctl_4_cond_4_qs;
   logic adc_chn1_filter_ctl_4_cond_4_wd;
+  logic adc_chn1_filter_ctl_4_cond_4_busy;
   logic [9:0] adc_chn1_filter_ctl_4_max_v_4_qs;
   logic [9:0] adc_chn1_filter_ctl_4_max_v_4_wd;
+  logic adc_chn1_filter_ctl_4_max_v_4_busy;
+  logic adc_chn1_filter_ctl_4_en_4_qs;
+  logic adc_chn1_filter_ctl_4_en_4_wd;
+  logic adc_chn1_filter_ctl_4_en_4_busy;
   logic adc_chn1_filter_ctl_5_we;
   logic [9:0] adc_chn1_filter_ctl_5_min_v_5_qs;
   logic [9:0] adc_chn1_filter_ctl_5_min_v_5_wd;
+  logic adc_chn1_filter_ctl_5_min_v_5_busy;
   logic adc_chn1_filter_ctl_5_cond_5_qs;
   logic adc_chn1_filter_ctl_5_cond_5_wd;
+  logic adc_chn1_filter_ctl_5_cond_5_busy;
   logic [9:0] adc_chn1_filter_ctl_5_max_v_5_qs;
   logic [9:0] adc_chn1_filter_ctl_5_max_v_5_wd;
+  logic adc_chn1_filter_ctl_5_max_v_5_busy;
+  logic adc_chn1_filter_ctl_5_en_5_qs;
+  logic adc_chn1_filter_ctl_5_en_5_wd;
+  logic adc_chn1_filter_ctl_5_en_5_busy;
   logic adc_chn1_filter_ctl_6_we;
   logic [9:0] adc_chn1_filter_ctl_6_min_v_6_qs;
   logic [9:0] adc_chn1_filter_ctl_6_min_v_6_wd;
+  logic adc_chn1_filter_ctl_6_min_v_6_busy;
   logic adc_chn1_filter_ctl_6_cond_6_qs;
   logic adc_chn1_filter_ctl_6_cond_6_wd;
+  logic adc_chn1_filter_ctl_6_cond_6_busy;
   logic [9:0] adc_chn1_filter_ctl_6_max_v_6_qs;
   logic [9:0] adc_chn1_filter_ctl_6_max_v_6_wd;
+  logic adc_chn1_filter_ctl_6_max_v_6_busy;
+  logic adc_chn1_filter_ctl_6_en_6_qs;
+  logic adc_chn1_filter_ctl_6_en_6_wd;
+  logic adc_chn1_filter_ctl_6_en_6_busy;
   logic adc_chn1_filter_ctl_7_we;
   logic [9:0] adc_chn1_filter_ctl_7_min_v_7_qs;
   logic [9:0] adc_chn1_filter_ctl_7_min_v_7_wd;
+  logic adc_chn1_filter_ctl_7_min_v_7_busy;
   logic adc_chn1_filter_ctl_7_cond_7_qs;
   logic adc_chn1_filter_ctl_7_cond_7_wd;
+  logic adc_chn1_filter_ctl_7_cond_7_busy;
   logic [9:0] adc_chn1_filter_ctl_7_max_v_7_qs;
   logic [9:0] adc_chn1_filter_ctl_7_max_v_7_wd;
+  logic adc_chn1_filter_ctl_7_max_v_7_busy;
+  logic adc_chn1_filter_ctl_7_en_7_qs;
+  logic adc_chn1_filter_ctl_7_en_7_wd;
+  logic adc_chn1_filter_ctl_7_en_7_busy;
   logic [1:0] adc_chn_val_0_adc_chn_value_ext_0_qs;
+  logic adc_chn_val_0_adc_chn_value_ext_0_busy;
   logic [9:0] adc_chn_val_0_adc_chn_value_0_qs;
+  logic adc_chn_val_0_adc_chn_value_0_busy;
   logic [1:0] adc_chn_val_0_adc_chn_value_intr_ext_0_qs;
+  logic adc_chn_val_0_adc_chn_value_intr_ext_0_busy;
   logic [9:0] adc_chn_val_0_adc_chn_value_intr_0_qs;
+  logic adc_chn_val_0_adc_chn_value_intr_0_busy;
   logic [1:0] adc_chn_val_1_adc_chn_value_ext_1_qs;
+  logic adc_chn_val_1_adc_chn_value_ext_1_busy;
   logic [9:0] adc_chn_val_1_adc_chn_value_1_qs;
+  logic adc_chn_val_1_adc_chn_value_1_busy;
   logic [1:0] adc_chn_val_1_adc_chn_value_intr_ext_1_qs;
+  logic adc_chn_val_1_adc_chn_value_intr_ext_1_busy;
   logic [9:0] adc_chn_val_1_adc_chn_value_intr_1_qs;
+  logic adc_chn_val_1_adc_chn_value_intr_1_busy;
   logic adc_wakeup_ctl_we;
-  logic adc_wakeup_ctl_chn0_1_filter0_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter0_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter1_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter1_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter2_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter2_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter3_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter3_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter4_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter4_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter5_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter5_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter6_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter6_en_wd;
-  logic adc_wakeup_ctl_chn0_1_filter7_en_qs;
-  logic adc_wakeup_ctl_chn0_1_filter7_en_wd;
-  logic adc_wakeup_status_we;
-  logic adc_wakeup_status_cc_sink_det_qs;
-  logic adc_wakeup_status_cc_sink_det_wd;
-  logic adc_wakeup_status_cc_1a5_sink_det_qs;
-  logic adc_wakeup_status_cc_1a5_sink_det_wd;
-  logic adc_wakeup_status_cc_3a0_sink_det_qs;
-  logic adc_wakeup_status_cc_3a0_sink_det_wd;
-  logic adc_wakeup_status_cc_src_det_qs;
-  logic adc_wakeup_status_cc_src_det_wd;
-  logic adc_wakeup_status_cc_1a5_src_det_qs;
-  logic adc_wakeup_status_cc_1a5_src_det_wd;
-  logic adc_wakeup_status_cc_src_det_flip_qs;
-  logic adc_wakeup_status_cc_src_det_flip_wd;
-  logic adc_wakeup_status_cc_1a5_src_det_flip_qs;
-  logic adc_wakeup_status_cc_1a5_src_det_flip_wd;
-  logic adc_wakeup_status_cc_discon_qs;
-  logic adc_wakeup_status_cc_discon_wd;
+  logic [7:0] adc_wakeup_ctl_qs;
+  logic [7:0] adc_wakeup_ctl_wd;
+  logic adc_wakeup_ctl_busy;
+  logic filter_status_we;
+  logic [7:0] filter_status_qs;
+  logic [7:0] filter_status_wd;
+  logic filter_status_busy;
   logic adc_intr_ctl_we;
-  logic adc_intr_ctl_chn0_1_filter0_en_qs;
-  logic adc_intr_ctl_chn0_1_filter0_en_wd;
-  logic adc_intr_ctl_chn0_1_filter1_en_qs;
-  logic adc_intr_ctl_chn0_1_filter1_en_wd;
-  logic adc_intr_ctl_chn0_1_filter2_en_qs;
-  logic adc_intr_ctl_chn0_1_filter2_en_wd;
-  logic adc_intr_ctl_chn0_1_filter3_en_qs;
-  logic adc_intr_ctl_chn0_1_filter3_en_wd;
-  logic adc_intr_ctl_chn0_1_filter4_en_qs;
-  logic adc_intr_ctl_chn0_1_filter4_en_wd;
-  logic adc_intr_ctl_chn0_1_filter5_en_qs;
-  logic adc_intr_ctl_chn0_1_filter5_en_wd;
-  logic adc_intr_ctl_chn0_1_filter6_en_qs;
-  logic adc_intr_ctl_chn0_1_filter6_en_wd;
-  logic adc_intr_ctl_chn0_1_filter7_en_qs;
-  logic adc_intr_ctl_chn0_1_filter7_en_wd;
-  logic adc_intr_ctl_oneshot_intr_en_qs;
-  logic adc_intr_ctl_oneshot_intr_en_wd;
+  logic [8:0] adc_intr_ctl_qs;
+  logic [8:0] adc_intr_ctl_wd;
   logic adc_intr_status_we;
   logic adc_intr_status_cc_sink_det_qs;
   logic adc_intr_status_cc_sink_det_wd;
@@ -423,215 +504,183 @@ module adc_ctrl_reg_top (
   // R[adc_en_ctl]: V(False)
 
   //   F[adc_enable]: 0:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_en_ctl_adc_enable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_en_ctl_we),
-    .wd     (adc_en_ctl_adc_enable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_en_ctl.adc_enable.q),
-
-    // to register interface (read)
-    .qs     (adc_en_ctl_adc_enable_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_en_ctl_we),
+    .src_wd_i     (adc_en_ctl_adc_enable_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_en_ctl_adc_enable_busy),
+    .src_qs_o     (adc_en_ctl_adc_enable_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_en_ctl.adc_enable.q)
   );
 
 
   //   F[oneshot_mode]: 1:1
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_en_ctl_oneshot_mode (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_en_ctl_we),
-    .wd     (adc_en_ctl_oneshot_mode_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_en_ctl.oneshot_mode.q),
-
-    // to register interface (read)
-    .qs     (adc_en_ctl_oneshot_mode_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_en_ctl_we),
+    .src_wd_i     (adc_en_ctl_oneshot_mode_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_en_ctl_oneshot_mode_busy),
+    .src_qs_o     (adc_en_ctl_oneshot_mode_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_en_ctl.oneshot_mode.q)
   );
 
 
   // R[adc_pd_ctl]: V(False)
 
   //   F[lp_mode]: 0:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_pd_ctl_lp_mode (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_pd_ctl_we),
-    .wd     (adc_pd_ctl_lp_mode_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_pd_ctl.lp_mode.qe),
-    .q      (reg2hw.adc_pd_ctl.lp_mode.q),
-
-    // to register interface (read)
-    .qs     (adc_pd_ctl_lp_mode_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_pd_ctl_we),
+    .src_wd_i     (adc_pd_ctl_lp_mode_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_pd_ctl_lp_mode_busy),
+    .src_qs_o     (adc_pd_ctl_lp_mode_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_pd_ctl.lp_mode.q)
   );
 
 
   //   F[pwrup_time]: 7:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6)
   ) u_adc_pd_ctl_pwrup_time (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_pd_ctl_we),
-    .wd     (adc_pd_ctl_pwrup_time_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_pd_ctl.pwrup_time.qe),
-    .q      (reg2hw.adc_pd_ctl.pwrup_time.q),
-
-    // to register interface (read)
-    .qs     (adc_pd_ctl_pwrup_time_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_pd_ctl_we),
+    .src_wd_i     (adc_pd_ctl_pwrup_time_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_pd_ctl_pwrup_time_busy),
+    .src_qs_o     (adc_pd_ctl_pwrup_time_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_pd_ctl.pwrup_time.q)
   );
 
 
   //   F[wakeup_time]: 31:8
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (24),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (24'h640)
   ) u_adc_pd_ctl_wakeup_time (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_pd_ctl_we),
-    .wd     (adc_pd_ctl_wakeup_time_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_pd_ctl.wakeup_time.qe),
-    .q      (reg2hw.adc_pd_ctl.wakeup_time.q),
-
-    // to register interface (read)
-    .qs     (adc_pd_ctl_wakeup_time_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_pd_ctl_we),
+    .src_wd_i     (adc_pd_ctl_wakeup_time_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_pd_ctl_wakeup_time_busy),
+    .src_qs_o     (adc_pd_ctl_wakeup_time_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_pd_ctl.wakeup_time.q)
   );
 
 
   // R[adc_lp_sample_ctl]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h4)
   ) u_adc_lp_sample_ctl (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_lp_sample_ctl_we),
-    .wd     (adc_lp_sample_ctl_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_lp_sample_ctl.qe),
-    .q      (reg2hw.adc_lp_sample_ctl.q),
-
-    // to register interface (read)
-    .qs     (adc_lp_sample_ctl_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_lp_sample_ctl_we),
+    .src_wd_i     (adc_lp_sample_ctl_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_lp_sample_ctl_busy),
+    .src_qs_o     (adc_lp_sample_ctl_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_lp_sample_ctl.q)
   );
 
 
   // R[adc_sample_ctl]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h9b)
   ) u_adc_sample_ctl (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_sample_ctl_we),
-    .wd     (adc_sample_ctl_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_sample_ctl.qe),
-    .q      (reg2hw.adc_sample_ctl.q),
-
-    // to register interface (read)
-    .qs     (adc_sample_ctl_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_sample_ctl_we),
+    .src_wd_i     (adc_sample_ctl_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_sample_ctl_busy),
+    .src_qs_o     (adc_sample_ctl_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_sample_ctl.q)
   );
 
 
   // R[adc_fsm_rst]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_fsm_rst (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_fsm_rst_we),
-    .wd     (adc_fsm_rst_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_fsm_rst.q),
-
-    // to register interface (read)
-    .qs     (adc_fsm_rst_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_fsm_rst_we),
+    .src_wd_i     (adc_fsm_rst_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_fsm_rst_busy),
+    .src_qs_o     (adc_fsm_rst_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_fsm_rst.q)
   );
 
 
@@ -640,80 +689,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_0]: V(False)
 
   // F[min_v_0]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_0_min_v_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_0_we),
-    .wd     (adc_chn0_filter_ctl_0_min_v_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[0].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[0].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_0_min_v_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_0_we),
+    .src_wd_i     (adc_chn0_filter_ctl_0_min_v_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_0_min_v_0_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_0_min_v_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[0].min_v.q)
   );
 
 
   // F[cond_0]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_0_cond_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_0_we),
-    .wd     (adc_chn0_filter_ctl_0_cond_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[0].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[0].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_0_cond_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_0_we),
+    .src_wd_i     (adc_chn0_filter_ctl_0_cond_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_0_cond_0_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_0_cond_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[0].cond.q)
   );
 
 
   // F[max_v_0]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_0_max_v_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_0_we),
+    .src_wd_i     (adc_chn0_filter_ctl_0_max_v_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_0_max_v_0_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_0_max_v_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[0].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_0_we),
-    .wd     (adc_chn0_filter_ctl_0_max_v_0_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[0].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[0].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_0_max_v_0_qs)
+  // F[en_0]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_0_en_0 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_0_we),
+    .src_wd_i     (adc_chn0_filter_ctl_0_en_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_0_en_0_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_0_en_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[0].en.q)
   );
 
 
@@ -721,80 +780,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_1]: V(False)
 
   // F[min_v_1]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_1_min_v_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_1_we),
-    .wd     (adc_chn0_filter_ctl_1_min_v_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[1].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[1].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_1_min_v_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_1_we),
+    .src_wd_i     (adc_chn0_filter_ctl_1_min_v_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_1_min_v_1_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_1_min_v_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[1].min_v.q)
   );
 
 
   // F[cond_1]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_1_cond_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_1_we),
-    .wd     (adc_chn0_filter_ctl_1_cond_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[1].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[1].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_1_cond_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_1_we),
+    .src_wd_i     (adc_chn0_filter_ctl_1_cond_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_1_cond_1_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_1_cond_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[1].cond.q)
   );
 
 
   // F[max_v_1]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_1_max_v_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_1_we),
+    .src_wd_i     (adc_chn0_filter_ctl_1_max_v_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_1_max_v_1_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_1_max_v_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[1].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_1_we),
-    .wd     (adc_chn0_filter_ctl_1_max_v_1_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[1].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[1].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_1_max_v_1_qs)
+  // F[en_1]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_1_en_1 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_1_we),
+    .src_wd_i     (adc_chn0_filter_ctl_1_en_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_1_en_1_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_1_en_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[1].en.q)
   );
 
 
@@ -802,80 +871,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_2]: V(False)
 
   // F[min_v_2]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_2_min_v_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_2_we),
-    .wd     (adc_chn0_filter_ctl_2_min_v_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[2].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[2].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_2_min_v_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_2_we),
+    .src_wd_i     (adc_chn0_filter_ctl_2_min_v_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_2_min_v_2_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_2_min_v_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[2].min_v.q)
   );
 
 
   // F[cond_2]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_2_cond_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_2_we),
-    .wd     (adc_chn0_filter_ctl_2_cond_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[2].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[2].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_2_cond_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_2_we),
+    .src_wd_i     (adc_chn0_filter_ctl_2_cond_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_2_cond_2_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_2_cond_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[2].cond.q)
   );
 
 
   // F[max_v_2]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_2_max_v_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_2_we),
+    .src_wd_i     (adc_chn0_filter_ctl_2_max_v_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_2_max_v_2_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_2_max_v_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[2].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_2_we),
-    .wd     (adc_chn0_filter_ctl_2_max_v_2_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[2].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[2].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_2_max_v_2_qs)
+  // F[en_2]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_2_en_2 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_2_we),
+    .src_wd_i     (adc_chn0_filter_ctl_2_en_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_2_en_2_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_2_en_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[2].en.q)
   );
 
 
@@ -883,80 +962,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_3]: V(False)
 
   // F[min_v_3]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_3_min_v_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_3_we),
-    .wd     (adc_chn0_filter_ctl_3_min_v_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[3].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[3].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_3_min_v_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_3_we),
+    .src_wd_i     (adc_chn0_filter_ctl_3_min_v_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_3_min_v_3_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_3_min_v_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[3].min_v.q)
   );
 
 
   // F[cond_3]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_3_cond_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_3_we),
-    .wd     (adc_chn0_filter_ctl_3_cond_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[3].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[3].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_3_cond_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_3_we),
+    .src_wd_i     (adc_chn0_filter_ctl_3_cond_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_3_cond_3_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_3_cond_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[3].cond.q)
   );
 
 
   // F[max_v_3]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_3_max_v_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_3_we),
+    .src_wd_i     (adc_chn0_filter_ctl_3_max_v_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_3_max_v_3_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_3_max_v_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[3].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_3_we),
-    .wd     (adc_chn0_filter_ctl_3_max_v_3_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[3].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[3].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_3_max_v_3_qs)
+  // F[en_3]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_3_en_3 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_3_we),
+    .src_wd_i     (adc_chn0_filter_ctl_3_en_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_3_en_3_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_3_en_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[3].en.q)
   );
 
 
@@ -964,80 +1053,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_4]: V(False)
 
   // F[min_v_4]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_4_min_v_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_4_we),
-    .wd     (adc_chn0_filter_ctl_4_min_v_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[4].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[4].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_4_min_v_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_4_we),
+    .src_wd_i     (adc_chn0_filter_ctl_4_min_v_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_4_min_v_4_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_4_min_v_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[4].min_v.q)
   );
 
 
   // F[cond_4]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_4_cond_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_4_we),
-    .wd     (adc_chn0_filter_ctl_4_cond_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[4].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[4].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_4_cond_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_4_we),
+    .src_wd_i     (adc_chn0_filter_ctl_4_cond_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_4_cond_4_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_4_cond_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[4].cond.q)
   );
 
 
   // F[max_v_4]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_4_max_v_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_4_we),
+    .src_wd_i     (adc_chn0_filter_ctl_4_max_v_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_4_max_v_4_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_4_max_v_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[4].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_4_we),
-    .wd     (adc_chn0_filter_ctl_4_max_v_4_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[4].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[4].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_4_max_v_4_qs)
+  // F[en_4]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_4_en_4 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_4_we),
+    .src_wd_i     (adc_chn0_filter_ctl_4_en_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_4_en_4_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_4_en_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[4].en.q)
   );
 
 
@@ -1045,80 +1144,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_5]: V(False)
 
   // F[min_v_5]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_5_min_v_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_5_we),
-    .wd     (adc_chn0_filter_ctl_5_min_v_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[5].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[5].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_5_min_v_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_5_we),
+    .src_wd_i     (adc_chn0_filter_ctl_5_min_v_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_5_min_v_5_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_5_min_v_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[5].min_v.q)
   );
 
 
   // F[cond_5]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_5_cond_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_5_we),
-    .wd     (adc_chn0_filter_ctl_5_cond_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[5].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[5].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_5_cond_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_5_we),
+    .src_wd_i     (adc_chn0_filter_ctl_5_cond_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_5_cond_5_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_5_cond_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[5].cond.q)
   );
 
 
   // F[max_v_5]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_5_max_v_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_5_we),
+    .src_wd_i     (adc_chn0_filter_ctl_5_max_v_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_5_max_v_5_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_5_max_v_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[5].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_5_we),
-    .wd     (adc_chn0_filter_ctl_5_max_v_5_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[5].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[5].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_5_max_v_5_qs)
+  // F[en_5]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_5_en_5 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_5_we),
+    .src_wd_i     (adc_chn0_filter_ctl_5_en_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_5_en_5_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_5_en_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[5].en.q)
   );
 
 
@@ -1126,80 +1235,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_6]: V(False)
 
   // F[min_v_6]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_6_min_v_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_6_we),
-    .wd     (adc_chn0_filter_ctl_6_min_v_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[6].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[6].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_6_min_v_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_6_we),
+    .src_wd_i     (adc_chn0_filter_ctl_6_min_v_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_6_min_v_6_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_6_min_v_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[6].min_v.q)
   );
 
 
   // F[cond_6]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_6_cond_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_6_we),
-    .wd     (adc_chn0_filter_ctl_6_cond_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[6].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[6].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_6_cond_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_6_we),
+    .src_wd_i     (adc_chn0_filter_ctl_6_cond_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_6_cond_6_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_6_cond_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[6].cond.q)
   );
 
 
   // F[max_v_6]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_6_max_v_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_6_we),
+    .src_wd_i     (adc_chn0_filter_ctl_6_max_v_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_6_max_v_6_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_6_max_v_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[6].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_6_we),
-    .wd     (adc_chn0_filter_ctl_6_max_v_6_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[6].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[6].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_6_max_v_6_qs)
+  // F[en_6]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_6_en_6 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_6_we),
+    .src_wd_i     (adc_chn0_filter_ctl_6_en_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_6_en_6_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_6_en_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[6].en.q)
   );
 
 
@@ -1207,80 +1326,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_7]: V(False)
 
   // F[min_v_7]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_7_min_v_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_7_we),
-    .wd     (adc_chn0_filter_ctl_7_min_v_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[7].min_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[7].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_7_min_v_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_7_we),
+    .src_wd_i     (adc_chn0_filter_ctl_7_min_v_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_7_min_v_7_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_7_min_v_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[7].min_v.q)
   );
 
 
   // F[cond_7]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_7_cond_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn0_filter_ctl_7_we),
-    .wd     (adc_chn0_filter_ctl_7_cond_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[7].cond.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[7].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_7_cond_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_7_we),
+    .src_wd_i     (adc_chn0_filter_ctl_7_cond_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_7_cond_7_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_7_cond_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[7].cond.q)
   );
 
 
   // F[max_v_7]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_7_max_v_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_7_we),
+    .src_wd_i     (adc_chn0_filter_ctl_7_max_v_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_7_max_v_7_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_7_max_v_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[7].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn0_filter_ctl_7_we),
-    .wd     (adc_chn0_filter_ctl_7_max_v_7_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn0_filter_ctl[7].max_v.qe),
-    .q      (reg2hw.adc_chn0_filter_ctl[7].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn0_filter_ctl_7_max_v_7_qs)
+  // F[en_7]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn0_filter_ctl_7_en_7 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn0_filter_ctl_7_we),
+    .src_wd_i     (adc_chn0_filter_ctl_7_en_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn0_filter_ctl_7_en_7_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_7_en_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn0_filter_ctl[7].en.q)
   );
 
 
@@ -1290,80 +1419,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_0]: V(False)
 
   // F[min_v_0]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_0_min_v_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_0_we),
-    .wd     (adc_chn1_filter_ctl_0_min_v_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[0].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[0].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_0_min_v_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_0_we),
+    .src_wd_i     (adc_chn1_filter_ctl_0_min_v_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_0_min_v_0_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_0_min_v_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[0].min_v.q)
   );
 
 
   // F[cond_0]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_0_cond_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_0_we),
-    .wd     (adc_chn1_filter_ctl_0_cond_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[0].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[0].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_0_cond_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_0_we),
+    .src_wd_i     (adc_chn1_filter_ctl_0_cond_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_0_cond_0_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_0_cond_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[0].cond.q)
   );
 
 
   // F[max_v_0]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_0_max_v_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_0_we),
+    .src_wd_i     (adc_chn1_filter_ctl_0_max_v_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_0_max_v_0_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_0_max_v_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[0].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_0_we),
-    .wd     (adc_chn1_filter_ctl_0_max_v_0_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[0].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[0].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_0_max_v_0_qs)
+  // F[en_0]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_0_en_0 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_0_we),
+    .src_wd_i     (adc_chn1_filter_ctl_0_en_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_0_en_0_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_0_en_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[0].en.q)
   );
 
 
@@ -1371,80 +1510,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_1]: V(False)
 
   // F[min_v_1]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_1_min_v_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_1_we),
-    .wd     (adc_chn1_filter_ctl_1_min_v_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[1].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[1].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_1_min_v_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_1_we),
+    .src_wd_i     (adc_chn1_filter_ctl_1_min_v_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_1_min_v_1_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_1_min_v_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[1].min_v.q)
   );
 
 
   // F[cond_1]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_1_cond_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_1_we),
-    .wd     (adc_chn1_filter_ctl_1_cond_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[1].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[1].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_1_cond_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_1_we),
+    .src_wd_i     (adc_chn1_filter_ctl_1_cond_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_1_cond_1_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_1_cond_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[1].cond.q)
   );
 
 
   // F[max_v_1]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_1_max_v_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_1_we),
+    .src_wd_i     (adc_chn1_filter_ctl_1_max_v_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_1_max_v_1_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_1_max_v_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[1].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_1_we),
-    .wd     (adc_chn1_filter_ctl_1_max_v_1_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[1].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[1].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_1_max_v_1_qs)
+  // F[en_1]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_1_en_1 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_1_we),
+    .src_wd_i     (adc_chn1_filter_ctl_1_en_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_1_en_1_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_1_en_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[1].en.q)
   );
 
 
@@ -1452,80 +1601,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_2]: V(False)
 
   // F[min_v_2]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_2_min_v_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_2_we),
-    .wd     (adc_chn1_filter_ctl_2_min_v_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[2].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[2].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_2_min_v_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_2_we),
+    .src_wd_i     (adc_chn1_filter_ctl_2_min_v_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_2_min_v_2_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_2_min_v_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[2].min_v.q)
   );
 
 
   // F[cond_2]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_2_cond_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_2_we),
-    .wd     (adc_chn1_filter_ctl_2_cond_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[2].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[2].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_2_cond_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_2_we),
+    .src_wd_i     (adc_chn1_filter_ctl_2_cond_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_2_cond_2_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_2_cond_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[2].cond.q)
   );
 
 
   // F[max_v_2]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_2_max_v_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_2_we),
+    .src_wd_i     (adc_chn1_filter_ctl_2_max_v_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_2_max_v_2_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_2_max_v_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[2].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_2_we),
-    .wd     (adc_chn1_filter_ctl_2_max_v_2_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[2].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[2].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_2_max_v_2_qs)
+  // F[en_2]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_2_en_2 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_2_we),
+    .src_wd_i     (adc_chn1_filter_ctl_2_en_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_2_en_2_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_2_en_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[2].en.q)
   );
 
 
@@ -1533,80 +1692,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_3]: V(False)
 
   // F[min_v_3]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_3_min_v_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_3_we),
-    .wd     (adc_chn1_filter_ctl_3_min_v_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[3].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[3].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_3_min_v_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_3_we),
+    .src_wd_i     (adc_chn1_filter_ctl_3_min_v_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_3_min_v_3_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_3_min_v_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[3].min_v.q)
   );
 
 
   // F[cond_3]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_3_cond_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_3_we),
-    .wd     (adc_chn1_filter_ctl_3_cond_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[3].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[3].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_3_cond_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_3_we),
+    .src_wd_i     (adc_chn1_filter_ctl_3_cond_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_3_cond_3_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_3_cond_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[3].cond.q)
   );
 
 
   // F[max_v_3]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_3_max_v_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_3_we),
+    .src_wd_i     (adc_chn1_filter_ctl_3_max_v_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_3_max_v_3_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_3_max_v_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[3].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_3_we),
-    .wd     (adc_chn1_filter_ctl_3_max_v_3_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[3].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[3].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_3_max_v_3_qs)
+  // F[en_3]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_3_en_3 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_3_we),
+    .src_wd_i     (adc_chn1_filter_ctl_3_en_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_3_en_3_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_3_en_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[3].en.q)
   );
 
 
@@ -1614,80 +1783,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_4]: V(False)
 
   // F[min_v_4]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_4_min_v_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_4_we),
-    .wd     (adc_chn1_filter_ctl_4_min_v_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[4].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[4].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_4_min_v_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_4_we),
+    .src_wd_i     (adc_chn1_filter_ctl_4_min_v_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_4_min_v_4_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_4_min_v_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[4].min_v.q)
   );
 
 
   // F[cond_4]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_4_cond_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_4_we),
-    .wd     (adc_chn1_filter_ctl_4_cond_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[4].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[4].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_4_cond_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_4_we),
+    .src_wd_i     (adc_chn1_filter_ctl_4_cond_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_4_cond_4_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_4_cond_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[4].cond.q)
   );
 
 
   // F[max_v_4]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_4_max_v_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_4_we),
+    .src_wd_i     (adc_chn1_filter_ctl_4_max_v_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_4_max_v_4_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_4_max_v_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[4].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_4_we),
-    .wd     (adc_chn1_filter_ctl_4_max_v_4_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[4].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[4].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_4_max_v_4_qs)
+  // F[en_4]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_4_en_4 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_4_we),
+    .src_wd_i     (adc_chn1_filter_ctl_4_en_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_4_en_4_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_4_en_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[4].en.q)
   );
 
 
@@ -1695,80 +1874,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_5]: V(False)
 
   // F[min_v_5]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_5_min_v_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_5_we),
-    .wd     (adc_chn1_filter_ctl_5_min_v_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[5].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[5].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_5_min_v_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_5_we),
+    .src_wd_i     (adc_chn1_filter_ctl_5_min_v_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_5_min_v_5_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_5_min_v_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[5].min_v.q)
   );
 
 
   // F[cond_5]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_5_cond_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_5_we),
-    .wd     (adc_chn1_filter_ctl_5_cond_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[5].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[5].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_5_cond_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_5_we),
+    .src_wd_i     (adc_chn1_filter_ctl_5_cond_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_5_cond_5_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_5_cond_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[5].cond.q)
   );
 
 
   // F[max_v_5]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_5_max_v_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_5_we),
+    .src_wd_i     (adc_chn1_filter_ctl_5_max_v_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_5_max_v_5_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_5_max_v_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[5].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_5_we),
-    .wd     (adc_chn1_filter_ctl_5_max_v_5_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[5].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[5].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_5_max_v_5_qs)
+  // F[en_5]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_5_en_5 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_5_we),
+    .src_wd_i     (adc_chn1_filter_ctl_5_en_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_5_en_5_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_5_en_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[5].en.q)
   );
 
 
@@ -1776,80 +1965,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_6]: V(False)
 
   // F[min_v_6]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_6_min_v_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_6_we),
-    .wd     (adc_chn1_filter_ctl_6_min_v_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[6].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[6].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_6_min_v_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_6_we),
+    .src_wd_i     (adc_chn1_filter_ctl_6_min_v_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_6_min_v_6_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_6_min_v_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[6].min_v.q)
   );
 
 
   // F[cond_6]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_6_cond_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_6_we),
-    .wd     (adc_chn1_filter_ctl_6_cond_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[6].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[6].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_6_cond_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_6_we),
+    .src_wd_i     (adc_chn1_filter_ctl_6_cond_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_6_cond_6_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_6_cond_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[6].cond.q)
   );
 
 
   // F[max_v_6]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_6_max_v_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_6_we),
+    .src_wd_i     (adc_chn1_filter_ctl_6_max_v_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_6_max_v_6_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_6_max_v_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[6].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_6_we),
-    .wd     (adc_chn1_filter_ctl_6_max_v_6_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[6].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[6].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_6_max_v_6_qs)
+  // F[en_6]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_6_en_6 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_6_we),
+    .src_wd_i     (adc_chn1_filter_ctl_6_en_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_6_en_6_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_6_en_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[6].en.q)
   );
 
 
@@ -1857,80 +2056,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_7]: V(False)
 
   // F[min_v_7]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_7_min_v_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_7_we),
-    .wd     (adc_chn1_filter_ctl_7_min_v_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[7].min_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[7].min_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_7_min_v_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_7_we),
+    .src_wd_i     (adc_chn1_filter_ctl_7_min_v_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_7_min_v_7_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_7_min_v_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[7].min_v.q)
   );
 
 
   // F[cond_7]: 12:12
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_7_cond_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_chn1_filter_ctl_7_we),
-    .wd     (adc_chn1_filter_ctl_7_cond_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[7].cond.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[7].cond.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_7_cond_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_7_we),
+    .src_wd_i     (adc_chn1_filter_ctl_7_cond_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_7_cond_7_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_7_cond_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[7].cond.q)
   );
 
 
   // F[max_v_7]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_7_max_v_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_7_we),
+    .src_wd_i     (adc_chn1_filter_ctl_7_max_v_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_7_max_v_7_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_7_max_v_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[7].max_v.q)
+  );
 
-    // from register interface
-    .we     (adc_chn1_filter_ctl_7_we),
-    .wd     (adc_chn1_filter_ctl_7_max_v_7_wd),
 
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (reg2hw.adc_chn1_filter_ctl[7].max_v.qe),
-    .q      (reg2hw.adc_chn1_filter_ctl[7].max_v.q),
-
-    // to register interface (read)
-    .qs     (adc_chn1_filter_ctl_7_max_v_7_qs)
+  // F[en_7]: 31:31
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_adc_chn1_filter_ctl_7_en_7 (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_chn1_filter_ctl_7_we),
+    .src_wd_i     (adc_chn1_filter_ctl_7_en_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_chn1_filter_ctl_7_en_7_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_7_en_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_chn1_filter_ctl[7].en.q)
   );
 
 
@@ -1940,106 +2149,90 @@ module adc_ctrl_reg_top (
   // R[adc_chn_val_0]: V(False)
 
   // F[adc_chn_value_ext_0]: 1:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_0_adc_chn_value_ext_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[0].adc_chn_value_ext.de),
-    .d      (hw2reg.adc_chn_val[0].adc_chn_value_ext.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_0_adc_chn_value_ext_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value_ext.de),
+    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value_ext.d),
+    .src_busy_o   (adc_chn_val_0_adc_chn_value_ext_0_busy),
+    .src_qs_o     (adc_chn_val_0_adc_chn_value_ext_0_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
   // F[adc_chn_value_0]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_0_adc_chn_value_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[0].adc_chn_value.de),
-    .d      (hw2reg.adc_chn_val[0].adc_chn_value.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_0_adc_chn_value_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value.de),
+    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value.d),
+    .src_busy_o   (adc_chn_val_0_adc_chn_value_0_busy),
+    .src_qs_o     (adc_chn_val_0_adc_chn_value_0_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
   // F[adc_chn_value_intr_ext_0]: 17:16
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_0_adc_chn_value_intr_ext_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.de),
-    .d      (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_0_adc_chn_value_intr_ext_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.de),
+    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.d),
+    .src_busy_o   (adc_chn_val_0_adc_chn_value_intr_ext_0_busy),
+    .src_qs_o     (adc_chn_val_0_adc_chn_value_intr_ext_0_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
   // F[adc_chn_value_intr_0]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_0_adc_chn_value_intr_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[0].adc_chn_value_intr.de),
-    .d      (hw2reg.adc_chn_val[0].adc_chn_value_intr.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_0_adc_chn_value_intr_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value_intr.de),
+    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value_intr.d),
+    .src_busy_o   (adc_chn_val_0_adc_chn_value_intr_0_busy),
+    .src_qs_o     (adc_chn_val_0_adc_chn_value_intr_0_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
@@ -2047,544 +2240,153 @@ module adc_ctrl_reg_top (
   // R[adc_chn_val_1]: V(False)
 
   // F[adc_chn_value_ext_1]: 1:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_1_adc_chn_value_ext_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[1].adc_chn_value_ext.de),
-    .d      (hw2reg.adc_chn_val[1].adc_chn_value_ext.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_1_adc_chn_value_ext_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value_ext.de),
+    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value_ext.d),
+    .src_busy_o   (adc_chn_val_1_adc_chn_value_ext_1_busy),
+    .src_qs_o     (adc_chn_val_1_adc_chn_value_ext_1_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
   // F[adc_chn_value_1]: 11:2
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_1_adc_chn_value_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[1].adc_chn_value.de),
-    .d      (hw2reg.adc_chn_val[1].adc_chn_value.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_1_adc_chn_value_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value.de),
+    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value.d),
+    .src_busy_o   (adc_chn_val_1_adc_chn_value_1_busy),
+    .src_qs_o     (adc_chn_val_1_adc_chn_value_1_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
   // F[adc_chn_value_intr_ext_1]: 17:16
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_1_adc_chn_value_intr_ext_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.de),
-    .d      (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_1_adc_chn_value_intr_ext_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.de),
+    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.d),
+    .src_busy_o   (adc_chn_val_1_adc_chn_value_intr_ext_1_busy),
+    .src_qs_o     (adc_chn_val_1_adc_chn_value_intr_ext_1_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
   // F[adc_chn_value_intr_1]: 27:18
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_1_adc_chn_value_intr_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.adc_chn_val[1].adc_chn_value_intr.de),
-    .d      (hw2reg.adc_chn_val[1].adc_chn_value_intr.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_chn_val_1_adc_chn_value_intr_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (1'b0),
+    .src_wd_i     ('0),
+    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value_intr.de),
+    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value_intr.d),
+    .src_busy_o   (adc_chn_val_1_adc_chn_value_intr_1_busy),
+    .src_qs_o     (adc_chn_val_1_adc_chn_value_intr_1_qs),
+    .dst_qe_o     (),
+    .q            ()
   );
 
 
 
   // R[adc_wakeup_ctl]: V(False)
 
-  //   F[chn0_1_filter0_en]: 0:0
-  prim_subreg #(
-    .DW      (1),
+  prim_subreg_async #(
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter0_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter0_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter0_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter0_en_qs)
+    .RESVAL  (8'h0)
+  ) u_adc_wakeup_ctl (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (adc_wakeup_ctl_we),
+    .src_wd_i     (adc_wakeup_ctl_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (adc_wakeup_ctl_busy),
+    .src_qs_o     (adc_wakeup_ctl_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.adc_wakeup_ctl.q)
   );
 
 
-  //   F[chn0_1_filter1_en]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter1_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
+  // R[filter_status]: V(False)
 
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter1_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter1_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter1_en_qs)
-  );
-
-
-  //   F[chn0_1_filter2_en]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter2_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter2_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter2_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter2_en_qs)
-  );
-
-
-  //   F[chn0_1_filter3_en]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter3_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter3_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter3_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter3_en_qs)
-  );
-
-
-  //   F[chn0_1_filter4_en]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter4_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter4_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter4_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter4_en_qs)
-  );
-
-
-  //   F[chn0_1_filter5_en]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter5_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter5_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter5_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter5_en_qs)
-  );
-
-
-  //   F[chn0_1_filter6_en]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter6_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter6_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter6_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter6_en_qs)
-  );
-
-
-  //   F[chn0_1_filter7_en]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_ctl_chn0_1_filter7_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_ctl_we),
-    .wd     (adc_wakeup_ctl_chn0_1_filter7_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_wakeup_ctl.chn0_1_filter7_en.q),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_ctl_chn0_1_filter7_en_qs)
-  );
-
-
-  // R[adc_wakeup_status]: V(False)
-
-  //   F[cc_sink_det]: 0:0
-  prim_subreg #(
-    .DW      (1),
+  prim_subreg_async #(
+    .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_sink_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_sink_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_sink_det.de),
-    .d      (hw2reg.adc_wakeup_status.cc_sink_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_sink_det_qs)
-  );
-
-
-  //   F[cc_1a5_sink_det]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_1a5_sink_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_1a5_sink_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_1a5_sink_det.de),
-    .d      (hw2reg.adc_wakeup_status.cc_1a5_sink_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_1a5_sink_det_qs)
-  );
-
-
-  //   F[cc_3a0_sink_det]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_3a0_sink_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_3a0_sink_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_3a0_sink_det.de),
-    .d      (hw2reg.adc_wakeup_status.cc_3a0_sink_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_3a0_sink_det_qs)
-  );
-
-
-  //   F[cc_src_det]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_src_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_src_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_src_det.de),
-    .d      (hw2reg.adc_wakeup_status.cc_src_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_src_det_qs)
-  );
-
-
-  //   F[cc_1a5_src_det]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_1a5_src_det (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_1a5_src_det_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_1a5_src_det.de),
-    .d      (hw2reg.adc_wakeup_status.cc_1a5_src_det.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_1a5_src_det_qs)
-  );
-
-
-  //   F[cc_src_det_flip]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_src_det_flip (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_src_det_flip_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_src_det_flip.de),
-    .d      (hw2reg.adc_wakeup_status.cc_src_det_flip.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_src_det_flip_qs)
-  );
-
-
-  //   F[cc_1a5_src_det_flip]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_1a5_src_det_flip (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_1a5_src_det_flip_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_1a5_src_det_flip.de),
-    .d      (hw2reg.adc_wakeup_status.cc_1a5_src_det_flip.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_1a5_src_det_flip_qs)
-  );
-
-
-  //   F[cc_discon]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_adc_wakeup_status_cc_discon (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_wakeup_status_we),
-    .wd     (adc_wakeup_status_cc_discon_wd),
-
-    // from internal hardware
-    .de     (hw2reg.adc_wakeup_status.cc_discon.de),
-    .d      (hw2reg.adc_wakeup_status.cc_discon.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (adc_wakeup_status_cc_discon_qs)
+    .RESVAL  (8'h0)
+  ) u_filter_status (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (filter_status_we),
+    .src_wd_i     (filter_status_wd),
+    .dst_de_i     (hw2reg.filter_status.de),
+    .dst_d_i      (hw2reg.filter_status.d),
+    .src_busy_o   (filter_status_busy),
+    .src_qs_o     (filter_status_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.filter_status.q)
   );
 
 
   // R[adc_intr_ctl]: V(False)
 
-  //   F[chn0_1_filter0_en]: 0:0
   prim_subreg #(
-    .DW      (1),
+    .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter0_en (
+    .RESVAL  (9'h0)
+  ) u_adc_intr_ctl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter0_en_wd),
+    .wd     (adc_intr_ctl_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2592,218 +2394,10 @@ module adc_ctrl_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter0_en.q),
+    .q      (reg2hw.adc_intr_ctl.q),
 
     // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter0_en_qs)
-  );
-
-
-  //   F[chn0_1_filter1_en]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter1_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter1_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter1_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter1_en_qs)
-  );
-
-
-  //   F[chn0_1_filter2_en]: 2:2
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter2_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter2_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter2_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter2_en_qs)
-  );
-
-
-  //   F[chn0_1_filter3_en]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter3_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter3_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter3_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter3_en_qs)
-  );
-
-
-  //   F[chn0_1_filter4_en]: 4:4
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter4_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter4_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter4_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter4_en_qs)
-  );
-
-
-  //   F[chn0_1_filter5_en]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter5_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter5_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter5_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter5_en_qs)
-  );
-
-
-  //   F[chn0_1_filter6_en]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter6_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter6_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter6_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter6_en_qs)
-  );
-
-
-  //   F[chn0_1_filter7_en]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_chn0_1_filter7_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_chn0_1_filter7_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.chn0_1_filter7_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_chn0_1_filter7_en_qs)
-  );
-
-
-  //   F[oneshot_intr_en]: 8:8
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_adc_intr_ctl_oneshot_intr_en (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (adc_intr_ctl_we),
-    .wd     (adc_intr_ctl_oneshot_intr_en_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.adc_intr_ctl.oneshot_intr_en.q),
-
-    // to register interface (read)
-    .qs     (adc_intr_ctl_oneshot_intr_en_qs)
+    .qs     (adc_intr_ctl_qs)
   );
 
 
@@ -3076,7 +2670,7 @@ module adc_ctrl_reg_top (
     addr_hit[25] = (reg_addr == ADC_CTRL_ADC_CHN_VAL_0_OFFSET);
     addr_hit[26] = (reg_addr == ADC_CTRL_ADC_CHN_VAL_1_OFFSET);
     addr_hit[27] = (reg_addr == ADC_CTRL_ADC_WAKEUP_CTL_OFFSET);
-    addr_hit[28] = (reg_addr == ADC_CTRL_ADC_WAKEUP_STATUS_OFFSET);
+    addr_hit[28] = (reg_addr == ADC_CTRL_FILTER_STATUS_OFFSET);
     addr_hit[29] = (reg_addr == ADC_CTRL_ADC_INTR_CTL_OFFSET);
     addr_hit[30] = (reg_addr == ADC_CTRL_ADC_INTR_STATUS_OFFSET);
   end
@@ -3158,6 +2752,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_0_cond_0_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_0_max_v_0_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_0_en_0_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_1_we = addr_hit[10] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_1_min_v_1_wd = reg_wdata[11:2];
@@ -3165,6 +2761,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_1_cond_1_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_1_max_v_1_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_1_en_1_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_2_we = addr_hit[11] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_2_min_v_2_wd = reg_wdata[11:2];
@@ -3172,6 +2770,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_2_cond_2_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_2_max_v_2_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_2_en_2_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_3_we = addr_hit[12] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_3_min_v_3_wd = reg_wdata[11:2];
@@ -3179,6 +2779,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_3_cond_3_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_3_max_v_3_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_3_en_3_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_4_we = addr_hit[13] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_4_min_v_4_wd = reg_wdata[11:2];
@@ -3186,6 +2788,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_4_cond_4_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_4_max_v_4_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_4_en_4_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_5_we = addr_hit[14] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_5_min_v_5_wd = reg_wdata[11:2];
@@ -3193,6 +2797,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_5_cond_5_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_5_max_v_5_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_5_en_5_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_6_we = addr_hit[15] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_6_min_v_6_wd = reg_wdata[11:2];
@@ -3200,6 +2806,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_6_cond_6_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_6_max_v_6_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_6_en_6_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_7_we = addr_hit[16] & reg_we & !reg_error;
 
   assign adc_chn0_filter_ctl_7_min_v_7_wd = reg_wdata[11:2];
@@ -3207,6 +2815,8 @@ module adc_ctrl_reg_top (
   assign adc_chn0_filter_ctl_7_cond_7_wd = reg_wdata[12];
 
   assign adc_chn0_filter_ctl_7_max_v_7_wd = reg_wdata[27:18];
+
+  assign adc_chn0_filter_ctl_7_en_7_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_0_we = addr_hit[17] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_0_min_v_0_wd = reg_wdata[11:2];
@@ -3214,6 +2824,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_0_cond_0_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_0_max_v_0_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_0_en_0_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_1_we = addr_hit[18] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_1_min_v_1_wd = reg_wdata[11:2];
@@ -3221,6 +2833,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_1_cond_1_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_1_max_v_1_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_1_en_1_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_2_we = addr_hit[19] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_2_min_v_2_wd = reg_wdata[11:2];
@@ -3228,6 +2842,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_2_cond_2_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_2_max_v_2_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_2_en_2_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_3_we = addr_hit[20] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_3_min_v_3_wd = reg_wdata[11:2];
@@ -3235,6 +2851,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_3_cond_3_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_3_max_v_3_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_3_en_3_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_4_we = addr_hit[21] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_4_min_v_4_wd = reg_wdata[11:2];
@@ -3242,6 +2860,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_4_cond_4_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_4_max_v_4_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_4_en_4_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_5_we = addr_hit[22] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_5_min_v_5_wd = reg_wdata[11:2];
@@ -3249,6 +2869,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_5_cond_5_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_5_max_v_5_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_5_en_5_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_6_we = addr_hit[23] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_6_min_v_6_wd = reg_wdata[11:2];
@@ -3256,6 +2878,8 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_6_cond_6_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_6_max_v_6_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_6_en_6_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_7_we = addr_hit[24] & reg_we & !reg_error;
 
   assign adc_chn1_filter_ctl_7_min_v_7_wd = reg_wdata[11:2];
@@ -3263,59 +2887,17 @@ module adc_ctrl_reg_top (
   assign adc_chn1_filter_ctl_7_cond_7_wd = reg_wdata[12];
 
   assign adc_chn1_filter_ctl_7_max_v_7_wd = reg_wdata[27:18];
+
+  assign adc_chn1_filter_ctl_7_en_7_wd = reg_wdata[31];
   assign adc_wakeup_ctl_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign adc_wakeup_ctl_chn0_1_filter0_en_wd = reg_wdata[0];
+  assign adc_wakeup_ctl_wd = reg_wdata[7:0];
+  assign filter_status_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign adc_wakeup_ctl_chn0_1_filter1_en_wd = reg_wdata[1];
-
-  assign adc_wakeup_ctl_chn0_1_filter2_en_wd = reg_wdata[2];
-
-  assign adc_wakeup_ctl_chn0_1_filter3_en_wd = reg_wdata[3];
-
-  assign adc_wakeup_ctl_chn0_1_filter4_en_wd = reg_wdata[4];
-
-  assign adc_wakeup_ctl_chn0_1_filter5_en_wd = reg_wdata[5];
-
-  assign adc_wakeup_ctl_chn0_1_filter6_en_wd = reg_wdata[6];
-
-  assign adc_wakeup_ctl_chn0_1_filter7_en_wd = reg_wdata[7];
-  assign adc_wakeup_status_we = addr_hit[28] & reg_we & !reg_error;
-
-  assign adc_wakeup_status_cc_sink_det_wd = reg_wdata[0];
-
-  assign adc_wakeup_status_cc_1a5_sink_det_wd = reg_wdata[1];
-
-  assign adc_wakeup_status_cc_3a0_sink_det_wd = reg_wdata[2];
-
-  assign adc_wakeup_status_cc_src_det_wd = reg_wdata[3];
-
-  assign adc_wakeup_status_cc_1a5_src_det_wd = reg_wdata[4];
-
-  assign adc_wakeup_status_cc_src_det_flip_wd = reg_wdata[5];
-
-  assign adc_wakeup_status_cc_1a5_src_det_flip_wd = reg_wdata[6];
-
-  assign adc_wakeup_status_cc_discon_wd = reg_wdata[7];
+  assign filter_status_wd = reg_wdata[7:0];
   assign adc_intr_ctl_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign adc_intr_ctl_chn0_1_filter0_en_wd = reg_wdata[0];
-
-  assign adc_intr_ctl_chn0_1_filter1_en_wd = reg_wdata[1];
-
-  assign adc_intr_ctl_chn0_1_filter2_en_wd = reg_wdata[2];
-
-  assign adc_intr_ctl_chn0_1_filter3_en_wd = reg_wdata[3];
-
-  assign adc_intr_ctl_chn0_1_filter4_en_wd = reg_wdata[4];
-
-  assign adc_intr_ctl_chn0_1_filter5_en_wd = reg_wdata[5];
-
-  assign adc_intr_ctl_chn0_1_filter6_en_wd = reg_wdata[6];
-
-  assign adc_intr_ctl_chn0_1_filter7_en_wd = reg_wdata[7];
-
-  assign adc_intr_ctl_oneshot_intr_en_wd = reg_wdata[8];
+  assign adc_intr_ctl_wd = reg_wdata[8:0];
   assign adc_intr_status_we = addr_hit[30] & reg_we & !reg_error;
 
   assign adc_intr_status_cc_sink_det_wd = reg_wdata[0];
@@ -3383,96 +2965,112 @@ module adc_ctrl_reg_top (
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_0_min_v_0_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_0_cond_0_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_0_max_v_0_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_0_en_0_qs;
       end
 
       addr_hit[10]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_1_min_v_1_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_1_cond_1_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_1_max_v_1_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_1_en_1_qs;
       end
 
       addr_hit[11]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_2_min_v_2_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_2_cond_2_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_2_max_v_2_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_2_en_2_qs;
       end
 
       addr_hit[12]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_3_min_v_3_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_3_cond_3_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_3_max_v_3_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_3_en_3_qs;
       end
 
       addr_hit[13]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_4_min_v_4_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_4_cond_4_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_4_max_v_4_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_4_en_4_qs;
       end
 
       addr_hit[14]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_5_min_v_5_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_5_cond_5_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_5_max_v_5_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_5_en_5_qs;
       end
 
       addr_hit[15]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_6_min_v_6_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_6_cond_6_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_6_max_v_6_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_6_en_6_qs;
       end
 
       addr_hit[16]: begin
         reg_rdata_next[11:2] = adc_chn0_filter_ctl_7_min_v_7_qs;
         reg_rdata_next[12] = adc_chn0_filter_ctl_7_cond_7_qs;
         reg_rdata_next[27:18] = adc_chn0_filter_ctl_7_max_v_7_qs;
+        reg_rdata_next[31] = adc_chn0_filter_ctl_7_en_7_qs;
       end
 
       addr_hit[17]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_0_min_v_0_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_0_cond_0_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_0_max_v_0_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_0_en_0_qs;
       end
 
       addr_hit[18]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_1_min_v_1_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_1_cond_1_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_1_max_v_1_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_1_en_1_qs;
       end
 
       addr_hit[19]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_2_min_v_2_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_2_cond_2_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_2_max_v_2_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_2_en_2_qs;
       end
 
       addr_hit[20]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_3_min_v_3_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_3_cond_3_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_3_max_v_3_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_3_en_3_qs;
       end
 
       addr_hit[21]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_4_min_v_4_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_4_cond_4_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_4_max_v_4_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_4_en_4_qs;
       end
 
       addr_hit[22]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_5_min_v_5_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_5_cond_5_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_5_max_v_5_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_5_en_5_qs;
       end
 
       addr_hit[23]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_6_min_v_6_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_6_cond_6_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_6_max_v_6_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_6_en_6_qs;
       end
 
       addr_hit[24]: begin
         reg_rdata_next[11:2] = adc_chn1_filter_ctl_7_min_v_7_qs;
         reg_rdata_next[12] = adc_chn1_filter_ctl_7_cond_7_qs;
         reg_rdata_next[27:18] = adc_chn1_filter_ctl_7_max_v_7_qs;
+        reg_rdata_next[31] = adc_chn1_filter_ctl_7_en_7_qs;
       end
 
       addr_hit[25]: begin
@@ -3490,37 +3088,15 @@ module adc_ctrl_reg_top (
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[0] = adc_wakeup_ctl_chn0_1_filter0_en_qs;
-        reg_rdata_next[1] = adc_wakeup_ctl_chn0_1_filter1_en_qs;
-        reg_rdata_next[2] = adc_wakeup_ctl_chn0_1_filter2_en_qs;
-        reg_rdata_next[3] = adc_wakeup_ctl_chn0_1_filter3_en_qs;
-        reg_rdata_next[4] = adc_wakeup_ctl_chn0_1_filter4_en_qs;
-        reg_rdata_next[5] = adc_wakeup_ctl_chn0_1_filter5_en_qs;
-        reg_rdata_next[6] = adc_wakeup_ctl_chn0_1_filter6_en_qs;
-        reg_rdata_next[7] = adc_wakeup_ctl_chn0_1_filter7_en_qs;
+        reg_rdata_next[7:0] = adc_wakeup_ctl_qs;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[0] = adc_wakeup_status_cc_sink_det_qs;
-        reg_rdata_next[1] = adc_wakeup_status_cc_1a5_sink_det_qs;
-        reg_rdata_next[2] = adc_wakeup_status_cc_3a0_sink_det_qs;
-        reg_rdata_next[3] = adc_wakeup_status_cc_src_det_qs;
-        reg_rdata_next[4] = adc_wakeup_status_cc_1a5_src_det_qs;
-        reg_rdata_next[5] = adc_wakeup_status_cc_src_det_flip_qs;
-        reg_rdata_next[6] = adc_wakeup_status_cc_1a5_src_det_flip_qs;
-        reg_rdata_next[7] = adc_wakeup_status_cc_discon_qs;
+        reg_rdata_next[7:0] = filter_status_qs;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[0] = adc_intr_ctl_chn0_1_filter0_en_qs;
-        reg_rdata_next[1] = adc_intr_ctl_chn0_1_filter1_en_qs;
-        reg_rdata_next[2] = adc_intr_ctl_chn0_1_filter2_en_qs;
-        reg_rdata_next[3] = adc_intr_ctl_chn0_1_filter3_en_qs;
-        reg_rdata_next[4] = adc_intr_ctl_chn0_1_filter4_en_qs;
-        reg_rdata_next[5] = adc_intr_ctl_chn0_1_filter5_en_qs;
-        reg_rdata_next[6] = adc_intr_ctl_chn0_1_filter6_en_qs;
-        reg_rdata_next[7] = adc_intr_ctl_chn0_1_filter7_en_qs;
-        reg_rdata_next[8] = adc_intr_ctl_oneshot_intr_en_qs;
+        reg_rdata_next[8:0] = adc_intr_ctl_qs;
       end
 
       addr_hit[30]: begin
@@ -3545,6 +3121,158 @@ module adc_ctrl_reg_top (
   always_comb begin
     reg_busy = '0;
     unique case (1'b1)
+      addr_hit[4]: begin
+        reg_busy =
+          adc_en_ctl_adc_enable_busy |
+          adc_en_ctl_oneshot_mode_busy;
+      end
+      addr_hit[5]: begin
+        reg_busy =
+          adc_pd_ctl_lp_mode_busy |
+          adc_pd_ctl_pwrup_time_busy |
+          adc_pd_ctl_wakeup_time_busy;
+      end
+      addr_hit[6]: begin
+        reg_busy = adc_lp_sample_ctl_busy;
+      end
+      addr_hit[7]: begin
+        reg_busy = adc_sample_ctl_busy;
+      end
+      addr_hit[8]: begin
+        reg_busy = adc_fsm_rst_busy;
+      end
+      addr_hit[9]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_0_min_v_0_busy |
+          adc_chn0_filter_ctl_0_cond_0_busy |
+          adc_chn0_filter_ctl_0_max_v_0_busy |
+          adc_chn0_filter_ctl_0_en_0_busy;
+      end
+      addr_hit[10]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_1_min_v_1_busy |
+          adc_chn0_filter_ctl_1_cond_1_busy |
+          adc_chn0_filter_ctl_1_max_v_1_busy |
+          adc_chn0_filter_ctl_1_en_1_busy;
+      end
+      addr_hit[11]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_2_min_v_2_busy |
+          adc_chn0_filter_ctl_2_cond_2_busy |
+          adc_chn0_filter_ctl_2_max_v_2_busy |
+          adc_chn0_filter_ctl_2_en_2_busy;
+      end
+      addr_hit[12]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_3_min_v_3_busy |
+          adc_chn0_filter_ctl_3_cond_3_busy |
+          adc_chn0_filter_ctl_3_max_v_3_busy |
+          adc_chn0_filter_ctl_3_en_3_busy;
+      end
+      addr_hit[13]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_4_min_v_4_busy |
+          adc_chn0_filter_ctl_4_cond_4_busy |
+          adc_chn0_filter_ctl_4_max_v_4_busy |
+          adc_chn0_filter_ctl_4_en_4_busy;
+      end
+      addr_hit[14]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_5_min_v_5_busy |
+          adc_chn0_filter_ctl_5_cond_5_busy |
+          adc_chn0_filter_ctl_5_max_v_5_busy |
+          adc_chn0_filter_ctl_5_en_5_busy;
+      end
+      addr_hit[15]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_6_min_v_6_busy |
+          adc_chn0_filter_ctl_6_cond_6_busy |
+          adc_chn0_filter_ctl_6_max_v_6_busy |
+          adc_chn0_filter_ctl_6_en_6_busy;
+      end
+      addr_hit[16]: begin
+        reg_busy =
+          adc_chn0_filter_ctl_7_min_v_7_busy |
+          adc_chn0_filter_ctl_7_cond_7_busy |
+          adc_chn0_filter_ctl_7_max_v_7_busy |
+          adc_chn0_filter_ctl_7_en_7_busy;
+      end
+      addr_hit[17]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_0_min_v_0_busy |
+          adc_chn1_filter_ctl_0_cond_0_busy |
+          adc_chn1_filter_ctl_0_max_v_0_busy |
+          adc_chn1_filter_ctl_0_en_0_busy;
+      end
+      addr_hit[18]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_1_min_v_1_busy |
+          adc_chn1_filter_ctl_1_cond_1_busy |
+          adc_chn1_filter_ctl_1_max_v_1_busy |
+          adc_chn1_filter_ctl_1_en_1_busy;
+      end
+      addr_hit[19]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_2_min_v_2_busy |
+          adc_chn1_filter_ctl_2_cond_2_busy |
+          adc_chn1_filter_ctl_2_max_v_2_busy |
+          adc_chn1_filter_ctl_2_en_2_busy;
+      end
+      addr_hit[20]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_3_min_v_3_busy |
+          adc_chn1_filter_ctl_3_cond_3_busy |
+          adc_chn1_filter_ctl_3_max_v_3_busy |
+          adc_chn1_filter_ctl_3_en_3_busy;
+      end
+      addr_hit[21]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_4_min_v_4_busy |
+          adc_chn1_filter_ctl_4_cond_4_busy |
+          adc_chn1_filter_ctl_4_max_v_4_busy |
+          adc_chn1_filter_ctl_4_en_4_busy;
+      end
+      addr_hit[22]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_5_min_v_5_busy |
+          adc_chn1_filter_ctl_5_cond_5_busy |
+          adc_chn1_filter_ctl_5_max_v_5_busy |
+          adc_chn1_filter_ctl_5_en_5_busy;
+      end
+      addr_hit[23]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_6_min_v_6_busy |
+          adc_chn1_filter_ctl_6_cond_6_busy |
+          adc_chn1_filter_ctl_6_max_v_6_busy |
+          adc_chn1_filter_ctl_6_en_6_busy;
+      end
+      addr_hit[24]: begin
+        reg_busy =
+          adc_chn1_filter_ctl_7_min_v_7_busy |
+          adc_chn1_filter_ctl_7_cond_7_busy |
+          adc_chn1_filter_ctl_7_max_v_7_busy |
+          adc_chn1_filter_ctl_7_en_7_busy;
+      end
+      addr_hit[25]: begin
+        reg_busy =
+          adc_chn_val_0_adc_chn_value_ext_0_busy |
+          adc_chn_val_0_adc_chn_value_0_busy |
+          adc_chn_val_0_adc_chn_value_intr_ext_0_busy |
+          adc_chn_val_0_adc_chn_value_intr_0_busy;
+      end
+      addr_hit[26]: begin
+        reg_busy =
+          adc_chn_val_1_adc_chn_value_ext_1_busy |
+          adc_chn_val_1_adc_chn_value_1_busy |
+          adc_chn_val_1_adc_chn_value_intr_ext_1_busy |
+          adc_chn_val_1_adc_chn_value_intr_1_busy;
+      end
+      addr_hit[27]: begin
+        reg_busy = adc_wakeup_ctl_busy;
+      end
+      addr_hit[28]: begin
+        reg_busy = filter_status_busy;
+      end
       default: begin
         reg_busy  = '0;
       end

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2763,7 +2763,7 @@
       reset_connections:
       {
         rst_ni: sys_io_div4
-        rst_slow_ni: sys_aon
+        rst_aon_ni: sys_aon
       }
       clock_reset_export:
       [

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -372,7 +372,7 @@
       type: "adc_ctrl",
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon"},
       clock_group: "peri",
-      reset_connections: {rst_ni: "sys_io_div4", rst_slow_ni: "sys_aon"},
+      reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon"},
       clock_reset_export: ["ast"],
       domain: "Aon",
       base_addr: "0x40440000"
@@ -1399,7 +1399,7 @@
         ],
       },
 
-pinmux: {
+      pinmux: {
         special_signals: [
           // Straps
           { name: 'tap0',   pad: 'IOC0' ,        desc: 'TAP strap signal, maps to a stubbed-off MIO.'  },
@@ -1449,7 +1449,7 @@ pinmux: {
         ],
       },
 
-pinmux: {
+      pinmux: {
         special_signals: [
           // Straps
           { name: 'tap0',   pad: 'IOC0' ,        desc: 'TAP strap signal, maps to a stubbed-off MIO.'  },

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1896,7 +1896,7 @@ module top_earlgrey #(
       .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
       .clk_aon_i (clkmgr_aon_clocks.clk_aon_peri),
       .rst_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]),
-      .rst_slow_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel])
+      .rst_aon_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel])
   );
 
   pwm #(


### PR DESCRIPTION
- adjust adc style to use prim_pulse_sync_data
- adjust certain registers to multi-reg to reduce manual typing
- adjust other registers to just a multi-bit field to reduce typing
- rename blocks and modules according to style
- add clock domain prefix for cdc
- fix wakeup generation requiring the fast clock

The CDC handling will likely be updated again to simplify the
programmer interface and number of separate CDC primitives used now.

Signed-off-by: Timothy Chen <timothytim@google.com>