### PR TITLE
[ast] Add lint target and waiver files for AST

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -48,6 +48,26 @@ filesets:
 
     file_type: systemVerilogSource
 
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/ast.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/ast.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
 
 parameters:
   SYNTHESIS:
@@ -58,15 +78,17 @@ parameters:
 targets:
   default: &default_target
     filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
     toplevel: ast
-    parameters:
-     - SYNTHESIS
-
 
   lint:
     <<: *default_target
     default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
     tools:
       verilator:
         mode: lint-only

--- a/hw/top_earlgrey/ip/ast/lint/ast.vlt
+++ b/hw/top_earlgrey/ip/ast/lint/ast.vlt
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for ast

--- a/hw/top_earlgrey/ip/ast/lint/ast.waiver
+++ b/hw/top_earlgrey/ip/ast/lint/ast.waiver
@@ -4,3 +4,90 @@
 #
 # waiver file for ast
 
+waive -rules IFDEF_CODE -location {ast.sv} \
+      -msg {Assignment to 'ast2pad_t0_ao' contained within `else block at ast.sv} \
+      -comment {This ifdef statement is used for analog simulations and is OK.}
+
+waive -rules CLOCK_EDGE -location {aon_osc.sv io_osc.sv sys_osc.sv usb_osc.sv} \
+      -msg {Falling edge of clock 'clk' used here, should use rising edge} \
+      -comment {This negedge trigger is done on purpose.}
+
+waive -rules CLOCK_USE -location {ast_dft.sv} \
+      -regexp {('clk_byp'|'clk_osc') is used for some other purpose, and as clock ('clk_ast_ext_i'|'clk_io_osc_i') at ast_dft.sv} \
+      -comment {This message pops up due to a clock OR operation.}
+
+waive -rules RESET_DRIVER -location {aon_clk.sv io_clk.sv sys_clk.sv usb_clk.sv} \
+      -msg {'rst_val_n' is driven here, and used as an asynchronous reset 'rst_ni' at prim_generic_flop.sv} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {rng.sv} \
+      -msg {'rst_n' is driven here, and used as an asynchronous reset at rng.sv} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {ast.sv} \
+      -regexp {('vcaon_pok_h'|'por_rst_n'|'vcmain_pok_por') is driven here, and used as an asynchronous reset} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {ast.sv} \
+      -msg {'clk_io_osc_val' is driven by instance 'u_io_clk' of module 'io_clk', and used as an asynchronous reset 'rst_clk_osc_n' at ast_dft.sv} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {ast.sv} \
+      -msg {'clk_src_io_val_o' driven in module 'io_clk' by port 'u_val_sync.q_o[0]' at io_clk.sv} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {ast.sv dev_entropy.sv} \
+      -regexp {'q_o[0]' driven in module 'prim_flop_2sync' by port .* at prim_.*flop_2sync.sv} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {ast.sv} \
+      -msg {'vcmain_pok_por_sys' is driven by instance 'u_rst_sys_dasrt' of module 'prim_flop_2sync', and used as an asynchronous reset 'rst_dev_ni' at dev_entropy.sv} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_DRIVER -location {dev_entropy.sv} \
+      -msg {'rst_es_dev_nd' is driven by instance 'u_rst_es_n_da' of module 'prim_flop_2sync', and used as an asynchronous reset 'rst_es_dev_n'} \
+      -comment {This is reset generation logic, hence it needs to drive this reset signal.}
+
+waive -rules RESET_MUX -location {aon_clk.sv io_clk.sv sys_clk.sv usb_clk.sv} \
+      -msg {Asynchronous reset 'rst_val_n' is driven by a multiplexer here, used as a reset 'rst_ni' at prim_generic_flop.sv} \
+      -comment {This is reset generation logic, hence reset muxes are allowed.}
+
+waive -rules RESET_MUX -location {ast.sv} \
+      -msg {Asynchronous reset 'rst_src_sys_n' is driven by a multiplexer here, used as a reset 'rst_dev_ni' at dev_entropy.sv} \
+      -comment {This is reset generation logic, hence reset muxes are allowed.}
+
+waive -rules RESET_MUX -location {rng.sv} \
+      -msg {Asynchronous reset 'rst_n' is driven by a multiplexer here, used as a reset at rng.sv} \
+      -comment {This is reset generation logic, hence reset muxes are allowed.}
+
+waive -rules RESET_USE -location {ast.sv} \
+      -regexp {('vcore_pok_h_i'|'vcaon_pok') is used for some other purpose, and as asynchronous reset 'vcore_pok_h_i' at (aon_osc.sv|sys_osc.sv)} \
+      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+waive -rules RESET_USE -location {ast.sv} \
+      -msg {'vcmain_pok_por' is connected to 'rglts_pdm_3p3v' port 'vcmain_pok_o_h_i', and used as an asynchronous reset or set 'rst_ni' at prim_generic_flop.} \
+      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+waive -rules RESET_USE -location {ast.sv} \
+      -msg {'vcmain_pok_por' is connected to 'rglts_pdm_3p3v' port 'vcmain_pok_o_h_i', and used as an asynchronous reset or set 'rst_ni' at prim_generic_flop.} \
+      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+waive -rules RESET_USE -location {ast.sv} \
+      -regexp {'rst_(usb|aon|io|sys)_clk_n' is connected to '(usb|aon|io|sys)_clk' port 'rst_(usb|aon|io|sys)_clk_ni', and used as an asynchronous reset or set ('rst_ni'|'vcore_pok_h_i'|'rst_clk_byp_n')} \
+      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+waive -rules RESET_USE -location {io_osc.sv sys_osc.sv usb_osc.sv aon_osc.sv} \
+      -msg {'vcore_pok_h_i' is used for some other purpose, and as asynchronous reset at} \
+      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+waive -rules RESET_USE -location {ast_dft.sv} \
+      -msg {'clk_io_osc_val_i' is used for some other purpose, and as asynchronous reset 'rst_clk_osc_n' at ast_dft.sv} \
+      -comment {This is reset / clock generation logic, hence special reset usage is allowed.}
+
+waive -rules {TRI_DRIVER} -location {ast.sv} \
+      -regexp {'ast2pad_(t0|t1)_ao' is driven by a tristate driver} \
+      -comment {This part models a tristate driver.}
+
+waive -rules {Z_USE} -location {ast.sv} \
+      -msg {Constant with 'Z literal value '1'bz' encountered} \
+      -comment {This part models a tristate driver.}

--- a/hw/top_earlgrey/ip/ast/lint/ast.waiver
+++ b/hw/top_earlgrey/ip/ast/lint/ast.waiver
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for ast
+

--- a/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_lint_cfgs.hjson
@@ -39,6 +39,17 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/aon_timer/lint/{tool}"
              },
+             {    name: ast
+                  fusesoc_core: lowrisc:systems:ast
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/top_earlgrey/ip/ast/lint/{tool}"
+                  overrides: [
+                    {
+                      name: design_level
+                      value: "top"
+                    }
+                  ]
+             },
              {    name: entropy_src
                   fusesoc_core: lowrisc:ip:entropy_src
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]


### PR DESCRIPTION
AST has so far only been passed through lint implicitly as part of `top_earlgrey` lint runs.

This adds a dedicated lint target setup for AST, including AscentLint and Verilator waiver files.

Several AscentLint waivers are added to waive messages that occur in the clock and reset generation logic.

Once this has been merged, the AST lint results will be reported as a separate item on the nightly lint dashboard.