### PR TITLE
[memutil] Allow use without scrambled memories

### DIFF
--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -9,14 +9,11 @@ filesets:
   files_cpp:
     depend:
       - lowrisc:dv:secded_enc
-      - lowrisc:dv:scramble_model
     files:
       - cpp/dpi_memutil.cc
       - cpp/dpi_memutil.h: { is_include_file: true }
       - cpp/ecc32_mem_area.cc
       - cpp/ecc32_mem_area.h: { is_include_file: true }
-      - cpp/scrambled_ecc32_mem_area.cc
-      - cpp/scrambled_ecc32_mem_area.h: { is_include_file: true }
       - cpp/mem_area.cc
       - cpp/mem_area.h: { is_include_file: true }
       - cpp/ranged_map.h: { is_include_file: true }

--- a/hw/dv/verilator/memutil_dpi_scrambled.core
+++ b/hw/dv/verilator/memutil_dpi_scrambled.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:dv_verilator:memutil_dpi_scrambled"
+description: "DPI memory utilities for scrambled memories"
+filesets:
+  files_cpp:
+    depend:
+      - lowrisc:dv_verilator:memutil_dpi
+      - lowrisc:dv:scramble_model
+    files:
+      - cpp/scrambled_ecc32_mem_area.cc
+      - cpp/scrambled_ecc32_mem_area.h: { is_include_file: true }
+    file_type: cppSource
+
+targets:
+  default:
+    filesets:
+      - files_cpp

--- a/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson
+++ b/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Additional build-time options needed to compile C++ sources in
+  // simulators such as VCS and Xcelium for anything that uses
+  // memutil_dpi_scrambled.
+  memutil_dpi_core: "lowrisc:dv_verilator:memutil_dpi:0"
+  memutil_dpi_src_dir: "{eval_cmd} echo \"{memutil_dpi_core}\" | tr ':' '_'"
+
+  memutil_dpi_scrambled_core: "lowrisc:dv_verilator:memutil_dpi_scrambled:0"
+  memutil_dpi_scrambled_src_dir: "{eval_cmd} echo \"{memutil_dpi_scrambled_core}\" | tr ':' '_'"
+
+  secded_enc_core: "lowrisc:dv:secded_enc:0"
+  secded_enc_src_dir: "{eval_cmd} echo \"{secded_enc_core}\" | tr ':' '_'"
+
+  scramble_model_core: "lowrisc:dv:scramble_model:0"
+  scramble_model_dir: "{eval_cmd} echo \"{scramble_model_core}\" | tr ':' '_'"
+
+  prince_ref_core: "lowrisc:dv:crypto_prince_ref:0.1"
+  prince_ref_src_dir: "{eval_cmd} echo \"{prince_ref_core}\" | tr ':' '_'"
+
+
+  build_modes: [
+    {
+      name: vcs_memutil_dpi_scrambled_build_opts
+      build_opts: ["-CFLAGS -I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
+                   "-CFLAGS -I{build_dir}/src/{memutil_dpi_scrambled_src_dir}/cpp",
+                   "-CFLAGS -I{build_dir}/src/{secded_enc_src_dir}",
+                   "-CFLAGS -I{build_dir}/src/{scramble_model_dir}",
+                   "-CFLAGS -I{build_dir}/src/{prince_ref_src_dir}",
+                   "-lelf"]
+    }
+
+    {
+      name: xcelium_memutil_dpi_scrambled_build_opts
+      build_opts: ["-I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
+                   "-I{build_dir}/src/{memutil_dpi_scrambled_src_dir}/cpp",
+                   "-I{build_dir}/src/{prince_ref_src_dir}",
+                   "-I{build_dir}/src/{scramble_model_dir}",
+                   "-lelf"]
+    }
+  ]
+}

