### PR TITLE
[otbn] P256: Improve the way we handle blinding randomness

### DIFF
--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -1444,13 +1444,13 @@ mod_inv_var:
  * host side. The signature is valid if x1 == r.
  * This routine runs in variable time.
  *
- * @param[in]  dmem[4]: dptr_x1, pointer to dmem location where the reduced
- *                           affine x1-coordinate will be stored
  * @param[in]  dmem[8]: dptr_msg, pointer to the message to be verified in dmem
  * @param[in]  dmem[12]: dptr_r, pointer to s of signature in dmem
  * @param[in]  dmem[16]: dptr_s, pointer to r of signature in dmem
  * @param[in]  dmem[20]: dptr_x, pointer to x-coordinate of public key in dmem
  * @param[in]  dmem[20]: dptr_y, pointer to y-coordinate of public key in dmem
+ * @param[in]  dmem[32]: dptr_x_r, pointer to dmem location where the reduced
+ *                           affine x_r-coordinate will be stored (aka x_1)
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
@@ -1468,8 +1468,8 @@ p256_verify:
   la        x3, p256_b
   bn.lid    x2, 0(x3)
 
-  /* load dmem pointer to x1 (result) from dmem: x17 <= dptr_rnd = dmem[4] */
-  la        x17, dptr_rnd
+  /* load dmem pointer to x_r (result) from dmem: x17 <= dptr_x_r = dmem[32] */
+  la        x17, dptr_x_r
   lw        x17, 0(x17)
 
   /* load dmem pointer to message msg in dmem: x18 <= dptr_msg = dmem[8] */
@@ -1679,7 +1679,7 @@ p256_verify:
   bn.subm   w24, w19, w31
 
   fail:
-  /* store affine x-coordinate in dmem: dmem[dptr_x1] = w24 = x1 */
+  /* store affine x-coordinate in dmem: dmem[dptr_x_r] = w24 = x_r */
   li        x2, 24
   bn.sid    x2, 0(x17)
 
@@ -1799,6 +1799,12 @@ dptr_y:
 .globl dptr_d
 .balign 4
 dptr_d:
+  .zero 4
+
+/* pointer to verification result x_r aka x_1 (dptr_x_r) */
+.globl dptr_x_r
+.balign 4
+dptr_x_r:
   .zero 4
 
 /* P-256 domain parameter b */

--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -1156,6 +1156,10 @@ p256_sign:
   li        x2, 0
   bn.lid    x2, 0(x16)
 
+  /* load random number for blinding from dmem: w1 = dmem[dptr_rnd] */
+  li        x2, 1
+  bn.lid    x2, 0(x17)
+
   /* scalar multiplication with base point
      (x_1, y_1) = (w11, w12) <= d*G = w0*(dmem[dptr_x], dmem[dptr_y]) */
   la        x21, p256_gx
@@ -1248,7 +1252,6 @@ p256_base_mult:
   /* load scalar d: w0 <= d = dmem[dptr_d] */
   la        x16, dptr_d
   lw        x16, 0(x16)
-  bn.lid    x0, 0(x16)
 
   /* load dmem pointer to random number for blinding rnd in dmem:
      x17 <= dptr_rnd = dmem[4] */
@@ -1258,6 +1261,14 @@ p256_base_mult:
   /* set dmem pointers to base point coordinates */
   la        x21, p256_gx
   la        x22, p256_gy
+
+  /* load private key d from dmem: w0 = dmem[dptr_d] */
+  li        x2, 0
+  bn.lid    x2, 0(x16)
+
+  /* load random number for blinding from dmem: w1 = dmem[dptr_rnd] */
+  li        x2, 1
+  bn.lid    x2, 0(x17)
 
   /* call internal scalar multiplication routine
      R = (x_a, y_a) = (w11, w12) <= k*P = w0*P */
