### PR TITLE
[lint] Remove line numbers from top_earlgrey.vbw

### DIFF
--- a/hw/top_earlgrey/lint/top_earlgrey.vbw
+++ b/hw/top_earlgrey/lint/top_earlgrey.vbw
@@ -1,4 +1,3 @@
 
 # These lines are too long due to templating
-waive --rule=line-length --line=91 --location=".*top_earlgrey.*"
-waive --rule=line-length --line=92 --location=".*top_earlgrey.*"
+waive --rule=line-length --location=".*top_earlgrey.*"


### PR DESCRIPTION
This is supposed to be waiving long line checks in the auto-generated
code, which seems like a good idea. Don't just apply to specified
lines; apply to all of them.

This is following up from #7339.