### PR TITLE
[rom_ctrl] Cut the instantiated ROM width back down to 39 bits

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -408,7 +408,7 @@ jobs:
 
       ./hw/top_earlgrey/util/top_earlgrey_reduce.py
 
-      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
+      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.39.vmem"
       test -f "$BOOTROM_VMEM"
       OTP_VMEM="$BIN_DIR/sw/device/otp_img/otp_img_fpga_nexysvideo.vmem"
       test -f "$OTP_VMEM"
@@ -467,7 +467,7 @@ jobs:
 
       ./hw/top_earlgrey/util/top_earlgrey_reduce.py
 
-      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
+      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.39.vmem"
       test -f "$BOOTROM_VMEM"
       OTP_VMEM="$BIN_DIR/sw/device/otp_img/otp_img_fpga_nexysvideo.vmem"
       test -f "$OTP_VMEM"
@@ -528,7 +528,7 @@ jobs:
       mkdir -p "$OBJ_DIR/hw"
       mkdir -p "$BIN_DIR/hw/top_englishbreakfast"
 
-      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
+      BOOTROM_VMEM="$BIN_DIR/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.39.vmem"
       test -f "$BOOTROM_VMEM"
 
       fusesoc --cores-root=. \

--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -47,7 +47,7 @@ The programs listed after `--meminit` are loaded into the system's specified mem
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
 ```
@@ -104,7 +104,7 @@ A full command-line invocation of the simulation could then look like that:
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   +UARTDPI_LOG_uart0=-
@@ -196,7 +196,7 @@ Tracing slows down the simulation by roughly factor of 1000.
 ```console
 $ cd $REPO_TOP
 $ build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   --trace

--- a/doc/ug/quickstart.md
+++ b/doc/ug/quickstart.md
@@ -36,7 +36,7 @@ $ tar -C $OT_TOP -xvf opentitan-snapshot-20191101-1.tar.xz --strip-components=1
 Run the provided simulator binary with
 ```console
 $ cd $OT_TOP
-$ ./hw/top_earlgrey/Vchip_earlgrey_verilator --rominit=./sw/device/sim/boot_rom/boot_rom_sim_verilator.scr.40.vmem --flashinit=./sw/device/sim/examples/hello_world/sw.vmem
+$ ./hw/top_earlgrey/Vchip_earlgrey_verilator --rominit=./sw/device/sim/boot_rom/boot_rom_sim_verilator.scr.39.vmem --flashinit=./sw/device/sim/examples/hello_world/sw.vmem
 
 Simulation of OpenTitan Earl Grey
 =================================

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -8,21 +8,21 @@
 // The data decoding is different from SRAM, but most of the underlying SRAM functions are reused
 // Also note that this function returns the raw data rather than data + syndrome + error because
 // the rom_ctrl testbench needs this for checking.
-virtual function bit [39:0] rom_encrypt_read32(bit [bus_params_pkg::BUS_AW-1:0] addr,
+virtual function bit [38:0] rom_encrypt_read32(bit [bus_params_pkg::BUS_AW-1:0] addr,
                                                logic [SRAM_KEY_WIDTH-1:0]       key,
                                                logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
                                                bit                              unscramble_data);
 
   logic [bus_params_pkg::BUS_AW-1:0] mem_addr = '0;
-  logic [39:0]                       data = '0;
+  logic [38:0]                       data = '0;
 
   logic addr_arr      [] = new[addr_width];
   logic scrambled_addr[] = new[addr_width];
-  logic data_arr      [] = new[40];
+  logic data_arr      [] = new[39];
   logic key_arr       [] = new[SRAM_KEY_WIDTH];
   logic nonce_arr     [] = new[SRAM_BLOCK_WIDTH];
   logic keystream     [] = new[SRAM_BLOCK_WIDTH];
-  logic zero_key      [] = new[40];
+  logic zero_key      [] = new[39];
 
   key_arr   = {<<{key}};
   nonce_arr = {<<{nonce}};
@@ -55,12 +55,12 @@ virtual function bit [39:0] rom_encrypt_read32(bit [bus_params_pkg::BUS_AW-1:0] 
   // Generate the keystream
   keystream = sram_scrambler_pkg::gen_keystream(addr_arr, addr_width, key_arr, nonce_arr);
 
-  for (int i = 0; i < 40; i++) begin
+  for (int i = 0; i < 39; i++) begin
     zero_key[i] = '0;
   end
 
-  data_arr = sram_scrambler_pkg::sp_decrypt(data_arr, 40, zero_key);
-  for (int i = 0; i < 40; i++) begin
+  data_arr = sram_scrambler_pkg::sp_decrypt(data_arr, 39, zero_key);
+  for (int i = 0; i < 39; i++) begin
     data[i] = data_arr[i] ^ keystream[i];
   end
 

--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -105,7 +105,7 @@ simulation run, e.g.
 
 ```sh
 build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem \
