### PR TITLE
[topgen] Pull the 'clocks' code into a separate class in topgen

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -5,10 +5,7 @@
 // functionality but is incomplete
 
 <%
-clks_attr = cfg['clocks']
-srcs = clks_attr['srcs']
-grps = clks_attr['groups']
-num_grps = len(grps)
+clocks = cfg['clocks']
 %>
 
 # CLKMGR register template
@@ -18,13 +15,13 @@ num_grps = len(grps)
   scan: "true",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
-% for src in srcs:
-    % if src['aon'] == 'no':
-    {reset: "rst_${src['name']}_ni"},
+% for src in clocks.srcs.values():
+    % if not src.aon:
+    {reset: "rst_${src.name}_ni"},
     % endif
 % endfor
-% for src in div_srcs:
-    {reset: "rst_${src['name']}_ni"},
+% for src in clocks.derived_srcs.values():
+    {reset: "rst_${src.name}_ni"},
 % endfor
   ]
   bus_interfaces: [
@@ -42,7 +39,7 @@ num_grps = len(grps)
     { name: "NumGroups",
       desc: "Number of clock groups",
       type: "int",
-      default: "${num_grps}",
+      default: "${len(clocks.groups)}",
       local: "true"
     },
   ],
@@ -98,10 +95,10 @@ num_grps = len(grps)
     },
 
   // All clock inputs
-% for src in srcs:
+% for src in clocks.srcs.values():
     { struct:  "logic",
       type:    "uni",
-      name:    "clk_${src['name']}",
+      name:    "clk_${src.name}",
       act:     "rcv",
       package: "",
     },

--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -5,8 +5,7 @@
 <%
 from collections import OrderedDict
 
-clks_attr = cfg['clocks']
-grps = clks_attr['groups']
+clocks = cfg['clocks']
 num_hints = len(hint_clks)
 %>
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -36,29 +36,21 @@
         name: main
         aon: no
         freq: "100000000"
-        derived: no
-        params: {}
       }
       {
         name: io
         aon: no
         freq: "96000000"
-        derived: no
-        params: {}
       }
       {
         name: usb
         aon: no
         freq: "48000000"
-        derived: no
-        params: {}
       }
       {
         name: aon
         aon: yes
         freq: "200000"
-        derived: no
-        params: {}
       }
     ]
     derived_srcs:
@@ -66,16 +58,16 @@
       {
         name: io_div2
         aon: no
-        div: 2
-        src: io
         freq: "48000000"
+        div: "2"
+        src: io
       }
       {
         name: io_div4
         aon: no
-        div: 4
-        src: io
         freq: "24000000"
+        div: "4"
+        src: io
       }
     ]
     groups:

