### PR TITLE
[dv/otp] Fix otp_init_fail regression error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -143,7 +143,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                              otp_hw_cfg_data_t'({<<32 {otp_a[HwCfgOffset/4 +: HwCfgSize/4]}});
             `DV_CHECK_EQ(cfg.otp_ctrl_vif.otp_hw_cfg_o.data, exp_hwcfg_data)
 
-            if (!cfg.otp_ctrl_vif.under_error_states()) begin
+            if (!cfg.otp_ctrl_vif.under_error_states() && cfg.en_scb) begin
               // ---------------------- Check lc_data_o output -----------------------------------
               // Because initialization was succesful, the valid should be set and error should be
               // reset.


### PR DESCRIPTION
This PR fixes the regression error on otp_ctrl_init_fail when it turns
of the scoreboard.
The scoreboard did not check again if the `scb_en` is set to 0 in the
middle of the simulation.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>