### PR TITLE
[Spi_host/doc] updated documentation to reach V1 ready

### DIFF
--- a/hw/ip/spi_host/data/spi_host.prj.hjson
+++ b/hw/ip/spi_host/data/spi_host.prj.hjson
@@ -5,6 +5,8 @@
 {
     name:               "spi_host",
     design_spec:        "../doc",
+    dv_doc:             "../doc/dv",
+    hw_checklist:       "../doc/checklist",
     revisions: [
       {
         version:            "0.5",

--- a/hw/ip/spi_host/data/spi_host_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_testplan.hjson
@@ -18,12 +18,7 @@
 
             Stimulus:
               - Enable spi_host ip
-              - Clear/enable interrupt (if needed)
-              - Program configuration registers (CONTROL) to reset spi_fsm, reset/set watermark for the fifos
-              - Program the CONFIGOPTS register to config spi_host channel
-                operating in different modes (single, dual, or quad)
-              - Randomize the content of COMMAND register
-              - Program/retrive data in TXDATA/RXDATA register w.r.t transmitted/received transactions
+              - Write data in standard mode - and read it back
 
             Checking:
               - Ensure transactions are transmitted/received correctly
@@ -32,7 +27,7 @@
       tests: ["spi_host_smoke"]
     }
     {
-      name: perf
+      name: performance
       desc: '''
             Send/receive transactions at max bandwidth
 
@@ -45,7 +40,7 @@
               - Ensure transactions are transmitted/received correctly
             '''
       milestone: V2
-      tests: ["spi_host_perf"]
+      tests: []
     }
     {
       name: error_event_intr
@@ -54,7 +49,7 @@
             (except TX OVERFLOW error interrupt is verified in separate test)
 
             Stimulus:
-              - Program ERROR_ENABLE/EVENT_ENABLE register to enable 
+              - Program ERROR_ENABLE/EVENT_ENABLE register to enable
                 corresponding error/event interrupt assertion
               - Program transaction with proper constraints to assert error/event interrupts
 
@@ -66,32 +61,56 @@
                 once the event interrupt pin is asserted
             '''
       milestone: V2
-      tests: ["spi_host_error_event_intr"]
+      tests: []
     }
     {
-      name: tx_overflow_error
+      name: clock_rate
       desc: '''
-            Test TX OVERFLOW error is asserted by the spi_host
-
             Stimulus:
-              - Program ERROR_ENABLE register to enable the TXOVERFLOW interrupt
-              - Program transaction with proper constraints to assert the TXOVERFLOW interrupts
+              - select different settings for:
+              * CONFIGOPTS_0.CSNIDLE_0
+              * CONFIGOPTS_0.CSNLEAD_0
+              * CONFIGOPTS_0.CSNTRAIL_0
 
             Checking:
-              - Ensure excess tx data is dropped
-              - Ensure the matching between the value of OVERFLOW bit in the ERROR_STATUS
-                and the ERROR_ENABLE register the once error interrupt pin is asserted
+              - verify that merging of commands work correctly
+              - verify that the DUT can handle different sck -> cs_n timings
             '''
       milestone: V2
-      tests: ["spi_host_tx_overflow_error"]
+      tests: []
     }
     {
-      name: component_reset
+      name: speed
       desc: '''
-            Test components (spi_fsm, rx_fifo, tx_fifo) are randomly reset
+            Stimulus:
+              - randomly select the DUT to run single/dual/quad mode
+
+            Checking:
+              - verify that all speeds are supported
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_select_timing
+      desc: '''
+            Stimulus:
+              - Randomly select a setting for the 16bit clock divider
+
+            Checking:
+              - Check that the DUT operates correctly under different SPI clock speeds
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: sw_reset
+      desc: '''
+            verify software reset behavior
 
             Stimulus:
-              - Reset the components of spi_host randomly after a random number of data shows up on fifos
+              - Reset the spi_host randomly
+                after a random number of data shows up on fifos
 
             Checking:
               - Ensure that reads to RXDATA register yield 0s after the rx_fifo is reset
@@ -99,35 +118,83 @@
                 after the tx_fifo or spi_fsm is reset
             '''
       milestone: V2
-      tests: ["spi_host_component_reset"]
+      tests: []
     }
     {
-      name: clock_domain
+      name: passthrough_mode
       desc: '''
-            TBD - Verify the function of clock-crossing domain for spi_host
+            - Verify the function of spi_host in passthrough_mode
 
             Stimulus:
               - TBD
-
             Checking:
               - TBD
       '''
       milestone: V2
-      tests: ["spi_host_clock_domain"]
+      tests: []
     }
     {
-      name: special_modes
+      name: cpol_cpha
       desc: '''
-            TBD - Verify the function of spi_host in special_modes (passthrough and manual_ctrl_cs)
-
             Stimulus:
-              - TBD
+              - Randomly chip select for different polarity / phase
 
             Checking:
-              - TBD
-      '''
+              - Check that the DUT operates correctly under different cs_n settings
+            '''
       milestone: V2
-      tests: ["spi_host_special_modes"]
+      tests: []
+    }
+    {
+      name: full_cycle
+      desc: '''
+            Stimulus:
+              - randomly select FULLCYC to be set
+
+            Checking:
+              - Check that the data can be read one full cycle after the data was asserted
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: endian
+      desc: '''
+            Stimulus:
+              - set the compile time parameter to configure the DUT in both modes.
+              if possible this should be randomized for all test to verify support in both modes
+
+            Checking:
+              - Check all features are supported correctly in both little and big endian mode
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: duplex
+      desc: '''
+            Stimulus:
+              - in standard mode set the DUT to run full duplex
+
+            Checking:
+              - verify that the DUT support both half and full duplex in standard mode.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: tx_rx_only
+      desc: '''
+            Stimulus:
+              - in standard mode enable tx only and have the env send garbage back
+              - in standard mode enable rx only and have the env ignore the incoming data
+
+            Checking:
+              - verify that the DUT ignores rx line when in tx only mode
+              - verify that the DUT does not drain the tx fifo in rx only mode
+            '''
+      milestone: V2
+      tests: []
     }
     {
       name: stress_all
@@ -144,7 +211,119 @@
               - Ensure reset is handled correctly
             '''
       milestone: V2
-      tests: ["spi_host_stress_all"]
+      tests: []
+    }
+  ]
+  covergroups: [
+    {
+      name: tx_fifo_overflow_cg
+      desc: '''
+            Collect coverage to verify that an attempt was made to overflow the TX FIFO
+            by attempting to write to a full FIFO
+            '''
+    }
+    {
+      name: rx_fifo_underflow_cg
+      desc: '''
+            Collect coverage to verify that an attempt was made to underflow the RX FIFO
+            by attempting to read from an empty FIFO
+            '''
+    }
+    {
+      name: long_commands_cg
+      desc: '''
+            Collect coverage to verify that both a read and write command longer than 4 bytes
+            was seen
+            '''
+    }
+    {
+      name:config_opts_cg
+      desc: '''
+            Collect coverage on the config opts register, some important crosses:
+
+            -  CPOL and CPHA, check all 4 combinations are tested
+            -  CSNLEAD, CSNTRAIL and CSNIDLE
+            '''
+    }
+    {
+      name: cdc_cg
+      desc: '''
+            Collect coverage on the relationship between the core_clk and the spi_sck to verify that
+            both scenarios with both a slow spi_sck, a very fast spi_sck (2x core_clk)
+            and where the two clocks are very close has been tested
+            '''
+    }
+    {
+      name: unaligned_data_cg
+      desc: '''
+            Collect coverage the alignment of writes to the data window
+            to verify that all possible alignments was seen
+            '''
+    }
+    {
+      name: duplex_cg
+      desc: '''
+            Collect coverage that we verified both duplex and half duplex
+            '''
+    }
+    {
+      name: interrupts_cg
+      desc: '''
+            Collect coverage that all types of interrupt was seen
+            '''
+    }
+    {
+      name: alert_cg
+      desc: '''
+            Collect coverage to verify all alerts are triggered correctly
+            '''
+    }
+    {
+      name: control_cg
+      desc: '''
+            Collect coverage on the control register to make sure all options are excercised
+            - Tx and RX water mark should have a bin for min value, max value
+              and one for everything in between
+            '''
+    }
+    {
+      name: status_cg
+      desc: '''
+            Collect coverage on the status register to make sure all scenarios are checked
+            '''
+    }
+    {
+      name: csid_cg
+      desc: '''
+            Collect coverage that different IDs are used.
+            '''
+    }
+    {
+      name: command_cg
+      desc: '''
+            Collect coverage that different commant settings, important cross:
+
+            - Direction and SPEED
+            - CSAAT and SPEED
+            '''
+    }
+    {
+      name: error_en_cg
+      desc: '''
+            Collect coverage that all possible errors was enabled
+            '''
+    }
+    {
+      name: error_status_cg
+      desc: '''
+            Collect coverage that all possible errors was seen
+            '''
+    }
+    {
+      name: event_en_cg
+      desc: '''
+            Collect coverage that all events was enabled and seen
+            '''
     }
   ]
 }

