### PR TITLE
[util] Shadow reset prep work 

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -12,7 +12,7 @@
   name: "RSTMGR",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
-% for clk in clks:
+% for clk in reset_obj.get_clocks():
     {clock: "clk_${clk}_i"}
 % endfor
   ]

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -16,7 +16,7 @@ module rstmgr
   // Primary module clocks
   input clk_i,
   input rst_ni, // this is connected to the top level reset
-% for clk in clks:
+% for clk in reset_obj.get_clocks():
   input clk_${clk}_i,
 % endfor
 
@@ -251,14 +251,14 @@ module rstmgr
 % for i, rst in enumerate(leaf_rsts):
   logic [PowerDomains-1:0] rst_${rst['name']}_n;
   % for domain in power_domains:
-    % if domain in rst['domains']:
+     % if domain in reset_obj.get_reset_domains(rst['name']):
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
   ) u_${domain.lower()}_${rst['name']} (
     .clk_i(clk_${rst['clk']}_i),
     .rst_ni(rst_${rst['parent']}_n[Domain${domain}Sel]),
-      % if "sw" in rst:
+      % if rst["sw"]:
     .d_i(sw_rst_ctrl_n[${rst['name'].upper()}]),
       % else:
     .d_i(1'b1),

--- a/hw/ip/rstmgr/data/rstmgr_pkg.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr_pkg.sv.tpl
@@ -19,14 +19,14 @@ package rstmgr_pkg;
 
   // positions of software controllable reset bits
 % for rst in sw_rsts:
-  parameter int ${rst['name'].upper()} = ${loop.index};
+  parameter int ${rst.upper()} = ${loop.index};
 % endfor
 
   // resets generated and broadcast
   // This should be templatized and generated
   typedef struct packed {
 % for rst in output_rsts:
-    logic [PowerDomains-1:0] rst_${rst['name']}_n;
+    logic [PowerDomains-1:0] rst_${rst}_n;
 % endfor
   } rstmgr_out_t;
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -175,6 +175,10 @@
         name: rst_ni
         gen: false
         type: ext
+        domains: []
+        shadowed: false
+        sw: false
+        path: rst_ni
       }
       {
         name: por_aon
@@ -184,29 +188,30 @@
         [
           Aon
         ]
-        clk: aon
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_aon_n
+        clock: aon
       }
       {
         name: lc_src
         gen: false
         type: int
-        domains:
-        [
-          Aon
-          "0"
-        ]
-        clk: io_div4
+        domains: []
+        shadowed: false
+        sw: false
+        path: ""
+        clock: io_div4
       }
       {
         name: sys_src
         gen: false
         type: int
-        domains:
-        [
-          Aon
-          "0"
-        ]
-        clk: io_div4
+        domains: []
+        shadowed: false
+        sw: false
+        path: ""
+        clock: io_div4
       }
       {
         name: por
@@ -216,8 +221,11 @@
         [
           Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_n
         parent: por_aon
-        clk: main
+        clock: main
       }
       {
         name: por_io
@@ -227,8 +235,11 @@
         [
           Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_io_n
         parent: por_aon
-        clk: io
+        clock: io
       }
       {
         name: por_io_div2
@@ -238,8 +249,11 @@
         [
           Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_io_div2_n
         parent: por_aon
-        clk: io_div2
+        clock: io_div2
       }
       {
         name: por_io_div4
@@ -249,8 +263,11 @@
         [
           Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_io_div4_n
         parent: por_aon
-        clk: io_div4
+        clock: io_div4
       }
       {
         name: por_usb
@@ -260,8 +277,11 @@
         [
           Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_por_usb_n
         parent: por_aon
-        clk: usb
+        clock: usb
       }
       {
         name: lc
@@ -271,8 +291,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_lc_n
         parent: lc_src
-        clk: main
+        clock: main
       }
       {
         name: lc_io_div4
@@ -280,11 +303,14 @@
         type: top
         domains:
         [
-          Aon
           "0"
+          Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_lc_io_div4_n
         parent: lc_src
-        clk: io_div4
+        clock: io_div4
       }
       {
         name: sys
@@ -294,8 +320,11 @@
         [
           "0"
         ]
+        shadowed: true
+        sw: false
+        path: rstmgr_aon_resets.rst_sys_n
         parent: sys_src
-        clk: main
+        clock: main
       }
       {
         name: sys_io_div4
@@ -303,11 +332,14 @@
         type: top
         domains:
         [
-          Aon
           "0"
+          Aon
         ]
+        shadowed: true
+        sw: false
+        path: rstmgr_aon_resets.rst_sys_io_div4_n
         parent: sys_src
-        clk: io_div4
+        clock: io_div4
       }
       {
         name: sys_aon
@@ -315,11 +347,14 @@
         type: top
         domains:
         [
-          Aon
           "0"
+          Aon
         ]
+        shadowed: false
+        sw: false
+        path: rstmgr_aon_resets.rst_sys_aon_n
         parent: sys_src
-        clk: aon
+        clock: aon
       }
       {
         name: spi_device
@@ -329,9 +364,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_spi_device_n
         parent: sys_src
-        clk: io_div2
-        sw: 1
+        clock: io_div2
       }
       {
         name: spi_host0
@@ -341,9 +378,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_spi_host0_n
         parent: sys_src
-        clk: io
-        sw: 1
+        clock: io
       }
       {
         name: spi_host1
@@ -353,9 +392,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_spi_host1_n
         parent: sys_src
-        clk: io_div2
-        sw: 1
+        clock: io_div2
       }
       {
         name: usb
@@ -365,9 +406,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_usb_n
         parent: sys_src
-        clk: usb
-        sw: 1
+        clock: usb
       }
       {
         name: i2c0
@@ -377,9 +420,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_i2c0_n
         parent: sys_src
-        clk: io_div2
-        sw: 1
+        clock: io_div2
       }
       {
         name: i2c1
@@ -389,9 +434,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_i2c1_n
         parent: sys_src
-        clk: io_div2
-        sw: 1
+        clock: io_div2
       }
       {
         name: i2c2
@@ -401,9 +448,11 @@
         [
           "0"
         ]
+        shadowed: false
+        sw: true
+        path: rstmgr_aon_resets.rst_i2c2_n
         parent: sys_src
-        clk: io_div2
-        sw: 1
+        clock: io_div2
       }
     ]
   }
@@ -420,7 +469,7 @@
       }
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_group: secure
       clock_connections:
@@ -460,7 +509,7 @@
       }
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_group: secure
       clock_connections:
@@ -500,7 +549,7 @@
       }
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_group: secure
       clock_connections:
@@ -540,7 +589,7 @@
       }
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_group: secure
       clock_connections:
@@ -581,7 +630,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_connections:
       {
@@ -622,7 +671,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_spi_device_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: spi_device
       }
       clock_connections:
       {
@@ -698,8 +747,8 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel]
-        rst_core_ni: rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: spi_host0
+        rst_core_ni: spi_host0
       }
       clock_connections:
       {
@@ -753,8 +802,8 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_spi_host1_n[rstmgr_pkg::Domain0Sel]
-        rst_core_ni: rstmgr_aon_resets.rst_spi_host1_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: spi_host1
+        rst_core_ni: spi_host1
       }
       clock_connections:
       {
@@ -805,7 +854,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_i2c0_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: i2c0
       }
       clock_connections:
       {
@@ -845,7 +894,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_i2c1_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: i2c1
       }
       clock_connections:
       {
@@ -885,7 +934,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_i2c2_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: i2c2
       }
       clock_connections:
       {
@@ -925,7 +974,7 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_connections:
       {
@@ -965,7 +1014,7 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       clock_connections:
       {
@@ -1011,9 +1060,9 @@
       ]
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
-        rst_aon_ni: rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]
-        rst_usb_48mhz_ni: rstmgr_aon_resets.rst_usb_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
+        rst_aon_ni: sys_aon
+        rst_usb_48mhz_ni: usb
       }
       clock_connections:
       {
@@ -1162,8 +1211,8 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
-        rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: lc_io_div4
+        rst_edn_ni: sys
       }
       base_addrs:
       {
@@ -1464,8 +1513,8 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
-        rst_kmac_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: lc_io_div4
+        rst_kmac_ni: sys
       }
       clock_connections:
       {
@@ -1907,8 +1956,8 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
-        rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
+        rst_edn_ni: sys
       }
       attr: templated
       clock_connections:
