### PR TITLE
[otbn,util] De-duplicate Python decoding code

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -5,17 +5,14 @@
 '''Code to load instruction words into a simulator'''
 
 import struct
-from typing import List, Optional, Tuple, Type
+from typing import List
 
 from .err_bits import ILLEGAL_INSN
-from .isa import DecodeError, OTBNInsn
+from .isa import INSNS_FILE, DecodeError, OTBNInsn
 from .insn import INSN_CLASSES
 from .state import OTBNState
 
-# A tuple as returned by get_insn_masks: an element (m0, m1, cls) means "if a
-# word has all the bits in m0 clear and all the bits in m1 set, then you should
-# decode it with the given class".
-_MaskTuple = Tuple[int, int, Type[OTBNInsn]]
+MNEM_TO_CLASS = {cls.insn.mnemonic: cls for cls in INSN_CLASSES}
 
 
 class IllegalInsn(OTBNInsn):
@@ -42,50 +39,14 @@ class IllegalInsn(OTBNInsn):
         state.stop_at_end_of_cycle(ILLEGAL_INSN)
 
 
-MASK_TUPLES = None  # type: Optional[List[_MaskTuple]]
-
-
-def get_insn_masks() -> List[_MaskTuple]:
-    '''Generate a list of zeros/ones masks for known instructions
-
-    The result is memoized.
-
-    '''
-    global MASK_TUPLES
-    if MASK_TUPLES is None:
-        tuples = []
-        for cls in INSN_CLASSES:
-            # cls is the class for some OTBNInsn: an object that represents a
-            # decoded instruction. It has a class variable called "insn", which is
-            # the subclass of insn_yaml.Insn that represents that instruction
-            # (without operand values).
-            insn = cls.insn
-            if insn.encoding is None:
-                continue
-
-            m0, m1 = insn.encoding.get_masks()
-
-            # Encoding.get_masks sets bits that are 'x', so we have to do a
-            # difference operation too.
-            tuples.append((m0 & ~m1, m1 & ~m0, cls))
-        MASK_TUPLES = tuples
-
-    return MASK_TUPLES
-
-
 def _decode_word(pc: int, word: int) -> OTBNInsn:
-    found_cls = None
-    for m0, m1, cls in get_insn_masks():
-        # If any bit is set that should be zero or if any bit is clear that
-        # should be one, ignore this instruction.
-        if word & m0 or (~ word) & m1:
-            continue
-
-        found_cls = cls
-        break
-
-    if found_cls is None:
+    mnem = INSNS_FILE.mnem_for_word(word)
+    if mnem is None:
         return IllegalInsn(pc, word, 'No legal decoding')
+
+    cls = MNEM_TO_CLASS.get(mnem)
+    if cls is None:
+        return IllegalInsn(pc, word, f'No insn class for mnemonic {mnem}')
 
     # Decode the instruction. We know that we have an encoding (we checked in
     # get_insn_masks).

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -15,7 +15,7 @@ from .state import OTBNState
 # a particular Insn object from shared.insn_yaml, so we want a class variable
 # on the OTBNInsn that points at the corresponding Insn.
 try:
-    _INSNS_FILE = load_insns_yaml()
+    INSNS_FILE = load_insns_yaml()
 except RuntimeError as err:
     sys.stderr.write('{}\n'.format(err))
     sys.exit(1)
