### PR TITLE
[opentitantool] Add meson build target for opentitantool

### DIFF
--- a/sw/host/meson.build
+++ b/sw/host/meson.build
@@ -5,3 +5,4 @@
 subdir('vendor')
 subdir('spiflash')
 subdir('rom_ext_image_tools')
+subdir('opentitantool')

--- a/sw/host/opentitantool/meson.build
+++ b/sw/host/opentitantool/meson.build
@@ -1,0 +1,63 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+cargo = find_program('cargo', required: false, disabler: true)
+
+build_type = 'release'
+build_dir = meson.current_build_dir()
+manifest_path = meson.current_source_dir() / 'Cargo.toml'
+
+# CARGO FLAGS:
+# These flags will only apply to the final binary, and won't get propogated
+# to the dependency crate builds.
+cargo_flags_array = [
+  'manifest-path=' + manifest_path,
+  'target-dir=' + build_dir,
+   build_type,
+]
+
+cargo_flags = ''
+foreach flag : cargo_flags_array
+  cargo_flags += '--' + flag + ' '
+endforeach
+
+# RUSTFLAGS:
+# These flags will apply to all the dependencies, as well as the final
+# binary. Linker and linker flavor amongst other things can be passed through
+# these flags.
+rust_flags = ''
+
+# The cargo invocation script.
+cargo_invoke_cmd = meson.source_root() / 'util/invoke_cargo.sh'
+
+# Note: the opentitantool depends on opentitanlib. This dependency is handled
+# by cargo itself but perhaps should be handled by the build system.
+opentitantool = custom_target(
+  'opentitantool',
+  command: [
+    cargo_invoke_cmd,
+    cargo,
+    cargo_flags,
+    rust_flags,
+    meson.source_root(),
+    meson.build_root(),
+  ],
+  depend_files: [
+    cargo_invoke_cmd,
+    manifest_path,
+  ],
+  output: '.',
+  console: true,
+  build_always_stale: true,
+  build_by_default: true,
+)
+
+opentitantool_export = custom_target(
+  'opentitantool_export',
+  command: ['cp', '@INPUT@' / build_type / 'opentitantool', '@OUTPUT@'],
+  input: opentitantool,
+  output: 'opentitantool',
+  build_always_stale: true,
+  build_by_default: true,
+)


### PR DESCRIPTION
This change means that the CI infratructure will build the
opentitantool (and therefore check that it compiles) although it
won't actually use it for anything yet. This will at least help
us detect totally broken builds.

This is a straightforward copy of the meson build target for the
rom_ext_signer. The build is conditional on rust (cargo
specifically) being installed and will otherwise be skipped.

I'm not sure how we should model the opentitanlib dependency in
meson so I've left it up to cargo to handle for now. It seems to
do the right thing.