### PR TITLE
[csrng/rtl] fix for dif test

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -1005,10 +1005,12 @@ module csrng_core import csrng_pkg::*; #(
 
   // Capture entropy from entropy_src
   assign entropy_src_seed_d =
+         cmd_req_dly_q ? '0 :                  // reset after every cmd
          (cmd_entropy_avail && flag0_q) ? '0 : // special case where zero is used
          cmd_entropy_avail ? (entropy_src_hw_if_i.es_bits ^ seed_diversification) :
          entropy_src_seed_q;
   assign entropy_src_fips_d =
+         cmd_req_dly_q ? '0 :                  // reset after every cmd
          (cmd_entropy_avail && flag0_q) ? '0 : // special case where zero is used
          cmd_entropy_avail ? entropy_src_hw_if_i.es_fips :
          entropy_src_fips_q;


### PR DESCRIPTION
Fix will clear out any residual seed info when doing KAT.
Discovered at full chip where ES does a normal boot sequence first.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>