### PR TITLE
[dv/chip] Update jtag agent

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
@@ -16,4 +16,9 @@ class jtag_riscv_agent_cfg extends dv_base_agent_cfg;
     this.has_driver = 0;
   endfunction : new
 
+  // assert trst_n for a number of cycles
+  task do_trst_n(int cycles = $urandom_range(5, 20));
+    m_jtag_agent_cfg.do_trst_n(cycles);
+  endtask
+
 endclass

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -14,7 +14,7 @@ filesets:
       - lowrisc:dv:str_utils
       - lowrisc:dv:cip_lib
       - lowrisc:dv:uart_agent
-      - lowrisc:dv:jtag_agent
+      - lowrisc:dv:jtag_riscv_agent
       - lowrisc:dv:spi_agent
       - lowrisc:dv:mem_bkdr_util
       - lowrisc:dv:sw_test_status

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -11,7 +11,7 @@ class chip_env extends cip_base_env #(
   `uvm_component_utils(chip_env)
 
   uart_agent          m_uart_agent;
-  jtag_agent          m_jtag_agent;
+  jtag_riscv_agent    m_jtag_riscv_agent;
   spi_agent           m_spi_agent;
 
   `uvm_component_new
@@ -65,8 +65,9 @@ class chip_env extends cip_base_env #(
     m_uart_agent = uart_agent::type_id::create("m_uart_agent", this);
     uvm_config_db#(uart_agent_cfg)::set(this, "m_uart_agent*", "cfg", cfg.m_uart_agent_cfg);
 
-    m_jtag_agent = jtag_agent::type_id::create("m_jtag_agent", this);
-    uvm_config_db#(jtag_agent_cfg)::set(this, "m_jtag_agent*", "cfg", cfg.m_jtag_agent_cfg);
+    m_jtag_riscv_agent = jtag_riscv_agent::type_id::create("m_jtag_riscv_agent", this);
+    uvm_config_db#(jtag_riscv_agent_cfg)::set(this, "m_jtag_riscv_agent*", "cfg",
+                   cfg.m_jtag_riscv_agent_cfg);
 
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
     uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
@@ -82,13 +83,13 @@ class chip_env extends cip_base_env #(
     if (cfg.en_scb) begin
       m_uart_agent.monitor.tx_analysis_port.connect(scoreboard.uart_tx_fifo.analysis_export);
       m_uart_agent.monitor.rx_analysis_port.connect(scoreboard.uart_rx_fifo.analysis_export);
-      m_jtag_agent.monitor.analysis_port.connect(scoreboard.jtag_fifo.analysis_export);
+      m_jtag_riscv_agent.monitor.analysis_port.connect(scoreboard.jtag_fifo.analysis_export);
     end
     if (cfg.is_active && cfg.m_uart_agent_cfg.is_active) begin
       virtual_sequencer.uart_sequencer_h = m_uart_agent.sequencer;
     end
