### PR TITLE
[dv/shadow_reg] Fix alert shadow reg regression error

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -153,6 +153,11 @@ class dv_base_reg extends uvm_reg;
     en_shadow_wr = val;
   endfunction
 
+  // A helper function for shadow register or field read to clear the `shadow_wr_staged` flag.
+  virtual function void clear_shadow_wr_staged();
+    if (is_shadowed) shadow_wr_staged = 0;
+  endfunction
+
   function bit get_is_shadowed();
     return is_shadowed;
   endfunction
@@ -208,7 +213,7 @@ class dv_base_reg extends uvm_reg;
 
   // shadow register read will clear its phase tracker
   virtual task post_read(uvm_reg_item rw);
-    if (is_shadowed) shadow_wr_staged = 0;
+    clear_shadow_wr_staged();
   endtask
 
   virtual function void set_is_ext_reg(bit is_ext);

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -126,6 +126,12 @@ class dv_base_reg_field extends uvm_reg_field;
     lockable_flds_q = lockable_flds;
   endfunction
 
+  // shadow register field read will clear its phase tracker
+  virtual task post_read(uvm_reg_item rw);
+    dv_base_reg parent_csr = get_dv_base_reg_parent();
+    parent_csr.clear_shadow_wr_staged();
+  endtask
+
   // override RAL's reset function to support enable registers
   // when reset issued - the lockable field's access will be reset to original access
   virtual function void reset(string kind = "HARD");


### PR DESCRIPTION
This PR fixes a regression error where shadow register read did not
clear the phase tracker in DV environment.
The reason is because the sequence uses a field read instead of
register read.
So this PR extends the helper function to clear the phase tracker in CSR
field read as well.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>