### PR TITLE
[top] Remove setting of Sec parameters from Aes

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3983,8 +3983,6 @@
       {
         Masking: "1"
         SBoxImpl: aes_pkg::SBoxImplDom
-        SecStartTriggerDelay: "0"
-        SecAllowForcingMasks: 1'b0
       }
       clock_connections:
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -465,10 +465,7 @@
       reset_connections: {rst_ni: "sys", rst_edn_ni: "sys"},
       param_decl: {
         Masking: "1",
-        SBoxImpl: "aes_pkg::SBoxImplDom",
-        SecStartTriggerDelay: "0",
-        SecAllowForcingMasks: "1'b0",
-
+        SBoxImpl: "aes_pkg::SBoxImplDom"
       }
       base_addr: "0x41100000",
     },


### PR DESCRIPTION
- For ASIC flow, the Sec parameters should use the module default.
- Sec parameters should only ever be changed non-ASIC variants (verilator / FPGA etc)

Signed-off-by: Timothy Chen <timothytim@google.com>