### PR TITLE
[spi_device] Add Last Read Address CSR and latch

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -356,6 +356,22 @@
         }
       ],
     },
+    { name: "LAST_READ_ADDR"
+      desc: '''Last Read Address
+
+        This register shows the last address accessed by the host system.
+        It is updated by the HW when CSb is de-asserted.
+        '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      hwext: true
+      fields: [
+        { bits: "31:0"
+          name: "addr"
+          desc: "Last address"
+        }
+      ]
+    } // R: LAST_READ_ADDR
     { multireg: {
         cname: "SPI_DEVICE"
         name:  "CMD_FILTER"

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -283,6 +283,10 @@ package spi_device_reg_pkg;
     } rptr;
   } spi_device_hw2reg_txf_ptr_reg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+  } spi_device_hw2reg_last_read_addr_reg_t;
+
   // Register -> HW type
   typedef struct packed {
     spi_device_reg2hw_intr_state_reg_t intr_state; // [828:823]
@@ -304,11 +308,12 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [67:56]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [55:40]
-    spi_device_hw2reg_status_reg_t status; // [39:34]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [33:17]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [16:0]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [99:88]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [87:72]
+    spi_device_hw2reg_status_reg_t status; // [71:66]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [65:49]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [48:32]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [31:0]
   } spi_device_hw2reg_t;
 
   // Register offsets
@@ -325,32 +330,33 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_PTR_OFFSET = 13'h 28;
   parameter logic [BlockAw-1:0] SPI_DEVICE_RXF_ADDR_OFFSET = 13'h 2c;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_ADDR_OFFSET = 13'h 30;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 34;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 38;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 3c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 40;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 44;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 48;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 4c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 50;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 54;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 58;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 5c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 60;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 64;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 68;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 6c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 70;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 74;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_LAST_READ_ADDR_OFFSET = 13'h 34;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 38;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 3c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 40;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 44;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 48;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 4c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 50;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 54;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 58;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 5c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 60;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 64;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 68;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 6c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 70;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 74;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 78;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h 9c;
 
   // Reset values for hwext registers and their fields
   parameter logic [5:0] SPI_DEVICE_INTR_TEST_RESVAL = 6'h 0;
@@ -368,6 +374,7 @@ package spi_device_reg_pkg;
   parameter logic [0:0] SPI_DEVICE_STATUS_TXF_EMPTY_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_ABORT_DONE_RESVAL = 1'h 1;
   parameter logic [0:0] SPI_DEVICE_STATUS_CSB_RESVAL = 1'h 1;
+  parameter logic [31:0] SPI_DEVICE_LAST_READ_ADDR_RESVAL = 32'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] SPI_DEVICE_BUFFER_OFFSET = 13'h 1000;
@@ -388,6 +395,7 @@ package spi_device_reg_pkg;
     SPI_DEVICE_TXF_PTR,
     SPI_DEVICE_RXF_ADDR,
     SPI_DEVICE_TXF_ADDR,
+    SPI_DEVICE_LAST_READ_ADDR,
     SPI_DEVICE_CMD_FILTER_0,
     SPI_DEVICE_CMD_FILTER_1,
     SPI_DEVICE_CMD_FILTER_2,
@@ -417,7 +425,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [39] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [40] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -431,32 +439,33 @@ package spi_device_reg_pkg;
     4'b 1111, // index[10] SPI_DEVICE_TXF_PTR
     4'b 1111, // index[11] SPI_DEVICE_RXF_ADDR
     4'b 1111, // index[12] SPI_DEVICE_TXF_ADDR
-    4'b 1111, // index[13] SPI_DEVICE_CMD_FILTER_0
-    4'b 1111, // index[14] SPI_DEVICE_CMD_FILTER_1
-    4'b 1111, // index[15] SPI_DEVICE_CMD_FILTER_2
-    4'b 1111, // index[16] SPI_DEVICE_CMD_FILTER_3
-    4'b 1111, // index[17] SPI_DEVICE_CMD_FILTER_4
-    4'b 1111, // index[18] SPI_DEVICE_CMD_FILTER_5
-    4'b 1111, // index[19] SPI_DEVICE_CMD_FILTER_6
-    4'b 1111, // index[20] SPI_DEVICE_CMD_FILTER_7
-    4'b 1111, // index[21] SPI_DEVICE_ADDR_SWAP_MASK
-    4'b 1111, // index[22] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 0111, // index[23] SPI_DEVICE_CMD_INFO_0
-    4'b 0111, // index[24] SPI_DEVICE_CMD_INFO_1
-    4'b 0111, // index[25] SPI_DEVICE_CMD_INFO_2
-    4'b 0111, // index[26] SPI_DEVICE_CMD_INFO_3
-    4'b 0111, // index[27] SPI_DEVICE_CMD_INFO_4
-    4'b 0111, // index[28] SPI_DEVICE_CMD_INFO_5
-    4'b 0111, // index[29] SPI_DEVICE_CMD_INFO_6
-    4'b 0111, // index[30] SPI_DEVICE_CMD_INFO_7
-    4'b 0111, // index[31] SPI_DEVICE_CMD_INFO_8
-    4'b 0111, // index[32] SPI_DEVICE_CMD_INFO_9
-    4'b 0111, // index[33] SPI_DEVICE_CMD_INFO_10
-    4'b 0111, // index[34] SPI_DEVICE_CMD_INFO_11
-    4'b 0111, // index[35] SPI_DEVICE_CMD_INFO_12
-    4'b 0111, // index[36] SPI_DEVICE_CMD_INFO_13
-    4'b 0111, // index[37] SPI_DEVICE_CMD_INFO_14
-    4'b 0111  // index[38] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[13] SPI_DEVICE_LAST_READ_ADDR
+    4'b 1111, // index[14] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[15] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[16] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[17] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[18] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[19] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[20] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[21] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[22] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111, // index[23] SPI_DEVICE_ADDR_SWAP_DATA
+    4'b 0111, // index[24] SPI_DEVICE_CMD_INFO_0
+    4'b 0111, // index[25] SPI_DEVICE_CMD_INFO_1
+    4'b 0111, // index[26] SPI_DEVICE_CMD_INFO_2
+    4'b 0111, // index[27] SPI_DEVICE_CMD_INFO_3
+    4'b 0111, // index[28] SPI_DEVICE_CMD_INFO_4
+    4'b 0111, // index[29] SPI_DEVICE_CMD_INFO_5
+    4'b 0111, // index[30] SPI_DEVICE_CMD_INFO_6
+    4'b 0111, // index[31] SPI_DEVICE_CMD_INFO_7
+    4'b 0111, // index[32] SPI_DEVICE_CMD_INFO_8
+    4'b 0111, // index[33] SPI_DEVICE_CMD_INFO_9
+    4'b 0111, // index[34] SPI_DEVICE_CMD_INFO_10
+    4'b 0111, // index[35] SPI_DEVICE_CMD_INFO_11
+    4'b 0111, // index[36] SPI_DEVICE_CMD_INFO_12
+    4'b 0111, // index[37] SPI_DEVICE_CMD_INFO_13
+    4'b 0111, // index[38] SPI_DEVICE_CMD_INFO_14
+    4'b 0111  // index[39] SPI_DEVICE_CMD_INFO_15
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -249,6 +249,8 @@ module spi_device_reg_top (
   logic [15:0] txf_addr_base_wd;
   logic [15:0] txf_addr_limit_qs;
   logic [15:0] txf_addr_limit_wd;
+  logic last_read_addr_re;
+  logic [31:0] last_read_addr_qs;
   logic cmd_filter_0_we;
   logic cmd_filter_0_filter_0_qs;
   logic cmd_filter_0_filter_0_wd;
@@ -2186,6 +2188,22 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (txf_addr_limit_qs)
+  );
+
+
+  // R[last_read_addr]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (32)
+  ) u_last_read_addr (
+    .re     (last_read_addr_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.last_read_addr.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (last_read_addr_qs)
   );
 
 
@@ -12721,7 +12739,7 @@ module spi_device_reg_top (
 
 
 
-  logic [38:0] addr_hit;
+  logic [39:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -12737,32 +12755,33 @@ module spi_device_reg_top (
     addr_hit[10] = (reg_addr == SPI_DEVICE_TXF_PTR_OFFSET);
     addr_hit[11] = (reg_addr == SPI_DEVICE_RXF_ADDR_OFFSET);
     addr_hit[12] = (reg_addr == SPI_DEVICE_TXF_ADDR_OFFSET);
-    addr_hit[13] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
-    addr_hit[14] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
-    addr_hit[15] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
-    addr_hit[16] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
-    addr_hit[17] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
-    addr_hit[18] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
-    addr_hit[19] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
-    addr_hit[20] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
-    addr_hit[21] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
-    addr_hit[22] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[13] = (reg_addr == SPI_DEVICE_LAST_READ_ADDR_OFFSET);
+    addr_hit[14] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[15] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[16] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[17] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[18] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[19] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[20] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[22] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[23] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
+    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -12808,7 +12827,8 @@ module spi_device_reg_top (
                (addr_hit[35] & (|(SPI_DEVICE_PERMIT[35] & ~reg_be))) |
                (addr_hit[36] & (|(SPI_DEVICE_PERMIT[36] & ~reg_be))) |
                (addr_hit[37] & (|(SPI_DEVICE_PERMIT[37] & ~reg_be))) |
-               (addr_hit[38] & (|(SPI_DEVICE_PERMIT[38] & ~reg_be)))));
+               (addr_hit[38] & (|(SPI_DEVICE_PERMIT[38] & ~reg_be))) |
+               (addr_hit[39] & (|(SPI_DEVICE_PERMIT[39] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -12899,7 +12919,8 @@ module spi_device_reg_top (
   assign txf_addr_base_wd = reg_wdata[15:0];
 
   assign txf_addr_limit_wd = reg_wdata[31:16];
-  assign cmd_filter_0_we = addr_hit[13] & reg_we & !reg_error;
+  assign last_read_addr_re = addr_hit[13] & reg_re & !reg_error;
+  assign cmd_filter_0_we = addr_hit[14] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
@@ -12964,7 +12985,7 @@ module spi_device_reg_top (
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
-  assign cmd_filter_1_we = addr_hit[14] & reg_we & !reg_error;
+  assign cmd_filter_1_we = addr_hit[15] & reg_we & !reg_error;
 
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
@@ -13029,7 +13050,7 @@ module spi_device_reg_top (
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
-  assign cmd_filter_2_we = addr_hit[15] & reg_we & !reg_error;
+  assign cmd_filter_2_we = addr_hit[16] & reg_we & !reg_error;
 
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
@@ -13094,7 +13115,7 @@ module spi_device_reg_top (
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
-  assign cmd_filter_3_we = addr_hit[16] & reg_we & !reg_error;
+  assign cmd_filter_3_we = addr_hit[17] & reg_we & !reg_error;
 
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
@@ -13159,7 +13180,7 @@ module spi_device_reg_top (
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
-  assign cmd_filter_4_we = addr_hit[17] & reg_we & !reg_error;
+  assign cmd_filter_4_we = addr_hit[18] & reg_we & !reg_error;
 
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
@@ -13224,7 +13245,7 @@ module spi_device_reg_top (
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
-  assign cmd_filter_5_we = addr_hit[18] & reg_we & !reg_error;
+  assign cmd_filter_5_we = addr_hit[19] & reg_we & !reg_error;
 
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
@@ -13289,7 +13310,7 @@ module spi_device_reg_top (
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
-  assign cmd_filter_6_we = addr_hit[19] & reg_we & !reg_error;
+  assign cmd_filter_6_we = addr_hit[20] & reg_we & !reg_error;
 
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
@@ -13354,7 +13375,7 @@ module spi_device_reg_top (
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
-  assign cmd_filter_7_we = addr_hit[20] & reg_we & !reg_error;
+  assign cmd_filter_7_we = addr_hit[21] & reg_we & !reg_error;
 
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
@@ -13419,13 +13440,13 @@ module spi_device_reg_top (
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-  assign addr_swap_mask_we = addr_hit[21] & reg_we & !reg_error;
+  assign addr_swap_mask_we = addr_hit[22] & reg_we & !reg_error;
 
   assign addr_swap_mask_wd = reg_wdata[31:0];
-  assign addr_swap_data_we = addr_hit[22] & reg_we & !reg_error;
+  assign addr_swap_data_we = addr_hit[23] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[23] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[24] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -13444,7 +13465,7 @@ module spi_device_reg_top (
   assign cmd_info_0_payload_en_0_wd = reg_wdata[19:16];
 
   assign cmd_info_0_payload_dir_0_wd = reg_wdata[20];
-  assign cmd_info_1_we = addr_hit[24] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[25] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -13463,7 +13484,7 @@ module spi_device_reg_top (
   assign cmd_info_1_payload_en_1_wd = reg_wdata[19:16];
 
   assign cmd_info_1_payload_dir_1_wd = reg_wdata[20];
-  assign cmd_info_2_we = addr_hit[25] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[26] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -13482,7 +13503,7 @@ module spi_device_reg_top (
   assign cmd_info_2_payload_en_2_wd = reg_wdata[19:16];
 
   assign cmd_info_2_payload_dir_2_wd = reg_wdata[20];
-  assign cmd_info_3_we = addr_hit[26] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[27] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -13501,7 +13522,7 @@ module spi_device_reg_top (
   assign cmd_info_3_payload_en_3_wd = reg_wdata[19:16];
 
   assign cmd_info_3_payload_dir_3_wd = reg_wdata[20];
-  assign cmd_info_4_we = addr_hit[27] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[28] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -13520,7 +13541,7 @@ module spi_device_reg_top (
   assign cmd_info_4_payload_en_4_wd = reg_wdata[19:16];
 
   assign cmd_info_4_payload_dir_4_wd = reg_wdata[20];
-  assign cmd_info_5_we = addr_hit[28] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[29] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -13539,7 +13560,7 @@ module spi_device_reg_top (
   assign cmd_info_5_payload_en_5_wd = reg_wdata[19:16];
 
   assign cmd_info_5_payload_dir_5_wd = reg_wdata[20];
-  assign cmd_info_6_we = addr_hit[29] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[30] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -13558,7 +13579,7 @@ module spi_device_reg_top (
   assign cmd_info_6_payload_en_6_wd = reg_wdata[19:16];
 
   assign cmd_info_6_payload_dir_6_wd = reg_wdata[20];
-  assign cmd_info_7_we = addr_hit[30] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[31] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -13577,7 +13598,7 @@ module spi_device_reg_top (
   assign cmd_info_7_payload_en_7_wd = reg_wdata[19:16];
 
   assign cmd_info_7_payload_dir_7_wd = reg_wdata[20];
-  assign cmd_info_8_we = addr_hit[31] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[32] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -13596,7 +13617,7 @@ module spi_device_reg_top (
   assign cmd_info_8_payload_en_8_wd = reg_wdata[19:16];
 
   assign cmd_info_8_payload_dir_8_wd = reg_wdata[20];
-  assign cmd_info_9_we = addr_hit[32] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[33] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -13615,7 +13636,7 @@ module spi_device_reg_top (
   assign cmd_info_9_payload_en_9_wd = reg_wdata[19:16];
 
   assign cmd_info_9_payload_dir_9_wd = reg_wdata[20];
-  assign cmd_info_10_we = addr_hit[33] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[34] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -13634,7 +13655,7 @@ module spi_device_reg_top (
   assign cmd_info_10_payload_en_10_wd = reg_wdata[19:16];
 
   assign cmd_info_10_payload_dir_10_wd = reg_wdata[20];
-  assign cmd_info_11_we = addr_hit[34] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -13653,7 +13674,7 @@ module spi_device_reg_top (
   assign cmd_info_11_payload_en_11_wd = reg_wdata[19:16];
 
   assign cmd_info_11_payload_dir_11_wd = reg_wdata[20];
-  assign cmd_info_12_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -13672,7 +13693,7 @@ module spi_device_reg_top (
   assign cmd_info_12_payload_en_12_wd = reg_wdata[19:16];
 
   assign cmd_info_12_payload_dir_12_wd = reg_wdata[20];
-  assign cmd_info_13_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -13691,7 +13712,7 @@ module spi_device_reg_top (
   assign cmd_info_13_payload_en_13_wd = reg_wdata[19:16];
 
   assign cmd_info_13_payload_dir_13_wd = reg_wdata[20];
-  assign cmd_info_14_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -13710,7 +13731,7 @@ module spi_device_reg_top (
   assign cmd_info_14_payload_en_14_wd = reg_wdata[19:16];
 
   assign cmd_info_14_payload_dir_14_wd = reg_wdata[20];
-  assign cmd_info_15_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -13822,6 +13843,10 @@ module spi_device_reg_top (
       end
 
       addr_hit[13]: begin
+        reg_rdata_next[31:0] = last_read_addr_qs;
+      end
+
+      addr_hit[14]: begin
         reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
         reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
         reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
@@ -13856,7 +13881,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[15]: begin
         reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
         reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
         reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
@@ -13891,7 +13916,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
         reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
         reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
@@ -13926,7 +13951,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
         reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
         reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
@@ -13961,7 +13986,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
         reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
         reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
@@ -13996,7 +14021,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
         reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
         reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
@@ -14031,7 +14056,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
         reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
         reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
@@ -14066,7 +14091,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
         reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
         reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
@@ -14101,15 +14126,15 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[31:0] = addr_swap_mask_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[8] = cmd_info_0_addr_en_0_qs;
         reg_rdata_next[9] = cmd_info_0_addr_swap_en_0_qs;
@@ -14121,7 +14146,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_0_payload_dir_0_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[8] = cmd_info_1_addr_en_1_qs;
         reg_rdata_next[9] = cmd_info_1_addr_swap_en_1_qs;
@@ -14133,7 +14158,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_1_payload_dir_1_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[8] = cmd_info_2_addr_en_2_qs;
         reg_rdata_next[9] = cmd_info_2_addr_swap_en_2_qs;
@@ -14145,7 +14170,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_2_payload_dir_2_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[8] = cmd_info_3_addr_en_3_qs;
         reg_rdata_next[9] = cmd_info_3_addr_swap_en_3_qs;
@@ -14157,7 +14182,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_3_payload_dir_3_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[8] = cmd_info_4_addr_en_4_qs;
         reg_rdata_next[9] = cmd_info_4_addr_swap_en_4_qs;
@@ -14169,7 +14194,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_4_payload_dir_4_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[8] = cmd_info_5_addr_en_5_qs;
         reg_rdata_next[9] = cmd_info_5_addr_swap_en_5_qs;
@@ -14181,7 +14206,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_5_payload_dir_5_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[8] = cmd_info_6_addr_en_6_qs;
         reg_rdata_next[9] = cmd_info_6_addr_swap_en_6_qs;
@@ -14193,7 +14218,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_6_payload_dir_6_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[8] = cmd_info_7_addr_en_7_qs;
         reg_rdata_next[9] = cmd_info_7_addr_swap_en_7_qs;
@@ -14205,7 +14230,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_7_payload_dir_7_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[8] = cmd_info_8_addr_en_8_qs;
         reg_rdata_next[9] = cmd_info_8_addr_swap_en_8_qs;
@@ -14217,7 +14242,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_8_payload_dir_8_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[8] = cmd_info_9_addr_en_9_qs;
         reg_rdata_next[9] = cmd_info_9_addr_swap_en_9_qs;
@@ -14229,7 +14254,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_9_payload_dir_9_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[8] = cmd_info_10_addr_en_10_qs;
         reg_rdata_next[9] = cmd_info_10_addr_swap_en_10_qs;
@@ -14241,7 +14266,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_10_payload_dir_10_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[8] = cmd_info_11_addr_en_11_qs;
         reg_rdata_next[9] = cmd_info_11_addr_swap_en_11_qs;
@@ -14253,7 +14278,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_11_payload_dir_11_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[8] = cmd_info_12_addr_en_12_qs;
         reg_rdata_next[9] = cmd_info_12_addr_swap_en_12_qs;
@@ -14265,7 +14290,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_12_payload_dir_12_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[8] = cmd_info_13_addr_en_13_qs;
         reg_rdata_next[9] = cmd_info_13_addr_swap_en_13_qs;
@@ -14277,7 +14302,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_13_payload_dir_13_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[8] = cmd_info_14_addr_en_14_qs;
         reg_rdata_next[9] = cmd_info_14_addr_swap_en_14_qs;
@@ -14289,7 +14314,7 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_14_payload_dir_14_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[8] = cmd_info_15_addr_en_15_qs;
         reg_rdata_next[9] = cmd_info_15_addr_swap_en_15_qs;


### PR DESCRIPTION
[spi_device] Add Last Read Address CSR
    
This commit adds last read address accessed by the host system. While
operating (SPI interface is in active), the CSR is not updated. Using
latch and CSb as an enable signal, the CSR is updated when the SPI
interface is in idle.
    
TODO: need to check if still 2FF sync on core clock domain is necessary
or not.