### PR TITLE
[mask_rom] Clean up mask ROM assembly

### DIFF
--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
@@ -117,7 +117,7 @@ mask_rom_epmp_init:
            CFG_INDEX(2  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* ROM         */
   li   t1, CFG_INDEX(5  % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LR)    /* eFLASH      */
   li   t2, CFG_INDEX(11 % 4, EPMP_CFG_A_TOR   | EPMP_CFG_LRW)   /* MMIO        */
-  li   t3, CFG_INDEX(14 % 4, EPMP_CFG_A_NA4   | EPMP_CFG_LRW) | /* Stack Guard */ \
+  li   t3, CFG_INDEX(14 % 4, EPMP_CFG_A_NA4   | EPMP_CFG_L)   | /* Stack Guard */ \
            CFG_INDEX(15 % 4, EPMP_CFG_A_NAPOT | EPMP_CFG_LRW)   /* RAM         */
   csrw pmpcfg0, t0
   csrw pmpcfg1, t1
@@ -132,24 +132,3 @@ mask_rom_epmp_init:
 
   // Set function size to allow disassembly.
   .size mask_rom_epmp_init, .-mask_rom_epmp_init
-
-/**
- * Disable all accesses to the stack guard word.
- *
- * This function follows the standard ILP32 calling convention but does not
- * require a valid stack pointer, thread pointer or global pointer.
- *
- * Clobbers t0.
- */
-mask_rom_epmp_stack_guard_init:
-  .globl mask_rom_epmp_stack_guard_init
-  .type mask_rom_epmp_stack_guard_init, @function
-
-  // Remove all permissions from entry 14 (the stack guard).
-  li   t0, CFG_INDEX(14 % 4, EPMP_CFG_R | EPMP_CFG_W | EPMP_CFG_X)
-  csrc pmpcfg3, t0
-
-  ret
-
-  // Set function size to allow disassembly.
-  .size mask_rom_epmp_stack_guard_init, .-mask_rom_epmp_stack_guard_init

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -230,11 +230,8 @@ _mask_rom_start_boot:
   li x30, 0x0
   li x31, 0x0
 
-  .extern crt_section_clear
-  .extern crt_section_copy
-  .extern mask_rom_epmp_init
-
   // Must be called prior to any Main RAM access.
+  .extern mask_rom_epmp_init
   call mask_rom_epmp_init
 
   /**
@@ -245,11 +242,13 @@ _mask_rom_start_boot:
   la   a0, _data_start
   la   a1, _data_end
   la   a2, _data_init_start
+  .extern crt_section_copy
   call crt_section_copy
 
   // Initialize the `.bss` section.
   la   a0, _bss_start
   la   a1, _bss_end
+  .extern crt_section_clear
   call crt_section_clear
 
   // Setup global pointer.

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -233,12 +233,9 @@ _mask_rom_start_boot:
   .extern crt_section_clear
   .extern crt_section_copy
   .extern mask_rom_epmp_init
-  .extern mask_rom_epmp_stack_guard_init
 
   // Must be called prior to any Main RAM access.
-  // FIXME: merge these two functions.
   call mask_rom_epmp_init
-  call mask_rom_epmp_stack_guard_init
 
   /**
    * Setup C Runtime

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -252,25 +252,6 @@ _mask_rom_start_boot:
   la   a1, _bss_end
   call crt_section_clear
 
-  // Re-clobber all of the temporary registers (may have been used in calls).
-  li t0, 0x0
-  li t1, 0x0
-  li t2, 0x0
-  li t3, 0x0
-  li t4, 0x0
-  li t5, 0x0
-  li t6, 0x0
-
-  // Re-clobber all of the argument registers (may have been used in calls).
-  li a0, 0x0
-  li a1, 0x0
-  li a2, 0x0
-  li a3, 0x0
-  li a4, 0x0
-  li a5, 0x0
-  li a6, 0x0
-  li a7, 0x0
-
   // Setup global pointer.
   //
   // This requires that we disable linker relaxations, or it will be relaxed to

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -248,9 +248,6 @@ _mask_rom_start_boot:
   call crt_section_copy
 
   // Initialize the `.bss` section.
-  //
-  // We do this despite zeroing all of SRAM above, so that we still zero `.bss`
-  // once we've enabled SRAM scrambling.
   la   a0, _bss_start
   la   a1, _bss_end
   call crt_section_clear


### PR DESCRIPTION
Various clean ups to simplify the mask ROM assembly code. The biggest change is removing the separate stack guard setup function - we don't need to do this separately any more since we no longer clear the stack.