### PR TITLE
[opentitantool] Add the verilator backend.

### DIFF
--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -9,6 +9,8 @@ use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
+pub mod verilator;
+
 bitflags! {
     /// A bitmap of capabilities which may be provided by a transport.
     pub struct Capability: u32 {

--- a/sw/host/opentitanlib/src/transport/verilator/mod.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/mod.rs
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod subprocess;
+pub mod transport;
+pub mod uart;
+
+pub use subprocess::Options;
+pub use transport::Verilator;

--- a/sw/host/opentitanlib/src/transport/verilator/subprocess.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/subprocess.rs
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::file;
+use anyhow::Result;
+use log::info;
+use regex::Regex;
+use std::io::Read;
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Verilator startup options.
+pub struct Options {
+    /// The verilator executable.
+    pub executable: String,
+    /// The ROM image used to boot the CPU.
+    pub rom_image: String,
+    /// The flash image stored in internal flash memory.
+    pub flash_image: String,
+    /// The OTP settings.
+    pub otp_image: String,
+    /// Any extra arguments to verilator.
+    pub extra_args: Vec<String>,
+}
+
+pub struct Subprocess {
+    child: Child,
+    stdout: ChildStdout,
+    accumulated_output: String,
+}
+
+impl Subprocess {
+    /// Starts a verilator [`Subprocess`] based on [`Options`].
+    pub fn from_options(options: Options) -> Result<Self> {
+        let mut command = Command::new(&options.executable);
+        let mut args = Vec::new();
+
+        if !options.rom_image.is_empty() {
+            args.push(format!("--meminit=rom,{}", options.rom_image));
+        }
+        if !options.flash_image.is_empty() {
+            args.push(format!("--meminit=flash,{}", options.flash_image));
+        }
+        if !options.otp_image.is_empty() {
+            args.push(format!("--meminit=otp,{}", options.otp_image));
+        }
+        args.extend_from_slice(&options.extra_args);
+        command.args(&args[..]);
+
+        info!("Spawning verilator: {:?} {:?}", options.executable, args);
+
+        let mut child = command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let stdout = child.stdout.take().unwrap();
+        Ok(Subprocess {
+            child,
+            stdout,
+            accumulated_output: String::default(),
+        })
+    }
+
+    /// Accumulates output from verilator's `stdout`.
+    pub fn accumulate(&mut self, timeout: Duration) -> Result<()> {
+        let mut buf = [0u8; 256];
+        file::wait_read_timeout(&self.stdout, timeout)?;
+        let n = self.stdout.read(&mut buf)?;
+        let s = String::from_utf8_lossy(&buf[..n]);
+        self.accumulated_output.push_str(&s);
+        Ok(())
+    }
+
+    /// Finds a string within the verilator output.
+    /// It is assumed that the [`Regex`] `re` has exactly one capture.
+    pub fn find(&mut self, re: &Regex, timeout: Duration) -> Result<String> {
+        assert_eq!(re.captures_len(), 1);
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(captures) = re.captures(&self.accumulated_output) {
+                let val = captures.get(1).expect("expected a capture");
+                return Ok(val.as_str().to_owned());
+            } else {
+                self.accumulate(deadline.saturating_duration_since(Instant::now()))?;
+            }
+        }
+    }
+
+    /// Kill the verilator subprocess.
+    pub fn kill(&mut self) -> Result<()> {
+        self.child.kill()?;
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use lazy_static::lazy_static;
+use log::info;
+use regex::Regex;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::transport::verilator::subprocess::{Options, Subprocess};
+use crate::transport::verilator::uart::VerilatorUart;
+use crate::transport::{Capabilities, Capability, Transport};
+
+/// Represents the verilator transport object.
+pub struct Verilator {
+    subprocess: Option<Subprocess>,
+    pub uart_file: String,
+    pub spi_file: String,
+    pub gpio_read_file: String,
+    pub gpio_write_file: String,
+}
+
+impl Verilator {
+    /// Creates a verilator subprocess-hosting transport from [`options`].
+    pub fn from_options(options: Options) -> Result<Self> {
+        lazy_static! {
+            static ref UART: Regex = Regex::new("UART: Created ([^ ]+) for uart0").unwrap();
+            static ref SPI: Regex = Regex::new("SPI: Created ([^ ]+) for spi0").unwrap();
+            static ref GPIO_RD: Regex =
+                Regex::new(r#"GPIO: FIFO pipes created at ([^ ]+) \(read\) and [^ ]+ \(write\) for 32-bit wide GPIO."#).unwrap();
+            static ref GPIO_WR: Regex =
+                Regex::new(r#"GPIO: FIFO pipes created at [^ ]+ \(read\) and ([^ ]+) \(write\) for 32-bit wide GPIO."#).unwrap();
+        }
+
+        let mut subprocess = Subprocess::from_options(options)?;
+        let gpio_rd = subprocess.find(&GPIO_RD, Duration::from_secs(5))?;
+        let gpio_wr = subprocess.find(&GPIO_WR, Duration::from_secs(5))?;
+        let uart = subprocess.find(&UART, Duration::from_secs(5))?;
+        let spi = subprocess.find(&SPI, Duration::from_secs(5))?;
+
+        info!("Verilator started with the following interaces:");
+        info!("gpio_read = {}", gpio_rd);
+        info!("gpio_write = {}", gpio_wr);
+        info!("uart = {}", uart);
+        info!("spi = {}", spi);
+        Ok(Verilator {
+            subprocess: Some(subprocess),
+            uart_file: uart,
+            spi_file: spi,
+            gpio_read_file: gpio_rd,
+            gpio_write_file: gpio_wr,
+        })
+    }
+
+    /// Shuts down the verilator subprocess.
+    pub fn shutdown(&mut self) -> Result<()> {
+        if let Some(mut subprocess) = self.subprocess.take() {
+            subprocess.kill()
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for Verilator {
+    fn drop(&mut self) {
+        self.shutdown().expect("Kill verilator subprocess");
+    }
+}
+
+impl Transport for Verilator {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::UART)
+    }
+
+    fn uart(&self) -> Result<Box<dyn Uart>> {
+        Ok(Box::new(VerilatorUart::open(&self.uart_file)?))
+    }
+}

--- a/sw/host/opentitanlib/src/transport/verilator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/uart.rs
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::util::file;
+
+/// Represents the verilator virtual UART.
+pub struct VerilatorUart {
+    file: File,
+}
+
+impl VerilatorUart {
+    pub fn open(path: &str) -> Result<Self> {
+        Ok(VerilatorUart {
+            file: OpenOptions::new().read(true).write(true).open(path)?,
+        })
+    }
+}
+
+impl Uart for VerilatorUart {
+    fn get_baudrate(&self) -> u32 {
+        // The verilator UART operates at 7200 baud.
+        // See `sw/device/lib/arch/device_sim_verilator.c`.
+        7200
+    }
+
+    fn set_baudrate(&mut self, _baudrate: u32) -> Result<()> {
+        // As a virtual uart, setting the baudrate is a no-op.
+        Ok(())
+    }
+
+    fn read_timeout(&mut self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        file::wait_read_timeout(&self.file, timeout)?;
+        Ok(self.file.read(buf)?)
+    }
+}
+
+impl Read for VerilatorUart {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.file.read(buf)
+    }
+}
+
+impl Write for VerilatorUart {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.file.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file.flush()
+    }
+}

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -8,10 +8,15 @@ use thiserror::Error;
 
 use opentitanlib::transport::{EmptyTransport, Transport};
 
+pub mod verilator;
+
 #[derive(Debug, StructOpt)]
 pub struct BackendOpts {
     #[structopt(long, default_value)]
     interface: String,
+
+    #[structopt(flatten)]
+    verilator_opts: verilator::VerilatorOpts,
 }
 
 #[derive(Error, Debug)]
@@ -24,6 +29,7 @@ pub enum Error {
 pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
     match args.interface.as_str() {
         "" => Ok(Box::new(EmptyTransport)),
+        "verilator" => verilator::create(&args.verilator_opts),
         _ => Err(Error::UnknownInterface(args.interface.clone()).into()),
     }
 }

--- a/sw/host/opentitantool/src/backend/verilator.rs
+++ b/sw/host/opentitantool/src/backend/verilator.rs
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::transport::verilator::{Options, Verilator};
+use opentitanlib::transport::Transport;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct VerilatorOpts {
+    #[structopt(long, default_value)]
+    verilator_bin: String,
+
+    #[structopt(long, default_value)]
+    verilator_rom: String,
+    #[structopt(long, default_value)]
+    verilator_flash: String,
+    #[structopt(long, default_value)]
+    verilator_otp: String,
+
+    #[structopt(long, required = false)]
+    verilator_args: Vec<String>,
+}
+
+pub fn create(args: &VerilatorOpts) -> Result<Box<dyn Transport>> {
+    let options = Options {
+        executable: args.verilator_bin.clone(),
+        rom_image: args.verilator_rom.clone(),
+        flash_image: args.verilator_flash.clone(),
+        otp_image: args.verilator_otp.clone(),
+        extra_args: args.verilator_args.clone(),
+    };
+    Ok(Box::new(Verilator::from_options(options)?))
+}


### PR DESCRIPTION
1. Add the verilator backend to opentitanlib.
2. Integrate the backend into opentitantool.

Signed-off-by: Chris Frantz <cfrantz@google.com>