### PR TITLE
[sw/silicon_creator] Configure software strap pins (used for bootstrap)

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/gpio.c
+++ b/sw/device/silicon_creator/lib/drivers/gpio.c
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/gpio.h"
+
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+
+#include "gpio_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  kBase = TOP_EARLGREY_GPIO_BASE_ADDR,
+};
+
+uint32_t gpio_read(void) {
+  return abs_mmio_read32(kBase + GPIO_DATA_IN_REG_OFFSET);
+}

--- a/sw/device/silicon_creator/lib/drivers/gpio.h
+++ b/sw/device/silicon_creator/lib/drivers/gpio.h
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_GPIO_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_GPIO_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Read the value of all 32 GPIO pins.
+ *
+ * The least significant bit in the returned value is index 0, the
+ * most significant bit is index 31.
+ *
+ * The pinmux must be configured to connect GPIO pins to MIO pads,
+ * see the pinmux driver for the configuration details.
+ * Unconnected pins will be set to 0.
+ *
+ * @return The `DATA_IN` value for the GPIO pins.
+ */
+uint32_t gpio_read(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_GPIO_H_

--- a/sw/device/silicon_creator/lib/drivers/gpio_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/gpio_unittest.cc
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/gpio.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+
+#include "gpio_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+namespace gpio_unittest {
+namespace {
+class GpioTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_GPIO_BASE_ADDR;
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+TEST_F(GpioTest, Read) {
+  uint32_t kValue = 0x89abcdef;
+  EXPECT_ABS_READ32(base_ + GPIO_DATA_IN_REG_OFFSET, kValue);
+
+  EXPECT_EQ(gpio_read(), kValue);
+}
+
+}  // namespace
+}  // namespace gpio_unittest

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -485,3 +485,35 @@ test('sw_silicon_creator_lib_driver_flash_ctrl_unittest', executable(
   ),
   suite: 'mask_rom',
 )
+
+# Mask ROM GPIO driver
+sw_silicon_creator_lib_driver_gpio = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_gpio',
+    sources: [
+      hw_ip_gpio_reg_h,
+      'gpio.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_base_abs_mmio,
+    ],
+  ),
+)
+
+test('sw_silicon_creator_lib_driver_gpio_unittest', executable(
+    'sw_silicon_creator_lib_driver_gpio_unittest',
+    sources: [
+      'gpio_unittest.cc',
+      hw_ip_gpio_reg_h,
+      'gpio.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+  ),
+  suite: 'mask_rom',
+)

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -23,10 +23,14 @@ typedef struct pinmux_input {
  */
 static const pinmux_input_t kPinmuxInputs[] = {
     /**
-     * UART
+     * Connect software strap pins to GPIO module.
      */
-    {.periph = kTopEarlgreyPinmuxPeripheralInUart0Rx,
-     .pad = kTopEarlgreyPinmuxInselIoc10},
+    {.periph = kTopEarlgreyPinmuxPeripheralInGpioGpio0,
+     .pad = kTopEarlgreyPinmuxInselIoc0},
+    {.periph = kTopEarlgreyPinmuxPeripheralInGpioGpio1,
+     .pad = kTopEarlgreyPinmuxInselIoc1},
+    {.periph = kTopEarlgreyPinmuxPeripheralInGpioGpio2,
+     .pad = kTopEarlgreyPinmuxInselIoc2},
 };
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -60,8 +60,12 @@ class InitTest : public PinmuxTest {
 
 TEST_F(InitTest, Initialize) {
   // The inputs that will be configured.
-  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
-                     kTopEarlgreyPinmuxInselIoc10);
+  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio0),
+                     kTopEarlgreyPinmuxInselIoc0);
+  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio1),
+                     kTopEarlgreyPinmuxInselIoc1);
+  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio2),
+                     kTopEarlgreyPinmuxInselIoc2);
 
   // The outputs that will be configured.
   EXPECT_ABS_WRITE32(RegOut(kTopEarlgreyPinmuxMioOutIoc11),

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -22,6 +22,23 @@ class PinmuxTest : public mask_rom_test::MaskRomTest {
 class InitTest : public PinmuxTest {
  protected:
   /**
+   * Set to track which pad attributes have already been configured.
+   */
+  std::set<top_earlgrey_pinmux_mio_out_t> configured_attr_;
+
+  /**
+   * Register the configuration of the pad attribute in the tracking
+   * set and return its computed address.
+   *
+   * Triggers a test failure if the pad attribute has already been registered.
+   */
+  uint32_t RegAttr(top_earlgrey_pinmux_mio_out_t index) {
+    EXPECT_TRUE(index >= 0 && index < kTopEarlgreyPinmuxMioOutLast);
+    EXPECT_TRUE(configured_attr_.insert(index).second);
+    return base_ + PINMUX_MIO_PAD_ATTR_0_REG_OFFSET +
+           static_cast<uint32_t>(index) * sizeof(uint32_t);
+  }
+  /**
    * Set to track which peripheral inputs have already been configured.
    */
   std::set<top_earlgrey_pinmux_peripheral_in_t> configured_in_;
@@ -59,6 +76,16 @@ class InitTest : public PinmuxTest {
 };
 
 TEST_F(InitTest, Initialize) {
+  // The pad attributes that will be configured.
+  // TODO: generate pad attributes.
+  const uint32_t kAttrPullDownEnabled = 1 << 2;
+  EXPECT_ABS_WRITE32(RegAttr(kTopEarlgreyPinmuxMioOutIoc0),
+                     kAttrPullDownEnabled);
+  EXPECT_ABS_WRITE32(RegAttr(kTopEarlgreyPinmuxMioOutIoc1),
+                     kAttrPullDownEnabled);
+  EXPECT_ABS_WRITE32(RegAttr(kTopEarlgreyPinmuxMioOutIoc2),
+                     kAttrPullDownEnabled);
+
   // The inputs that will be configured.
   EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio0),
                      kTopEarlgreyPinmuxInselIoc0);


### PR DESCRIPTION
Work in progress.

- [ ] Clean up constants generated by pinmux (we should generate a clean MIO pad index enum + constants for pad attributes)