### PR TITLE
[otbn] Describe WSR error conditions in docs and ISS

### DIFF
--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -734,7 +734,7 @@
       doc: The WSR to read
   doc: |
     Reads a WSR to a WDR.
-    If `wsr` isn't the index of a valid WSR, this halts with an error (TODO: Specify error code).
+    If `wsr` isn't the index of a valid WSR, this results in an error (setting bit `illegal_insn` in `ERR_BITS`).
   encoding:
     scheme: wcsr
     mapping:
@@ -756,7 +756,7 @@
       doc: Source WDR
   doc: |
     Writes a WDR to a WSR.
-    If `wsr` isn't the index of a valid WSR, this halts with an error (TODO: Specify error code).
+    If `wsr` isn't the index of a valid WSR, this results in an error (setting bit `illegal_insn` in `ERR_BITS`).
   encoding:
     scheme: wcsr
     mapping:

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -1004,6 +1004,11 @@ class BNWSRR(OTBNInsn):
         return True
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.check_idx(self.wsr):
+            # Invalid WSR index. Stop with an illegal instruction error.
+            state.stop_at_end_of_cycle(ILLEGAL_INSN)
+            return
+
         val = state.wsrs.read_at_idx(self.wsr)
         state.wdrs.get_reg(self.wrd).write_unsigned(val)
 
@@ -1017,6 +1022,11 @@ class BNWSRW(OTBNInsn):
         self.wrs = op_vals['wrs']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.check_idx(self.wsr):
+            # Invalid WSR index. Stop with an illegal instruction error.
+            state.stop_at_end_of_cycle(ILLEGAL_INSN)
+            return
+
         val = state.wdrs.get_reg(self.wrs).read_unsigned()
         state.wsrs.write_at_idx(self.wsr, val)
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -156,22 +156,32 @@ class WSRFile:
         self.RND = RandWSR('RND')
         self.ACC = DumbWSR('ACC')
 
-    def _wsr_for_idx(self, idx: int) -> WSR:
-        assert 0 <= idx <= 3
-        return {
+        self._by_idx = {
             0: self.MOD,
             1: self.RND,
             # TODO: Implement 2: URND
             3: self.ACC
-        }[idx]
+        }
+
+    def check_idx(self, idx: int) -> bool:
+        '''Return True if idx is a valid WSR index'''
+        return idx in self._by_idx
 
     def read_at_idx(self, idx: int) -> int:
-        '''Read the WSR at idx as an unsigned 256-bit value'''
-        return self._wsr_for_idx(idx).read_unsigned()
+        '''Read the WSR at idx as an unsigned 256-bit value
+
+        Assumes that idx is a valid index (call check_idx to ensure this).
+
+        '''
+        return self._by_idx[idx].read_unsigned()
 
     def write_at_idx(self, idx: int, value: int) -> None:
-        '''Write the WSR at idx as an unsigned 256-bit value'''
-        return self._wsr_for_idx(idx).write_unsigned(value)
+        '''Write the WSR at idx as an unsigned 256-bit value
+
+        Assumes that idx is a valid index (call check_idx to ensure this).
+
+        '''
+        return self._by_idx[idx].write_unsigned(value)
 
     def commit(self) -> None:
         self.MOD.commit()


### PR DESCRIPTION
This actually got added to the RTL back in September with commit
d3154ec2 but we didn't update the docs or the ISS to match. :-(

The slightly odd looking "check, then look up again" structure in the
two `execute()` functions is to get a nice documentation rendering. We
have to check before we start reading GPRs (to avoid side effects with
`x1`), but don't have a nice way to render "`xxx = state.get_wsr(idx)`" in
the documentation. Checking the index and then using it again avoids
both problems.
