### PR TITLE
[otbn,dv] Properly report an error if the ISS process dies

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -557,12 +557,17 @@ bool ISSWrapper::read_child_response(std::vector<std::string> *dst) const {
   }
 }
 
-bool ISSWrapper::run_command(const std::string &cmd,
+void ISSWrapper::run_command(const std::string &cmd,
                              std::vector<std::string> *dst) const {
   assert(cmd.size() > 0);
   assert(cmd.back() == '\n');
 
   fputs(cmd.c_str(), child_write_file);
   fflush(child_write_file);
-  return read_child_response(dst);
+  if (!read_child_response(dst)) {
+    std::ostringstream oss;
+    std::string cmd_line = cmd.substr(0, cmd.size() - 1);
+    oss << "Failed to run command '" << cmd_line << "': EOF from ISS.";
+    throw std::runtime_error(oss.str());
+  }
 }

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -92,9 +92,9 @@ struct ISSWrapper {
   // is not null, append to it each line that was read.
   bool read_child_response(std::vector<std::string> *dst) const;
 
-  // Send a command to the child and wait for its response. Return
-  // value and dst argument behave as for read_child_response.
-  bool run_command(const std::string &cmd, std::vector<std::string> *dst) const;
+  // Send a command to the child and wait for its response. If no
+  // response, raise a runtime_error.
+  void run_command(const std::string &cmd, std::vector<std::string> *dst) const;
 
   pid_t child_pid;
   FILE *child_write_file;


### PR DESCRIPTION
Before, run_command was returning a `bool`... which every call site
ignored! Threading the return value through is a bit messy, and it's
hard to work out what went wrong. Raise a `runtime_error` instead (we
already catch them, and it lets us give some context about what went
wrong).

Without this change, you get a very mysterious error if the ISS
dies (the first thing that goes wrong is a mismatch on the instruction
count register!)
