### PR TITLE
[dv/dv_lib] Add post_apply_reset for extra delay

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -595,6 +595,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
           // delay to avoid race condition when sending item and checking no item after reset occur
           // at the same time
           #1ps;
+          post_apply_reset("HARD");
           if (do_read_and_check_all_csrs) read_and_check_all_csrs_after_reset();
         end : isolation_fork
       join

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -78,8 +78,10 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
    * startup, reset and shutdown related tasks
    */
   virtual task dut_init(string reset_kind = "HARD");
-    if (do_apply_reset)         apply_reset(reset_kind);
-    else if (do_wait_for_reset) wait_for_reset(reset_kind);
+    if (do_apply_reset) begin
+      apply_reset(reset_kind);
+      post_apply_reset(reset_kind);
+    end else if (do_wait_for_reset) wait_for_reset(reset_kind);
     // delay after reset for tl agent check seq_item_port empty
     #1ps;
   endtask
@@ -135,6 +137,11 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
       #(reset_duration_ps * $urandom_range(2, 10) * 1ps);
       cfg.clk_rst_vif.drive_rst_pin(1);
     end
+  endtask
+
+  // This is called after apply_reset in this class and after apply_resets_concurrently
+  // in cip_base_vseq::run_stress_all_with_rand_reset_vseq.
+  virtual task post_apply_reset(string reset_kind = "HARD");
   endtask
 
   virtual task wait_for_reset(string reset_kind     = "HARD",


### PR DESCRIPTION
This task enables different IPs to wait for some extra conditions
when they are not ready for transactions right after reset.
At least pwrmgr and keymgr need this.

Signed-off-by: Guillermo Maturana <maturana@google.com>