### PR TITLE
[lc_ctrl] Do not assert escalate_en in post transition state

### DIFF
--- a/hw/ip/lc_ctrl/doc/lc_ctrl_function_signals_table.md
+++ b/hw/ip/lc_ctrl/doc/lc_ctrl_function_signals_table.md
@@ -17,31 +17,31 @@
   <tr>
     <td style="text-align:left">RAW</td>
     <td rowspan = "9" colspan="4" style="text-align:center;vertical-align:middle"> See <a href="../../../../doc/security/specs/device_life_cycle/#manufacturing-states">life cycle definition table</a> </td>
-    <td colspan="1" style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td><td>Y*</td><td>Y*</td>
+    <td style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
    <td style="text-align:left">TEST_LOCKED</td>
-   <td colspan="1" style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td><td>Y*</td><td>Y*</td>
+   <td style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left">TEST_UNLOCKED</td>
-    <td colspan="2" style="background:#dadce0"></td><td>Y*</td><td>Y*</td><td>Y*</td>
+    <td colspan="2" style="background:#dadce0"></td><td>Y*</td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left">DEV</td>
-    <td>Y</td><td style="background:#dadce0"></td><td>Y*</td><td>Y*</td><td>Y*</td>
+    <td>Y</td><td style="background:#dadce0"></td><td>Y*</td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left">PROD</td>
-    <td>Y</td><td style="background:#dadce0"></td><td>Y*</td><td>Y*</td><td>Y*</td>
+    <td>Y</td><td style="background:#dadce0"></td><td>Y*</td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left">PROD_END</td>
-    <td>Y</td><td colspan="2" style="background:#dadce0"></td><td>Y*</td><td>Y*</td>
+    <td>Y</td><td colspan="2" style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left">RMA</td>
-    <td>Y</td><td colspan="2" style="background:#dadce0"></td><td>Y*</td><td>Y*</td>
+    <td>Y</td><td colspan="2" style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left">SCRAP</td>
@@ -53,7 +53,7 @@
   </tr>
   <tr>
     <td style="text-align:left;color:red">POST_TRANSITION</td>
-    <td colspan="7" style="background:#dadce0"></td><td>Y*</td><td>Y</td>
+    <td colspan="7" style="background:#dadce0"></td><td>Y*</td><td style="background:#dadce0"></td>
   </tr>
   <tr>
     <td style="text-align:left;color:red">ESCALATION</td>

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -81,7 +81,7 @@ package lc_ctrl_env_pkg;
     // Scrap
     {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, On},
     // PostTrans
-    {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, On},
+    {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, Off},
     // Escalate
     {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, On},
     // Invalid

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -145,9 +145,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
       "lc_transition_cnt", "lc_state": do_read_check = 1;
       "status": begin
         if (data_phase_read) begin
-          // when lc successfully req a transition, all outputs are turned off, except for the
-          // lc_escalate_en_o signal, which is asserted when in scrap state.
-          exp.lc_escalate_en_o = lc_ctrl_pkg::On;
+          // when lc successfully req a transition, all outputs are turned off.
           if (item.d_data[ral.status.transition_successful.get_lsb_pos()]) check_lc_outputs(exp);
         end
       end

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_signal_decode.sv
@@ -174,9 +174,14 @@ module lc_ctrl_signal_decode
         end
       end
       ///////////////////////////////////////////////////////////////////
+      // Post-transition state. Behaves similarly to the virtual scrap
+      // states below, with the exception that escalate_en, since that
+      // could trigger unwanted alerts / escalations and system resets.
+      // is NOT asserted.
+      PostTransSt: ;
+      ///////////////////////////////////////////////////////////////////
       // Virtual scrap states, make sure the escalation signal is
       // also asserted in this case.
-      PostTransSt,
       EscalateSt,
       InvalidSt: begin
         lc_escalate_en = On;
@@ -316,7 +321,8 @@ module lc_ctrl_signal_decode
                             FlashRmaSt,
                             TokenHashSt,
                             TokenCheck0St,
-                            TokenCheck1St})
+                            TokenCheck1St,
+                            PostTransSt})
       |=>
       lc_escalate_en_o == On)
 
@@ -330,7 +336,8 @@ module lc_ctrl_signal_decode
                           FlashRmaSt,
                           TokenHashSt,
                           TokenCheck0St,
-                          TokenCheck1St} &&
+                          TokenCheck1St,
+                          PostTransSt} &&
       !(lc_state_i inside {LcStRaw,
                            LcStTestUnlocked0,
                            LcStTestLocked0,


### PR DESCRIPTION
Although the post-transition state is a virtual scrap state, we should not assert `escalate_en` in order to avoid accidental triggering of alerts and escalation sequences. Such escalation sequences typically lead to lead to autonomous system resets, and that could cause issues with the life cycle transition status readout via the life cycle TAP.

Addresses https://github.com/lowRISC/opentitan/issues/7251

Signed-off-by: Michael Schaffner <msf@opentitan.org>