### PR TITLE
TEST: Use Vivado 2021.1 in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
   TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
-  VIVADO_VERSION: "2020.1"
+  VIVADO_VERSION: "2020.2"
 
 trigger:
   batch: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ variables:
   TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.
   BUILD_ROOT: $(Build.ArtifactStagingDirectory)
-  VIVADO_VERSION: "2020.2"
+  VIVADO_VERSION: "2021.1"
 
 trigger:
   batch: true

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -65,6 +65,7 @@ Depending on how you interact with the OpenTitan hardware code, one of more of t
 
 * [Verilator](https://verilator.org) {{< tool_version "verilator" >}}
 * Xilinx Vivado {{< tool_version "vivado" >}}
+  (Do not use versions earlier than 2020.2 due to a [critical synthesis bug](https://forums.xilinx.com/t5/Synthesis/Simulation-Synthesis-Mismatch-with-Vivado-2018-3/m-p/1065923#M33849).)
 * Synopsys VCS
 * Cadence Xcelium
 * Cadence JasperGold

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -42,7 +42,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'vivado': {
-        'min_version': '2020.1',
+        'min_version': '2020.2',
         'as_needed': True
     },
 }


### PR DESCRIPTION
This is a test if Vivado 2021.1 does work in CI. I don't intend to make the switch at this point (and there's no real reason for it right now), but it's always good to have another version ready as backup if 2020.2 has a critical bug that we need to work around.