### PR TITLE
[topgen/rom_ctrl] Add optional memory configuration for comportable IPs

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1317,6 +1317,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -1604,6 +1605,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -2040,12 +2042,6 @@
         rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
       }
       attr: templated
-      localparam:
-      {
-        EscCntDw: 32
-        AccuCntDw: 16
-        LfsrSeed: 0x7FFFFFFF
-      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
@@ -2053,6 +2049,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -2956,6 +2953,7 @@
         clk_aon_i: clkmgr_aon_clocks.clk_aon_powerup
       }
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -3438,6 +3436,7 @@
         clk_otp_i: clkmgr_aon_clocks.clk_io_div4_infra
       }
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -3627,6 +3626,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -3889,6 +3889,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -4073,6 +4074,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -4325,6 +4327,7 @@
         clk_edn_i: clkmgr_aon_clocks.clk_main_kmac
       }
       domain: "0"
+      memory: {}
       param_list:
       [
         {
@@ -4449,6 +4452,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -4771,6 +4775,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -4909,6 +4914,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -5200,6 +5206,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -5386,6 +5393,7 @@
       }
       domain: "0"
       param_decl: {}
+      memory: {}
       param_list:
       [
         {
@@ -5554,6 +5562,15 @@
       {
         rom: 0x00008000
         regs: 0x411e0000
+      }
+      memory:
+      {
+        rom:
+        {
+          label: rom
+          swaccess: rx
+          size: 0x4000
+        }
       }
       clock_connections:
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -413,11 +413,6 @@
       reset_connections: {rst_ni: "sys_io_div4", rst_edn_ni: "sys"},
       base_addr: "0x40150000",
       attr: "templated",
-      localparam: {
-        EscCntDw:  32,
-        AccuCntDw: 16,
-        LfsrSeed:  "0x7FFFFFFF"
-      }
     },
     // dummy module to capture the alert handler escalation signals
     // and test them by converting them into IRQs
@@ -631,6 +626,13 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "sys"},
       base_addrs: {rom: "0x00008000", regs: "0x411e0000"}
+      memory: {
+        rom: {
+          label:    "rom",
+          swaccess: "rx",
+          size:     "0x4000"
+        }
+      }
     },
     { name: "rv_core_ibex_peri",
       type: "rv_core_ibex_peri",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -500,6 +500,16 @@ package top_earlgrey_pkg;
    */
   parameter int unsigned TOP_EARLGREY_EFLASH_SIZE_BYTES = 32'h100000;
 
+  /**
+   * Memory base address for rom in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_ROM_BASE_ADDR = 32'h8000;
+
+  /**
+   * Memory size for rom in top earlgrey.
+   */
+  parameter int unsigned TOP_EARLGREY_ROM_SIZE_BYTES = 32'h4000;
+
 
   // Enumeration of IO power domains.
   // Only used in ASIC target.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -884,6 +884,16 @@ extern "C" {
  */
 #define TOP_EARLGREY_EFLASH_SIZE_BYTES 0x100000u
 
+/**
+ * Memory base address for rom in top earlgrey.
+ */
+#define TOP_EARLGREY_ROM_BASE_ADDR 0x8000u
+
+/**
+ * Memory size for rom in top earlgrey.
+ */
+#define TOP_EARLGREY_ROM_SIZE_BYTES 0x4000u
+
 
 /**
  * PLIC Interrupt Source Peripheral.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -20,15 +20,17 @@
 // Include guard for assembler
 #ifdef __ASSEMBLER__
 
+
 /**
- * Memory base address for rom in top earlgrey.
+ * Memory base for rom_ctrl_rom in top earlgrey.
  */
 #define TOP_EARLGREY_ROM_BASE_ADDR 0x00008000
 
 /**
- * Memory size for rom in top earlgrey.
+ * Memory size for rom_ctrl_rom in top earlgrey.
  */
 #define TOP_EARLGREY_ROM_SIZE_BYTES 0x4000
+
 
 /**
  * Memory base address for ram_main in top earlgrey.

--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -25,13 +25,15 @@ from .window import Window
 def genout(outfile: TextIO, msg: str) -> None:
     outfile.write(msg)
 
+
 def to_snake_case(s: str) -> str:
     val = []
     for i, ch in enumerate(s):
-      if i > 0 and ch.isupper():
-        val.append('_')
-      val.append(ch)
+        if i > 0 and ch.isupper():
+            val.append('_')
+        val.append(ch)
     return ''.join(val)
+
 
 def as_define(s: str) -> str:
     s = s.upper()

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -122,16 +122,6 @@ def generate_alert_handler(top, out_path):
 
     topname = top["name"]
 
-    # check if there are any params to be passed through reggen and placed into
-    # the generated package
-    ip_list_in_top = [x["name"].lower() for x in top["module"]]
-    ah_idx = ip_list_in_top.index("alert_handler")
-    if 'localparam' in top['module'][ah_idx]:
-        if 'EscCntDw' in top['module'][ah_idx]['localparam']:
-            esc_cnt_dw = int(top['module'][ah_idx]['localparam']['EscCntDw'])
-        if 'AccuCntDw' in top['module'][ah_idx]['localparam']:
-            accu_cnt_dw = int(top['module'][ah_idx]['localparam']['AccuCntDw'])
-
     if esc_cnt_dw < 1:
         log.error("EscCntDw must be larger than 0")
     if accu_cnt_dw < 1:
@@ -151,7 +141,7 @@ def generate_alert_handler(top, out_path):
             for k in range(alert['width']):
                 async_on = str(alert['async']) + async_on
         # convert to hexstring to shorten line length
-        async_on = ("%d'h" % n_alerts) + hex(int(async_on,2))[2:]
+        async_on = ("%d'h" % n_alerts) + hex(int(async_on, 2))[2:]
 
     log.info("alert handler parameterization:")
     log.info("NAlerts   = %d" % n_alerts)

--- a/util/topgen/c.py
+++ b/util/topgen/c.py
@@ -147,11 +147,25 @@ class TopGenC:
         return ret
 
     def memories(self):
-        return [(m["name"],
-                 MemoryRegion(self._top_name + Name.from_snake_case(m["name"]),
-                              int(m["base_addr"], 0),
-                              int(m["size"], 0)))
-                for m in self.top["memory"]]
+        ret = []
+        for m in self.top["memory"]:
+            ret.append((m["name"],
+                        MemoryRegion(self._top_name +
+                                     Name.from_snake_case(m["name"]),
+                                     int(m["base_addr"], 0),
+                                     int(m["size"], 0))))
+
+        for inst in self.top['module']:
+            if "memory" in inst:
+                for if_name, val in inst["memory"].items():
+                    base, size = get_base_and_size(self._name_to_block,
+                                                   inst, if_name)
+
+                    name = self._top_name + Name.from_snake_case(val["label"])
+                    region = MemoryRegion(name, base, size)
+                    ret.append((val["label"], region))
+
+        return ret
 
     def _init_plic_targets(self):
         enum = CEnum(self._top_name + Name(["plic", "target"]))

--- a/util/topgen/templates/toplevel_memory.h.tpl
+++ b/util/topgen/templates/toplevel_memory.h.tpl
@@ -20,15 +20,23 @@
 // Include guard for assembler
 #ifdef __ASSEMBLER__
 
+
+% for m in top["module"]:
+  % if "memory" in m:
+    % for key, val in m["memory"].items():
 /**
- * Memory base address for rom in top earlgrey.
+ * Memory base for ${m["name"]}_${val["label"]} in top ${top["name"]}.
  */
-#define TOP_EARLGREY_ROM_BASE_ADDR 0x00008000
+#define TOP_${top["name"].upper()}_${val["label"].upper()}_BASE_ADDR ${m["base_addrs"][key]}
 
 /**
- * Memory size for rom in top earlgrey.
+ * Memory size for ${m["name"]}_${val["label"]} in top ${top["name"]}.
  */
-#define TOP_EARLGREY_ROM_SIZE_BYTES 0x4000
+#define TOP_${top["name"].upper()}_${val["label"].upper()}_SIZE_BYTES ${val["size"]}
+
+    % endfor
+  % endif
+% endfor
 
 % for m in top["memory"]:
 /**

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -25,7 +25,13 @@ def memory_to_flags(memory):
  * translation base
  */
 MEMORY {
-  rom(rx) : ORIGIN = 0x00008000, LENGTH = 0x4000
+% for m in top["module"]:
+  % if "memory" in m:
+    % for key, val in m["memory"].items():
+  ${val["label"]}(${val["swaccess"]}) : ORIGIN = ${m["base_addrs"][key]}, LENGTH = ${val["size"]}
+    % endfor
+  % endif
+% endfor
 % for m in top["memory"]:
   ${m["name"]}(${memory_to_flags(m)}) : ORIGIN = ${m["base_addr"]}, LENGTH = ${m["size"]}
 % endfor


### PR DESCRIPTION
This change allows to specify (linkable) memory regions as part of the comportable IP instance declarations in the top-level Hjson. This information was previously available in the `memory` list in the top-level Hjson. However, as we move towards absorbing the memory primitives into their corresponding controllers, this information needs to be moved into the instance declarations if we want to retain the ability to generate linker scripts and/or parameterize the memories from top-level Hson information.

In order to cope with multiple instances of the same IP with different memory sizes, topgen/reggen is extended with the class `MemSize*`. This parameter class is similar to `RandCnst*` in the sense that topgen automatically overrides this parameter with the corresponding memory size configuration if it is declared in the IP hjson file.

The functionality is illustrated with the example of `rom_ctrl` in this PR, since this is currently the only comportable memory IP that contains a linkable memory region. Note however that I did not make use of the `MemSize*` parameter in this case, since this would conflict with the way the ROM size is currently parameterized. I.e., the `rom_ctrl` connects the ROM primitive through a TL-UL window in the secondary CSR node, and the depth of that window is specified in the Hjson of `rom_ctrl`. In order to use the `MemSize*` parameter we would have to remove that CSR node / TL-UL window and connect the TL-UL bus directly to the TL-UL adapter.

I am currently in the process of updating the `sram_ctrl` in the follow-up PR #7218. That one will make use of the `MemSize*` parameter in order to instantiate two differently sized memories (main RAM and retention RAM).

In the future, we may also want to update `flash_ctrl` to use this feature (see #4709).
