### PR TITLE
[dv/chip] Add lc_ctrl_state_transition test                                                         

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
@@ -23,6 +23,8 @@ package jtag_riscv_agent_pkg;
   parameter uint DMI_DRW   = DMI_OPW + DMI_DATAW + DMI_ADDRW;
   parameter uint DTMCS_DRW = 32;
 
+  string msg_id = "jtag_riscv_agent_pkg";
+
   // local types
   typedef enum bit [DMI_IRW-1:0] {
     JtagBypass0   = 'h0,
@@ -64,5 +66,14 @@ package jtag_riscv_agent_pkg;
   `include "jtag_riscv_sequencer.sv"
   `include "jtag_riscv_agent.sv"
   `include "jtag_riscv_seq_list.sv"
+
+  task automatic jtag_read_csr(bit [bus_params_pkg::BUS_AW-1:0]     csr_addr,
+                               jtag_riscv_sequencer                 seqr,
+                               ref bit [bus_params_pkg::BUS_DW-1:0] csr_val);
+    jtag_riscv_csr_seq jtag_csr_seq = jtag_riscv_csr_seq::type_id::create("jtag_csr_seq");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(jtag_csr_seq, addr == csr_addr; do_write == 0;, , msg_id)
+    jtag_csr_seq.start(seqr);
+    csr_val = jtag_csr_seq.data;
+  endtask
 
 endpackage: jtag_riscv_agent_pkg

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -976,7 +976,7 @@
             X-ref'ed chip_otp_ctrl_program.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
       name: chip_lc_ctrl_kmac_req
@@ -1865,7 +1865,7 @@
               LC state and LC count CSRs.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
       name: chip_otp_ctrl_program_error

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -224,6 +224,12 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
+      name: chip_sw_lc_ctrl_transition
+      uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
+      sw_images: ["sw/device/tests/lc_ctrl_transition_test:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
+    {
       name: chip_sw_pwrmgr_usbdev_smoketest
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/pwrmgr_usbdev_smoketest:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -35,6 +35,7 @@ filesets:
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -68,6 +68,18 @@ package chip_env_pkg;
     SwTypeOtp   // OTP image.
   } sw_type_e;
 
+  typedef enum bit [1:0] {
+    DeselectJtagTap = 2'b00,
+    SelectLCJtagTap = 2'b01,
+    SelectRVJtagTap = 2'b10
+  } chip_tap_type_e;
+
+  // Two status for LC JTAG to identify if LC state transition is successful.
+  typedef enum {
+    LcReady,
+    LcTransitionSuccessful
+  } lc_ctrl_status_e;
+
   // Extracts the address and size of a const symbol in a SW test (supplied as an ELF file).
   //
   // Used by a testbench to modify the given symbol in an executable (elf) generated for an embedded

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -70,7 +70,7 @@ class chip_base_vseq extends cip_base_vseq #(
 
     // Drive strap signals at the start.
     if (do_strap_pins_init) begin
-      cfg.tap_straps_vif.drive(2'b10); // Select JTAG.
+      cfg.tap_straps_vif.drive(SelectRVJtagTap); // Select JTAG.
       cfg.dft_straps_vif.drive(2'b00);
       cfg.sw_straps_vif.drive({2'b00, cfg.use_spi_load_bootstrap});
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -13,7 +13,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   virtual task pre_start();
     super.pre_start();
     // Deselect JTAG interface.
-    cfg.tap_straps_vif.drive(2'b00);
+    cfg.tap_straps_vif.drive(DeselectJtagTap);
     enable_asserts_in_hw_reset_rand_wr = 0;
 
     // In top-level uart RX pin may be selected in pinmux. CSR tests may randomly enable line
@@ -42,9 +42,9 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     // make sure jtag rst triggers
-    cfg.tap_straps_vif.drive(2'b10);
+    cfg.tap_straps_vif.drive(SelectRVJtagTap);
     super.dut_init(reset_kind);
-    cfg.tap_straps_vif.drive(2'b00);
+    cfg.tap_straps_vif.drive(DeselectJtagTap);
   endtask
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_lc_ctrl_transition_vseq)
+
+  `uvm_object_new
+
+  virtual task dut_init(string reset_kind = "HARD");
+    bit [otp_ctrl_reg_pkg::TestUnlockTokenSize-1:0] rand_unlock_token;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(rand_unlock_token)
+
+    super.dut_init(reset_kind);
+
+    // Override the LC partition to TestUnlocked2.
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition(lc_ctrl_state_pkg::LcStTestUnlocked2);
+
+    // Override the test exit token to match SW test's input token.
+    // TODO: randomize the exit_token.
+    cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(
+        .unlock_token(rand_unlock_token),
+        .exit_token('h547070d7503264af5b9a971b894ef3be));
+  endtask
+
+  virtual task body();
+    super.body();
+
+     // Select LC jtag.
+    cfg.tap_straps_vif.drive(SelectLCJtagTap);
+
+    // Wait for SW to finish set up LC_CTRL.
+    cfg.clk_rst_vif.wait_clks(21000);
+
+    while(1) begin
+      bit [TL_DW-1:0]  status_val;
+      lc_ctrl_status_e dummy;
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
+      jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.status.get_offset(),
+                                          p_sequencer.jtag_sequencer_h,
+                                          status_val);
+
+      // Ensure that none of the other status bits are set.
+      `DV_CHECK_EQ(status_val >> dummy.num(), 0,
+                   $sformatf("Unexpected status error %0h", status_val))
+      if (status_val[LcTransitionSuccessful]) break;
+    end
+
+    // Issue hard reset.
+    apply_reset();
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -9,4 +9,5 @@
 `include "chip_sw_uart_tx_rx_vseq.sv"
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
+`include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define LC_TOKEN_SIZE 16
+
+static dif_lc_ctrl_t lc;
+
+const test_config_t kTestConfig;
+
+// TODO: Issue more resets and andomize this array in each reset.
+// LC exit token value for LC state transition.
+static const uint8_t lc_exit_token[LC_TOKEN_SIZE] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+};
+
+static void check_lc_state_transition_count(uint8_t exp_lc_count) {
+  LOG_INFO("Read LC count and check with expect_val=%0d", exp_lc_count);
+  uint8_t lc_count;
+  CHECK(dif_lc_ctrl_get_attempts(&lc, &lc_count) == kDifLcCtrlAttemptsOk,
+        "Read lc_count register failed!");
+  CHECK(lc_count == exp_lc_count,
+        "LC_count error, expected %0d but actual count is %0d", exp_lc_count,
+        lc_count);
+}
+
+/**
+ * Tests the state transition request handshake between LC_CTRL and OTP_CTRL.
+ *
+ * 1). OTP pre-load image with lc_count = `8`.
+ * 2). Backdoor write OTP's LC parition to `TestUnlocked2` state, and backdoor
+ * write OTP's `test_exit` token to match the pattern
+ * `h00_01_02_03_04_05_06_07_08_09_0a_0b_0c_0d`.
+ * 3). When LC_CTRL is ready, check LC_CNT and LC_STATE register.
+ * 4). Program LC state transition request to advance to `Prod` state.
+ * 5). Issue hard reset.
+ * 6). Wait for LC_CTRL is ready, then check if LC_STATE advanced to `Dev`
+ * state, and lc_count advanced to `9`.
+ */
+
+bool test_main(void) {
+  LOG_INFO("Start LC_CTRL transition test.");
+
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  CHECK(dif_lc_ctrl_init((dif_lc_ctrl_params_t){.base_addr = lc_reg}, &lc) ==
+        kDifLcCtrlOk);
+
+  LOG_INFO("Read and check LC state.");
+  dif_lc_ctrl_state_t curr_state;
+  CHECK(dif_lc_ctrl_get_state(&lc, &curr_state) == kDifLcCtrlOk);
+
+  // The OTP preload image hardcode lc_count as 8.
+  const uint8_t LcStateTransitionCount = 8;
+
+  if (curr_state == kDifLcCtrlStateTestUnlocked2) {
+    // LC TestUnlocked2 is the intial test state for this sequence.
+    // The sequence will check if lc_count matches the preload value.
+    check_lc_state_transition_count(LcStateTransitionCount);
+
+    // Request lc_state transfer to Dev state.
+    dif_lc_ctrl_token_t token;
+    memcpy(token.data, lc_exit_token, sizeof(lc_exit_token));
+    CHECK(dif_lc_ctrl_mutex_try_acquire(&lc) == kDifLcCtrlMutexOk);
+    CHECK(dif_lc_ctrl_transition(&lc, kDifLcCtrlStateDev, &token) ==
+              kDifLcCtrlMutexOk,
+          "LC_transition failed!");
+
+    LOG_INFO("Waiting for LC transtition done and reboot.");
+    wait_for_interrupt();
+
+  } else {
+    // LC Dev is the requested state from previous lc_state transition request.
+    // Once the sequence checks current state and count via CSRs, the test can
+    // exit successfully.
+    CHECK(curr_state == kDifLcCtrlStateDev, "State transition failed!");
+    check_lc_state_transition_count(LcStateTransitionCount + 1);
+    return true;
+  }
+
+  return false;
+}

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -51,6 +51,26 @@ sw_tests += {
   }
 }
 
+lc_ctrl_transition_test_lib = declare_dependency(
+  link_with: static_library(
+    'lc_ctrl_transition_test_lib',
+    sources: [
+      'lc_ctrl_transition_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_lc_ctrl,
+      sw_lib_runtime_log,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+    ],
+  ),
+)
+sw_tests += {
+  'lc_ctrl_transition_test': {
+    'library': lc_ctrl_transition_test_lib,
+  }
+}
+
 spi_tx_rx_test_lib = declare_dependency(
   link_with: static_library(
     'spi_tx_rx_test_lib',


### PR DESCRIPTION
This PR adds the lc_ctrl state transition test. (This PR is based on PR #7269)                                                                    
This PR backdoor writes OTP's lc partition and secret0 partition to allow LC transit from TestUnlock2 state to Prod state.                                              
                                                                                                    
Signed-off-by: Cindy Chen <chencindy@opentitan.org>  