--- a/hw/ip/clkmgr/rtl/clkmgr.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr.sv
@@ -248,4 +248,4 @@ module clkmgr import clkmgr_pkg::*; (
   ////////////////////////////////////////////////////
 
 
-endmodule // rstmgr
+endmodule // clkmgr

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.core
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.core
@@ -9,7 +9,7 @@ description: "A wrapper around memutil_verilator for OTBN"
 filesets:
   files_cpp:
     depend:
-      - lowrisc:dv_verilator:memutil_dpi
+      - lowrisc:dv_verilator:memutil_dpi_scrambled
     files:
       - otbn_memutil.cc
       - otbn_memutil.h: { is_include_file: true }

--- a/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson
@@ -5,40 +5,20 @@
   // Additional build-time options needed to compile C++ sources in
   // simulators such as VCS and Xcelium for anything that uses
   // otbn_memutil.
-  memutil_dpi_core: "lowrisc:dv_verilator:memutil_dpi:0"
-  memutil_dpi_src_dir: "{eval_cmd} echo \"{memutil_dpi_core}\" | tr ':' '_'"
-
-  secded_enc_core: "lowrisc:dv:secded_enc:0"
-  secded_enc_src_dir: "{eval_cmd} echo \"{secded_enc_core}\" | tr ':' '_'"
-
+  // In addition to the build options here the user also must include the
+  // hw/dv/verilator/memutil_dpi_scrambled_opts.hjson file.
   otbn_memutil_core: "lowrisc:dv:otbn_memutil:0"
   otbn_memutil_src_dir: "{eval_cmd} echo \"{otbn_memutil_core}\" | tr ':' '_'"
-
-  scramble_model_core: "lowrisc:dv:scramble_model:0"
-  scramble_model_dir: "{eval_cmd} echo \"{scramble_model_core}\" | tr ':' '_'"
-
-  prince_ref_core: "lowrisc:dv:crypto_prince_ref:0.1"
-  prince_ref_src_dir: "{eval_cmd} echo \"{prince_ref_core}\" | tr ':' '_'"
-
 
   build_modes: [
     {
       name: vcs_otbn_memutil_build_opts
-      build_opts: ["-CFLAGS -I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
-                   "-CFLAGS -I{build_dir}/src/{otbn_memutil_src_dir}",
-                   "-CFLAGS -I{build_dir}/src/{secded_enc_src_dir}",
-                   "-CFLAGS -I{build_dir}/src/{scramble_model_dir}",
-                   "-CFLAGS -I{build_dir}/src/{prince_ref_src_dir}",
-                   "-lelf"]
+      build_opts: ["-CFLAGS -I{build_dir}/src/{otbn_memutil_src_dir}"]
     }
 
     {
       name: xcelium_otbn_memutil_build_opts
-      build_opts: ["-I{build_dir}/src/{memutil_dpi_src_dir}/cpp",
-                   "-I{build_dir}/src/{otbn_memutil_src_dir}",
-                   "-I{build_dir}/src/{prince_ref_src_dir}",
-                   "-I{build_dir}/src/{scramble_model_dir}",
-                   "-lelf"]
+      build_opts: ["-I{build_dir}/src/{otbn_memutil_src_dir}"]
     }
   ]
 }

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -31,6 +31,7 @@ name:
       // Project wide common sim cfg file
       "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
       // Config files to get the correct flags for otbn_memutil and otbn_tracer
+      "{proj_root}/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson",
       "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
       "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
       // Common CIP test lists
@@ -41,9 +42,11 @@ name:
       "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
   ]
 
-  // Add options needed to compile against otbn_memutil and otbn_tracer
+  // Add options needed to compile against otbn_memutil, otbn_tracer, and
+  // memutil_dpi_scrambled.
   en_build_modes: ["{tool}_otbn_memutil_build_opts",
-                   "{tool}_otbn_tracer_build_opts"]
+                   "{tool}_otbn_tracer_build_opts",
+                   "{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add additional tops for simulation.
   sim_tops: ["otbn_bind"]

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -176,6 +176,9 @@ module tb;
 
     .start_i      (model_if.start),
     .done_o       (model_if.done),
