### PR TITLE
[csrng/sec] remove halt sm function

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -223,45 +223,6 @@
         }
       ]
     },
-    { name: "HALT_MAIN_SM",
-      desc: "Halt the CSRNG main state machine register",
-      swaccess: "wo",
-      hwaccess: "hro",
-      fields: [
-        {
-            bits: "0",
-            name: "HALT_MAIN_SM",
-            desc: '''
-                  Setting this bit halts the main state machine that processes
-                  csrng application commands. The purpose of this register is to
-                  allow reading the internal state registers in a controlled manner.
-                  After this bit is set, the status bit should be polled to determine if the
-                  state machine has halted. Once halted, the internal state can be read
-                  out. To resume operation, this bit should be reset.
-                  '''
-        },
-      ]
-    },
-    { name: "MAIN_SM_STS",
-      desc: "CSRNG main state machine status register",
-      swaccess: "ro",
-      hwaccess: "hwo",
-      fields: [
-        { bits: "0",
-          name: "MAIN_SM_STS",
-          desc: '''
-                This bit indicates when the CSRNG main state machine has been halted.
-                When the halt bit is set, this bit should be polled until this
-                status bit is set. When set, it is safe to read the internal state
-                registers. When the halt bit is cleared, this register can be
-                polled to make sure the main state machine is operational again.
-                '''
-          tags: [// Internal HW can modify status register
-                 "excl:CsrAllTests:CsrExclCheck"]
-          resval: "0"
-        }
-      ]
-    },
     { name: "INT_STATE_NUM",
       desc: "Internal state number register",
       swaccess: "rw",

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -307,8 +307,6 @@ module csrng_core import csrng_pkg::*; #(
   logic                    state_db_reg_rd_id_pulse;
   logic [StateId-1:0]      state_db_reg_rd_id;
   logic [31:0]             state_db_reg_rd_val;
-  logic                    halt_main_sm;
-  logic                    main_sm_sts;
 
   logic [30:0]             err_code_test_bit;
   logic                    ctr_drbg_upd_es_ack;
@@ -830,7 +828,6 @@ module csrng_core import csrng_pkg::*; #(
   assign shid_d =
          (!cs_enable) ? '0 :
          acmd_sop ? shid :
-         state_db_reg_rd_id_pulse ? state_db_reg_rd_id :
          shid_q;
 
   assign gen_last_d =
@@ -863,8 +860,6 @@ module csrng_core import csrng_pkg::*; #(
     .update_req_o(update_req),
     .uninstant_req_o(uninstant_req),
     .cmd_complete_i(state_db_wr_req),
-    .halt_main_sm_i(halt_main_sm),
-    .main_sm_halted_o(main_sm_sts),
     .main_sm_err_o(main_sm_err)
   );
 
@@ -926,11 +921,6 @@ module csrng_core import csrng_pkg::*; #(
   assign state_db_reg_rd_id_pulse = reg2hw.int_state_num.qe;
   assign hw2reg.int_state_val.d = state_db_reg_rd_val;
 
-  // main sm control
-  assign halt_main_sm = reg2hw.halt_main_sm.q;
-  assign hw2reg.main_sm_sts.de = 1'b1;
-  assign hw2reg.main_sm_sts.d = main_sm_sts;
-
 
   csrng_state_db #(
     .NApps(NApps),
@@ -960,9 +950,10 @@ module csrng_core import csrng_pkg::*; #(
     .state_db_wr_res_ctr_i(state_db_wr_rc),
     .state_db_wr_sts_i(state_db_wr_sts),
 
-    .state_db_lc_en_i(lc_hw_debug_on),
+    .state_db_is_dump_en_i(cs_enable), // TODO: add efuse and new config bit
     .state_db_reg_rd_sel_i(state_db_reg_rd_sel),
     .state_db_reg_rd_id_pulse_i(state_db_reg_rd_id_pulse),
