### PR TITLE
[flah_ctrl/dv] Changing Red to Redundancy

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -71,10 +71,10 @@ package flash_ctrl_env_pkg;
 
   // Partition select for DV
   typedef enum logic [flash_ctrl_pkg::InfoTypes:0] { // Data partition and all info partitions
-    FlashPartData  = 0,
-    FlashPartInfo  = 1,
-    FlashPartInfo1 = 2,
-    FlashPartRed   = 4
+    FlashPartData         = 0,
+    FlashPartInfo         = 1,
+    FlashPartInfo1        = 2,
+    FlashPartRedundancy   = 4
   } flash_dv_part_e;
 
   typedef struct packed {

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -44,10 +44,10 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Flash ctrl op randomization knobs.
 
   // Partition select. Make sure to keep sum equals to 100.
-  uint op_on_data_partition_pc;  // Choose data partition.
-  uint op_on_info_partition_pc;  // Choose info partition.
-  uint op_on_info1_partition_pc; // Choose info1 partition.
-  uint op_on_red_partition_pc;   // Choose redundancy partition.
+  uint op_on_data_partition_pc;         // Choose data partition.
+  uint op_on_info_partition_pc;         // Choose info partition.
+  uint op_on_info1_partition_pc;        // Choose info1 partition.
+  uint op_on_redundancy_partition_pc;   // Choose redundancy partition.
 
   bit op_readonly_on_info_partition;  // Make info partition read-only.
   bit op_readonly_on_info1_partition; // Make info1 partition read-only.
@@ -82,19 +82,20 @@ class flash_ctrl_seq_cfg extends uvm_object;
   virtual function void set_partition_pc(uint sel_data_part_pc = 100,
                                          uint sel_info_part_pc = 0,
                                          uint sel_info1_part_pc = 0,
-                                         uint sel_red_part_pc = 0);
+                                         uint sel_redundancy_part_pc = 0);
 
-    `DV_CHECK_EQ(sel_data_part_pc + sel_info_part_pc + sel_info1_part_pc + sel_red_part_pc, 100,
-                        $sformatf("Error! sum of arguments must be 100. Be aware of arguments \
-default values - 100 for data partition and 0 for all the others. Arguments current value: \
-sel_data_part_pc=%0d , sel_info_part_pc=%0d , sel_info1_part_pc=%0d , sel_red_part_pc=%0d",
-                                   sel_data_part_pc, sel_info_part_pc, sel_info1_part_pc,
-                                   sel_red_part_pc))
+    `DV_CHECK_EQ(sel_data_part_pc + sel_info_part_pc + sel_info1_part_pc + sel_redundancy_part_pc,
+                 100, $sformatf({"Error! sum of arguments must be 100. Be aware of arguments ",
+                                 "default values - 100 for data partition and 0 for all the ",
+                                 "others. Arguments current value: sel_data_part_pc=%0d , ",
+                                 "sel_info_part_pc=%0d , sel_info1_part_pc=%0d , ",
+                                 "sel_redundancy_part_pc=%0d"}, sel_data_part_pc,
+                                 sel_info_part_pc, sel_info1_part_pc, sel_redundancy_part_pc))
 
-    op_on_data_partition_pc = sel_data_part_pc;
-    op_on_info_partition_pc = sel_info_part_pc;
-    op_on_info1_partition_pc = sel_info1_part_pc;
-    op_on_red_partition_pc = sel_red_part_pc;
+    op_on_data_partition_pc       = sel_data_part_pc;
+    op_on_info_partition_pc       = sel_info_part_pc;
+    op_on_info1_partition_pc      = sel_info1_part_pc;
+    op_on_redundancy_partition_pc = sel_redundancy_part_pc;
 
   endfunction : set_partition_pc
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -162,13 +162,13 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
     csr_wr(.ptr(ral.addr), .value(flash_op.addr));
 
-    // flash_op.partition -> partition_sel  ,    info_sel         |
-    //  (flash_dv_part_e) | (flash_part_e)  | bit[InfoTypesWidth] |
-    // -------------------|-----------------|---------------------|
-    //  FlashPartData = 0 | FlashPartData=0 |         0           |
-    //  FlashPartInfo = 1 | FlashPartInfo=1 |         0           |
-    //  FlashPartInfo1= 2 | FlashPartInfo=1 |         1           |
-    //  FlashPartRed  = 4 | FlashPartInfo=1 |         2           |
+    //    flash_op.partition     -> partition_sel  ,    info_sel         |
+    //     (flash_dv_part_e)     | (flash_part_e)  | bit[InfoTypesWidth] |
+    // --------------------------|-----------------|---------------------|
+    //  FlashPartData        = 0 | FlashPartData=0 |         0           |
+    //  FlashPartInfo        = 1 | FlashPartInfo=1 |         0           |
+    //  FlashPartInfo1       = 2 | FlashPartInfo=1 |         1           |
+    //  FlashPartRedundancy  = 4 | FlashPartInfo=1 |         2           |
     partition_sel = |flash_op.partition;
     info_sel = flash_op.partition >> 1;
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -42,10 +42,10 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
         };
 
     flash_op.partition dist {
-      FlashPartData  :/ cfg.seq_cfg.op_on_data_partition_pc,
-      FlashPartInfo  :/ cfg.seq_cfg.op_on_info_partition_pc,
-      FlashPartInfo1 :/ cfg.seq_cfg.op_on_info1_partition_pc,
-      FlashPartRed   :/ cfg.seq_cfg.op_on_red_partition_pc
+      FlashPartData         :/ cfg.seq_cfg.op_on_data_partition_pc,
+      FlashPartInfo         :/ cfg.seq_cfg.op_on_info_partition_pc,
+      FlashPartInfo1        :/ cfg.seq_cfg.op_on_info1_partition_pc,
+      FlashPartRedundancy   :/ cfg.seq_cfg.op_on_redundancy_partition_pc
     };
 
     if (cfg.seq_cfg.op_readonly_on_info_partition) {


### PR DESCRIPTION
Very small PR, changing redundancy related variables & parameters names in flash_ctrl files from red/Red to redundancy/Redundancy.

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>