### PR TITLE
[otbn] Clarify error behavior in specification

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -217,15 +217,15 @@
         }
         { bits: "5",
           name: "fatal_imem"
-          desc: "A fatal failure was seen on an instruction fetch."
+          desc: "A fatal error was seen on an instruction fetch."
         }
         { bits: "6",
           name: "fatal_dmem"
-          desc: "A fatal failure was seen on a DMEM read."
+          desc: "A fatal error was seen on a DMEM read."
         }
         { bits: "7",
           name: "fatal_reg"
-          desc: "A fatal failure was seen on a GPR or WDR read."
+          desc: "A fatal error was seen on a GPR or WDR read."
         }
       ]
     } // register : err_bits

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -816,14 +816,16 @@ Passing data between the host CPU and OTBN is done through the data memory (DMEM
 No standard or required calling convention exists, every application is free to pass data in and out of OTBN in whatever format it finds convenient.
 All data passing must be done when OTBN is not running, as indicated by the {{< regref "STATUS.busy" >}} bit; during the OTBN operation both the instruction and the data memory are inaccessible from the host CPU.
 
-## Returning from an application
+## Returning from an application {#writing-otbn-applications-ecall}
 
 The software running on OTBN signals completion by executing the {{< otbnInsnRef "ECALL" >}} instruction.
 
-When it executes this instruction, OTBN:
-- Stops fetching and executing instructions.
-- Sets {{< regref "INTR_STATE.done" >}} and clears {{< regref "STATUS.busy" >}}, marking the operation as completed.
-- Writes zero to {{< regref "ERR_BITS" >}}.
+Once OTBN has executed the {{< otbnInsnRef "ECALL" >}} instruction, the following things happen:
+
+- No more instructions are fetched or executed.
+- A [secure wipe of internal state](#design-details-secure-wipe-internal) is performed.
+- The {{< regref "ERR_BITS" >}} register is set to 0, indicating a successful operation.
+- The current operation is marked as completed by setting {{< regref "INTR_STATE.done" >}} and clearing {{< regref "STATUS.busy" >}}.
 
 The DMEM can be used to pass data back to the host processor, e.g. a "return value" or an "exit code".
 Refer to the section [Passing of data between the host CPU and OTBN]({{<relref "#writing-otbn-applications-datapassing" >}}) for more information.


### PR DESCRIPTION
- Use consistent terminology: an error is when OTBN detects something
  went wrong. An alert is one of multiple actions as result of an error.
- Explicitly spell out what happens as result of a recoverable or fatal
  error.
- Give a bit more general context on errors, including a "over the
  thumb" guidance on when an error is recoverable, and when it is fatal.
- To avoid error nesting, specify that a secure wipe operation does not
  trigger any errors on its own.
- Specify that secure wipe operations triggered as part of the error
  handling scheme, or as part of a normal program termination, do not
  raise the done interrupt. Otherwise, we get two done interrupts for a
  normal program termination (one from the program, and one from the
  internal wipe), or a spurious done interrupt if a fatal alert was
  detected, but host software never started an operation (e.g. if a
  integrity violation is detected when reading the DMEM).
- Remove the big TODO note in the specification. Most of it is already
  covered implicitly in the text (e.g. program termination is following
  ECALL semantics, and we do an internal wipe, which clears the reg
  files). For the bus blocking topic we have an issue on file.
- Use "signaled" instead of "signalled" consistently, following American
  spelling.