### PR TITLE
[dv/mem_bkdr_util] Add OTP specific functions for chip-level test

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
@@ -11,12 +11,16 @@ filesets:
       - lowrisc:opentitan:bus_params_pkg
       - lowrisc:dv:dv_utils
       - lowrisc:dv:crypto_dpi_prince:0.1
+      - lowrisc:dv:crypto_dpi_present:0.1
       - lowrisc:prim:cipher_pkg:0.1
       - lowrisc:prim:secded:0.1
+      - lowrisc:ip:otp_ctrl_pkg:0.1
     files:
+      - otp_scrambler_pkg.sv
       - sram_scrambler_pkg.sv
       - mem_bkdr_util_pkg.sv
       - mem_bkdr_util.sv: {is_include_file: true}
+      - mem_bkdr_util__otp.sv: {is_include_file: true}
       - mem_bkdr_util__rom.sv: {is_include_file: true}
       - mem_bkdr_util__sram.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -443,6 +443,9 @@ class mem_bkdr_util extends uvm_object;
               addr, rw_data, err_mask, rw_data ^ err_mask), UVM_HIGH)
   endfunction
 
+  // Wrapper function for backdoor write OTP partitions.
+  `include "mem_bkdr_util__otp.sv"
+
   // Wrapper functions for encrypted SRAM reads and writes.
   `include "mem_bkdr_util__sram.sv"
 

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper functions to write different partitions in OTP.
+// This file is included in `mem_bkdr_util.sv` as a continuation of `mem_bkdr_util` class.
+
+virtual function void otp_write_lc_partition(lc_ctrl_state_pkg::lc_state_e lc_state);
+  for (int i = 0; i < LcStateSize; i+=4) begin
+    write32(i + LcStateOffset, lc_state[i*8+:32]);
+  end
+endfunction
+
+// The following steps are needed to backdoor write a secret partition:
+// 1). Scramble the RAW input data.
+// 2). Backdoor write the scrambled input data to OTP memory.
+// 3). Calculate the correct digest for the secret partition.
+// 4). Backdoor write digest data to OTP memory.
+virtual function void otp_write_secret0_partition(bit [TestUnlockTokenSize*8-1:0] unlock_token,
+                                                  bit [TestExitTokenSize*8-1:0]   exit_token);
+  bit [Secret0DigestSize*8-1:0] digest;
+
+  bit [TestUnlockTokenSize*8-1:0] scrambled_unlock_token;
+  bit [TestExitTokenSize*8-1:0] scrambled_exit_token;
+  bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
+
+  for (int i = 0; i < TestUnlockTokenSize; i+=8) begin
+    scrambled_unlock_token[i*8+:64] = scramble_data(unlock_token[i*8+:64], Secret0Idx);
+    write64(i + TestUnlockTokenOffset, scrambled_unlock_token[i*8+:64]);
+  end
+  for (int i = 0; i < TestExitTokenSize; i+=8) begin
+    scrambled_exit_token[i*8+:64] = scramble_data(exit_token[i*8+:64], Secret0Idx);
+    write64(i + TestExitTokenOffset, scrambled_exit_token[i*8+:64]);
+  end
+
+  secret_data = {<<32 {scrambled_exit_token, scrambled_unlock_token}};
+  digest = cal_digest(Secret0Idx, secret_data);
+
+  write64(Secret0DigestOffset, digest);
+endfunction

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
@@ -6,6 +6,10 @@ package mem_bkdr_util_pkg;
   // dep packages
   import bus_params_pkg::BUS_AW;
   import dv_utils_pkg::uint32_t;
+  import lc_ctrl_state_pkg::*;
+  import otp_ctrl_part_pkg::*;
+  import otp_ctrl_reg_pkg::*;
+  import otp_scrambler_pkg::*;
   import prim_secded_pkg::*;
   import sram_scrambler_pkg::*;
   import uvm_pkg::*;

