### PR TITLE
[otbn] Spec: CSR or WSR permission errors are ignored

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -196,10 +196,6 @@
             <ul>
               <li>An instruction being excuted had an invalid encoding.</li>
               <li>An access occurred for an invalid CSR or WSR.</li>
-              <li>
-                A CSR or WSR access occurred that is not permitted (e.g. writing
-                to a read-only CSR or WSR).
-              </li>
             </ul>
           '''
         }


### PR DESCRIPTION
Writes to read-only CSRs or WSRs are ignored (currently). Update another
place in the documentation to match.