@@ -1705,7 +1716,6 @@ p256_scalar_mult:
   /* load dmem pointer to scalar k: x16 <= dptr_k = dmem[0] */
   la        x16, dptr_k
   lw        x16, 0(x16)
-  bn.lid    x0, 0(x16)
 
   /* load dmem pointer to random number for blinding rnd in dmem:
      x17 <= dptr_rnd = dmem[4] */
@@ -1719,6 +1729,14 @@ p256_scalar_mult:
   /* set dmem pointer to point y-coordinate */
   la        x22, dptr_y
   lw        x22, 0(x22)
+
+  /* load private key d from dmem: w0 = dmem[dptr_d] */
+  li        x2, 0
+  bn.lid    x2, 0(x16)
+
+  /* load random number for blinding from dmem: w1 = dmem[dptr_rnd] */
+  li        x2, 1
+  bn.lid    x2, 0(x17)
 
   /* call internal scalar multiplication routine
      R = (x_a, y_a) = (w11, w12) <= k*P = w0*P */

--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -1753,50 +1753,57 @@ p256_scalar_mult:
 
 .section .data
 
-.balign 4
-
 /* pointer to k (dptr_k) */
 .globl dptr_k
+.balign 4
 dptr_k:
   .zero 4
 
 /* pointer to rnd (dptr_rnd) */
 .globl dptr_rnd
+.balign 4
 dptr_rnd:
   .zero 4
 
 /* pointer to msg (dptr_msg) */
 .globl dptr_msg
+.balign 4
 dptr_msg:
   .zero 4
 
 /* pointer to R (dptr_r) */
 .globl dptr_r
+.balign 4
 dptr_r:
   .zero 4
 
 /* pointer to S (dptr_s) */
 .globl dptr_s
+.balign 4
 dptr_s:
   .zero 4
 
 /* pointer to X (dptr_x) */
 .globl dptr_x
+.balign 4
 dptr_x:
   .zero 4
 
 /* pointer to Y (dptr_y) */
 .globl dptr_y
+.balign 4
 dptr_y:
   .zero 4
 
 /* pointer to D (dptr_d) */
 .globl dptr_d
+.balign 4
 dptr_d:
   .zero 4
 
 /* P-256 domain parameter b */
 .globl p256_b
+.balign 32
 p256_b:
   .word 0x27d2604b
   .word 0x3bce3c3e
@@ -1809,6 +1816,7 @@ p256_b:
 
 /* P-256 domain parameter p (modulus) */
 .globl p256_p
+.balign 32
 p256_p:
   .word 0xffffffff
   .word 0xffffffff
@@ -1821,6 +1829,7 @@ p256_p:
 
 /* Barrett constant u for modulus p */
 .globl p256_u_p
+.balign 32
 p256_u_p:
   .word 0x00000003
   .word 0x00000000
@@ -1833,6 +1842,7 @@ p256_u_p:
 
 /* P-256 domain parameter n (order of base point) */
 .globl p256_n
+.balign 32
 p256_n:
   .word 0xfc632551
   .word 0xf3b9cac2
@@ -1845,6 +1855,7 @@ p256_n:
 
 /* Barrett constant u for n */
 .globl p256_u_n
+.balign 32
 p256_u_n:
   .word 0xeedf9bfe
   .word 0x012ffd85
@@ -1857,6 +1868,7 @@ p256_u_n:
 
 /* P-256 basepoint G affine x-coordinate */
 .globl p256_gx
+.balign 32
 p256_gx:
   .word 0xd898c296
   .word 0xf4a13945
@@ -1869,6 +1881,7 @@ p256_gx:
 
 /* P-256 basepoint G affine y-coordinate */
 .globl p256_gy
+.balign 32
 p256_gy:
   .word 0x37bf51f5
   .word 0xcbb64068

--- a/sw/otbn/code-snippets/p256.s
+++ b/sw/otbn/code-snippets/p256.s
@@ -918,7 +918,7 @@ proj_double:
  *         with R, P being valid P-256 curve points in affine coordinates
  *              k being a 256 bit scalar
  *
