### PR TITLE
[otbn,dv] Fix index of ACC WSR

### DIFF
--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -318,8 +318,8 @@ They can be accessed with the {{< otbnInsnRef "BN.WSRR" >}} and {{< otbnInsnRef 
 Writes to read-only (RO) registers are ignored; they do not signal an error.
 All read-write (RW) WSRs are set to 0 when OTBN starts an operation (when 1 is written to {{< regref "CMD.start" >}}).
 
-<!-- This list of WSRs is replicated in the RTL, in otbn_env_cov.sv and in
-     wsr.py. If editing one, edit the other three as well. -->
+<!-- This list of WSRs is replicated in otbn_env_cov.sv, wsr.py, the
+     RTL and in rig/model.py. If editing one, edit the other four as well. -->
 <table>
   <thead>
     <tr>

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -158,7 +158,7 @@ class Model:
 
         wsrs.touch_addr(0x0)        # MOD
         wsrs.touch_addr(0x1)        # RND
-        wsrs.touch_addr(0x2)        # ACC
+        wsrs.touch_addr(0x3)        # ACC
 
         # The current PC (the address of the next instruction that needs
         # generating)


### PR DESCRIPTION
This index changed in commit 19afa99 and we missed it here.

The change was causing lots of test failures, which turn out to be because we don't yet have a nice error path specified for a WSRR or WSRW with an invalid WSR index. The RIG was generating accesses for index 2, which is now URND (that doesn't exist in the model) rather than ACC.