### PR TITLE
[topgen,clkmgr] Further tidy-ups paving the way for multiple "hint" clocks in a module

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -5,7 +5,8 @@
 // functionality but is incomplete
 
 <%
-clocks = cfg['clocks']
+hint_clks = typed_clocks.hint_clks
+sw_clks = typed_clocks.sw_clks
 %>
 
 # CLKMGR register template
@@ -100,7 +101,7 @@ clocks = cfg['clocks']
 % endfor
 
   // Exported clocks
-% for intf in export_clks:
+% for intf in cfg['exported_clks']:
     { struct:  "clkmgr_${intf}_out",
       type:    "uni",
       name:    "clocks_${intf}",
@@ -223,7 +224,7 @@ clocks = cfg['clocks']
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-% for clk in hint_clks:
+% for clk in hint_clks.keys():
         {
           bits: "${loop.index}",
           name: "${clk.upper()}_HINT",

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -15,13 +15,8 @@ clocks = cfg['clocks']
   scan: "true",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
-% for src in clocks.srcs.values():
-    % if not src.aon:
-    {reset: "rst_${src.name}_ni"},
-    % endif
-% endfor
-% for src in clocks.derived_srcs.values():
-    {reset: "rst_${src.name}_ni"},
+% for rst in clocks.reset_signals():
+    {reset: "${rst}"},
 % endfor
   ]
   bus_interfaces: [

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -340,49 +340,49 @@ clocks = cfg['clocks']
   // clock target
   ////////////////////////////////////////////////////
 
-% for k in hint_clks:
-  logic ${k}_hint;
-  logic ${k}_en;
+% for clk in hint_clks:
+  logic ${clk}_hint;
+  logic ${clk}_en;
 % endfor
 
-% for k,v in hint_clks.items():
-  assign ${k}_en = ${k}_hint | ~idle_i[${v["name"].capitalize()}];
+% for clk, src in hint_clks.items():
+  assign ${clk}_en = ${clk}_hint | ~idle_i[${hint_names[clk]}];
 
   prim_flop_2sync #(
     .Width(1)
-  ) u_${k}_hint_sync (
-    .clk_i(clk_${v["src"].name}_i),
-    .rst_ni(rst_${v["src"].name}_ni),
-    .d_i(reg2hw.clk_hints.${k}_hint.q),
-    .q_o(${k}_hint)
+  ) u_${clk}_hint_sync (
+    .clk_i(clk_${src.name}_i),
+    .rst_ni(rst_${src.name}_ni),
+    .d_i(reg2hw.clk_hints.${clk}_hint.q),
+    .q_o(${clk}_hint)
   );
 
-  lc_tx_t ${k}_scanmode;
+  lc_tx_t ${clk}_scanmode;
   prim_lc_sync #(
     .NumCopies(1),
     .AsyncOn(0)
-  ) u_${k}_scanmode_sync  (
+  ) u_${clk}_scanmode_sync  (
     .clk_i(1'b0),  //unused
     .rst_ni(1'b1), //unused
     .lc_en_i(scanmode_i),
-    .lc_en_o(${k}_scanmode)
+    .lc_en_o(${clk}_scanmode)
   );
 
   prim_clock_gating #(
     .NoFpgaGate(1'b1)
-  ) u_${k}_cg (
-    .clk_i(clk_${v["src"].name}_root),
-    .en_i(${k}_en & clk_${v["src"].name}_en),
-    .test_en_i(${k}_scanmode == lc_ctrl_pkg::On),
-    .clk_o(clocks_o.${k})
+  ) u_${clk}_cg (
+    .clk_i(clk_${src.name}_root),
+    .en_i(${clk}_en & clk_${src.name}_en),
+    .test_en_i(${clk}_scanmode == lc_ctrl_pkg::On),
+    .clk_o(clocks_o.${clk})
   );
 
 % endfor
 
   // state readback
-% for k,v in hint_clks.items():
-  assign hw2reg.clk_hints_status.${k}_val.de = 1'b1;
-  assign hw2reg.clk_hints_status.${k}_val.d = ${k}_en;
+% for clk in hint_clks:
+  assign hw2reg.clk_hints_status.${clk}_val.de = 1'b1;
+  assign hw2reg.clk_hints_status.${clk}_val.d = ${clk}_en;
 % endfor
 
   assign jitter_en_o = reg2hw.jitter_enable.q;

--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -11,21 +11,13 @@ num_hints = len(hint_clks)
 package clkmgr_pkg;
 
   typedef enum int {
-% for idx, blk_name in list(enumerate(hint_blocks)):
-    ${blk_name.capitalize()} = ${idx}${"," if not loop.last else ""}
+% for idx, hint_name in list(enumerate(hint_names.values())):
+    ${hint_name} = ${idx}${"," if not loop.last else ""}
 % endfor
   } hint_names_e;
 
   typedef struct packed {
-<%
-# Merge Clock Dicts together
-all_clocks = OrderedDict()
-all_clocks.update(ft_clks)
-all_clocks.update(hint_clks)
-all_clocks.update(rg_clks)
-all_clocks.update(sw_clks)
-%>\
-% for clk in all_clocks:
+% for clk in all_clks:
     logic ${clk};
 % endfor
 

--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -5,7 +5,6 @@
 <%
 from collections import OrderedDict
 
-clocks = cfg['clocks']
 num_hints = len(hint_clks)
 %>
 

--- a/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr_pkg.sv.tpl
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 <%
-from collections import OrderedDict
-
-num_hints = len(hint_clks)
+num_hints = len(typed_clocks.hint_clks)
 %>
 
 package clkmgr_pkg;
@@ -17,13 +15,13 @@ package clkmgr_pkg;
   } hint_names_e;
 
   typedef struct packed {
-% for clk in all_clks:
+% for clk in typed_clocks.all_clocks():
     logic ${clk};
 % endfor
 
   } clkmgr_out_t;
 
-% for intf, eps in export_clks.items():
+% for intf, eps in cfg['exported_clks'].items():
   typedef struct packed {
   % for ep, clks in eps.items():
     % for clk in clks:

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -572,7 +572,7 @@
   logic clk_io_div4_otbn_hint;
   logic clk_io_div4_otbn_en;
 
-  assign clk_main_aes_en = clk_main_aes_hint | ~idle_i[Aes];
+  assign clk_main_aes_en = clk_main_aes_hint | ~idle_i[HintMainAes];
 
   prim_flop_2sync #(
     .Width(1)
@@ -603,7 +603,7 @@
     .clk_o(clocks_o.clk_main_aes)
   );
 
-  assign clk_main_hmac_en = clk_main_hmac_hint | ~idle_i[Hmac];
+  assign clk_main_hmac_en = clk_main_hmac_hint | ~idle_i[HintMainHmac];
 
   prim_flop_2sync #(
     .Width(1)
@@ -634,7 +634,7 @@
     .clk_o(clocks_o.clk_main_hmac)
   );
 
-  assign clk_main_kmac_en = clk_main_kmac_hint | ~idle_i[Kmac];
+  assign clk_main_kmac_en = clk_main_kmac_hint | ~idle_i[HintMainKmac];
 
   prim_flop_2sync #(
     .Width(1)
@@ -665,7 +665,7 @@
     .clk_o(clocks_o.clk_main_kmac)
   );
 
