### PR TITLE
[ spi_host ] Cleanup AscentLint issues

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -100,17 +100,6 @@
                    clearing this bit.''',
           resval: "0x0"
         },
-        { bits: "29",
-          name: "PASSTHRU",
-          desc: '''Enables Pass-through mode, wherein the SPI_HOST IP surrenders
-                   control of the SPI bus to another block. In this mode the
-                   `sck`, `cs_n` and `sd` signals are no longer driven by
-                   the SPI_HOST IP, rather they are multiplexed out to match the
-                   on-chip inputs `pt_sck_i`, `pt_cs_n_i`, `pt_sden_i`, `pt_sdo_i`,
-                   and `pt_sdi_o`.  (Since the `sd` bus is bidirectional, there are
-                   separate input, output and tri-state controls for this bus.)''',
-          resval: "0x0"
-        },
         { bits: "15:8",
           name: "TX_WATERMARK"
           desc: '''If !!EVENT_ENABLE.TXWM is set, the IP will send
@@ -319,8 +308,8 @@
     { name: "COMMAND",
       desc: '''Command Register
 
-               Parameters specific to each command segment.  One common register for all
-               devices''',
+               Parameters specific to each command segment.  Unlike the `CONFIGOPTS` multi-register,
+               there is only one command register for controlling all attached SPI devices''',
       swaccess: "rw",
       hwaccess: "hro",
       hwqe: "true",
@@ -328,7 +317,7 @@
         { bits: "13:12",
           name: "DIRECTION",
           desc: '''The direction for the following command: "0" = Dummy cycles
-                   (no TX/RX). "1" = Rx only, "2" = Tx only, "3" Bidirectional
+                   (no TX/RX). "1" = Rx only, "2" = Tx only, "3" = Bidirectional
                    Tx/Rx (Standard SPI mode only).'''
           resval: "0x0"
         }

--- a/hw/ip/spi_host/rtl/spi_host_data_cdc.sv
+++ b/hw/ip/spi_host/rtl/spi_host_data_cdc.sv
@@ -116,12 +116,12 @@ module spi_host_data_cdc #(
     assign tx_data_be_async_fifo = tx_data_be;
     assign tx_valid_async_fifo   = tx_valid_i;
     assign tx_ready_o            = tx_ready_async_fifo;
-    assign tx_depth_total        = byte'(tx_depth_async_fifo);
+    assign tx_depth_total        = 8'(tx_depth_async_fifo);
 
   end else begin : gen_tx_async_plus_sync
 
     logic [TxSyncDepthW-1:0] tx_depth_sync_fifo;
-    assign tx_depth_total = byte'(tx_depth_async_fifo) + byte'(tx_depth_sync_fifo);
+    assign tx_depth_total = 8'(tx_depth_async_fifo) + 8'(tx_depth_sync_fifo);
 
     prim_fifo_sync #(
       .Width(36),
@@ -187,12 +187,12 @@ module spi_host_data_cdc #(
     assign rx_data_unordered   = rx_data_async_fifo;
     assign rx_valid_o          = rx_valid_async_fifo;
     assign rx_ready_async_fifo = rx_ready_i;
-    assign rx_depth_total      = byte'(rx_depth_async_fifo);
+    assign rx_depth_total      = 8'(rx_depth_async_fifo);
 
   end else begin : gen_rx_async_plus_sync
 
     logic [RxSyncDepthW-1:0] rx_depth_sync_fifo;
-    assign rx_depth_total = byte'(rx_depth_async_fifo) + byte'(rx_depth_sync_fifo);
+    assign rx_depth_total = 8'(rx_depth_async_fifo) + 8'(rx_depth_sync_fifo);
 
     prim_fifo_sync #(
       .Width(32),

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -63,9 +63,6 @@ package spi_host_reg_pkg;
     } tx_watermark;
     struct packed {
       logic        q;
-    } passthru;
-    struct packed {
-      logic        q;
     } sw_rst;
     struct packed {
       logic        q;
@@ -267,11 +264,11 @@ package spi_host_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_host_reg2hw_intr_state_reg_t intr_state; // [125:124]
-    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [123:122]
-    spi_host_reg2hw_intr_test_reg_t intr_test; // [121:118]
-    spi_host_reg2hw_alert_test_reg_t alert_test; // [117:116]
-    spi_host_reg2hw_control_reg_t control; // [115:97]
+    spi_host_reg2hw_intr_state_reg_t intr_state; // [124:123]
+    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [122:121]
+    spi_host_reg2hw_intr_test_reg_t intr_test; // [120:117]
+    spi_host_reg2hw_alert_test_reg_t alert_test; // [116:115]
+    spi_host_reg2hw_control_reg_t control; // [114:97]
     spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [96:66]
     spi_host_reg2hw_csid_reg_t csid; // [65:34]
     spi_host_reg2hw_command_reg_t command; // [33:16]

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -172,8 +172,6 @@ module spi_host_reg_top (
   logic [7:0] control_rx_watermark_wd;
   logic [7:0] control_tx_watermark_qs;
   logic [7:0] control_tx_watermark_wd;
-  logic control_passthru_qs;
-  logic control_passthru_wd;
   logic control_sw_rst_qs;
   logic control_sw_rst_wd;
   logic control_spien_qs;
@@ -462,32 +460,6 @@ module spi_host_reg_top (
 
     // to register interface (read)
     .qs     (control_tx_watermark_qs)
-  );
-
-
-  //   F[passthru]: 29:29
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_control_passthru (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (control_we),
-    .wd     (control_passthru_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.control.passthru.q),
-
-    // to register interface (read)
-    .qs     (control_passthru_qs)
   );
 
 
@@ -1686,8 +1658,6 @@ module spi_host_reg_top (
 
   assign control_tx_watermark_wd = reg_wdata[15:8];
 
-  assign control_passthru_wd = reg_wdata[29];
-
   assign control_sw_rst_wd = reg_wdata[30];
 
   assign control_spien_wd = reg_wdata[31];
@@ -1780,7 +1750,6 @@ module spi_host_reg_top (
       addr_hit[4]: begin
         reg_rdata_next[7:0] = control_rx_watermark_qs;
         reg_rdata_next[15:8] = control_tx_watermark_qs;
-        reg_rdata_next[29] = control_passthru_qs;
         reg_rdata_next[30] = control_sw_rst_qs;
         reg_rdata_next[31] = control_spien_qs;
       end


### PR DESCRIPTION
Clean up remaining issues for spi_host in AscentLint report.

Also includes the removal of the "PASSTHRU" register field, an important change which seems stuck in review in #7135.