+  --meminit=rom,build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
   --meminit=flash,build-bin/sw/device/tests/dif_otbn_smoketest_sim_verilator.elf \
   --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   +UARTDPI_LOG_uart0=- \

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -34,8 +34,8 @@ package rom_ctrl_env_pkg;
   parameter uint MAX_CHECK_ADDR = rom_ctrl_reg_pkg::ROM_CTRL_ROM_SIZE - (DIGEST_SIZE / 8);
   // The data for each line in rom up to the digest is padded out to the kmac message width
   parameter uint KMAC_DATA_SIZE = MAX_CHECK_ADDR / (TL_DW / 8) * (kmac_pkg::MsgWidth / 8);
-  // The rom width is rounded up to 40 for scrambling symmetry
-  parameter uint ROM_MEM_W = 40;
+  // The rom width in bits
+  parameter uint ROM_MEM_W = 39;
 
   // types
   typedef virtual rom_ctrl_if rom_ctrl_vif;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -50,8 +50,8 @@ module rom_ctrl
 
   logic [RomIndexWidth-1:0] rom_index;
   logic                     rom_req;
-  logic [39:0]              rom_scr_rdata;
-  logic [39:0]              rom_clr_rdata;
+  logic [38:0]              rom_scr_rdata;
+  logic [38:0]              rom_clr_rdata;
   logic                     rom_rvalid;
 
   logic [RomIndexWidth-1:0] bus_rom_index;
@@ -62,7 +62,7 @@ module rom_ctrl
 
   logic [RomIndexWidth-1:0] checker_rom_index;
   logic                     checker_rom_req;
-  logic [39:0]              checker_rom_rdata;
+  logic [38:0]              checker_rom_rdata;
 
   // Pack / unpack kmac connection data ========================================
 
@@ -172,7 +172,7 @@ module rom_ctrl
 
   rom_ctrl_scrambled_rom #(
     .MemInitFile (BootRomInitFile),
-    .Width       (40),
+    .Width       (39),
     .Depth       (RomSizeWords),
     .ScrNonce    (RndCnstScrNonce),
     .ScrKey      (RndCnstScrKey)
@@ -188,7 +188,7 @@ module rom_ctrl
   );
 
   // Zero expand checker rdata to pass to KMAC
