### PR TITLE
[kmac] Remove entropy refresh timer

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -67,6 +67,12 @@
       desc:    "Number of words for Encoded NsPrefix."
       local:   "true"
     }
+    { name:    "HashCntW"
+      type:    "int unsigned"
+      default: "10"
+      desc:    "Width of the hash counter in the entropy"
+      local:   "true"
+    }
   ]
   inter_signal_list: [
     { struct:  "hw_key_req"
@@ -357,6 +363,17 @@
             } // e: done
           ] // enum
         } // f: cmd
+        { bits: "8"
+          name: "entropy_req"
+          desc: '''SW triggered Entropy Request
+
+          If writes 1 to this field
+          '''
+        } // f: entropy_req
+        { bits: "9"
+          name: "hash_cnt_clr"
+          desc: "If writes 1, it clears the hash (KMAC) counter in the entropy module"
+        }
       ]
     } // R: CMD
     { name: "STATUS"
@@ -402,22 +419,20 @@
       hwaccess: "hro"
       regwen: "CFG_REGWEN"
       fields: [
-        { bits: "15:0"
-          name: "entropy_timer"
-          desc: '''Entropy period in clock cycles This register determines
-          the refresh period. The value is the number of clock cycles. In
-          every entropy period, the entropy generation logic in KMAC requests
-          new entropy to EDN and feed the value into LFSR seed.
+        { bits: "9:0"
+          name: "prescaler"
+          desc: '''EDN Wait timer prescaler.
 
-          If 0, the entropy generation logic does not refresh its seed. The
-          software manually updates the seed by writing into "ENTROPY_SEED"
-          registers. '''
+          EDN Wait timer has 16 bit value. The timer value is increased when the timer pulse is generated. Timer pulse is raises when the number of the clock cycles hit this prescaler value.
+
+          The exact period of the timer pulse is unknown as the KMAC input clock may contain jitters.
+          '''
         }
         { bits: "31:16"
           name: "wait_timer"
           desc: '''EDN request wait timer.
 
-          The entropy module in KMAC waits up to this field in clock cycles
+          The entropy module in KMAC waits up to this field in the timer pulse
           after it sends request to EDN module. If the timer expires, the
           entropy module moves to an error state and notifies to the system.
 
@@ -430,6 +445,34 @@
         }
       ]
     } // R: ENTROPY_PERIOD
+    {
+      name: "ENTROPY_REFRESH"
+      desc: '''Entropy Refresh Threshold and Counter
+
+      KMAC entropy can be refreshed after the given threshold KMAC operations
+      run. If the KMAC hash counter hits (GTE) the configured threshold, the
+      entropy module in the KMAC IP requests new seed to EDN and reset the KMAC
+      hash counter.
+
+      If the threshold is 0, the refresh by the counter does not work. And the
+      counter is only reset by the CMD.hash_cnt_clr CSR bit.
+      '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      regwen: "CFG_REGWEN"
+      fields: [
+        { bits: "HashCntW-1:0"
+          name: "threshold"
+          desc: "Hash Threshold"
+        }
+        { bits: "HashCntW+15:16"
+          name: "hash_cnt"
+          desc: "Hash (KMAC) counter"
+          swaccess: "ro"
+          hwaccess: "hwo"
+        }
+      ]
+    } // R: ENTROPY_REFRESH
     { name: "ENTROPY_SEED_LOWER"
       desc: '''Entropy Seed [31:0].
 

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2166,13 +2166,6 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                   //cfg.clk_rst_vif.wait_clks(1);
                   //sha3_idle = 1;
 
-                  // if using EDN, KMAC will refresh entropy after finishing a hash operation
-                  if (entropy_mode == EntropyModeEdn) begin
-                    cfg.clk_rst_vif.wait_clks(1);
-                    in_edn_fetch = cfg.enable_masking;
-                    refresh_entropy = cfg.enable_masking;
-                    `uvm_info(`gfn, "refreshing entropy from EDN", UVM_HIGH)
-                  end
                 end else begin // SW sent wrong command
 
                   kmac_err.valid = 1;

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -19,14 +19,14 @@ filesets:
       - lowrisc:prim:edn_req
       - lowrisc:ip:kmac_pkg
     files:
+      - rtl/kmac_reg_pkg.sv
+      - rtl/kmac_reg_top.sv
       - rtl/kmac_core.sv
       - rtl/kmac_msgfifo.sv
       - rtl/kmac_staterd.sv
       - rtl/kmac_app.sv
       - rtl/kmac_entropy.sv
       - rtl/kmac_errchk.sv
-      - rtl/kmac_reg_pkg.sv
-      - rtl/kmac_reg_top.sv
       - rtl/kmac.sv
     file_type: systemVerilogSource
 

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -80,8 +80,8 @@ package kmac_pkg;
   } kmac_cmd_e;
 
   // Timer
-  parameter int unsigned EntropyTimerW = 16;
-  parameter int unsigned EdnWaitTimerW = 16;
+  parameter int unsigned TimerPrescalerW = 10;
+  parameter int unsigned EdnWaitTimerW   = 16;
 
   // Entropy Mode Selection : Should be matched to register package Enum value
   typedef enum logic [1:0] {

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -9,6 +9,7 @@ package kmac_reg_pkg;
   // Param list
   parameter int NumWordsKey = 16;
   parameter int NumWordsPrefix = 11;
+  parameter int unsigned HashCntW = 10;
   parameter int NumAlerts = 1;
 
   // Address widths within the block
@@ -96,18 +97,34 @@ package kmac_reg_pkg;
   } kmac_reg2hw_cfg_reg_t;
 
   typedef struct packed {
-    logic [3:0]  q;
-    logic        qe;
+    struct packed {
+      logic [3:0]  q;
+      logic        qe;
+    } cmd;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } entropy_req;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } hash_cnt_clr;
   } kmac_reg2hw_cmd_reg_t;
 
   typedef struct packed {
     struct packed {
-      logic [15:0] q;
-    } entropy_timer;
+      logic [9:0] q;
+    } prescaler;
     struct packed {
       logic [15:0] q;
     } wait_timer;
   } kmac_reg2hw_entropy_period_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [9:0] q;
+    } threshold;
+  } kmac_reg2hw_entropy_refresh_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -189,19 +206,27 @@ package kmac_reg_pkg;
   } kmac_hw2reg_status_reg_t;
 
   typedef struct packed {
+    struct packed {
+      logic [9:0] d;
+      logic        de;
+    } hash_cnt;
+  } kmac_hw2reg_entropy_refresh_reg_t;
+
+  typedef struct packed {
     logic [31:0] d;
     logic        de;
   } kmac_hw2reg_err_code_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    kmac_reg2hw_intr_state_reg_t intr_state; // [1541:1539]
-    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1538:1536]
-    kmac_reg2hw_intr_test_reg_t intr_test; // [1535:1530]
-    kmac_reg2hw_alert_test_reg_t alert_test; // [1529:1528]
-    kmac_reg2hw_cfg_reg_t cfg; // [1527:1514]
-    kmac_reg2hw_cmd_reg_t cmd; // [1513:1509]
-    kmac_reg2hw_entropy_period_reg_t entropy_period; // [1508:1477]
+    kmac_reg2hw_intr_state_reg_t intr_state; // [1549:1547]
+    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1546:1544]
+    kmac_reg2hw_intr_test_reg_t intr_test; // [1543:1538]
+    kmac_reg2hw_alert_test_reg_t alert_test; // [1537:1536]
+    kmac_reg2hw_cfg_reg_t cfg; // [1535:1522]
+    kmac_reg2hw_cmd_reg_t cmd; // [1521:1513]
+    kmac_reg2hw_entropy_period_reg_t entropy_period; // [1512:1487]
+    kmac_reg2hw_entropy_refresh_reg_t entropy_refresh; // [1486:1477]
     kmac_reg2hw_entropy_seed_lower_reg_t entropy_seed_lower; // [1476:1444]
     kmac_reg2hw_entropy_seed_upper_reg_t entropy_seed_upper; // [1443:1411]
     kmac_reg2hw_key_share0_mreg_t [15:0] key_share0; // [1410:883]
@@ -212,10 +237,11 @@ package kmac_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    kmac_hw2reg_intr_state_reg_t intr_state; // [53:48]
-    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [47:47]
-    kmac_hw2reg_cfg_reg_t cfg; // [46:43]
-    kmac_hw2reg_status_reg_t status; // [42:33]
+    kmac_hw2reg_intr_state_reg_t intr_state; // [64:59]
+    kmac_hw2reg_cfg_regwen_reg_t cfg_regwen; // [58:58]
+    kmac_hw2reg_cfg_reg_t cfg; // [57:54]
+    kmac_hw2reg_status_reg_t status; // [53:44]
+    kmac_hw2reg_entropy_refresh_reg_t entropy_refresh; // [43:33]
     kmac_hw2reg_err_code_reg_t err_code; // [32:0]
   } kmac_hw2reg_t;
 
@@ -229,53 +255,54 @@ package kmac_reg_pkg;
   parameter logic [BlockAw-1:0] KMAC_CMD_OFFSET = 12'h 18;
   parameter logic [BlockAw-1:0] KMAC_STATUS_OFFSET = 12'h 1c;
   parameter logic [BlockAw-1:0] KMAC_ENTROPY_PERIOD_OFFSET = 12'h 20;
-  parameter logic [BlockAw-1:0] KMAC_ENTROPY_SEED_LOWER_OFFSET = 12'h 24;
-  parameter logic [BlockAw-1:0] KMAC_ENTROPY_SEED_UPPER_OFFSET = 12'h 28;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_0_OFFSET = 12'h 2c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_1_OFFSET = 12'h 30;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_2_OFFSET = 12'h 34;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_3_OFFSET = 12'h 38;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_4_OFFSET = 12'h 3c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_5_OFFSET = 12'h 40;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_6_OFFSET = 12'h 44;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_7_OFFSET = 12'h 48;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_8_OFFSET = 12'h 4c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_9_OFFSET = 12'h 50;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_10_OFFSET = 12'h 54;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_11_OFFSET = 12'h 58;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_12_OFFSET = 12'h 5c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_13_OFFSET = 12'h 60;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_14_OFFSET = 12'h 64;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_15_OFFSET = 12'h 68;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_0_OFFSET = 12'h 6c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_1_OFFSET = 12'h 70;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_2_OFFSET = 12'h 74;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_3_OFFSET = 12'h 78;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_4_OFFSET = 12'h 7c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_5_OFFSET = 12'h 80;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_6_OFFSET = 12'h 84;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_7_OFFSET = 12'h 88;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_8_OFFSET = 12'h 8c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_9_OFFSET = 12'h 90;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_10_OFFSET = 12'h 94;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_11_OFFSET = 12'h 98;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_12_OFFSET = 12'h 9c;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_13_OFFSET = 12'h a0;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_14_OFFSET = 12'h a4;
-  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_15_OFFSET = 12'h a8;
-  parameter logic [BlockAw-1:0] KMAC_KEY_LEN_OFFSET = 12'h ac;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_0_OFFSET = 12'h b0;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_1_OFFSET = 12'h b4;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_2_OFFSET = 12'h b8;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_3_OFFSET = 12'h bc;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_4_OFFSET = 12'h c0;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_5_OFFSET = 12'h c4;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_6_OFFSET = 12'h c8;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_7_OFFSET = 12'h cc;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_8_OFFSET = 12'h d0;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_9_OFFSET = 12'h d4;
-  parameter logic [BlockAw-1:0] KMAC_PREFIX_10_OFFSET = 12'h d8;
-  parameter logic [BlockAw-1:0] KMAC_ERR_CODE_OFFSET = 12'h dc;
+  parameter logic [BlockAw-1:0] KMAC_ENTROPY_REFRESH_OFFSET = 12'h 24;
+  parameter logic [BlockAw-1:0] KMAC_ENTROPY_SEED_LOWER_OFFSET = 12'h 28;
+  parameter logic [BlockAw-1:0] KMAC_ENTROPY_SEED_UPPER_OFFSET = 12'h 2c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_0_OFFSET = 12'h 30;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_1_OFFSET = 12'h 34;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_2_OFFSET = 12'h 38;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_3_OFFSET = 12'h 3c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_4_OFFSET = 12'h 40;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_5_OFFSET = 12'h 44;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_6_OFFSET = 12'h 48;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_7_OFFSET = 12'h 4c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_8_OFFSET = 12'h 50;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_9_OFFSET = 12'h 54;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_10_OFFSET = 12'h 58;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_11_OFFSET = 12'h 5c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_12_OFFSET = 12'h 60;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_13_OFFSET = 12'h 64;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_14_OFFSET = 12'h 68;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE0_15_OFFSET = 12'h 6c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_0_OFFSET = 12'h 70;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_1_OFFSET = 12'h 74;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_2_OFFSET = 12'h 78;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_3_OFFSET = 12'h 7c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_4_OFFSET = 12'h 80;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_5_OFFSET = 12'h 84;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_6_OFFSET = 12'h 88;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_7_OFFSET = 12'h 8c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_8_OFFSET = 12'h 90;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_9_OFFSET = 12'h 94;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_10_OFFSET = 12'h 98;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_11_OFFSET = 12'h 9c;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_12_OFFSET = 12'h a0;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_13_OFFSET = 12'h a4;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_14_OFFSET = 12'h a8;
+  parameter logic [BlockAw-1:0] KMAC_KEY_SHARE1_15_OFFSET = 12'h ac;
+  parameter logic [BlockAw-1:0] KMAC_KEY_LEN_OFFSET = 12'h b0;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_0_OFFSET = 12'h b4;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_1_OFFSET = 12'h b8;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_2_OFFSET = 12'h bc;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_3_OFFSET = 12'h c0;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_4_OFFSET = 12'h c4;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_5_OFFSET = 12'h c8;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_6_OFFSET = 12'h cc;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_7_OFFSET = 12'h d0;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_8_OFFSET = 12'h d4;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_9_OFFSET = 12'h d8;
+  parameter logic [BlockAw-1:0] KMAC_PREFIX_10_OFFSET = 12'h dc;
+  parameter logic [BlockAw-1:0] KMAC_ERR_CODE_OFFSET = 12'h e0;
 
   // Reset values for hwext registers and their fields
   parameter logic [2:0] KMAC_INTR_TEST_RESVAL = 3'h 0;
@@ -286,7 +313,7 @@ package kmac_reg_pkg;
   parameter logic [0:0] KMAC_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] KMAC_CFG_REGWEN_RESVAL = 1'h 1;
   parameter logic [0:0] KMAC_CFG_REGWEN_EN_RESVAL = 1'h 1;
-  parameter logic [3:0] KMAC_CMD_RESVAL = 4'h 0;
+  parameter logic [9:0] KMAC_CMD_RESVAL = 10'h 0;
   parameter logic [15:0] KMAC_STATUS_RESVAL = 16'h 4001;
   parameter logic [0:0] KMAC_STATUS_SHA3_IDLE_RESVAL = 1'h 1;
   parameter logic [0:0] KMAC_STATUS_FIFO_EMPTY_RESVAL = 1'h 1;
@@ -340,6 +367,7 @@ package kmac_reg_pkg;
     KMAC_CMD,
     KMAC_STATUS,
     KMAC_ENTROPY_PERIOD,
+    KMAC_ENTROPY_REFRESH,
     KMAC_ENTROPY_SEED_LOWER,
     KMAC_ENTROPY_SEED_UPPER,
     KMAC_KEY_SHARE0_0,
@@ -390,63 +418,64 @@ package kmac_reg_pkg;
   } kmac_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] KMAC_PERMIT [56] = '{
+  parameter logic [3:0] KMAC_PERMIT [57] = '{
     4'b 0001, // index[ 0] KMAC_INTR_STATE
     4'b 0001, // index[ 1] KMAC_INTR_ENABLE
     4'b 0001, // index[ 2] KMAC_INTR_TEST
     4'b 0001, // index[ 3] KMAC_ALERT_TEST
     4'b 0001, // index[ 4] KMAC_CFG_REGWEN
     4'b 1111, // index[ 5] KMAC_CFG
-    4'b 0001, // index[ 6] KMAC_CMD
+    4'b 0011, // index[ 6] KMAC_CMD
     4'b 0011, // index[ 7] KMAC_STATUS
     4'b 1111, // index[ 8] KMAC_ENTROPY_PERIOD
-    4'b 1111, // index[ 9] KMAC_ENTROPY_SEED_LOWER
-    4'b 1111, // index[10] KMAC_ENTROPY_SEED_UPPER
-    4'b 1111, // index[11] KMAC_KEY_SHARE0_0
-    4'b 1111, // index[12] KMAC_KEY_SHARE0_1
-    4'b 1111, // index[13] KMAC_KEY_SHARE0_2
-    4'b 1111, // index[14] KMAC_KEY_SHARE0_3
-    4'b 1111, // index[15] KMAC_KEY_SHARE0_4
-    4'b 1111, // index[16] KMAC_KEY_SHARE0_5
-    4'b 1111, // index[17] KMAC_KEY_SHARE0_6
-    4'b 1111, // index[18] KMAC_KEY_SHARE0_7
-    4'b 1111, // index[19] KMAC_KEY_SHARE0_8
-    4'b 1111, // index[20] KMAC_KEY_SHARE0_9
-    4'b 1111, // index[21] KMAC_KEY_SHARE0_10
-    4'b 1111, // index[22] KMAC_KEY_SHARE0_11
-    4'b 1111, // index[23] KMAC_KEY_SHARE0_12
-    4'b 1111, // index[24] KMAC_KEY_SHARE0_13
-    4'b 1111, // index[25] KMAC_KEY_SHARE0_14
-    4'b 1111, // index[26] KMAC_KEY_SHARE0_15
-    4'b 1111, // index[27] KMAC_KEY_SHARE1_0
-    4'b 1111, // index[28] KMAC_KEY_SHARE1_1
-    4'b 1111, // index[29] KMAC_KEY_SHARE1_2
-    4'b 1111, // index[30] KMAC_KEY_SHARE1_3
-    4'b 1111, // index[31] KMAC_KEY_SHARE1_4
-    4'b 1111, // index[32] KMAC_KEY_SHARE1_5
-    4'b 1111, // index[33] KMAC_KEY_SHARE1_6
-    4'b 1111, // index[34] KMAC_KEY_SHARE1_7
-    4'b 1111, // index[35] KMAC_KEY_SHARE1_8
-    4'b 1111, // index[36] KMAC_KEY_SHARE1_9
-    4'b 1111, // index[37] KMAC_KEY_SHARE1_10
-    4'b 1111, // index[38] KMAC_KEY_SHARE1_11
-    4'b 1111, // index[39] KMAC_KEY_SHARE1_12
-    4'b 1111, // index[40] KMAC_KEY_SHARE1_13
-    4'b 1111, // index[41] KMAC_KEY_SHARE1_14
-    4'b 1111, // index[42] KMAC_KEY_SHARE1_15
-    4'b 0001, // index[43] KMAC_KEY_LEN
-    4'b 1111, // index[44] KMAC_PREFIX_0
-    4'b 1111, // index[45] KMAC_PREFIX_1
-    4'b 1111, // index[46] KMAC_PREFIX_2
-    4'b 1111, // index[47] KMAC_PREFIX_3
-    4'b 1111, // index[48] KMAC_PREFIX_4
-    4'b 1111, // index[49] KMAC_PREFIX_5
-    4'b 1111, // index[50] KMAC_PREFIX_6
-    4'b 1111, // index[51] KMAC_PREFIX_7
-    4'b 1111, // index[52] KMAC_PREFIX_8
-    4'b 1111, // index[53] KMAC_PREFIX_9
-    4'b 1111, // index[54] KMAC_PREFIX_10
-    4'b 1111  // index[55] KMAC_ERR_CODE
+    4'b 1111, // index[ 9] KMAC_ENTROPY_REFRESH
+    4'b 1111, // index[10] KMAC_ENTROPY_SEED_LOWER
+    4'b 1111, // index[11] KMAC_ENTROPY_SEED_UPPER
+    4'b 1111, // index[12] KMAC_KEY_SHARE0_0
+    4'b 1111, // index[13] KMAC_KEY_SHARE0_1
+    4'b 1111, // index[14] KMAC_KEY_SHARE0_2
+    4'b 1111, // index[15] KMAC_KEY_SHARE0_3
+    4'b 1111, // index[16] KMAC_KEY_SHARE0_4
+    4'b 1111, // index[17] KMAC_KEY_SHARE0_5
+    4'b 1111, // index[18] KMAC_KEY_SHARE0_6
+    4'b 1111, // index[19] KMAC_KEY_SHARE0_7
+    4'b 1111, // index[20] KMAC_KEY_SHARE0_8
+    4'b 1111, // index[21] KMAC_KEY_SHARE0_9
+    4'b 1111, // index[22] KMAC_KEY_SHARE0_10
+    4'b 1111, // index[23] KMAC_KEY_SHARE0_11
+    4'b 1111, // index[24] KMAC_KEY_SHARE0_12
+    4'b 1111, // index[25] KMAC_KEY_SHARE0_13
+    4'b 1111, // index[26] KMAC_KEY_SHARE0_14
+    4'b 1111, // index[27] KMAC_KEY_SHARE0_15
+    4'b 1111, // index[28] KMAC_KEY_SHARE1_0
+    4'b 1111, // index[29] KMAC_KEY_SHARE1_1
+    4'b 1111, // index[30] KMAC_KEY_SHARE1_2
+    4'b 1111, // index[31] KMAC_KEY_SHARE1_3
+    4'b 1111, // index[32] KMAC_KEY_SHARE1_4
+    4'b 1111, // index[33] KMAC_KEY_SHARE1_5
+    4'b 1111, // index[34] KMAC_KEY_SHARE1_6
+    4'b 1111, // index[35] KMAC_KEY_SHARE1_7
+    4'b 1111, // index[36] KMAC_KEY_SHARE1_8
+    4'b 1111, // index[37] KMAC_KEY_SHARE1_9
+    4'b 1111, // index[38] KMAC_KEY_SHARE1_10
+    4'b 1111, // index[39] KMAC_KEY_SHARE1_11
+    4'b 1111, // index[40] KMAC_KEY_SHARE1_12
+    4'b 1111, // index[41] KMAC_KEY_SHARE1_13
+    4'b 1111, // index[42] KMAC_KEY_SHARE1_14
+    4'b 1111, // index[43] KMAC_KEY_SHARE1_15
+    4'b 0001, // index[44] KMAC_KEY_LEN
+    4'b 1111, // index[45] KMAC_PREFIX_0
+    4'b 1111, // index[46] KMAC_PREFIX_1
+    4'b 1111, // index[47] KMAC_PREFIX_2
+    4'b 1111, // index[48] KMAC_PREFIX_3
+    4'b 1111, // index[49] KMAC_PREFIX_4
+    4'b 1111, // index[50] KMAC_PREFIX_5
+    4'b 1111, // index[51] KMAC_PREFIX_6
+    4'b 1111, // index[52] KMAC_PREFIX_7
+    4'b 1111, // index[53] KMAC_PREFIX_8
+    4'b 1111, // index[54] KMAC_PREFIX_9
+    4'b 1111, // index[55] KMAC_PREFIX_10
+    4'b 1111  // index[56] KMAC_ERR_CODE
   };
 
 endpackage

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -195,9 +195,6 @@ dif_kmac_result_t dif_kmac_configure(dif_kmac_t *kmac,
   // Write entropy period register.
   uint32_t entropy_period_reg = 0;
   entropy_period_reg = bitfield_field32_write(
-      entropy_period_reg, KMAC_ENTROPY_PERIOD_ENTROPY_TIMER_FIELD,
-      config.entropy_reseed_interval);
-  entropy_period_reg = bitfield_field32_write(
       entropy_period_reg, KMAC_ENTROPY_PERIOD_WAIT_TIMER_FIELD,
       config.entropy_wait_timer);
   mmio_region_write32(kmac->params.base_addr, KMAC_ENTROPY_PERIOD_REG_OFFSET,


### PR DESCRIPTION
This commit removes the entropy refresh timer. The timer introduces
complex modeling in the KMAC scoreboard and does not help the security
model much.

The design is changed to:

- Remove the entropy timer entirely
- Introduce SW triggered EDN refresh request
- Increase EDN wait timer to support more than 5ms wait, which is the
  maximum wait time to be expected.
- Add CSR for SW to check the number of Hashing op run