@@ -53,7 +53,7 @@ def insn_for_mnemonic(mnemonic: str, num_operands: int) -> Insn:
     on this way).
 
     '''
-    insn = _INSNS_FILE.mnemonic_to_insn.get(mnemonic)
+    insn = INSNS_FILE.mnemonic_to_insn.get(mnemonic)
     if insn is None:
         sys.stderr.write('Failed to find an instruction for mnemonic {!r} in '
                          'insns.yml.\n'

--- a/hw/ip/otbn/util/otbn-objdump
+++ b/hw/ip/otbn/util/otbn-objdump
@@ -8,9 +8,9 @@
 import re
 import subprocess
 import sys
-from typing import List, Optional, Tuple
+from typing import List
 
-from shared.insn_yaml import Insn, InsnsFile, load_insns_yaml
+from shared.insn_yaml import InsnsFile, load_insns_yaml
 from shared.toolchain import find_tool
 
 
@@ -27,29 +27,6 @@ def snoop_disasm_flags(argv: List[str]) -> bool:
     return False
 
 
-def get_insn(raw: int, masks: List[Tuple[int, int, Insn]]) -> Optional[Insn]:
-    '''Try to find a mnemonic for this raw instruction
-
-    masks is a list of tuples (m0, m1, mnemonic) as returned by
-    get_insn_masks. If no tuple matches, returns None.
-
-    '''
-    found = None
-    for m0, m1, insn in masks:
-        # If any bit is set that should be zero or if any bit is clear that
-        # should be one, ignore this instruction.
-        if raw & m0 or (~ raw) & m1:
-            continue
-
-        # We have a match! The code in insn_yaml should already have checked
-        # this is the only one, but it can't hurt to be careful.
-        assert found is None
-
-        found = insn
-
-    return found
-
-
 # OTBN instructions are 32 bit wide, so there's just one "word" in the second
 # column. The stuff that gets passed through looks like this:
 #
@@ -64,8 +41,7 @@ _RAW_INSN_RE = re.compile(r'([\s]*([0-9a-f]+):[\s]+([0-9a-f]{8})[\s]+)'
                           r'0x[0-9a-f]+\s*$')
 
 
-def transform_disasm_line(line: str,
-                          masks: List[Tuple[int, int, Insn]]) -> str:
+def transform_disasm_line(line: str, insns_file: InsnsFile) -> str:
     '''Transform filter to insert OTBN disasm as needed'''
     match = _RAW_INSN_RE.match(line)
     if match is None:
@@ -76,16 +52,18 @@ def transform_disasm_line(line: str,
     raw = int(match.group(3), 16)
     assert 0 <= raw < (1 << 32)
 
-    insn = get_insn(raw, masks)
-    if insn is None:
+    mnem = insns_file.mnem_for_word(raw)
+    if mnem is None:
         # No match for this instruction pattern. Leave as-is.
         return line
+
+    insn = insns_file.mnemonic_to_insn[mnem]
 
     # match.group(2) is the PC in hex.
     pc = int(match.group(2), 16)
 
-    # Extract the encoded values. We know we have an encoding (otherwise
-    # get_insn_masks wouldn't have added the instruction to the masks list).
+    # Extract the encoded values. We know we have an encoding (otherwise the
+    # instruction wouldn't have appeared in the the masks list).
     assert insn.encoding is not None
     enc_vals = insn.encoding.extract_operands(raw)
 
@@ -96,27 +74,6 @@ def transform_disasm_line(line: str,
     # Similarly, we know we have a syntax (again, get_insn_masks requires it).
     # The rendering of the fields is done by the syntax object.
     return match.group(1) + insn.disassemble(pc, op_vals)
-
-
-def get_insn_masks(insns_file: InsnsFile) -> List[Tuple[int, int, Insn]]:
-    '''Generate a list of zeros/ones masks for known instructions
-
-    The returned list has elements (m0, m1, mnemonic). We don't check here that
-    the results are unambiguous: that check is supposed to happen in insn_yaml
-    already, and we'll do a belt-and-braces check for each instruction as we
-    go.
-
-    '''
-    ret = []
-    for insn in insns_file.insns:
-        if insn.encoding is None:
-            continue
-
-        m0, m1 = insn.encoding.get_masks()
-        # Encoding.get_masks sets bits that are 'x', so we have to do a
-        # difference operation too.
-        ret.append((m0 & ~m1, m1 & ~m0, insn))
-    return ret
 
 
 def main() -> int:
@@ -150,12 +107,10 @@ def main() -> int:
         sys.stderr.write('{}\n'.format(err))
         return 1
 
-    insn_masks = get_insn_masks(insns_file)
-
     # If we get here, we think we're disassembling something, objdump ran
     # successfully and we have its results in proc.stdout
     for line in proc.stdout.split('\n'):
-        transformed = transform_disasm_line(line, insn_masks)
+        transformed = transform_disasm_line(line, insns_file)
         sys.stdout.write(transformed + '\n')
 
     return 0

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -14,7 +14,7 @@ from .encoding_scheme import EncSchemes
 from .lsu_desc import LSUDesc
 from .operand import Operand
 from .syntax import InsnSyntax
-from .yaml_parse_helpers import (check_keys, check_str, check_bool, check_int,
+from .yaml_parse_helpers import (check_keys, check_str, check_bool,
                                  check_list, index_list, get_optional_str,
                                  load_yaml)
 
@@ -203,38 +203,6 @@ class Insn:
         return mnem + ''.join(hunks).lstrip()
 
 
-def find_ambiguous_encodings(insns: List[Insn]) -> List[Tuple[str, str, int]]:
-    '''Check for ambiguous instruction encodings
-
-    Returns a list of ambiguous pairs (mnemonic0, mnemonic1, bits) where
-    bits is a bit pattern that would match either instruction.
-
-    '''
-    masks = {}
-    for insn in insns:
-        if insn.encoding is not None:
-            masks[insn.mnemonic] = insn.encoding.get_masks()
-
-    ret = []
-    for mnem0, mnem1 in itertools.combinations(masks.keys(), 2):
-        m00, m01 = masks[mnem0]
-        m10, m11 = masks[mnem1]
-
-        # The pair of instructions is ambiguous if a bit pattern might be
-        # either instruction. That happens if each bit index is either
-        # allowed to be a 0 in both or allowed to be a 1 in both.
-        # ambiguous_mask is the set of bits that don't distinguish the
-        # instructions from each other.
-        m0 = m00 & m10
-        m1 = m01 & m11
-
-        ambiguous_mask = m0 | m1
-        if ambiguous_mask == (1 << 32) - 1:
-            ret.append((mnem0, mnem1, m1 & ~m0))
-
-    return ret
-
-
 class InsnGroup:
     def __init__(self,
                  path: str,
@@ -307,19 +275,76 @@ class InsnsFile:
         self.mnemonic_to_insn = index_list('insns', self.insns,
                                            lambda insn: insn.mnemonic.lower())
 
-        ambiguous_encodings = find_ambiguous_encodings(self.insns)
-        if ambiguous_encodings:
-            ambiguity_msgs = []
-            for mnem0, mnem1, bits in ambiguous_encodings:
-                ambiguity_msgs.append('{!r} and {!r} '
-                                      'both match bit pattern {:#010x}'
-                                      .format(mnem0, mnem1, bits))
+        masks_exc, ambiguities = self._get_masks()
+        if ambiguities:
             raise ValueError('Ambiguous instruction encodings: ' +
-                             ', '.join(ambiguity_msgs))
+                             ', '.join(ambiguities))
+
+        self._masks = masks_exc
 
     def grouped_insns(self) -> List[Tuple[InsnGroup, List[Insn]]]:
         '''Return the instructions in groups'''
         return [(grp, grp.insns) for grp in self.groups.groups]
+
+    def _get_masks(self) -> Tuple[Dict[str, Tuple[int, int]], List[str]]:
+        '''Generate a list of zeros/ones masks and do ambiguity checks
+
+        Returns a pair (masks, ambiguities). Masks is keyed by instruction
+        mnemonic. Its elements are pairs (m0, m1) where m0 is the bits that are
+        always zero for this instruction's in the encoding and m1 is the bits
+        that are always one. (Bits that can be either are not set in m0 or m1).
+
+        ambiguities is a list of error messages describing ambiguities in the
+        encoding. Unless something has gone wrong, it should be empty.
+
+        '''
+        masks_inc = {}
+        masks_exc = {}
+        for insn in self.insns:
+            if insn.encoding is not None:
+                m0, m1 = insn.encoding.get_masks()
+                masks_inc[insn.mnemonic] = (m0, m1)
+                masks_exc[insn.mnemonic] = (m0 & ~m1, m1 & ~m0)
+
+        ambiguities = []
+        for mnem0, mnem1 in itertools.combinations(masks_inc.keys(), 2):
+            m00, m01 = masks_inc[mnem0]
+            m10, m11 = masks_inc[mnem1]
+
+            # The pair of instructions is ambiguous if a bit pattern might be
+            # either instruction. That happens if each bit index is either
+            # allowed to be a 0 in both or allowed to be a 1 in both.
+            # ambiguous_mask is the set of bits that don't distinguish the
+            # instructions from each other.
+            m0 = m00 & m10
+            m1 = m01 & m11
+
+            ambiguous_mask = m0 | m1
+            if ambiguous_mask == (1 << 32) - 1:
+                ambiguities.append('{!r} and {!r} '
+                                   'both match bit pattern {:#010x}'
+                                   .format(mnem0, mnem1, m1 & ~m0))
+
+        return (masks_exc, ambiguities)
+
+    def mnem_for_word(self, word: int) -> Optional[str]:
+        '''Find the instruction that could be encoded as word
+
+        If there is no such instruction, return None.
+
+        '''
+        ret = None
+        for mnem, (m0, m1) in self._masks.items():
+            # If any bit is set that should be zero or if any bit is clear that
+            # should be one, ignore this instruction.
+            if word & m0 or (~ word) & m1:
+                continue
+
+            # Belt-and-braces ambiguity check
+            assert ret is None
+            ret = mnem
+
+        return ret
 
 
 def load_file(path: str) -> InsnsFile:


### PR DESCRIPTION
This is marginally more efficient, because we now only call
`Encoding.get_masks()` once for each `Insn`. More importantly, it's a bit
simpler: moving the duplicated code back into `insn_yaml.py` throws away
most of `otbn-objdump`!

Also (finally) I want the decode logic in yet another place, to
implement a "generate a known bad instruction" sequence for the RIG.