+    .state_db_reg_rd_id_i(state_db_reg_rd_id),
     .state_db_reg_rd_val_o(state_db_reg_rd_val),
     .state_db_sts_ack_o(state_db_sts_ack),
     .state_db_sts_sts_o(state_db_sts_sts),

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -93,10 +93,6 @@ package csrng_reg_pkg;
   } csrng_reg2hw_genbits_reg_t;
 
   typedef struct packed {
-    logic        q;
-  } csrng_reg2hw_halt_main_sm_reg_t;
-
-  typedef struct packed {
     logic [3:0]  q;
     logic        qe;
   } csrng_reg2hw_int_state_num_reg_t;
@@ -166,11 +162,6 @@ package csrng_reg_pkg;
   typedef struct packed {
     logic [31:0] d;
   } csrng_hw2reg_genbits_reg_t;
-
-  typedef struct packed {
-    logic        d;
-    logic        de;
-  } csrng_hw2reg_main_sm_sts_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -291,14 +282,13 @@ package csrng_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    csrng_reg2hw_intr_state_reg_t intr_state; // [136:133]
-    csrng_reg2hw_intr_enable_reg_t intr_enable; // [132:129]
-    csrng_reg2hw_intr_test_reg_t intr_test; // [128:121]
-    csrng_reg2hw_alert_test_reg_t alert_test; // [120:119]
-    csrng_reg2hw_ctrl_reg_t ctrl; // [118:113]
-    csrng_reg2hw_cmd_req_reg_t cmd_req; // [112:80]
-    csrng_reg2hw_genbits_reg_t genbits; // [79:47]
-    csrng_reg2hw_halt_main_sm_reg_t halt_main_sm; // [46:46]
+    csrng_reg2hw_intr_state_reg_t intr_state; // [135:132]
+    csrng_reg2hw_intr_enable_reg_t intr_enable; // [131:128]
+    csrng_reg2hw_intr_test_reg_t intr_test; // [127:120]
+    csrng_reg2hw_alert_test_reg_t alert_test; // [119:118]
+    csrng_reg2hw_ctrl_reg_t ctrl; // [117:112]
+    csrng_reg2hw_cmd_req_reg_t cmd_req; // [111:79]
+    csrng_reg2hw_genbits_reg_t genbits; // [78:46]
     csrng_reg2hw_int_state_num_reg_t int_state_num; // [45:41]
     csrng_reg2hw_int_state_val_reg_t int_state_val; // [40:8]
     csrng_reg2hw_err_code_test_reg_t err_code_test; // [7:2]
@@ -307,13 +297,12 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [204:197]
-    csrng_hw2reg_regwen_reg_t regwen; // [196:196]
-    csrng_hw2reg_sum_sts_reg_t sum_sts; // [195:171]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [170:167]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [166:165]
-    csrng_hw2reg_genbits_reg_t genbits; // [164:133]
-    csrng_hw2reg_main_sm_sts_reg_t main_sm_sts; // [132:131]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [202:195]
+    csrng_hw2reg_regwen_reg_t regwen; // [194:194]
+    csrng_hw2reg_sum_sts_reg_t sum_sts; // [193:169]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [168:165]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [164:163]
+    csrng_hw2reg_genbits_reg_t genbits; // [162:131]
     csrng_hw2reg_int_state_val_reg_t int_state_val; // [130:99]
     csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [98:83]
     csrng_hw2reg_err_code_reg_t err_code; // [82:33]
@@ -332,15 +321,13 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 20;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 24;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] CSRNG_HALT_MAIN_SM_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STS_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] CSRNG_SEL_TRACKING_SM_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] CSRNG_TRACKING_SM_OBS_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_SEL_TRACKING_SM_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] CSRNG_TRACKING_SM_OBS_OFFSET = 7'h 44;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -369,8 +356,6 @@ package csrng_reg_pkg;
     CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
     CSRNG_GENBITS,
