### PR TITLE
[prim_subreg] Prevent lint error on string param

### DIFF
--- a/hw/ip/prim/lint/prim_subreg.vlt
+++ b/hw/ip/prim/lint/prim_subreg.vlt
@@ -7,3 +7,7 @@
 // prim_subreg
 // for RO wd is not used
 lint_off -rule UNUSED -file "*/rtl/prim_subreg.sv" -match "Signal is not used: 'wd'"
+
+// prim_subreg_shadow
+// Operations on a string parameter (without explicit data type) are fine.
+lint_off -rule WIDTH -file "*/rtl/prim_subreg_shadow.sv" -match "*SWACCESS*"

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -37,8 +37,8 @@ module prim_subreg_shadow #(
   // we need to invert the polarity of the SW access if it is either "W1S" or "W0C".
   // W1C is forbidden since the W0S complement is not implemented.
   `ASSERT_INIT(CheckSwAccessIsLegal_A, SWACCESS inside {"RW", "RO", "WO", "W1S", "W0C", "RC"})
-  parameter bit [3*8-1:0] INVERTED_SWACCESS = (SWACCESS == "W1S") ? "W0C" :
-                                              (SWACCESS == "W0C") ? "W1S" : SWACCESS;
+  parameter INVERTED_SWACCESS = (SWACCESS == "W1S") ? "W0C" :
+                                (SWACCESS == "W0C") ? "W1S" : SWACCESS;
 
   // Subreg control signals
   logic          phase_clear;


### PR DESCRIPTION
We operate on a string parameter (without an explicit data type for tool
compatibility). This causes Verilator lint warnings:

```
%Warning-WIDTH: ../src/lowrisc_prim_subreg_0/rtl/prim_subreg_shadow.sv:40:57: Operator EQ expects 24 bits on the LHS, but LHS's VARREF 'SWACCESS' generates 16 bits.

%Warning-WIDTH: ../src/lowrisc_prim_subreg_0/rtl/prim_subreg_shadow.sv:41:57: Operator EQ expects 24 bits on the LHS, but LHS's VARREF 'SWACCESS' generates 16 bits.

%Warning-WIDTH: ../src/lowrisc_prim_subreg_0/rtl/prim_subreg_shadow.sv:41:67: Operator COND expects 24 bits on the Conditional False, but Conditional False's VARREF 'SWACCESS' generates 16 bits.
```

This commit removes the "bit" data type from the inverted string
parameter (since there's no real value in having it if it doesn't solve
the lint problem) and simply waives the message.

AscentLint doesn't show errors on the previous code.