### PR TITLE
[dv] Small optimization in memutil

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -431,7 +431,7 @@ void DpiMemUtil::LoadElfToMemories(bool verbose, const std::string &filepath) {
 
     const MemArea &mem_area = *mem_areas_[mem_area_it->second];
 
-    for (const auto seg_pr : staged_mem.GetSegs()) {
+    for (const auto &seg_pr : staged_mem.GetSegs()) {
       const AddrRange<uint32_t> &seg_rng = seg_pr.first;
       const std::vector<uint8_t> &seg_data = seg_pr.second;
 


### PR DESCRIPTION
GCC11 suggests using a reference, so let's do that!

```
../src/lowrisc_dv_verilator_memutil_dpi_0/cpp/dpi_memutil.cc:434:21: warning: loop variable ‘seg_pr’ creates a copy from type ‘const std::pair<const AddrRange<unsigned int>, std::vector<unsigned char> >’ [-Wrange-loop-construct]
  434 |     for (const auto seg_pr : staged_mem.GetSegs()) {
      |                     ^~~~~~
../src/lowrisc_dv_verilator_memutil_dpi_0/cpp/dpi_memutil.cc:434:21: note: use reference type to prevent copying
  434 |     for (const auto seg_pr : staged_mem.GetSegs()) {
      |                     ^~~~~~
      |                     &
```