--- a/hw/ip/spi_host/doc/checklist.md
+++ b/hw/ip/spi_host/doc/checklist.md
@@ -115,8 +115,8 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [SPI_HOST DV document]({{<relref "dv" >}})
-Documentation | [TESTPLAN_COMPLETED][]                | Not Started | [SPI_HOST Testplan]({{<relref "dv/index.md#testplan" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | DONE        | [SPI_HOST DV document]({{<relref "dv" >}})
+Documentation | [TESTPLAN_COMPLETED][]                | DONE        | [SPI_HOST Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Not Started |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |
@@ -125,17 +125,17 @@ Testbench     | [CSR_CHECK_GEN_AUTOMATED][]           | Not Started |
 Testbench     | [TB_GEN_AUTOMATED][]                  | Not Started |
 Tests         | [SIM_SMOKE_TEST_PASSING][]            | Not Started |
 Tests         | [SIM_CSR_MEM_TEST_SUITE_PASSING][]    | Not Started |
-Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | Not Started |
+Tests         | [FPV_MAIN_ASSERTIONS_PROVEN][]        | N/A         |
 Tool Setup    | [SIM_ALT_TOOL_SETUP][]                | Not Started |
 Regression    | [SIM_SMOKE_REGRESSION_SETUP][]        | Not Started |
 Regression    | [SIM_NIGHTLY_REGRESSION_SETUP][]      | Not Started |
 Regression    | [FPV_REGRESSION_SETUP][]              | Not Started |
 Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Not Started |
 Code Quality  | [TB_LINT_SETUP][]                     | Not Started |
-Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | Not Started |
-Review        | [DESIGN_SPEC_REVIEWED][]              | Not Started |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         |
+Review        | [DESIGN_SPEC_REVIEWED][]              | DONE        |
 Review        | [TESTPLAN_REVIEWED][]                 | Not Started |
-Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Not Started | Exception (?)
+Review        | [STD_TEST_CATEGORIES_PLANNED][]       | DONE        |
 Review        | [V2_CHECKLIST_SCOPED][]               | Not Started |
 
 [DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv_doc_draft_completed" >}}

--- a/hw/ip/spi_host/doc/dv/index.md
+++ b/hw/ip/spi_host/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "SPI_HOST DV Plan"
 ## Goals
 * **DV**
   * Verify all SPI_HOST IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run tests that exercise all testpoint in the [DV plan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -31,9 +31,9 @@ In addition, it instantiates the following interfaces, connects them to the DUT 
 * [Clock and reset interface]({{< relref "hw/dv/sv/common_ifs" >}})
 * [TileLink host interface]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
 * SPI_HOST IOs
-* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
-* Alerts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
-* Devmode ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}})
+* Interrupts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
+* Alerts ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
+* Devmode ([`pins_if`]({{< relref "hw/dv/sv/common_ifs" >}}))
 
 ### Common DV utility components
 The following utilities provide generic helper tasks and functions to perform activities that are common across the project:
@@ -43,6 +43,9 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ### Compile-time configurations
 [list compile time configurations, if any and what are they used for]
+```systemverilog
+TODO
+```
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
@@ -53,13 +56,13 @@ TODO
 ### TL_agent
 SPI_HOST testbench instantiates (already handled in CIP base env) 
 [tl_agent]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
-which provides the ability to drive and independently monitor random traffic via
-TL host interface into SPI_HOST device.
+which provides the ability to drive and independently monitor random traffic via TL host interface into SPI_HOST device.
+Transactions will be sampled by the monitor and passed on to the predictor in the scoreboard.
 
 ###  SPI Agent
-SPI agent is configured to work host mode. 
-The agent monitor captures data generated in channels then sends to the scoreboard for verification  
-Since the DUT does not require any response thus agent driver is fairly simple.
+SPI agent is configured to work in target mode.
+The agent monitor samples the pins and stores the data in a sequence item that is forwarded to the predictor in the scoreboard.
+The sequence item is then compared to a sequence item from the predictor generated on the stimulus from the TL_UL accesses.
 
 ### UVM RAL Model
 The SPI_HOST RAL model is created with the [`ralgen`]({{< relref "hw/dv/tools/ralgen/README.md" >}}) FuseSoC generator script automatically when the simulation is at the build stage.
@@ -73,28 +76,45 @@ The `spi_host_base_vseq` virtual sequence is extended from `cip_base_vseq` and s
 All test sequences are extended from `spi_host_base_vseq`.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
 Some of the most commonly used tasks / functions are as follows:
-* task 1:
-* task 2:
+* spi_read(int len, bit [3:0] addr)
+
+  read ***len*** bytes from address ***addr***
+
+* spi_write(int len, bit [3:0] addr)
+
+  write ***len*** bytes to address ***addr***
 
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
-The following covergroups have been developed to prove that the test intent has been adequately met:
-* cg1:
-* cg2:
+the list of functional coverpoints can be found under covergroups in the [DV plan](#testplan)
+
 
 ### Self-checking strategy
 #### Scoreboard
 The `spi_host_scoreboard` is primarily used for end to end checking.
 It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* analysis port1:
-* analysis port2:
-<!-- explain inputs monitored, flow of data and outputs checked -->
+
+**TL_UL AGENT**
+
+* tl_a_chan_fifo: tl address channel
+* tl_d_chan_fifo: tl data channel
+
+**SPI_AGENT**
+
+* spi_channel: TBD - subject to change until env is in place
+
+The tl_ul FIFOs provide the transaction items that will be converted to SPI transactions in the DUT.
+A predictor in the DUT will collect these transactions and convert them into SPI items with an address and data.
+
+On the SPI channel transactions are received in segments.
+These segments are re-assembled into full SPI transactions and stored in SPI sequence items.
+
+The generated item from the predictor and the re-assembled item from the SPI channel is then compared in the scoreboard to validate then transaction.
 
 #### Assertions
 * TLUL assertions: The `tb/spi_host_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
-* assert prop 1:
-* assert prop 2:
+
 
 ## Building and running tests
 We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.


### PR DESCRIPTION
This PR includes 3 commits.
1. Update test plan with test points for both V1 and V2
    Update Coverage plan with functional coverage points
    several test points were added - and the original ones are cleaned up. 
    I also removed the list of tests that were mentioned in each test point as none of these exist and therefore should not be listed 
2. update dv plan so that should now be ready for V1 review
3. updated checklist to track the status of the documentation.

I also added the test plan to the hardware dashboard.

A PR will follow this with the Spi host environment and smoke test.

with approval of this document, I will consider the SPI_HOST documentation reviewed and approved for V1.
IP will stay at V0 until the checklist is complete and reviewed.