### PR TITLE
[sw/silicon_creator] Make `GlobalMock<Mock>` a base class to support multiple types of mocks for the same module

### DIFF
--- a/sw/device/lib/base/testing/mock_csr.h
+++ b/sw/device/lib/base/testing/mock_csr.h
@@ -14,18 +14,16 @@ namespace mock_csr {
 
 namespace internal {
 
-class MockCsr {
+class MockCsr : public ::mask_rom_test::GlobalMock<MockCsr> {
  public:
   MOCK_METHOD(uint32_t, Read, (uint32_t csr));
   MOCK_METHOD(void, Write, (uint32_t csr, uint32_t value));
   MOCK_METHOD(void, SetBits, (uint32_t csr, uint32_t mask));
   MOCK_METHOD(void, ClearBits, (uint32_t csr, uint32_t mask));
-  virtual ~MockCsr() {}
 };
 }  // namespace internal
 
-using MockCsr =
-    ::mask_rom_test::GlobalMock<testing::StrictMock<internal::MockCsr>>;
+using MockCsr = testing::StrictMock<internal::MockCsr>;
 
 /**
  * Conveninence fixture for creating CSR tests.

--- a/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
@@ -14,18 +14,16 @@ namespace internal {
 /**
  * Mock class for abs_mmio.c.
  */
-class MockAbsMmio {
+class MockAbsMmio : public GlobalMock<MockAbsMmio> {
  public:
   MOCK_METHOD(uint8_t, Read8, (uint32_t addr));
   MOCK_METHOD(void, Write8, (uint32_t addr, uint8_t value));
   MOCK_METHOD(uint32_t, Read32, (uint32_t addr));
   MOCK_METHOD(void, Write32, (uint32_t addr, uint32_t value));
-
-  virtual ~MockAbsMmio() {}
 };
 }  // namespace internal
 
-using MockAbsMmio = GlobalMock<testing::StrictMock<internal::MockAbsMmio>>;
+using MockAbsMmio = testing::StrictMock<internal::MockAbsMmio>;
 
 /**
  * Expect a read to the device `dev` at the given offset, returning the given

--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -14,7 +14,7 @@ namespace internal {
 /**
  * Mock class for abs_mmio.c.
  */
-class MockSecMmio {
+class MockSecMmio : public GlobalMock<MockSecMmio> {
  public:
   MOCK_METHOD(void, Init, (sec_mmio_shutdown_handler callee));
   MOCK_METHOD(uint32_t, Read32, (uint32_t addr));
@@ -22,12 +22,10 @@ class MockSecMmio {
   MOCK_METHOD(void, WriteIncrement, (uint32_t value));
   MOCK_METHOD(void, CheckValues, (uint32_t rnd_offset));
   MOCK_METHOD(void, CheckCounters, (uint32_t expected_check_count));
-
-  virtual ~MockSecMmio() {}
 };
 }  // namespace internal
 
-using MockSecMmio = GlobalMock<testing::StrictMock<internal::MockSecMmio>>;
+using MockSecMmio = testing::StrictMock<internal::MockSecMmio>;
 
 /**
  * Expect a read to the device `dev` at the given offset, returning the given

--- a/sw/device/silicon_creator/lib/drivers/mock_alert.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_alert.h
@@ -14,7 +14,7 @@ namespace internal {
 /**
  * Mock class for alert.c.
  */
-class MockAlert {
+class MockAlert : public GlobalMock<MockAlert> {
  public:
   MOCK_METHOD(rom_error_t, alert_configure,
               (size_t, alert_class_t, alert_enable_t));
@@ -23,12 +23,11 @@ class MockAlert {
   MOCK_METHOD(rom_error_t, alert_class_configure,
               (alert_class_t, const alert_class_config_t *));
   MOCK_METHOD(rom_error_t, alert_ping_enable, ());
-  virtual ~MockAlert() {}
 };
 
 }  // namespace internal
 
-using MockAlert = GlobalMock<testing::StrictMock<internal::MockAlert>>;
+using MockAlert = testing::StrictMock<internal::MockAlert>;
 
 extern "C" {
 

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.h
@@ -14,17 +14,16 @@ namespace internal {
 /**
  * Mock class for hmac.c.
  */
-class MockHmac {
+class MockHmac : public GlobalMock<MockHmac> {
  public:
   MOCK_METHOD(void, sha256_init, ());
   MOCK_METHOD(rom_error_t, sha256_update, (const void *, size_t));
   MOCK_METHOD(rom_error_t, sha256_final, (hmac_digest_t *));
-  virtual ~MockHmac() {}
 };
 
 }  // namespace internal
 
-using MockHmac = GlobalMock<testing::StrictMock<internal::MockHmac>>;
+using MockHmac = testing::StrictMock<internal::MockHmac>;
 
 extern "C" {
 

--- a/sw/device/silicon_creator/lib/drivers/mock_otp.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_otp.h
@@ -14,19 +14,26 @@ namespace internal {
 /**
  * Mock class for otp.c.
  */
-class MockOtp {
+class MockOtp : public GlobalMock<MockOtp> {
  public:
   MOCK_METHOD(uint32_t, read32, (uint32_t address));
   MOCK_METHOD(uint32_t, read64, (uint32_t address));
   MOCK_METHOD(void, read, (uint32_t address, uint32_t *data, size_t num_words));
-  virtual ~MockOtp() {}
 };
 
 }  // namespace internal
 
-using MockOtp = GlobalMock<testing::StrictMock<internal::MockOtp>>;
+// Nice mock for shutdown unit tests.
+using NiceMockOtp = testing::NiceMock<internal::MockOtp>;
+// Strict mock for other unit tests.
+using MockOtp = testing::StrictMock<internal::MockOtp>;
 
 extern "C" {
+
+// Note: In the functions below, we use `MockOtp` only for conciseness. The
+// static `Instance()` method returns a reference to the same
+// `internal::MockOtp` instance regardless if we use `MockOtp`, `NiceMockOtp`,
+// or `internal::MockOtp`.
 
 uint32_t otp_read32(uint32_t address) {
   return MockOtp::Instance().read32(address);

--- a/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_ibex.h
+++ b/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_ibex.h
@@ -14,18 +14,17 @@ namespace internal {
 /**
  * Mock class for sigverify_mod_exp_ibex.c
  */
-class MockSigverifyModExpIbex {
+class MockSigverifyModExpIbex : public GlobalMock<MockSigverifyModExpIbex> {
  public:
   MOCK_METHOD(rom_error_t, mod_exp,
               (const sigverify_rsa_key_t *, const sigverify_rsa_buffer_t *,
                sigverify_rsa_buffer_t *));
-  virtual ~MockSigverifyModExpIbex() {}
 };
 
 }  // namespace internal
 
 using MockSigverifyModExpIbex =
-    GlobalMock<testing::StrictMock<internal::MockSigverifyModExpIbex>>;
+    testing::StrictMock<internal::MockSigverifyModExpIbex>;
 
 extern "C" {
 

--- a/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h
+++ b/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h
@@ -14,18 +14,17 @@ namespace internal {
 /**
  * Mock class for sigverify_mod_exp_otbn.c
  */
-class MockSigverifyModExpOtbn {
+class MockSigverifyModExpOtbn : public GlobalMock<MockSigverifyModExpOtbn> {
  public:
   MOCK_METHOD(rom_error_t, mod_exp,
               (const sigverify_rsa_key_t *, const sigverify_rsa_buffer_t *,
                sigverify_rsa_buffer_t *));
-  virtual ~MockSigverifyModExpOtbn() {}
 };
 
 }  // namespace internal
 
 using MockSigverifyModExpOtbn =
-    GlobalMock<testing::StrictMock<internal::MockSigverifyModExpOtbn>>;
+    testing::StrictMock<internal::MockSigverifyModExpOtbn>;
 
 extern "C" {
 

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -36,28 +36,26 @@ int base_printf(const char *fmt, ...) { return 0; }
 // TODO(lowRISC/opentitan#7148): Refactor mocks into their own headers.
 namespace internal {
 // Create a mock for reading OTP words.
-class MockOtp {
+class MockOtp : public ::mask_rom_test::GlobalMock<MockOtp> {
  public:
   MOCK_METHOD(uint32_t, otp_read32, (uint32_t));
   virtual ~MockOtp() {}
 };
 
 // Create a mock for shutdown functions.
-class MockShutdown {
+class MockShutdown : public ::mask_rom_test::GlobalMock<MockShutdown> {
  public:
   MOCK_METHOD(void, shutdown_software_escalate, ());
   MOCK_METHOD(void, shutdown_keymgr_kill, ());
   MOCK_METHOD(void, shutdown_flash_kill, ());
   MOCK_METHOD(void, shutdown_hang, ());
-  virtual ~MockShutdown() {}
 };
 
 }  // namespace internal
 // Use NiceMock because we aren't interested in the specifics of OTP reads,
 // but we want to mock out calls to otp_read32.
-using MockOtp = mask_rom_test::GlobalMock<testing::NiceMock<internal::MockOtp>>;
-using MockShutdown =
-    mask_rom_test::GlobalMock<testing::StrictMock<internal::MockShutdown>>;
+using MockOtp = testing::NiceMock<internal::MockOtp>;
+using MockShutdown = testing::StrictMock<internal::MockShutdown>;
 extern "C" {
 uint32_t otp_read32(uint32_t address) {
   return MockOtp::Instance().otp_read32(address);

--- a/sw/device/silicon_creator/mask_rom/mock_romextimage_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/mock_romextimage_ptrs.h
@@ -14,18 +14,15 @@ namespace internal {
 /**
  * Mock class for romextimage_ptrs.h
  */
-class MockRomextimagePtrs {
+class MockRomextimagePtrs : public GlobalMock<MockRomextimagePtrs> {
  public:
   MOCK_METHOD(const manifest_t *, slot_a_manifest_ptr_get, ());
   MOCK_METHOD(const manifest_t *, slot_b_manifest_ptr_get, ());
-
-  virtual ~MockRomextimagePtrs() {}
 };
 
 }  // namespace internal
 
-using MockRomextimagePtrs =
-    GlobalMock<testing::StrictMock<internal::MockRomextimagePtrs>>;
+using MockRomextimagePtrs = testing::StrictMock<internal::MockRomextimagePtrs>;
 
 extern "C" {
 


### PR DESCRIPTION
Context: Shutdown module performs a large number of OTP reads (100+) to configure the alert handler and shutdown_unittest models the data in OTP using a struct and a nice mock to keep tests manageable. Since there are other tests that use a strict mock for OTP accesses and our framework does not support multiple types of mocks for the same mask rom module, shutdown_unittest uses a separate definition of `MockOtp` which is not ideal.

This PR addresses this issue by making `GlobalMock<Mock>` defined in `mask_rom_test.h` a base class that mock classes should derive from (CRTP). This allows us to define different types of mocks using type aliases that can be used in tests as we do today. Having `GlobalMock<Mock>` as the base class also allows us to enforce that there is at most one instance of `Mock` by construction (regardless of its strictness or niceness) without using additional data structures.

This approach does not require any changes in existing tests (except for removing MockOtp from shutdown_unittest) but we need to touch existing mocks to use the new class.