-    CSRNG_HALT_MAIN_SM,
-    CSRNG_MAIN_SM_STS,
     CSRNG_INT_STATE_NUM,
     CSRNG_INT_STATE_VAL,
     CSRNG_HW_EXC_STS,
@@ -381,7 +366,7 @@ package csrng_reg_pkg;
   } csrng_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CSRNG_PERMIT [20] = '{
+  parameter logic [3:0] CSRNG_PERMIT [18] = '{
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
@@ -393,15 +378,13 @@ package csrng_reg_pkg;
     4'b 0001, // index[ 8] CSRNG_SW_CMD_STS
     4'b 0001, // index[ 9] CSRNG_GENBITS_VLD
     4'b 1111, // index[10] CSRNG_GENBITS
-    4'b 0001, // index[11] CSRNG_HALT_MAIN_SM
-    4'b 0001, // index[12] CSRNG_MAIN_SM_STS
-    4'b 0001, // index[13] CSRNG_INT_STATE_NUM
-    4'b 1111, // index[14] CSRNG_INT_STATE_VAL
-    4'b 0011, // index[15] CSRNG_HW_EXC_STS
-    4'b 1111, // index[16] CSRNG_ERR_CODE
-    4'b 0001, // index[17] CSRNG_ERR_CODE_TEST
-    4'b 0001, // index[18] CSRNG_SEL_TRACKING_SM
-    4'b 1111  // index[19] CSRNG_TRACKING_SM_OBS
+    4'b 0001, // index[11] CSRNG_INT_STATE_NUM
+    4'b 1111, // index[12] CSRNG_INT_STATE_VAL
+    4'b 0011, // index[13] CSRNG_HW_EXC_STS
+    4'b 1111, // index[14] CSRNG_ERR_CODE
+    4'b 0001, // index[15] CSRNG_ERR_CODE_TEST
+    4'b 0001, // index[16] CSRNG_SEL_TRACKING_SM
+    4'b 1111  // index[17] CSRNG_TRACKING_SM_OBS
   };
 
 endpackage

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -148,9 +148,6 @@ module csrng_reg_top (
   logic genbits_vld_genbits_fips_qs;
   logic genbits_re;
   logic [31:0] genbits_qs;
-  logic halt_main_sm_we;
-  logic halt_main_sm_wd;
-  logic main_sm_sts_qs;
   logic int_state_num_we;
   logic [3:0] int_state_num_qs;
   logic [3:0] int_state_num_wd;
@@ -731,60 +728,6 @@ module csrng_reg_top (
     .qe     (),
     .q      (reg2hw.genbits.q),
     .qs     (genbits_qs)
-  );
-
-
-  // R[halt_main_sm]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("WO"),
-    .RESVAL  (1'h0)
-  ) u_halt_main_sm (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (halt_main_sm_we),
-    .wd     (halt_main_sm_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.halt_main_sm.q),
-
-    // to register interface (read)
-    .qs     ()
-  );
-
-
-  // R[main_sm_sts]: V(False)
-
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RO"),
-    .RESVAL  (1'h0)
-  ) u_main_sm_sts (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.main_sm_sts.de),
-    .d      (hw2reg.main_sm_sts.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (main_sm_sts_qs)
   );
 
 
@@ -1593,7 +1536,7 @@ module csrng_reg_top (
 
 
 
-  logic [19:0] addr_hit;
+  logic [17:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
@@ -1607,15 +1550,13 @@ module csrng_reg_top (
     addr_hit[ 8] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
     addr_hit[ 9] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
     addr_hit[10] = (reg_addr == CSRNG_GENBITS_OFFSET);
-    addr_hit[11] = (reg_addr == CSRNG_HALT_MAIN_SM_OFFSET);
-    addr_hit[12] = (reg_addr == CSRNG_MAIN_SM_STS_OFFSET);
-    addr_hit[13] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
-    addr_hit[14] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
-    addr_hit[15] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
-    addr_hit[16] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
-    addr_hit[17] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
-    addr_hit[18] = (reg_addr == CSRNG_SEL_TRACKING_SM_OFFSET);
-    addr_hit[19] = (reg_addr == CSRNG_TRACKING_SM_OBS_OFFSET);
+    addr_hit[11] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
+    addr_hit[12] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
+    addr_hit[13] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
+    addr_hit[14] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
+    addr_hit[15] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
+    addr_hit[16] = (reg_addr == CSRNG_SEL_TRACKING_SM_OFFSET);
+    addr_hit[17] = (reg_addr == CSRNG_TRACKING_SM_OBS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1640,9 +1581,7 @@ module csrng_reg_top (
                (addr_hit[14] & (|(CSRNG_PERMIT[14] & ~reg_be))) |
                (addr_hit[15] & (|(CSRNG_PERMIT[15] & ~reg_be))) |
                (addr_hit[16] & (|(CSRNG_PERMIT[16] & ~reg_be))) |
-               (addr_hit[17] & (|(CSRNG_PERMIT[17] & ~reg_be))) |
-               (addr_hit[18] & (|(CSRNG_PERMIT[18] & ~reg_be))) |
-               (addr_hit[19] & (|(CSRNG_PERMIT[19] & ~reg_be)))));
+               (addr_hit[17] & (|(CSRNG_PERMIT[17] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -1687,20 +1626,17 @@ module csrng_reg_top (
   assign cmd_req_wd = reg_wdata[31:0];
   assign genbits_vld_re = addr_hit[9] & reg_re & !reg_error;
   assign genbits_re = addr_hit[10] & reg_re & !reg_error;
-  assign halt_main_sm_we = addr_hit[11] & reg_we & !reg_error;
-
-  assign halt_main_sm_wd = reg_wdata[0];
-  assign int_state_num_we = addr_hit[13] & reg_we & !reg_error;
+  assign int_state_num_we = addr_hit[11] & reg_we & !reg_error;
 
   assign int_state_num_wd = reg_wdata[3:0];
-  assign int_state_val_re = addr_hit[14] & reg_re & !reg_error;
-  assign hw_exc_sts_we = addr_hit[15] & reg_we & !reg_error;
+  assign int_state_val_re = addr_hit[12] & reg_re & !reg_error;
+  assign hw_exc_sts_we = addr_hit[13] & reg_we & !reg_error;
 
   assign hw_exc_sts_wd = reg_wdata[14:0];
-  assign err_code_test_we = addr_hit[17] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[15] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
-  assign sel_tracking_sm_we = addr_hit[18] & reg_we & !reg_error;
+  assign sel_tracking_sm_we = addr_hit[16] & reg_we & !reg_error;
 
   assign sel_tracking_sm_wd = reg_wdata[1:0];
 
@@ -1766,26 +1702,18 @@ module csrng_reg_top (
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[0] = '0;
-      end
-
-      addr_hit[12]: begin
-        reg_rdata_next[0] = main_sm_sts_qs;
-      end
-
-      addr_hit[13]: begin
         reg_rdata_next[3:0] = int_state_num_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[12]: begin
         reg_rdata_next[31:0] = int_state_val_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[13]: begin
         reg_rdata_next[14:0] = hw_exc_sts_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = err_code_sfifo_cmd_err_qs;
         reg_rdata_next[1] = err_code_sfifo_genbits_err_qs;
         reg_rdata_next[2] = err_code_sfifo_cmdreq_err_qs;
@@ -1813,15 +1741,15 @@ module csrng_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[15]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[16]: begin
         reg_rdata_next[1:0] = '0;
       end
 
-      addr_hit[19]: begin
+      addr_hit[17]: begin
         reg_rdata_next[31:0] = tracking_sm_obs_qs;
       end
 


### PR DESCRIPTION
Having a way to halt the main state machine may open a window to tamper with downstream entropy.
Refactored the RTL to elimate the need for this function.
The internal state can be read per instance with no restrictions.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>