### PR TITLE
[otbn] Test access to randomness

### DIFF
--- a/sw/device/tests/dif/dif_otbn_smoketest.c
+++ b/sw/device/tests/dif/dif_otbn_smoketest.c
@@ -11,7 +11,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-// Temporary solution to configue/enable the EDN and CSRNG to allow OTBN to run
+// Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to run
 // before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
 static const uint32_t kEntropySrcConfRegOffset = 0x18;
 static const uint32_t kCsrngCtrlRegOffset = 0x14;

--- a/sw/device/tests/otbn/meson.build
+++ b/sw/device/tests/otbn/meson.build
@@ -39,3 +39,22 @@ sw_tests += {
     'library': otbn_ecdsa_p256_test_lib
   }
 }
+
+otbn_randomness_test_lib = declare_dependency(
+  link_with: static_library(
+    'otbn_randomness_test_lib',
+    sources: ['otbn_randomness_test.c'],
+    dependencies: [
+      sw_lib_runtime_otbn,
+      sw_lib_runtime_log,
+      sw_lib_runtime_ibex,
+      top_earlgrey,
+      sw_otbn['randomness']['rv32embed_dependency'],
+    ],
+  ),
+)
+sw_tests += {
+  'otbn_randomness_test': {
+    'library': otbn_randomness_test_lib
+  }
+}

--- a/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
+++ b/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
@@ -11,7 +11,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-// Temporary solution to configue/enable the EDN and CSRNG to allow OTBN to run
+// Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to run
 // before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
 static const uint32_t kEntropySrcConfRegOffset = 0x18;
 static const uint32_t kCsrngCtrlRegOffset = 0x14;

--- a/sw/device/tests/otbn/otbn_randomness_test.c
+++ b/sw/device/tests/otbn/otbn_randomness_test.c
@@ -1,0 +1,90 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/otbn.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to run
+// before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
+static const uint32_t kEntropySrcConfRegOffset = 0x18;
+static const uint32_t kCsrngCtrlRegOffset = 0x14;
+static const uint32_t kEdnCtrlRegOffset = 0x14;
+
+static void setup_edn(void) {
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+                      kEntropySrcConfRegOffset, 0x2);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+                      kCsrngCtrlRegOffset, 0x1);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+                      kEdnCtrlRegOffset, 0x9);
+}
+
+OTBN_DECLARE_APP_SYMBOLS(randomness);
+OTBN_DECLARE_PTR_SYMBOL(randomness, main);
+OTBN_DECLARE_PTR_SYMBOL(randomness, rv);
+OTBN_DECLARE_PTR_SYMBOL(randomness, fail_idx);
+OTBN_DECLARE_PTR_SYMBOL(randomness, rnd_out);
+OTBN_DECLARE_PTR_SYMBOL(randomness, urnd_out);
+
+static const otbn_app_t kOtbnAppCfiTest = OTBN_APP_T_INIT(randomness);
+static const otbn_ptr_t kFuncMain = OTBN_PTR_T_INIT(randomness, main);
+static const otbn_ptr_t kVarRv = OTBN_PTR_T_INIT(randomness, rv);
+static const otbn_ptr_t kVarFailIdx = OTBN_PTR_T_INIT(randomness, fail_idx);
+static const otbn_ptr_t kVarRndOut = OTBN_PTR_T_INIT(randomness, rnd_out);
+static const otbn_ptr_t kVarUrndOut = OTBN_PTR_T_INIT(randomness, urnd_out);
+
+const test_config_t kTestConfig;
+
+/**
+ * LOG_INFO with a 256b unsigned integer as hexadecimal number with a prefix.
+ */
+static void print_uint256(otbn_t *ctx, const otbn_ptr_t var,
+                          const char *prefix) {
+  uint32_t data[32 / sizeof(uint32_t)];
+  CHECK(otbn_copy_data_from_otbn(ctx, /*len_bytes=*/32, var, &data) == kOtbnOk);
+  LOG_INFO("%s0x%08x%08x%08x%08x%08x%08x%08x%08x", prefix, data[7], data[6],
+           data[5], data[4], data[3], data[2], data[1], data[0]);
+}
+
+bool test_main() {
+  setup_edn();
+
+  // Initialize
+  otbn_t otbn_ctx;
+  dif_otbn_config_t otbn_config = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR),
+  };
+  CHECK(otbn_init(&otbn_ctx, otbn_config) == kOtbnOk);
+  CHECK(otbn_load_app(&otbn_ctx, kOtbnAppCfiTest) == kOtbnOk);
+
+  CHECK(otbn_call_function(&otbn_ctx, kFuncMain) == kOtbnOk);
+  CHECK(otbn_busy_wait_for_done(&otbn_ctx) == kOtbnOk);
+
+  // Check for successful test execution (self-reported).
+  uint32_t rv;
+  CHECK(otbn_copy_data_from_otbn(&otbn_ctx, /*len_bytes=*/4, kVarRv, &rv) ==
+        kOtbnOk);
+
+  // Log some of the random numbers we got (for manual checks).
+  print_uint256(&otbn_ctx, kVarRndOut, "rnd = ");
+  print_uint256(&otbn_ctx, kVarUrndOut, "urnd = ");
+
+  if (rv != 0) {
+    uint32_t fail_idx;
+    CHECK(otbn_copy_data_from_otbn(&otbn_ctx, /*len_bytes=*/4, kVarFailIdx,
+                                   &fail_idx) == kOtbnOk);
+    LOG_INFO("ERROR: Test with index %d failed.", fail_idx);
+    return false;
+  }
+
+  return true;
+}

