### PR TITLE
[edn/sec] create fields to enable functions

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -53,12 +53,12 @@
     { name: "REGWEN",
       desc: "Register write enable for all control registers",
       swaccess: "rw0c",
-      hwaccess: "hro",
+      hwaccess: "none",
       fields: [
         { bits: "0",
           desc: '''
-                When true, the BOOT_REQ_DIS and BCAST_MODE_DIS fields within the CTRL registers
-                can be modified. When false, this field read-only. Defaults true, write one to clear.
+                When true, the CTRL can be written by software.
+                When false, this field read-only. Defaults true, write one to clear.
                 Note that this needs to be cleared after initial configuration at boot in order to
                 lock in the listed register settings.
                 '''
@@ -70,53 +70,47 @@
       desc: "EDN control register",
       swaccess: "rw",
       hwaccess: "hro",
+      regwen: "REGWEN",
       tags: [ // Exclude from writes to these bits since hardware actions will start.
               "excl:CsrAllTests:CsrExclWrite"]
       fields: [
-        { bits: "0",
+        { bits: "3:0",
           name: "EDN_ENABLE",
           desc: '''
-                 Setting this bit enables the EDN module.
+                Setting this field to 0xA enables the EDN module.
                  '''
+          resval: "0x5"
         },
-        { bits: "1",
-          name: "CMD_FIFO_RST",
+        { bits: "7:4",
+          name: "BOOT_REQ_MODE",
           desc: '''
-                Setting this bit clears the three command FIFOs: the SW_CMD_REQ FIFO, the
-                RESEED_CMD FIFO, and the GENERATE_CMD FIFO. This bit must be cleared by
-                software before any further commands can be issued to these FIFOs.
-                '''
-        }
-        { bits: "3:2",
-          name: "HW_REQ_MODE",
-          resval: 0
-          desc: This field determines what hardware-based operational modes the EDN block will operate in.
-          enum: [
-            { value: 0,
-              name: "DISABLED",
-              desc: Disables BOOT_REQ_MODE and AUTO_REQ_MODE.
-            },
-            { value: 1,
-              name: "AUTO_REQ_MODE",
-              desc: '''
-                Setting this bit will enable the EDN block to automatically send another request to
-                CSRNG application interface. It is assumed that the command has been set up ahead of
-                time, such that when the previous command has returned ack, then a new command will be
-                send out again without software intervention. It is expected that the generate command
-                will be sent repeatedly so that a continuous supply of entropy can be delivered to the
-                endpoints.
-                '''
-            },
-            { value: 2,
-              name: "BOOT_REQ_MODE",
-              desc: '''
-                This decode will enable the feature where the EDN block will automatically
-                send a boot-time request to the CSRNG application interface.
+                Setting this field to 0xA will enable the feature where the EDN block will
+                automatically send a boot-time request to the CSRNG application interface.
                 The purpose of this feature is to request entropy as fast as possible after reset,
                 and during chip boot-time.
+                 '''
+          resval: "0x5"
+        },
+        { bits: "11:8",
+          name: "AUTO_REQ_MODE",
+          desc: '''
+                Setting this field to 0xA will enable the EDN block to automatically send another
+                request to CSRNG application interface. It is assumed that the command has been
+                set up ahead of time, such that when the previous command has returned ack, then
+                a new command will be send out again without software intervention. It is expected
+                that the generate command will be sent repeatedly so that a continuous supply of
+                entropy can be delivered to the endpoints.
+                 '''
+          resval: "0x5"
+        },
+        { bits: "15:12",
+          name: "CMD_FIFO_RST",
+          desc: '''
+                Setting this field to 0xA  clears the three command FIFOs: the SW_CMD_REQ FIFO, the
+                RESEED_CMD FIFO, and the GENERATE_CMD FIFO. This field must be set to the reset
+                state by software before any further commands can be issued to these FIFOs.
                 '''
-            },
-          ]
+          resval: "0x5"
         },
       ]
     },
@@ -156,7 +150,6 @@
       hwaccess: "hro",
       hwext: "true",
       hwqe: "true",
-      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "SW_CMD_REQ",
@@ -200,7 +193,6 @@
       hwaccess: "hro",
       hwext: "true",
       hwqe: "true",
-      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "RESEED_CMD",
@@ -221,7 +213,6 @@
       hwaccess: "hro",
       hwext: "true",
       hwqe: "true",
-      regwen: "REGWEN",
       fields: [
         { bits: "31:0",
           name: "GENERATE_CMD",
@@ -330,7 +321,6 @@
       swaccess: "rw",
       hwaccess: "hro",
       hwqe: "true",
-      regwen: "REGWEN",
       fields: [
         {
             bits: "4:0",

--- a/hw/ip/edn/dv/env/edn_env_cfg.sv
+++ b/hw/ip/edn/dv/env/edn_env_cfg.sv
@@ -19,18 +19,20 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
   `uvm_object_new
 
   // Knobs & Weights
-  uint                 enable_pct, auto_req_mode_pct;
+  uint                 enable_pct, boot_req_mode_pct, auto_req_mode_pct;
 
-  rand bit             enable;
-  rand hw_req_mode_e   hw_req_mode;
+  // TODO: confirm that modes are a signle bit below
+  rand bit       enable;
+  rand bit       boot_req_mode;
+  rand bit       auto_req_mode;
 
   // Constraints
-  constraint c_enable {enable dist { 1 :/ enable_pct,
-                                     0:/ (100 - enable_pct) };}
+  constraint c_enable {enable dist { 1 :/ enable_pct, 0:/ (100 - enable_pct) };}
 
-  // boot_req_mode_pct is (100 - auto_req_mode_pct)
-  constraint c_hw_req_mode {hw_req_mode dist { AutoReqMode :/ auto_req_mode_pct,
-                                               BootReqMode :/ (100 - auto_req_mode_pct) };}
+  constraint c_boot_req_mode {boot_req_mode dist { 1 :/ boot_req_mode_pct,
+                                                  0 :/ (100 - boot_req_mode_pct) };}
+  constraint c_auto_req_mode {auto_req_mode dist { 1 :/ auto_req_mode_pct,
+                                                  0 :/ (100 - auto_req_mode_pct) };}
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = edn_env_pkg::LIST_OF_ALERTS;
@@ -59,9 +61,11 @@ class edn_env_cfg extends cip_base_env_cfg #(.RAL_T(edn_reg_block));
     str = {str, "\n"};
     str = {str,  $sformatf("\n\t |************** edn_env_cfg *******************| \t")              };
     str = {str,  $sformatf("\n\t |***** enable                : %10d *****| \t", enable)            };
-    str = {str,  $sformatf("\n\t |***** hw_req_mode          : %10s *****| \t", hw_req_mode.name()) };
+    str = {str,  $sformatf("\n\t |***** boot_req_mode         : %10d *****| \t", boot_req_mode)     };
+    str = {str,  $sformatf("\n\t |***** auto_req_mode         : %10d *****| \t", auto_req_mode)     };
     str = {str,  $sformatf("\n\t |---------- knobs -----------------------------| \t")              };
     str = {str,  $sformatf("\n\t |***** enable_pct            : %10d *****| \t", enable_pct)        };
+    str = {str,  $sformatf("\n\t |***** boot_req_mode_pct     : %10d *****| \t", boot_req_mode_pct) };
     str = {str,  $sformatf("\n\t |***** auto_req_mode_pct     : %10d *****| \t", auto_req_mode_pct) };
     str = {str,  $sformatf("\n\t |**********************************************| \t")              };
     str = {str, "\n"};

--- a/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
@@ -13,7 +13,8 @@ class edn_smoke_vseq extends edn_base_vseq;
     super.body();
 
     // Enable edn
-    csr_wr(.ptr(ral.ctrl), .value({cfg.hw_req_mode, 1'b0, cfg.enable}));
+    // TODO: determine if below muxing for field updates is the best way
+    csr_wr(.ptr(ral.ctrl), .value({(cfg.boot_req_mode ? 4'ha : 4'h0), (cfg.enable ? 4'ha : 4'h0)}));
 
     m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
         create("m_endpoint_pull_seq");

--- a/hw/ip/edn/dv/tests/edn_smoke_test.sv
+++ b/hw/ip/edn/dv/tests/edn_smoke_test.sv
@@ -11,6 +11,7 @@ class edn_smoke_test extends edn_base_test;
     super.configure_env();
 
     cfg.auto_req_mode_pct = 0;
+    cfg.boot_req_mode_pct = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -131,7 +131,6 @@ module edn_core import edn_pkg::*;
   logic                               fifo_read_err_sum;
   logic                               fifo_status_err_sum;
   logic                               unused_err_code_test_bit;
-  logic                               unused_reg2hw_regwen;
 
   // flops
   logic [31:0]                        cs_cmd_req_q, cs_cmd_req_d;
@@ -288,8 +287,8 @@ module edn_core import edn_pkg::*;
   };
 
   // master module enable
-  assign edn_enable = reg2hw.ctrl.edn_enable.q;
-  assign cmd_fifo_rst = reg2hw.ctrl.cmd_fifo_rst.q;
+  assign edn_enable = (edn_enb_e'(reg2hw.ctrl.edn_enable.q) == EDN_FIELD_ON);
+  assign cmd_fifo_rst = (edn_enb_e'(reg2hw.ctrl.cmd_fifo_rst.q) == EDN_FIELD_ON);
 
   //--------------------------------------------
   // sw register interface
@@ -299,7 +298,7 @@ module edn_core import edn_pkg::*;
   // cmd req
   assign sw_cmd_req_load = reg2hw.sw_cmd_req.qe;
   assign sw_cmd_req_bus = reg2hw.sw_cmd_req.q;
-  assign auto_req_mode = (reg2hw.ctrl.hw_req_mode.q == 2'b01);
+  assign auto_req_mode = (edn_enb_e'(reg2hw.ctrl.auto_req_mode.q) == EDN_FIELD_ON);
   assign hw2reg.sum_sts.req_mode_sm_sts.de = 1'b1;
   assign hw2reg.sum_sts.req_mode_sm_sts.d = seq_auto_req_mode;
   assign hw2reg.sum_sts.boot_inst_ack.de = 1'b1;
@@ -479,7 +478,7 @@ module edn_core import edn_pkg::*;
 
 
   // boot request
-  assign boot_request = (reg2hw.ctrl.hw_req_mode.q == 2'b10);
+  assign boot_request = (edn_enb_e'(reg2hw.ctrl.boot_req_mode.q) == EDN_FIELD_ON);
 
   assign boot_req_d[0] =
          (!edn_enable) ? '0 :
@@ -619,7 +618,6 @@ module edn_core import edn_pkg::*;
   //--------------------------------------------
 
   assign unused_err_code_test_bit = (|err_code_test_bit[19:2]) || (|err_code_test_bit[27:22]);
-  assign unused_reg2hw_regwen = reg2hw.regwen.q;
 
 
 endmodule

--- a/hw/ip/edn/rtl/edn_pkg.sv
+++ b/hw/ip/edn/rtl/edn_pkg.sv
@@ -26,4 +26,10 @@ package edn_pkg;
   parameter edn_req_t EDN_REQ_DEFAULT = '0;
   parameter edn_rsp_t EDN_RSP_DEFAULT = '0;
 
+  // Sparse four-value signal type
+  parameter int EDN_MODE_WIDTH = 4;
+  typedef enum logic [EDN_MODE_WIDTH-1:0] {
+    EDN_FIELD_ON = 4'b1010
+  } edn_enb_e;
+
 endpackage : edn_pkg

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -51,19 +51,18 @@ package edn_reg_pkg;
   } edn_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    logic        q;
-  } edn_reg2hw_regwen_reg_t;
-
-  typedef struct packed {
     struct packed {
-      logic        q;
+      logic [3:0]  q;
     } edn_enable;
     struct packed {
-      logic        q;
-    } cmd_fifo_rst;
+      logic [3:0]  q;
+    } boot_req_mode;
     struct packed {
-      logic [1:0]  q;
-    } hw_req_mode;
+      logic [3:0]  q;
+    } auto_req_mode;
+    struct packed {
+      logic [3:0]  q;
+    } cmd_fifo_rst;
   } edn_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
@@ -157,12 +156,11 @@ package edn_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    edn_reg2hw_intr_state_reg_t intr_state; // [152:151]
-    edn_reg2hw_intr_enable_reg_t intr_enable; // [150:149]
-    edn_reg2hw_intr_test_reg_t intr_test; // [148:145]
-    edn_reg2hw_alert_test_reg_t alert_test; // [144:143]
-    edn_reg2hw_regwen_reg_t regwen; // [142:142]
-    edn_reg2hw_ctrl_reg_t ctrl; // [141:138]
+    edn_reg2hw_intr_state_reg_t intr_state; // [163:162]
+    edn_reg2hw_intr_enable_reg_t intr_enable; // [161:160]
+    edn_reg2hw_intr_test_reg_t intr_test; // [159:156]
+    edn_reg2hw_alert_test_reg_t alert_test; // [155:154]
+    edn_reg2hw_ctrl_reg_t ctrl; // [153:138]
     edn_reg2hw_sw_cmd_req_reg_t sw_cmd_req; // [137:105]
     edn_reg2hw_reseed_cmd_reg_t reseed_cmd; // [104:72]
     edn_reg2hw_generate_cmd_reg_t generate_cmd; // [71:39]
@@ -229,7 +227,7 @@ package edn_reg_pkg;
     4'b 0001, // index[ 2] EDN_INTR_TEST
     4'b 0001, // index[ 3] EDN_ALERT_TEST
     4'b 0001, // index[ 4] EDN_REGWEN
-    4'b 0001, // index[ 5] EDN_CTRL
+    4'b 0011, // index[ 5] EDN_CTRL
     4'b 0001, // index[ 6] EDN_SUM_STS
     4'b 1111, // index[ 7] EDN_SW_CMD_REQ
     4'b 0001, // index[ 8] EDN_SW_CMD_STS

--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -91,7 +91,7 @@ _start:
   sw   t0, CSRNG_CTRL_REG_OFFSET(a0)
 
   li   a0, TOP_EARLGREY_EDN0_BASE_ADDR
-  li   t0, 0x9
+  li   t0, 0xaa
   sw   t0, EDN_CTRL_REG_OFFSET(a0)
 
   // Request memory scrambling and init

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -159,7 +159,7 @@ _mask_rom_start_boot:
   sw t0, CSRNG_CTRL_REG_OFFSET(a0)
 
   li a0, TOP_EARLGREY_EDN0_BASE_ADDR
-  li t0, (1 << EDN_CTRL_EDN_ENABLE_BIT) | (EDN_CTRL_HW_REQ_MODE_VALUE_BOOT_REQ_MODE << EDN_CTRL_HW_REQ_MODE_OFFSET)
+  li t0, (0xa << EDN_CTRL_EDN_ENABLE_OFFSET) | (0xa << EDN_CTRL_BOOT_REQ_MODE_OFFSET)
   sw t0, EDN_CTRL_REG_OFFSET(a0)
 
   // Scramble and initialize main memory (main SRAM).

--- a/sw/device/tests/dif/dif_aes_smoketest.c
+++ b/sw/device/tests/dif/dif_aes_smoketest.c
@@ -76,7 +76,7 @@ bool test_main(void) {
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
                       CSRNG_CTRL_REG_OFFSET, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      EDN_CTRL_REG_OFFSET, 0x9);
+                      EDN_CTRL_REG_OFFSET, 0xaa);
 
   // Initialise AES.
   dif_aes_params_t params = {

--- a/sw/device/tests/dif/dif_otbn_smoketest.c
+++ b/sw/device/tests/dif/dif_otbn_smoketest.c
@@ -23,9 +23,9 @@ static void setup_edn(void) {
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
                       kCsrngCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
 }
 
 OTBN_DECLARE_APP_SYMBOLS(barrett384);

--- a/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
+++ b/sw/device/tests/otbn/otbn_ecdsa_p256_test.c
@@ -23,9 +23,9 @@ static void setup_edn(void) {
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
                       kCsrngCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
 }
 
 /**

--- a/sw/device/tests/otbn/otbn_randomness_test.c
+++ b/sw/device/tests/otbn/otbn_randomness_test.c
@@ -23,9 +23,9 @@ static void setup_edn(void) {
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
                       kCsrngCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
 }
 
 OTBN_DECLARE_APP_SYMBOLS(randomness);

--- a/sw/device/tests/otbn/otbn_rsa_test.c
+++ b/sw/device/tests/otbn/otbn_rsa_test.c
@@ -23,9 +23,9 @@ static void setup_edn(void) {
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
                       kCsrngCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                      kEdnCtrlRegOffset, 0x9);
+                      kEdnCtrlRegOffset, 0xaa);
 }
 
 /**


### PR DESCRIPTION
A four-bit field will now be used to enable module functions.
For security reasons, it is assume to be harder to force four bits to a known state than just one.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>