### PR TITLE
[dv/jtag] Fix jtag sequence typo

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
@@ -49,7 +49,7 @@ class jtag_riscv_csr_seq extends jtag_riscv_base_seq;
     while (1) begin
       bit [DMI_DRW-1:0] dout;
       send_csr_dr_req(DmiStatus, 0, 0, dout);
-      status = rdata[0 +: DMI_OPW];
+      status = dout[0 +: DMI_OPW];
 
       // The DmiInProgress status is sticky and has to be cleared by dmireset via DTMCS.
       if (status == DmiInProgress) begin


### PR DESCRIPTION
This PR fixes a jtag typo: I should use the jtag output `dout` instead
of `rdata` to get the read/write status.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>