--- a/sw/device/tests/otbn/otbn_rsa_test.c
+++ b/sw/device/tests/otbn/otbn_rsa_test.c
@@ -11,7 +11,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-// Temporary solution to configue/enable the EDN and CSRNG to allow OTBN to run
+// Temporary solution to configure/enable the EDN and CSRNG to allow OTBN to run
 // before a DIF is available, https://github.com/lowRISC/opentitan/issues/6082
 static const uint32_t kEntropySrcConfRegOffset = 0x18;
 static const uint32_t kCsrngCtrlRegOffset = 0x14;

--- a/sw/otbn/code-snippets/meson.build
+++ b/sw/otbn/code-snippets/meson.build
@@ -59,4 +59,7 @@ sw_otbn_sources += {
     'p256_ecdsa.s',
     'p256.s',
   ),
+  'randomness': files(
+    'randomness.s',
+  ),
 }

--- a/sw/otbn/code-snippets/randomness.s
+++ b/sw/otbn/code-snippets/randomness.s
@@ -1,0 +1,163 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* Test access to randomness from OTBN. */
+
+.text
+
+/* Test entry point, no arguments need to be passed in nor results returned */
+.globl main
+main:
+  jal x1, test_rnd
+  jal x1, test_urnd
+
+  jal x0, exit_success
+
+/**
+ * Tests access to cryptographic-strength randomness.
+ *
+ * Test reading from the RND CSR and WSR, as well as prefetching randomness
+ * through RND_PREFETCH.
+ *
+ * This test increases confidence in the functional correctness of the RND
+ * functionality, but isn't free of false positives or negatives.
+ *
+ * - The test considers it a failure if two consecutive values read from RND
+ *   are equal. In rare cases, this could happen and the test should be
+ *   re-executed.
+ * - The randomness prefetch is an optimization to hide unknown and highly
+ *   variable latency from the EDN. This, plus the fact that OTBN software
+ *   cannot measure its own execution time, makes it impossible to automate
+ *   a test for RND_PREFETCH. The instruction is kept nonetheless to help
+ *   debugging with waveforms.
+ */
+test_rnd:
+  /* Initial read. */
+  csrrs x2, 0xfc0 /* RND */, x0
+
+  /* Read again, should block for a while. */
+  csrrs x3, 0xfc0 /* RND */, x0
+
+  /* If two consecutive reads return the same random number that's most likely
+     a bug. (But it doesn't have to be a bug! Re-run the test if it fails.) */
+  addi x31, x0, 1
+  beq x2, x3, exit_fail
+
+  /* Request a RND value from the EDN by writing to RND_PREFETCH. */
+  csrrw x0, 0x7d8 /* RND_PREFETCH */, x0
+
+  /* Give the prefetch a while to complete. */
+  /* An EDN request for a random number can take up to around 5 ms. Do not
+     expect the following RND read to return immediately. */
+  loopi 1023, 1
+    nop
+
+  /* Read RND again, should block less. */
+  csrrs x2, 0xFC0 /* RND */, x0
+
+  /* Compare to previous value again to detect RND getting stuck. */
+  addi x31, x0, 2
+  beq x3, x2, exit_fail
+
+
+  /* Read the RND WSR. */
+  bn.wsrr w0, 0x1 /* RND */
+
+  /* Write w0 to DMEM. */
+  la x11, rnd_out
+  bn.sid x0, 0(x11)
+
+  /* Read the RND WSR again. */
+  bn.wsrr w1, 0x1 /* RND */
+
+  /* Fail the test if the two numbers read from RND are equal. */
+  bn.cmp w0, w1
+  csrrs x2, 0x7c0 /* FG0 */, x0
+  andi x2, x2, 8 /* filter out Z (zero) bit */
+  addi x31, x0, 3
+  bne x2, x0, exit_fail
+
+  ret
+
+/**
+ * Tests access to "unlimited" randomness (URND).
+ *
+ * The test considers it a failure if two consecutive values read from RND
+ * are equal. In rare cases, this could happen and the test should be
+ * re-executed.
+ */
+test_urnd:
+  /* Read the URND CSR. */
+  csrrs x2, 0xfc1 /* URND */, x0
+
+  /* Read again. */
+  csrrs x3, 0xfc1 /* URND */, x0
+
+  /* If two consecutive reads return the same random number that's most likely
+     a bug. (But it doesn't have to be a bug! Re-run the test if it fails.) */
+  addi x31, x0, 32
+  beq x2, x3, exit_fail
+
+
+  /* Read the URND WSR. */
+  bn.wsrr w0, 0x2 /* URND */
+
+  /* Write w0 to DMEM. */
+  la x11, urnd_out
+  bn.sid x0, 0(x11)
+
+  /* Read the URND WSR again. */
+  bn.wsrr w1, 0x2 /* URND */
+
+  /* Fail the test if the two numbers read from URND are equal. */
+  bn.cmp w0, w1
+  csrrs x2, 0x7c0 /* FG0 */, x0
+  andi x2, x2, 8 /* filter out Z (zero) bit */
+  addi x31, x0, 33
+  bne x2, x0, exit_fail
+
+  ret
+
+/* Terminate the program with a 0 (SUCCESS) return code. */
+exit_success:
+  li x10, 0
+  la x11, rv
+  sw x10, 0(x11)
+  ecall
+
+/* Terminate the program with a 1 (FAIL) return code. */
+exit_fail:
+  li x10, 1
+  la x11, rv
+  sw x10, 0(x11)
+
+  la x11, fail_idx
+  sw x31, 0(x11)
+
+  ecall
+
+.data
+/* Return value. */
+.globl rv
+.balign 4
+rv:
+  .word 0xFFFFFFFF
+
+/* Test status. */
+.globl fail_idx
+.balign 4
+fail_idx:
+  .word 0x0
+
+/* One of the values read from RND. */
+.globl rnd_out
+.balign 32
+rnd_out:
+  .zero 32
+
+/* One of the values read from URND. */
+.globl urnd_out
+.balign 32
+urnd_out:
+  .zero 32

--- a/test/systemtest/config.py
+++ b/test/systemtest/config.py
@@ -33,6 +33,12 @@ TEST_APPS_SELFCHECKING = [
         "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
         "targets": ["sim_verilator"],
     },
+    {
+        "name": "otbn_randomness_test",
+        # TODO: Run this test also against the ISS once URND and RND are
+        # implemented.
+        "targets": ["sim_verilator", "fpga_cw310"],
+    },
     # The OTBN end-to-end tests can be run in simulation, but take a long time
     # there. Run them on the CW310 FPGA board only for faster test results.
     {


### PR DESCRIPTION
Test access to randomness from OTBN software. The test is triggered from Ibex to enable it to configure the EDN appropriately first.

~Only the last patch in this PR is relevant; the other patches will go away with the merge of #7341.~