### PR TITLE
[prim_lfsr] Fix assertion issue occuring right after reset

### DIFF
--- a/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -310,7 +310,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     esc_ping_fail_o   = spurious_esc_ping;
 
     unique case (state_q)
-      // wait until activiated
+      // wait until activated
       // we never return to this state
       // once activated!
       InitSt: begin


### PR DESCRIPTION
I came across an instance of this bug by chance in #7328.

There are cases where the LFSR enable signal remains asserted by the instantiating design while in reset. In such a case,
the `NextStateCheck_A` may erroneously fire in the first cycle after reset release due to a SystemVerilog scheduler peculiarity when the reset is synchronized with a reset synchronizer flop that releases the reset right on the active clock edge with zero
simulation delay.

If this happens, the assertion body may be out of sync with the design, since the `disable_iff` statement is evaluated with unsampled values (i.e. values NOT sampled in the PREPONED region). In other words: when the assertion body is evaluated in the OBSERVED region (after ACTIVE and NBA), `rst_ni` may already be read as 1 if it has been deasserted in the synchronizer in this simulation scheduler pass - however the flops in the design may not have seen that change yet. This can lead to an assertion failure because the flops have not yet changed state, whereas the assertion expects otherwise.

There are a couple of possible solutions to this issue:
1) ignore the first clock tick after reset release by shifting the
assertion by one clock tick to the right `##1`
2) use a sampled reset value for `disable_iff ($sampled(!rst_ni))`
3) make sure the surrounding logic never asserts the LFSR enable
signal while in reset.
4) make sure that there is an artificial propagation delay on
all reset synchronizer outputs to move reset deassertion away from
the active clock edge.

It is in general uncommon that assertion preconditions are true at reset release. Hence, this patch implements 3 so that this condition does not occur anymore in the design.

Let me know if you think we should go for another solution.

Signed-off-by: Michael Schaffner <msf@google.com>