### PR TITLE
[flah_ctrl/dv] Creating type for data bus + adding function for expected calculation.

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -95,6 +95,9 @@ package flash_ctrl_env_pkg;
     bit [TL_AW-1:0] addr;       // starting addr for the op
   } flash_op_t;
 
+  // Data queue for flash transactions
+  typedef logic [TL_DW-1:0] data_q_t[$];
+
   // functions
 
   // package sources

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -184,7 +184,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Program data into flash, stopping whenever full.
   // The flash op is assumed to have already commenced.
-  virtual task flash_ctrl_write(bit [TL_DW-1:0] data[$], bit poll_fifo_status);
+  virtual task flash_ctrl_write(data_q_t data, bit poll_fifo_status);
     foreach (data[i]) begin
       // Check if prog fifo is full. If yes, then wait for space to become available.
       // Note that this polling is not needed since the interface is backpressure enabled.
@@ -198,7 +198,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Read data from flash, stopping whenever empty.
   // The flash op is assumed to have already commenced.
-  virtual task flash_ctrl_read(uint num_words, ref bit [TL_DW-1:0] data[$], bit poll_fifo_status);
+  virtual task flash_ctrl_read(uint num_words, ref data_q_t data, bit poll_fifo_status);
     for (int i = 0; i < num_words; i++) begin
       // Check if rd fifo is empty. If yes, then wait for data to become available.
       // Note that this polling is not needed since the interface is backpressure enabled.


### PR DESCRIPTION
Hi,
This PR additions:
* Defining new type in **flash_ctrl_env_pkg** which is data bus queue.
* Adding another function added for program transactions to enable expected data calculation, when the expected is not simply the input data. In the OS this function isn't doing anything for now, but in the partner env it's already required. Relevant mainly when skipping **prep_mem** task (see PR #7274).
  This function's creation is specifically requiring the above type definition.

Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>