### PR TITLE
[rtl/prim_diff_decode] Add prim_flop_2sync dependency

### DIFF
--- a/hw/ip/prim/prim_diff_decode.core
+++ b/hw/ip/prim/prim_diff_decode.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:flop_2sync
     files:
       - rtl/prim_diff_decode.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This PR adds prim_flop_2sync dependency to prim_diff_decode,
because in prim_diff_decode, it instantiates the prim_flop_2sync module.

DV hits this missing dependency when trying to build an independent
testbench for alert rx/tx pair.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>