### PR TITLE
[usbdev] Properly link HW checklist

### DIFF
--- a/hw/ip/usbdev/data/usbdev.prj.hjson
+++ b/hw/ip/usbdev/data/usbdev.prj.hjson
@@ -6,6 +6,7 @@
     name:               "usbdev",
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
+    hw_checklist:       "../doc/checklist",
     sw_checklist:       "/sw/device/lib/dif/dif_usbdev",
     version:            "0.5",
     life_stage:         "L1",


### PR DESCRIPTION
This fixes one of the inconsistencies mentioned on #3601.

Signed-off-by: Michael Schaffner <msf@opentitan.org>