### PR TITLE
[dv/otp_ctrl_base_vseq] added timeout specification

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -30,6 +30,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   bit default_req_blocking = 1;
   bit lc_prog_blocking     = 1;
 
+  uint32_t op_done_spinwait_timeout_ns = 20_000_000;
+
   // Collect current lc_state and lc_cnt. This is used to create next lc_state and lc_cnt without
   // error.
   lc_ctrl_state_pkg::lc_state_e lc_state;
@@ -295,6 +297,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
         begin
           csr_spinwait(.ptr(ral.status.dai_idle),
                        .exp_data(1),
+                       .timeout_ns(op_done_spinwait_timeout_ns),
                        .spinwait_delay_ns($urandom_range(0, 5)));
         end
         begin


### PR DESCRIPTION
Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

Partner implementation is slower than ImplGeneric which causes some tests (e.g. otp_ctrl_parallel_lc_req) to fail due to an insufficient timeout length (default is 10ms, increased to 20ms). 