### PR TITLE
[xbar/dv] Fix a name search issue

### DIFF
--- a/hw/ip/tlul/generic_dv/env/xbar_env.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env.sv
@@ -27,7 +27,7 @@ class xbar_env extends dv_base_env#(.CFG_T              (xbar_env_cfg),
       host_agent[i] = tl_agent::type_id::create(
                       $sformatf("%0s_agent", xbar_hosts[i].host_name), this);
       uvm_config_db#(tl_agent_cfg)::set(this,
-        $sformatf("*%0s*", xbar_hosts[i].host_name),"cfg", cfg.host_agent_cfg[i]);
+        $sformatf("%0s_agent", xbar_hosts[i].host_name),"cfg", cfg.host_agent_cfg[i]);
       cfg.host_agent_cfg[i].en_cov = cfg.en_cov;
     end
     device_agent = new[cfg.num_devices];
@@ -35,7 +35,7 @@ class xbar_env extends dv_base_env#(.CFG_T              (xbar_env_cfg),
       device_agent[i] = tl_agent::type_id::create(
                       $sformatf("%0s_agent", xbar_devices[i].device_name), this);
       uvm_config_db#(tl_agent_cfg)::set(this,
-        $sformatf("*%0s*", xbar_devices[i].device_name), "cfg", cfg.device_agent_cfg[i]);
+        $sformatf("%0s_agent", xbar_devices[i].device_name), "cfg", cfg.device_agent_cfg[i]);
       cfg.device_agent_cfg[i].en_cov = cfg.en_cov;
     end
 

--- a/hw/ip/tlul/generic_dv/tb/xbar_macros.svh
+++ b/hw/ip/tlul/generic_dv/tb/xbar_macros.svh
@@ -18,13 +18,13 @@
 `define DRIVE_TL_DEVICE_IF(tl_name, path = dut, clk, rst_n, i_sfx = i, o_sfx = o) \
      force ``tl_name``_tl_if.h2d = ``path``.tl_``tl_name``_``o_sfx``; \
      force ``path``.tl_``tl_name``_``i_sfx`` = ``tl_name``_tl_if.d2h; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 `define DRIVE_TL_HOST_IF(tl_name, path = dut, clk, rst_n, i_sfx = i, o_sfx = o) \
      force ``tl_name``_tl_if.d2h = ``path``.tl_``tl_name``_``o_sfx``; \
      force ``path``.tl_``tl_name``_``i_sfx`` = ``tl_name``_tl_if.h2d; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 `define CONNECT_TL_DEVICE_IF(tl_name, path = dut, clk, rst_n, i_sfx = i, o_sfx = o) \

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -8,20 +8,20 @@
      force ``tl_name``_tl_if.d2h = dut.top_earlgrey.u_``inst_name``.``sig_name``_i; \
      force dut.top_earlgrey.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.h2d; \
      force dut.top_earlgrey.u_``inst_name``.clk_i = 0; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 `define DRIVE_CHIP_TL_DEVICE_IF(tl_name, inst_name, sig_name) \
      force ``tl_name``_tl_if.h2d = dut.top_earlgrey.u_``inst_name``.``sig_name``_i; \
      force dut.top_earlgrey.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.d2h; \
      force dut.top_earlgrey.u_``inst_name``.clk_i = 0; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 `define DRIVE_CHIP_TL_EXT_DEVICE_IF(tl_name, port_name) \
      force ``tl_name``_tl_if.h2d = dut.top_earlgrey.``port_name``_req_o; \
      force dut.top_earlgrey.``port_name``_rsp_i = ``tl_name``_tl_if.d2h; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 wire clk_main;

--- a/util/topgen/templates/tb__xbar_connect.sv.tpl
+++ b/util/topgen/templates/tb__xbar_connect.sv.tpl
@@ -38,20 +38,20 @@ def escape_if_name(qual_if_name):
      force ``tl_name``_tl_if.d2h = dut.top_earlgrey.u_``inst_name``.``sig_name``_i; \
      force dut.top_earlgrey.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.h2d; \
      force dut.top_earlgrey.u_``inst_name``.clk_i = 0; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 `define DRIVE_CHIP_TL_DEVICE_IF(tl_name, inst_name, sig_name) \
      force ``tl_name``_tl_if.h2d = dut.top_earlgrey.u_``inst_name``.``sig_name``_i; \
      force dut.top_earlgrey.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.d2h; \
      force dut.top_earlgrey.u_``inst_name``.clk_i = 0; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 
 `define DRIVE_CHIP_TL_EXT_DEVICE_IF(tl_name, port_name) \
      force ``tl_name``_tl_if.h2d = dut.top_earlgrey.``port_name``_req_o; \
      force dut.top_earlgrey.``port_name``_rsp_i = ``tl_name``_tl_if.d2h; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*%0s*", `"tl_name`"), "vif", \
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
                                         ``tl_name``_tl_if);
 </%text>\
 


### PR DESCRIPTION
Fix failures in #7257
We set interface and cfg object using wildcard name, like `*name*`
If we have 2 interfaces with names `AA` and `AA1`, the drivers will end up
getting the same interface handle

Signed-off-by: Weicai Yang <weicai@google.com>