### PR TITLE
[dv/otp_ctrl] add checkings regarding the `lc_data_o` valid output

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -118,6 +118,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
           if (!cfg.under_reset && !cfg.otp_ctrl_vif.alert_reqs) begin
             otp_ctrl_part_pkg::otp_hw_cfg_data_t exp_hwcfg_data;
             otp_ctrl_pkg::otp_keymgr_key_t       exp_keymgr_data;
+            otp_ctrl_pkg::otp_lc_data_t          exp_lc_data;
             bit [otp_ctrl_pkg::KeyMgrKeyWidth-1:0] exp_keymgr_key0, exp_keymgr_key1;
 
             if (dai_digest_ip != LifeCycleIdx) begin
@@ -143,28 +144,71 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
             `DV_CHECK_EQ(cfg.otp_ctrl_vif.otp_hw_cfg_o.data, exp_hwcfg_data)
 
             if (!cfg.otp_ctrl_vif.under_error_states()) begin
-              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.count, otp_lc_data[0 +: LcCountWidth])
-              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.state,
-                           otp_lc_data[LcCountWidth +: LcStateWidth])
-            end
+              // ---------------------- Check lc_data_o output -----------------------------------
+              // Because initialization was succesful, the valid should be set and error should be
+              // reset.
+              exp_lc_data.valid = 1;
+              exp_lc_data.error = 0;
 
-            // Otp_keymgr outputs creator root key shares from the secret2 partition.
-            // Depends on lc_seed_hw_rd_en_i, it will output the real keys or a constant
-            exp_keymgr_data.valid = get_otp_digest_val(Secret2Idx) != 0;
-            if (cfg.otp_ctrl_vif.lc_seed_hw_rd_en_i == lc_ctrl_pkg::On) begin
-              exp_keymgr_data.key_share0 =
-                  {<<32 {otp_a[CreatorRootKeyShare0Offset/4 +: CreatorRootKeyShare0Size/4]}};
-              exp_keymgr_data.key_share1 =
-                  {<<32 {otp_a[CreatorRootKeyShare1Offset/4 +: CreatorRootKeyShare1Size/4]}};
-            end else begin
-              exp_keymgr_data.key_share0 =
-                  PartInvDefault[CreatorRootKeyShare0Offset*8 +: CreatorRootKeyShare0Size*8];
-              exp_keymgr_data.key_share1 =
-                  PartInvDefault[CreatorRootKeyShare1Offset*8 +: CreatorRootKeyShare1Size*8];
-            end
-            // Check keymgr_key_o in otp_ctrl_if
-            if (cfg.otp_ctrl_vif.under_error_states() == 0) begin
+              // Secrets and tokens valid signals are depend on whether secret partitions are
+              // locked.
+              exp_lc_data.secrets_valid = get_otp_digest_val(Secret2Idx) ? On : Off;
+              exp_lc_data.test_tokens_valid = get_otp_digest_val(Secret0Idx) ? On : Off;
+              // TODO: should this be secret2. Issue filed: #7294.
+              exp_lc_data.rma_token_valid = get_otp_digest_val(Secret0Idx) ? On : Off;
+
+              // LC output is depend on LC partitions value.
+              exp_lc_data.count = otp_lc_data[0 +: LcCountWidth];
+              exp_lc_data.state = otp_lc_data[LcCountWidth +: LcStateWidth];
+
+              // Token values are depend on secret partitions value.
+              exp_lc_data.test_unlock_token =
+                      {<<32 {otp_a[TestUnlockTokenOffset/4 +: TestUnlockTokenSize/4]}};
+              exp_lc_data.test_exit_token =
+                      {<<32 {otp_a[TestExitTokenOffset/4 +: TestExitTokenSize/4]}};
+              exp_lc_data.rma_token = {<<32 {otp_a[RmaTokenOffset/4 +: RmaTokenSize/4]}};
+
+              // Check otp_lc_data_t struct by item is easier to debug.
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.valid, exp_lc_data.valid)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.error, exp_lc_data.error)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.state, exp_lc_data.state)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.count, exp_lc_data.count)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.secrets_valid, exp_lc_data.secrets_valid)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.test_tokens_valid,
+                           exp_lc_data.test_tokens_valid)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.test_unlock_token,
+                           exp_lc_data.test_unlock_token)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.test_exit_token, exp_lc_data.test_exit_token)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.rma_token_valid, exp_lc_data.rma_token_valid)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o.rma_token, exp_lc_data.rma_token)
+
+              // Check otp_lc_data_t all together in case there is any missed item.
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.lc_data_o, exp_lc_data)
+
+              // ---------------------- Check keymgr_key_o output ---------------------------------
+              // Otp_keymgr outputs creator root key shares from the secret2 partition.
+              // Depends on lc_seed_hw_rd_en_i, it will output the real keys or a constant
+              exp_keymgr_data.valid = get_otp_digest_val(Secret2Idx) != 0;
+              if (cfg.otp_ctrl_vif.lc_seed_hw_rd_en_i == lc_ctrl_pkg::On) begin
+                exp_keymgr_data.key_share0 =
+                    {<<32 {otp_a[CreatorRootKeyShare0Offset/4 +: CreatorRootKeyShare0Size/4]}};
+                exp_keymgr_data.key_share1 =
+                    {<<32 {otp_a[CreatorRootKeyShare1Offset/4 +: CreatorRootKeyShare1Size/4]}};
+              end else begin
+                exp_keymgr_data.key_share0 =
+                    PartInvDefault[CreatorRootKeyShare0Offset*8 +: CreatorRootKeyShare0Size*8];
+                exp_keymgr_data.key_share1 =
+                    PartInvDefault[CreatorRootKeyShare1Offset*8 +: CreatorRootKeyShare1Size*8];
+              end
+
+              // Check otp_keymgr_key_t struct by item is easier to debug.
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.keymgr_key_o.valid, exp_keymgr_data.valid)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.keymgr_key_o.key_share0, exp_keymgr_data.key_share0)
+              `DV_CHECK_EQ(cfg.otp_ctrl_vif.keymgr_key_o.key_share1, exp_keymgr_data.key_share1)
+
+              // Check otp_keymgr_key_t struct all together in case there is any missed item.
               `DV_CHECK_EQ(cfg.otp_ctrl_vif.keymgr_key_o, exp_keymgr_data)
+
               if (cfg.en_cov) begin
                 cov.keymgr_o_cg.sample(cfg.otp_ctrl_vif.lc_seed_hw_rd_en_i == lc_ctrl_pkg::On,
                                        exp_keymgr_data.valid);

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -127,7 +127,7 @@ package otp_ctrl_pkg;
     lc_ctrl_state_pkg::lc_token_t    test_unlock_token;
     lc_ctrl_state_pkg::lc_token_t    test_exit_token;
     // This is set to "On" if the partition containing the
-    // test tokens has been locked.
+    // rma token has been locked.
     lc_ctrl_pkg::lc_tx_t             rma_token_valid;
     lc_ctrl_state_pkg::lc_token_t    rma_token;
   } otp_lc_data_t;


### PR DESCRIPTION
This PR is an enhancement to current design change that adds three valid
signals in `otp_lc_data_o` output.
This PR adds the corresponding checkings for these valid signals and
tokens.
This PR also fixes a typo in design comment.


Signed-off-by: Cindy Chen <chencindy@opentitan.org>