### PR TITLE
[kmac] Add a path to return to Idle in KeyInvalid

### DIFF
--- a/hw/ip/kmac/doc/checklist.md
+++ b/hw/ip/kmac/doc/checklist.md
@@ -35,12 +35,12 @@ Code Quality  | [LINT_SETUP][]                 | Done        |
 
 Type          | Item                    | Resolution  | Note/Collaterals
 --------------|-------------------------|-------------|------------------
-Documentation | [NEW_FEATURES][]        | Done        |
+Documentation | [NEW_FEATURES][]        | In Progress |
 Documentation | [BLOCK_DIAGRAM][]       | Done        |
 Documentation | [DOC_INTERFACE][]       | Done        |
 Documentation | [MISSING_FUNC][]        | N/A         |
 Documentation | [FEATURE_FROZEN][]      | Done        |
-RTL           | [FEATURE_COMPLETE][]    | Done        |
+RTL           | [FEATURE_COMPLETE][]    | In Progress |
 RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -777,7 +777,8 @@ module kmac
 
     .app_active_o(app_active),
 
-    .error_i  (sha3_err.valid),
+    .error_i         (sha3_err.valid),
+    .err_processed_i (err_processed),
 
     // Command interface
     .sw_cmd_i (sw_cmd),


### PR DESCRIPTION
This commit revises the App FSM to:

- change the FSM to be resilient to FI : HD3 sparse encoded
- enable SW to move FSM back to Idle state when error occurs
- discard incoming App traffic to not block the selected App