--- a/util/topgen/c.py
+++ b/util/topgen/c.py
@@ -427,28 +427,25 @@ class TopGenC:
         We differentiate "gateable" clocks and "hintable" clocks because the
         clock manager has separate register interfaces for each group.
         """
+        clocks = self.top['clocks']
 
-        aon_clocks = set()
-        for src in self.top['clocks']['srcs'] + self.top['clocks'][
-                'derived_srcs']:
-            if src['aon'] == 'yes':
-                aon_clocks.add(src['name'])
+        aon_clocks = set(src.name
+                         for src in clocks.all_srcs.values() if src.aon)
 
         gateable_clocks = CEnum(self._top_name + Name(["gateable", "clocks"]))
         hintable_clocks = CEnum(self._top_name + Name(["hintable", "clocks"]))
 
         # This replicates the behaviour in `topgen.py` in deriving `hints` and
         # `sw_clocks`.
-        for group in self.top['clocks']['groups']:
-            for (name, source) in group['clocks'].items():
-                if source not in aon_clocks:
+        for group in clocks.groups.values():
+            for name, source in group.clocks.items():
+                if source.name not in aon_clocks:
                     # All these clocks start with `clk_` which is redundant.
                     clock_name = Name.from_snake_case(name).remove_part("clk")
-                    docstring = "Clock {} in group {}".format(
-                        name, group['name'])
-                    if group["sw_cg"] == "yes":
+                    docstring = "Clock {} in group {}".format(name, group.name)
+                    if group.sw_cg == "yes":
                         gateable_clocks.add_constant(clock_name, docstring)
-                    elif group["sw_cg"] == "hint":
+                    elif group.sw_cg == "hint":
                         hintable_clocks.add_constant(clock_name, docstring)
 
         gateable_clocks.add_last_constant("Last Valid Gateable Clock")

--- a/util/topgen/clocks.py
+++ b/util/topgen/clocks.py
@@ -1,0 +1,162 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, List
+
+
+def _yn_to_bool(yn: object) -> bool:
+    yn_str = str(yn)
+    if yn_str.lower() == 'yes':
+        return True
+    if yn_str.lower() == 'no':
+        return False
+    raise ValueError('Unknown yes/no value: {!r}.'.format(yn))
+
+
+def _bool_to_yn(val: bool) -> str:
+    return 'yes' if val else 'no'
+
+
+def _to_int(val: object) -> int:
+    if isinstance(val, int):
+        return val
+    return int(str(val))
+
+
+def _check_choices(val: str, what: str, choices: List[str]) -> str:
+    if val in choices:
+        return val
+    raise ValueError('{} is {!r}, which is not one of the expected values: {}.'
+                     .format(what, val, choices))
+
+
+class SourceClock:
+    '''A clock source (input to the top-level)'''
+    def __init__(self, raw: Dict[str, object]):
+        self.name = str(raw['name'])
+        self.aon = _yn_to_bool(raw['aon'])
+        self.freq = _to_int(raw['freq'])
+
+    def _asdict(self) -> Dict[str, object]:
+        return {
+            'name': self.name,
+            'aon': _bool_to_yn(self.aon),
+            'freq': str(self.freq)
+        }
+
+
+class DerivedSourceClock(SourceClock):
+    '''A derived source clock (divided down from some other clock)'''
+    def __init__(self,
+                 raw: Dict[str, object],
+                 sources: Dict[str, SourceClock]):
+        super().__init__(raw)
+        self.div = _to_int(raw['div'])
+        self.src = sources[str(raw['src'])]
+
+    def _asdict(self) -> Dict[str, object]:
+        ret = super()._asdict()
+        ret['div'] = str(self.div)
+        ret['src'] = self.src.name
+        return ret
+
+
+class Group:
+    def __init__(self,
+                 raw: Dict[str, object],
+                 sources: Dict[str, SourceClock],
+                 what: str):
+        self.name = str(raw['name'])
+        self.src = str(raw['src'])
+        self.sw_cg = _check_choices(str(raw['sw_cg']), 'sw_cg for ' + what,
+                                    ['yes', 'no', 'hint'])
+        if self.src == 'yes' and self.sw_cg != 'no':
+            raise ValueError(f'Clock group {self.name} has an invalid '
+                             f'combination of src and sw_cg: {self.src} and '
+                             f'{self.sw_cg}, respectively.')
+
+        self.unique = _yn_to_bool(raw.get('unique', 'no'))
+        if self.sw_cg == 'no' and self.unique:
+            raise ValueError(f'Clock group {self.name} has an invalid '
+                             f'combination with sw_cg of {self.sw_cg} and '
+                             f'unique set.')
+
+        self.clocks = {}  # type: Dict[str, SourceClock]
+        raw_clocks = raw.get('clocks', {})
+        if not isinstance(raw_clocks, dict):
+            raise ValueError(f'clocks for {what} is not a dictionary')
+        for clk_name, src_name in raw_clocks.items():
+            src = sources.get(src_name)
+            if src is None:
+                raise ValueError(f'The {clk_name} entry of clocks for {what} '
+                                 f'has source {src_name}, which is not a '
+                                 f'known clock source.')
+            self.clocks[clk_name] = src
+
+    def add_clock(self, clk_name: str, src: SourceClock):
+        # Duplicates are ok, so long as they have the same source.
+        existing_src = self.clocks.get(clk_name)
+        if existing_src is not None:
+            if existing_src is not src:
+                raise ValueError(f'Cannot add clock {clk_name} to group '
+                                 f'{self.name} with source {src.name}: the '
+                                 f'clock is there already with source '
+                                 f'{existing_src.name}.')
+        else:
+            self.clocks[clk_name] = src
+
+    def _asdict(self) -> Dict[str, object]:
+        return {
+            'name': self.name,
+            'src': self.src,
+            'sw_cg': self.sw_cg,
+            'unique': _bool_to_yn(self.unique),
+            'clocks': {name: src.name for name, src in self.clocks.items()}
+        }
+
+
+class Clocks:
+    '''Clock connections for the chip'''
+    def __init__(self, raw: Dict[str, object]):
+        self.hier_paths = {}
+        assert isinstance(raw['hier_paths'], dict)
+        for grp_src, path in raw['hier_paths'].items():
+            self.hier_paths[str(grp_src)] = str(path)
+
+        assert isinstance(raw['srcs'], list)
+        self.srcs = {}
+        for r in raw['srcs']:
+            clk = SourceClock(r)
+            self.srcs[clk.name] = clk
+
+        self.derived_srcs = {}
+        for r in raw['derived_srcs']:
+            clk = DerivedSourceClock(r, self.srcs)
+            self.derived_srcs[clk.name] = clk
+
+        self.all_srcs = self.srcs.copy()
+        self.all_srcs.update(self.derived_srcs)
+
+        self.groups = {}
+        assert isinstance(raw['groups'], list)
+        for idx, raw_grp in enumerate(raw['groups']):
+            assert isinstance(raw_grp, dict)
+            grp = Group(raw_grp, self.srcs, f'clocks.groups[{idx}]')
+            self.groups[grp.name] = grp
+
+    def _asdict(self) -> Dict[str, object]:
+        return {
+            'hier_paths': self.hier_paths,
+            'srcs': list(self.srcs.values()),
+            'derived_srcs': list(self.derived_srcs.values()),
+            'groups': list(self.groups.values())
+        }
+
+    def add_clock_to_group(self, grp: Group, clk_name: str, src_name: str):
+        src = self.all_srcs.get(src_name)
+        if src is None:
+            raise ValueError(f'Cannot add clock {clk_name} to group '
+                             f'{grp.name}: the given source name is '
+                             f'{src_name}, which is unknown.')
+        grp.add_clock(clk_name, src)

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -62,11 +62,10 @@ num_im = sum([x["width"] if "width" in x else 1 for x in top["inter_signal"]["ex
 max_sigwidth = max([x["width"] if "width" in x else 1 for x in top["pinmux"]["ios"]])
 max_sigwidth = len("{}".format(max_sigwidth))
 
-clks_attr = top['clocks']
-cpu_clk = top['clocks']['hier_paths']['top'] + "clk_proc_main"
+cpu_clk = top['clocks'].hier_paths['top'] + "clk_proc_main"
 cpu_rst = top["reset_paths"]["sys"]
 dm_rst = top["reset_paths"]["lc"]
-esc_clk = top['clocks']['hier_paths']['top'] + "clk_io_div4_timers"
+esc_clk = top['clocks'].hier_paths['top'] + "clk_io_div4_timers"
 esc_rst = top["reset_paths"]["sys_io_div4"]
 
 unused_resets = lib.get_unused_resets(top)

--- a/util/topgen/templates/tb__xbar_connect.sv.tpl
+++ b/util/topgen/templates/tb__xbar_connect.sv.tpl
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import topgen.lib as lib
 
 top_hier = 'tb.dut.top_' + top["name"] + '.'
-clk_hier = top_hier + top["clocks"]["hier_paths"]["top"]
+clk_hier = top_hier + top["clocks"].hier_paths["top"]
 
 clk_src = OrderedDict()
 for xbar in top["xbar"]:
@@ -16,9 +16,9 @@ for xbar in top["xbar"]:
     clk_src[clk] = src
 
 clk_freq = OrderedDict()
-for clock in top["clocks"]["srcs"] + top["clocks"]["derived_srcs"]:
-  if clock["name"] in clk_src.values():
-    clk_freq[clock["name"]] = clock["freq"]
+for clock in top["clocks"].all_srcs.values():
+  if clock.name in clk_src.values():
+    clk_freq[clock.name] = clock.freq
 
 hosts = OrderedDict()
 devices = OrderedDict()

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -25,11 +25,10 @@ num_im = sum([x["width"] if "width" in x else 1 for x in top["inter_signal"]["ex
 max_sigwidth = max([x["width"] if "width" in x else 1 for x in top["pinmux"]["ios"]])
 max_sigwidth = len("{}".format(max_sigwidth))
 
-clks_attr = top['clocks']
-cpu_clk = top['clocks']['hier_paths']['top'] + "clk_proc_main"
+cpu_clk = top['clocks'].hier_paths['top'] + "clk_proc_main"
 cpu_rst = top["reset_paths"]["sys"]
 dm_rst = top["reset_paths"]["lc"]
-esc_clk = top['clocks']['hier_paths']['top'] + "clk_io_div4_timers"
+esc_clk = top['clocks'].hier_paths['top'] + "clk_io_div4_timers"
 esc_rst = top["reset_paths"]["sys_io_div4"]
 
 unused_resets = lib.get_unused_resets(top)


### PR DESCRIPTION
This slightly replicates the changes we made in reggen earlier in the
year. The reason to do this here is that we have several different
places in the code where we figure out the list of aon clocks, hint
clocks etc. and they all have to stay in sync.

Rather than rely on this, let's move all the cleverness into a single
class whose code can be run multiple times (to give the same answer
each time!).

This patch doesn't really do much of this consolidating, but it does
all the infrastructure work, converting `top['clocks']` from a load of
nested dictionaries into a class and teaching everything that reads
`top['clocks']` to understand the new format.