-  assign kmac_rom_data = {24'd0, checker_rom_rdata};
+  assign kmac_rom_data = {25'd0, checker_rom_rdata};
 
   // Register block ============================================================
 

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -25,13 +25,13 @@ module rom_ctrl_mux #(
   // Interface for ROM checker
   input logic [AW-1:0]  chk_addr_i,
   input logic           chk_req_i,
-  output logic [39:0]   chk_rdata_o,
+  output logic [38:0]   chk_rdata_o,
 
   // Interface for ROM
   output logic [AW-1:0] rom_addr_o,
   output logic          rom_req_o,
-  input logic [39:0]    rom_scr_rdata_i,
-  input logic [39:0]    rom_clr_rdata_i,
+  input logic [38:0]    rom_scr_rdata_i,
+  input logic [38:0]    rom_clr_rdata_i,
   input logic           rom_rvalid_i,
 
   // Alert output
@@ -54,7 +54,7 @@ module rom_ctrl_mux #(
 
   // The bus can have access every cycle, once the select signal is zero.
   assign bus_gnt_o    = ~sel_i;
-  assign bus_rdata_o  = rom_clr_rdata_i[38:0];
+  assign bus_rdata_o  = rom_clr_rdata_i;
   // A high rom_rvalid_i is a response to a bus request if sel_i was zero on the previous cycle.
   assign bus_rvalid_o = ~sel_q & rom_rvalid_i;
 
@@ -62,12 +62,5 @@ module rom_ctrl_mux #(
 
   assign rom_addr_o = sel_i ? chk_addr_i : bus_addr_i;
   assign rom_req_o  = sel_i ? chk_req_i  : bus_req_i;
-
-  // We use a Hsiao (39,32) ECC scheme for data integrity, but have expanded the ROM to 40 bits
-  // rather than 39 bits (it's no more expensive with many macro libraries, and it's slightly nicer
-  // for scrambling, because 40 is a whole number of 4-bit sboxes). Of course, this means that we
-  // never actually pass the top bit through to the bus. Waive that here.
-  logic unused_bus_rdata_top;
-  assign unused_bus_rdata_top = rom_clr_rdata_i[39];
 
 endmodule

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -367,11 +367,11 @@ class Scrambler:
 
         return flattened
 
-    def scramble40(self, mem: MemFile) -> MemFile:
+    def scramble(self, mem: MemFile) -> MemFile:
         assert len(mem.chunks) == 1
         assert len(mem.chunks[0].words) == self.rom_size_words
 
-        word_width = 40
+        word_width = mem.width
 
         # Write addr_sp, data_sp for the S&P networks for address and data,
         # respectively. Write clr[i] for unscrambled data word i and scr[i] for
@@ -485,14 +485,10 @@ def main() -> int:
 
     # Extend from 32 bits to 39 by adding Hsiao (39,32) ECC bits.
     clr_flat.add_ecc32()
-
-    # Zero-extend the cleartext memory by one more bit (this is the size we
-    # actually use in the physical ROM)
     assert clr_flat.width == 39
-    clr_flat.width = 40
 
     # Scramble the memory
-    scr_mem = scrambler.scramble40(clr_flat)
+    scr_mem = scrambler.scramble(clr_flat)
 
     # Insert the expected hash here to the top 8 words
     scrambler.add_hash(scr_mem)

--- a/hw/top_earlgrey/chip_earlgrey_cw310.core
+++ b/hw/top_earlgrey/chip_earlgrey_cw310.core
@@ -35,14 +35,14 @@ filesets:
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
-  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_cw310.scr.40.vmem
+  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_cw310.scr.39.vmem
   # XXX: The VMEM file should be added to the sources of the Vivado project to
   # make the Vivado dependency tracking work. However this requires changes to
   # fusesoc first.
   BootRomInitFile:
     datatype: str
     description: Scrambled boot ROM initialization file in 40 bit vmem hex format
-    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
+    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.39.vmem"
     paramtype: vlogparam
   OtpCtrlMemInitFile:
     datatype: str

--- a/hw/top_earlgrey/chip_earlgrey_nexysvideo.core
+++ b/hw/top_earlgrey/chip_earlgrey_nexysvideo.core
@@ -35,14 +35,14 @@ filesets:
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
-  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem
+  # --BootRomInitFile=$PWD/build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.39.vmem
   # XXX: The VMEM file should be added to the sources of the Vivado project to
   # make the Vivado dependency tracking work. However this requires changes to
   # fusesoc first.
   BootRomInitFile:
     datatype: str
     description: Scrambled boot ROM initialization file in 40 bit vmem hex format
-    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.40.vmem"
+    default: "../../../../../build-bin/sw/device/boot_rom/boot_rom_fpga_nexysvideo.scr.39.vmem"
     paramtype: vlogparam
   OtpCtrlMemInitFile:
     datatype: str

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -37,7 +37,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.mem_bkdr_util_h[FlashBank1Data].set_mem();
 
     // Backdoor load memories with sw images.
-    cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".scr.40.vmem"});
+    cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".scr.39.vmem"});
 
     // TODO: the location of the main execution image should be randomized to either bank in future.
     if (cfg.use_spi_load_bootstrap) begin

