### PR TITLE
[fpv/rv_plic] Fix compile error with alert

### DIFF
--- a/hw/ip/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
+++ b/hw/ip/rv_plic/fpv/tb/rv_plic_bind_fpv.sv
@@ -9,6 +9,7 @@ module rv_plic_bind_fpv;
   bind rv_plic rv_plic_assert_fpv #(
     .NumSrc(rv_plic_reg_pkg::NumSrc),
     .NumTarget(rv_plic_reg_pkg::NumTarget),
+    .NumAlerts(rv_plic_reg_pkg::NumAlerts),
     .PRIOW($clog2(7+1))
   ) rv_plic_assert_fpv(
     .clk_i,

--- a/hw/ip/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
+++ b/hw/ip/rv_plic/fpv/vip/rv_plic_assert_fpv.sv
@@ -7,6 +7,7 @@
 
 module rv_plic_assert_fpv #(parameter int NumSrc = 1,
                             parameter int NumTarget = 1,
+                            parameter int NumAlerts = 1,
                             parameter int PRIOW = $clog2(7+1)
 ) (
   input clk_i,

--- a/hw/top_earlgrey/ip/rv_plic/fpv/rv_plic_bind_fpv.sv
+++ b/hw/top_earlgrey/ip/rv_plic/fpv/rv_plic_bind_fpv.sv
@@ -9,6 +9,7 @@ module rv_plic_bind_fpv;
   bind rv_plic rv_plic_assert_fpv #(
     .NumSrc(rv_plic_reg_pkg::NumSrc),
     .NumTarget(rv_plic_reg_pkg::NumTarget),
+    .NumAlerts(rv_plic_reg_pkg::NumAlerts),
     .PRIOW(rv_plic_reg_pkg::PrioWidth)
   ) rv_plic_assert_fpv (
     .clk_i,


### PR DESCRIPTION
This PR fixes rv_plic FPV compile error due to the `NumAlerts` keyword.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>