### PR TITLE
[otbn] Clear the loop stack on start

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -123,7 +123,7 @@ module otbn_controller
   output logic rnd_prefetch_req_o,
   input  logic rnd_valid_i,
 
-  input  logic        insn_cnt_reset_i,
+  input  logic        state_reset_i,
   output logic [31:0] insn_cnt_o
 );
   otbn_state_e state_q, state_d, state_raw;
@@ -351,8 +351,8 @@ module otbn_controller
     end
   end
 
-  assign insn_cnt_d = insn_cnt_reset_i ? 32'd0 : (insn_cnt_q + 32'd1);
-  assign insn_cnt_en = (insn_executing & ~stall & (insn_cnt_q != 32'hffffffff)) | insn_cnt_reset_i;
+  assign insn_cnt_d = state_reset_i ? 32'd0 : (insn_cnt_q + 32'd1);
+  assign insn_cnt_en = (insn_executing & ~stall & (insn_cnt_q != 32'hffffffff)) | state_reset_i;
   assign insn_cnt_o = insn_cnt_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -368,6 +368,8 @@ module otbn_controller
   ) u_otbn_loop_controller (
     .clk_i,
     .rst_ni,
+
+    .state_reset_i,
 
     .insn_valid_i,
     .insn_addr_i,

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -166,7 +166,7 @@ module otbn_core
   logic                     controller_start;
   logic [ImemAddrWidth-1:0] controller_start_addr;
 
-  logic        insn_cnt_reset;
+  logic        state_reset;
   logic [31:0] insn_cnt;
 
   // Start stop control start OTBN execution when requested and deals with any pre start or post
@@ -188,8 +188,8 @@ module otbn_core
     .urnd_reseed_busy_i (urnd_reseed_busy),
     .urnd_advance_o     (urnd_advance),
 
-    .ispr_init_o      (ispr_init),
-    .insn_cnt_reset_o (insn_cnt_reset)
+    .ispr_init_o   (ispr_init),
+    .state_reset_o (state_reset)
   );
 
   // Depending on its usage, the instruction address (program counter) is qualified by two valid
@@ -347,7 +347,7 @@ module otbn_core
     .rnd_prefetch_req_o (rnd_prefetch_req),
     .rnd_valid_i        (rnd_valid),
 
-    .insn_cnt_reset_i   (insn_cnt_reset),
+    .state_reset_i      (state_reset),
     .insn_cnt_o         (insn_cnt)
   );
 
@@ -390,7 +390,7 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .start_i,
+    .state_reset_i (state_reset),
 
     .wr_addr_i          (rf_base_wr_addr),
     .wr_en_i            (rf_base_wr_en),

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -36,7 +36,7 @@ module otbn_rf_base
   input  logic                     clk_i,
   input  logic                     rst_ni,
 
-  input  logic                     start_i,
+  input  logic                     state_reset_i,
 
   input  logic [4:0]               wr_addr_i,
   input  logic                     wr_en_i,
@@ -124,7 +124,7 @@ module otbn_rf_base
 
     .full_o        (stack_full),
 
-    .clear_i       (start_i),
+    .clear_i       (state_reset_i),
 
     .push_i        (push_stack),
     .push_data_i   (wr_data_intg_mux_out),

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -37,7 +37,7 @@ module otbn_start_stop_control
   output logic urnd_advance_o,
 
   output logic ispr_init_o,
-  output logic insn_cnt_reset_o
+  output logic state_reset_o
 );
   otbn_start_stop_state_e state_q, state_d;
 
@@ -59,12 +59,12 @@ module otbn_start_stop_control
   end
 
   always_comb begin
-    urnd_reseed_req_o  = 1'b0;
-    urnd_advance_o     = 1'b0;
-    start_addr_en      = 1'b0;
-    state_d            = state_q;
-    ispr_init_o        = 1'b0;
-    insn_cnt_reset_o   = 1'b0;
+    urnd_reseed_req_o = 1'b0;
+    urnd_advance_o    = 1'b0;
+    start_addr_en     = 1'b0;
+    state_d           = state_q;
+    ispr_init_o       = 1'b0;
+    state_reset_o     = 1'b0;
 
     unique case(state_q)
       OtbnStartStopStateHalt: begin
@@ -72,7 +72,7 @@ module otbn_start_stop_control
           start_addr_en     = 1'b1;
           urnd_reseed_req_o = 1'b1;
           ispr_init_o       = 1'b1;
-          insn_cnt_reset_o  = 1'b1;
+          state_reset_o     = 1'b1;
           state_d           = OtbnStartStopStateUrndRefresh;
         end
       end


### PR DESCRIPTION
This is to match 15d28dad9, which cleared the call stack. We also tidy
things up a bit: rather than passing the `start_i` signal directly, we
switch to using its registered version, generated by
`otbn_start_stop_control`. We don't really care about the exact timing
here, so may as well break the combinatorial path.

Of course, this signal is now used for several things other than
clearing the `INSN_CNT` register, so we rename it from `insn_cnt_reset` to
`state_reset`.
