### PR TITLE
[kmac] Error Checker to send valid cmd only

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -215,11 +215,13 @@ module kmac
 
   // Command
   // sw_cmd is the command written by SW
+  // checked_sw_cmd is checked in the kmac_errchk module.
+  //   Invalid command is filtered out in the module.
   // kmac_cmd is generated in KeyMgr interface.
   // If SW initiates the KMAC/SHA3, kmac_cmd represents SW command,
   // if KeyMgr drives the data, kmac_cmd is controled in the state machine
   // in KeyMgr interface logic.
-  kmac_cmd_e sw_cmd, kmac_cmd;
+  kmac_cmd_e sw_cmd, checked_sw_cmd, kmac_cmd;
 
   // Entropy configurations
   logic [15:0] entropy_timer_limit;
@@ -781,7 +783,7 @@ module kmac
     .err_processed_i (err_processed),
 
     // Command interface
-    .sw_cmd_i (sw_cmd),
+    .sw_cmd_i (checked_sw_cmd),
     .cmd_o    (kmac_cmd),
 
     // Error report
@@ -847,6 +849,7 @@ module kmac
 
     // SW commands
     .sw_cmd_i(sw_cmd),
+    .sw_cmd_o(checked_sw_cmd),
 
     // Status from KMAC_APP
     .app_active_i(app_active),

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -56,8 +56,9 @@ module kmac_errchk
   input        kmac_en_i,
   input [47:0] cfg_prefix_6B_i, // first 6B of PREFIX
 
-  // SW commands
-  input kmac_cmd_e sw_cmd_i,
+  // SW commands: Only valid command is sent out to the rest of the modules
+  input  kmac_cmd_e sw_cmd_i,
+  output kmac_cmd_e sw_cmd_o,
 
   // Status from KMAC_APP
   input app_active_i,
@@ -156,6 +157,13 @@ module kmac_errchk
         err_swsequence = 1'b 0;
       end
     endcase
+  end
+
+  // sw_cmd_o latch
+  // To reduce the command path delay, sw_cmd is latched here
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni)              sw_cmd_o <= CmdNone;
+    else if (!err_swsequence) sw_cmd_o <= sw_cmd_i;
   end
 
   // Mode & Strength


### PR DESCRIPTION
This commit revises kmac_errchk to send only valid commands to the rest
of the modules. So that the following modules does not have complex
sequence checker anymore.

Due to timing concern, this module latches the sw_cmd input signal. It
changes the cycle accurate model in the DV environment.

The CI (private) will fail. I am looking at the scoreboard to fix.