### PR TITLE
[keymgr] Add otbn sideload and widen kmac intf to 384-bits

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -17,8 +17,8 @@ interface kmac_app_intf (input clk, input rst_n);
   push_pull_if #(.HostDataWidth(kmac_app_agent_pkg::KMAC_REQ_DATA_WIDTH))
       req_data_if(.clk(clk), .rst_n(rst_n));
   wire rsp_done;
-  wire [KeyWidth-1:0] rsp_digest_share0;
-  wire [KeyWidth-1:0] rsp_digest_share1;
+  wire [kmac_pkg::AppDigestW-1:0] rsp_digest_share0;
+  wire [kmac_pkg::AppDigestW-1:0] rsp_digest_share1;
   wire rsp_error;
 
   // all the host pins are handled by push_pull driver, only include clk and rst here

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -49,6 +49,12 @@
       act:     "req",
       package: "keymgr_pkg",  // Origin package (only needs for the requester)
     },
+    { struct:  "otbn_key_req",
+      type:    "uni",
+      name:    "otbn_key",
+      act:     "req",
+      package: "keymgr_pkg",
+    },
     { struct:  "app",   // kmac_pkg::app_req_t, kmac_pkg::app_rsp_t
       type:    "req_rsp",
       name:    "kmac_data",   // kmac_data_o (req), kmac_data_i (rsp)
@@ -172,6 +178,13 @@
 
     { name:      "RndCnstKmacSeed",
       desc:      "Compile-time random bits for generation seed when kmac destination selected",
+      type:      "keymgr_pkg::seed_t"
+      randcount: "256",
+      randtype:  "data",
+    },
+
+    { name:      "RndCnstOtbnSeed",
+      desc:      "Compile-time random bits for generation seed when otbn destination selected",
       type:      "keymgr_pkg::seed_t"
       randcount: "256",
       randtype:  "data",
@@ -324,8 +337,7 @@
           ],
         },
 
