### PR TITLE
[DRAFT] [CI] Update Verilator to 4.210

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   # If updating VERILATOR_VERSION, OPENOCD_VERSION, TOOLCHAIN_VERSION or RUST_VERSION
   # update the definitions in util/container/Dockerfile as well.
   #
-  VERILATOR_VERSION: 4.104
+  VERILATOR_VERSION: 4.210
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-1213-g9e5c085


### PR DESCRIPTION
Newer Verilator versions have a fair amount of changes to improve
compile time and run time performance specificially for OpenTitan.

Let's see how it looks in CI to make an informed decision about potential next steps.