--- a/hw/dv/sv/mem_bkdr_util/otp_scrambler_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/otp_scrambler_pkg.sv
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/////////////////////////////////////////////////
+// OTP secret data and digest scrambling logic //
+/////////////////////////////////////////////////
+
+package otp_scrambler_pkg;
+
+  import uvm_pkg::*;
+  import otp_ctrl_reg_pkg::*;
+  import otp_ctrl_part_pkg::*;
+  import bus_params_pkg::*;
+
+  `include "uvm_macros.svh"
+
+  parameter int SCRAMBLE_DATA_SIZE = 64;
+  parameter int SCRAMBLE_KEY_SIZE  = 128;
+  parameter int NUM_ROUND          = 31;
+  string path = "otp_scrambler_pkg";
+
+  // When secret data write into otp_array, it will be scrambled.
+  function automatic bit [SCRAMBLE_DATA_SIZE-1:0] scramble_data(
+    bit [SCRAMBLE_DATA_SIZE-1:0] input_data,
+    int part_idx
+  );
+
+    int secret_idx = part_idx - Secret0Idx;
+    bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] output_data;
+    crypto_dpi_present_pkg::sv_dpi_present_encrypt(input_data,
+                                                   RndCnstKey[secret_idx],
+                                                   SCRAMBLE_KEY_SIZE == 80,
+                                                   output_data);
+    scramble_data = output_data[NUM_ROUND-1];
+  endfunction
+
+  // When secret data read out of otp_array, it will be descrambled.
+  function automatic bit [SCRAMBLE_DATA_SIZE-1:0] descramble_data(
+    bit [SCRAMBLE_DATA_SIZE-1:0] input_data,
+    int part_idx
+  );
+
+    int secret_idx = part_idx - Secret0Idx;
+    bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] output_data;
+    bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] padded_input;
+
+    padded_input[NUM_ROUND-1] = input_data;
+    crypto_dpi_present_pkg::sv_dpi_present_decrypt(padded_input,
+                                                   RndCnstKey[secret_idx],
+                                                   SCRAMBLE_KEY_SIZE == 80,
+                                                   output_data);
+    descramble_data = output_data[NUM_ROUND-1];
+    if (input_data != 0) begin
+    end
+  endfunction
+
+  function automatic bit [SCRAMBLE_DATA_SIZE-1:0] cal_digest(int part_idx,
+                                                             ref bit [BUS_DW-1:0] mem_q[$]);
+    int array_size = mem_q.size();
+    real key_factor  = SCRAMBLE_KEY_SIZE / BUS_DW;
+    bit [NUM_ROUND-1:0] [SCRAMBLE_DATA_SIZE-1:0] enc_array;
+    bit [SCRAMBLE_DATA_SIZE-1:0] init_vec = RndCnstDigestIV[0];
+    bit [SCRAMBLE_DATA_SIZE-1:0] digest;
+
+    for (int i = 0; i < $ceil(array_size / key_factor); i++) begin
+      bit [SCRAMBLE_DATA_SIZE-1:0] input_data = (i == 0) ? init_vec : digest;
+      bit [SCRAMBLE_KEY_SIZE-1:0]  key;
+
+      // Pad 32-bit partition data into 128-bit key input.
+      // Because the mem_q size is a multiple of 64-bit, so if the last round only has 64-bits key,
+      // it will repeat the last 64-bits twice.
+      for (int j = 0; j < key_factor; j++) begin
+        int index = i * key_factor + j;
+        key |= ((index >= array_size ? mem_q[index-2] : mem_q[index]) << (j * BUS_DW));
+      end
+
+      // Trigger 32 round of PRESENT encrypt.
+      crypto_dpi_present_pkg::sv_dpi_present_encrypt(input_data, key, SCRAMBLE_KEY_SIZE == 80,
+                                                     enc_array);
+      // XOR the previous state into the digest result according to the Davies-Meyer scheme.
+      digest = enc_array[NUM_ROUND-1] ^ input_data;
+    end
+
+    // Last 32 round of digest is calculated with a digest constant.
+    crypto_dpi_present_pkg::sv_dpi_present_encrypt(digest,
+                                                   RndCnstDigestConst[0],
+                                                   SCRAMBLE_KEY_SIZE == 80,
+                                                   enc_array);
+    // XOR the previous state into the digest result according to the Davies-Meyer scheme.
+    digest ^= enc_array[NUM_ROUND-1];
+    return digest;
+  endfunction
+
+endpackage

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -21,6 +21,7 @@ package otp_ctrl_env_pkg;
   import lc_ctrl_state_pkg::*;
   import lc_ctrl_dv_utils_pkg::*;
   import mem_bkdr_util_pkg::*;
+  import otp_scrambler_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -83,11 +84,6 @@ package otp_ctrl_env_pkg;
   parameter uint FLASH_DATA_SIZE = 1 + FlashKeyWidth;
   // lc program data has lc_state data and lc_cnt data
   parameter uint LC_PROG_DATA_SIZE = LcStateWidth + LcCountWidth;
-
-  // scramble related parameters
-  parameter uint SCRAMBLE_DATA_SIZE = 64;
-  parameter uint SCRAMBLE_KEY_SIZE  = 128;
-  parameter uint NUM_ROUND          = 31;
 
   parameter uint NUM_SRAM_EDN_REQ = 12;
   parameter uint NUM_OTBN_EDN_REQ = 10;
@@ -239,41 +235,6 @@ package otp_ctrl_env_pkg;
   function automatic bit [TL_DW-1:0] normalize_dai_addr(bit [TL_DW-1:0] dai_addr);
     normalize_dai_addr = (is_secret(dai_addr) || is_digest(dai_addr)) ? dai_addr >> 3 << 3 :
                                                                         dai_addr >> 2 << 2;
-  endfunction
-
-  // When secret data write into otp_array, it will be scrambled
-  function automatic bit [SCRAMBLE_DATA_SIZE-1:0] scramble_data(
-    bit [SCRAMBLE_DATA_SIZE-1:0] input_data,
-    int part_idx
-  );
-
-    int secret_idx = part_idx - Secret0Idx;
-    bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] output_data;
-    crypto_dpi_present_pkg::sv_dpi_present_encrypt(input_data,
-                                                   RndCnstKey[secret_idx],
-                                                   SCRAMBLE_KEY_SIZE == 80,
-                                                   output_data);
-    scramble_data = output_data[NUM_ROUND-1];
-  endfunction
-
-  // When secret data read out of otp_array, it will be descrambled
-  function automatic bit [SCRAMBLE_DATA_SIZE-1:0] descramble_data(
-    bit [SCRAMBLE_DATA_SIZE-1:0] input_data,
-    int part_idx
-  );
-
-    int secret_idx = part_idx - Secret0Idx;
-    bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] output_data;
-    bit [NUM_ROUND-1:0][SCRAMBLE_DATA_SIZE-1:0] padded_input;
-
-    padded_input[NUM_ROUND-1] = input_data;
-    crypto_dpi_present_pkg::sv_dpi_present_decrypt(padded_input,
-                                                   RndCnstKey[secret_idx],
-                                                   SCRAMBLE_KEY_SIZE == 80,
-                                                   output_data);
-    descramble_data = output_data[NUM_ROUND-1];
-    if (input_data != 0) begin
-    end
   endfunction
 
   // package sources


### PR DESCRIPTION
This PR adds methods in `mem_bkdr_utils.sv` to backdoor write OTP
partitions.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>