### PR TITLE
[otbn,dv,doc] Handle bad CSRs properly in ISS and docs

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -372,6 +372,8 @@
     The initial value in `grs1` is treated as a bit mask that specifies bits to be set in the CSR.
     Any bit that is high in `grs1` will cause the corresponding bit to be set in the CSR, if that CSR bit is writable.
     Other bits in the CSR are unaffected (though CSRs might have side effects when written).
+
+    If `csr` isn't the index of a valid CSR, this results in an error (setting bit `illegal_insn` in `ERR_BITS`).
   encoding:
     scheme: I
     mapping:
@@ -393,6 +395,8 @@
     Reads the old value of the CSR, and writes it to the GPR `grd`.
     Writes the initial value in `grs1` to the CSR `csr`.
     If `grd == x0` the instruction does not read the CSR or cause any read-related side-effects.
+
+    If `csr` isn't the index of a valid CSR, this results in an error (setting bit `illegal_insn` in `ERR_BITS`).
   encoding:
     scheme: I
     mapping:

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -267,7 +267,7 @@ All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is w
     </tr>
     <tr>
       <td>0xFC0</td>
-      <td>R</td>
+      <td>RO</td>
       <td>RND</td>
       <td>
 An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
@@ -279,7 +279,7 @@ Reads when the cache is empty will cause OTBN to be stalled until a new random n
     </tr>
     <tr>
       <td>0xFC1</td>
-      <td>R</td>
+      <td>RO</td>
       <td>URND</td>
       <td>
 A random number without guaranteed secrecy properties or specific statistical properties.
@@ -343,7 +343,7 @@ This WSR is also visible as CSRs `MOD0` through to `MOD7`.
     </tr>
     <tr>
       <td>0x1</td>
-      <td>R</td>
+      <td>RO</td>
       <td>RND</td>
       <td>
 An AIS31-compliant class PTG.3 random number with guaranteed entropy and forward and backward secrecy.
@@ -355,7 +355,7 @@ Reads when the cache is empty will cause OTBN to be stalled until a new random n
     </tr>
     <tr>
       <td>0x2</td>
-      <td>R</td>
+      <td>RO</td>
       <td>URND</td>
       <td>
 A random number without guaranteed secrecy properties or specific statistical properties.

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -105,8 +105,8 @@ CSRs can be accessed through dedicated instructions, {{< otbnInsnRef "CSRRS" >}}
 Writes to read-only (RO) registers are ignored; they do not signal an error.
 All read-write (RW) CSRs are set to 0 when OTBN starts an operation (when 1 is written to {{< regref "CMD.start" >}}).
 
-<!-- This list of CSRs is replicated in the RTL, in otbn_env_cov.sv and in csr.py.
-     If editing one, edit the other three as well. -->
+<!-- This list of CSRs is replicated in otbn_env_cov.sv, wsr.py, the
+     RTL and in rig/model.py. If editing one, edit the other four as well. -->
 <table>
   <thead>
     <tr>

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -290,6 +290,11 @@ class CSRRS(OTBNInsn):
         return True
 
     def execute(self, state: OTBNState) -> None:
+        if not state.csrs.check_idx(self.csr):
+            # Invalid CSR index. Stop with an illegal instruction error.
+            state.stop_at_end_of_cycle(ILLEGAL_INSN)
+            return
+
         old_val = state.read_csr(self.csr)
         bits_to_set = state.gprs.get_reg(self.grs1).read_unsigned()
         new_val = old_val | bits_to_set
@@ -317,6 +322,11 @@ class CSRRW(OTBNInsn):
         return True
 
     def execute(self, state: OTBNState) -> None:
+        if not state.csrs.check_idx(self.csr):
+            # Invalid CSR index. Stop with an illegal instruction error.
+            state.stop_at_end_of_cycle(ILLEGAL_INSN)
+            return
+
         new_val = state.gprs.get_reg(self.grs1).read_unsigned()
 
         if self.grd != 0:


### PR DESCRIPTION
The first commit is just a minor clean-up. The interesting commit in the PR has the following message:

> This is (sadly) playing catch-up with the RTL, which implemented its
> current behaviour a while ago. Document what happens on bad CSRs, then
> implement it properly in the ISS. Note that the ISS behaviour has
> changed for writes to RND.
> 
> The result now matches both the existing spec and RTL.