-  assign clk_main_otbn_en = clk_main_otbn_hint | ~idle_i[Otbn];
+  assign clk_main_otbn_en = clk_main_otbn_hint | ~idle_i[HintMainOtbn];
 
   prim_flop_2sync #(
     .Width(1)
@@ -696,7 +696,7 @@
     .clk_o(clocks_o.clk_main_otbn)
   );
 
-  assign clk_io_div4_otbn_en = clk_io_div4_otbn_hint | ~idle_i[Otbn];
+  assign clk_io_div4_otbn_en = clk_io_div4_otbn_hint | ~idle_i[HintIoDiv4Otbn];
 
   prim_flop_2sync #(
     .Width(1)

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -13,10 +13,11 @@
 package clkmgr_pkg;
 
   typedef enum int {
-    Aes = 0,
-    Hmac = 1,
-    Kmac = 2,
-    Otbn = 3
+    HintMainAes = 0,
+    HintMainHmac = 1,
+    HintMainKmac = 2,
+    HintIoDiv4Otbn = 3,
+    HintMainOtbn = 4
   } hint_names_e;
 
   typedef struct packed {

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -404,11 +404,11 @@ def generate_clkmgr(top, cfg_path, out_path):
     clocks = top['clocks']
     assert isinstance(clocks, Clocks)
 
-    by_type = clocks.typed_clocks()
+    typed_clocks = clocks.typed_clocks()
 
     # A map from block name to the list of hint clocks that it uses.
     block_to_hints = {}
-    for clk, src in by_type.hint_clks.items():
+    for clk, src in typed_clocks.hint_clks.items():
         block = clk.rsplit('_', 1)[-1]
         block_to_hints.setdefault(block, []).append(clk)
 
@@ -430,13 +430,8 @@ def generate_clkmgr(top, cfg_path, out_path):
             tpl = Template(fin.read())
             try:
                 out = tpl.render(cfg=top,
-                                 rg_srcs=by_type.rg_srcs,
-                                 ft_clks=by_type.ft_clks,
-                                 rg_clks=by_type.rg_clks,
-                                 sw_clks=by_type.sw_clks,
-                                 hint_clks=by_type.hint_clks,
-                                 all_clks=by_type.all_clocks(),
-                                 export_clks=top['exported_clks'],
+                                 clocks=clocks,
+                                 typed_clocks=typed_clocks,
                                  hint_names=hint_names)
             except:  # noqa: E722
                 log.error(exceptions.text_error_template().render())

--- a/util/topgen/c.py
+++ b/util/topgen/c.py
@@ -429,26 +429,24 @@ class TopGenC:
         """
         clocks = self.top['clocks']
 
-        aon_clocks = set(src.name
-                         for src in clocks.all_srcs.values() if src.aon)
-
         gateable_clocks = CEnum(self._top_name + Name(["gateable", "clocks"]))
         hintable_clocks = CEnum(self._top_name + Name(["hintable", "clocks"]))
 
-        # This replicates the behaviour in `topgen.py` in deriving `hints` and
-        # `sw_clocks`.
-        for group in clocks.groups.values():
-            for name, source in group.clocks.items():
-                if source.name not in aon_clocks:
-                    # All these clocks start with `clk_` which is redundant.
-                    clock_name = Name.from_snake_case(name).remove_part("clk")
-                    docstring = "Clock {} in group {}".format(name, group.name)
-                    if group.sw_cg == "yes":
-                        gateable_clocks.add_constant(clock_name, docstring)
-                    elif group.sw_cg == "hint":
-                        hintable_clocks.add_constant(clock_name, docstring)
+        c2g = clocks.make_clock_to_group()
+        by_type = clocks.typed_clocks()
 
+        for name in by_type.sw_clks.keys():
+            # All these clocks start with `clk_` which is redundant.
+            clock_name = Name.from_snake_case(name).remove_part("clk")
+            docstring = "Clock {} in group {}".format(name, c2g[name].name)
+            gateable_clocks.add_constant(clock_name, docstring)
         gateable_clocks.add_last_constant("Last Valid Gateable Clock")
+
+        for name in by_type.hint_clks.keys():
+            # All these clocks start with `clk_` which is redundant.
+            clock_name = Name.from_snake_case(name).remove_part("clk")
+            docstring = "Clock {} in group {}".format(name, c2g[name].name)
+            hintable_clocks.add_constant(clock_name, docstring)
         hintable_clocks.add_last_constant("Last Valid Hintable Clock")
 
         self.clkmgr_gateable_clocks = gateable_clocks

--- a/util/topgen/clocks.py
+++ b/util/topgen/clocks.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List
+from typing import Dict, List, NamedTuple
 
 
 def _yn_to_bool(yn: object) -> bool:
@@ -116,6 +116,35 @@ class Group:
         }
 
 
+class TypedClocks(NamedTuple):
+    # Clocks fed through clkmgr but not disturbed in any way. This maintains
+    # the clocking structure consistency. This includes two groups of clocks:
+    #
+    #   - Clocks fed from the always-on source
+    #   - Clocks fed to the powerup group
+    ft_clks: Dict[str, SourceClock]
+
+    # Non-feedthrough clocks that have no software control. These clocks are
+    # root-gated and the root-gated clock is then exposed directly in clocks_o.
+    rg_clks: Dict[str, SourceClock]
+
+    # Non-feedthrough clocks that have direct software control. These are
+    # root-gated, but (unlike rg_clks) then go through a second clock gate
+    # which is controlled by software.
+    sw_clks: Dict[str, SourceClock]
+
+    # Non-feedthrough clocks that have "hint" software control (with a feedback
+    # mechanism to allow blocks to avoid being suspended when they are not
+    # idle).
+    hint_clks: Dict[str, SourceClock]
+
+    # A list of the of non-always-on clock sources that are exposed without
+    # division, sorted by name. This doesn't include clock sources that are
+    # only used to derive divided clocks (we might gate the divided clocks, but
+    # don't bother gating the upstream source).
+    rg_srcs: List[str]
+
+
 class Clocks:
     '''Clock connections for the chip'''
     def __init__(self, raw: Dict[str, object]):
@@ -160,3 +189,73 @@ class Clocks:
                              f'{grp.name}: the given source name is '
                              f'{src_name}, which is unknown.')
         grp.add_clock(clk_name, src)
+
+    def reset_signals(self) -> List[str]:
+        '''Return the list of clock reset signal names
+
+        These signals are inputs to the clock manager (from the reset
+        manager)
+
+        '''
+        ret = []
+        for src in self.srcs.values():
+            if not src.aon:
+                ret.append(f'rst_{src.name}_ni')
+        for src in self.derived_srcs.values():
+            ret.append(f'rst_{src.name}_ni')
+        return ret
+
+    def typed_clocks(self) -> TypedClocks:
+        '''Split the clocks by type'''
+        ft_clks = {}
+        rg_clks = {}
+        sw_clks = {}
+        hint_clks = {}
+        rg_srcs_set = set()
+
+        for grp in self.groups.values():
+            if grp.name == 'powerup':
+                # All clocks in the "powerup" group are considered feed-throughs.
+                ft_clks.update(grp.clocks)
+                continue
+
+            for clk, src in grp.clocks.items():
+                if src.aon:
+                    # Any always-on clock is a feedthrough
+                    ft_clks[clk] = src
+                    continue
+
+                rg_srcs_set.add(src.name)
+
+                if grp.sw_cg == 'no':
+                    # A non-feedthrough clock with no software control
+                    rg_clks[clk] = src
+                    continue
+
+                if grp.sw_cg == 'yes':
+                    # A non-feedthrough clock with direct software control
+                    sw_clks[clk] = src
+                    continue
+
+                # The only other valid value for the sw_cg field is "hint", which
+                # means a non-feedthrough clock with "hint" software control.
+                assert grp.sw_cg == 'hint'
+                hint_clks[clk] = src
+                continue
+
+        # Define a canonical ordering for rg_srcs
+        rg_srcs = list(sorted(rg_srcs_set))
+
+        return TypedClocks(ft_clks=ft_clks,
+                           rg_clks=rg_clks,
+                           sw_clks=sw_clks,
+                           hint_clks=hint_clks,
+                           rg_srcs=rg_srcs)
+
+    def make_clock_to_group(self) -> Dict[str, Group]:
+        '''Return a map from clock name to the group containing the clock'''
+        c2g = {}
+        for grp in self.groups.values():
+            for clk_name in grp.clocks.keys():
+                c2g[clk_name] = grp
+        return c2g

--- a/util/topgen/clocks.py
+++ b/util/topgen/clocks.py
@@ -144,6 +144,19 @@ class TypedClocks(NamedTuple):
     # don't bother gating the upstream source).
     rg_srcs: List[str]
 
+    def all_clocks(self) -> List[str]:
+        '''Return a list of all clock names
+
+        These are ordered ft, hint, rg, sw.
+
+        '''
+        ret = {}
+        ret.update(self.ft_clks)
+        ret.update(self.hint_clks)
+        ret.update(self.rg_clks)
+        ret.update(self.sw_clks)
+        return ret
+
 
 class Clocks:
     '''Clock connections for the chip'''

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1193,7 +1193,7 @@ module chip_${top["name"]}_${target["name"]} (
   always_comb begin : p_trigger
     mio_out = mio_out_pre;
     mio_out[MioIdxTrigger] = mio_out_pre[MioIdxTrigger] &
-                             ~top_${top["name"]}.clkmgr_aon_idle[clkmgr_pkg::Aes];
+                             ~top_${top["name"]}.clkmgr_aon_idle[clkmgr_pkg::HintMainAes];
   end
 
   //////////////////////


### PR DESCRIPTION
The first two patches in this queue are all about de-duplicating logic to make sure everything matches. The third patch expands some of the names in clkmgr so that it's possible for a block to expose more than one "idle" hint. We don't actually *do* that yet, but this is a necessary change to make it happen. The final patch is just a tweak to tidy up how we're expand templates.