- * This routines performs scalar multiplication based on the group laws
+ * This routine performs scalar multiplication based on the group laws
  * of Weierstrass curves.
  * A constant time double-and-add algorithm (sometimes referred to as
  * double-and-add-always) is used.

--- a/sw/otbn/code-snippets/p256_ecdsa.s
+++ b/sw/otbn/code-snippets/p256_ecdsa.s
@@ -32,6 +32,7 @@ p256_ecdsa_verify:
 k:
   .zero 32
 
+/* randomness for blinding */
 .globl rnd
 .balign 32
 rnd:

--- a/sw/otbn/code-snippets/p256_ecdsa.s
+++ b/sw/otbn/code-snippets/p256_ecdsa.s
@@ -73,3 +73,9 @@ y:
 .balign 32
 d:
   .zero 32
+
+/* verification result x_r (aka x_1) */
+.globl x_r
+.balign 32
+x_r:
+  .zero 32

--- a/sw/otbn/code-snippets/p256_ecdsa_verify_test.s
+++ b/sw/otbn/code-snippets/p256_ecdsa_verify_test.s
@@ -9,7 +9,7 @@
  * Coordinates of the public key, the message digest and R and S of the
  * signature are provided in the .data section below.
  *
- * The signature verification was successful if the return value in rnd and R
+ * The signature verification was successful if the return value in x_r and R
  * are identical.
  */
 
@@ -39,8 +39,8 @@ ecdsa_verify_test:
   sw       x2, 0(x3)
 
   /* set dmem pointer to point to signature verifcation result */
-  la       x2, sig_xres
-  la       x3, dptr_rnd
+  la       x2, sig_x_r
+  la       x3, dptr_x_r
   sw       x2, 0(x3)
 
   /* call ECDSA signature verification subroutine in P-256 lib */
@@ -48,7 +48,7 @@ ecdsa_verify_test:
 
   /* load signature to wregs for comparison with reference */
   li        x2, 0
-  la        x3, sig_xres
+  la        x3, sig_x_r
   bn.lid    x2, 0(x3)
 
   ecall
@@ -110,10 +110,10 @@ pub_y:
   .word 0x1f31c143
   .word 0x42a1c697
 
-/* signature verification result x_res */
-sig_xres:
+/* signature verification result x_r */
+sig_x_r:
   .zero 32
 
-/* Expected values wide register file (w0=rnd == R):
+/* Expected values wide register file (w0=x_r == R):
 w0 = 0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a
 */

--- a/sw/otbn/code-snippets/p256_ecdsa_verify_test.s
+++ b/sw/otbn/code-snippets/p256_ecdsa_verify_test.s
@@ -9,9 +9,8 @@
  * Coordinates of the public key, the message digest and R and S of the
  * signature are provided in the .data section below.
  *
- * Signature verification was successful, if the return values in the rnd and R
- * location are identical. The return values are copied to wide registers. See
- * comment at the end of the file for expected values for this example.
+ * The signature verification was successful if the return value in rnd and R
+ * are identical.
  */
 
 .text
@@ -115,6 +114,6 @@ pub_y:
 sig_xres:
   .zero 32
 
-/* Expected values wide register file (w0=rnd, w1=R):
+/* Expected values wide register file (w0=rnd == R):
 w0 = 0x815215ad7dd27f336b35843cbe064de299504edd0c7d87dd1147ea5680a9674a
 */

--- a/sw/otbn/code-snippets/p256_proj_add_test.s
+++ b/sw/otbn/code-snippets/p256_proj_add_test.s
@@ -16,7 +16,7 @@
 
 p256_proj_add_test:
 
-  /* load curver points to w8..w13 */
+  /* load curve points to w8..w13 */
   li       x2, 8
   la       x3, p1_x
   bn.lid   x2++, 0(x3)
@@ -62,7 +62,7 @@ p256_proj_add_test:
 
 .data
 
