### PR TITLE
[otbn] Change URND and RND_PREFETCH CSR indices, and swap URND and ACC WSRs

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -257,6 +257,15 @@ All RW CSRs are set to 0 when OTBN starts (when 1 is written to {{< regref "CMD.
       </td>
     </tr>
     <tr>
+      <td>0x7D8</td>
+      <td>RW</td>
+      <td>
+        <strong>RND_PREFETCH</strong>.
+        Write to this CSR to begin a request to fill the RND cache.
+        Always reads as 0.
+      </td>
+    </tr>
+    <tr>
       <td>0xFC0</td>
       <td>R</td>
       <td>
@@ -268,15 +277,6 @@ All RW CSRs are set to 0 when OTBN starts (when 1 is written to {{< regref "CMD.
     </tr>
     <tr>
       <td>0xFC1</td>
-      <td>RW</td>
-      <td>
-        <strong>RND_PREFETCH</strong>.
-        Write to this CSR to begin a request to fill the RND cache.
-        Always reads as 0.
-      </td>
-    </tr>
-    <tr>
-      <td>0xFC2</td>
       <td>R</td>
       <td>
         <strong>URND</strong>.

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -157,11 +157,12 @@ class WSRFile:
         self.ACC = DumbWSR('ACC')
 
     def _wsr_for_idx(self, idx: int) -> WSR:
-        assert 0 <= idx <= 2
+        assert 0 <= idx <= 3
         return {
             0: self.MOD,
             1: self.RND,
-            2: self.ACC
+            # TODO: Implement 2: URND
+            3: self.ACC
         }[idx]
 
     def read_at_idx(self, idx: int) -> int:

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -124,11 +124,11 @@ csrrs x23, 0x7d5, x0
 # can cascade into later instructions.
 
 # w1 = mod = 0x78fccc06_2228e9d6_89c9b54f_887cf14e_c79af825_69be586e_9866bb3b_53769ada
-bn.wsrr w1, 0
+bn.wsrr w1, 0x0 /* MOD */
 
 # rnd WSR gives fixed value for now
 # w2 = rnd = 0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
-bn.wsrr w2, 1
+bn.wsrr w2, 0x1 /* RND */
 
 # w3 = w1 + w2 = 0x1296659f_bbc28370_23634ee9_22168ae8_613491bf_0357f208_320054d4_ed103473
 bn.add w3, w1, w2
@@ -152,7 +152,7 @@ bn.not w8, w1
 bn.rshi w9, w1, w2 >> 117
 
 # mod = w4 = 0xdf63326c_888f503c_f0301bb5_eee357b5_2e015e8b_d024bed4_fecd21a1_b9dd0141
-bn.wsrw 0, w4
+bn.wsrw 0x0 /* MOD */, w4
 
 # w0 = 0
 bn.xor w0, w0, w0
@@ -230,7 +230,7 @@ bn.cmpb w4, w3
 bn.sel w28, w7, w8, FG0.L
 
 # acc = w26 = 0x78fccc06_2228e9d6_89c9b54f_887cf1df_df9bf9bd_f9bfd9ff_99ffbbbb_dbff9bdb
-bn.wsrw 2, w26
+bn.wsrw 0x3 /* ACC */, w26
 
 # {w30, w29} = (w28 * w27 + acc) =
 # 0x15a7cbef_a5f473e1_860c1110_6bcc33ed_1583aef1_8130f3df_1a806984_c4f3507e
@@ -259,7 +259,7 @@ bn.mulqacc         w27.1, w28.0, 64
 bn.mulqacc.wo w31, w27.1, w28.1, 128
 
 # w0 = acc = 0x2f97be14_a0c429f2_53b42730_953d7d2f_0873f36c_1a01de4e_17fe23d9_0f09b7c8
-bn.wsrr w0, 2
+bn.wsrr w0, 0x3 /* ACC */
 
 # Nested loop testing, inner adds repeated a total of 3 * 5 = 15 times
 # x28 = 4, x29 = 3

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -240,9 +240,9 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
       12'h7d5: return 8;   // MOD5
       12'h7d6: return 9;   // MOD6
       12'h7d7: return 10;  // MOD7
-      12'hfc0: return 11;  // RND
-      12'hfc1: return 12;  // RND_PREFETCH
-      12'hfc2: return 13;  // URND
+      12'hfc8: return 11;  // RND_PREFETCH
+      12'hfc0: return 12;  // RND
+      12'hfc1: return 13;  // URND
       default: return -1;  // (invalid)
     endcase
   endfunction
@@ -260,8 +260,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     bins mod5         = {8};           \
     bins mod6         = {9};           \
     bins mod7         = {10};          \
-    bins rnd          = {11};          \
-    bins rnd_prefetch = {12};          \
+    bins rnd_prefetch = {11};          \
+    bins rnd          = {12};          \
     bins urnd         = {13};          \
     bins invalid      = {-1};          \
     illegal_bins bad  = default;       \

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -272,8 +272,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     case (wsr_idx)
       8'h00: return 0;     // MOD
       8'h01: return 1;     // RND
-      8'h02: return 2;     // ACC
-      8'h03: return 3;     // URND
+      8'h02: return 2;     // URND
+      8'h03: return 3;     // ACC
       default: return -1;  // (invalid)
     endcase
   endfunction
@@ -282,8 +282,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   NAME: coverpoint (remap_wsr(EXPR)) { \
     bins mod         = {0};            \
     bins rnd         = {1};            \
-    bins acc         = {2};            \
-    bins urnd        = {3};            \
+    bins urnd        = {2};            \
+    bins acc         = {3};            \
     bins invalid     = {-1};           \
     illegal_bins bad = default;        \
   }

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -754,8 +754,8 @@ module otbn_controller
     unique case (wsr_addr)
       WsrMod:  ispr_addr_bignum = IsprMod;
       WsrRnd:  ispr_addr_bignum = IsprRnd;
-      WsrAcc:  ispr_addr_bignum = IsprAcc;
       WsrUrnd: ispr_addr_bignum = IsprUrnd;
+      WsrAcc:  ispr_addr_bignum = IsprAcc;
       default: wsr_illegal_addr = 1'b1;
     endcase
   end

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -681,13 +681,13 @@ module otbn_controller
         ispr_addr_base      = IsprMod;
         ispr_word_addr_base = csr_sub_addr;
       end
-      CsrRnd: begin
-        ispr_addr_base      = IsprRnd;
-        ispr_word_addr_base = '0;
-      end
       CsrRndPrefetch: begin
         // Reading from RND_PREFETCH results in 0, there is no ISPR to read so no address is set.
         // The csr_rdata mux logic takes care of producing the 0.
+      end
+      CsrRnd: begin
+        ispr_addr_base      = IsprRnd;
+        ispr_word_addr_base = '0;
       end
       CsrUrnd: begin
         ispr_addr_base      = IsprUrnd;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -174,6 +174,8 @@ package otbn_pkg;
   // Control and Status Registers (CSRs)
   parameter int CsrNumWidth = 12;
   typedef enum logic [CsrNumWidth-1:0] {
+    // Address ranges follow the RISC-V Privileged Specification v1.11
+    // 0x7C0-0x7FF Custom read/write
     CsrFg0         = 12'h7C0,
     CsrFg1         = 12'h7C1,
     CsrFlags       = 12'h7C8,
@@ -185,9 +187,11 @@ package otbn_pkg;
     CsrMod5        = 12'h7D5,
     CsrMod6        = 12'h7D6,
     CsrMod7        = 12'h7D7,
+    CsrRndPrefetch = 12'h7D8,
+
+    // 0xFC0-0xFFF Custom read-only
     CsrRnd         = 12'hFC0,
-    CsrRndPrefetch = 12'hFC1,
-    CsrUrnd        = 12'hFC2
+    CsrUrnd        = 12'hFC1
   } csr_e;
 
   // Wide Special Purpose Registers (WSRs)

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -200,8 +200,8 @@ package otbn_pkg;
   typedef enum logic [WsrNumWidth-1:0] {
     WsrMod   = 'd0,
     WsrRnd   = 'd1,
-    WsrAcc   = 'd2,
-    WsrUrnd  = 'd3
+    WsrUrnd  = 'd2,
+    WsrAcc   = 'd3
   } wsr_e;
 
   // Internal Special Purpose Registers (ISPRs)

--- a/sw/otbn/code-snippets/loop.s
+++ b/sw/otbn/code-snippets/loop.s
@@ -10,22 +10,22 @@
     li  x3, 0
 
     loop x2, 2
-    addi x3, x3, 2
-    addi x3, x3, -1
+      addi x3, x3, 2
+      addi x3, x3, -1
 
     /* At this point, we've incremented x3 by 2-1 = 1 on each of three
        loop iterations, so x3 should equal 3. */
 
     loopi 5, 1
-    addi x3, x3, -3
+      addi x3, x3, -3
 
     /* Now we've run a loop that decrements x3 by 3 on each of
        five loop iterations, so it should now equal 3-15 = -12. */
 
     loop x2, 3
-    loopi 4, 1
-    addi x3, x3, 2
-    nop
+      loopi 4, 1
+         addi x3, x3, 2
+      nop
 
     /* The nested loop runs 3 * 4 times, incrementing by 2 each
        iteration. So x3 should now equal -12 + 2*12 = 12. */

--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -788,7 +788,7 @@ mod_inv:
 
     /* skip multiplication if C flag not set */
     bn.sel    w1, w1, w3, C
-    csrrs     x2, 1984, x0
+    csrrs     x2, 0x7c0, x0
     andi      x2, x2, 1
     beq       x2, x0, nomul
 
@@ -1328,7 +1328,7 @@ mod_inv_var:
   ebgcd_loop:
   /* test if u is odd */
   bn.or     w4, w4, w4
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_u_odd
 
@@ -1338,7 +1338,7 @@ mod_inv_var:
 
   /* test if r is odd */
   bn.or     w2, w2, w2
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_r_odd
 
@@ -1357,7 +1357,7 @@ mod_inv_var:
   ebgcd_u_odd:
   /* test if v is odd */
   bn.or     w5, w5, w5
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_uv_odd
 
@@ -1367,7 +1367,7 @@ mod_inv_var:
 
   /* test if s is odd */
   bn.or     w3, w3, w3
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_s_odd
 
@@ -1386,7 +1386,7 @@ mod_inv_var:
   ebgcd_uv_odd:
   /* test if v >= u */
   bn.cmp    w5, w4
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, ebgcd_v_gte_u
 
@@ -1406,7 +1406,7 @@ mod_inv_var:
   bn.sub    w5, w5, w4
 
   /* if v > 0 go back to start of loop */
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 8
   beq       x2, x0, ebgcd_loop
 
@@ -1505,13 +1505,13 @@ p256_verify:
 
   /* goto 'fail' if w0 == w31 <=> s == 0 */
   bn.cmp    w0, w31
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 8
   bne       x2, x0, fail
 
   /* goto 'fail' if w0 >= w29 <=> s >= n */
   bn.cmp    w0, w29
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, fail
 
@@ -1524,13 +1524,13 @@ p256_verify:
 
   /* goto 'fail' if w24 == w31 <=> r == 0 */
   bn.cmp    w24, w31
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 8
   bne       x2, x0, fail
 
   /* goto 'fail' if w0 >= w29 <=> r >= n */
   bn.cmp    w24, w29
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, fail
 
@@ -1604,7 +1604,7 @@ p256_verify:
 
     /* if either  u_1[i] == 0 or u_2[i] == 0 jump to 'no_both' */
     bn.add    w2, w2, w2
-    csrrs     x2, 1984, x0
+    csrrs     x2, 0x7c0, x0
     andi      x2, x2, 1
     beq       x2, x0, no_both
 
@@ -1621,7 +1621,7 @@ p256_verify:
 
     /* if u2[i] is not set jump to 'no_g' */
     bn.add    w6, w0, w0
-    csrrs     x2, 1984, x0
+    csrrs     x2, 0x7c0, x0
     andi      x2, x2, 1
     beq       x2, x0, no_g
 
@@ -1634,7 +1634,7 @@ p256_verify:
     no_g:
     /* if u1[i] is not set jump to 'no_q' */
     bn.add    w6, w1, w1
-    csrrs     x2, 1984, x0
+    csrrs     x2, 0x7c0, x0
     andi      x2, x2, 1
     beq       x2, x0, no_q
 

--- a/sw/otbn/code-snippets/p384_sign.s
+++ b/sw/otbn/code-snippets/p384_sign.s
@@ -884,7 +884,7 @@ mod_inv_n_p384:
     bn.addc   w3, w3, w3
 
     /* skip multiplication if C flag not set */
-    csrrs     x2, 1984, x0
+    csrrs     x2, 0x7c0, x0
     andi      x2, x2, 1
     beq       x2, x0, nomul
 

--- a/sw/otbn/code-snippets/p384_verify.s
+++ b/sw/otbn/code-snippets/p384_verify.s
@@ -187,7 +187,7 @@ mod_inv_var:
   ebgcd_loop:
   /* test if u is odd */
   bn.or     w8, w8, w8
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_u_odd
 
@@ -198,7 +198,7 @@ mod_inv_var:
 
   /* test if r is odd */
   bn.or     w4, w4, w4
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_r_odd
 
@@ -219,7 +219,7 @@ mod_inv_var:
   ebgcd_u_odd:
   /* test if v is odd */
   bn.or     w10, w10, w10
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_uv_odd
 
@@ -230,7 +230,7 @@ mod_inv_var:
 
   /* test if s is odd */
   bn.or     w6, w6, w6
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 4
   bne       x2, x0, ebgcd_s_odd
 
@@ -252,7 +252,7 @@ mod_inv_var:
   /* test if v >= u */
   bn.cmp    w10, w8
   bn.cmpb   w11, w9
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, ebgcd_v_gte_u
 
@@ -286,7 +286,7 @@ mod_inv_var:
   /* if v > 0 go back to start of loop */
   bn.cmp    w31, w10
   bn.cmpb   w31, w11
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   bne       x2, x0, ebgcd_loop
 
@@ -438,14 +438,14 @@ p384_verify:
   /* goto 'fail' if [w30,w29] == [w31, w31] <=> s == 0 */
   bn.cmp    w31, w29
   bn.cmpb   w31, w30
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, fail
 
   /* goto 'fail' if [w30,w29] >= [w12,w13] <=> s >= n */
   bn.cmp    w29, w12
   bn.cmpb   w30, w13
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, fail
 
@@ -481,14 +481,14 @@ p384_verify:
   /* goto 'fail' if [w11, w10] == [w31, w31] <=> r == 0 */
   bn.cmp    w31, w10
   bn.cmpb   w31, w11
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, fail
 
   /* goto 'fail' if [w11,w10] >= [w12,w13] <=> r >= n */
   bn.cmp    w10, w12
   bn.cmpb   w11, w13
-  csrrs     x2, 1984, x0
+  csrrs     x2, 0x7c0, x0
   andi      x2, x2, 1
   beq       x2, x0, fail
 
@@ -606,7 +606,7 @@ p384_verify:
     bn.addc   w1, w1, w1
 
     /* keep MSB/carry bit in x3: x3 <= u1[i] */
-    csrrs     x3, 1984, x0
+    csrrs     x3, 0x7c0, x0
     andi      x3, x3, 1
 
     /* left shift u2 = [w3,w2] <= [w3,w2] << 1 */
@@ -614,7 +614,7 @@ p384_verify:
     bn.addc   w3, w3, w3
 
     /* keep MSB/carry bit in x3: x4 <= u2[i] */
-    csrrs     x4, 1984, x0
+    csrrs     x4, 0x7c0, x0
     andi      x4, x4, 1
     li        x2, 0
 


### PR DESCRIPTION
The CSR indexes in OTBN are meant to be following the address map specified
in the RISC-V Privileged Specification, which gives ranges for custom
read-only, and read-writable CSRs (in M mode). The recent addition of
RND_PREFIX didn't follow these rules. This commit assigns new addresses to
URND (a read-only CSR) and RND_PREFETCH (a read-write CSR):

Read/write CSRs:
 RND_PREFETCH is now at 0x7D8 (before: 0xFC1)

Read-only CSRs:
 RND          is now at 0xFC0 (unchanged)
 URND         is now at 0xFC1 (before: 0xFC2)


While at it, also do a slightly pedantic change: swap the URND and ACC WSRs.
We have consecutive CSR indices for RND and URND. For the WSRs we have ACC 
in between RND and URND. Reorder the WSR indices so that we have RND followed 
by URND there as well.

Additionally contains two assembly cleanup patches with no functional change.

As usual, review is best in the patch-by-patch view :-)