### PR TITLE
[otbn] Add missing extern function declarations

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -24,6 +24,8 @@ extern unsigned int otbn_base_call_stack_get_size();
 extern unsigned int otbn_base_call_stack_get_element(int index);
 extern unsigned int otbn_base_reg_get(int index);
 extern unsigned int otbn_bignum_reg_get(int index, int quarter);
+extern svBit otbn_err_get();
+extern int otbn_core_get_stop_pc();
 }
 
 /**


### PR DESCRIPTION
GCC in CI doesn't complain, but GCC11 locally does.

```
../src/lowrisc_ip_otbn_top_sim_0.1/otbn_top_sim.cc: In function ‘int main(int, char**)’:
../src/lowrisc_ip_otbn_top_sim_0.1/otbn_top_sim.cc:121:21: error: ‘otbn_err_get’ was not declared in this scope
  121 |   svBit model_err = otbn_err_get();
      |                     ^~~~~~~~~~~~
../src/lowrisc_ip_otbn_top_sim_0.1/otbn_top_sim.cc:186:23: error: ‘otbn_core_get_stop_pc’ was not declared in this scope
  186 |     int act_stop_pc = otbn_core_get_stop_pc();
      |                       ^~~~~~~~~~~~~~~~~~~~~
```