### PR TITLE
[util] Add ability to declare parameter values from top

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -572,6 +572,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -611,6 +612,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -650,6 +652,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -689,6 +692,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -728,6 +732,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -769,6 +774,7 @@
         scan_clk_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -845,6 +851,7 @@
         clk_core_i: clkmgr_aon_clocks.clk_io_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -899,6 +906,7 @@
         clk_core_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -948,6 +956,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -987,6 +996,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -1026,6 +1036,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -1065,6 +1076,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -1104,6 +1116,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -1153,6 +1166,7 @@
         clk_usb_48mhz_i: clkmgr_aon_clocks.clk_usb_peri
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -1301,6 +1315,7 @@
         clk_edn_i: clkmgr_aon_clocks.clk_main_timers
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -1587,6 +1602,7 @@
         clk_kmac_i: clkmgr_aon_clocks.clk_main_timers
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -2035,6 +2051,7 @@
         clk_edn_i: clkmgr_aon_clocks.clk_main_timers
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -2154,6 +2171,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_slow_i: clkmgr_aon_clocks.clk_aon_powerup
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -2401,6 +2419,7 @@
         clk_io_div2_i: clkmgr_aon_clocks.clk_io_div2_powerup
         clk_io_div4_i: clkmgr_aon_clocks.clk_io_div4_powerup
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -2531,6 +2550,7 @@
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -2751,6 +2771,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
         clk_aon_i: clkmgr_aon_clocks.clk_aon_secure
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -2821,6 +2842,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
         clk_aon_i: clkmgr_aon_clocks.clk_aon_peri
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -2888,6 +2910,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_core_i: clkmgr_aon_clocks.clk_aon_powerup
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -2931,6 +2954,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_aon_i: clkmgr_aon_clocks.clk_aon_powerup
       }
+      param_decl: {}
       param_list:
       [
         {
@@ -3182,6 +3206,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
         clk_aon_i: clkmgr_aon_clocks.clk_aon_timers
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -3274,6 +3299,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -3315,6 +3341,7 @@
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -3409,6 +3436,7 @@
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
         clk_otp_i: clkmgr_aon_clocks.clk_io_div4_peri
       }
+      param_decl: {}
       param_list:
       [
         {
@@ -3597,6 +3625,7 @@
         clk_otp_i: clkmgr_aon_clocks.clk_io_div4_infra
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -3858,6 +3887,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_infra
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -3998,6 +4028,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -4040,6 +4071,7 @@
         clk_edn_i: clkmgr_aon_clocks.clk_main_aes
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -4233,6 +4265,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_hmac
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -4270,6 +4303,10 @@
     {
       name: kmac
       type: kmac
+      param_decl:
+      {
+        EnMasking: "1"
+      }
       clock_srcs:
       {
         clk_i: main
@@ -4410,6 +4447,7 @@
         clk_edn_i: clkmgr_aon_clocks.clk_main_secure
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -4731,6 +4769,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_secure
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -4868,6 +4907,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_secure
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -5005,6 +5045,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -5079,6 +5120,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_secure
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [
@@ -5156,6 +5198,7 @@
         clk_otp_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -5341,6 +5384,7 @@
         clk_otp_i: clkmgr_aon_clocks.clk_io_div4_otbn
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -5503,6 +5547,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_infra
       }
       domain: "0"
+      param_decl: {}
       param_list:
       [
         {
@@ -5633,6 +5678,7 @@
         clk_i: clkmgr_aon_clocks.clk_main_infra
       }
       domain: "0"
+      param_decl: {}
       param_list: []
       inter_signal_list:
       [

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -566,8 +566,9 @@
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x41110000",
     },
-    { name: "kmac"
-      type: "kmac"
+    { name: "kmac",
+      type: "kmac",
+      param_decl: {EnMasking: "1"}
       clock_srcs: {clk_i: "main", clk_edn_i: "main"}
       clock_group: "trans"
       reset_connections: {rst_ni: "sys", rst_edn_ni: "sys"}

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -731,7 +731,7 @@ module chip_earlgrey_nexysvideo #(
   top_earlgrey #(
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
-    .KmacEnMasking(0),
+    .KmacEnMasking(1'b0),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
     .SecAesSkipPRNGReseeding(1'b0),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1092,7 +1092,7 @@ module chip_${top["name"]}_${target["name"]} (
 % else:
     .AesMasking(1'b0),
     .AesSBoxImpl(aes_pkg::SBoxImplLut),
-    .KmacEnMasking(0),
+    .KmacEnMasking(1'b0),
     .SecAesStartTriggerDelay(0),
     .SecAesAllowForcingMasks(1'b0),
     .SecAesSkipPRNGReseeding(1'b0),


### PR DESCRIPTION
[util] Add ability to declare parameter level directly from top_earlgrey.hjson

Addresses #5227

- This will allow us to control what the ASIC variant should look like from
  inside top_earlgrey, while still allowing top level overrides for FPGA.

- This will be particularly useful for rv_core_ibex templating

Signed-off-by: Timothy Chen <timothytim@google.com>