### PR TITLE
[otbn] P256: Don't overlap blinding `rnd` with output `x1`

### DIFF
--- a/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
+++ b/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
@@ -53,7 +53,7 @@ OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, p256_ecdsa_sign);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, p256_ecdsa_verify);
 
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_k);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_rnd);
+OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_x1);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_msg);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_r);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_s);
@@ -62,7 +62,7 @@ OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_y);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_d);
 
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, k);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, rnd);
+OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, x1);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, msg);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, r);
 OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, s);
@@ -77,7 +77,7 @@ static const otbn_ptr_t kOtbnAppP256EcdsaFuncVerify =
     OTBN_PTR_T_INIT(p256_ecdsa, p256_ecdsa_verify);
 
 static const otbn_ptr_t kOtbnVarDptrK = OTBN_PTR_T_INIT(p256_ecdsa, dptr_k);
-static const otbn_ptr_t kOtbnVarDptrRnd = OTBN_PTR_T_INIT(p256_ecdsa, dptr_rnd);
+static const otbn_ptr_t kOtbnVarDptrX1 = OTBN_PTR_T_INIT(p256_ecdsa, dptr_x1);
 static const otbn_ptr_t kOtbnVarDptrMsg = OTBN_PTR_T_INIT(p256_ecdsa, dptr_msg);
 static const otbn_ptr_t kOtbnVarDptrR = OTBN_PTR_T_INIT(p256_ecdsa, dptr_r);
 static const otbn_ptr_t kOtbnVarDptrS = OTBN_PTR_T_INIT(p256_ecdsa, dptr_s);
@@ -86,7 +86,7 @@ static const otbn_ptr_t kOtbnVarDptrY = OTBN_PTR_T_INIT(p256_ecdsa, dptr_y);
 static const otbn_ptr_t kOtbnVarDptrD = OTBN_PTR_T_INIT(p256_ecdsa, dptr_d);
 
 static const otbn_ptr_t kOtbnVarK = OTBN_PTR_T_INIT(p256_ecdsa, k);
-static const otbn_ptr_t kOtbnVarRnd = OTBN_PTR_T_INIT(p256_ecdsa, rnd);
+static const otbn_ptr_t kOtbnVarX1 = OTBN_PTR_T_INIT(p256_ecdsa, x1);
 static const otbn_ptr_t kOtbnVarMsg = OTBN_PTR_T_INIT(p256_ecdsa, msg);
 static const otbn_ptr_t kOtbnVarR = OTBN_PTR_T_INIT(p256_ecdsa, r);
 static const otbn_ptr_t kOtbnVarS = OTBN_PTR_T_INIT(p256_ecdsa, s);