@@ -2028,8 +2077,8 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_por_n[rstmgr_pkg::DomainAonSel]
-        rst_slow_ni: rstmgr_aon_resets.rst_por_aon_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: por
+        rst_slow_ni: por_aon
       }
       domain: Aon
       attr: templated
@@ -2406,12 +2455,12 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_main_ni: rstmgr_aon_resets.rst_por_n[rstmgr_pkg::DomainAonSel]
-        rst_io_ni: rstmgr_aon_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]
-        rst_usb_ni: rstmgr_aon_resets.rst_por_usb_n[rstmgr_pkg::DomainAonSel]
-        rst_io_div2_ni: rstmgr_aon_resets.rst_por_io_div2_n[rstmgr_pkg::DomainAonSel]
-        rst_io_div4_ni: rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: por_io_div4
+        rst_main_ni: por
+        rst_io_ni: por_io
+        rst_usb_ni: por_usb
+        rst_io_div2_ni: por_io_div2
+        rst_io_div4_ni: por_io_div4
       }
       domain: Aon
       attr: templated
@@ -2631,8 +2680,8 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_aon_ni: rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
+        rst_aon_ni: sys_aon
       }
       domain: Aon
       clock_connections:
@@ -2698,8 +2747,8 @@
       clock_group: peri
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_slow_ni: rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
+        rst_slow_ni: sys_aon
       }
       clock_reset_export:
       [
@@ -2770,8 +2819,8 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_core_ni: rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
+        rst_core_ni: sys_aon
       }
       domain: Aon
       clock_connections:
