### PR TITLE
[sw/silicon_creator] Check key validity using OTP, add unit tests

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/mock_otp.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_otp.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_OTP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_OTP_H_
+
+#include "sw/device/lib/testing/mask_rom_test.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for otp.c.
+ */
+class MockOtp {
+ public:
+  MOCK_METHOD(uint32_t, read32, (uint32_t address));
+  MOCK_METHOD(uint32_t, read64, (uint32_t address));
+  MOCK_METHOD(void, read, (uint32_t address, uint32_t *data, size_t num_words));
+  virtual ~MockOtp() {}
+};
+
+}  // namespace internal
+
+using MockOtp = GlobalMock<testing::StrictMock<internal::MockOtp>>;
+
+extern "C" {
+
+uint32_t otp_read32(uint32_t address) {
+  return MockOtp::Instance().read32(address);
+}
+
+uint64_t otp_read64(uint32_t address) {
+  return MockOtp::Instance().read64(address);
+}
+
+void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
+  return MockOtp::Instance().read(address, data, num_words);
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_OTP_H_

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -67,6 +67,7 @@ enum module_ {
   X(kErrorHmacInvalidArgument,        ERROR_(1, kModuleHmac, kInvalidArgument)), \
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadExponent,       ERROR_(2, kModuleSigverify, kInvalidArgument)), \
+  X(kErrorSigverifyBadKey,            ERROR_(3, kModuleSigverify, kInvalidArgument)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   X(kErrorManifestBadLength,          ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadEntryPoint,      ERROR_(2, kModuleManifest, kInternal)), \

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -15,6 +15,7 @@
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/print.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
@@ -26,6 +27,11 @@
 #include "sw/device/silicon_creator/mask_rom/sigverify_keys.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// TODO(#7325): Defined here for now to be able to use the OTP driver since
+// sec_mmio requires this symbol. For the actual target, we need to define a
+// memory region to share the data with ROM_EXT.
+sec_mmio_ctx_t sec_mmio_ctx;
 
 static inline rom_error_t mask_rom_irq_error(void) {
   uint32_t mcause;

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -20,9 +20,12 @@ sw_silicon_creator_mask_rom_sigverify = declare_dependency(
     'sw_silicon_creator_mask_rom_sigverify',
     sources: [
       'sigverify_keys.c',
+      hw_ip_otp_ctrl_reg_h,
     ],
     dependencies: [
       sw_silicon_creator_lib_sigverify,
+      sw_silicon_creator_lib_driver_otp,
+      sw_lib_bitfield,
     ],
   ),
 )
@@ -274,9 +277,11 @@ test('sw_silicon_creator_mask_rom_sigverify_keys_unittest', executable(
     sources: [
       'sigverify_keys.c',
       'sigverify_keys_unittest.cc',
+      hw_ip_otp_ctrl_reg_h,
     ] + sw_silicon_creator_lib_sigverify_sources_for_boot_stage_tests,
     dependencies: [
       sw_vendor_gtest,
+      sw_lib_testing_bitfield,
     ],
     native: true,
   ),

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys.c
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys.c
@@ -109,5 +109,5 @@ rom_error_t sigverify_rsa_key_get(uint32_t key_id,
       return kErrorOk;
     }
   }
-  return kErrorSigverifyBadEncodedMessage;
+  return kErrorSigverifyBadKey;
 }

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys.h
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys.h
@@ -19,6 +19,15 @@ enum {
    * Number of RSA public keys.
    */
   kSigVerifyNumRsaKeys = 2,
+  /**
+   * Number of key validity entries per OTP word.
+   *
+   * Validity of each public key is encoded using a byte-sized
+   * `hardened_byte_bool_t` in the `CREATOR_SW_CFG_KEY_IS_VALID` OTP item. Size
+   * of a `hardened_byte_bool_t` is 1 byte, thus each 32-bit OTP word has 4
+   * entries.
+   */
+  kSigverifyNumEntriesPerOtpWord = sizeof(uint32_t),
 };
 
 /**
@@ -30,6 +39,10 @@ extern const sigverify_rsa_key_t kSigVerifyRsaKeys[kSigVerifyNumRsaKeys];
 
 /**
  * Returns the key with the given ID.
+ *
+ * This function also checks whether the key with the given ID is valid by
+ * reading the corresponding entry from the `CREATOR_SW_CFG_KEY_IS_VALID` OTP
+ * item.
  *
  * @param key_id A key ID.
  * @param key Key with the given ID, valid only if it exists.

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -9,6 +9,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/lib/sigverify.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
 


### PR DESCRIPTION
This change
* Adds `MockOtp`,
* Adds key validity checks using OTP, and
* Adds unit tests for `sigverify_rsa_key_get`.

OTP images were updated in #7175.