### PR TITLE
[rstmgr] Clean up rstmgr por connection

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -63,6 +63,12 @@
 
   // Define rstmgr struct package
   inter_signal_list: [
+    { struct:  "logic",
+      type:    "uni",
+      name:    "por_n",
+      act:     "rcv",
+    },
+
     { struct:  "pwr_rst",    // pwr_rst_req_t, pwr_rst_rsp_t
       type:    "req_rsp",
       name:    "pwr",        // resets_o (req), resets_i (rsp)

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -15,10 +15,13 @@ module rstmgr
 ) (
   // Primary module clocks
   input clk_i,
-  input rst_ni, // this is connected to the top level reset
+  input rst_ni,
 % for clk in reset_obj.get_clocks():
   input clk_${clk}_i,
 % endfor
+
+  // POR input
+  input por_n_i,
 
   // Bus Interface
   input tlul_pkg::tl_h2d_t tl_i,
@@ -77,7 +80,7 @@ module rstmgr
 
       rstmgr_por u_rst_por_aon (
         .clk_i(clk_aon_i),
-        .rst_ni, // this is the only use of rst_ni in this module
+        .rst_ni(por_n_i),
         .scan_rst_ni,
         .scanmode_i(por_aon_scanmode == lc_ctrl_pkg::On),
         .rst_no(rst_por_aon_n[i])
@@ -94,17 +97,13 @@ module rstmgr
   // Register Interface                             //
   ////////////////////////////////////////////////////
 
-  // local_rst_n is the reset used by the rstmgr for its internal logic
-  logic local_rst_n;
-  assign local_rst_n = resets_o.rst_por_io_div2_n[DomainAonSel];
-
   logic [NumAlerts-1:0] alert_test, alerts;
   rstmgr_reg_pkg::rstmgr_reg2hw_t reg2hw;
   rstmgr_reg_pkg::rstmgr_hw2reg_t hw2reg;
 
   rstmgr_reg_top u_reg (
     .clk_i,
-    .rst_ni(local_rst_n),
+    .rst_ni,
     .tl_i,
     .tl_o,
     .reg2hw,
@@ -150,7 +149,7 @@ module rstmgr
     .ResetValue('0)
   ) u_sync (
     .clk_i,
-    .rst_ni(local_rst_n),
+    .rst_ni,
     .d_i(ndmreset_req_i),
     .q_o(ndmreset_req_q)
   );
@@ -186,7 +185,7 @@ module rstmgr
     .clk_i,
     .scanmode_i(rst_ctrl_scanmode == lc_ctrl_pkg::On),
     .scan_rst_ni,
-    .rst_ni(local_rst_n),
+    .rst_ni,
     .rst_req_i(pwr_i.rst_lc_req),
     .rst_parent_ni({PowerDomains{1'b1}}),
     .rst_no(rst_lc_src_n)
@@ -197,7 +196,7 @@ module rstmgr
     .clk_i,
     .scanmode_i(rst_ctrl_scanmode == lc_ctrl_pkg::On),
     .scan_rst_ni,
-    .rst_ni(local_rst_n),
+    .rst_ni,
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),
     .rst_parent_ni(rst_lc_src_n),
     .rst_no(rst_sys_src_n)
@@ -219,7 +218,7 @@ module rstmgr
       .RESVAL(1)
     ) u_rst_sw_ctrl_reg (
       .clk_i,
-      .rst_ni(local_rst_n),
+      .rst_ni,
       .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regen[i]),
       .wd(reg2hw.sw_rst_ctrl_n[i].q),
       .de('0),
@@ -312,14 +311,14 @@ module rstmgr
     .ResetValue('0)
   ) u_cpu_reset_synced (
     .clk_i,
-    .rst_ni(local_rst_n),
+    .rst_ni,
     .d_i(rst_cpu_n_i),
     .q_o(rst_cpu_nq)
   );
 
   // first reset is a flag that blocks reset recording until first de-assertion
-  always_ff @(posedge clk_i or negedge local_rst_n) begin
-    if (!local_rst_n) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
       first_reset <= 1'b1;
     end else if (rst_cpu_nq) begin
       first_reset <= 1'b0;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -172,15 +172,6 @@
     nodes:
     [
       {
-        name: rst_ni
-        gen: false
-        type: ext
-        domains: []
-        shadowed: false
-        sw: false
-        path: rst_ni
-      }
-      {
         name: por_aon
         gen: false
         type: top
@@ -2334,7 +2325,7 @@
       clock_group: powerup
       reset_connections:
       {
-        rst_ni: rst_ni
+        rst_ni: por_io_div4
       }
       domain: Aon
       attr: templated
@@ -2352,6 +2343,19 @@
       param_list: []
       inter_signal_list:
       [
+        {
+          name: por_n
+          struct: logic
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: rstmgr_aon
+          default: ""
+          package: ""
+          external: true
+          top_signame: por_n
+          index: -1
+        }
         {
           name: pwr
           struct: pwr_rst
@@ -7157,6 +7161,7 @@
       otp_ctrl.otp_ast_pwr_seq: ""
       otp_ctrl.otp_ast_pwr_seq_h: ""
       otp_ctrl.otp_alert: otp_alert
+      rstmgr_aon.por_n: por_n
       sensor_ctrl_aon.ast_alert: sensor_ctrl_ast_alert
       sensor_ctrl_aon.ast_status: sensor_ctrl_ast_status
       sensor_ctrl_aon.ast2pinmux: ast2pinmux
@@ -14330,6 +14335,19 @@
         index: -1
       }
       {
+        name: por_n
+        struct: logic
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: rstmgr_aon
+        default: ""
+        package: ""
+        external: true
+        top_signame: por_n
+        index: -1
+      }
+      {
         name: pwr
         struct: pwr_rst
         type: req_rsp
@@ -17958,6 +17976,18 @@
         conn_type: false
         index: -1
         netname: otp_alert
+      }
+      {
+        package: ""
+        struct: logic
+        signame: por_n_i
+        width: 1
+        type: uni
+        default: ""
+        direction: in
+        conn_type: false
+        index: -1
+        netname: por_n
       }
       {
         package: ast_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -140,7 +140,6 @@
     // likely external or generated from a voltage comparator
     //
     nodes: [
-      { name: "rst_ni",      gen: false, type: "ext",                                                          }
       { name: "por_aon",     gen: false, type: "top",                    clk: "aon"     }
       { name: "lc_src",      gen: false, type: "int",                    clk: "io_div4" }
       { name: "sys_src",     gen: false, type: "int",                    clk: "io_div4" }
@@ -346,7 +345,7 @@
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
                    clk_io_div2_i: "io_div2", clk_io_div4_i: "io_div4"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "rst_ni"},
+      reset_connections: {rst_ni: "por_io_div4"},
       domain: "Aon",
       base_addr: "0x40410000",
       attr: "templated",
@@ -1031,6 +1030,7 @@
         'otp_ctrl.otp_ast_pwr_seq'     : '',
         'otp_ctrl.otp_ast_pwr_seq_h'   : '',
         'otp_ctrl.otp_alert'           : 'otp_alert',
+        'rstmgr_aon.por_n'             : 'por_n'
         'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',
         'sensor_ctrl_aon.ast_status'   : 'sensor_ctrl_ast_status',
         'sensor_ctrl_aon.ast2pinmux'   : 'ast2pinmux',

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -70,6 +70,12 @@
 
   // Define rstmgr struct package
   inter_signal_list: [
+    { struct:  "logic",
+      type:    "uni",
+      name:    "por_n",
+      act:     "rcv",
+    },
+
     { struct:  "pwr_rst",    // pwr_rst_req_t, pwr_rst_rsp_t
       type:    "req_rsp",
       name:    "pwr",        // resets_o (req), resets_i (rsp)

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -1077,8 +1077,8 @@ module chip_earlgrey_asic (
   top_earlgrey #(
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .rst_ni                       ( aon_pok                    ),
     // ast connections
+    .por_n_i                      ( aon_pok                    ),
     .clk_main_i                   ( ast_base_clks.clk_sys      ),
     .clk_io_i                     ( ast_base_clks.clk_io       ),
     .clk_usb_i                    ( ast_base_clks.clk_usb      ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -743,7 +743,7 @@ module chip_earlgrey_cw310 #(
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .rst_ni                       ( rst_n            ),
+    .por_n_i                      ( rst_n            ),
     .clk_main_i                   ( clk_main         ),
     .clk_io_i                     ( clk_main         ),
     .clk_usb_i                    ( clk_usb_48mhz    ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -748,7 +748,7 @@ module chip_earlgrey_nexysvideo #(
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .rst_ni                       ( rst_n            ),
+    .por_n_i                      ( rst_n            ),
     .clk_main_i                   ( clk_main         ),
     .clk_io_i                     ( clk_main         ),
     .clk_usb_i                    ( clk_usb_48mhz    ),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -95,9 +95,6 @@ module top_earlgrey #(
       tl_main_pkg::ADDR_SPACE_RV_DM__ROM + dm::ExceptionAddress[31:0],
   parameter bit RvCoreIbexPipeLine = 0
 ) (
-  // Reset, clocks defined as part of intermodule
-  input               rst_ni,
-
   // Multiplexed I/O
   input        [46:0] mio_in_i,
   output logic [46:0] mio_out_o,
@@ -144,6 +141,7 @@ module top_earlgrey #(
   output otp_ctrl_pkg::otp_ast_req_t       otp_ctrl_otp_ast_pwr_seq_o,
   input  otp_ctrl_pkg::otp_ast_rsp_t       otp_ctrl_otp_ast_pwr_seq_h_i,
   output ast_pkg::ast_dif_t       otp_alert_o,
+  input  logic       por_n_i,
   input  ast_pkg::ast_alert_req_t       sensor_ctrl_ast_alert_req_i,
   output ast_pkg::ast_alert_rsp_t       sensor_ctrl_ast_alert_rsp_o,
   input  ast_pkg::ast_status_t       sensor_ctrl_ast_status_i,
@@ -1761,6 +1759,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[21:21] ),
 
       // Inter-module signals
+      .por_n_i(por_n_i),
       .pwr_i(pwrmgr_aon_pwr_rst_req),
       .pwr_o(pwrmgr_aon_pwr_rst_rsp),
       .resets_o(rstmgr_aon_resets),
@@ -1782,7 +1781,7 @@ module top_earlgrey #(
       .clk_usb_i (clkmgr_aon_clocks.clk_usb_powerup),
       .clk_io_div2_i (clkmgr_aon_clocks.clk_io_div2_powerup),
       .clk_io_div4_i (clkmgr_aon_clocks.clk_io_div4_powerup),
-      .rst_ni (rst_ni)
+      .rst_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
 
   clkmgr #(

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -156,7 +156,7 @@ module chip_earlgrey_verilator (
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .rst_ni                       (rst_ni            ),
+    .por_n_i                      (rst_ni            ),
     .clk_main_i                   (clk_i             ),
     .clk_io_i                     (clk_i             ),
     .clk_usb_i                    (clk_i             ),

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -140,23 +140,22 @@
     // likely external or generated from a voltage comparator
     //
     nodes: [
-      { name: "rst_ni",      gen: false, type: "ext",                                                          }
-      { name: "por_aon",     gen: false, type: "top", domains: ["Aon"     ],                    clk: "aon"     }
-      { name: "lc_src",      gen: false, type: "int", domains: ["Aon", "0"],                    clk: "io_div4" }
-      { name: "sys_src",     gen: false, type: "int", domains: ["Aon", "0"],                    clk: "io_div4" }
-      { name: "por",         gen: true,  type: "top", domains: ["Aon"     ], parent: "por_aon", clk: "main"    }
-      { name: "por_io",      gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io"      }
-      { name: "por_io_div2", gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io_div2" }
-      { name: "por_io_div4", gen: true , type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "io_div4" }
-      { name: "por_usb",     gen: true,  type: "top", domains: ["Aon",    ], parent: "por_aon", clk: "usb"     }
-      { name: "lc",          gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "main"    }
-      { name: "lc_io_div4",  gen: true,  type: "top", domains: [       "0"], parent: "lc_src",  clk: "io_div4" }
-      { name: "sys",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "main"    }
-      { name: "sys_io_div4", gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "io_div4" }
-      { name: "sys_aon",     gen: true,  type: "top", domains: ["Aon", "0"], parent: "sys_src", clk: "aon"     }
-      { name: "spi_device",  gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "spi_host0",   gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "io_div2", sw: 1 }
-      { name: "usb",         gen: true,  type: "top", domains: [       "0"], parent: "sys_src", clk: "usb",     sw: 1 }
+      { name: "por_aon",     gen: false, type: "top",                    clk: "aon"     }
+      { name: "lc_src",      gen: false, type: "int",                    clk: "io_div4" }
+      { name: "sys_src",     gen: false, type: "int",                    clk: "io_div4" }
+      { name: "por",         gen: true,  type: "top", parent: "por_aon", clk: "main"    }
+      { name: "por_io",      gen: true,  type: "top", parent: "por_aon", clk: "io"      }
+      { name: "por_io_div2", gen: true,  type: "top", parent: "por_aon", clk: "io_div2" }
+      { name: "por_io_div4", gen: true , type: "top", parent: "por_aon", clk: "io_div4" }
+      { name: "por_usb",     gen: true,  type: "top", parent: "por_aon", clk: "usb"     }
+      { name: "lc",          gen: true,  type: "top", parent: "lc_src",  clk: "main"    }
+      { name: "lc_io_div4",  gen: true,  type: "top", parent: "lc_src",  clk: "io_div4" }
+      { name: "sys",         gen: true,  type: "top", parent: "sys_src", clk: "main"    }
+      { name: "sys_io_div4", gen: true,  type: "top", parent: "sys_src", clk: "io_div4" }
+      { name: "sys_aon",     gen: true,  type: "top", parent: "sys_src", clk: "aon"     }
+      { name: "spi_device",  gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true }
+      { name: "spi_host0",   gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true }
+      { name: "usb",         gen: true,  type: "top", parent: "sys_src", clk: "usb",     sw: true }
     ]
   }
 
@@ -260,7 +259,7 @@
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
                    clk_io_div2_i: "io_div2", clk_io_div4_i: "io_div4"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "rst_ni"},
+      reset_connections: {rst_ni: "por_io_div4"},
       domain: "Aon",
       base_addr: "0x40410000",
       attr: "templated",
@@ -747,6 +746,7 @@
         'pinmux_aon.dft_strap_test'    : 'dft_strap_test'
         'pinmux_aon.dft_hold_tap_sel'  : 'dft_hold_tap_sel',
         'pwrmgr_aon.pwr_ast'           : 'pwrmgr_ast',
+        'rstmgr_aon.por_n'             : 'por_n'
         # 'otp_ctrl.otp_ast_pwr_seq'     : '',
         # 'otp_ctrl.otp_ast_pwr_seq_h'   : '',
         'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -162,7 +162,7 @@ module chip_englishbreakfast_verilator (
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_englishbreakfast (
-    .rst_ni                       (rst_ni            ),
+    .por_n_i                      (rst_ni            ),
     .clk_main_i                   (clk_i             ),
     .clk_io_i                     (clk_i             ),
     .clk_usb_i                    (clk_i             ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -925,8 +925,8 @@ module chip_${top["name"]}_${target["name"]} (
   top_${top["name"]} #(
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_${top["name"]} (
-    .rst_ni                       ( aon_pok                    ),
     // ast connections
+    .por_n_i                      ( aon_pok                    ),
     .clk_main_i                   ( ast_base_clks.clk_sys      ),
     .clk_io_i                     ( ast_base_clks.clk_io       ),
     .clk_usb_i                    ( ast_base_clks.clk_usb      ),
@@ -1097,7 +1097,7 @@ module chip_${top["name"]}_${target["name"]} (
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_${top["name"]} (
-    .rst_ni                       ( rst_n            ),
+    .por_n_i                      ( rst_n            ),
     .clk_main_i                   ( clk_main         ),
     .clk_io_i                     ( clk_main         ),
     .clk_usb_i                    ( clk_usb_48mhz    ),

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -65,9 +65,6 @@ module top_${top["name"]} #(
   % endfor
 % endfor
 ) (
-  // Reset, clocks defined as part of intermodule
-  input               rst_ni,
-
 % if num_mio_pads != 0:
   // Multiplexed I/O
   input        ${lib.bitarray(num_mio_pads, max_sigwidth)} mio_in_i,


### PR DESCRIPTION
Fixes #7459

Removes the confusion of rstmgr `rst_ni` not REALLY being
the module reset signal.