### PR TITLE
[csrng/rtl] fix for app command arbiter

### DIFF
--- a/hw/ip/csrng/lint/csrng.waiver
+++ b/hw/ip/csrng/lint/csrng.waiver
@@ -4,3 +4,6 @@
 #
 # waiver file for csrng
 
+waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_arbiter_ppc.sv} -regexp {.*has word width which is single bit wide.*} \
+      -comment "Usage case specific to CSRNG and how the arbiter is used."
+

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -185,36 +185,41 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   //---------------------------------------------------------
   // state machine to process command
   //---------------------------------------------------------
-
 // Encoding generated with:
-// $ ./util/design/sparse-fsm-encode.py -d 3 -m 7 -n 6 \
-//      -s 2519129599 --language=sv
+// $ ./util/design/sparse-fsm-encode.py -d 3 -m 10 -n 8 \
+//      -s 170131814 --language=sv
 //
 // Hamming distance histogram:
 //
 //  0: --
 //  1: --
 //  2: --
-//  3: |||||||||||||||||||| (57.14%)
-//  4: ||||||||||||||| (42.86%)
-//  5: --
-//  6: --
+//  3: |||||||||||||||| (28.89%)
+//  4: |||||||||||||||||||| (35.56%)
+//  5: |||||||||||| (22.22%)
+//  6: ||||| (8.89%)
+//  7: | (2.22%)
+//  8: | (2.22%)
 //
 // Minimum Hamming distance: 3
-// Maximum Hamming distance: 4
+// Maximum Hamming distance: 8
 // Minimum Hamming weight: 1
-// Maximum Hamming weight: 5
+// Maximum Hamming weight: 7
 //
 
-  localparam int StateWidth = 6;
+// Encoding generated with:
+  localparam int StateWidth = 8;
   typedef    enum logic [StateWidth-1:0] {
-    Idle      = 6'b001010, // idle
-    SendSOP   = 6'b000111, // send sop (start of packet)
-    SendMOP   = 6'b010000, // send mop (middle of packet)
-    GenCmdChk = 6'b011101, // gen cmd check
-    CmdAck    = 6'b111011, // wait for command ack
-    GenReq    = 6'b110110, // process gen requests
-    Error     = 6'b101100  // illegal state reached and hang
+    Idle      = 8'b00011011, // idle
+    ArbGnt    = 8'b11110101, // general arbiter request
+    SendSOP   = 8'b00011100, // send sop (start of packet)
+    SendMOP   = 8'b00000001, // send mop (middle of packet)
+    GenCmdChk = 8'b01010110, // gen cmd check
+    CmdAck    = 8'b10001101, // wait for command ack
+    GenReq    = 8'b11000000, // process gen requests
+    GenArbGnt = 8'b11111110, // generate subsequent arb request
+    GenSOP    = 8'b10110010, // generate subsequent request
+    Error     = 8'b10111001  // illegal state reached and hang
   } state_e;
 
   state_e state_d, state_q;
@@ -252,28 +257,30 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     unique case (state_q)
       Idle: begin
         if (!cmd_fifo_zero) begin
+          state_d = ArbGnt;
+        end
+      end
+      ArbGnt: begin
+        cmd_arb_req_o = 1'b1;
+        if (cmd_arb_gnt_i) begin
           state_d = SendSOP;
         end
       end
       SendSOP: begin