@@ -2813,8 +2862,8 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_aon_ni: rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
+        rst_aon_ni: sys_aon
       }
       domain: Aon
       attr: templated
@@ -3066,8 +3115,8 @@
       clock_group: timers
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_aon_ni: rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
+        rst_aon_ni: sys_aon
       }
       domain: Aon
       attr: templated
@@ -3161,7 +3210,7 @@
       ]
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys_io_div4
       }
       attr: reggen_only
       clock_connections:
@@ -3203,7 +3252,7 @@
       ]
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
       }
       domain: Aon
       attr: reggen_top
@@ -3297,8 +3346,8 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
-        rst_otp_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
+        rst_otp_ni: lc_io_div4
       }
       domain: Aon
       param_decl:
@@ -3484,8 +3533,8 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]
-        rst_otp_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: lc
+        rst_otp_ni: lc_io_div4
       }
       base_addrs:
       {
@@ -3750,7 +3799,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: lc
       }
       base_addrs:
       {
@@ -3898,7 +3947,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       attr: templated
       clock_connections:
@@ -3977,8 +4026,8 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
+        rst_edn_ni: sys
       }
       param_decl:
       {
@@ -4180,7 +4229,7 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       clock_connections:
       {
@@ -4238,8 +4287,8 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
+        rst_edn_ni: sys
       }
       clock_connections:
       {
@@ -4362,8 +4411,8 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
+        rst_edn_ni: sys
       }
       clock_connections:
       {
@@ -4687,7 +4736,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       clock_connections:
       {
@@ -4822,7 +4871,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       clock_reset_export:
       [
@@ -4961,7 +5010,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       clock_reset_export:
       [
@@ -5040,7 +5089,7 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       clock_connections:
       {
@@ -5116,8 +5165,8 @@
       clock_group: secure
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_otp_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
+        rst_otp_ni: lc_io_div4
       }
       param_decl:
       {
@@ -5304,9 +5353,9 @@
       clock_group: trans
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_edn_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_otp_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
+        rst_edn_ni: sys
+        rst_otp_ni: lc_io_div4
       }
       clock_connections:
       {
@@ -5479,7 +5528,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       base_addrs:
       {
@@ -5664,8 +5713,8 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_esc_ni: rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
+        rst_esc_ni: lc_io_div4
       }
       clock_connections:
       {
@@ -6042,7 +6091,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: sys
       }
       type: ram_1p_scr
       base_addr: 0x10000000
@@ -6143,7 +6192,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::DomainAonSel]
+        rst_ni: sys_io_div4
       }
       domain: Aon
       type: ram_1p_scr
@@ -6244,7 +6293,7 @@
       clock_group: infra
       reset_connections:
       {
-        rst_ni: rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]
+        rst_ni: lc
       }
       type: eflash
       base_addr: 0x20000000
@@ -7091,8 +7140,8 @@
       reset: rst_main_ni
       reset_connections:
       {
-        rst_main_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-        rst_fixed_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_main_ni: sys
+        rst_fixed_ni: sys_io_div4
       }
       clock_connections:
       {
@@ -7878,7 +7927,7 @@
       reset: rst_peri_ni
       reset_connections:
       {
-        rst_peri_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+        rst_peri_ni: sys_io_div4
       }
       clock_connections:
       {
@@ -12982,28 +13031,6 @@
         sys
       ]
     }
-  }
-  reset_paths:
-  {
-    rst_ni: rst_ni
-    por_aon: rstmgr_aon_resets.rst_por_aon_n
-    por: rstmgr_aon_resets.rst_por_n
-    por_io: rstmgr_aon_resets.rst_por_io_n
-    por_io_div2: rstmgr_aon_resets.rst_por_io_div2_n
-    por_io_div4: rstmgr_aon_resets.rst_por_io_div4_n
-    por_usb: rstmgr_aon_resets.rst_por_usb_n
-    lc: rstmgr_aon_resets.rst_lc_n
-    lc_io_div4: rstmgr_aon_resets.rst_lc_io_div4_n
-    sys: rstmgr_aon_resets.rst_sys_n
-    sys_io_div4: rstmgr_aon_resets.rst_sys_io_div4_n
-    sys_aon: rstmgr_aon_resets.rst_sys_aon_n
-    spi_device: rstmgr_aon_resets.rst_spi_device_n
-    spi_host0: rstmgr_aon_resets.rst_spi_host0_n
-    spi_host1: rstmgr_aon_resets.rst_spi_host1_n
-    usb: rstmgr_aon_resets.rst_usb_n
-    i2c0: rstmgr_aon_resets.rst_i2c0_n
-    i2c1: rstmgr_aon_resets.rst_i2c1_n
-    i2c2: rstmgr_aon_resets.rst_i2c2_n
   }
   inter_signal:
   {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -141,26 +141,26 @@
     //
     nodes: [
       { name: "rst_ni",      gen: false, type: "ext",                                                          }
-      { name: "por_aon",     gen: false, type: "top", domains: ["Aon"     ],                    clk: "aon"     }
-      { name: "lc_src",      gen: false, type: "int", domains: ["Aon", "0"],                    clk: "io_div4" }
-      { name: "sys_src",     gen: false, type: "int", domains: ["Aon", "0"],                    clk: "io_div4" }
-      { name: "por",         gen: true,  type: "top", domains: ["Aon"     ], parent: "por_aon", clk: "main"    }
-      { name: "por_io",      gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io"      }
-      { name: "por_io_div2", gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io_div2" }
-      { name: "por_io_div4", gen: true , type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io_div4" }
-      { name: "por_usb",     gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "usb"     }
-      { name: "lc",          gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "main"    }
-      { name: "lc_io_div4",  gen: true,  type: "top", domains: ["Aon", "0"], parent: "lc_src",  clk: "io_div4" }
-      { name: "sys",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "main"    }
-      { name: "sys_io_div4", gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "io_div4" }
-      { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "aon"     }
-      { name: "spi_device",  gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "spi_host0",   gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io",      sw: 1 }
-      { name: "spi_host1",   gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "usb",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "usb",     sw: 1 }
-      { name: "i2c0",        gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 },
-      { name: "i2c1",        gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 },
-      { name: "i2c2",        gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 },
+      { name: "por_aon",     gen: false, type: "top",                    clk: "aon"     }
+      { name: "lc_src",      gen: false, type: "int",                    clk: "io_div4" }
+      { name: "sys_src",     gen: false, type: "int",                    clk: "io_div4" }
+      { name: "por",         gen: true,  type: "top", parent: "por_aon", clk: "main"    }
+      { name: "por_io",      gen: true,  type: "top", parent: "por_aon", clk: "io"      }
+      { name: "por_io_div2", gen: true,  type: "top", parent: "por_aon", clk: "io_div2" }
+      { name: "por_io_div4", gen: true , type: "top", parent: "por_aon", clk: "io_div4" }
+      { name: "por_usb",     gen: true,  type: "top", parent: "por_aon", clk: "usb"     }
+      { name: "lc",          gen: true,  type: "top", parent: "lc_src",  clk: "main"    }
+      { name: "lc_io_div4",  gen: true,  type: "top", parent: "lc_src",  clk: "io_div4" }
+      { name: "sys",         gen: true,  type: "top", parent: "sys_src", clk: "main"    }
+      { name: "sys_io_div4", gen: true,  type: "top", parent: "sys_src", clk: "io_div4" }
+      { name: "sys_aon",     gen: true,  type: "top", parent: "sys_src", clk: "aon"     }
+      { name: "spi_device",  gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true }
+      { name: "spi_host0",   gen: true,  type: "top", parent: "sys_src", clk: "io",      sw: true }
+      { name: "spi_host1",   gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true }
+      { name: "usb",         gen: true,  type: "top", parent: "sys_src", clk: "usb",     sw: true }
+      { name: "i2c0",        gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true },
+      { name: "i2c1",        gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true },
+      { name: "i2c2",        gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true },
     ]
   }
 

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -17,8 +17,8 @@
   reset: rst_main_ni
   reset_connections:
   {
-    rst_main_ni: rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]
-    rst_fixed_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+    rst_main_ni: sys
+    rst_fixed_ni: sys_io_div4
   }
   clock_connections:
   {

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -16,7 +16,7 @@
   reset: rst_peri_ni
   reset_connections:
   {
-    rst_peri_ni: rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]
+    rst_peri_ni: sys_io_div4
   }
   clock_connections:
   {

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -10,7 +10,7 @@ import hjson  # type: ignore
 
 from .alert import Alert
 from .bus_interfaces import BusInterfaces
-from .clocking import Clocking
+from .clocking import Clocking, ClockingItem
 from .inter_signal import InterSignal
 from .lib import (check_keys, check_name, check_int, check_bool,
                   check_list, check_optional_str)
@@ -348,3 +348,18 @@ class IpBlock:
         else:
             raise ValueError("Signal {} does not exist in IP block {}"
                              .format(name, self.name))
+
+    def has_shadowed_reg(self) -> bool:
+        '''Return boolean indication whether reg block contains shadowed registers'''
+
+        for rb in self.reg_blocks.values():
+            if rb.has_shadowed_reg():
+                return True
+
+        # if we are here, then no one has has a shadowed register
+        return False
+
+    def get_primary_clock(self) -> ClockingItem:
+        '''Return primary clock of an block'''
+
+        return self.clocking.primary

--- a/util/reggen/reg_block.py
+++ b/util/reggen/reg_block.py
@@ -419,3 +419,11 @@ class RegBlock:
     def get_addr_width(self) -> int:
         '''Calculate the number of bits to address every byte of the block'''
         return (self.offset - 1).bit_length()
+
+    def has_shadowed_reg(self) -> bool:
+        '''Return boolean indication whether reg block contains shadowed reigsters'''
+        for r in self.flat_regs:
+            if r.shadowed:
+                return True
+
+        return False

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -582,33 +582,19 @@ def generate_rstmgr(topcfg, out_path):
             outputs.append(rtl_path / Path(x))
 
     # Parameters needed for generation
-    clks = []
-    output_rsts = OrderedDict()
-    sw_rsts = OrderedDict()
-    leaf_rsts = OrderedDict()
+    reset_obj = topcfg['resets']
 
     # unique clocks
-    for rst in topcfg["resets"]["nodes"]:
-        if rst['type'] != "ext" and rst['clk'] not in clks:
-            clks.append(rst['clk'])
+    clks = reset_obj.get_clocks()
 
     # resets sent to reset struct
-    output_rsts = [
-        rst for rst in topcfg["resets"]["nodes"] if rst['type'] == "top"
-    ]
+    output_rsts = reset_obj.get_top_resets()
 
     # sw controlled resets
-    sw_rsts = [
-        rst for rst in topcfg["resets"]["nodes"]
-        if 'sw' in rst and rst['sw'] == 1
-    ]
+    sw_rsts = reset_obj.get_sw_resets()
 
     # leaf resets
-    leaf_rsts = [rst for rst in topcfg["resets"]["nodes"] if rst['gen']]
-
-    log.info("output resets {}".format(output_rsts))
-    log.info("software resets {}".format(sw_rsts))
-    log.info("leaf resets {}".format(leaf_rsts))
+    leaf_rsts = reset_obj.get_generated_resets()
 
     # Number of reset requests
     n_rstreqs = len(topcfg["reset_requests"])
@@ -625,7 +611,8 @@ def generate_rstmgr(topcfg, out_path):
                                  sw_rsts=sw_rsts,
                                  output_rsts=output_rsts,
                                  leaf_rsts=leaf_rsts,
-                                 export_rsts=topcfg['exported_rsts'])
+                                 export_rsts=topcfg['exported_rsts'],
+                                 reset_obj=topcfg['resets'])
 
             except:  # noqa: E722
                 log.error(exceptions.text_error_template().render())

--- a/util/topgen/c.py
+++ b/util/topgen/c.py
@@ -388,16 +388,13 @@ class TopGenC:
 
     # Enumerates the positions of all software controllable resets
     def _init_rstmgr_sw_rsts(self):
-        sw_rsts = [
-            rst for rst in self.top["resets"]["nodes"]
-            if 'sw' in rst and rst['sw'] == 1
-        ]
+        sw_rsts = self.top['resets'].get_sw_resets()
 
         enum = CEnum(self._top_name +
                      Name(["reset", "manager", "sw", "resets"]))
 
         for rst in sw_rsts:
-            enum.add_constant(Name.from_snake_case(rst["name"]))
+            enum.add_constant(Name.from_snake_case(rst))
 
         enum.add_last_constant("Last valid rstmgr software reset request")
 

--- a/util/topgen/clocks.py
+++ b/util/topgen/clocks.py
@@ -160,3 +160,10 @@ class Clocks:
                              f'{grp.name}: the given source name is '
                              f'{src_name}, which is unknown.')
         grp.add_clock(clk_name, src)
+
+    def get_clock_by_name(self, name: str) -> object:
+
+        ret = self.all_srcs.get(name)
+        if ret is None:
+            raise ValueError(f'{name} is not a valid clock')
+        return ret

--- a/util/topgen/resets.py
+++ b/util/topgen/resets.py
@@ -1,0 +1,182 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Optional
+from .clocks import Clocks
+
+
+class ResetItem:
+    '''Individual resets'''
+    def __init__(self, hier: Dict[str, str], raw: Dict[str, object], clocks: Clocks):
+        if not raw['name']:
+            raise ValueError('Reset has no name')
+
+        self.name = raw['name']
+        self.gen = raw.get('gen', True)
+        self.rst_type = raw.get('type', 'top')
+
+        self.path = ""
+        if self.rst_type == 'top':
+            self.path = f"{hier['top']}rst_{self.name}_n"
+        elif self.rst_type == 'ext':
+            self.path = f"{hier['ext']}{self.name}"
+
+        # to be constructed later
+        self.domains = []
+        self.shadowed = False
+
+        self.parent = raw.get('parent', "")
+
+        # This can be a source clock or a derived source
+        if self.rst_type != 'ext':
+            self.clock = clocks.get_clock_by_name(raw['clk'])
+        else:
+            self.clock = None
+
+        self.sw = bool(raw.get('sw', 0))
+
+    def _asdict(self) -> Dict[str, object]:
+        ret = {
+            'name': self.name,
+            'gen': self.gen,
+            'type': self.rst_type,
+            'domains': self.domains,
+            'shadowed': self.shadowed,
+            'sw': self.sw,
+            'path': self.path
+        }
+
+        if self.parent:
+            ret['parent'] = self.parent
+
+        if self.clock:
+            ret['clock'] = self.clock.name
+
+        return ret
+
+
+class Resets:
+    '''Resets for the chip'''
+    def __init__(self, raw: Dict[str, object], clocks: Clocks):
+        self.hier_paths = {}
+        assert isinstance(raw['hier_paths'], dict)
+        for rst_src, path in raw['hier_paths'].items():
+            self.hier_paths[str(rst_src)] = str(path)
+
+        assert isinstance(raw['nodes'], list)
+
+        self.nodes = {}
+        for node in raw['nodes']:
+            assert isinstance(node, dict)
+            reset = ResetItem(self.hier_paths, node, clocks)
+            self.nodes[reset.name] = reset
+
+    def _asdict(self) -> Dict[str, object]:
+        ret = {
+            'hier_paths': self.hier_paths,
+            'nodes': list(self.nodes.values())
+        }
+
+        return ret
+
+    def get_reset_by_name(self, name: str) -> ResetItem:
+
+        ret = self.nodes.get(name, None)
+        if ret:
+            return ret
+        else:
+            raise ValueError(f'{name} is not a defined reset')
+
+    def mark_reset_shadowed(self, name: str):
+        '''Mark particular reset as requiring shadow'''
+
+        reset = self.get_reset_by_name(name)
+        reset.shadowed = True
+
+    def get_reset_domains(self, name: str):
+        '''Get available domains for a reset'''
+
+        return self.get_reset_by_name(name).domains
+
+    def get_clocks(self) -> list:
+        '''Get associated clocks'''
+
+        clocks = {}
+        for reset in self.nodes.values():
+            if reset.rst_type != 'ext':
+                clocks[reset.clock.name] = 1
+
+        return clocks.keys()
+
+    def get_generated_resets(self) -> Dict[str, object]:
+        '''Get generated resets and return dict with
+           with related clock
+        '''
+
+        ret = []
+        for reset in self.nodes.values():
+            if reset.gen:
+                entry = {}
+                entry['name'] = reset.name
+                entry['clk'] = reset.clock.name
+                entry['parent'] = reset.parent
+                entry['sw'] = reset.sw
+                ret.append(entry)
+
+        return ret
+
+    def get_top_resets(self) -> list:
+        '''Get resets pushed to the top level'''
+
+        return [reset.name
+                for reset in self.nodes.values()
+                if reset.rst_type == 'top']
+
+    def get_sw_resets(self) -> list:
+        '''Get software controlled resets'''
+
+        return [reset.name
+                for reset in self.nodes.values()
+                if reset.sw]
+
+    def get_path(self, name: str, domain: Optional[str]) -> str:
+        '''Get path to reset'''
+
+        reset = self.get_reset_by_name(name)
+        if reset.rst_type == 'int':
+            raise ValueError(f'Reset {name} is not a reset exported from rstmgr')
+
+        if reset.rst_type == 'ext':
+            return reset.path
+
+        # if a generated reset
+        if domain:
+            return f'{reset.path}[rstmgr_pkg::Domain{domain}Sel]'
+        else:
+            return reset.path
+
+    def get_unused_resets(self, domains: list) -> Dict[str, str]:
+        '''Get unused resets'''
+
+        top_resets = [reset
+                      for reset in self.nodes.values()
+                      if reset.rst_type == 'top']
+
+        ret = {}
+        for reset in top_resets:
+            for dom in domains:
+                if dom not in reset.domains:
+                    ret[reset.name] = dom
+
+        return ret
+
+    def add_reset_domain(self, name: str, domain: str):
+        '''Mark particular reset as requiring shadow'''
+
+        reset = self.get_reset_by_name(name)
+
+        # Other reset types of hardwired domains
+        if reset.rst_type == 'top':
+            if domain not in reset.domains:
+                reset.domains.append(domain)

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -63,12 +63,7 @@ max_sigwidth = max([x["width"] if "width" in x else 1 for x in top["pinmux"]["io
 max_sigwidth = len("{}".format(max_sigwidth))
 
 cpu_clk = top['clocks'].hier_paths['top'] + "clk_proc_main"
-cpu_rst = top["reset_paths"]["sys"]
-dm_rst = top["reset_paths"]["lc"]
-esc_clk = top['clocks'].hier_paths['top'] + "clk_io_div4_timers"
-esc_rst = top["reset_paths"]["sys_io_div4"]
 
-unused_resets = lib.get_unused_resets(top)
 unused_im_defs, undriven_im_defs = lib.get_dangling_im_def(top["inter_signal"]["definitions"])
 
 %>\

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -26,10 +26,6 @@ max_sigwidth = max([x["width"] if "width" in x else 1 for x in top["pinmux"]["io
 max_sigwidth = len("{}".format(max_sigwidth))
 
 cpu_clk = top['clocks'].hier_paths['top'] + "clk_proc_main"
-cpu_rst = top["reset_paths"]["sys"]
-dm_rst = top["reset_paths"]["lc"]
-esc_clk = top['clocks'].hier_paths['top'] + "clk_io_div4_timers"
-esc_rst = top["reset_paths"]["sys_io_div4"]
 
 unused_resets = lib.get_unused_resets(top)
 unused_im_defs, undriven_im_defs = lib.get_dangling_im_def(top["inter_signal"]["definitions"])
@@ -268,7 +264,7 @@ module top_${top["name"]} #(
   logic unused_d${v.lower()}_rst_${k};
 % endfor
 % for k, v in unused_resets.items():
-  assign unused_d${v.lower()}_rst_${k} = ${lib.get_reset_path(k, v, top['resets'])};
+  assign unused_d${v.lower()}_rst_${k} = ${lib.get_reset_path(k, v, top)};
 % endfor
 
   // ibex specific assignments
@@ -335,8 +331,8 @@ module top_${top["name"]} #(
     % for key in clocks:
     .${key}   (${clocks[key]}),
     % endfor
-    % for key, value in resets.items():
-    .${key}   (${value}),
+    % for port, reset in resets.items():
+    .${port}   (${lib.get_reset_path(reset, m['domain'], top)}),
     % endfor
     .tl_i        (${m["name"]}_tl_req),
     .tl_o        (${m["name"]}_tl_rsp),
@@ -370,8 +366,8 @@ mem_name = lib.Name(mem_name[1:])
     % for key in clocks:
     .${key}   (${clocks[key]}),
     % endfor
-    % for key, value in resets.items():
-    .${key}   (${value}),
+    % for port, reset in resets.items():
+    .${port}   (${lib.get_reset_path(reset, m['domain'], top)}),
     % endfor
 
     .key_valid_i (${m["inter_signal_list"][1]["top_signame"]}_req.valid),
@@ -425,8 +421,8 @@ mem_name = lib.Name(mem_name[1:])
     % for key in clocks:
     .${key}   (${clocks[key]}),
     % endfor
-    % for key, value in resets.items():
-    .${key}   (${value}),
+    % for port, reset in resets.items():
+    .${port}   (${lib.get_reset_path(reset, m['domain'], top)}),
     % endfor
 
     .tl_i        (${m["name"]}_tl_req),
@@ -453,8 +449,8 @@ mem_name = lib.Name(mem_name[1:])
     % for key in clocks:
     .${key}   (${clocks[key]}),
     % endfor
-    % for key, value in resets.items():
-    .${key}   (${value}),
+    % for port, reset in resets.items():
+    .${port}   (${lib.get_reset_path(reset, m['domain'], top)}),
     % endfor
     .req_i    (${m["name"]}_req),
     .addr_i   (${m["name"]}_addr),
@@ -488,8 +484,8 @@ mem_name = lib.Name(mem_name[1:])
     % for key in clocks:
     .${key}   (${clocks[key]}),
     % endfor
-    % for key, value in resets.items():
-    .${key}   (${value}),
+    % for port, reset in resets.items():
+    .${port}   (${lib.get_reset_path(reset, m['domain'], top)}),
     % endfor
 
     .tl_i        (${m["name"]}_tl_req),
@@ -512,8 +508,8 @@ mem_name = lib.Name(mem_name[1:])
     % for key in clocks:
     .${key}   (${clocks[key]}),
     % endfor
-    % for key, value in resets.items():
-    .${key}   (${value}),
+    % for port, reset in resets.items():
+    .${port}   (${lib.get_reset_path(reset, m['domain'], top)}),
     % endfor
     .host_req_i        (flash_host_req),
     .host_intg_err_i   (flash_host_intg_err),
@@ -664,8 +660,8 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
     % for k, v in m["clock_connections"].items():
       .${k} (${v}),
     % endfor
-    % for k, v in m["reset_connections"].items():
-      .${k} (${v})${"," if not loop.last else ""}
+    % for port, reset in m["reset_connections"].items():
+      .${port} (${lib.get_reset_path(reset, m['domain'], top)})${"," if not loop.last else ""}
     % endfor
   );
 
@@ -689,8 +685,8 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
   % for k, v in xbar["clock_connections"].items():
     .${k} (${v}),
   % endfor
-  % for k, v in xbar["reset_connections"].items():
-    .${k} (${v}),
+  % for port, reset in xbar["reset_connections"].items():
+    .${port} (${lib.get_reset_path(reset, xbar["domain"], top)}),
   % endfor
 
   ## Inter-module signal

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -752,21 +752,6 @@ def check_power_domains(top):
         error += 1
         return error
 
-    # check that power domain definition is consistent with reset and module definition
-    for reset in top['resets']['nodes']:
-        if reset['gen']:
-            if 'domains' not in reset:
-                log.error("{} missing domain definition".format(reset['name']))
-                error += 1
-                return error
-            else:
-                for domain in reset['domains']:
-                    if domain not in top['power']['domains']:
-                        log.error("{} defined invalid domain {}".format(
-                            reset['name'], domain))
-                        error += 1
-                        return error
-
     # Check that each module, xbar, memory has a power domain defined.
     # If not, give it a default.
     # If there is one defined, check that it is a valid definition


### PR DESCRIPTION
- This cleans up the python files behind rstmgr a bit
  and makes them into a class (following clk examples)

- Add some plumbing for resets to self determine domains
  and need for shadow resets.  This will remove the need
  for correct accounting in the hjson