-
-        { bits: "13:12",
+        { bits: "14:12",
           name: "DEST_SEL",
           desc: '''
             When the OPERATION field is programmed to generate output, this field selects
@@ -357,6 +369,16 @@
               name: "KMAC",
               desc: '''
                 KMAC selected
+                '''
+            },
+            { value: "4",
+              name: "OTBN",
+              desc: '''
+                OTBN selected.  Note for OTBN hardware operations, the generated output is 384-bits, while for all
+                other operations (including OTBN software), it is 256-bits.
+
+                Generating a hardware 384-bit seed directly for OTBN sideload reduces some of the OTBN code burden for entropy expansion.
+                When generating for software, this is not a concern.
                 '''
             },
           ]

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -167,7 +167,7 @@ interface keymgr_if(input clk, input rst_n);
                                          keymgr_pkg::keymgr_working_state_e state,
                                          bit good_key = 1);
 
-    kmac_key_exp <= '{1'b1, key_shares[0], key_shares[1]};
+    kmac_key_exp <= '{1'b1, key_shares};
     is_kmac_key_good = good_key;
   endfunction
 
@@ -186,17 +186,17 @@ interface keymgr_if(input clk, input rst_n);
                                               bit good_key = 1);
     case (dest)
       keymgr_pkg::Kmac: begin
-        kmac_key_exp             <= '{1'b1, key_shares[0], key_shares[1]};
+        kmac_key_exp             <= '{1'b1, key_shares};
         is_kmac_key_good         <= good_key;
         is_kmac_sideload_avail   <= 1;
         kmac_sideload_key_shares <= key_shares;
       end
       keymgr_pkg::Hmac: begin
-        hmac_key_exp     <= '{1'b1, key_shares[0], key_shares[1]};
+        hmac_key_exp     <= '{1'b1, key_shares};
         is_hmac_key_good <= good_key;
       end
       keymgr_pkg::Aes: begin
-        aes_key_exp     <= '{1'b1, key_shares[0], key_shares[1]};
+        aes_key_exp     <= '{1'b1, key_shares};
         is_aes_key_good <= good_key;
       end
       default: `uvm_fatal("keymgr_if", $sformatf("Unexpect dest type %0s", dest.name))
@@ -258,7 +258,7 @@ interface keymgr_if(input clk, input rst_n);
       @(posedge clk);
       if (kmac_data_rsp.done) begin
         if (is_kmac_sideload_avail) begin
-          kmac_key_exp <= '{1'b1, kmac_sideload_key_shares[0], kmac_sideload_key_shares[1]};
+          kmac_key_exp <= '{1'b1, kmac_sideload_key_shares};
           is_kmac_key_good <= 1;
         end else begin
           kmac_key_exp.valid <= 0;
@@ -299,7 +299,7 @@ interface keymgr_if(input clk, input rst_n);
   function automatic void check_invalid_key(keymgr_pkg::hw_key_req_t act_key, string key_name);
     if (rst_n && act_key.valid && !is_cmd_err && !is_fsm_err) begin
       foreach (keys_a_array[i, j]) begin
-        `DV_CHECK_NE({act_key.key_share1, act_key.key_share0}, keys_a_array[i][j],
+        `DV_CHECK_NE({act_key.key[1], act_key.key[0]}, keys_a_array[i][j],
             $sformatf("%s key at state %s from %s", key_name, i, j), , msg_id)
       end
     end

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -176,12 +176,13 @@ module keymgr_ctrl import keymgr_pkg::*; (
   // - when there are no operations, the key state also should be exposed.
   assign key_o.valid = op_req;
   assign cdi_sel_o = advance_sel ? cdi_cnt : op_cdi_sel_i;
-  assign key_o.key_share0 = stage_sel_o == Disable ?
-                            {EntropyRounds{entropy_i[0]}} :
-                            key_state_q[cnt[cdi_sel_o]][0];
-  assign key_o.key_share1 = stage_sel_o == Disable ?
-                            {EntropyRounds{entropy_i[1]}} :
-                            key_state_q[cnt[cdi_sel_o]][1];
+
+  for (genvar i = 0; i < Shares; i++) begin : gen_key_out_assign
+    assign key_o.key[i] = stage_sel_o == Disable ?
+                          {EntropyRounds{entropy_i[i]}} :
+                          key_state_q[cnt[cdi_sel_o]][i];
+  end
+
 
   // key state is intentionally not reset
   always_ff @(posedge clk_i) begin

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -23,7 +23,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   input id_en_i,
   input gen_en_i,
   output logic done_o,
-  output logic [Shares-1:0][KeyWidth-1:0] data_o,
+  output logic [Shares-1:0][kmac_pkg::AppDigestW-1:0] data_o,
 
   // actual connection to kmac
   output kmac_pkg::app_req_t kmac_data_o,
@@ -67,7 +67,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   localparam int CntWidth = $clog2(MaxRounds);
   localparam int IfBytes = KmacDataIfWidth / 8;
   localparam int DecoyCopies = KmacDataIfWidth / 32;
-  localparam int DecoyOutputCopies = (KeyWidth / 32) * Shares;
+  localparam int DecoyOutputCopies = (kmac_pkg::AppDigestW / 32) * Shares;
 
   localparam int unsigned LastAdvRoundInt = AdvRounds - 1;
   localparam int unsigned LastIdRoundInt = IdRounds - 1;

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -10,6 +10,7 @@ package keymgr_pkg;
   parameter int KeyWidth = 256;
   parameter int CDIs = 2; // 2 different CDIs, sealing / attestation
   parameter int CdiWidth = prim_util_pkg::vbits(CDIs);
+  parameter int OtbnKeyWidth = 384;
   parameter int DigestWidth = 128;     // uses truncated hash
   parameter int KmacDataIfWidth = 64;  // KMAC interface data width
   parameter int KeyMgrStages = 3;      // Number of key manager stages (creator, ownerInt, owner)
@@ -49,6 +50,8 @@ package keymgr_pkg;
     256'h075CF7939313EEC797019BD0036D9500374A8FD9121CC8E78E1E3359D5F77C4E;
   parameter seed_t RndCnstKmacSeedDefault =
     256'h0A5CCCD9627BF6169B3A765D3D6D0CD89DBDCB7B6DF8D3C03746D60A0145D3ED;
+  parameter seed_t RndCnstOtbnSeedDefault =
+    256'h17B0AF865F8ACDDFC7580C2B7BC3FB33FC9BB5A4B292216C123ACF99A7861F96;
 
   // Default Lfsr configurations
   // These LFSR parameters have been generated with
@@ -96,7 +99,8 @@ package keymgr_pkg;
     None,
     Aes,
     Hmac,
-    Kmac
+    Kmac,
+    Otbn
   } keymgr_key_dest_e;
 
   // Enumeration for key select
@@ -152,17 +156,26 @@ package keymgr_pkg;
     KeyUpdateWipe
   } keymgr_key_update_e;
 
-  // Key connection to various modules
+  // Key connection to various symmetric modules
   typedef struct packed {
     logic valid;
-    logic [KeyWidth-1:0] key_share0;
-    logic [KeyWidth-1:0] key_share1;
+    logic [Shares-1:0][KeyWidth-1:0] key;
   } hw_key_req_t;
+
+  // Key connection to otbn
+  typedef struct packed {
+    logic valid;
+    logic [Shares-1:0][OtbnKeyWidth-1:0] key;
+  } otbn_key_req_t;
 
   parameter hw_key_req_t HW_KEY_REQ_DEFAULT = '{
     valid: 1'b0,
-    key_share0: KeyWidth'(32'hDEADBEEF),
-    key_share1: KeyWidth'(32'hFACEBEEF)
+    key: {Shares{KeyWidth'(32'hDEADBEEF)}}
+  };
+
+  parameter otbn_key_req_t OTBN_KEY_REQ_DEFAULT = '{
+    valid: 1'b0,
+    key: {Shares{OtbnKeyWidth'(32'hDEADBEEF)}}
   };
 
   // The following structs should be sourced from other modules

--- a/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_pkg.sv
@@ -55,7 +55,7 @@ package keymgr_reg_pkg;
       logic        q;
     } cdi_sel;
     struct packed {
-      logic [1:0]  q;
+      logic [2:0]  q;
     } dest_sel;
   } keymgr_reg2hw_control_reg_t;
 
@@ -176,11 +176,11 @@ package keymgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    keymgr_reg2hw_intr_state_reg_t intr_state; // [933:933]
-    keymgr_reg2hw_intr_enable_reg_t intr_enable; // [932:932]
-    keymgr_reg2hw_intr_test_reg_t intr_test; // [931:930]
-    keymgr_reg2hw_alert_test_reg_t alert_test; // [929:926]
-    keymgr_reg2hw_control_reg_t control; // [925:919]
+    keymgr_reg2hw_intr_state_reg_t intr_state; // [934:934]
+    keymgr_reg2hw_intr_enable_reg_t intr_enable; // [933:933]
+    keymgr_reg2hw_intr_test_reg_t intr_test; // [932:931]
+    keymgr_reg2hw_alert_test_reg_t alert_test; // [930:927]
+    keymgr_reg2hw_control_reg_t control; // [926:919]
     keymgr_reg2hw_sideload_clear_reg_t sideload_clear; // [918:918]
     keymgr_reg2hw_reseed_interval_reg_t reseed_interval; // [917:902]
     keymgr_reg2hw_sw_binding_regwen_reg_t sw_binding_regwen; // [901:900]

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -124,8 +124,8 @@ module keymgr_reg_top (
   logic [2:0] control_operation_wd;
   logic control_cdi_sel_qs;
   logic control_cdi_sel_wd;
-  logic [1:0] control_dest_sel_qs;
-  logic [1:0] control_dest_sel_wd;
+  logic [2:0] control_dest_sel_qs;
+  logic [2:0] control_dest_sel_wd;
   logic sideload_clear_we;
   logic sideload_clear_qs;
   logic sideload_clear_wd;
@@ -490,11 +490,11 @@ module keymgr_reg_top (
   );
 
 
-  //   F[dest_sel]: 13:12
+  //   F[dest_sel]: 14:12
   prim_subreg #(
-    .DW      (2),
+    .DW      (3),
     .SWACCESS("RW"),
-    .RESVAL  (2'h0)
+    .RESVAL  (3'h0)
   ) u_control_dest_sel (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2181,7 +2181,7 @@ module keymgr_reg_top (
 
   assign control_cdi_sel_wd = reg_wdata[7];
 
-  assign control_dest_sel_wd = reg_wdata[13:12];
+  assign control_dest_sel_wd = reg_wdata[14:12];
   assign sideload_clear_we = addr_hit[6] & reg_we & !reg_error;
 
   assign sideload_clear_wd = reg_wdata[0];
@@ -2375,7 +2375,7 @@ module keymgr_reg_top (
         reg_rdata_next[0] = control_start_qs;
         reg_rdata_next[6:4] = control_operation_qs;
         reg_rdata_next[7] = control_cdi_sel_qs;
-        reg_rdata_next[13:12] = control_dest_sel_qs;
+        reg_rdata_next[14:12] = control_dest_sel_qs;
       end
 
       addr_hit[6]: begin

--- a/hw/ip/keymgr/rtl/keymgr_sideload_key.sv
+++ b/hw/ip/keymgr/rtl/keymgr_sideload_key.sv
@@ -6,7 +6,9 @@
 
 `include "prim_assert.sv"
 
-module keymgr_sideload_key import keymgr_pkg::*;(
+module keymgr_sideload_key import keymgr_pkg::*; #(
+  parameter int Width = KeyWidth
+) (
   input clk_i,
   input rst_ni,
   input en_i,
@@ -14,18 +16,18 @@ module keymgr_sideload_key import keymgr_pkg::*;(
   input set_i,
   input clr_i,
   input [Shares-1:0][RandWidth-1:0] entropy_i,
-  input [Shares-1:0][KeyWidth-1:0] key_i,
-  output hw_key_req_t key_o
+  input [Shares-1:0][Width-1:0] key_i,
+  output logic valid_o,
+  output logic [Shares-1:0][Width-1:0] key_o
 );
 
-  localparam int EntropyCopies = KeyWidth / 32;
+  localparam int EntropyCopies = Width / 32;
 
   logic valid_q;
-  logic [Shares-1:0][KeyWidth-1:0] key_q;
+  logic [Shares-1:0][Width-1:0] key_q;
 
-  assign key_o.valid = valid_q & en_i;
-  assign key_o.key_share0 = key_q[0];
-  assign key_o.key_share1 = key_q[1];
+  assign valid_o = valid_q & en_i;
+  assign key_o = key_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -32,7 +32,7 @@
   param_list: [
     { name:    "EnMasking"
       type:    "bit"
-      default: "0"
+      default: "1"
       desc:    '''
         Disable(0) or enable(1) first-order masking of Keccak round.
 

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -312,8 +312,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
             `uvm_info(`gfn, $sformatf("detected valid sideload_key: %0p", sideload_key), UVM_HIGH)
 
             for (int i = 0; i < keymgr_pkg::KeyWidth / 32; i++) begin
-              keymgr_keys[0][i] = sideload_key.key_share0[i*32 +: 32];
-              keymgr_keys[1][i] = sideload_key.key_share1[i*32 +: 32];
+              keymgr_keys[0][i] = sideload_key.key[0][i*32 +: 32];
+              keymgr_keys[1][i] = sideload_key.key[1][i*32 +: 32];
             end
 
             // Sequence will drop the sideloaded key after scb can process the digest

--- a/hw/ip/kmac/dv/env/kmac_sideload_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_sideload_if.sv
@@ -18,8 +18,8 @@ interface kmac_sideload_if;
     keymgr_pkg::hw_key_req_t key;
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(key, key.valid == key_valid;, , path)
-    key.key_share0 = (key_valid) ? share0 : 'hx;
-    key.key_share1 = (key_valid) ? share1 : 'hx;
+    key[0] = (key_valid) ? share0 : 'hx;
+    key[1] = (key_valid) ? share1 : 'hx;
 
     sideload_key = key;
   endtask

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -180,7 +180,7 @@ package kmac_pkg;
 
   // MsgWidth : 64
   // MsgStrbW : 8
-  parameter int unsigned AppDigestW = 256;
+  parameter int unsigned AppDigestW = 384;
 
   typedef struct packed {
     logic valid;

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -29,7 +29,9 @@ package rom_ctrl_env_pkg;
   parameter uint   NUM_ALERTS = 1;
 
   // The top bytes in memory hold the digest
-  parameter uint MAX_CHECK_ADDR = rom_ctrl_reg_pkg::ROM_CTRL_ROM_SIZE - (kmac_pkg::AppDigestW / 8);
+  // KMAC's max digest size is larger than what is required, so declare the size here.
+  parameter uint DIGEST_SIZE    = 256;
+  parameter uint MAX_CHECK_ADDR = rom_ctrl_reg_pkg::ROM_CTRL_ROM_SIZE - (DIGEST_SIZE / 8);
   // The data for each line in rom up to the digest is padded out to the kmac message width
   parameter uint KMAC_DATA_SIZE = MAX_CHECK_ADDR / (TL_DW / 8) * (kmac_pkg::MsgWidth / 8);
   // The rom width is rounded up to 40 for scrambling symmetry

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -72,12 +72,12 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task read_digest_regs();
     bit [TL_DW-1:0] rdata;
-    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+    for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
       string digest_name = $sformatf("digest_%0d", i);
       uvm_reg csr = ral.get_reg_by_name(digest_name);
       csr_rd(.ptr(csr), .value(rdata));
     end
-    for (int i = 0; i < kmac_pkg::AppDigestW / TL_DW; i++) begin
+    for (int i = 0; i < DIGEST_SIZE / TL_DW; i++) begin
       string digest_name = $sformatf("exp_digest_%0d", i);
       uvm_reg csr = ral.get_reg_by_name(digest_name);
       csr_rd(.ptr(csr), .value(rdata));

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -80,10 +80,15 @@ module rom_ctrl
 
   assign kmac_rom_rdy = kmac_data_i.ready;
   assign kmac_done = kmac_data_i.done;
-  assign kmac_digest = kmac_data_i.digest_share0 ^ kmac_data_i.digest_share1;
+  assign kmac_digest = kmac_data_i.digest_share0[255:0] ^ kmac_data_i.digest_share1[255:0];
 
   logic unused_kmac_error;
-  assign unused_kmac_error = &{1'b0, kmac_data_i.error};
+  assign unused_kmac_error = ^kmac_data_i.error;
+  logic unused_kmac_digest;
+  assign unused_kmac_digest = ^{
+    kmac_data_i.digest_share0[kmac_pkg::AppDigestW-1:256],
+    kmac_data_i.digest_share1[kmac_pkg::AppDigestW-1:256]
+  };
 
   // TL interface ==============================================================
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4298,7 +4298,7 @@
             If masking is enabled, ReuseShare parameter will impact the design.
             '''
           type: bit
-          default: "0"
+          default: "1"
           expose: "true"
           name_top: KmacEnMasking
         }
@@ -4533,13 +4533,23 @@
           randwidth: 256
         }
         {
+          name: RndCnstOtbnSeed
+          desc: Compile-time random bits for generation seed when otbn destination selected
+          type: keymgr_pkg::seed_t
+          randcount: 256
+          randtype: data
+          name_top: RndCnstKeymgrOtbnSeed
+          default: 0x56289223d7e05db35983fe5a262a6e3ab1655d42b3090ae475a2df4171fdfd7c
+          randwidth: 256
+        }
+        {
           name: RndCnstNoneSeed
           desc: Compile-time random bits for generation seed when no destination selected
           type: keymgr_pkg::seed_t
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0x56289223d7e05db35983fe5a262a6e3ab1655d42b3090ae475a2df4171fdfd7c
+          default: 0xe9d1b1f891dcab64f5a52883a710b72b92e47f6e0845f450ead8f3095ff32c32
           randwidth: 256
         }
       ]
@@ -4589,6 +4599,16 @@
           end_idx: -1
           top_type: broadcast
           top_signame: keymgr_kmac_key
+          index: -1
+        }
+        {
+          name: otbn_key
+          struct: otbn_key_req
+          package: keymgr_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: keymgr
           index: -1
         }
         {
@@ -4720,7 +4740,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0x3a1955e3d4549f3608232d03f93eed0fe9d1b1f891dcab64f5a52883a710b72b92e47f6e0845f450ead8f3095ff32c32
+          default: 0xb6fee0311af608b7123f603c251a36ab2e658548c5420be549da272d96ae771b3a1955e3d4549f3608232d03f93eed0f
           randwidth: 384
         }
         {
@@ -4730,7 +4750,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0x220e25ba7743095f2c1194fb74487a86b6fee0311af608b7123f603c251a36ab2e658548c5420be549da272d96ae771b
+          default: 0xcb942155264f8c121b7387a0a07db44fe8c330ca072829f9970f91074501568220e25ba7743095f2c1194fb74487a86
           randwidth: 384
         }
         {
@@ -5145,7 +5165,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xfe8c330ca072829f9970f91074501568
+          default: 0x1dd6e62190d79f1230d02f643ac42fa7
           randwidth: 128
         }
         {
@@ -5155,7 +5175,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0xcb942155264f8c121b7387a0a07db44
+          default: 0x5120695530d16a94098e681252f1c774
           randwidth: 128
         }
         {
@@ -5165,7 +5185,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainSramLfsrPerm
-          default: 0x2bc503fee4ec68862f5c4db196cc15df82a1c8ce
+          default: 0x2dc87cedcba3e48e7595fc2221a74051acdc4fc1
           randwidth: 160
         }
         {
@@ -5346,7 +5366,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndLfsrSeed
-          default: 0x44c7bd9e98eb2847fa1a35f74a8586d23e3bd765866c6f6363a02ed345973cf
+          default: 0x983d914e80a925bc15891b60c560a7fb75457e09e258c252c3083125be14e22d
           randwidth: 256
         }
         {
@@ -5356,7 +5376,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstOtbnUrndChunkLfsrPerm
-          default: 0xc12f0e2b9ea5a371fd0f691ca53bf257b7531e119cef75b206a2ca62f4d02ee4a4029144fe8521d5f36637ee6805c7a
+          default: 0x7e95af64caa87b2e1aed74700fc12c9793c18dcd269ce74beab6096c81addee885340fbd2900a4513cff852d47560db1
           randwidth: 384
         }
         {
@@ -5366,7 +5386,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0x2fb69c3aab936b415a0d6e7185eaa2e0
+          default: 0xfd9c13ac08496db56fbc4894d38bd867
           randwidth: 128
         }
         {
@@ -5376,7 +5396,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0x3ae54e9e45da6e66
+          default: 0x9e4da0e3ff9f3036
           randwidth: 64
         }
       ]
@@ -5500,7 +5520,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0xce44cbff5e09e6dd
+          default: 0x5d7717a4b76a8aff
           randwidth: 64
         }
         {
@@ -5510,7 +5530,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0xe58a331208f189de6265edc8fde06db0
+          default: 0xb798ab7845c3feab0d2f4c7cf730a567
           randwidth: 128
         }
       ]
@@ -15187,6 +15207,16 @@
         end_idx: -1
         top_type: broadcast
         top_signame: keymgr_kmac_key
+        index: -1
+      }
+      {
+        name: otbn_key
+        struct: otbn_key_req
+        package: keymgr_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: keymgr
         index: -1
       }
       {

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -1077,7 +1077,6 @@ module chip_earlgrey_asic (
     .AesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
-    .KmacEnMasking(1),  // DOM AND + Masking scheme
     .KmacReuseShare(0),
     .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -731,6 +731,7 @@ module chip_earlgrey_cw310 #(
   top_earlgrey #(
     .AesMasking(1'b1),
     .AesSBoxImpl(aes_pkg::SBoxImplDom),
+    .KmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -731,6 +731,7 @@ module chip_earlgrey_nexysvideo #(
   top_earlgrey #(
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .KmacEnMasking(0),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
     .SecAesSkipPRNGReseeding(1'b0),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -20,7 +20,7 @@ module top_earlgrey #(
   parameter int unsigned SecAesStartTriggerDelay = 0,
   parameter bit SecAesAllowForcingMasks = 1'b0,
   parameter bit SecAesSkipPRNGReseeding = 1'b0,
-  parameter bit KmacEnMasking = 0,
+  parameter bit KmacEnMasking = 1,
   parameter int KmacReuseShare = 0,
   parameter aes_pkg::sbox_impl_e CsrngSBoxImpl = aes_pkg::SBoxImplCanright,
   parameter bit EntropySrcStub = 0,
@@ -2284,6 +2284,7 @@ module top_earlgrey #(
     .RndCnstAesSeed(RndCnstKeymgrAesSeed),
     .RndCnstHmacSeed(RndCnstKeymgrHmacSeed),
     .RndCnstKmacSeed(RndCnstKeymgrKmacSeed),
+    .RndCnstOtbnSeed(RndCnstKeymgrOtbnSeed),
     .RndCnstNoneSeed(RndCnstKeymgrNoneSeed)
   ) u_keymgr (
 
@@ -2300,6 +2301,7 @@ module top_earlgrey #(
       .aes_key_o(),
       .hmac_key_o(),
       .kmac_key_o(keymgr_kmac_key),
+      .otbn_key_o(),
       .kmac_data_o(kmac_app_req[0]),
       .kmac_data_i(kmac_app_rsp[0]),
       .otp_key_i(otp_ctrl_otp_keymgr_key),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -191,9 +191,14 @@ package top_earlgrey_rnd_cnst_pkg;
     256'h63DD2AF7CA1C6AE78EFCBDC6ADA112F1235EE7DBA5042C13061068C02CEF00B7
   };
 
+  // Compile-time random bits for generation seed when otbn destination selected
+  parameter keymgr_pkg::seed_t RndCnstKeymgrOtbnSeed = {
+    256'h56289223D7E05DB35983FE5A262A6E3AB1655D42B3090AE475A2DF4171FDFD7C
+  };
+
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'h56289223D7E05DB35983FE5A262A6E3AB1655D42B3090AE475A2DF4171FDFD7C
+    256'hE9D1B1F891DCAB64F5A52883A710B72B92E47F6E0845F450EAD8F3095FF32C32
   };
 
   ////////////////////////////////////////////
@@ -201,14 +206,14 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'h3A1955E3D4549F3608232D03F93EED0F,
-    256'hE9D1B1F891DCAB64F5A52883A710B72B92E47F6E0845F450EAD8F3095FF32C32
+    128'hB6FEE0311AF608B7123F603C251A36AB,
+    256'h2E658548C5420BE549DA272D96AE771B3A1955E3D4549F3608232D03F93EED0F
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'h220E25BA7743095F2C1194FB74487A86,
-    256'hB6FEE0311AF608B7123F603C251A36AB2E658548C5420BE549DA272D96AE771B
+    128'h0CB942155264F8C121B7387A0A07DB44,
+    256'hFE8C330CA072829F9970F91074501568220E25BA7743095F2C1194FB74487A86
   };
 
   ////////////////////////////////////////////
@@ -216,17 +221,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hFE8C330CA072829F9970F91074501568
+    128'h1DD6E62190D79F1230D02F643AC42FA7
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h0CB942155264F8C121B7387A0A07DB44
+    128'h5120695530D16A94098E681252F1C774
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainSramLfsrPerm = {
-    160'h2BC503FEE4EC68862F5C4DB196CC15DF82A1C8CE
+    160'h2DC87CEDCBA3E48E7595FC2221A74051ACDC4FC1
   };
 
   ////////////////////////////////////////////
@@ -234,23 +239,23 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_lfsr_seed_t RndCnstOtbnUrndLfsrSeed = {
-    256'h044C7BD9E98EB2847FA1A35F74A8586D23E3BD765866C6F6363A02ED345973CF
+    256'h983D914E80A925BC15891B60C560A7FB75457E09E258C252C3083125BE14E22D
   };
 
   // Permutation applied to the LFSR chunks of the PRNG used for URND.
   parameter otbn_pkg::urnd_chunk_lfsr_perm_t RndCnstOtbnUrndChunkLfsrPerm = {
-    128'h0C12F0E2B9EA5A371FD0F691CA53BF25,
-    256'h7B7531E119CEF75B206A2CA62F4D02EE4A4029144FE8521D5F36637EE6805C7A
+    128'h7E95AF64CAA87B2E1AED74700FC12C97,
+    256'h93C18DCD269CE74BEAB6096C81ADDEE885340FBD2900A4513CFF852D47560DB1
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'h2FB69C3AAB936B415A0D6E7185EAA2E0
+    128'hFD9C13AC08496DB56FBC4894D38BD867
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'h3AE54E9E45DA6E66
+    64'h9E4DA0E3FF9F3036
   };
 
   ////////////////////////////////////////////
@@ -258,12 +263,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'hCE44CBFF5E09E6DD
+    64'h5D7717A4B76A8AFF
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'hE58A331208F189DE6265EDC8FDE06DB0
+    128'hB798AB7845C3FEAB0D2F4C7CF730A567
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -154,7 +154,6 @@ module chip_earlgrey_verilator (
   top_earlgrey #(
     .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),
-    .KmacEnMasking(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
     .rst_ni                       (rst_ni            ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -931,7 +931,6 @@ module chip_${top["name"]}_${target["name"]} (
     .AesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
-    .KmacEnMasking(1),  // DOM AND + Masking scheme
     .KmacReuseShare(0),
     .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),
@@ -1077,6 +1076,7 @@ module chip_${top["name"]}_${target["name"]} (
 % if target["name"] == "cw310":
     .AesMasking(1'b1),
     .AesSBoxImpl(aes_pkg::SBoxImplDom),
+    .KmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
@@ -1092,6 +1092,7 @@ module chip_${top["name"]}_${target["name"]} (
 % else:
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .KmacEnMasking(0),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
     .SecAesSkipPRNGReseeding(1'b0),


### PR DESCRIPTION
This PR does a few things

- Add otbn sideload support to keymgr
- Widen otbn sideload to 384-bits instead of the 256-bits that everyone else uses
- Widen kmac digest to 384-bits as well
- Minor fixes on other modules due to the widening. 