### PR TITLE
[otbn,dv] Teach the RIG to generate error sequences (bad instructions)

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -5,7 +5,7 @@
 import sys
 from typing import Dict, Optional, Tuple
 
-from shared.insn_yaml import Insn, load_insns_yaml
+from shared.insn_yaml import Insn, DummyInsn, load_insns_yaml
 
 from .state import OTBNState
 
@@ -28,19 +28,6 @@ class DecodeError(Exception):
 
     def __str__(self) -> str:
         return 'DecodeError: {}'.format(self.msg)
-
-
-class DummyInsn(Insn):
-    '''A dummy instruction that will never be decoded. Used for the insn class
-    variable in the OTBNInsn base class.
-
-    '''
-    def __init__(self) -> None:
-        fake_yml = {
-            'mnemonic': 'dummy-insn',
-            'operands': []
-        }
-        super().__init__(fake_yml, None)
 
 
 def insn_for_mnemonic(mnemonic: str, num_operands: int) -> Insn:

--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -3,8 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gen-weights:
+  # Generators that can continue the program
   Branch: 0.1
-  ECall: 1.0
   Jump: 0.1
   Loop: 0.1
   StraightLineInsn: 1.0
+
+  # Generators that end the program
+  ECall: 1
+  BadInsn: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
@@ -1,0 +1,60 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional
+
+from shared.insn_yaml import InsnsFile
+
+from ..config import Config
+from ..program import DummyProgInsn, Program
+from ..model import Model
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
+
+
+class BadInsn(SnippetGen):
+    '''A simple snippet generator that generates one invalid instruction'''
+
+    ends_program = True
+
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__()
+
+        # Take a copy of the instructions file: we'll need it when generating
+        # random data in order to make sure we generate junk.
+        self.insns_file = insns_file
+
+    def _get_badbits(self) -> int:
+        for _ in range(50):
+            data = random.getrandbits(32)
+            # Is this (by fluke) actually a valid instruction? It's not very
+            # likely, but we need to check that it isn't.
+            if self.insns_file.mnem_for_word(data) is None:
+                return data
+
+        # Since the encoding density isn't all that high (< 25%), the chances
+        # of getting here are vanishingly small (should be < 2^100). Just
+        # assert that it doesn't happen.
+        assert 0
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+        prog_insn = DummyProgInsn(self._get_badbits())
+        snippet = ProgSnippet(model.pc, [prog_insn])
+        snippet.insert_into_program(program)
+        return (snippet, True, model)
+
+    def pick_weight(self,
+                    model: Model,
+                    program: Program) -> float:
+        # Choose small weights when we've got lots of room and large ones when
+        # we haven't.
+        room = min(model.fuel, program.space)
+        assert 0 < room
+        return (1e-10 if room > 5
+                else 0.1 if room > 1
+                else 1e10)

--- a/hw/ip/otbn/dv/rig/rig/gens/ecall.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/ecall.py
@@ -15,6 +15,9 @@ from ..snippet_gen import GenCont, GenRet, SnippetGen
 
 class ECall(SnippetGen):
     '''A generator that makes a snippet with a single ECALL instruction'''
+
+    ends_program = True
+
     def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
         super().__init__()
 

