### PR TITLE
[sw/dif] Add FW override support to entropy src.

### DIFF
--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -37,7 +37,11 @@ static void setup_entropy_src(void) {
       .route_to_firmware = false,
       .sample_rate = 2,
       .lfsr_seed = 0,
-  };
+      .fw_override = {
+          .enable = false,
+          .entropy_insert_enable = false,
+          .buffer_threshold = kDifEntropyFifoIntDefaultThreshold,
+      }};
   CHECK(dif_entropy_configure(&entropy, config) == kDifEntropyOk);
 }
 

--- a/sw/device/tests/entropy_src/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src/entropy_src_fw_ovr_test.c
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_entropy.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+const test_config_t kTestConfig;
+
+enum {
+  /**
+   * The size of the buffer used in firmware to process the entropy bits in
+   * firmware override mode. */
+  kEntropyFifoBufferSize = 32,
+};
+
+/**
+ * Flushes the data entropy buffer until there is no data available to read.
+ *
+ * Asserts test error if any of the returned words is equal to zero. Logs the
+ * number of entropy words flushed in a single call.
+ *
+ * @param entropy An entropy source instance.
+ */
+static void entropy_data_flush(dif_entropy_t *entropy) {
+  uint32_t entropy_bits;
+  uint32_t read_count = 0;
+  while (dif_entropy_avail(entropy) == kDifEntropyOk) {
+    CHECK(dif_entropy_read(entropy, &entropy_bits) == kDifEntropyOk);
+    CHECK(entropy_bits != 0);
+    read_count++;
+  }
+  LOG_INFO("Flushed %d entropy words.", read_count);
+}
+
+/**
+ * Configures the entropy source module in firmware override mode.
+ *
+ * Output is routed to firmware, and the fw_override mode is enabled to get data
+ * post-health tests and before the pre conditioner block.
+ *
+ * @param entropy An entropy source instance.
+ */
+static void entropy_with_fw_override_enable(dif_entropy_t *entropy) {
+  const dif_entropy_config_t config = {
+      .mode = kDifEntropyModeLfsr,
+      .tests =
+          {
+              [kDifEntropyTestRepCount] = false,
+              [kDifEntropyTestAdaptiveProportion] = false,
+              [kDifEntropyTestBucket] = false,
+              [kDifEntropyTestMarkov] = false,
+              [kDifEntropyTestMailbox] = false,
+              [kDifEntropyTestVendorSpecific] = false,
+          },
+      .reset_health_test_registers = false,
+      .single_bit_mode = kDifEntropySingleBitModeDisabled,
+      .route_to_firmware = true,
+      .sample_rate = 2,
+      .lfsr_seed = 2,
+      .fw_override =
+          {
+              .enable = true,
+              .entropy_insert_enable = true,
+              .buffer_threshold = kEntropyFifoBufferSize,
+          },
+  };
+  CHECK(dif_entropy_configure(entropy, config) == kDifEntropyOk);
+}
+
+/**
+ * Test the firmware override path.
+ *
+ * This tests disconnects the observation buffer from the entropy src
+ * pre-conditioner block to read the raw entropy data after the hardware
+ * health tests. It then feeds the data back into the conditioner block until
+ * there is data available in the output FIFO.
+ *
+ * @param entropy An Entropy handle.
+ */
+void test_firmware_override(dif_entropy_t *entropy) {
+  CHECK(dif_entropy_disable(entropy) == kDifEntropyOk);
+  entropy_with_fw_override_enable(entropy);
+  entropy_data_flush(entropy);
+
+  // Read data from the obeservation and write it back into the pre conditioner
+  // until there is data available in the output buffer.
+  uint32_t buf[kEntropyFifoBufferSize] = {0};
+  uint32_t word_count = 0;
+  do {
+    CHECK(dif_entropy_fifo_read(entropy, buf, kEntropyFifoBufferSize) ==
+          kDifEntropyOk);
+    for (size_t i = 0; i < kEntropyFifoBufferSize; ++i) {
+      CHECK(buf[i] != 0);
+    }
+    CHECK(dif_entropy_fifo_write(entropy, buf, kEntropyFifoBufferSize) ==
+          kDifEntropyOk);
+    word_count += kEntropyFifoBufferSize;
+  } while (dif_entropy_avail(entropy) == kDifEntropyDataUnAvailable);
+  LOG_INFO("Processed %d words via FIFO_OVR buffer.", word_count);
+  entropy_data_flush(entropy);
+}
+
+bool test_main() {
+  const dif_entropy_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+  };
+  dif_entropy_t entropy;
+  CHECK(dif_entropy_init(params, &entropy) == kDifEntropyOk);
+
+  test_firmware_override(&entropy);
+  return true;
+}

--- a/sw/device/tests/entropy_src/meson.build
+++ b/sw/device/tests/entropy_src/meson.build
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+entropy_src_fw_ovr_test_lib = declare_dependency(
+  link_with: static_library(
+    'entropy_src_fw_ovr_test_lib',
+    sources: ['entropy_src_fw_ovr_test.c'],
+    dependencies: [
+      sw_lib_dif_entropy,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'entropy_src_fw_ovr_test': {
+    'library': entropy_src_fw_ovr_test_lib,
+  }
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -26,6 +26,7 @@ sw_rom_ext_tests = {
 }
 
 subdir('dif')
+subdir('entropy_src')
 subdir('sim_dv')
 subdir('otbn')
 

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -105,6 +105,9 @@ TEST_APPS_SELFCHECKING = [
         "name": "dif_kmac_kmac_smoketest",
     },
     {
+        "name": "entropy_src_fw_ovr_test",
+    },
+    {
         "name": "flash_ctrl_test",
         "targets": ["sim_verilator", "fpga_cw310", "fpga_nexysvideo"],
     },


### PR DESCRIPTION
The entropy src allows the firmware to disconnect the raw entropy from the pre-conditioner block at the output of the health checks. This allows firmware to access raw entropy.

The firmware can also write data into the pre-conditioner block to provide firmware-controlled entropy at the output of the entropy src.

This functionality can be useful to:

1) Implement additional health checks in firmware.
2) Implement KAT tests of the pre-conditioner block.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>