### PR TITLE
[dv/otp_ctrl] Fix wake_up test

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -22,6 +22,8 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
 
     // check status
     cfg.clk_rst_vif.wait_clks(1);
+
+    // turn on all intr_enable
     csr_wr(ral.intr_enable, (1'b1 << NumOtpCtrlIntr) - 1);
     csr_rd_check(.ptr(ral.status.dai_idle), .compare_value(1));
 
@@ -30,14 +32,14 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
     csr_wr(ral.direct_access_wdata[0], '1);
     csr_wr(ral.direct_access_cmd, 2);
     wait(cfg.intr_vif.pins[OtpOperationDone] == 1);
-    csr_wr(ral.intr_state, (1'b1 << NumOtpCtrlIntr) - 1);
+    csr_wr(ral.intr_state, 1'b1 << OtpOperationDone);
 
     // read seq
     csr_wr(ral.direct_access_address, rand_addr);
     csr_wr(ral.direct_access_cmd, 1);
     wait(cfg.intr_vif.pins[OtpOperationDone] == 1);
     csr_rd_check(.ptr(ral.direct_access_rdata[0]), .compare_value('1));
-    csr_wr(ral.intr_state, (1'b1 << NumOtpCtrlIntr) - 1);
+    csr_wr(ral.intr_state, 1'b1 << OtpOperationDone);
 
     // digest sw error seq
     csr_wr(ral.direct_access_address, 2);
@@ -50,8 +52,10 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
     csr_wr(ral.direct_access_address, 11'h600);
     csr_wr(ral.direct_access_cmd, 4);
     wait(cfg.intr_vif.pins[OtpOperationDone] == 1);
-    csr_wr(ral.intr_state, OtpOperationDone);
+    csr_wr(ral.intr_state, 1'b1 << OtpOperationDone);
 
+    // check all interrupts are cleared
+    csr_rd_check(.ptr(ral.intr_state), .compare_value(0));
   endtask : body
 
 endclass : otp_ctrl_wake_up_vseq


### PR DESCRIPTION
This PR fixes wake up test when clearing the interrupts at the end of
the sequence - it should write `1` to the OperationDone bit instead of
`0`.
This PR also adds a final intr_state read to ensure all interrupts are
cleared.

Thanks Dror for finding this issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>