### PR TITLE
[sw/silicon_creator] Constrain otp_read to aligned reads

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -28,18 +28,9 @@ uint64_t otp_read64(uint32_t address) {
   return value;
 }
 
-rom_error_t otp_read(uint32_t address, void *data, size_t len) {
-  // TODO Update to use alignment utility functions.
-  // https://github.com/lowRISC/opentitan/issues/6112
-  if (address % alignof(uint32_t) != 0 || len % sizeof(uint32_t) != 0) {
-    return kErrorOtpBadAlignment;
-  }
-
+void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
   uint32_t reg_offset = OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + address;
-  for (size_t i = 0; i < len; i += sizeof(uint32_t)) {
-    uint32_t word = sec_mmio_read32(kBase + reg_offset + i);
-    memcpy(data + i, &word, sizeof(uint32_t));
+  for (size_t i = 0; i < num_words; ++i) {
+    data[i] = sec_mmio_read32(kBase + reg_offset + i * sizeof(uint32_t));
   }
-
-  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -37,18 +37,14 @@ OTP_WARN_UNUSED_RESULT
 uint64_t otp_read64(uint32_t address);
 
 /**
- * Perform a blocking read of `len` bytes from the memory mapped software config
- * partitions. It is required that both `address` and `address` + `len` be
- * word-aligned.
+ * Perform a blocking read of `num_words` 32-bit words from the memory mapped
+ * software config partitions.
  *
  * @param address The address to read from offset from the start of OTP memory.
- * @param data The output buffer of at least length `len`.
- * @param len The number of bytes to read from OTP.
- * @return `kErrorOtpBadAlignment` if `address` or `address` + `len` are
- * misaligned, `kErrorOk` otherwise.
+ * @param data The output buffer of at least length `num_words`.
+ * @param num_words The number of 32-bit words to read from OTP.
  */
-OTP_WARN_UNUSED_RESULT
-rom_error_t otp_read(uint32_t address, void *data, size_t len);
+void otp_read(uint32_t address, uint32_t *data, size_t num_words);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Update the signature for otp_read as a follow-up to
https://github.com/lowRISC/opentitan/pull/7000/files#r652890537