+
+    .err_bits_o   (),
+
     .start_addr_i (model_if.start_addr),
 
     .edn_rnd_data_valid_i  (edn_rnd_data_valid),

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson
@@ -4,7 +4,7 @@
 {
   // Additional build-time options needed to compile C++ sources in
   // simulators such as VCS and Xcelium for anything that uses
-  // otbn_memutil.
+  // crypto_prince_ref.
   crypto_prince_ref_core: "lowrisc:dv:crypto_prince_ref:0.1"
   crypto_prince_ref_src_dir: "{eval_cmd} echo \"{crypto_prince_ref_core}\" | tr ':' '_'"
 

--- a/hw/ip/prim/prim_ram_1p_scr.core
+++ b/hw/ip/prim/prim_ram_1p_scr.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:prim:all
       - lowrisc:prim:util_get_scramble_params
+      - lowrisc:dv_verilator:memutil_dpi_scrambled
     files:
       - rtl/prim_ram_1p_scr.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/rtl/prim_util_get_scramble_params.svh
+++ b/hw/ip/prim/rtl/prim_util_get_scramble_params.svh
@@ -29,7 +29,7 @@
       return 0;
     end
 
-    nonce = 0;
+    nonce = '0;
     nonce[NonceWidth-1:0] = nonce_i;
     return 1;
   endfunction

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -27,8 +27,8 @@
   // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
-                // Config files to get the correct flags for crypto_dpi_prince
-                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
+                // Config files to get the correct flags for prim_ram_1p_scr
+                "{proj_root}/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
@@ -36,7 +36,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
-  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
+  en_build_modes: ["{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add additional tops for simulation.
   sim_tops: ["sram_ctrl_bind"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -38,6 +38,7 @@
                 // xbar tests
                 "{proj_root}/hw/ip/tlul/generic_dv/xbar_tests.hjson",
                 // Config files to get the correct flags for otbn_memutil and otbn_tracer
+                "{proj_root}/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson",
                 "{proj_root}/hw/ip/otbn/dv/memutil/otbn_memutil_sim_opts.hjson",
                 "{proj_root}/hw/ip/otbn/dv/tracer/otbn_tracer_sim_opts.hjson",
                 "{proj_root}/hw/top_earlgrey/dv/chip_dif_tests.hjson",
@@ -96,9 +97,11 @@
     }
   ]
 
-  // Add options needed to compile against otbn_memutil and otbn_tracer
+  // Add options needed to compile against otbn_memutil, otbn_tracer, and
+  // memutil_dpi_scrambled.
   en_build_modes: ["{tool}_otbn_memutil_build_opts",
-                   "{tool}_otbn_tracer_build_opts"]
+                   "{tool}_otbn_tracer_build_opts",
+                   "{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add run modes.
   run_modes: [


### PR DESCRIPTION
The scrambled memory primitive prim_ram_1p_scr includes the
header file prim_util_get_scramble_params.svh, which defines and exports
(on the SV side) two functions (simutil_get_scramble_key() and
simutil_get_scramble_nonce()). These functions are used by
scrambled_ecc32_mem_area.[cc|h]. Currently, the file
scrambled_ecc32_mem_area.cc is always built as part of the memutil
library. However, the functions exported over DPI in
prim_util_get_scramble_params.svh are only built if prim_ram_1p_scr is
used.

None of that really matters in OpenTitan, since prim_ram_1p_scr is used
and the DPI exports will always be present (globally).

However we also use memutil in Ibex, and there no scrambled memories are
used. We therefore have to make sure that scrambled_ecc32_mem_area.cc
is not part of the build, which is what this commit does.

As part of enabling memutil to be used in Ibex again I also had to make
a connected change: sram_ctrl is using prim_ram_1p_scr in DV code, but
did not include the build options for scrambled memories in its dvsim
configuration. This worked in the past because all memory-related build
options (include paths) were always included globally. With that not the
case any more after this split we need to explicitly include the
scrambled memory include build options.

While at it I also refactored the dvsim OTBN configuration to avoid
duplicating the build options.

*(Additionally includes a couple of trivial changes in separate commits that I found when digging through the code.)*