### PR TITLE
[otbn,dv] Teach the RIG to occasionally generate loopi instructions with 1023 iterations

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -155,15 +155,15 @@ class Loop(SnippetGen):
         assert 3 <= space_here
         max_bodysize = space_here - 2
 
-        # Another upper bound comes from program.get_insn_space_left(). If
-        # bodysize is 2 or more, our body will need to generate at least 2
-        # instructions (either a straight line of length bodysize, or a jump
-        # from the start and then a straight line instruction at the end). In
-        # this case, we need space for at least 3 instructions (including the
-        # LOOP/LOOPI instruction itself).
+        # Another upper bound comes from program.space. If bodysize is 2 or
+        # more, our body will need to generate at least 2 instructions (either
+        # a straight line of length bodysize, or a jump from the start and then
+        # a straight line instruction at the end). In this case, we need space
+        # for at least 3 instructions (including the LOOP/LOOPI instruction
+        # itself).
         #
-        # We know that program.get_insn_space_left() is at least 2 (checked in
-        # gen()), but if it's 2, we can only have a bodysize of 1.
+        # We know that program.space is at least 2 (checked in gen()), but if
+        # it's 2, we can only have a bodysize of 1.
         assert 2 <= program.space
         if program.space == 2:
             max_bodysize = min(max_bodysize, 1)

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -158,5 +158,10 @@ name:
       name: smoke
       tests: ["otbn_smoke"]
     }
+
+    {
+      name: "core",
+      tests: ["otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset"]
+    }
   ]
 }

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -80,6 +80,10 @@ name:
     }
   ]
 
+  // The value to pass to the --size parameter for gen-binaries.py. This
+  // controls the number of instructions that are run before ECALL or error.
+  binary_size: 2000
+
   otbn_obj_dir: "{build_dir}/build-out"
   gen_binaries_py: "{proj_root}/hw/ip/otbn/dv/uvm/gen-binaries.py"
   gen_binary: "{gen_binaries_py} --count 1 --obj-dir {otbn_obj_dir}"
@@ -92,7 +96,7 @@ name:
     {
       name: build_otbn_rig_binary_mode
       pre_run_cmds: [
-        "{gen_binary} --no-smoke --seed {seed} {otbn_elf_dir}"
+        "{gen_binary} --no-smoke --seed {seed} --size {binary_size} {otbn_elf_dir}"
       ]
     }
 
@@ -109,7 +113,7 @@ name:
     {
       name: build_otbn_rig_binaries_mode
       pre_run_cmds: [
-        "{gen_binaries} --no-smoke --seed {seed} {otbn_elf_dir}"
+        "{gen_binaries} --no-smoke --seed {seed} --size {binary_size} {otbn_elf_dir}"
       ]
     }
   ]


### PR DESCRIPTION
There are a couple of scaffolding patches first, including bumping up the amount of "fuel" we give the tests (otherwise we'll never actually see such a long loop).