--- a/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator_sim_cfg.hjson
@@ -64,7 +64,7 @@
         '''{eval_cmd} \
         opts=;  \
         types=(rom flash otbn otp); \
-        exts=(scr.40.vmem elf elf vmem); \
+        exts=(scr.39.vmem elf elf vmem); \
         images=`echo {sw_images}`; \
         for image in $images; do \
           path=`echo $image | cut -d: -f 1`;  \

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_pin_config_sim.sh
@@ -7,7 +7,7 @@
 VERILATOR=build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator
 
 # Code to load
-ROMCODE=build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem
+ROMCODE=build-bin/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem
 FLASH=build-bin/sw/device/examples/hello_usbdev/hello_usbdev_sim_verilator.elf
 OTP=build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
 

--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -121,7 +121,7 @@ scramble_image_hjson = [
   meson.source_root() / 'hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson'
 ]
 scramble_image_outputs = [
-  '@BASENAME@.scr.40.vmem',
+  '@BASENAME@.scr.39.vmem',
 ]
 scramble_image_command = [
     prog_python,

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -209,7 +209,7 @@ def rom_selfchecking(request, bin_dir):
     # Allow tests to optionally specify their subdir within the project.
     test_dir = rom_config.get('test_dir', 'sw/device/tests')
 
-    test_filename = binary_name + '_sim_verilator.scr.40.vmem'
+    test_filename = binary_name + '_sim_verilator.scr.39.vmem'
     bin_path = bin_dir / test_dir / test_filename
     assert bin_path.is_file()
 
@@ -348,7 +348,7 @@ def test_apps_selfchecking(tmp_path, bin_dir, app_selfchecking):
     """
 
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem"
+    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem"
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
     sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)
@@ -374,7 +374,7 @@ def test_apps_selfchecking_silicon_creator(tmp_path, bin_dir,
 
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
     rom_vmem_path = bin_dir / ("sw/device/silicon_creator/mask_rom/"
-                               "mask_rom_sim_verilator.scr.40.vmem")
+                               "mask_rom_sim_verilator.scr.39.vmem")
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
     # Use a longer timeout for boot due to the overhead of signature verification.
@@ -398,7 +398,7 @@ def test_spiflash(tmp_path, bin_dir):
     """ Load a single application to the Verilator simulation using spiflash """
 
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem"
+    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem"
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
     sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)
@@ -428,7 +428,7 @@ def test_openocd_basic_connectivity(tmp_path, bin_dir, topsrcdir, openocd):
     """
     # Run a simulation (bootrom only, no app beyond that)
     sim_path = bin_dir / "hw/top_earlgrey/Vchip_earlgrey_verilator"
-    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.40.vmem"
+    rom_vmem_path = bin_dir / "sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem"
     otp_img_path = bin_dir / "sw/device/otp_img/otp_img_sim_verilator.vmem"
 
     sim = VerilatorSimEarlgrey(sim_path, rom_vmem_path, otp_img_path, tmp_path)


### PR DESCRIPTION
We don't really have any need to keep it at 40 because our macro
wrapper can do the rounding up if needed for the technology library.
It also avoids an awkward situation where we were "encrypting" a zero
bit in counter mode. This didn't really matter for the ROM
application (where confidentiality isn't a requirement), but it's a
bit awkward and easy to avoid.

Closes #7033.