-        cmd_arb_req_o = 1'b1;
-        if (cmd_arb_gnt_i) begin
-          cmd_gen_1st_req = 1'b1;
-          cmd_arb_sop_o = 1'b1;
-          cmd_fifo_pop = 1'b1;
-          if (sfifo_cmd_rdata[30:12] == GenBitsCntrWidth'(1)) begin
-            cmd_gen_cnt_last = 1'b1;
-          end
-          if (cmd_len == '0) begin
-            cmd_arb_eop_o = 1'b1;
-            state_d = GenCmdChk;
-          end else begin
-            state_d = SendMOP;
-          end
+        cmd_gen_1st_req = 1'b1;
+        cmd_arb_sop_o = 1'b1;
+        cmd_fifo_pop = 1'b1;
+        if (sfifo_cmd_rdata[30:12] == GenBitsCntrWidth'(1)) begin
+          cmd_gen_cnt_last = 1'b1;
+        end
+        if (cmd_len == '0) begin
+          cmd_arb_eop_o = 1'b1;
+          state_d = GenCmdChk;
+        end else begin
+          state_d = SendMOP;
         end
       end
       SendMOP: begin
-        cmd_arb_req_o = 1'b1;
         if (!cmd_fifo_zero) begin
           cmd_fifo_pop = 1'b1;
           cmd_len_dec = 1'b1;
@@ -307,23 +314,29 @@ module csrng_cmd_stage import csrng_pkg::*; #(
               state_d = Idle;
             end else begin
               // issue a subsequent gen request
-              cmd_arb_req_o = 1'b1;
-              if (cmd_arb_gnt_i) begin
-                cmd_arb_sop_o = 1'b1;
-                cmd_arb_eop_o = 1'b1;
-                cmd_gen_inc_req = 1'b1;
-                state_d = GenCmdChk;
-                // check for final genbits beat
-                if (cmd_gen_cnt_q == GenBitsCntrWidth'(1)) begin
-                  cmd_gen_cnt_last = 1'b1;
-                end
-              end
+              state_d = GenArbGnt;
             end
           end
         end else begin
           // ack for the non-gen request case
           cmd_final_ack = 1'b1;
           state_d = Idle;
+        end
+      end
+      GenArbGnt: begin
+        cmd_arb_req_o = 1'b1;
+        if (cmd_arb_gnt_i) begin
+          state_d = GenSOP;
+        end
+      end
+      GenSOP: begin
+        cmd_arb_sop_o = 1'b1;
+        cmd_arb_eop_o = 1'b1;
+        cmd_gen_inc_req = 1'b1;
+        state_d = GenCmdChk;
+        // check for final genbits beat
+        if (cmd_gen_cnt_q == GenBitsCntrWidth'(1)) begin
+          cmd_gen_cnt_last = 1'b1;
         end
       end
       Error: begin

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -277,6 +277,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [NApps-1:0]       cmd_stage_rdy;
   logic [NApps-1:0]       cmd_arb_req;
   logic [NApps-1:0]       cmd_arb_gnt;
+  logic [$clog2(NApps)-1:0] cmd_arb_idx;
   logic [NApps-1:0]       cmd_arb_sop;
   logic [NApps-1:0]       cmd_arb_mop;
   logic [NApps-1:0]       cmd_arb_eop;
@@ -322,6 +323,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [3:0]  shid_q, shid_d;
   logic        gen_last_q, gen_last_d;
   logic        flag0_q, flag0_d;
+  logic [$clog2(NApps)-1:0] cmd_arb_idx_q, cmd_arb_idx_d;
   logic        statedb_wr_select_q, statedb_wr_select_d;
   logic        genbits_stage_fips_sw_q, genbits_stage_fips_sw_d;
   logic        cmd_req_dly_q, cmd_req_dly_d;
@@ -337,6 +339,7 @@ module csrng_core import csrng_pkg::*; #(
       shid_q  <= '0;
       gen_last_q <= '0;
       flag0_q <= '0;
+      cmd_arb_idx_q <= '0;
       statedb_wr_select_q <= '0;
       genbits_stage_fips_sw_q <= '0;
       cmd_req_dly_q <= '0;
@@ -350,6 +353,7 @@ module csrng_core import csrng_pkg::*; #(
       shid_q  <= shid_d;
       gen_last_q <= gen_last_d;
       flag0_q <= flag0_d;
+      cmd_arb_idx_q <= cmd_arb_idx_d;
       statedb_wr_select_q <= statedb_wr_select_d;
       genbits_stage_fips_sw_q <= genbits_stage_fips_sw_d;
       cmd_req_dly_q <= cmd_req_dly_d;
@@ -786,25 +790,27 @@ module csrng_core import csrng_pkg::*; #(
   // and processed by the main state machine
   // logic block.
 
+  assign cmd_arb_idx_d = (acmd_avail && acmd_accept) ? cmd_arb_idx : cmd_arb_idx_q;
 
-  // create control bus for commands
-  assign acmd_sop = (|cmd_arb_sop);
-  assign acmd_mop = (|cmd_arb_mop);
-  assign acmd_eop = (|cmd_arb_eop);
+  assign acmd_sop = cmd_arb_sop[cmd_arb_idx_q];
+  assign acmd_mop = cmd_arb_mop[cmd_arb_idx_q];
+  assign acmd_eop = cmd_arb_eop[cmd_arb_idx_q];
+  assign acmd_bus = cmd_arb_bus[cmd_arb_idx_q];
 
   prim_arbiter_ppc #(
+    .EnDataPort(0),    // Ignore data port
     .N(NApps),  // Number of request ports
-    .DW(AppCmdWidth) // Data width
+    .DW(1) // Data width
   ) u_prim_arbiter_ppc_acmd (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
     .req_chk_i(1'b1),
     .req_i(cmd_arb_req),
-    .data_i(cmd_arb_bus),
+    .data_i('{default: 1'b0}),
     .gnt_o(cmd_arb_gnt),
-    .idx_o(), // NC
+    .idx_o(cmd_arb_idx),
     .valid_o(acmd_avail), // 1 req
-    .data_o(acmd_bus), // info with req
+    .data_o(), //NC
     .ready_i(acmd_accept) // 1 fsm rdy
   );
 

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -28,42 +28,42 @@ module csrng_main_sm import csrng_pkg::*; (
   input logic                cmd_complete_i,
   output logic               main_sm_err_o
 );
-
 // Encoding generated with:
-// $ ./util/design/sparse-fsm-encode.py -d 3 -m 11 -n 8 \
-//      -s 610129199 --language=sv
+// $ ./util/design/sparse-fsm-encode.py -d 3 -m 12 -n 8 \
+//      -s 2565810189 --language=sv
 //
 // Hamming distance histogram:
 //
 //  0: --
 //  1: --
 //  2: --
-//  3: |||||||||||||||||| (32.73%)
-//  4: |||||||||||||||||||| (36.36%)
-//  5: |||||||| (14.55%)
-//  6: ||||| (9.09%)
-//  7: |||| (7.27%)
+//  3: |||||||||||||||| (30.30%)
+//  4: |||||||||||||||||||| (37.88%)
+//  5: ||||||||| (18.18%)
+//  6: |||| (9.09%)
+//  7: || (4.55%)
 //  8: --
 //
 // Minimum Hamming distance: 3
 // Maximum Hamming distance: 7
-// Minimum Hamming weight: 3
+// Minimum Hamming weight: 2
 // Maximum Hamming weight: 6
 //
 
   localparam int StateWidth = 8;
   typedef    enum logic [StateWidth-1:0] {
-    Idle    =      8'b01110011, // idle
-    InstantPrep  = 8'b11010010, // instantiate prep
-    InstantReq   = 8'b01010100, // instantiate request (takes adata or entropy)
-    ReseedPrep   = 8'b10101111, // reseed prep
-    ReseedReq    = 8'b00101010, // reseed request (takes adata and entropy and Key,V,RC)
-    GenerateReq  = 8'b00100101, // generate request (takes adata? and Key,V,RC)
-    UpdatePrep   = 8'b11001011, // update prep
-    UpdateReq    = 8'b00010111, // update request (takes adata and Key,V,RC)
-    UninstantReq = 8'b10000110, // uninstantiate request (no input)
-    CmdCompWait  = 8'b10011100, // wait for command to complete
-    Error        = 8'b11000101  // error state, results in fatal alert
+    Idle         = 8'b01010011, // idle
+    ParseCmd     = 8'b01001100, // parse the cmd
+    InstantPrep  = 8'b00101010, // instantiate prep
+    InstantReq   = 8'b11011101, // instantiate request (takes adata or entropy)
+    ReseedPrep   = 8'b10110111, // reseed prep
+    ReseedReq    = 8'b11001011, // reseed request (takes adata and entropy and Key,V,RC)
+    GenerateReq  = 8'b10011110, // generate request (takes adata? and Key,V,RC)
+    UpdatePrep   = 8'b10101001, // update prep
+    UpdateReq    = 8'b00011001, // update request (takes adata and Key,V,RC)
+    UninstantReq = 8'b00000111, // uninstantiate request (no input)
+    CmdCompWait  = 8'b00010100, // wait for command to complete
+    Error        = 8'b11110001  // error state, results in fatal alert
   } state_e;
 
   state_e state_d, state_q;
@@ -99,30 +99,38 @@ module csrng_main_sm import csrng_pkg::*; (
       Idle: begin
         if (enable_i) begin
           if (ctr_drbg_cmd_req_rdy_i) begin
+            // signal the arbiter to grant this request
             if (acmd_avail_i) begin
               acmd_accept_o = 1'b1;
-              if (acmd_i == INS) begin
-                if (acmd_eop_i) begin
-                  acmd_hdr_capt_o = 1'b1;
-                  state_d = InstantPrep;
-                end
-              end else if (acmd_i == RES) begin
-                if (acmd_eop_i) begin
-                  acmd_hdr_capt_o = 1'b1;
-                  state_d = ReseedPrep;
-                end
-              end else if (acmd_i == GEN) begin
+              state_d = ParseCmd;
+            end
+          end
+        end
+      end
+      ParseCmd: begin
+        if (enable_i) begin
+          if (ctr_drbg_cmd_req_rdy_i) begin
+            if (acmd_i == INS) begin
+              if (acmd_eop_i) begin
                 acmd_hdr_capt_o = 1'b1;
-                state_d = GenerateReq;
-              end else if (acmd_i == UPD) begin
-                if (acmd_eop_i) begin
-                  acmd_hdr_capt_o = 1'b1;
-                  state_d = UpdatePrep;
-                end
-              end else if (acmd_i == UNI) begin
-                acmd_hdr_capt_o = 1'b1;
-                state_d = UninstantReq;
+                state_d = InstantPrep;
               end
+            end else if (acmd_i == RES) begin
+              if (acmd_eop_i) begin
+                acmd_hdr_capt_o = 1'b1;
+                state_d = ReseedPrep;
+              end
+            end else if (acmd_i == GEN) begin
+              acmd_hdr_capt_o = 1'b1;
+              state_d = GenerateReq;
+            end else if (acmd_i == UPD) begin
+              if (acmd_eop_i) begin
+                acmd_hdr_capt_o = 1'b1;
+                state_d = UpdatePrep;
+              end
+            end else if (acmd_i == UNI) begin
+              acmd_hdr_capt_o = 1'b1;
+              state_d = UninstantReq;
             end
           end
         end


### PR DESCRIPTION
Application commands use a common arbiter which only supports one cycle of transfer natively.
Added support logic to allow a stream of data per arbitration resolution.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>