### PR TITLE
[tools/ascent] updated ascent to use the --job-prefix option

### DIFF
--- a/hw/lint/tools/dvsim/common_lint_cfg.hjson
+++ b/hw/lint/tools/dvsim/common_lint_cfg.hjson
@@ -19,7 +19,7 @@
   build_log:  "{build_dir}/{tool}.log"
 
   // We rely on fusesoc to run lint for us
-  build_cmd:  "fusesoc"
+  build_cmd:  "{job_prefix} fusesoc"
   build_opts: ["--cores-root {proj_root}",
                "run",
                "--flag=fileset_{design_level}",


### PR DESCRIPTION
this PR contains a very small update that enables the --job-prefix command for ascentlint