### PR TITLE
[top, ibex, aon_timer] Connect watchdog bark to NMI

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -40,6 +40,13 @@
     // wakeup and reset request signals
     { struct:  "logic",
       type:    "uni",
+      name:    "nmi_wdog_timer_bark",
+      act:     "req",
+      package: "",
+      default: "1'b0"
+    },
+    { struct:  "logic",
+      type:    "uni",
       name:    "aon_timer_wkup_req",
       act:     "req",
       package: "",

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -26,6 +26,7 @@ module aon_timer import aon_timer_reg_pkg::*;
   input  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
   output logic                intr_wkup_timer_expired_o,
   output logic                intr_wdog_timer_bark_o,
+  output logic                nmi_wdog_timer_bark_o,
 
   // clk_aon_i domain
   output logic                aon_timer_wkup_req_o,
@@ -244,6 +245,9 @@ module aon_timer import aon_timer_reg_pkg::*;
     .d_i     (intr_out[AON_WDOG]),
     .q_o     (intr_wdog_timer_bark_o)
   );
+
+  // The interrupt line can be routed as nmi as well.
+  assign nmi_wdog_timer_bark_o = intr_wdog_timer_bark_o;
 
   ///////////////////
   // Reset Request //

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -129,6 +129,13 @@
       package: "pwrmgr_pkg",
     },
 