--- a/hw/ip/otbn/dv/rig/rig/rig.py
+++ b/hw/ip/otbn/dv/rig/rig/rig.py
@@ -58,5 +58,5 @@ def gen_program(config: Config,
         raise RuntimeError('Failed to initialise snippet generators: {}'
                            .format(err)) from None
 
-    snippet, end_addr = gens.gen_rest(model, program)
+    snippet, end_addr = gens.gen_program(model, program)
     return init_data, snippet, end_addr

--- a/hw/ip/otbn/dv/rig/rig/snippet_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gen.py
@@ -45,6 +45,10 @@ class SnippetGen:
     binary.
 
     '''
+    # A class-level variable that is set for generators that will end the
+    # program (with an ECALL or an error)
+    ends_program: bool = False
+
     def __init__(self) -> None:
         self.disabled = False
 

--- a/hw/ip/otbn/dv/rig/rig/snippet_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gen.py
@@ -25,7 +25,7 @@ from .snippet import Snippet
 # which case it still points at the ECALL.
 GenRet = Tuple[Snippet, bool, Model]
 
-# An "internal" return type for generators that never generate ECALLs.
+# An "internal" return type for generators that never cause termination.
 # (Essentially the same as GenRet, but with done = False)
 SimpleGenRet = Tuple[Snippet, Model]
 

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -19,15 +19,19 @@ from .gens.jump import Jump
 from .gens.loop import Loop
 from .gens.straight_line_insn import StraightLineInsn
 
+from .gens.bad_insn import BadInsn
+
 
 class SnippetGens:
     '''A collection of snippet generators'''
     _CLASSES = [
         Branch,
-        ECall,
         Jump,
         Loop,
-        StraightLineInsn
+        StraightLineInsn,
+
+        ECall,
+        BadInsn
     ]
 
     def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
@@ -206,7 +210,7 @@ class SnippetGens:
 
         '''
         snippets, next_model = self._gens(model, program, False)
-        # _gens() only sets next_model to None if ecall is True.
+        # _gens() only sets next_model to None if finish is True.
         assert next_model is not None
         snippet = Snippet.merge_list(snippets) if snippets else None
         return (snippet, next_model)

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -71,6 +71,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   `DEF_MNEM(mnem_bn_movr,       "bn.movr");
   `DEF_MNEM(mnem_bn_wsrr,       "bn.wsrr");
   `DEF_MNEM(mnem_bn_wsrw,       "bn.wsrw");
+  // A fake mnemonic, used for bits that don't decode to a real instruction
+  `DEF_MNEM(mnem_dummy,         "dummy-insn");
 `undef DEF_MNEM
 
   // A macro used for coverpoints for mnemonics. This expands to entries like
@@ -1617,6 +1619,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     insn_encodings[mnem_bn_movr]       = "bnmovr";
     insn_encodings[mnem_bn_wsrr]       = "wcsr";
     insn_encodings[mnem_bn_wsrw]       = "wcsr";
+    insn_encodings[mnem_dummy]         = "dummy";
   endfunction
 
   // Handle coverage for an instruction that was executed
@@ -1724,6 +1727,9 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
         enc_u_cg.sample(mnem, insn_data);
       "wcsr":
         enc_wcsr_cg.sample(mnem, insn_data);
+      "dummy":
+        // Bad instruction: no encoding-level coverage.
+        ;
       default: `dv_fatal($sformatf("Unknown encoding (%0s) for instruction `%0s'", encoding, mnem),
                          `gfn)
     endcase

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -203,6 +203,22 @@ class Insn:
         return mnem + ''.join(hunks).lstrip()
 
 
+class DummyInsn(Insn):
+    '''A dummy instruction that will never be decoded.
+
+    This shouldn't appear in an InsnGroup or InsnsFile, but can be handy when
+    you have an object that wraps an instruction but need to easily handle the
+    case of a bogus encoding.
+
+    '''
+    def __init__(self) -> None:
+        fake_yml = {
+            'mnemonic': 'dummy-insn',
+            'operands': []
+        }
+        super().__init__(fake_yml, None)
+
+
 class InsnGroup:
     def __init__(self,
                  path: str,


### PR DESCRIPTION
The next step for OTBN testing is to generate various badly behaved programs, to check that we handle errors in the way specified. This PR adds a simple framework to the RIG to allow it to do this (commit 2/3) and then adds a `BadInsn` generator (commit 3/3), which generates a single "instruction" which can't be decoded properly.

There are lots more bad behaviours that we're going to want to cover: this is intended to be the easiest one, which lets us get the framework up and running quickly.

The other commit (1/3) is a small bug-fix to the coverage collection code to teach it not to explode if we see an invalid instruction (an event that starts happening once commit 3/3 appears!)