-    if (cfg.is_active && cfg.m_jtag_agent_cfg.is_active) begin
-      virtual_sequencer.jtag_sequencer_h = m_jtag_agent.sequencer;
+    if (cfg.is_active && cfg.m_jtag_riscv_agent_cfg.is_active) begin
+      virtual_sequencer.jtag_sequencer_h = m_jtag_riscv_agent.sequencer;
     end
     if (cfg.is_active && cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -58,15 +58,15 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   sw_test_status_vif  sw_test_status_vif;
 
   // ext component cfgs
-  rand uart_agent_cfg m_uart_agent_cfg;
-  rand jtag_agent_cfg m_jtag_agent_cfg;
-  rand spi_agent_cfg  m_spi_agent_cfg;
+  rand uart_agent_cfg       m_uart_agent_cfg;
+  rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
+  rand spi_agent_cfg        m_spi_agent_cfg;
 
   `uvm_object_utils_begin(chip_env_cfg)
-    `uvm_field_int   (stub_cpu,             UVM_DEFAULT)
-    `uvm_field_object(m_uart_agent_cfg,     UVM_DEFAULT)
-    `uvm_field_object(m_jtag_agent_cfg,     UVM_DEFAULT)
-    `uvm_field_object(m_spi_agent_cfg,      UVM_DEFAULT)
+    `uvm_field_int   (stub_cpu,               UVM_DEFAULT)
+    `uvm_field_object(m_uart_agent_cfg,       UVM_DEFAULT)
+    `uvm_field_object(m_jtag_riscv_agent_cfg, UVM_DEFAULT)
+    `uvm_field_object(m_spi_agent_cfg,        UVM_DEFAULT)
   `uvm_object_utils_end
 
   // TODO: Fixing core clk freq to 50MHz for now.
@@ -92,7 +92,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
     m_uart_agent_cfg = uart_agent_cfg::type_id::create("m_uart_agent_cfg");
 
     // create jtag agent config obj
-    m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
+    m_jtag_riscv_agent_cfg = jtag_riscv_agent_cfg::type_id::create("m_jtag_riscv_agent_cfg");
 
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -14,7 +14,7 @@ package chip_env_pkg;
   import csr_utils_pkg::*;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;
-  import jtag_agent_pkg::*;
+  import jtag_riscv_agent_pkg::*;
   import spi_agent_pkg::*;
   import dv_lib_pkg::*;
   import cip_base_pkg::*;

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -12,14 +12,14 @@ class chip_scoreboard extends cip_base_scoreboard #(
   // local variables
 
   // TLM agent fifos
-  uvm_tlm_analysis_fifo #(uart_item) uart_tx_fifo;
-  uvm_tlm_analysis_fifo #(uart_item) uart_rx_fifo;
-  uvm_tlm_analysis_fifo #(jtag_item) jtag_fifo;
+  uvm_tlm_analysis_fifo #(uart_item)       uart_tx_fifo;
+  uvm_tlm_analysis_fifo #(uart_item)       uart_rx_fifo;
+  uvm_tlm_analysis_fifo #(jtag_riscv_item) jtag_fifo;
 
   // local queues to hold incoming packets pending comparison
-  uart_item uart_tx_q[$];
-  uart_item uart_rx_q[$];
-  jtag_item jtag_q[$];
+  uart_item       uart_tx_q[$];
+  uart_item       uart_rx_q[$];
+  jtag_riscv_item jtag_q[$];
 
   `uvm_component_new
 
@@ -42,7 +42,7 @@ class chip_scoreboard extends cip_base_scoreboard #(
   endtask
 
   virtual task process_jtag_fifo();
-    jtag_item item;
+    jtag_riscv_item item;
     forever begin
       jtag_fifo.get(item);
       `uvm_info(`gfn, $sformatf("received jtag item:\n%0s", item.sprint()), UVM_HIGH)

--- a/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
+++ b/hw/top_earlgrey/dv/env/chip_virtual_sequencer.sv
@@ -8,9 +8,9 @@ class chip_virtual_sequencer extends cip_base_virtual_sequencer #(
   );
   `uvm_component_utils(chip_virtual_sequencer)
 
-  uart_sequencer  uart_sequencer_h;
-  jtag_sequencer  jtag_sequencer_h;
-  spi_sequencer   spi_sequencer_h;
+  uart_sequencer       uart_sequencer_h;
+  jtag_riscv_sequencer jtag_sequencer_h;
+  spi_sequencer        spi_sequencer_h;
 
   // Grab packets from UART TX port for in-sequence checking.
   uvm_tlm_analysis_fifo #(uart_item) uart_tx_fifo;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -38,7 +38,7 @@ class chip_base_vseq extends cip_base_vseq #(
     // TODO: Cannot assert different types of resets in parallel; due to randomization
     // resets de-assert at different times. If the main rst_n de-asserts before others,
     // the CPU starts executing right away which can cause breakages.
-    cfg.m_jtag_agent_cfg.do_trst_n();
+    cfg.m_jtag_riscv_agent_cfg.do_trst_n();
     super.apply_reset(kind);
   endtask
 

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -249,7 +249,7 @@ module tb;
     // IO Interfaces
     uvm_config_db#(virtual pins_if #(NUM_GPIOS))::set(null, "*.env", "gpio_vif", gpio_if);
     uvm_config_db#(virtual uart_if)::set(null, "*.env.m_uart_agent*", "vif", uart_if);
-    uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_agent*", "vif", jtag_if);
+    uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_riscv_agent*", "vif", jtag_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", cpu_d_tl_if);
 


### PR DESCRIPTION
This PR updates jtag agent to jtag riscv agent.
Jtag agent becomes a base agent, the jtag_riscv_agent is the agent to
actually drive CSR commands.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>