### PR TITLE
[entropy_src/rtl] convert bit to field enables

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -86,9 +86,8 @@
   registers: [
     { name: "REGWEN",
       desc: "Register write enable for all control registers",
-      swaccess: "ro", // lock is managed by HW
-      hwaccess: "hwo",
-      hwext: "true",
+      swaccess: "rw0c",
+      hwaccess: "none",
       fields: [
         {
             bits: "0",
@@ -125,48 +124,60 @@
       desc: "Configuration register",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe:     "true",
+      regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they cause side affects.
+             "excl:CsrAllTests:CsrExclAll"]
+// TODO: fix up exclusions after env is fixed
+//             "excl:CsrAllTests:CsrExclWrite"]
       fields: [
-        { bits: "1:0",
+        { bits: "3:0",
           name: "ENABLE",
-          desc: '''This field is the module enable for the ENTROPY_SRC entropy generation function.
-                This two bit field determines what source will be used for all processing:
-                0b00: Disabled
-                0b01: PTRNG mode enabled
-                0b10: LFSR mode enabled
-                0b11: Reserved
+          desc: '''
+                Setting this field to 0xA will enable the ENTROPY_SRC module.
                 '''
-          tags: [// Exclude from writes to these bits to avoid Xs from entropy FIFO.
-                 "excl:CsrAllTests:CsrExclWrite"]
-        }
-        { bits: "3",
+          resval: "0x5"
+        },
+        { bits: "7:4",
+          name: "ENTROPY_DATA_REG_ENABLE",
+          desc: '''
+                Setting this field to 0xA will enable reading entropy values from the
+                ENTROPY_DATA register. This function also requires that the efuse_es_sw_reg_en
+                input is set.
+                '''
+          resval: "0x5"
+        },
+        { bits: "11:8",
+          name: "LFSR_ENABLE",
+          desc: '''
+                Setting this field to 0xA will enable the ENTROPY_SRC LFSR mode.
+                '''
+          resval: "0x5"
+        },
+        { bits: "15:12",
           name: "BOOT_BYPASS_DISABLE",
-          desc: "Setting this bit disables the initial generation of non-FIPS entropy."
-        }
-        { bits: "4",
-          name: "REPCNT_DISABLE",
-          desc: "Setting this bit disables the health test called Repetition Count test."
-        }
-        { bits: "5",
-          name: "ADAPTP_DISABLE",
-          desc: "Setting this bit disables the health test called  Adaptive Proportion test."
-        }
-        { bits: "6",
-          name: "BUCKET_DISABLE",
-          desc: "Setting this bit disables the health test called Bucket test."
-        }
-        { bits: "7",
-          name: "MARKOV_DISABLE",
-          desc: "Setting this bit disables the health test called Markov test."
-        }
-        { bits: "8",
+          desc: '''
+                Setting this field to 0xA will disables the initial generation of non-FIPS entropy.
+                '''
+          resval: "0x5"
+        },
+        { bits: "19:16",
           name: "HEALTH_TEST_CLR",
-          desc: "Setting this bit will clear all registers related to the health test operations."
-        }
-        { bits: "9",
-          name: "RNG_BIT_EN",
-          desc: "Setting this bit enables the single RNG bit mode, where only one bit is sampled."
-        }
-        { bits: "11:10",
+          desc: '''
+                Setting this field to 0xA will clear all registers related to the
+                health test operations.
+                '''
+          resval: "0x5"
+        },
+        { bits: "23:20",
+          name: "RNG_BIT_ENABLE",
+          desc: '''
+                Setting this field to 0xA enables the single RNG bit mode, where only
+                one bit is sampled.
+                '''
+          resval: "0x5"
+        },
+        { bits: "25:24",
           name: "RNG_BIT_SEL",
           desc: '''When the above bit iset, this field selects which bit from the RNG bus will
                 be processed when in single RNG bit mode.
@@ -175,18 +186,6 @@
                 0b01: RNG bit 1
                 0b10: RNG bit 2
                 0b11: RNG bit 3
-                '''
-        }
-        { bits: "12",
-          name: "EXTHT_ENABLE",
-          desc: '''Setting this bit enables the hardware-based health test that is external
-                to ENTROPY_SRC."
-                '''
-        }
-        { bits: "13",
-          name: "REPCNTS_DISABLE",
-          desc: '''Setting this bit disables the health test called Repetition Count test,
-                which is based on counting symbols.
                 '''
         }
       ]
@@ -210,22 +209,30 @@
       desc: "Entropy control register",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe:     "true",
       regwen:   "REGWEN",
+      tags: [// Exclude from writes to these field because they cause side affects.
+             "excl:CsrAllTests:CsrExclAll"]
+// TODO: remove above tag when working
       fields: [
-        { bits: "0",
+        { bits: "3:0",
           name: "ES_ROUTE",
-          desc: '''Setting this bit routes the generated entropy value to the ENTROPY_DATA
-                register to be read by firmware. When this bit is zero, the generated
+          desc: '''
+                Setting this field to 0xA routes the generated entropy value to the ENTROPY_DATA
+                register to be read by firmware. When this field is 0x5, the generated
                 entropy will be forwarded out of this module to the hardware interface.
                 '''
-        }
-        { bits: "1",
+          resval: "0x5"
+        },
+        { bits: "7:4",
           name: "ES_TYPE",
-          desc: '''Setting this bit will bypass the conditioning logic and bring raw entropy
-                data to the ENTROPY_DATA register. When zero, FIPS compliant entropy
+          desc: '''
+                Setting this field to 0xA will bypass the conditioning logic and bring raw entropy
+                data to the ENTROPY_DATA register. When 0x5, FIPS compliant entropy
                 will be brought the ENTROPY_DATA register, after being conditioned.
                 '''
-        }
+          resval: "0x5"
+        },
       ]
     },
     { name: "ENTROPY_DATA",
@@ -998,24 +1005,31 @@
       desc: "Firmware override control register",
       swaccess: "rw",
       hwaccess: "hro",
+      hwqe:     "true",
       regwen:   "REGWEN",
       fields: [
-        { bits: "0",
+        { bits: "3:0",
           name: "FW_OV_MODE",
-          desc: '''Setting this bit will put the entropy flow in firmware override mode.
+          desc: '''
+                Setting this field to 0xA will put the entropy flow in firmware override mode.
                 In this mode, firmware can monitor the post-health test entropy by reading
-                the observe FIFO.
+                the observe FIFO. This function also requires that the efuse_es_sw_ov_en
+                input is set.
                 '''
-        }
-        { bits: "1",
+          resval: "0x5"
+        },
+        { bits: "7:4",
           name: "FW_OV_ENTROPY_INSERT",
-          desc: '''Setting this bit will switch the input into the pre-conditioner packer FIFO.
-                Firmware can directly write into the packer FIFO, enabling the ability to insert
-                entropy bits back into the hardware flow. Firmware can read data from the health
-                check packer FIFO, then do optional health checks or optional conditioning, then
-                insert the results back into the flow. Also, the !!FW_OV_MODE bit must be set.
+          desc: '''
+                Setting this field to 0xA will switch the input into the pre-conditioner
+                packer FIFO. Firmware can directly write into the packer FIFO, enabling
+                the ability to insert entropy bits back into the hardware flow. Firmware
+                can read data from the health check packer FIFO, then do optional health
+                checks or optional conditioning, then insert the results back into the flow.
+                Also, the !!FW_OV_MODE bit must be set.
                 '''
-        }
+          resval: "0x5"
+        },
       ]
     },
     { name: "FW_OV_RD_DATA",

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -36,13 +36,23 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     cfg.efuse_es_sw_reg_en_vif.drive_pin(.idx(0), .val(cfg.efuse_es_sw_reg_en));
 
     // Set entropy_src controls
-    ral.entropy_control.es_type.set(cfg.type_bypass);
-    ral.entropy_control.es_route.set(cfg.route_software);
+    // TODO: hardcode for now, fix up contraints
+    //    ral.entropy_control.es_type.set(cfg.type_bypass);
+    //    ral.entropy_control.es_route.set(cfg.route_software);
+    //    csr_update(.csr(ral.entropy_control));
+    ral.entropy_control.es_type.set(4'h5);
+    ral.entropy_control.es_route.set(4'ha);
     csr_update(.csr(ral.entropy_control));
 
     // Enable entropy_src in ptrng or lfsr mode
-    ral.conf.enable.set(cfg.mode);
-    ral.conf.boot_bypass_disable.set(cfg.boot_bypass_disable);
+    // TODO: hardcode for now, fix up contraints
+    // ral.conf.enable.set(cfg.mode);
+    // ral.conf.boot_bypass_disable.set(cfg.boot_bypass_disable);
+    ral.entropy_control.es_route.set(4'ha);
+    csr_update(.csr(ral.entropy_control));
+    ral.conf.enable.set(4'ha);
+    ral.conf.entropy_data_reg_enable.set(4'ha);
+    ral.conf.boot_bypass_disable.set(4'h5);
     csr_update(.csr(ral.conf));
 
   endtask

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -62,6 +62,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   localparam int ObserveFifoDepth = 64;
   localparam int PreCondWidth = 64;
   localparam int Clog2ObserveFifoDepth = $clog2(ObserveFifoDepth);
+  // TODO: remove or enable below
+  // localparam int FieldEnableWidth = 4;
 
   //-----------------------
   // SHA3 parameters
@@ -78,17 +80,24 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic [RngBusWidth-1:0] seed_value;
   logic       load_seed;
   logic       fw_ov_mode;
+  logic       fw_ov_mode_pfe;
   logic       fw_ov_entropy_insert;
+  logic       fw_ov_entropy_insert_pfe;
   logic [ObserveFifoWidth-1:0] fw_ov_wr_data;
   logic       fw_ov_fifo_rd_pulse;
   logic       fw_ov_fifo_wr_pulse;
   logic       es_enable;
+  logic       es_enable_pfe;
   logic       es_enable_early;
   logic       es_enable_lfsr;
   logic       es_enable_rng;
   logic       rng_bit_en;
+  logic       rng_bit_en_pfe;
   logic [1:0] rng_bit_sel;
   logic       lfsr_incr;
+  logic       lfsr_enable_pfe;
+  logic       entropy_data_reg_en_pfe;
+  logic       es_data_reg_rd_en;
   logic       sw_es_rd_pulse;
   logic       event_es_entropy_valid;
   logic       event_es_health_test_failed;
@@ -150,15 +159,19 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     extht_active;
   logic                     alert_cntrs_clr;
   logic                     health_test_clr;
+  logic                     health_test_clr_pfe;
   logic                     health_test_done_pulse;
   logic [RngBusWidth-1:0]   health_test_esbus;
   logic                     health_test_esbus_vld;
+  logic                     es_route_pfe;
+  logic                     es_type_pfe;
   logic                     es_route_to_sw;
   logic                     es_bypass_to_sw;
   logic                     es_bypass_mode;
   logic                     rst_bypass_mode;
   logic                     rst_alert_cntr;
   logic                     boot_bypass_disable;
+  logic                     boot_bypass_dis_pfe;
   logic                     fips_compliance;
 
   logic [HalfRegWidth-1:0] health_test_fips_window;
@@ -367,6 +380,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                    unused_sha3_state;
   logic                    unused_entropy_data;
   logic                    unused_fw_ov_rd_data;
+  logic                    unused_rng_bit_sel;
 
   // flops
   logic [15:0] es_rate_cntr_q, es_rate_cntr_d;
@@ -417,18 +431,95 @@ module entropy_src_core import entropy_src_pkg::*; #(
       es_enable_q           <= es_enable_d;
     end
 
-  assign es_enable_d = reg2hw.conf.enable.q;
-  assign es_enable_early = (|reg2hw.conf.enable.q);
+
+  //--------------------------------------------
+  // set up secure enable bits
+  //--------------------------------------------
+
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_es_enable (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.conf.enable.qe),
+//    .wdata_i                (reg2hw.conf.enable.q),
+//    .enable_o               (es_enable_pfe)
+//  );
+
+  assign es_enable_pfe = (es_enb_e'(reg2hw.conf.enable.q) == ES_FIELD_ON);
+
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_lfsr_enable (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.conf.lfsr_enable.qe),
+//    .wdata_i                (reg2hw.conf.lfsr_enable.q),
+//    .enable_o               (lfsr_enable_pfe)
+//  );
+
+  assign lfsr_enable_pfe = (es_enb_e'(reg2hw.conf.lfsr_enable.q) == ES_FIELD_ON);
+
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_entropy_data_reg_en (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.conf.entropy_data_reg_enable.qe),
+//    .wdata_i                (reg2hw.conf.entropy_data_reg_enable.q),
+//    .enable_o               (entropy_data_reg_en_pfe)
+//  );
+
+  assign entropy_data_reg_en_pfe =
+         (es_enb_e'(reg2hw.conf.entropy_data_reg_enable.q) == ES_FIELD_ON);
+
+//  assign es_enable_d = reg2hw.conf.enable.q;  // TODO: remove
+  assign es_enable_d = {lfsr_enable_pfe,es_enable_pfe};
+  assign es_enable_early = lfsr_enable_pfe || es_enable_pfe;
   assign es_enable = (|es_enable_q);
   assign es_enable_lfsr = es_enable_q[1];
   assign es_enable_rng = es_enable_q[0];
   assign load_seed = !es_enable;
-  assign hw2reg.regwen.d = !es_enable; // hw reg lock implementation
   assign observe_fifo_thresh = reg2hw.observe_fifo_thresh.q;
 
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_fw_ov_mode (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.fw_ov_control.fw_ov_mode.qe),
+//    .wdata_i                (reg2hw.fw_ov_control.fw_ov_mode.q),
+//    .enable_o               (fw_ov_mode_pfe)
+//  );
+
+  assign fw_ov_mode_pfe = (es_enb_e'(reg2hw.fw_ov_control.fw_ov_mode.q) == ES_FIELD_ON);
+
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_fw_ov_entropy_insert (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.fw_ov_control.fw_ov_entropy_insert.qe),
+//    .wdata_i                (reg2hw.fw_ov_control.fw_ov_entropy_insert.q),
+//    .enable_o               (fw_ov_entropy_insert_pfe)
+//  );
+
+  assign fw_ov_entropy_insert_pfe =
+         (es_enb_e'(reg2hw.fw_ov_control.fw_ov_entropy_insert.q) == ES_FIELD_ON);
+
   // firmware override controls
-  assign fw_ov_mode = efuse_es_sw_ov_en_i && reg2hw.fw_ov_control.fw_ov_mode.q;
-  assign fw_ov_entropy_insert = reg2hw.fw_ov_control.fw_ov_entropy_insert.q;
+  assign fw_ov_mode = efuse_es_sw_ov_en_i && fw_ov_mode_pfe;
+  assign fw_ov_entropy_insert = fw_ov_entropy_insert_pfe;
   assign fw_ov_fifo_rd_pulse = reg2hw.fw_ov_rd_data.re;
   assign hw2reg.fw_ov_rd_data.d = sfifo_observe_rdata;
   assign fw_ov_fifo_wr_pulse = reg2hw.fw_ov_wr_data.qe;
@@ -694,7 +785,21 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   // pack esrng bus into signal bit packer
 
-  assign rng_bit_en = reg2hw.conf.rng_bit_en.q;
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_rng_bit_en (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.conf.rng_bit_enable.qe),
+//    .wdata_i                (reg2hw.conf.rng_bit_enable.q),
+//    .enable_o               (rng_bit_en_pfe)
+//  );
+
+  assign rng_bit_en_pfe = (es_enb_e'(reg2hw.conf.rng_bit_enable.q) == ES_FIELD_ON);
+
+  assign rng_bit_en = rng_bit_en_pfe;
   assign rng_bit_sel = reg2hw.conf.rng_bit_sel.q;
 
   prim_packer_fifo #(
@@ -737,14 +842,28 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign ht_esbus_dly_d     = es_enable ? health_test_esbus : '0;
   assign ht_esbus_vld_dly2_d = es_enable && ht_esbus_vld_dly_q;
 
-  assign repcnt_active = !reg2hw.conf.repcnt_disable.q && es_enable;
-  assign repcnts_active = !reg2hw.conf.repcnts_disable.q && es_enable;
-  assign adaptp_active = !reg2hw.conf.adaptp_disable.q && es_enable;
-  assign bucket_active = !reg2hw.conf.bucket_disable.q && es_enable;
-  assign markov_active = !reg2hw.conf.markov_disable.q && es_enable;
-  assign extht_active = reg2hw.conf.extht_enable.q && es_enable;
+  assign repcnt_active = es_enable;
+  assign repcnts_active = es_enable;
+  assign adaptp_active = es_enable;
+  assign bucket_active = es_enable;
+  assign markov_active = es_enable;
+  assign extht_active = es_enable;
 
-  assign health_test_clr = reg2hw.conf.health_test_clr.q;
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_health_test_clr (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.conf.health_test_clr.qe),
+//    .wdata_i                (reg2hw.conf.health_test_clr.q),
+//    .enable_o               (health_test_clr_pfe)
+//  );
+
+  assign health_test_clr_pfe = (es_enb_e'(reg2hw.conf.health_test_clr.q) == ES_FIELD_ON);
+
+  assign health_test_clr = health_test_clr_pfe;
 
   assign health_test_fips_window = reg2hw.health_test_windows.fips_window.q;
   assign health_test_bypass_window = reg2hw.health_test_windows.bypass_window.q;
@@ -1113,9 +1232,51 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign event_es_health_test_failed = recov_alert_event;
   assign event_es_observe_fifo_ready = observe_fifo_thresh_met;
 
-  assign es_route_to_sw = reg2hw.entropy_control.es_route.q;
-  assign es_bypass_to_sw = reg2hw.entropy_control.es_type.q;
-  assign boot_bypass_disable = reg2hw.conf.boot_bypass_disable.q;
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_es_route (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.entropy_control.es_route.qe),
+//    .wdata_i                (reg2hw.entropy_control.es_route.q),
+//    .enable_o               (es_route_pfe)
+//  );
+
+  assign es_route_pfe = (es_enb_e'(reg2hw.entropy_control.es_route.q) == ES_FIELD_ON);
+
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_es_type (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.entropy_control.es_type.qe),
+//    .wdata_i                (reg2hw.entropy_control.es_type.q),
+//    .enable_o               (es_type_pfe)
+//  );
+
+  assign es_type_pfe = (es_enb_e'(reg2hw.entropy_control.es_type.q) == ES_FIELD_ON);
+
+  // TODO: remove or enable prim_field_enable
+//  prim_field_enable #(
+//    .FieldW(FieldEnableWidth),
+//    .FieldEnVal(int'(ES_FIELD_ON))
+//  ) u_prim_field_enable_boot_bypass_dis (
+//    .clk_i                  (clk_i),
+//    .rst_ni                 (rst_ni),
+//    .wvalid_i               (reg2hw.conf.boot_bypass_disable.qe),
+//    .wdata_i                (reg2hw.conf.boot_bypass_disable.q),
+//    .enable_o               (boot_bypass_dis_pfe)
+//  );
+
+  assign boot_bypass_dis_pfe = (es_enb_e'(reg2hw.conf.boot_bypass_disable.q) == ES_FIELD_ON);
+
+  assign es_route_to_sw = es_route_pfe;
+  assign es_bypass_to_sw = es_type_pfe;
+  assign boot_bypass_disable = boot_bypass_dis_pfe;
 
   assign boot_bypass_d =
          (!es_enable_early) ? 1'b1 :  // special case for reset
@@ -2145,8 +2306,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign pfifo_swread_pop =  es_enable && sw_es_rd_pulse;
 
   // set the es entropy to the read reg
-  assign hw2reg.entropy_data.d = es_enable ? pfifo_swread_rdata : '0;
-  assign sw_es_rd_pulse = efuse_es_sw_reg_en_i && reg2hw.entropy_data.re;
+  assign es_data_reg_rd_en = es_enable && efuse_es_sw_reg_en_i && entropy_data_reg_en_pfe;
+  assign hw2reg.entropy_data.d = es_data_reg_rd_en ? pfifo_swread_rdata : '0;
+  assign sw_es_rd_pulse = es_data_reg_rd_en && reg2hw.entropy_data.re;
 
   //--------------------------------------------
   // unused signals
@@ -2156,6 +2318,17 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign unused_sha3_state = (|sha3_state[0][sha3_pkg::StateW-1:SeedLen]);
   assign unused_entropy_data = (|reg2hw.entropy_data.q);
   assign unused_fw_ov_rd_data = (|reg2hw.fw_ov_rd_data.q);
-
+  assign unused_rng_bit_sel = reg2hw.conf.rng_bit_sel.qe ||
+         // TODO: remove or enable these
+         reg2hw.conf.enable.qe ||
+         reg2hw.conf.lfsr_enable.qe ||
+         reg2hw.conf.entropy_data_reg_enable.qe ||
+         reg2hw.fw_ov_control.fw_ov_mode.qe ||
+         reg2hw.fw_ov_control.fw_ov_entropy_insert.qe ||
+         reg2hw.conf.rng_bit_enable.qe ||
+         reg2hw.conf.health_test_clr.qe ||
+         reg2hw.entropy_control.es_route.qe ||
+         reg2hw.entropy_control.es_type.qe ||
+         reg2hw.conf.boot_bypass_disable.qe;
 
 endmodule

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -74,4 +74,10 @@ package entropy_src_pkg;
   parameter entropy_src_xht_req_t ENTROPY_SRC_XHT_REQ_DEFAULT = '{default: '0};
   parameter entropy_src_xht_rsp_t ENTROPY_SRC_XHT_RSP_DEFAULT = '{default: '0};
 
+  // Sparse four-value signal type
+  parameter int ES_MODE_WIDTH = 4;
+  typedef enum logic [ES_MODE_WIDTH-1:0] {
+    ES_FIELD_ON = 4'b1010
+  } es_enb_e;
+
 endpackage : entropy_src_pkg

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -78,38 +78,33 @@ package entropy_src_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [1:0]  q;
+      logic [3:0]  q;
+      logic        qe;
     } enable;
     struct packed {
-      logic        q;
+      logic [3:0]  q;
+      logic        qe;
+    } entropy_data_reg_enable;
+    struct packed {
+      logic [3:0]  q;
+      logic        qe;
+    } lfsr_enable;
+    struct packed {
+      logic [3:0]  q;
+      logic        qe;
     } boot_bypass_disable;
     struct packed {
-      logic        q;
-    } repcnt_disable;
-    struct packed {
-      logic        q;
-    } adaptp_disable;
-    struct packed {
-      logic        q;
-    } bucket_disable;
-    struct packed {
-      logic        q;
-    } markov_disable;
-    struct packed {
-      logic        q;
+      logic [3:0]  q;
+      logic        qe;
     } health_test_clr;
     struct packed {
-      logic        q;
-    } rng_bit_en;
+      logic [3:0]  q;
+      logic        qe;
+    } rng_bit_enable;
     struct packed {
       logic [1:0]  q;
+      logic        qe;
     } rng_bit_sel;
-    struct packed {
-      logic        q;
-    } extht_enable;
-    struct packed {
-      logic        q;
-    } repcnts_disable;
   } entropy_src_reg2hw_conf_reg_t;
 
   typedef struct packed {
@@ -118,10 +113,12 @@ package entropy_src_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        q;
+      logic [3:0]  q;
+      logic        qe;
     } es_route;
     struct packed {
-      logic        q;
+      logic [3:0]  q;
+      logic        qe;
     } es_type;
   } entropy_src_reg2hw_entropy_control_reg_t;
 
@@ -249,10 +246,12 @@ package entropy_src_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        q;
+      logic [3:0]  q;
+      logic        qe;
     } fw_ov_mode;
     struct packed {
-      logic        q;
+      logic [3:0]  q;
+      logic        qe;
     } fw_ov_entropy_insert;
   } entropy_src_reg2hw_fw_ov_control_reg_t;
 
@@ -297,10 +296,6 @@ package entropy_src_reg_pkg;
       logic        de;
     } es_fatal_err;
   } entropy_src_hw2reg_intr_state_reg_t;
-
-  typedef struct packed {
-    logic        d;
-  } entropy_src_hw2reg_regwen_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -609,26 +604,26 @@ package entropy_src_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [538:535]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [534:531]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [530:523]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [522:519]
-    entropy_src_reg2hw_conf_reg_t conf; // [518:506]
-    entropy_src_reg2hw_rate_reg_t rate; // [505:490]
-    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [489:488]
-    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [487:455]
-    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [454:423]
-    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [422:389]
-    entropy_src_reg2hw_repcnts_thresholds_reg_t repcnts_thresholds; // [388:355]
-    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [354:321]
-    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [320:287]
-    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [286:253]
-    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [252:219]
-    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [218:185]
-    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [184:151]
-    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [150:117]
-    entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [116:85]
-    entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [84:83]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [574:571]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [570:567]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [566:559]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [558:555]
+    entropy_src_reg2hw_conf_reg_t conf; // [554:522]
+    entropy_src_reg2hw_rate_reg_t rate; // [521:506]
+    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [505:496]
+    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [495:463]
+    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [462:431]
+    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [430:397]
+    entropy_src_reg2hw_repcnts_thresholds_reg_t repcnts_thresholds; // [396:363]
+    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [362:329]
+    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [328:295]
+    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [294:261]
+    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [260:227]
+    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [226:193]
+    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [192:159]
+    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [158:125]
+    entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [124:93]
+    entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [92:83]
     entropy_src_reg2hw_fw_ov_rd_data_reg_t fw_ov_rd_data; // [82:50]
     entropy_src_reg2hw_fw_ov_wr_data_reg_t fw_ov_wr_data; // [49:17]
     entropy_src_reg2hw_observe_fifo_thresh_reg_t observe_fifo_thresh; // [16:10]
@@ -638,8 +633,7 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1023:1016]
-    entropy_src_hw2reg_regwen_reg_t regwen; // [1015:1015]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1022:1015]
     entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1014:983]
     entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [982:951]
     entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [950:919]
@@ -737,8 +731,6 @@ package entropy_src_reg_pkg;
   parameter logic [1:0] ENTROPY_SRC_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_RECOV_ALERT_RESVAL = 1'h 0;
   parameter logic [0:0] ENTROPY_SRC_ALERT_TEST_FATAL_ALERT_RESVAL = 1'h 0;
-  parameter logic [0:0] ENTROPY_SRC_REGWEN_RESVAL = 1'h 1;
-  parameter logic [0:0] ENTROPY_SRC_REGWEN_REGWEN_RESVAL = 1'h 1;
   parameter logic [31:0] ENTROPY_SRC_ENTROPY_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_REPCNT_THRESHOLDS_RESVAL = 32'h ffffffff;
   parameter logic [15:0] ENTROPY_SRC_REPCNT_THRESHOLDS_FIPS_THRESH_RESVAL = 16'h ffff;
@@ -860,7 +852,7 @@ package entropy_src_reg_pkg;
     4'b 0001, // index[ 3] ENTROPY_SRC_ALERT_TEST
     4'b 0001, // index[ 4] ENTROPY_SRC_REGWEN
     4'b 0111, // index[ 5] ENTROPY_SRC_REV
-    4'b 0011, // index[ 6] ENTROPY_SRC_CONF
+    4'b 1111, // index[ 6] ENTROPY_SRC_CONF
     4'b 0011, // index[ 7] ENTROPY_SRC_RATE
     4'b 0001, // index[ 8] ENTROPY_SRC_ENTROPY_CONTROL
     4'b 1111, // index[ 9] ENTROPY_SRC_ENTROPY_DATA

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -130,42 +130,35 @@ module entropy_src_reg_top (
   logic alert_test_we;
   logic alert_test_recov_alert_wd;
   logic alert_test_fatal_alert_wd;
-  logic regwen_re;
+  logic regwen_we;
   logic regwen_qs;
+  logic regwen_wd;
   logic [7:0] rev_abi_revision_qs;
   logic [7:0] rev_hw_revision_qs;
   logic [7:0] rev_chip_type_qs;
   logic conf_we;
-  logic [1:0] conf_enable_qs;
-  logic [1:0] conf_enable_wd;
-  logic conf_boot_bypass_disable_qs;
-  logic conf_boot_bypass_disable_wd;
-  logic conf_repcnt_disable_qs;
-  logic conf_repcnt_disable_wd;
-  logic conf_adaptp_disable_qs;
-  logic conf_adaptp_disable_wd;
-  logic conf_bucket_disable_qs;
-  logic conf_bucket_disable_wd;
-  logic conf_markov_disable_qs;
-  logic conf_markov_disable_wd;
-  logic conf_health_test_clr_qs;
-  logic conf_health_test_clr_wd;
-  logic conf_rng_bit_en_qs;
-  logic conf_rng_bit_en_wd;
+  logic [3:0] conf_enable_qs;
+  logic [3:0] conf_enable_wd;
+  logic [3:0] conf_entropy_data_reg_enable_qs;
+  logic [3:0] conf_entropy_data_reg_enable_wd;
+  logic [3:0] conf_lfsr_enable_qs;
+  logic [3:0] conf_lfsr_enable_wd;
+  logic [3:0] conf_boot_bypass_disable_qs;
+  logic [3:0] conf_boot_bypass_disable_wd;
+  logic [3:0] conf_health_test_clr_qs;
+  logic [3:0] conf_health_test_clr_wd;
+  logic [3:0] conf_rng_bit_enable_qs;
+  logic [3:0] conf_rng_bit_enable_wd;
   logic [1:0] conf_rng_bit_sel_qs;
   logic [1:0] conf_rng_bit_sel_wd;
-  logic conf_extht_enable_qs;
-  logic conf_extht_enable_wd;
-  logic conf_repcnts_disable_qs;
-  logic conf_repcnts_disable_wd;
   logic rate_we;
   logic [15:0] rate_qs;
   logic [15:0] rate_wd;
   logic entropy_control_we;
-  logic entropy_control_es_route_qs;
-  logic entropy_control_es_route_wd;
-  logic entropy_control_es_type_qs;
-  logic entropy_control_es_type_wd;
+  logic [3:0] entropy_control_es_route_qs;
+  logic [3:0] entropy_control_es_route_wd;
+  logic [3:0] entropy_control_es_type_qs;
+  logic [3:0] entropy_control_es_type_wd;
   logic entropy_data_re;
   logic [31:0] entropy_data_qs;
   logic health_test_windows_we;
@@ -291,10 +284,10 @@ module entropy_src_reg_top (
   logic [3:0] extht_fail_counts_extht_hi_fail_count_qs;
   logic [3:0] extht_fail_counts_extht_lo_fail_count_qs;
   logic fw_ov_control_we;
-  logic fw_ov_control_fw_ov_mode_qs;
-  logic fw_ov_control_fw_ov_mode_wd;
-  logic fw_ov_control_fw_ov_entropy_insert_qs;
-  logic fw_ov_control_fw_ov_entropy_insert_wd;
+  logic [3:0] fw_ov_control_fw_ov_mode_qs;
+  logic [3:0] fw_ov_control_fw_ov_mode_wd;
+  logic [3:0] fw_ov_control_fw_ov_entropy_insert_qs;
+  logic [3:0] fw_ov_control_fw_ov_entropy_insert_wd;
   logic fw_ov_rd_data_re;
   logic [31:0] fw_ov_rd_data_qs;
   logic fw_ov_wr_data_we;
@@ -633,18 +626,29 @@ module entropy_src_reg_top (
   );
 
 
-  // R[regwen]: V(True)
+  // R[regwen]: V(False)
 
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg #(
+    .DW      (1),
+    .SWACCESS("W0C"),
+    .RESVAL  (1'h1)
   ) u_regwen (
-    .re     (regwen_re),
-    .we     (1'b0),
-    .wd     ('0),
-    .d      (hw2reg.regwen.d),
-    .qre    (),
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (regwen_we),
+    .wd     (regwen_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
     .qe     (),
     .q      (),
+
+    // to register interface (read)
     .qs     (regwen_qs)
   );
 
@@ -668,17 +672,17 @@ module entropy_src_reg_top (
 
   // R[conf]: V(False)
 
-  //   F[enable]: 1:0
+  //   F[enable]: 3:0
   prim_subreg #(
-    .DW      (2),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (2'h0)
+    .RESVAL  (4'h5)
   ) u_conf_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_we),
+    .we     (conf_we & regwen_qs),
     .wd     (conf_enable_wd),
 
     // from internal hardware
@@ -686,7 +690,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.conf.enable.qe),
     .q      (reg2hw.conf.enable.q),
 
     // to register interface (read)
@@ -694,17 +698,69 @@ module entropy_src_reg_top (
   );
 
 
-  //   F[boot_bypass_disable]: 3:3
+  //   F[entropy_data_reg_enable]: 7:4
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
+  ) u_conf_entropy_data_reg_enable (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (conf_we & regwen_qs),
+    .wd     (conf_entropy_data_reg_enable_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (reg2hw.conf.entropy_data_reg_enable.qe),
+    .q      (reg2hw.conf.entropy_data_reg_enable.q),
+
+    // to register interface (read)
+    .qs     (conf_entropy_data_reg_enable_qs)
+  );
+
+
+  //   F[lfsr_enable]: 11:8
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h5)
+  ) u_conf_lfsr_enable (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (conf_we & regwen_qs),
+    .wd     (conf_lfsr_enable_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (reg2hw.conf.lfsr_enable.qe),
+    .q      (reg2hw.conf.lfsr_enable.q),
+
+    // to register interface (read)
+    .qs     (conf_lfsr_enable_qs)
+  );
+
+
+  //   F[boot_bypass_disable]: 15:12
+  prim_subreg #(
+    .DW      (4),
+    .SWACCESS("RW"),
+    .RESVAL  (4'h5)
   ) u_conf_boot_bypass_disable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_we),
+    .we     (conf_we & regwen_qs),
     .wd     (conf_boot_bypass_disable_wd),
 
     // from internal hardware
@@ -712,7 +768,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.conf.boot_bypass_disable.qe),
     .q      (reg2hw.conf.boot_bypass_disable.q),
 
     // to register interface (read)
@@ -720,121 +776,17 @@ module entropy_src_reg_top (
   );
 
 
-  //   F[repcnt_disable]: 4:4
+  //   F[health_test_clr]: 19:16
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_repcnt_disable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (conf_we),
-    .wd     (conf_repcnt_disable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.repcnt_disable.q),
-
-    // to register interface (read)
-    .qs     (conf_repcnt_disable_qs)
-  );
-
-
-  //   F[adaptp_disable]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_adaptp_disable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (conf_we),
-    .wd     (conf_adaptp_disable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.adaptp_disable.q),
-
-    // to register interface (read)
-    .qs     (conf_adaptp_disable_qs)
-  );
-
-
-  //   F[bucket_disable]: 6:6
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_bucket_disable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (conf_we),
-    .wd     (conf_bucket_disable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.bucket_disable.q),
-
-    // to register interface (read)
-    .qs     (conf_bucket_disable_qs)
-  );
-
-
-  //   F[markov_disable]: 7:7
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_markov_disable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (conf_we),
-    .wd     (conf_markov_disable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.markov_disable.q),
-
-    // to register interface (read)
-    .qs     (conf_markov_disable_qs)
-  );
-
-
-  //   F[health_test_clr]: 8:8
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
   ) u_conf_health_test_clr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_we),
+    .we     (conf_we & regwen_qs),
     .wd     (conf_health_test_clr_wd),
 
     // from internal hardware
@@ -842,7 +794,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.conf.health_test_clr.qe),
     .q      (reg2hw.conf.health_test_clr.q),
 
     // to register interface (read)
@@ -850,33 +802,33 @@ module entropy_src_reg_top (
   );
 
 
-  //   F[rng_bit_en]: 9:9
+  //   F[rng_bit_enable]: 23:20
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_rng_bit_en (
+    .RESVAL  (4'h5)
+  ) u_conf_rng_bit_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_we),
-    .wd     (conf_rng_bit_en_wd),
+    .we     (conf_we & regwen_qs),
+    .wd     (conf_rng_bit_enable_wd),
 
     // from internal hardware
     .de     (1'b0),
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.rng_bit_en.q),
+    .qe     (reg2hw.conf.rng_bit_enable.qe),
+    .q      (reg2hw.conf.rng_bit_enable.q),
 
     // to register interface (read)
-    .qs     (conf_rng_bit_en_qs)
+    .qs     (conf_rng_bit_enable_qs)
   );
 
 
-  //   F[rng_bit_sel]: 11:10
+  //   F[rng_bit_sel]: 25:24
   prim_subreg #(
     .DW      (2),
     .SWACCESS("RW"),
@@ -886,7 +838,7 @@ module entropy_src_reg_top (
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_we),
+    .we     (conf_we & regwen_qs),
     .wd     (conf_rng_bit_sel_wd),
 
     // from internal hardware
@@ -894,63 +846,11 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.conf.rng_bit_sel.qe),
     .q      (reg2hw.conf.rng_bit_sel.q),
 
     // to register interface (read)
     .qs     (conf_rng_bit_sel_qs)
-  );
-
-
-  //   F[extht_enable]: 12:12
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_extht_enable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (conf_we),
-    .wd     (conf_extht_enable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.extht_enable.q),
-
-    // to register interface (read)
-    .qs     (conf_extht_enable_qs)
-  );
-
-
-  //   F[repcnts_disable]: 13:13
-  prim_subreg #(
-    .DW      (1),
-    .SWACCESS("RW"),
-    .RESVAL  (1'h0)
-  ) u_conf_repcnts_disable (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (conf_we),
-    .wd     (conf_repcnts_disable_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.conf.repcnts_disable.q),
-
-    // to register interface (read)
-    .qs     (conf_repcnts_disable_qs)
   );
 
 
@@ -983,11 +883,11 @@ module entropy_src_reg_top (
 
   // R[entropy_control]: V(False)
 
-  //   F[es_route]: 0:0
+  //   F[es_route]: 3:0
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
   ) u_entropy_control_es_route (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1001,7 +901,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.entropy_control.es_route.qe),
     .q      (reg2hw.entropy_control.es_route.q),
 
     // to register interface (read)
@@ -1009,11 +909,11 @@ module entropy_src_reg_top (
   );
 
 
-  //   F[es_type]: 1:1
+  //   F[es_type]: 7:4
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
   ) u_entropy_control_es_type (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1027,7 +927,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.entropy_control.es_type.qe),
     .q      (reg2hw.entropy_control.es_type.q),
 
     // to register interface (read)
@@ -2036,11 +1936,11 @@ module entropy_src_reg_top (
 
   // R[fw_ov_control]: V(False)
 
-  //   F[fw_ov_mode]: 0:0
+  //   F[fw_ov_mode]: 3:0
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
   ) u_fw_ov_control_fw_ov_mode (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2054,7 +1954,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.fw_ov_control.fw_ov_mode.qe),
     .q      (reg2hw.fw_ov_control.fw_ov_mode.q),
 
     // to register interface (read)
@@ -2062,11 +1962,11 @@ module entropy_src_reg_top (
   );
 
 
-  //   F[fw_ov_entropy_insert]: 1:1
+  //   F[fw_ov_entropy_insert]: 7:4
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SWACCESS("RW"),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
   ) u_fw_ov_control_fw_ov_entropy_insert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -2080,7 +1980,7 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.fw_ov_control.fw_ov_entropy_insert.qe),
     .q      (reg2hw.fw_ov_control.fw_ov_entropy_insert.q),
 
     // to register interface (read)
@@ -2678,38 +2578,32 @@ module entropy_src_reg_top (
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
   assign alert_test_fatal_alert_wd = reg_wdata[1];
-  assign regwen_re = addr_hit[4] & reg_re & !reg_error;
+  assign regwen_we = addr_hit[4] & reg_we & !reg_error;
+
+  assign regwen_wd = reg_wdata[0];
   assign conf_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign conf_enable_wd = reg_wdata[1:0];
+  assign conf_enable_wd = reg_wdata[3:0];
 
-  assign conf_boot_bypass_disable_wd = reg_wdata[3];
+  assign conf_entropy_data_reg_enable_wd = reg_wdata[7:4];
 
-  assign conf_repcnt_disable_wd = reg_wdata[4];
+  assign conf_lfsr_enable_wd = reg_wdata[11:8];
 
-  assign conf_adaptp_disable_wd = reg_wdata[5];
+  assign conf_boot_bypass_disable_wd = reg_wdata[15:12];
 
-  assign conf_bucket_disable_wd = reg_wdata[6];
+  assign conf_health_test_clr_wd = reg_wdata[19:16];
 
-  assign conf_markov_disable_wd = reg_wdata[7];
+  assign conf_rng_bit_enable_wd = reg_wdata[23:20];
 
-  assign conf_health_test_clr_wd = reg_wdata[8];
-
-  assign conf_rng_bit_en_wd = reg_wdata[9];
-
-  assign conf_rng_bit_sel_wd = reg_wdata[11:10];
-
-  assign conf_extht_enable_wd = reg_wdata[12];
-
-  assign conf_repcnts_disable_wd = reg_wdata[13];
+  assign conf_rng_bit_sel_wd = reg_wdata[25:24];
   assign rate_we = addr_hit[7] & reg_we & !reg_error;
 
   assign rate_wd = reg_wdata[15:0];
   assign entropy_control_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign entropy_control_es_route_wd = reg_wdata[0];
+  assign entropy_control_es_route_wd = reg_wdata[3:0];
 
-  assign entropy_control_es_type_wd = reg_wdata[1];
+  assign entropy_control_es_type_wd = reg_wdata[7:4];
   assign entropy_data_re = addr_hit[9] & reg_re & !reg_error;
   assign health_test_windows_we = addr_hit[10] & reg_we & !reg_error;
 
@@ -2798,9 +2692,9 @@ module entropy_src_reg_top (
   assign extht_fail_counts_re = addr_hit[41] & reg_re & !reg_error;
   assign fw_ov_control_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign fw_ov_control_fw_ov_mode_wd = reg_wdata[0];
+  assign fw_ov_control_fw_ov_mode_wd = reg_wdata[3:0];
 
-  assign fw_ov_control_fw_ov_entropy_insert_wd = reg_wdata[1];
+  assign fw_ov_control_fw_ov_entropy_insert_wd = reg_wdata[7:4];
   assign fw_ov_rd_data_re = addr_hit[43] & reg_re & !reg_error;
   assign fw_ov_wr_data_we = addr_hit[44] & reg_we & !reg_error;
 
@@ -2857,17 +2751,13 @@ module entropy_src_reg_top (
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[1:0] = conf_enable_qs;
-        reg_rdata_next[3] = conf_boot_bypass_disable_qs;
-        reg_rdata_next[4] = conf_repcnt_disable_qs;
-        reg_rdata_next[5] = conf_adaptp_disable_qs;
-        reg_rdata_next[6] = conf_bucket_disable_qs;
-        reg_rdata_next[7] = conf_markov_disable_qs;
-        reg_rdata_next[8] = conf_health_test_clr_qs;
-        reg_rdata_next[9] = conf_rng_bit_en_qs;
-        reg_rdata_next[11:10] = conf_rng_bit_sel_qs;
-        reg_rdata_next[12] = conf_extht_enable_qs;
-        reg_rdata_next[13] = conf_repcnts_disable_qs;
+        reg_rdata_next[3:0] = conf_enable_qs;
+        reg_rdata_next[7:4] = conf_entropy_data_reg_enable_qs;
+        reg_rdata_next[11:8] = conf_lfsr_enable_qs;
+        reg_rdata_next[15:12] = conf_boot_bypass_disable_qs;
+        reg_rdata_next[19:16] = conf_health_test_clr_qs;
+        reg_rdata_next[23:20] = conf_rng_bit_enable_qs;
+        reg_rdata_next[25:24] = conf_rng_bit_sel_qs;
       end
 
       addr_hit[7]: begin
@@ -2875,8 +2765,8 @@ module entropy_src_reg_top (
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[0] = entropy_control_es_route_qs;
-        reg_rdata_next[1] = entropy_control_es_type_qs;
+        reg_rdata_next[3:0] = entropy_control_es_route_qs;
+        reg_rdata_next[7:4] = entropy_control_es_type_qs;
       end
 
       addr_hit[9]: begin
@@ -3039,8 +2929,8 @@ module entropy_src_reg_top (
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[0] = fw_ov_control_fw_ov_mode_qs;
-        reg_rdata_next[1] = fw_ov_control_fw_ov_entropy_insert_qs;
+        reg_rdata_next[3:0] = fw_ov_control_fw_ov_mode_qs;
+        reg_rdata_next[7:4] = fw_ov_control_fw_ov_entropy_insert_qs;
       end
 
       addr_hit[43]: begin

--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -83,7 +83,7 @@ _start:
 
   // Enable entropy complex - this is not the full enable
   li   a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
-  li   t0, 0x2
+  li   t0, 0xa0a
   sw   t0, ENTROPY_SRC_CONF_REG_OFFSET(a0)
 
   li   a0, TOP_EARLGREY_CSRNG_BASE_ADDR

--- a/sw/device/lib/dif/dif_entropy.c
+++ b/sw/device/lib/dif/dif_entropy.c
@@ -21,35 +21,40 @@ static void set_config_register(const dif_entropy_t *entropy,
   // TODO: Currently bypass disable cannot be set, as it causes the hw fsm to
   // get stuck
   // uint32_t reg = 0;
-  uint32_t reg =
-      bitfield_bit32_write(0, ENTROPY_SRC_CONF_BOOT_BYPASS_DISABLE_BIT, 1);
+  // TODO: rewrite below
+  //  uint32_t reg =
+  //    bitfield_bit32_write(0, ENTROPY_SRC_CONF_BOOT_BYPASS_DISABLE_FIELD, 1);
 
   // Configure test cases
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_REPCNT_DISABLE_BIT,
-                             !config->tests[kDifEntropyTestRepCount]);
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_ADAPTP_DISABLE_BIT,
-                             !config->tests[kDifEntropyTestAdaptiveProportion]);
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_BUCKET_DISABLE_BIT,
-                             !config->tests[kDifEntropyTestBucket]);
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_MARKOV_DISABLE_BIT,
-                             !config->tests[kDifEntropyTestMarkov]);
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_HEALTH_TEST_CLR_BIT,
-                             config->reset_health_test_registers);
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_EXTHT_ENABLE_BIT, 0);
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_REPCNT_DISABLE_BIT,
+  //                             !config->tests[kDifEntropyTestRepCount]);
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_ADAPTP_DISABLE_BIT,
+  //                           !config->tests[kDifEntropyTestAdaptiveProportion]);
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_BUCKET_DISABLE_BIT,
+  //                           !config->tests[kDifEntropyTestBucket]);
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_MARKOV_DISABLE_BIT,
+  //                           !config->tests[kDifEntropyTestMarkov]);
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_HEALTH_TEST_CLR_BIT,
+  //                           config->reset_health_test_registers);
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_EXTHT_ENABLE_BIT, 0);
 
   // Configure single RNG bit mode
-  bool rng_bit_en = config->single_bit_mode != kDifEntropySingleBitModeDisabled;
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_RNG_BIT_EN_BIT, rng_bit_en);
 
-  uint32_t rng_bit_sel = rng_bit_en ? config->single_bit_mode : 0;
-  reg = bitfield_field32_write(reg, ENTROPY_SRC_CONF_RNG_BIT_SEL_FIELD,
+  // TODO: rewrite below
+  // bool rng_bit_en = config->single_bit_mode != kDifEntropySingleBitModeDisabled;
+  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_CONF_RNG_BIT_EN_FIELD, rng_bit_en);
+
+  // TODO: rewrite below
+  // uint32_t rng_bit_sel = rng_bit_en ? config->single_bit_mode : 0;
+  // reg = bitfield_field32_write(reg, ENTROPY_SRC_CONF_RNG_BIT_SEL_FIELD,
                                rng_bit_sel);
 
   // Enable configuration
-  reg =
-      bitfield_field32_write(reg, ENTROPY_SRC_CONF_ENABLE_FIELD, config->mode);
-  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_CONF_REG_OFFSET,
-                      reg);
+  // TODO: rewrite below
+  // reg =
+  //    bitfield_field32_write(reg, ENTROPY_SRC_CONF_ENABLE_FIELD, config->mode);
+  // mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_CONF_REG_OFFSET,
+  //                    reg);
 }
 
 dif_entropy_result_t dif_entropy_init(dif_entropy_params_t params,
@@ -61,40 +66,41 @@ dif_entropy_result_t dif_entropy_init(dif_entropy_params_t params,
   return kDifEntropyOk;
 }
 
-dif_entropy_result_t dif_entropy_configure(const dif_entropy_t *entropy,
-                                           dif_entropy_config_t config) {
-  if (entropy == NULL) {
-    return kDifEntropyBadArg;
-  }
-
-  if (config.lfsr_seed > ENTROPY_SRC_SEED_LFSR_SEED_MASK) {
-    return kDifEntropyBadArg;
-  }
-
-  uint32_t seed = config.mode == kDifEntropyModeLfsr ? config.lfsr_seed : 0;
-  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_SEED_REG_OFFSET,
-                      seed);
-
-  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_RATE_REG_OFFSET,
-                      (uint32_t)config.sample_rate);
-
-  // Conditioning bypass is hardcoded to enabled. Bypass is not intended as
-  // a regular mode of operation.
-  uint32_t reg = bitfield_bit32_write(
-      0, ENTROPY_SRC_ENTROPY_CONTROL_ES_ROUTE_BIT, config.route_to_firmware);
-  reg = bitfield_bit32_write(reg, ENTROPY_SRC_ENTROPY_CONTROL_ES_TYPE_BIT, 0);
-  mmio_region_write32(entropy->params.base_addr,
-                      ENTROPY_SRC_ENTROPY_CONTROL_REG_OFFSET, reg);
-
-  // TODO: Add test configuration parameters.
-
-  // TODO: Add support for FIFO mode.
-  mmio_region_write32(entropy->params.base_addr,
-                      ENTROPY_SRC_FW_OV_CONTROL_REG_OFFSET, 0);
-
-  set_config_register(entropy, &config);
-  return kDifEntropyOk;
-}
+//dif_entropy_result_t dif_entropy_configure(const dif_entropy_t *entropy,
+//                                           dif_entropy_config_t config) {
+//  if (entropy == NULL) {
+//    return kDifEntropyBadArg;
+//  }
+//
+//  if (config.lfsr_seed > ENTROPY_SRC_SEED_LFSR_SEED_MASK) {
+//    return kDifEntropyBadArg;
+//  }
+//
+//  uint32_t seed = config.mode == kDifEntropyModeLfsr ? config.lfsr_seed : 0;
+//  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_SEED_REG_OFFSET,
+//                      seed);
+//
+//  mmio_region_write32(entropy->params.base_addr, ENTROPY_SRC_RATE_REG_OFFSET,
+//                      (uint32_t)config.sample_rate);
+//
+//  // Conditioning bypass is hardcoded to enabled. Bypass is not intended as
+//  // a regular mode of operation.
+//  // TODO: rewrite this below
+//  // uint32_t reg = bitfield_bit32_write(
+//  //    0, ENTROPY_SRC_ENTROPY_CONTROL_ES_ROUTE_BIT_FIELD, config.route_to_firmware);
+//  // reg = bitfield_bit32_write(reg, ENTROPY_SRC_ENTROPY_CONTROL_ES_TYPE_FIELD, 0x5);
+//  // mmio_region_write32(entropy->params.base_addr,
+//  //                    ENTROPY_SRC_ENTROPY_CONTROL_REG_OFFSET, reg);
+//
+//  // TODO: Add test configuration parameters.
+//
+//  // TODO: Add support for FIFO mode.
+//  // mmio_region_write32(entropy->params.base_addr,
+//  //                    ENTROPY_SRC_FW_OV_CONTROL_REG_OFFSET, 0);
+//
+//  set_config_register(entropy, &config);
+//  return kDifEntropyOk;
+//}
 
 static bool get_entropy_avail(const dif_entropy_t *entropy) {
   return mmio_region_get_bit32(entropy->params.base_addr,

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -38,7 +38,10 @@ static void setup_entropy_src(void) {
       .sample_rate = 2,
       .lfsr_seed = 0,
   };
-  CHECK(dif_entropy_configure(&entropy, config) == kDifEntropyOk);
+  // CHECK(dif_entropy_configure(&entropy, config) == kDifEntropyOk);
+  // TODO: Slamming in init value, clean up once LFSR mode has been removed
+  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+                      ENTROPY_SRC_CONF_REG_OFFSET, 0xa0a);
 }
 
 static void setup_csrng(void) {

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -151,7 +151,7 @@ _mask_rom_start_boot:
   // FIXME: Enable entropy complex - this is not the full enable.
   // TODO(#7221): Switch entropy source mode from LFSR to PTRNG.
   li a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
-  li t0, (2 << ENTROPY_SRC_CONF_ENABLE_OFFSET) // LFSR mode.
+  li t0, (0xa0a) // LFSR mode, Enable
   sw t0, ENTROPY_SRC_CONF_REG_OFFSET(a0)
 
   li a0, TOP_EARLGREY_CSRNG_BASE_ADDR


### PR DESCRIPTION
The enable bits have been expanded to 4 bits per function to provide a counter measure for attacks on register bits.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>