### PR TITLE
[kmac] Adjust app interface output length

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2529,8 +2529,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     // - the expected output length in bytes
     // - if we are using the xof version of kmac
     if (in_kmac_app) begin
-      // KMAC_APP output will always be 256 bits (32 bytes)
-      output_len_bytes = 32;
+      // KMAC_APP output will always be 384 bits (48 bytes)
+      output_len_bytes = AppDigestW / 8;
 
       // xof_en is 1 when the padded output length is 0,
       // but this will never happen in KMAC_APP

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -115,7 +115,12 @@ module kmac_app
 
   localparam key_len_e KeyLen [5] = '{Key128, Key192, Key256, Key384, Key512};
 
-  localparam int SelKeySize = (AppDigestW == 128) ? 0 :
+  localparam int SelKeySize = (AppKeyW == 128) ? 0 :
+                              (AppKeyW == 192) ? 1 :
+                              (AppKeyW == 256) ? 2 :
+                              (AppKeyW == 384) ? 3 :
+                              (AppKeyW == 512) ? 4 : 0 ;
+  localparam int SelDigSize = (AppDigestW == 128) ? 0 :
                               (AppDigestW == 192) ? 1 :
                               (AppDigestW == 256) ? 2 :
                               (AppDigestW == 384) ? 3 :
@@ -499,7 +504,7 @@ module kmac_app
   //////////////
 
   // Encoded output length
-  assign encoded_outlen      = EncodedOutLen[SelKeySize];
+  assign encoded_outlen      = EncodedOutLen[SelDigSize];
   assign encoded_outlen_mask = EncodedOutLenMask[SelKeySize];
 
   // Data mux

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -181,6 +181,7 @@ package kmac_pkg;
   // MsgWidth : 64
   // MsgStrbW : 8
   parameter int unsigned AppDigestW = 384;
+  parameter int unsigned AppKeyW = 256;
 
   typedef struct packed {
     logic valid;


### PR DESCRIPTION
The app interface digest is increased to 384-bits to better support
keymgr requirements.

Fixes #7278

Signed-off-by: Timothy Chen <timothytim@google.com>