### PR TITLE
[flah_ctrl/dv] Added field to seq_cfg for rand_ops_base_vseq

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -63,6 +63,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   //  Set by a higher level vseq that invokes this vseq 
   bit external_cfg;
 
+  // If pre-transaction back-door memory preperation isn't needed, set do_tran_prep_mem to 0.
+  bit do_tran_prep_mem;
+
   // When 0, the post-transaction back-door checks will be disabled.
   // Added to enable other post-transaction checks and actions.
   bit check_mem_post_tran;
@@ -129,6 +132,8 @@ sel_data_part_pc=%0d , sel_info_part_pc=%0d , sel_info1_part_pc=%0d , sel_red_pa
     poll_fifo_status_pc = 30;
 
     external_cfg = 1'b0;
+
+    do_tran_prep_mem = 1'b1;
 
     check_mem_post_tran = 1'b1;
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -255,7 +255,9 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
                                   j, num_flash_ops_per_cfg, flash_op), UVM_LOW)
 
         // Bkdr initialize the flash mem based on op.
-        flash_ctrl_prep_mem(flash_op);
+        // If you wish to do the transaction without the backdoor preperation
+        //  (when you want transaction to affect each other), set do_tran_prep_mem to 0.
+        if (cfg.seq_cfg.do_tran_prep_mem) flash_ctrl_prep_mem(flash_op);
 
         flash_ctrl_start_op(flash_op);
         `uvm_info(`gfn, $sformatf("Wait for operation to be done, then %s (check_mem_post_tran=%0d)",


### PR DESCRIPTION
Hi,
Small PR adding one field to **flash_ctrl_seq_cfg** to be used in **flash_ctrl_rand_ops_base_vseq**.
This field enable to skip the **prep_mem** method of **flash_ctrl_rand_ops_base_vseq** in order to do dependant transactions.
Thanks.

Signed-off-by: Eitan Shapira <eitan.shapira@nuvoton.com>