-/* point 1 x-cooridante p1_x*/
+/* point 1 x-coordinate p1_x */
 p1_x:
   .word 0xd898c296
   .word 0xf4a13945
@@ -73,7 +73,7 @@ p1_x:
   .word 0xe12c4247
   .word 0x6b17d1f2
 
-/* point 1 y-cooridante p1_y*/
+/* point 1 y-coordinate p1_y */
 p1_y:
   .word 0x37bf51f5
   .word 0xcbb64068
@@ -84,7 +84,7 @@ p1_y:
   .word 0xfe1a7f9b
   .word 0x4fe342e2
 
-/* point 1 z-cooridante p1_z*/
+/* point 1 z-coordinate p1_z */
 p1_z:
   .word 0x00000001
   .word 0x00000000
@@ -95,7 +95,7 @@ p1_z:
   .word 0x00000000
   .word 0x00000000
 
-/* point 2 x-cooridante p2_x*/
+/* point 2 x-coordinate p2_x */
 p2_x:
   .word 0xbfa8c334
   .word 0x9773b7b3
@@ -106,7 +106,7 @@ p2_x:
   .word 0xfacdc546
   .word 0xb5511a6a
 
-/* point 2 y-cooridante p2_y*/
+/* point 2 y-coordinate p2_y */
 p2_y:
   .word 0x9e008c2e
   .word 0xa8707058
@@ -117,7 +117,7 @@ p2_y:
   .word 0x1f31c143
   .word 0x42a1c697
 
-/* point 2 z-cooridante p2_z*/
+/* point 2 z-coordinate p2_z */
 p2_z:
   .word 0x00000001
   .word 0x00000000
@@ -128,7 +128,7 @@ p2_z:
   .word 0x00000000
   .word 0x00000000
 
-/* Expected values wide register file (x-, y-, z-coordinates of result):
+/* Expected values wide register file (x-, y-, z-coordinate of result):
  w11 = 0x592e1828fe28da49f90aede1688474f4f4c68bc0c51666812bf63ea329945969
  w12 = 0x3c57a35821690579a8e27ec0be7a3f100403f120312cf5b879e2f76f790331d7
  w13 = 0x20ee7815f61cb7b460e062016694a5411f852e298f26d449f355e47a9f192e78

--- a/sw/otbn/code-snippets/p384_verify.s
+++ b/sw/otbn/code-snippets/p384_verify.s
@@ -394,8 +394,8 @@ store_proj:
  * @param[in]  dmem[4]: dptr_rnd, pointer to dmem location where the reduced
  *                           affine x1-coordinate will be stored
  * @param[in]  dmem[8]: dptr_msg, pointer to the message to be verified in dmem
- * @param[in]  dmem[12]: dptr_r, pointer to s of signature in dmem
- * @param[in]  dmem[16]: dptr_s, pointer to r of signature in dmem
+ * @param[in]  dmem[12]: dptr_r, pointer to r of signature in dmem
+ * @param[in]  dmem[16]: dptr_s, pointer to s of signature in dmem
  * @param[in]  dmem[20]: dptr_x, pointer to x-coordinate of public key in dmem
  * @param[in]  dmem[20]: dptr_y, pointer to y-coordinate of public key in dmem
  *


### PR DESCRIPTION
The ECDSA P256 routines didn't read the blinding randomness from DMEM
before calling the `scalar_mult_int` routine. Fix that by explicitly
loading the variable into w1, using not the most efficient, but most
explicit syntax.

Going further, the input parameter `rnd` for blinding randomness was overlapping with the output parameter for the verification result, now called `x_r` (as discussed in https://github.com/lowRISC/opentitan/pull/7374#issuecomment-885259281). Separate the two.

This PR also contains some other small fixes that I came across when developing this fix, please review patch-by-patch.

See also https://github.com/lowRISC/opentitan/pull/7374#issuecomment-885259281 for a bit more discussion that is relevant to this PR.