### PR TITLE
[edn] Add MaxLatency assertion

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -875,7 +875,8 @@ module kmac
 
     // EDN Request
     prim_edn_req #(
-      .OutWidth (MsgWidth)
+      .OutWidth   (MsgWidth),
+      .MaxLatency (500000)  // 5ms expected
     ) u_edn_req (
       // Design side
       .clk_i,


### PR DESCRIPTION
edn_req primitive module now has MaxLatency integer parameter which
describes the max expected EDN response time (req --> ack) from the
consumer IP side.

It is useful to check the timing violation if the EDN/ Entropy Source/
CSRNG logic are changed but the consumer IP expects less than the max
latency.

This PR addresses the issue in #7280 