### PR TITLE
[kmac] Latch Entropy Mode when ready

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -63,9 +63,6 @@ class kmac_base_vseq extends cip_base_vseq #(
   //
   // So we use a static entropy mode value to hold the same mode through the whole test,
   // and constrain `entropy_mode` accordingly.
-  //
-  // Structure it in this way, as timer verification will allow different entropy modes to be used
-  // in different iterations.
   kmac_pkg::entropy_mode_e static_entropy_mode = EntropyModeSw;
 
   // entropy fast process mode


### PR DESCRIPTION
This commit allows the kmac_entropy module to latch the entropy mode
when it is out from `StReset` state. This is related to the issue #6831

In previous design, the SW may change the entropy mode at any time if
the module is not operating. But internal FSM did not expect the sudden
change of the entropy_mode.

It is decided to latch the entropy mode and not affected by the SW
change after the SW setting entropy_ready. To change the mode, SW need
to reset the IP.

It is intentional to not allow FSM to move back to `StReset` as in
`StReset` the entropy module generates garbage entropy to SHA3 core for
ROM_CTRL to verify its image.