### PR TITLE
[sw/silicon_creator] Scaffolding for sigverify_mod_exp_otbn

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -21,6 +21,13 @@
                     value: "0x0",
                 },
                 {
+                    name: "CREATOR_SW_CFG_USE_SW_RSA_VERIFY",
+                    // Use software mod_exp implementation for signature
+                    // verification. See the definition of `hardened_bool_t` in
+                    // sw/device/lib/base/hardened.h.
+                    value: "0x739",
+                },
+                {
                     name: "CREATOR_SW_CFG_KEY_IS_VALID",
                     // Mark the first two keys as valid and remaining as
                     // invalid since we have currently only two keys. See the

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -21,6 +21,13 @@
                     value: "0x0",
                 },
                 {
+                    name: "CREATOR_SW_CFG_USE_SW_RSA_VERIFY",
+                    // Use software mod_exp implementation for signature
+                    // verification. See the definition of `hardened_bool_t` in
+                    // sw/device/lib/base/hardened.h.
+                    value: "0x739",
+                },
+                {
                     name: "CREATOR_SW_CFG_KEY_IS_VALID",
                     // Mark the first two keys as valid and remaining as
                     // invalid since we have currently only two keys. See the

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -68,6 +68,7 @@ enum module_ {
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadExponent,       ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadKey,            ERROR_(3, kModuleSigverify, kInvalidArgument)), \
+  X(kErrorSigverifyBadOtpValue,       ERROR_(4, kModuleSigverify, kInternal)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   X(kErrorManifestBadLength,          ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadEntryPoint,      ERROR_(2, kModuleManifest, kInternal)), \

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -52,9 +52,11 @@ sw_silicon_creator_lib_sigverify = declare_dependency(
     sources: [
       'sigverify_mod_exp_ibex.c',
       'sigverify.c',
+      hw_ip_otp_ctrl_reg_h,
     ],
     dependencies: [
       sw_silicon_creator_lib_driver_hmac,
+      sw_silicon_creator_lib_driver_otp,
     ],
   ),
 )
@@ -167,6 +169,7 @@ test('sw_silicon_creator_lib_sigverify_unittest', executable(
     sources: [
       'sigverify_unittest.cc',
       'sigverify.c',
+      hw_ip_otp_ctrl_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -51,6 +51,7 @@ sw_silicon_creator_lib_sigverify = declare_dependency(
     'sw_silicon_creator_lib_sigverify',
     sources: [
       'sigverify_mod_exp_ibex.c',
+      'sigverify_mod_exp_otbn.c',
       'sigverify.c',
       hw_ip_otp_ctrl_reg_h,
     ],

--- a/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_ibex.h
+++ b/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_ibex.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_H_
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_IBEX_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_IBEX_H_
 
 #include "sw/device/lib/testing/mask_rom_test.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
@@ -12,30 +12,30 @@ namespace mask_rom_test {
 namespace internal {
 
 /**
- * Mock class for sigverify_mod_exp.h
+ * Mock class for sigverify_mod_exp_ibex.c
  */
-class MockSigverifyModExp {
+class MockSigverifyModExpIbex {
  public:
-  MOCK_METHOD(rom_error_t, ibex,
+  MOCK_METHOD(rom_error_t, mod_exp,
               (const sigverify_rsa_key_t *, const sigverify_rsa_buffer_t *,
                sigverify_rsa_buffer_t *));
-  virtual ~MockSigverifyModExp() {}
+  virtual ~MockSigverifyModExpIbex() {}
 };
 
 }  // namespace internal
 
-using MockSigverifyModExp =
-    GlobalMock<testing::StrictMock<internal::MockSigverifyModExp>>;
+using MockSigverifyModExpIbex =
+    GlobalMock<testing::StrictMock<internal::MockSigverifyModExpIbex>>;
 
 extern "C" {
 
 rom_error_t sigverify_mod_exp_ibex(const sigverify_rsa_key_t *key,
                                    const sigverify_rsa_buffer_t *sig,
                                    sigverify_rsa_buffer_t *result) {
-  return MockSigverifyModExp::Instance().ibex(key, sig, result);
+  return MockSigverifyModExpIbex::Instance().mod_exp(key, sig, result);
 }
 
 }  // extern "C"
 }  // namespace mask_rom_test
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_H_
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_IBEX_H_

--- a/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h
+++ b/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_OTBN_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_OTBN_H_
+
+#include "sw/device/lib/testing/mask_rom_test.h"
+#include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for sigverify_mod_exp_otbn.c
+ */
+class MockSigverifyModExpOtbn {
+ public:
+  MOCK_METHOD(rom_error_t, mod_exp,
+              (const sigverify_rsa_key_t *, const sigverify_rsa_buffer_t *,
+               sigverify_rsa_buffer_t *));
+  virtual ~MockSigverifyModExpOtbn() {}
+};
+
+}  // namespace internal
+
+using MockSigverifyModExpOtbn =
+    GlobalMock<testing::StrictMock<internal::MockSigverifyModExpOtbn>>;
+
+extern "C" {
+
+rom_error_t sigverify_mod_exp_otbn(const sigverify_rsa_key_t *key,
+                                   const sigverify_rsa_buffer_t *sig,
+                                   sigverify_rsa_buffer_t *result) {
+  return MockSigverifyModExpOtbn::Instance().mod_exp(key, sig, result);
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_OTBN_H_

--- a/sw/device/silicon_creator/lib/sigverify.c
+++ b/sw/device/silicon_creator/lib/sigverify.c
@@ -87,7 +87,7 @@ rom_error_t sigverify_rsa_verify(const void *signed_message,
       RETURN_IF_ERROR(sigverify_mod_exp_ibex(key, signature, &enc_msg));
       break;
     case kHardenedBoolFalse:
-      // FIXME: OTBN modular exponentiation.
+      RETURN_IF_ERROR(sigverify_mod_exp_otbn(key, signature, &enc_msg));
       break;
     default:
       return kErrorSigverifyBadOtpValue;

--- a/sw/device/silicon_creator/lib/sigverify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify_functest.c
@@ -2,10 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/sigverify.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
 static const char kMessage[] = "test message";
+
+// sec_mmio (used by the OTP driver) requires this symbol to be defined.
+sec_mmio_ctx_t sec_mmio_ctx;
 
 // See sw/device/silicon_creator/keys/README.md for more details on how to
 // update the structs below.

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp.h
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Computes the modular exponentiation of an RSA signature.
+ * Computes the modular exponentiation of an RSA signature on Ibex.
  *
  * Given an RSA public key and sig, this function computes sig^e mod n using
  * Montgomery multiplication, where
@@ -26,9 +26,26 @@ extern "C" {
  * @param key An RSA public key.
  * @param sig Buffer that holds the signature, little-endian.
  * @param result Buffer to write the result to, little-endian.
- * @return True if successful, false otherwise.
+ * @return The result of the operation.
  */
 rom_error_t sigverify_mod_exp_ibex(const sigverify_rsa_key_t *key,
+                                   const sigverify_rsa_buffer_t *sig,
+                                   sigverify_rsa_buffer_t *result);
+
+/**
+ * Computes the modular exponentiation of an RSA signature on OTBN.
+ *
+ * Given an RSA public key and sig, this function computes sig^e mod n using
+ * Montgomery multiplication, where
+ * - sig is an RSA signature,
+ * - e and n are the exponent and the modulus of the key, respectively.
+ *
+ * @param key An RSA public key.
+ * @param sig Buffer that holds the signature, little-endian.
+ * @param result Buffer to write the result to, little-endian.
+ * @return The result of the operation.
+ */
+rom_error_t sigverify_mod_exp_otbn(const sigverify_rsa_key_t *key,
                                    const sigverify_rsa_buffer_t *sig,
                                    sigverify_rsa_buffer_t *result);
 

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
+
+rom_error_t sigverify_mod_exp_otbn(const sigverify_rsa_key_t *key,
+                                   const sigverify_rsa_buffer_t *sig,
+                                   sigverify_rsa_buffer_t *result) {
+  // TODO(#7347): Implement this.
+  return kErrorSigverifyBadExponent;
+}

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/drivers/mock_hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h"
 #include "sw/device/silicon_creator/lib/sigverify.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
 

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -214,6 +214,7 @@ class SigverifyRsaVerify
       public testing::WithParamInterface<RsaVerifyTestCase> {
  protected:
   mask_rom_test::MockHmac hmac_;
+  mask_rom_test::MockOtp otp_;
 };
 
 TEST_P(SigverifyRsaVerify, Ibex) {
@@ -222,6 +223,10 @@ TEST_P(SigverifyRsaVerify, Ibex) {
       .WillOnce(Return(kErrorOk));
   EXPECT_CALL(hmac_, sha256_final(NotNull()))
       .WillOnce(DoAll(SetArgPointee<0>(kDigest), Return(kErrorOk)));
+  EXPECT_CALL(otp_,
+              read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_USE_SW_RSA_VERIFY_OFFSET))
+      .WillOnce(Return(kHardenedBoolTrue));
+
   EXPECT_EQ(sigverify_rsa_verify(kMessage.data(), kMessage.size(),
                                  &GetParam().sig, GetParam().key),
             kErrorOk);


### PR DESCRIPTION
This PR adds a skeleton `sigverify_mod_exp_otbn()` function to help with the OTBN integration that @jon-flatley is working on along with OTP reads and some test updates.

Created #7347 for OTBN integration and #7353 for how to handle default OTP values during manufacturing.