### PR TITLE
[csrng/sec] remove AES bypass, clean register debug

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -114,34 +114,6 @@
             tags: [// Exclude from writes to these bits.
                    "excl:CsrAllTests:CsrExclWrite"]
         },
-        {
-            bits: "1",
-            name: "AES_CIPHER_DISABLE",
-            desc: '''
-                  Setting this bit will disable the AES cipher core module. If set, then commands will
-                  bypass the AES cipher core, but still move through the logical flow of CSRNG.
-                  This mode is primarily for debug purposes.
-                  '''
-        },
-        {
-            bits: "19:16",
-            name: "FIFO_DEPTH_STS_SEL",
-            desc: "This field will select which FIFO depth will be read out for diagnostic purposes."
-        },
-      ]
-    },
-    {
-      name: "SUM_STS",
-      desc: "Summary status register",
-      swaccess: "ro",
-      hwaccess: "hwo",
-      tags: [// Internal HW can modify status register
-             "excl:CsrAllTests:CsrExclCheck"]
-      fields: [
-        { bits: "23:0",
-          name: "FIFO_DEPTH_STS",
-          desc: "These bits show the current status of the CRSNG FIFO depths."
-        }
       ]
     },
     {
@@ -563,14 +535,57 @@
       swaccess: "ro",
       hwaccess: "hwo",
       fields: [
-        { bits: "31:0",
-          name: "TRACKING_SM_OBS",
+        { bits: "7:0",
+          name: "TRACKING_SM_OBS0",
           desc: '''
-                This field will hold 4 csrng command tracking state machine fields,
-                each field being 8 bits. Bits 7:0 hold tracking field 0 for instance 0,
-                Bits 16:8 hold tracking field 1 for instance 1, etc.
+                This field will hold csrng command tracking state machine status,
+                This field holds tracking information for instance 0 if the
+                !!SEL_TRACKING_SM register is set to 0.
                 If more than 4 instances are active, then the selection register
                 can be programmed to select up to 3 other groups.
+                The life cycle state must be set to debug state to read this field.
+                '''
+          tags: [// Internal HW can modify status register
+                 "excl:CsrAllTests:CsrExclCheck"]
+          resval: "0"
+        }
+        { bits: "15:8",
+          name: "TRACKING_SM_OBS1",
+          desc: '''
+                This field will hold csrng command tracking state machine status,
+                This field holds tracking information for instance 1 if the
+                !!SEL_TRACKING_SM register is set to 0.
+                If more than 4 instances are active, then the selection register
+                can be programmed to select up to 3 other groups.
+                The life cycle state must be set to debug state to read this field.
+                '''
+          tags: [// Internal HW can modify status register
+                 "excl:CsrAllTests:CsrExclCheck"]
+          resval: "0"
+        }
+        { bits: "23:16",
+          name: "TRACKING_SM_OBS2",
+          desc: '''
+                This field will hold csrng command tracking state machine status,
+                This field holds tracking information for instance 2 if the
+                !!SEL_TRACKING_SM register is set to 0.
+                If more than 4 instances are active, then the selection register
+                can be programmed to select up to 3 other groups.
+                The life cycle state must be set to debug state to read this field.
+                '''
+          tags: [// Internal HW can modify status register
+                 "excl:CsrAllTests:CsrExclCheck"]
+          resval: "0"
+        }
+        { bits: "31:24",
+          name: "TRACKING_SM_OBS3",
+          desc: '''
+                This field will hold csrng command tracking state machine status,
+                This field holds tracking information for instance 3 if the
+                !!SEL_TRACKING_SM register is set to 0.
+                If more than 4 instances are active, then the selection register
+                can be programmed to select up to 3 other groups.
+                The life cycle state must be set to debug state to read this field.
                 '''
           tags: [// Internal HW can modify status register
                  "excl:CsrAllTests:CsrExclCheck"]

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -18,9 +18,9 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   virtual pins_if  efuse_sw_app_enable_vif;
 
   // Knobs & Weights
-  uint             efuse_sw_app_enable_pct, aes_cipher_disable_pct,
+  uint             efuse_sw_app_enable_pct,
                    cmd_length_0_pct, cmd_flags_0_pct, chk_int_state_pct;
-  rand bit         efuse_sw_app_enable, aes_cipher_disable, chk_int_state;
+  rand bit         efuse_sw_app_enable, chk_int_state;
   rand bit [3:0]   cmd_length, cmd_flags;
 
   // Variables
@@ -33,10 +33,6 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
   constraint c_efuse_sw_app_enable {efuse_sw_app_enable dist { 1 :/ efuse_sw_app_enable_pct,
                                                                0 :/ (100 - efuse_sw_app_enable_pct)
                                                              };}
-
-  constraint c_aes_cipher_disable {aes_cipher_disable dist { 1 :/ aes_cipher_disable_pct,
-                                                             0 :/ (100 - aes_cipher_disable_pct)
-                                                           };}
 
   constraint c_chk_int_state {chk_int_state dist { 1 :/ chk_int_state_pct,
                                                    0 :/ (100 - chk_int_state_pct)
@@ -99,13 +95,11 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
     str = {str, "\n"};
     str = {str,  $sformatf("\n\t |********** csrng_env_cfg ***********************| \t")                    };
     str = {str,  $sformatf("\n\t |***** efuse_sw_app_enable     : %10d *****| \t", efuse_sw_app_enable)     };
-    str = {str,  $sformatf("\n\t |***** aes_cipher_disable      : %10d *****| \t", aes_cipher_disable)      };
     str = {str,  $sformatf("\n\t |***** chk_int_state           : %10d *****| \t", chk_int_state)           };
     str = {str,  $sformatf("\n\t |***** cmd_length              : %10d *****| \t", cmd_length)              };
     str = {str,  $sformatf("\n\t |***** cmd_flags               : %10d *****| \t", cmd_flags)               };
     str = {str,  $sformatf("\n\t |---------- knobs -------------------------------| \t")                    };
     str = {str,  $sformatf("\n\t |***** efuse_sw_app_enable_pct : %10d *****| \t", efuse_sw_app_enable_pct) };
-    str = {str,  $sformatf("\n\t |***** aes_cipher_disable_pct  : %10d *****| \t", aes_cipher_disable_pct)  };
     str = {str,  $sformatf("\n\t |***** chk_int_state_pct       : %10d *****| \t", chk_int_state_pct)       };
     str = {str,  $sformatf("\n\t |***** cmd_length_0_pct        : %10d *****| \t", cmd_length_0_pct)        };
     str = {str,  $sformatf("\n\t |***** cmd_flags_0_pct         : %10d *****| \t", cmd_flags_0_pct)         };

--- a/hw/ip/csrng/dv/env/csrng_scoreboard.sv
+++ b/hw/ip/csrng/dv/env/csrng_scoreboard.sv
@@ -160,15 +160,11 @@ class csrng_scoreboard extends cip_base_scoreboard #(
 
     bit [csrng_env_pkg::BLOCK_LEN-1:0]   output_block;
 
-    if (cfg.aes_cipher_disable)
-      output_block = input_block;
-    else begin
-      sv_dpi_aes_crypt_block(.impl_i(1'b0), .op_i(1'b0), .mode_i(6'b00_0001), .key_len_i(3'b100),
-                             .iv_i('h0),
-                             .key_i(key),
-                             .data_i(input_block),
-                             .data_o(output_block));
-    end
+    sv_dpi_aes_crypt_block(.impl_i(1'b0), .op_i(1'b0), .mode_i(6'b00_0001), .key_len_i(3'b100),
+                           .iv_i('h0),
+                           .key_i(key),
+                           .data_i(input_block),
+                           .data_o(output_block));
     return output_block;
   endfunction
 

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_cmds_vseq.sv
@@ -16,7 +16,6 @@ class csrng_cmds_vseq extends csrng_base_vseq;
 
   task body();
     ral.ctrl.enable.set(1'b1);
-    ral.ctrl.aes_cipher_disable.set(cfg.aes_cipher_disable);
     csr_update(.csr(ral.ctrl));
 
     // TODO: Create/start entropy_src device sequence still under development. Will remove/modify

--- a/hw/ip/csrng/dv/env/seq_lib/csrng_smoke_vseq.sv
+++ b/hw/ip/csrng/dv/env/seq_lib/csrng_smoke_vseq.sv
@@ -9,9 +9,8 @@ class csrng_smoke_vseq extends csrng_base_vseq;
   `uvm_object_new
 
   task body();
-    // Enable CSRNG, Disable AES Cipher Core
+    // Enable CSRNG
     ral.ctrl.enable.set(1'b1);
-    ral.ctrl.aes_cipher_disable.set(cfg.aes_cipher_disable);
     csr_update(.csr(ral.ctrl));
 
     // Wait for CSRNG cmd_rdy
@@ -30,10 +29,15 @@ class csrng_smoke_vseq extends csrng_base_vseq;
     // Wait for CSRNG genbits_vld
     csr_spinwait(.ptr(ral.genbits_vld.genbits_vld), .exp_data(1'b1));
 
+    // TODO: remove code below and use scoreboard values
     //Read CSRNG genbits
-    for (int i = 0; i < 4; i++) begin
-      csr_rd_check(.ptr(ral.genbits.genbits), .compare_value(ZERO_SEED_GENBITS[i]));
-    end
+//    for (int i = 0; i < 4; i++) begin
+//      csr_rd_check(.ptr(ral.genbits.genbits), .compare_value(ZERO_SEED_GENBITS[i]));
+//    end
+      csr_rd_check(.ptr(ral.genbits.genbits), .compare_value(32'h735b27a0));
+      csr_rd_check(.ptr(ral.genbits.genbits), .compare_value(32'h497b246f));
+      csr_rd_check(.ptr(ral.genbits.genbits), .compare_value(32'h9a8f9420));
+      csr_rd_check(.ptr(ral.genbits.genbits), .compare_value(32'h91618fe9));
 
     // Expect/Clear interrupt bit
     csr_spinwait(.ptr(ral.intr_state.cs_cmd_req_done), .exp_data(1'b1));

--- a/hw/ip/csrng/dv/tests/csrng_base_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_base_test.sv
@@ -26,7 +26,6 @@ class csrng_base_test extends cip_base_test #(
   virtual function void configure_env();
     cfg.efuse_sw_app_enable_pct = 100;
     cfg.chk_int_state_pct       = 100;
-    cfg.aes_cipher_disable_pct  = 0;
     cfg.cmd_length_0_pct        = 0;
     cfg.cmd_flags_0_pct         = 0;
   endfunction

--- a/hw/ip/csrng/dv/tests/csrng_smoke_test.sv
+++ b/hw/ip/csrng/dv/tests/csrng_smoke_test.sv
@@ -10,8 +10,6 @@ class csrng_smoke_test extends csrng_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.aes_cipher_disable_pct = 100;
-
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
   endfunction

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -16,9 +16,7 @@ module csrng_block_encrypt import csrng_pkg::*; #(
   input logic                rst_ni,
 
    // update interface
-  input logic                block_encrypt_bypass_i,
   input logic                block_encrypt_enable_i,
-  input logic                block_encrypt_lc_hw_debug_not_on_i,
   input logic                block_encrypt_req_i,
   output logic               block_encrypt_rdy_o,
   input logic [KeyLen-1:0]   block_encrypt_key_i,
@@ -36,7 +34,7 @@ module csrng_block_encrypt import csrng_pkg::*; #(
 );
 
   localparam int BlkEncFifoDepth = 1;
-  localparam int BlkEncFifoWidth = BlkLen+StateId+Cmd;
+  localparam int BlkEncFifoWidth = StateId+Cmd;
   localparam int NumShares = 1;
 
   // signals
@@ -50,7 +48,6 @@ module csrng_block_encrypt import csrng_pkg::*; #(
   // breakout
   logic [Cmd-1:0]             sfifo_blkenc_cmd;
   logic [StateId-1:0]         sfifo_blkenc_id;
-  logic [BlkLen-1:0]          sfifo_blkenc_v;
 
   aes_pkg::sp2v_e       cipher_in_valid;
   aes_pkg::sp2v_e       cipher_in_ready;
@@ -81,7 +78,7 @@ module csrng_block_encrypt import csrng_pkg::*; #(
   // aes cipher core lifecycle enable
   //--------------------------------------------
 
-  assign aes_cipher_core_enable = (!block_encrypt_bypass_i) || block_encrypt_lc_hw_debug_not_on_i;
+  assign     aes_cipher_core_enable = block_encrypt_enable_i;
 
   //--------------------------------------------
   // aes cipher core
@@ -128,7 +125,7 @@ module csrng_block_encrypt import csrng_pkg::*; #(
 
 
   //--------------------------------------------
-  // bypass fifo - intent is to bypass the aes block
+  // cmd / id tracking fifo
   //--------------------------------------------
 
   prim_fifo_sync #(
@@ -150,24 +147,20 @@ module csrng_block_encrypt import csrng_pkg::*; #(
   );
 
   assign sfifo_blkenc_push = block_encrypt_req_i && !sfifo_blkenc_full;
-  assign sfifo_blkenc_wdata = {block_encrypt_v_i,block_encrypt_id_i,block_encrypt_cmd_i};
+  assign sfifo_blkenc_wdata = {block_encrypt_id_i,block_encrypt_cmd_i};
 
-  assign block_encrypt_rdy_o = !aes_cipher_core_enable ? !sfifo_blkenc_full :
-               (cipher_in_ready == aes_pkg::SP2V_HIGH) ? 1'b1               : 1'b0;
+  assign block_encrypt_rdy_o = (cipher_in_ready == aes_pkg::SP2V_HIGH);
 
   assign sfifo_blkenc_pop = block_encrypt_ack_o;
-  assign {sfifo_blkenc_v,sfifo_blkenc_id,sfifo_blkenc_cmd} = sfifo_blkenc_rdata;
+  assign {sfifo_blkenc_id,sfifo_blkenc_cmd} = sfifo_blkenc_rdata;
 
-  assign block_encrypt_ack_o = block_encrypt_rdy_i &&
-         (!aes_cipher_core_enable                  ? sfifo_blkenc_not_empty :
-          (cipher_out_valid == aes_pkg::SP2V_HIGH) ? 1'b1                   : 1'b0);
+  assign block_encrypt_ack_o = block_encrypt_rdy_i && (cipher_out_valid == aes_pkg::SP2V_HIGH);
 
   assign block_encrypt_cmd_o = sfifo_blkenc_cmd;
   assign block_encrypt_id_o = sfifo_blkenc_id;
-  assign block_encrypt_v_o = !aes_cipher_core_enable ? sfifo_blkenc_v : cipher_data_out;
-  assign cipher_out_ready =
-         block_encrypt_rdy_i ? aes_pkg::SP2V_HIGH :
-         aes_pkg::SP2V_LOW;
+  assign block_encrypt_v_o = cipher_data_out;
+
+  assign cipher_out_ready = block_encrypt_rdy_i ? aes_pkg::SP2V_HIGH : aes_pkg::SP2V_LOW;
 
   assign block_encrypt_sfifo_blkenc_err_o =
          {(sfifo_blkenc_push && sfifo_blkenc_full),

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -70,7 +70,6 @@ module csrng_core import csrng_pkg::*; #(
   logic       event_cs_hw_inst_exc;
   logic       event_cs_fatal_err;
   logic       cs_enable;
-  logic       aes_cipher_enable;
   logic       acmd_avail;
   logic       acmd_sop;
   logic       acmd_mop;
@@ -133,7 +132,6 @@ module csrng_core import csrng_pkg::*; #(
   logic                   generate_req;
   logic                   update_req;
   logic                   uninstant_req;
-  logic [3:0]             fifo_sel;
   logic [Cmd-1:0]         ctr_drbg_cmd_ccmd;
   logic                   ctr_drbg_cmd_req;
   logic                   ctr_drbg_gen_req;
@@ -298,10 +296,8 @@ module csrng_core import csrng_pkg::*; #(
   logic                    genbits_stage_bus_rd_sw;
   logic [31:0]             genbits_stage_bus_sw;
   logic                    genbits_stage_fips_sw;
-  logic [2:0]              pfifo_sw_genbits_depth;
 
   logic [14:0]             hw_exception_sts;
-  logic                    lc_hw_debug_not_on;
   logic                    lc_hw_debug_on;
   logic                    state_db_reg_rd_sel;
   logic                    state_db_reg_rd_id_pulse;
@@ -648,11 +644,8 @@ module csrng_core import csrng_pkg::*; #(
   };
 
   // master module enable
-  assign cs_enable = reg2hw.ctrl.enable.q;
-  assign aes_cipher_enable = !reg2hw.ctrl.aes_cipher_disable.q;
+  assign cs_enable = reg2hw.ctrl.q;
   assign hw2reg.regwen.d = !cs_enable; // hw reg lock implementation
-  // fifo selection for debug
-  assign fifo_sel = reg2hw.ctrl.fifo_depth_sts_sel.q;
 
   //------------------------------------------
   // application interface
@@ -733,7 +726,7 @@ module csrng_core import csrng_pkg::*; #(
     .rvalid_o   (genbits_stage_vldo_sw),
     .rdata_o    (genbits_stage_bus_sw),
     .rready_i   (genbits_stage_bus_rd_sw),
-    .depth_o    (pfifo_sw_genbits_depth)
+    .depth_o    ()
   );
 
   // flops for SW fips status
@@ -1208,10 +1201,10 @@ module csrng_core import csrng_pkg::*; #(
   // provide control logic to determine
   // how certain debug features are controlled.
 
-  lc_ctrl_pkg::lc_tx_t [1:0] lc_hw_debug_en_out;
+  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_out;
 
   prim_lc_sync #(
-    .NumCopies(2)
+    .NumCopies(1)
   ) u_prim_lc_sync (
     .clk_i,
     .rst_ni,
@@ -1219,8 +1212,7 @@ module csrng_core import csrng_pkg::*; #(
     .lc_en_o(lc_hw_debug_en_out)
   );
 
-  assign      lc_hw_debug_not_on = (lc_hw_debug_en_out[0] != lc_ctrl_pkg::On);
-  assign      lc_hw_debug_on = (lc_hw_debug_en_out[1] == lc_ctrl_pkg::On);
+  assign      lc_hw_debug_on = (lc_hw_debug_en_out == lc_ctrl_pkg::On);
 
 
   //-------------------------------------
@@ -1242,9 +1234,7 @@ module csrng_core import csrng_pkg::*; #(
   ) u_csrng_block_encrypt (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
-    .block_encrypt_bypass_i(!aes_cipher_enable),
     .block_encrypt_enable_i(cs_enable),
-    .block_encrypt_lc_hw_debug_not_on_i(lc_hw_debug_not_on),
     .block_encrypt_req_i(benblk_arb_vld),
     .block_encrypt_rdy_o(benblk_arb_rdy),
     .block_encrypt_key_i(benblk_arb_key),
@@ -1452,12 +1442,34 @@ module csrng_core import csrng_pkg::*; #(
 
   assign sel_track_sm_grp = reg2hw.sel_tracking_sm.q;
 
-  assign hw2reg.tracking_sm_obs.de = cs_enable;
-  assign hw2reg.tracking_sm_obs.d =
-         (sel_track_sm_grp == 2'h3) ? {track_sm[15],track_sm[14],track_sm[13],track_sm[12]} :
-         (sel_track_sm_grp == 2'h2) ? {track_sm[11],track_sm[10],track_sm[9],track_sm[8]} :
-         (sel_track_sm_grp == 2'h1) ? {track_sm[7],track_sm[6],track_sm[5],track_sm[4]} :
-         {track_sm[3],track_sm[2],track_sm[1],track_sm[0]};
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs0.de = cs_enable && lc_hw_debug_on;
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs1.de = cs_enable && lc_hw_debug_on;
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs2.de = cs_enable && lc_hw_debug_on;
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs3.de = cs_enable && lc_hw_debug_on;
+
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs3.d =
+         (sel_track_sm_grp == 2'h3) ? track_sm[15] :
+         (sel_track_sm_grp == 2'h2) ? track_sm[11] :
+         (sel_track_sm_grp == 2'h1) ? track_sm[7] :
+         track_sm[3];
+
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs2.d =
+         (sel_track_sm_grp == 2'h3) ? track_sm[14] :
+         (sel_track_sm_grp == 2'h2) ? track_sm[10] :
+         (sel_track_sm_grp == 2'h1) ? track_sm[6] :
+         track_sm[2];
+
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs1.d =
+         (sel_track_sm_grp == 2'h3) ? track_sm[13] :
+         (sel_track_sm_grp == 2'h2) ? track_sm[9] :
+         (sel_track_sm_grp == 2'h1) ? track_sm[5] :
+         track_sm[1];
+
+  assign hw2reg.tracking_sm_obs.tracking_sm_obs0.d =
+         (sel_track_sm_grp == 2'h3) ? track_sm[12] :
+         (sel_track_sm_grp == 2'h2) ? track_sm[8] :
+         (sel_track_sm_grp == 2'h1) ? track_sm[4] :
+         track_sm[0];
 
   //--------------------------------------------
   // report csrng request summary
@@ -1466,11 +1478,6 @@ module csrng_core import csrng_pkg::*; #(
 
   assign hw2reg.hw_exc_sts.de = cs_enable;
   assign hw2reg.hw_exc_sts.d  = hw_exception_sts;
-
-  assign hw2reg.sum_sts.de = cs_enable;
-  assign hw2reg.sum_sts.d  =
-         (fifo_sel == 4'h0) ? {21'b0,pfifo_sw_genbits_depth} :
-         24'b0;
 
   // unused signals
   assign unused_err_code_test_bit = (|err_code_test_bit[19:16]) || (|err_code_test_bit[27:26]);

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -71,15 +71,7 @@ package csrng_reg_pkg;
   } csrng_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } enable;
-    struct packed {
-      logic        q;
-    } aes_cipher_disable;
-    struct packed {
-      logic [3:0]  q;
-    } fifo_depth_sts_sel;
+    logic        q;
   } csrng_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
@@ -133,11 +125,6 @@ package csrng_reg_pkg;
   typedef struct packed {
     logic        d;
   } csrng_hw2reg_regwen_reg_t;
-
-  typedef struct packed {
-    logic [23:0] d;
-    logic        de;
-  } csrng_hw2reg_sum_sts_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -276,8 +263,22 @@ package csrng_reg_pkg;
   } csrng_hw2reg_err_code_reg_t;
 
   typedef struct packed {
-    logic [31:0] d;
-    logic        de;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } tracking_sm_obs0;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } tracking_sm_obs1;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } tracking_sm_obs2;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } tracking_sm_obs3;
   } csrng_hw2reg_tracking_sm_obs_reg_t;
 
   // Register -> HW type
@@ -303,10 +304,9 @@ package csrng_reg_pkg;
     csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [168:165]
     csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [164:163]
     csrng_hw2reg_genbits_reg_t genbits; // [162:131]
-    csrng_hw2reg_int_state_val_reg_t int_state_val; // [130:99]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [98:83]
-    csrng_hw2reg_err_code_reg_t err_code; // [82:33]
-    csrng_hw2reg_tracking_sm_obs_reg_t tracking_sm_obs; // [32:0]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [101:86]
+    csrng_hw2reg_err_code_reg_t err_code; // [85:36]
+    csrng_hw2reg_tracking_sm_obs_reg_t tracking_sm_obs; // [35:0]
   } csrng_hw2reg_t;
 
   // Register offsets
@@ -316,11 +316,11 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_ALERT_TEST_OFFSET = 7'h c;
   parameter logic [BlockAw-1:0] CSRNG_REGWEN_OFFSET = 7'h 10;
   parameter logic [BlockAw-1:0] CSRNG_CTRL_OFFSET = 7'h 14;
-  parameter logic [BlockAw-1:0] CSRNG_SUM_STS_OFFSET = 7'h 18;
-  parameter logic [BlockAw-1:0] CSRNG_CMD_REQ_OFFSET = 7'h 1c;
-  parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 20;
-  parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] CSRNG_CMD_REQ_OFFSET = 7'h 18;
+  parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 1c;
+  parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 20;
+  parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] CSRNG_HALT_MAIN_SM_OFFSET = 7'h 28;
   parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 2c;
   parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 30;
   parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 34;
@@ -351,7 +351,6 @@ package csrng_reg_pkg;
     CSRNG_ALERT_TEST,
     CSRNG_REGWEN,
     CSRNG_CTRL,
-    CSRNG_SUM_STS,
     CSRNG_CMD_REQ,
     CSRNG_SW_CMD_STS,
     CSRNG_GENBITS_VLD,
@@ -372,12 +371,12 @@ package csrng_reg_pkg;
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
     4'b 0001, // index[ 3] CSRNG_ALERT_TEST
     4'b 0001, // index[ 4] CSRNG_REGWEN
-    4'b 0111, // index[ 5] CSRNG_CTRL
-    4'b 0111, // index[ 6] CSRNG_SUM_STS
-    4'b 1111, // index[ 7] CSRNG_CMD_REQ
-    4'b 0001, // index[ 8] CSRNG_SW_CMD_STS
-    4'b 0001, // index[ 9] CSRNG_GENBITS_VLD
-    4'b 1111, // index[10] CSRNG_GENBITS
+    4'b 0001, // index[ 5] CSRNG_CTRL
+    4'b 1111, // index[ 6] CSRNG_CMD_REQ
+    4'b 0001, // index[ 7] CSRNG_SW_CMD_STS
+    4'b 0001, // index[ 8] CSRNG_GENBITS_VLD
+    4'b 1111, // index[ 9] CSRNG_GENBITS
+    4'b 0001, // index[10] CSRNG_HALT_MAIN_SM
     4'b 0001, // index[11] CSRNG_INT_STATE_NUM
     4'b 1111, // index[12] CSRNG_INT_STATE_VAL
     4'b 0011, // index[13] CSRNG_HW_EXC_STS

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -283,11 +283,11 @@ package csrng_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    csrng_reg2hw_intr_state_reg_t intr_state; // [135:132]
-    csrng_reg2hw_intr_enable_reg_t intr_enable; // [131:128]
-    csrng_reg2hw_intr_test_reg_t intr_test; // [127:120]
-    csrng_reg2hw_alert_test_reg_t alert_test; // [119:118]
-    csrng_reg2hw_ctrl_reg_t ctrl; // [117:112]
+    csrng_reg2hw_intr_state_reg_t intr_state; // [130:127]
+    csrng_reg2hw_intr_enable_reg_t intr_enable; // [126:123]
+    csrng_reg2hw_intr_test_reg_t intr_test; // [122:115]
+    csrng_reg2hw_alert_test_reg_t alert_test; // [114:113]
+    csrng_reg2hw_ctrl_reg_t ctrl; // [112:112]
     csrng_reg2hw_cmd_req_reg_t cmd_req; // [111:79]
     csrng_reg2hw_genbits_reg_t genbits; // [78:46]
     csrng_reg2hw_int_state_num_reg_t int_state_num; // [45:41]
@@ -298,12 +298,12 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [202:195]
-    csrng_hw2reg_regwen_reg_t regwen; // [194:194]
-    csrng_hw2reg_sum_sts_reg_t sum_sts; // [193:169]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [168:165]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [164:163]
-    csrng_hw2reg_genbits_reg_t genbits; // [162:131]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [180:173]
+    csrng_hw2reg_regwen_reg_t regwen; // [172:172]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [171:168]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [167:166]
+    csrng_hw2reg_genbits_reg_t genbits; // [165:134]
+    csrng_hw2reg_int_state_val_reg_t int_state_val; // [133:102]
     csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [101:86]
     csrng_hw2reg_err_code_reg_t err_code; // [85:36]
     csrng_hw2reg_tracking_sm_obs_reg_t tracking_sm_obs; // [35:0]
@@ -320,14 +320,13 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_SW_CMD_STS_OFFSET = 7'h 1c;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_VLD_OFFSET = 7'h 20;
   parameter logic [BlockAw-1:0] CSRNG_GENBITS_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] CSRNG_HALT_MAIN_SM_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] CSRNG_SEL_TRACKING_SM_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] CSRNG_TRACKING_SM_OBS_OFFSET = 7'h 44;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_NUM_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] CSRNG_INT_STATE_VAL_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] CSRNG_HW_EXC_STS_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CSRNG_SEL_TRACKING_SM_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CSRNG_TRACKING_SM_OBS_OFFSET = 7'h 40;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -365,7 +364,7 @@ package csrng_reg_pkg;
   } csrng_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CSRNG_PERMIT [18] = '{
+  parameter logic [3:0] CSRNG_PERMIT [17] = '{
     4'b 0001, // index[ 0] CSRNG_INTR_STATE
     4'b 0001, // index[ 1] CSRNG_INTR_ENABLE
     4'b 0001, // index[ 2] CSRNG_INTR_TEST
@@ -376,14 +375,13 @@ package csrng_reg_pkg;
     4'b 0001, // index[ 7] CSRNG_SW_CMD_STS
     4'b 0001, // index[ 8] CSRNG_GENBITS_VLD
     4'b 1111, // index[ 9] CSRNG_GENBITS
-    4'b 0001, // index[10] CSRNG_HALT_MAIN_SM
-    4'b 0001, // index[11] CSRNG_INT_STATE_NUM
-    4'b 1111, // index[12] CSRNG_INT_STATE_VAL
-    4'b 0011, // index[13] CSRNG_HW_EXC_STS
-    4'b 1111, // index[14] CSRNG_ERR_CODE
-    4'b 0001, // index[15] CSRNG_ERR_CODE_TEST
-    4'b 0001, // index[16] CSRNG_SEL_TRACKING_SM
-    4'b 1111  // index[17] CSRNG_TRACKING_SM_OBS
+    4'b 0001, // index[10] CSRNG_INT_STATE_NUM
+    4'b 1111, // index[11] CSRNG_INT_STATE_VAL
+    4'b 0011, // index[12] CSRNG_HW_EXC_STS
+    4'b 1111, // index[13] CSRNG_ERR_CODE
+    4'b 0001, // index[14] CSRNG_ERR_CODE_TEST
+    4'b 0001, // index[15] CSRNG_SEL_TRACKING_SM
+    4'b 1111  // index[16] CSRNG_TRACKING_SM_OBS
   };
 
 endpackage

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -132,13 +132,8 @@ module csrng_reg_top (
   logic regwen_re;
   logic regwen_qs;
   logic ctrl_we;
-  logic ctrl_enable_qs;
-  logic ctrl_enable_wd;
-  logic ctrl_aes_cipher_disable_qs;
-  logic ctrl_aes_cipher_disable_wd;
-  logic [3:0] ctrl_fifo_depth_sts_sel_qs;
-  logic [3:0] ctrl_fifo_depth_sts_sel_wd;
-  logic [23:0] sum_sts_qs;
+  logic ctrl_qs;
+  logic ctrl_wd;
   logic cmd_req_we;
   logic [31:0] cmd_req_wd;
   logic sw_cmd_sts_cmd_rdy_qs;
@@ -186,7 +181,10 @@ module csrng_reg_top (
   logic [4:0] err_code_test_wd;
   logic sel_tracking_sm_we;
   logic [1:0] sel_tracking_sm_wd;
-  logic [31:0] tracking_sm_obs_qs;
+  logic [7:0] tracking_sm_obs_tracking_sm_obs0_qs;
+  logic [7:0] tracking_sm_obs_tracking_sm_obs1_qs;
+  logic [7:0] tracking_sm_obs_tracking_sm_obs2_qs;
+  logic [7:0] tracking_sm_obs_tracking_sm_obs3_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -497,18 +495,17 @@ module csrng_reg_top (
 
   // R[ctrl]: V(False)
 
-  //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
     .SWACCESS("RW"),
     .RESVAL  (1'h0)
-  ) u_ctrl_enable (
+  ) u_ctrl (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (ctrl_we),
-    .wd     (ctrl_enable_wd),
+    .wd     (ctrl_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -516,89 +513,10 @@ module csrng_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.ctrl.enable.q),
+    .q      (reg2hw.ctrl.q),
 
     // to register interface (read)
-    .qs     (ctrl_enable_qs)
-  );
-
-
-  //   F[aes_cipher_disable]: 1:1
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_ctrl_aes_cipher_disable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (ctrl_we),
-    .wd     (ctrl_aes_cipher_disable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ctrl.aes_cipher_disable.q),
-
-    // to register interface (read)
-    .qs     (ctrl_aes_cipher_disable_qs)
-  );
-
-
-  //   F[fifo_depth_sts_sel]: 19:16
-  prim_subreg #(
-    .DW      (4),
-    .SWACCESS("RW"),
-    .RESVAL  (4'h0)
-  ) u_ctrl_fifo_depth_sts_sel (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (ctrl_we),
-    .wd     (ctrl_fifo_depth_sts_sel_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.ctrl.fifo_depth_sts_sel.q),
-
-    // to register interface (read)
-    .qs     (ctrl_fifo_depth_sts_sel_qs)
-  );
-
-
-  // R[sum_sts]: V(False)
-
-  prim_subreg #(
-    .DW      (24),
-    .SWACCESS("RO"),
-    .RESVAL  (24'h0)
-  ) u_sum_sts (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.sum_sts.de),
-    .d      (hw2reg.sum_sts.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (sum_sts_qs)
+    .qs     (ctrl_qs)
   );
 
 
@@ -1509,11 +1427,12 @@ module csrng_reg_top (
 
   // R[tracking_sm_obs]: V(False)
 
+  //   F[tracking_sm_obs0]: 7:0
   prim_subreg #(
-    .DW      (32),
+    .DW      (8),
     .SWACCESS("RO"),
-    .RESVAL  (32'h0)
-  ) u_tracking_sm_obs (
+    .RESVAL  (8'h0)
+  ) u_tracking_sm_obs_tracking_sm_obs0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -1522,21 +1441,99 @@ module csrng_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.tracking_sm_obs.de),
-    .d      (hw2reg.tracking_sm_obs.d),
+    .de     (hw2reg.tracking_sm_obs.tracking_sm_obs0.de),
+    .d      (hw2reg.tracking_sm_obs.tracking_sm_obs0.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (tracking_sm_obs_qs)
+    .qs     (tracking_sm_obs_tracking_sm_obs0_qs)
+  );
+
+
+  //   F[tracking_sm_obs1]: 15:8
+  prim_subreg #(
+    .DW      (8),
+    .SWACCESS("RO"),
+    .RESVAL  (8'h0)
+  ) u_tracking_sm_obs_tracking_sm_obs1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+  logic [17:0] addr_hit;
+    .de     (hw2reg.tracking_sm_obs.tracking_sm_obs1.de),
+    .d      (hw2reg.tracking_sm_obs.tracking_sm_obs1.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tracking_sm_obs_tracking_sm_obs1_qs)
+  );
+
+
+  //   F[tracking_sm_obs2]: 23:16
+  prim_subreg #(
+    .DW      (8),
+    .SWACCESS("RO"),
+    .RESVAL  (8'h0)
+  ) u_tracking_sm_obs_tracking_sm_obs2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tracking_sm_obs.tracking_sm_obs2.de),
+    .d      (hw2reg.tracking_sm_obs.tracking_sm_obs2.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tracking_sm_obs_tracking_sm_obs2_qs)
+  );
+
+
+  //   F[tracking_sm_obs3]: 31:24
+  prim_subreg #(
+    .DW      (8),
+    .SWACCESS("RO"),
+    .RESVAL  (8'h0)
+  ) u_tracking_sm_obs_tracking_sm_obs3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tracking_sm_obs.tracking_sm_obs3.de),
+    .d      (hw2reg.tracking_sm_obs.tracking_sm_obs3.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tracking_sm_obs_tracking_sm_obs3_qs)
   );
 
 
 
 
-  logic [17:0] addr_hit;
+  logic [18:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
@@ -1545,11 +1542,11 @@ module csrng_reg_top (
     addr_hit[ 3] = (reg_addr == CSRNG_ALERT_TEST_OFFSET);
     addr_hit[ 4] = (reg_addr == CSRNG_REGWEN_OFFSET);
     addr_hit[ 5] = (reg_addr == CSRNG_CTRL_OFFSET);
-    addr_hit[ 6] = (reg_addr == CSRNG_SUM_STS_OFFSET);
-    addr_hit[ 7] = (reg_addr == CSRNG_CMD_REQ_OFFSET);
-    addr_hit[ 8] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
-    addr_hit[ 9] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
-    addr_hit[10] = (reg_addr == CSRNG_GENBITS_OFFSET);
+    addr_hit[ 6] = (reg_addr == CSRNG_CMD_REQ_OFFSET);
+    addr_hit[ 7] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
+    addr_hit[ 8] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
+    addr_hit[ 9] = (reg_addr == CSRNG_GENBITS_OFFSET);
+    addr_hit[10] = (reg_addr == CSRNG_HALT_MAIN_SM_OFFSET);
     addr_hit[11] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
     addr_hit[12] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
     addr_hit[13] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
@@ -1616,16 +1613,12 @@ module csrng_reg_top (
   assign regwen_re = addr_hit[4] & reg_re & !reg_error;
   assign ctrl_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign ctrl_enable_wd = reg_wdata[0];
-
-  assign ctrl_aes_cipher_disable_wd = reg_wdata[1];
-
-  assign ctrl_fifo_depth_sts_sel_wd = reg_wdata[19:16];
-  assign cmd_req_we = addr_hit[7] & reg_we & !reg_error;
+  assign ctrl_wd = reg_wdata[0];
+  assign cmd_req_we = addr_hit[6] & reg_we & !reg_error;
 
   assign cmd_req_wd = reg_wdata[31:0];
-  assign genbits_vld_re = addr_hit[9] & reg_re & !reg_error;
-  assign genbits_re = addr_hit[10] & reg_re & !reg_error;
+  assign genbits_vld_re = addr_hit[8] & reg_re & !reg_error;
+  assign genbits_re = addr_hit[9] & reg_re & !reg_error;
   assign int_state_num_we = addr_hit[11] & reg_we & !reg_error;
 
   assign int_state_num_wd = reg_wdata[3:0];
@@ -1674,34 +1667,28 @@ module csrng_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[0] = ctrl_enable_qs;
-        reg_rdata_next[1] = ctrl_aes_cipher_disable_qs;
-        reg_rdata_next[19:16] = ctrl_fifo_depth_sts_sel_qs;
+        reg_rdata_next[0] = ctrl_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[23:0] = sum_sts_qs;
-      end
-
-      addr_hit[7]: begin
         reg_rdata_next[31:0] = '0;
       end
 
-      addr_hit[8]: begin
+      addr_hit[7]: begin
         reg_rdata_next[0] = sw_cmd_sts_cmd_rdy_qs;
         reg_rdata_next[1] = sw_cmd_sts_cmd_sts_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[8]: begin
         reg_rdata_next[0] = genbits_vld_genbits_vld_qs;
         reg_rdata_next[1] = genbits_vld_genbits_fips_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[9]: begin
         reg_rdata_next[31:0] = genbits_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[10]: begin
         reg_rdata_next[3:0] = int_state_num_qs;
       end
 
@@ -1750,7 +1737,10 @@ module csrng_reg_top (
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[31:0] = tracking_sm_obs_qs;
+        reg_rdata_next[7:0] = tracking_sm_obs_tracking_sm_obs0_qs;
+        reg_rdata_next[15:8] = tracking_sm_obs_tracking_sm_obs1_qs;
+        reg_rdata_next[23:16] = tracking_sm_obs_tracking_sm_obs2_qs;
+        reg_rdata_next[31:24] = tracking_sm_obs_tracking_sm_obs3_qs;
       end
 
       default: begin

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -1466,7 +1466,7 @@ module csrng_reg_top (
     .we     (1'b0),
     .wd     ('0),
 
-  logic [17:0] addr_hit;
+    // from internal hardware
     .de     (hw2reg.tracking_sm_obs.tracking_sm_obs1.de),
     .d      (hw2reg.tracking_sm_obs.tracking_sm_obs1.d),
 
@@ -1533,7 +1533,7 @@ module csrng_reg_top (
 
 
 
-  logic [18:0] addr_hit;
+  logic [16:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == CSRNG_INTR_STATE_OFFSET);
@@ -1546,14 +1546,13 @@ module csrng_reg_top (
     addr_hit[ 7] = (reg_addr == CSRNG_SW_CMD_STS_OFFSET);
     addr_hit[ 8] = (reg_addr == CSRNG_GENBITS_VLD_OFFSET);
     addr_hit[ 9] = (reg_addr == CSRNG_GENBITS_OFFSET);
-    addr_hit[10] = (reg_addr == CSRNG_HALT_MAIN_SM_OFFSET);
-    addr_hit[11] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
-    addr_hit[12] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
-    addr_hit[13] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
-    addr_hit[14] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
-    addr_hit[15] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
-    addr_hit[16] = (reg_addr == CSRNG_SEL_TRACKING_SM_OFFSET);
-    addr_hit[17] = (reg_addr == CSRNG_TRACKING_SM_OBS_OFFSET);
+    addr_hit[10] = (reg_addr == CSRNG_INT_STATE_NUM_OFFSET);
+    addr_hit[11] = (reg_addr == CSRNG_INT_STATE_VAL_OFFSET);
+    addr_hit[12] = (reg_addr == CSRNG_HW_EXC_STS_OFFSET);
+    addr_hit[13] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
+    addr_hit[14] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
+    addr_hit[15] = (reg_addr == CSRNG_SEL_TRACKING_SM_OFFSET);
+    addr_hit[16] = (reg_addr == CSRNG_TRACKING_SM_OBS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1577,8 +1576,7 @@ module csrng_reg_top (
                (addr_hit[13] & (|(CSRNG_PERMIT[13] & ~reg_be))) |
                (addr_hit[14] & (|(CSRNG_PERMIT[14] & ~reg_be))) |
                (addr_hit[15] & (|(CSRNG_PERMIT[15] & ~reg_be))) |
-               (addr_hit[16] & (|(CSRNG_PERMIT[16] & ~reg_be))) |
-               (addr_hit[17] & (|(CSRNG_PERMIT[17] & ~reg_be)))));
+               (addr_hit[16] & (|(CSRNG_PERMIT[16] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -1619,17 +1617,17 @@ module csrng_reg_top (
   assign cmd_req_wd = reg_wdata[31:0];
   assign genbits_vld_re = addr_hit[8] & reg_re & !reg_error;
   assign genbits_re = addr_hit[9] & reg_re & !reg_error;
-  assign int_state_num_we = addr_hit[11] & reg_we & !reg_error;
+  assign int_state_num_we = addr_hit[10] & reg_we & !reg_error;
 
   assign int_state_num_wd = reg_wdata[3:0];
-  assign int_state_val_re = addr_hit[12] & reg_re & !reg_error;
-  assign hw_exc_sts_we = addr_hit[13] & reg_we & !reg_error;
+  assign int_state_val_re = addr_hit[11] & reg_re & !reg_error;
+  assign hw_exc_sts_we = addr_hit[12] & reg_we & !reg_error;
 
   assign hw_exc_sts_wd = reg_wdata[14:0];
-  assign err_code_test_we = addr_hit[15] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[14] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
-  assign sel_tracking_sm_we = addr_hit[16] & reg_we & !reg_error;
+  assign sel_tracking_sm_we = addr_hit[15] & reg_we & !reg_error;
 
   assign sel_tracking_sm_wd = reg_wdata[1:0];
 
@@ -1692,15 +1690,15 @@ module csrng_reg_top (
         reg_rdata_next[3:0] = int_state_num_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[11]: begin
         reg_rdata_next[31:0] = int_state_val_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[12]: begin
         reg_rdata_next[14:0] = hw_exc_sts_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = err_code_sfifo_cmd_err_qs;
         reg_rdata_next[1] = err_code_sfifo_genbits_err_qs;
         reg_rdata_next[2] = err_code_sfifo_cmdreq_err_qs;
@@ -1728,15 +1726,15 @@ module csrng_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[14]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[15]: begin
         reg_rdata_next[1:0] = '0;
       end
 
-      addr_hit[17]: begin
+      addr_hit[16]: begin
         reg_rdata_next[7:0] = tracking_sm_obs_tracking_sm_obs0_qs;
         reg_rdata_next[15:8] = tracking_sm_obs_tracking_sm_obs1_qs;
         reg_rdata_next[23:16] = tracking_sm_obs_tracking_sm_obs2_qs;

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -131,12 +131,14 @@ dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng,
   }
 
   uint32_t reg = bitfield_bit32_write(0, CSRNG_CTRL_ENABLE_BIT, 1);
-  reg = bitfield_bit32_write(reg, CSRNG_CTRL_AES_CIPHER_DISABLE_BIT,
+  // TODO: Remove below
+  // reg = bitfield_bit32_write(reg, CSRNG_CTRL_AES_CIPHER_DISABLE_BIT,
                              config.debug_config.bypass_aes_cipher);
 
   // TODO: Determine if the dif library should support a diagnostics mode
   // of operation.
-  reg = bitfield_field32_write(reg, CSRNG_CTRL_FIFO_DEPTH_STS_SEL_FIELD, 0);
+  // TODO: Remove below
+  // reg = bitfield_field32_write(reg, CSRNG_CTRL_FIFO_DEPTH_STS_SEL_FIELD, 0);
 
   mmio_region_write32(csrng->params.base_addr, CSRNG_CTRL_REG_OFFSET, reg);
   return kDifCsrngOk;

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -124,23 +124,11 @@ dif_csrng_result_t dif_csrng_init(dif_csrng_params_t params,
   return kDifCsrngOk;
 }
 
-dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng,
-                                       dif_csrng_config_t config) {
+dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng) {
   if (csrng == NULL) {
     return kDifCsrngBadArg;
   }
-
-  uint32_t reg = bitfield_bit32_write(0, CSRNG_CTRL_ENABLE_BIT, 1);
-  // TODO: Remove below
-  // reg = bitfield_bit32_write(reg, CSRNG_CTRL_AES_CIPHER_DISABLE_BIT,
-                             config.debug_config.bypass_aes_cipher);
-
-  // TODO: Determine if the dif library should support a diagnostics mode
-  // of operation.
-  // TODO: Remove below
-  // reg = bitfield_field32_write(reg, CSRNG_CTRL_FIFO_DEPTH_STS_SEL_FIELD, 0);
-
-  mmio_region_write32(csrng->params.base_addr, CSRNG_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(csrng->params.base_addr, CSRNG_CTRL_REG_OFFSET, 1);
   return kDifCsrngOk;
 }
 

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -89,38 +89,6 @@ typedef struct dif_csrng_params {
 } dif_csrng_params_t;
 
 /**
- * Runtime debug configuration for CSRNG.
- *
- * This struct describes runtime debug configuration parameters for one-time
- * configuration of the hardware.
- */
-// TODO: Add support to disable this functionality in production mode.
-typedef struct dif_csrng_debug_config {
-  /**
-   * Bypass the AES cipher core.
-   *
-   * Commands will bypass the AES cipher core, but still move through the
-   * logical flow of CSRNG. this mode is for debug purposes only.
-   */
-  // TODO(#5576): Consider making AES_CIPHER_DISABLE configurable by fuses
-  // or RTL parameters.
-  bool bypass_aes_cipher;
-} dif_csrng_debug_config_t;
-
-/**
- * Runtime configuration for CSRNG.
- *
- * This struct describes runtime information for one-time configuration of the
- * hardware.
- */
-typedef struct dif_csrng_config {
-  /**
-   * Debug configuration parameters.
-   */
-  dif_csrng_debug_config_t debug_config;
-} dif_csrng_config_t;
-
-/**
  * A handle to CSRNG.
  *
  * This type should be treated as opaque by users.
@@ -283,17 +251,15 @@ dif_csrng_result_t dif_csrng_init(dif_csrng_params_t params,
                                   dif_csrng_t *csrng);
 
 /**
- * Configures CSRNG with runtime information.
+ * Configures CSRNG.
  *
  * This function should need to be called once for the lifetime of `csrng`.
  *
  * @param csrng A CSRNG handle.
- * @param config Runtime configuration parameters.
  * @return The result of the operation.
  */
 DIF_WARN_UNUSED_RESULT
-dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng,
-                                       dif_csrng_config_t config);
+dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng);
 
 /**
  * Initializes CSRNG instance with a new seed value.

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -35,40 +35,15 @@ TEST_F(InitTest, InitOk) {
   EXPECT_EQ(dif_csrng_init(params_, &csrng), kDifCsrngOk);
 }
 
-class ConfigTest : public DifCsrngTest {
- protected:
-  /**
-   * Sets CTRL write register expectations.
-   */
-  void ExpectCtrlWrite(bool bypass_aes_cipher) {
-    EXPECT_WRITE32(CSRNG_CTRL_REG_OFFSET,
-                   {
-                       {CSRNG_CTRL_ENABLE_BIT, true},
-                         // TODO: Remove/clean all references to AES
-//                       {CSRNG_CTRL_AES_CIPHER_DISABLE_BIT, bypass_aes_cipher},
-//                       {CSRNG_CTRL_FIFO_DEPTH_STS_SEL_OFFSET, 0},
-                   });
-  }
-
-  //  dif_csrng_config_t config_ = {
-  //      .debug_config = {.bypass_aes_cipher = false},
-  //  };
-};
+class ConfigTest : public DifCsrngTest {};
 
 TEST_F(ConfigTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_configure(nullptr, {}), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_configure(nullptr), kDifCsrngBadArg);
 }
 
 TEST_F(ConfigTest, ConfigOk) {
-  //  config_.debug_config.bypass_aes_cipher = false;
-  //  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
-  EXPECT_EQ(dif_csrng_configure(&csrng_, config_), kDifCsrngOk);
-}
-
-TEST_F(ConfigTest, ConfigAesBypassOk) {
-  //  config_.debug_config.bypass_aes_cipher = true;
-  //  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
-  EXPECT_EQ(dif_csrng_configure(&csrng_, config_), kDifCsrngOk);
+  EXPECT_WRITE32(CSRNG_CTRL_REG_OFFSET, 1);
+  EXPECT_EQ(dif_csrng_configure(&csrng_), kDifCsrngOk);
 }
 
 class GetCmdInterfaceStatusTest : public DifCsrngTest {};

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -44,14 +44,15 @@ class ConfigTest : public DifCsrngTest {
     EXPECT_WRITE32(CSRNG_CTRL_REG_OFFSET,
                    {
                        {CSRNG_CTRL_ENABLE_BIT, true},
-                       {CSRNG_CTRL_AES_CIPHER_DISABLE_BIT, bypass_aes_cipher},
-                       {CSRNG_CTRL_FIFO_DEPTH_STS_SEL_OFFSET, 0},
+                         // TODO: Remove/clean all references to AES
+//                       {CSRNG_CTRL_AES_CIPHER_DISABLE_BIT, bypass_aes_cipher},
+//                       {CSRNG_CTRL_FIFO_DEPTH_STS_SEL_OFFSET, 0},
                    });
   }
 
-  dif_csrng_config_t config_ = {
-      .debug_config = {.bypass_aes_cipher = false},
-  };
+  //  dif_csrng_config_t config_ = {
+  //      .debug_config = {.bypass_aes_cipher = false},
+  //  };
 };
 
 TEST_F(ConfigTest, NullArgs) {
@@ -59,14 +60,14 @@ TEST_F(ConfigTest, NullArgs) {
 }
 
 TEST_F(ConfigTest, ConfigOk) {
-  config_.debug_config.bypass_aes_cipher = false;
-  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
+  //  config_.debug_config.bypass_aes_cipher = false;
+  //  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
   EXPECT_EQ(dif_csrng_configure(&csrng_, config_), kDifCsrngOk);
 }
 
 TEST_F(ConfigTest, ConfigAesBypassOk) {
-  config_.debug_config.bypass_aes_cipher = true;
-  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
+  //  config_.debug_config.bypass_aes_cipher = true;
+  //  ExpectCtrlWrite(config_.debug_config.bypass_aes_cipher);
   EXPECT_EQ(dif_csrng_configure(&csrng_, config_), kDifCsrngOk);
 }
 

--- a/sw/device/tests/dif/dif_csrng_smoketest.c
+++ b/sw/device/tests/dif/dif_csrng_smoketest.c
@@ -102,11 +102,7 @@ bool test_main() {
   };
   dif_csrng_t csrng;
   CHECK(dif_csrng_init(params, &csrng) == kDifCsrngOk);
-
-  const dif_csrng_config_t config = {
-      .debug_config = {.bypass_aes_cipher = false},
-  };
-  CHECK(dif_csrng_configure(&csrng, config) == kDifCsrngOk);
+  CHECK(dif_csrng_configure(&csrng) == kDifCsrngOk);
 
   test_ctr_drbg_ctr0(&csrng);
 


### PR DESCRIPTION
Removed the AES bypass option, as this has been debugged, and now may pose a security exposure.
Other debug registers have been cleaned up as well.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>