### PR TITLE
[dv/kmac] Update scb to match RTL updates in #7242

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_monitor.sv
@@ -48,6 +48,11 @@ class kmac_app_monitor extends dv_base_monitor #(
         bit last;
         push_pull_item#(`CONNECT_DATA_WIDTH) data_item;
 
+        // KMAC (device) supports prematurely ending an App transaction and going back to Idle state
+        // before the full data has been sent from the connected App host (KeyMgr/ROM/LC).
+        // As a result, we need to set `ok_to_end` here otherwise the monitor's corresponding
+        // objection will never drop in this scenario.
+        ok_to_end = 1;
         data_fifo.get(data_item);
         {data, strb, last} = data_item.h_data;
         ok_to_end = 0;

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -142,15 +142,16 @@ package kmac_env_pkg;
   } kmac_app_e;
 
   // state values of the App FSM
-  typedef enum bit [3:0] {
-    StIdle                  = 4'b0000,
-    StAppCfg                = 4'b1110,
-    StAppMsg                = 4'b0101,
-    StAppOutLen             = 4'b0110,
-    StAppProcess            = 4'b1010,
-    StAppWait               = 4'b0111,
-    StSw                    = 4'b0100,
-    StKeyMgrErrKeyNotValid  = 4'b1111
+  typedef enum bit [9:0] {
+    StIdle                  = 10'b1011011010,
+    StAppCfg                = 10'b0001010000,
+    StAppMsg                = 10'b0001011111,
+    StAppOutLen             = 10'b1011001111,
+    StAppProcess            = 10'b1000100110,
+    StAppWait               = 10'b0010010110,
+    StSw                    = 10'b0111111111,
+    StKeyMgrErrKeyNotValid  = 10'b1001110100,
+    StError                 = 10'b1101011101
   } kmac_app_st_e;
 
   // states of the error FSM

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -276,6 +276,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     ral.cfg.entropy_mode.set(entropy_mode);
     ral.cfg.entropy_fast_process.set(entropy_fast_process);
     ral.cfg.entropy_ready.set(entropy_ready);
+    ral.cfg.err_processed.set(1'b0);
     csr_update(.csr(ral.cfg));
 
     // setup KEY_LEN csr
@@ -331,6 +332,9 @@ class kmac_base_vseq extends cip_base_vseq #(
       // Need to pulse `entropy_ready` once we signal that SW has finished processing
       // the entropy-related errors, otherwise FSM will be infinitely looping in Reset state
       csr_wr(.ptr(ral.cfg.entropy_ready), .value(1'b1));
+    end else if (kmac_err_type == kmac_pkg::ErrKeyNotValid) begin
+      ral.cfg.err_processed.set(1);
+      csr_update(.csr(ral.cfg));
     end
     `uvm_info(`gfn, "Finished checking error", UVM_HIGH)
   endtask


### PR DESCRIPTION
This PR updates the cycle accurate model to match RTL updates made in
PR#7242.

The scb model can now support fully dropping an App transaction and
returning to Idle state in 2 different scenarios:
- SW clears error immediately, before the App hash is completed.
  In this case, immediately return to Idle state waiting for the next
  transaction and force the `kmac_app_monitor` to signal that it is
  idling as well.
- SW clears error after waiting for the hash to be completed.
  In this case, there is no guarantee of output digest correctness, so
  we do not check this in the scb, and then return to Idle as usual
  afterwards.

In addition, the app_fsm model in the scb is updated with the new
`StError` state that we transition into one cycle after seeing an error
on the App interface to allow forward progression without entering a
terminal state.

Signed-off-by: Udi Jonnalagadda <udij@google.com>