### PR TITLE
[rv_core_ibex_peri] Correct top-level config signal widths

### DIFF
--- a/hw/ip/rv_core_ibex_peri/data/rv_core_ibex_peri.hjson
+++ b/hw/ip/rv_core_ibex_peri/data/rv_core_ibex_peri.hjson
@@ -48,6 +48,7 @@
       type:    "uni",
       name:    "ibus_region_cfg",
       act:     "req",
+      width:   "2",
       package: "rv_core_ibex_peri_pkg",
     },
 
@@ -55,6 +56,7 @@
       type:    "uni",
       name:    "dbus_region_cfg",
       act:     "req",
+      width:   "2",
       package: "rv_core_ibex_peri_pkg",
     },
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -531,9 +531,9 @@
           type: uni
           name: ibus_region_cfg
           act: rcv
+          width: 2
           package: rv_core_ibex_peri_pkg
           inst_name: rv_core_ibex
-          width: 1
           default: ""
           top_signame: rv_core_ibex_peri_ibus_region_cfg
           index: -1
@@ -543,9 +543,9 @@
           type: uni
           name: dbus_region_cfg
           act: rcv
+          width: 2
           package: rv_core_ibex_peri_pkg
           inst_name: rv_core_ibex
-          width: 1
           default: ""
           top_signame: rv_core_ibex_peri_dbus_region_cfg
           index: -1
@@ -5658,7 +5658,7 @@
           package: rv_core_ibex_peri_pkg
           type: uni
           act: req
-          width: 1
+          width: 2
           inst_name: rv_core_ibex_peri
           default: ""
           end_idx: -1
@@ -5672,7 +5672,7 @@
           package: rv_core_ibex_peri_pkg
           type: uni
           act: req
-          width: 1
+          width: 2
           inst_name: rv_core_ibex_peri
           default: ""
           end_idx: -1
@@ -15854,7 +15854,7 @@
         package: rv_core_ibex_peri_pkg
         type: uni
         act: req
-        width: 1
+        width: 2
         inst_name: rv_core_ibex_peri
         default: ""
         end_idx: -1
@@ -15868,7 +15868,7 @@
         package: rv_core_ibex_peri_pkg
         type: uni
         act: req
-        width: 1
+        width: 2
         inst_name: rv_core_ibex_peri
         default: ""
         end_idx: -1
@@ -16907,9 +16907,9 @@
         type: uni
         name: ibus_region_cfg
         act: rcv
+        width: 2
         package: rv_core_ibex_peri_pkg
         inst_name: rv_core_ibex
-        width: 1
         default: ""
         top_signame: rv_core_ibex_peri_ibus_region_cfg
         index: -1
@@ -16919,9 +16919,9 @@
         type: uni
         name: dbus_region_cfg
         act: rcv
+        width: 2
         package: rv_core_ibex_peri_pkg
         inst_name: rv_core_ibex
-        width: 1
         default: ""
         top_signame: rv_core_ibex_peri_dbus_region_cfg
         index: -1
@@ -18466,7 +18466,7 @@
         package: rv_core_ibex_peri_pkg
         struct: region_cfg
         signame: rv_core_ibex_peri_ibus_region_cfg
-        width: 1
+        width: 2
         type: uni
         end_idx: -1
         act: req
@@ -18477,7 +18477,7 @@
         package: rv_core_ibex_peri_pkg
         struct: region_cfg
         signame: rv_core_ibex_peri_dbus_region_cfg
-        width: 1
+        width: 2
         type: uni
         end_idx: -1
         act: req

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -235,6 +235,7 @@
           type:    "uni",
           name:    "ibus_region_cfg",
           act:     "rcv",
+          width:   "2",
           package: "rv_core_ibex_peri_pkg",
         },
 
@@ -242,6 +243,7 @@
           type:    "uni",
           name:    "dbus_region_cfg",
           act:     "rcv",
+          width:   "2",
           package: "rv_core_ibex_peri_pkg",
         },
       ],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -544,8 +544,8 @@ module top_earlgrey #(
   rv_core_ibex_peri_pkg::alert_event_t       rv_core_ibex_fatal_intg_event;
   rv_core_ibex_peri_pkg::alert_event_t       rv_core_ibex_fatal_core_event;
   rv_core_ibex_peri_pkg::alert_event_t       rv_core_ibex_recov_core_event;
-  rv_core_ibex_peri_pkg::region_cfg_t       rv_core_ibex_peri_ibus_region_cfg;
-  rv_core_ibex_peri_pkg::region_cfg_t       rv_core_ibex_peri_dbus_region_cfg;
+  rv_core_ibex_peri_pkg::region_cfg_t [1:0] rv_core_ibex_peri_ibus_region_cfg;
+  rv_core_ibex_peri_pkg::region_cfg_t [1:0] rv_core_ibex_peri_dbus_region_cfg;
   spi_device_pkg::passthrough_req_t       spi_device_passthrough_req;
   spi_device_pkg::passthrough_rsp_t       spi_device_passthrough_rsp;
   logic       rv_dm_ndmreset_req;


### PR DESCRIPTION
The width mismatch breaks synthesis at the moment.
This is a temporary fix until `rv_core_ibex` has been converted to a fully comportable module (https://github.com/lowRISC/opentitan/issues/7212).

Signed-off-by: Michael Schaffner <msf@google.com>