+    { struct:  "logic",
+      type:    "uni",
+      name:    "nmi_wdog",
+      act:     "rcv",
+      package: "",
+    },
+
   ],
   param_list: [
     { name:    "PMPEnable"
@@ -411,12 +418,15 @@
                   For example, if the intended matching region is 0x8000_0000 to 0x8000_FFFF, the value programmed is 0x8000_7FFF.
 
                   The value programmed can be determined from the translation granule.
-                  Assume the user wishes to translate a specific 64KB block to a different address.
+                  Assume the user wishes to translate a specific 64KB block to a different address:
                   64KB has a hex value of 0x10000.
                   Subtract 1 from this value and then right shift by one to obtain 0x7FFF.
-                  This value OR'd with the upper matching address bits that select which 64KB block to translate would then be programmed.
+                  This value is then logically OR'd with the upper address bits that would select which 64KB to translate.
 
-                  Given a value of 0x8000_7FFF, it specifies that the 0x8000-th 64KB block is the translation target.
+                  In this exampole, the user wishes to translate the 0x8000-th 64KB block.
+                  The value programmed is then 0x8000_7FFF.
+
+                  If the user were to translate the 0x8001-th 64KB block, the value programmed would be 0x8001_7FFF.
           ''',
           count: "NumRegions",
           compact: false,
@@ -444,9 +454,9 @@
                   The remap bits apply only to top portion of address bits not covered by the matching region.
 
                   For example, if the translation region is 64KB, the remapped address applies only to the upper
-                                                                      address bits that select which 64KB to be translated.
-                                                                      ''',
-                                                                      count: "NumRegions",
+                  address bits that select which 64KB to be translated.
+                ''',
+          count: "NumRegions",
           compact: false,
           swaccess: "rw",
           hwaccess: "hro",
@@ -566,6 +576,46 @@
         },
       },
 
+      { name: "NMI_ENABLE",
+        desc: '''
+          Enable mask for NMI.
+          Once an enable mask is set, it cannot be disabled.
+        ''',
+        swaccess: "rw1s",
+        hwaccess: "hro",
+        fields: [
+          { bits: "0",
+            name: "ALERT_EN",
+            resval: "0x0",
+            desc: "Enable mask for alert NMI"
+          },
+          { bits: "1",
+            name: "WDOG_EN",
+            resval: "0x0",
+            desc: "Enable mask for watchdog NMI"
+          },
+        ]
+      },
+
+      { name: "NMI_STATE",
+        desc: '''
+          Current NMI state
+        ''',
+        swaccess: "rw1c",
+        hwaccess: "hrw",
+        fields: [
+          { bits: "0",
+            name: "ALERT",
+            resval: "0x0",
+            desc: "Current state for alert NMI"
+          },
+          { bits: "1",
+            name: "WDOG",
+            resval: "0x0",
+            desc: "Current state for watchdog NMI"
+          },
+        ]
+      },
 
       { name: "ERR_STATUS",
         desc: "error status",
@@ -575,30 +625,30 @@
           { bits: "0",
             name: "REG_INTG_ERR",
             resval: "0x0"
-                      desc: '''
-                              rv_core_ibex_peri detected a register transmission integrity error
-                              '''
+            desc: '''
+              rv_core_ibex_peri detected a register transmission integrity error
+            '''
           },
           { bits: "8",
             name: "FATAL_INTG_ERR",
             resval: "0x0"
-                      desc: '''
-                              rv_core_ibex detected a response integrity error
-                              '''
+            desc: '''
+              rv_core_ibex detected a response integrity error
+            '''
           },
           { bits: "9",
             name: "FATAL_CORE_ERR",
             resval: "0x0"
-                      desc: '''
-                              rv_core_ibex detected a fatal internal error
-                              '''
+            desc: '''
+              rv_core_ibex detected a fatal internal error
+            '''
           },
           { bits: "10",
             name: "RECOV_CORE_ERR",
             resval: "0x0"
-                      desc: '''
-                              rv_core_ibex detected a recoverable internal error
-                              '''
+            desc: '''
+              rv_core_ibex detected a recoverable internal error
+            '''
           },
         ]
       },

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -67,6 +67,35 @@ package rv_core_ibex_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+    } alert_en;
+    struct packed {
+      logic        q;
+    } wdog_en;
+  } rv_core_ibex_reg2hw_nmi_enable_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } alert;
+    struct packed {
+      logic        q;
+    } wdog;
+  } rv_core_ibex_reg2hw_nmi_state_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } wdog;
+  } rv_core_ibex_hw2reg_nmi_state_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } reg_intg_err;
@@ -86,18 +115,21 @@ package rv_core_ibex_reg_pkg;
 
   // Register -> HW type for cfg interface
   typedef struct packed {
-    rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [271:264]
-    rv_core_ibex_reg2hw_sw_alert_mreg_t [1:0] sw_alert; // [263:260]
-    rv_core_ibex_reg2hw_ibus_addr_en_mreg_t [1:0] ibus_addr_en; // [259:258]
-    rv_core_ibex_reg2hw_ibus_addr_matching_mreg_t [1:0] ibus_addr_matching; // [257:194]
-    rv_core_ibex_reg2hw_ibus_remap_addr_mreg_t [1:0] ibus_remap_addr; // [193:130]
-    rv_core_ibex_reg2hw_dbus_addr_en_mreg_t [1:0] dbus_addr_en; // [129:128]
-    rv_core_ibex_reg2hw_dbus_addr_matching_mreg_t [1:0] dbus_addr_matching; // [127:64]
-    rv_core_ibex_reg2hw_dbus_remap_addr_mreg_t [1:0] dbus_remap_addr; // [63:0]
+    rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [275:268]
+    rv_core_ibex_reg2hw_sw_alert_mreg_t [1:0] sw_alert; // [267:264]
+    rv_core_ibex_reg2hw_ibus_addr_en_mreg_t [1:0] ibus_addr_en; // [263:262]
+    rv_core_ibex_reg2hw_ibus_addr_matching_mreg_t [1:0] ibus_addr_matching; // [261:198]
+    rv_core_ibex_reg2hw_ibus_remap_addr_mreg_t [1:0] ibus_remap_addr; // [197:134]
+    rv_core_ibex_reg2hw_dbus_addr_en_mreg_t [1:0] dbus_addr_en; // [133:132]
+    rv_core_ibex_reg2hw_dbus_addr_matching_mreg_t [1:0] dbus_addr_matching; // [131:68]
+    rv_core_ibex_reg2hw_dbus_remap_addr_mreg_t [1:0] dbus_remap_addr; // [67:4]
+    rv_core_ibex_reg2hw_nmi_enable_reg_t nmi_enable; // [3:2]
+    rv_core_ibex_reg2hw_nmi_state_reg_t nmi_state; // [1:0]
   } rv_core_ibex_cfg_reg2hw_t;
 
   // HW -> register type for cfg interface
   typedef struct packed {
+    rv_core_ibex_hw2reg_nmi_state_reg_t nmi_state; // [11:8]
     rv_core_ibex_hw2reg_err_status_reg_t err_status; // [7:0]
   } rv_core_ibex_cfg_hw2reg_t;
 
@@ -123,7 +155,9 @@ package rv_core_ibex_reg_pkg;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET = 7'h 48;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET = 7'h 4c;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET = 7'h 50;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 7'h 54;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_ENABLE_OFFSET = 7'h 54;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_STATE_OFFSET = 7'h 58;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 7'h 5c;
 
   // Reset values for hwext registers and their fields for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
@@ -155,11 +189,13 @@ package rv_core_ibex_reg_pkg;
     RV_CORE_IBEX_DBUS_ADDR_MATCHING_1,
     RV_CORE_IBEX_DBUS_REMAP_ADDR_0,
     RV_CORE_IBEX_DBUS_REMAP_ADDR_1,
+    RV_CORE_IBEX_NMI_ENABLE,
+    RV_CORE_IBEX_NMI_STATE,
     RV_CORE_IBEX_ERR_STATUS
   } rv_core_ibex_cfg_id_e;
 
   // Register width information to check illegal writes for cfg interface
-  parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [22] = '{
+  parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [24] = '{
     4'b 0001, // index[ 0] RV_CORE_IBEX_ALERT_TEST
     4'b 0001, // index[ 1] RV_CORE_IBEX_SW_ALERT_REGWEN_0
     4'b 0001, // index[ 2] RV_CORE_IBEX_SW_ALERT_REGWEN_1
@@ -181,7 +217,9 @@ package rv_core_ibex_reg_pkg;
     4'b 1111, // index[18] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1
     4'b 1111, // index[19] RV_CORE_IBEX_DBUS_REMAP_ADDR_0
     4'b 1111, // index[20] RV_CORE_IBEX_DBUS_REMAP_ADDR_1
-    4'b 0011  // index[21] RV_CORE_IBEX_ERR_STATUS
+    4'b 0001, // index[21] RV_CORE_IBEX_NMI_ENABLE
+    4'b 0001, // index[22] RV_CORE_IBEX_NMI_STATE
+    4'b 0011  // index[23] RV_CORE_IBEX_ERR_STATUS
   };
 
 endpackage

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3080,6 +3080,20 @@
       inter_signal_list:
       [
         {
+          name: nmi_wdog_timer_bark
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          default: 1'b0
+          inst_name: aon_timer_aon
+          package: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: aon_timer_aon_nmi_wdog_timer_bark
+          index: -1
+        }
+        {
           name: aon_timer_wkup_req
           struct: logic
           type: uni
@@ -5985,6 +5999,18 @@
           index: -1
         }
         {
+          name: nmi_wdog
+          struct: logic
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: rv_core_ibex
+          default: ""
+          package: ""
+          top_signame: aon_timer_aon_nmi_wdog_timer_bark
+          index: -1
+        }
+        {
           name: corei_tl_h
           struct: tl
           package: tlul_pkg
@@ -6496,6 +6522,10 @@
         lc_ctrl.esc_scrap_state0_tx
         lc_ctrl.esc_scrap_state1_tx
         pwrmgr_aon.esc_rst_tx
+      ]
+      aon_timer_aon.nmi_wdog_timer_bark:
+      [
+        rv_core_ibex.nmi_wdog
       ]
       csrng.csrng_cmd:
       [
@@ -14836,6 +14866,20 @@
         index: -1
       }
       {
+        name: nmi_wdog_timer_bark
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        default: 1'b0
+        inst_name: aon_timer_aon
+        package: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: aon_timer_aon_nmi_wdog_timer_bark
+        index: -1
+      }
+      {
         name: aon_timer_wkup_req
         struct: logic
         type: uni
@@ -16446,6 +16490,18 @@
         index: -1
       }
       {
+        name: nmi_wdog
+        struct: logic
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: rv_core_ibex
+        default: ""
+        package: ""
+        top_signame: aon_timer_aon_nmi_wdog_timer_bark
+        index: -1
+      }
+      {
         name: corei_tl_h
         struct: tl
         package: tlul_pkg
@@ -18027,6 +18083,17 @@
         act: req
         suffix: ""
         default: prim_esc_pkg::ESC_TX_DEFAULT
+      }
+      {
+        package: ""
+        struct: logic
+        signame: aon_timer_aon_nmi_wdog_timer_bark
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: 1'b0
       }
       {
         package: csrng_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -839,6 +839,7 @@
                                    'lc_ctrl.esc_scrap_state0_tx',
                                    'lc_ctrl.esc_scrap_state1_tx',
                                    'pwrmgr_aon.esc_rst_tx'],
+      'aon_timer_aon.nmi_wdog_timer_bark' : ['rv_core_ibex.nmi_wdog']
       'csrng.csrng_cmd'         : ['edn0.csrng_cmd', 'edn1.csrng_cmd'],
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
       'csrng.cs_aes_halt'       : ['entropy_src.cs_aes_halt'],

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -511,6 +511,7 @@ module top_earlgrey #(
   alert_pkg::alert_crashdump_t       alert_handler_crashdump;
   prim_esc_pkg::esc_rx_t [3:0] alert_handler_esc_rx;
   prim_esc_pkg::esc_tx_t [3:0] alert_handler_esc_tx;
+  logic       aon_timer_aon_nmi_wdog_timer_bark;
   csrng_pkg::csrng_req_t [1:0] csrng_csrng_cmd_req;
   csrng_pkg::csrng_rsp_t [1:0] csrng_csrng_cmd_rsp;
   entropy_src_pkg::entropy_src_hw_if_req_t       csrng_entropy_src_hw_if_req;
@@ -1982,6 +1983,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[27:27] ),
 
       // Inter-module signals
+      .nmi_wdog_timer_bark_o(aon_timer_aon_nmi_wdog_timer_bark),
       .aon_timer_wkup_req_o(pwrmgr_aon_wakeups[4]),
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs[1]),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
@@ -2573,6 +2575,7 @@ module top_earlgrey #(
       .lc_cpu_en_i(lc_ctrl_lc_cpu_en),
       .pwrmgr_cpu_en_i(pwrmgr_aon_fetch_en),
       .pwrmgr_o(rv_core_ibex_pwrmgr),
+      .nmi_wdog_i(aon_timer_aon_nmi_wdog_timer_bark),
       .corei_tl_h_o(main_tl_rv_core_ibex__corei_req),
       .corei_tl_h_i(main_tl_rv_core_ibex__corei_rsp),
       .cored_tl_h_o(main_tl_rv_core_ibex__cored_req),

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -78,6 +78,7 @@ config = {
         "hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson",
         "hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson",
         "hw/top_earlgrey/ip/rv_plic/data/autogen/rv_plic.hjson",
+        "hw/ip/rv_core_ibex/data/rv_core_ibex.hjson",
         "hw/ip/rv_timer/data/rv_timer.hjson",
         "hw/ip/spi_host/data/spi_host.hjson",
         "hw/ip/spi_device/data/spi_device.hjson",


### PR DESCRIPTION
- Based on #7419, it is better to have watchdog as an NMI
  so that software can collect panic logs.

- This PR adds a simple mechanism to combine two NMI sources
  and present one NMI to ibex.  Each NMI has an enable
  mask and a state bit, it behaves almost identically to
  interrupts.

- The main difference is the enable-bit is one-way only.  Once
  enabled, the NMI cannot be disabled until next power cycle.
  The state however can still be cleared, in case software needs
  to operate outside of the NMI handler for any reason.

Signed-off-by: Timothy Chen <timothytim@google.com>