### PR TITLE
[dv/clkmgr] Add interrupt and alert tests

### DIFF
--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -29,9 +29,8 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                // Disable alert and interrupt tests until RTL adds support.
-                // "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                // "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 // Disable stress until the tests are created.
                 // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -387,9 +387,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         if (addr_phase_write && extclk_sel_regwen) begin
           cfg.clkmgr_vif.update_extclk_sel(item.a_data);
         end
-      "jitter": begin
-        // The functionality of jitter is not well specified. Assumming the
-        // values just stick.
+      "jitter_enable": begin
       end
       "clk_enables":
         if (addr_phase_write) begin


### PR DESCRIPTION
Also rename CSR jitter to jitter_enable.

Signed-off-by: Guillermo Maturana <maturana@google.com>