@@ -164,7 +164,7 @@ static void setup_data_pointer(otbn_t *otbn_ctx, const otbn_ptr_t dptr,
  */
 static void setup_data_pointers(otbn_t *otbn_ctx) {
   setup_data_pointer(otbn_ctx, kOtbnVarDptrK, kOtbnVarK);
-  setup_data_pointer(otbn_ctx, kOtbnVarDptrRnd, kOtbnVarRnd);
+  setup_data_pointer(otbn_ctx, kOtbnVarDptrX1, kOtbnVarX1);
   setup_data_pointer(otbn_ctx, kOtbnVarDptrMsg, kOtbnVarMsg);
   setup_data_pointer(otbn_ctx, kOtbnVarDptrR, kOtbnVarR);
   setup_data_pointer(otbn_ctx, kOtbnVarDptrS, kOtbnVarS);
@@ -253,7 +253,7 @@ static void p256_ecdsa_verify(otbn_t *otbn_ctx, const uint8_t *msg,
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
 
   // Read back results.
-  CHECK(otbn_copy_data_from_otbn(otbn_ctx, /*len_bytes=*/32, kOtbnVarRnd,
+  CHECK(otbn_copy_data_from_otbn(otbn_ctx, /*len_bytes=*/32, kOtbnVarX1,
                                  signature_r_out) == kOtbnOk);
 }
 

--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -1107,8 +1107,6 @@ scalar_mult_int:
  * This routine runs in constant time.
  *
  * @param[in]  dmem[0]: dptr_k, pointer to a 256 bit random secret in dmem
- * @param[in]  dmem[4]: dptr_rnd, pointer to location in dmem containing random
- *                                number for blinding
  * @param[in]  dmem[8]: dptr_msg, pointer to the message to be signed in dmem
  * @param[in]  dmem[12]: dptr_r, pointer to dmem location where s component
  *                               of signature will be placed
@@ -1130,11 +1128,6 @@ p256_sign:
   /* load dmem pointer to secret random scalar k: x16 <= dptr_k = dmem[0] */
   la        x16, dptr_k
   lw        x16, 0(x16)
-
-  /* load dmem pointer to random number for blinding rnd in dmem:
-     x17 <= dptr_rnd = dmem[4] */
-  la        x17, dptr_rnd
-  lw        x17, 0(x17)
 
   /* load dmem pointer to message msg in dmem: x18 <= dptr_msg = dmem[8] */
   la        x18, dptr_msg
@@ -1228,8 +1221,6 @@ p256_sign:
  * P-256.
  * This routine runs in constant time.
  *
- * @param[in]  dmem[4]: dptr_rnd, pointer to location in dmem containing random
- *                      number for blinding
  * @param[in]  dmem[20]: dptr_x, pointer to affine x-coordinate in dmem
  * @param[in]  dmem[22]: dptr_y, pointer to affine y-coordinate in dmem
  * @param[in]  dmem[28]: dptr_d, pointer to location in dmem containing
@@ -1237,7 +1228,7 @@ p256_sign:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2, x3, x16, x17, x21, x22, w0 to w26
+ * clobbered registers: x2, x3, x16, x21, x22, w0 to w26
  * clobbered flag groups: FG0
  */
 p256_base_mult:
@@ -1249,11 +1240,6 @@ p256_base_mult:
   la        x16, dptr_d
   lw        x16, 0(x16)
   bn.lid    x0, 0(x16)
-
-  /* load dmem pointer to random number for blinding rnd in dmem:
-     x17 <= dptr_rnd = dmem[4] */
-  la        x17, dptr_rnd
-  lw        x17, 0(x17)
 
   /* set dmem pointers to base point coordinates */
   la        x21, p256_gx
@@ -1457,8 +1443,8 @@ p256_verify:
   la        x3, p256_b
   bn.lid    x2, 0(x3)
 
-  /* load dmem pointer to x1 (result) from dmem: x17 <= dptr_rnd = dmem[4] */
-  la        x17, dptr_rnd
+  /* load dmem pointer to x1 (result) from dmem: x17 <= dptr_x1 = dmem[4] */
+  la        x17, dptr_x1
   lw        x17, 0(x17)
 
   /* load dmem pointer to message msg in dmem: x18 <= dptr_msg = dmem[8] */
@@ -1685,16 +1671,14 @@ p256_verify:
  * Sets up context and calls internal scalar multiplication routine.
  * This routine runs in constant time.
  *
- * @param[in]  dmem[0]: dK, pointer to location in dmem containing scalar k
- * @param[in]  dmem[4]: dRnd, pointer to location in dmem containing random
- *                        number for blinding
+ * @param[in]  dmem[0]: dptr_k, pointer to location in dmem containing scalar k
  * @param[in]  dmem[20]: dptr_x, pointer to affine x-coordinate in dmem
  * @param[in]  dmem[22]: dptr_y, pointer to affine y-coordinate in dmem
  *
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x16, x17, x21, x22, w0 to w25
+ * clobbered registers: x2, x3, x16, x21, x22, w0 to w25
  * clobbered flag groups: FG0
  */
 p256_scalar_mult:
@@ -1706,11 +1690,6 @@ p256_scalar_mult:
   la        x16, dptr_k
   lw        x16, 0(x16)
   bn.lid    x0, 0(x16)
-
-  /* load dmem pointer to random number for blinding rnd in dmem:
-     x17 <= dptr_rnd = dmem[4] */
-  la        x17, dptr_rnd
-  lw        x17, 0(x17)
 
   /* set dmem pointer to point x-coordinate */
   la        x21, dptr_x
@@ -1742,9 +1721,9 @@ p256_scalar_mult:
 dptr_k:
   .zero 4
 
-/* pointer to rnd (dptr_rnd) */
-.globl dptr_rnd
-dptr_rnd:
+/* pointer to x1 (dptr_x1) (the output of the verify operation) */
+.globl dptr_x1
+dptr_x1:
   .zero 4
 
 /* pointer to msg (dptr_msg) */

--- a/sw/otbn/code-snippets/p256_base_mult_test.s
+++ b/sw/otbn/code-snippets/p256_base_mult_test.s
@@ -21,11 +21,6 @@ p256_base_mult_test:
   la       x3, dptr_d
   sw       x2, 0(x3)
 
-  /* set dmem pointer to point to blinding parameter */
-  la       x2, blinding_param
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
-
   /* set dmem pointer to point to x-coordinate */
   la       x2, p1_x
   la       x3, dptr_x
@@ -61,17 +56,6 @@ scalar:
   .word 0xe5f2cbee
   .word 0x9144233d
   .word 0xc0fbe256
-
-   /* blinding parameter rnd */
- blinding_param:
-  .word 0x7ab203c3
-  .word 0xd6ee4951
-  .word 0xd5b89b43
-  .word 0x409d2b56
-  .word 0x8e9d2186
-  .word 0x1de0f8ec
-  .word 0x0fa0bf9a
-  .word 0xa21c2147
 
 /* result buffer x-coordinate */
 p1_x:

--- a/sw/otbn/code-snippets/p256_ecdsa.s
+++ b/sw/otbn/code-snippets/p256_ecdsa.s
@@ -32,9 +32,10 @@ p256_ecdsa_verify:
 k:
   .zero 32
 
-.globl rnd
+/* result of the verification x1 */
+.globl x1
 .balign 32
-rnd:
+x1:
   .zero 32
 
 /* message digest */

--- a/sw/otbn/code-snippets/p256_ecdsa_sign_test.s
+++ b/sw/otbn/code-snippets/p256_ecdsa_sign_test.s
@@ -24,11 +24,6 @@ ecdsa_sign_test:
   la       x3, dptr_k
   sw       x2, 0(x3)
 
-  /* set dmem pointer to point to blinding parameter */
-  la       x2, blinding_param
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
-
   /* set dmem pointer to point to message */
   la       x2, msg
   la       x3, dptr_msg

--- a/sw/otbn/code-snippets/p256_ecdsa_verify_test.s
+++ b/sw/otbn/code-snippets/p256_ecdsa_verify_test.s
@@ -9,7 +9,7 @@
  * Coordinates of the public key, the message digest and R and S of the
  * signature are provided in the .data section below.
  *
- * Signature verification was successful, if the return values in the rnd and R
+ * Signature verification was successful, if the return values in the x1 and R
  * location are identical. The return values are copied to wide registers. See
  * comment at the end of the file for expected values for this example.
  */
@@ -41,7 +41,7 @@ ecdsa_verify_test:
 
   /* set dmem pointer to point to signature verifcation result */
   la       x2, sig_xres
-  la       x3, dptr_rnd
+  la       x3, dptr_x1
   sw       x2, 0(x3)
 
   /* call ECDSA signature verification subroutine in P-256 lib */
@@ -115,6 +115,6 @@ pub_y:
 sig_xres:
   .zero 32
 
-/* Expected values wide register file (w0=rnd, w1=R):
+/* Expected values wide register file (w0=x1, w1=R):
 w0 = 0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a
 */

--- a/sw/otbn/code-snippets/p256_scalar_mult_test.s
+++ b/sw/otbn/code-snippets/p256_scalar_mult_test.s
@@ -32,11 +32,6 @@ scalar_mult_test:
   la       x3, dptr_k
   sw       x2, 0(x3)
 
-  /* set dmem pointer to point to blinding parameter */
-  la       x2, blinding_param
-  la       x3, dptr_rnd
-  sw       x2, 0(x3)
-
   /* call scalar point multiplication routine in P-256 lib */
   jal      x1, p256_scalar_mult
 
@@ -62,17 +57,6 @@ scalar:
   .word 0x1b76ebe8
   .word 0x74210263
   .word 0x1420fc41
-
-/* random number for blinding */
-blinding_param:
-  .word 0x7ab203c3
-  .word 0xd6ee4951
-  .word 0xd5b89b43
-  .word 0x409d2b56
-  .word 0x8e9d2186
-  .word 0x1de0f8ec
-  .word 0x0fa0bf9a
-  .word 0xa21c2147
 
 /* example curve point x-coordinate */
 p1_x:


### PR DESCRIPTION
The ECDSA P256 routine takes an input argument `rnd`, which is supposed
to be randomness used for blinding. However, I was unable to find code
that makes use of this blinding constant. The calling conventions
assigned `dmem[4]` to the pointer pointing to `rnd`.

At the same time, the verify operation writes its output `x1` also to
the variable pointed to by `dmem[4]`. In the code, this pointer is
therefore sometimes called `dptr_x1`.

With no blinding being employed and the `dmem[4]` memory location used
exclusively for storing the pointer to the x1 result, this commit
removes the blinding parameter completely and updates the software to
name the corresponding field x1.