### PR TITLE
[otbn,dv] Allow generation of loops with zero iteration counts

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -371,7 +371,10 @@ class LOOPI(OTBNInsn):
         self.bodysize = op_vals['bodysize']
 
     def execute(self, state: OTBNState) -> None:
-        state.loop_start(self.iterations, self.bodysize)
+        if self.iterations == 0:
+            state.stop_at_end_of_cycle(err_bits.LOOP)
+        else:
+            state.loop_start(self.iterations, self.bodysize)
 
 
 class BNADD(OTBNInsn):

--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -12,3 +12,4 @@ gen-weights:
   # Generators that end the program
   ECall: 1
   BadInsn: 1
+  BadZeroLoop: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_zero_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_zero_loop.py
@@ -1,0 +1,84 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional, Tuple
+
+from shared.operand import ImmOperandType, RegOperandType, OperandType
+
+from .loop import Loop
+from ..model import Model
+from ..program import ProgInsn, Program
+from ..snippet import LoopSnippet
+from ..snippet_gen import GenCont, GenRet
+
+
+class BadZeroLoop(Loop):
+    '''A snippet generator that generates loops with a zero count'''
+
+    ends_program = True
+
+    def _bad_loop_iterations(self, model: Model) -> Tuple[int, int]:
+        '''Like Loop._pick_loop_iterations but always returns 0 iterations'''
+        poss_pairs = []
+        for idx, value in model.regs_with_known_vals('gpr'):
+            if value == 0:
+                poss_pairs.append((idx, value))
+
+        # Since x0 contains zero, we'll always have at least one pair.
+        assert poss_pairs
+
+        return random.choice(poss_pairs)
+
+    def _bad_loopi_iterations(self) -> Tuple[int, int]:
+        '''Like Loop._pick_loopi_iterations but always returns 0 iterations'''
+        return (0, 0)
+
+    def _bad_iterations(self,
+                        op_type: OperandType,
+                        bodysize: int,
+                        model: Model) -> Tuple[int, int]:
+        '''Like Loop._pick_iterations but always returns 0 iterations'''
+        if isinstance(op_type, RegOperandType):
+            assert op_type.reg_type == 'gpr'
+            return self._bad_loop_iterations(model)
+        else:
+            assert isinstance(op_type, ImmOperandType)
+            return self._bad_loopi_iterations()
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        model_before = model.copy()
+
+        pieces = self._gen_pieces(cont, model, program)
+        if pieces is None:
+            return None
+
+        good_shape, good_hd_insn, body_snippet, model = pieces
+
+        # If we successfully generated a loop, generate a new head instruction
+        # with the same body size but with zero iterations.
+        _, _, bodysize = good_shape
+
+        insn = self._pick_loop_insn()
+        op0_type = insn.operands[0].op_type
+        op1_type = insn.operands[1].op_type
+
+        iter_opval, num_iters = self._bad_iterations(op0_type,
+                                                     bodysize, model_before)
+
+        # Generate a new head instruction
+        enc_bodysize = op1_type.op_val_to_enc_val(bodysize, model_before.pc)
+        assert enc_bodysize is not None
+        bad_hd_insn = ProgInsn(insn, [iter_opval, enc_bodysize], None)
+
+        snippet = LoopSnippet(model_before.pc, bad_hd_insn, body_snippet)
+        snippet.insert_into_program(program)
+
+        # Return with the initial model (because the head instruction is bad,
+        # we'll stop at it)
+        return (snippet, True, model_before)

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -5,7 +5,7 @@
 import random
 from typing import List, Optional, Tuple
 
-from shared.insn_yaml import InsnsFile
+from shared.insn_yaml import Insn, InsnsFile
 from shared.operand import ImmOperandType, RegOperandType, OperandType
 
 from .jump import Jump
@@ -19,6 +19,17 @@ from ..snippet_gen import GenCont, GenRet, SimpleGenRet, SnippetGen
 
 class Loop(SnippetGen):
     '''A generator that generates a LOOP / LOOPI'''
+
+    # The shape of a loop that's being generated. The triple is (opval,
+    # num_iters, bodysize) where opval is the encoded value for the operand,
+    # num_iters is the number of iterations and bodysize is the size of the
+    # loop body.
+    Shape = Tuple[int, int, int]
+
+    # The individual pieces of a generated loop. The tuple is (shape, hd_insn,
+    # body_snippet, model_afterwards)
+    Pieces = Tuple[Shape, ProgInsn, Snippet, Model]
+
     def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
         super().__init__()
 
@@ -174,7 +185,7 @@ class Loop(SnippetGen):
                          op1_type: ImmOperandType,
                          space_here: int,
                          model: Model,
-                         program: Program) -> Optional[Tuple[int, int, int]]:
+                         program: Program) -> Optional[Shape]:
         '''Pick the size of loop and number of iterations
 
         op_type is the type of the first operand (either 'grs' for loop or
@@ -398,11 +409,24 @@ class Loop(SnippetGen):
         model.pop_const(const_token)
         return (snippet, model)
 
-    def gen(self,
-            cont: GenCont,
-            model: Model,
-            program: Program) -> Optional[GenRet]:
+    def _pick_loop_insn(self) -> Insn:
+        '''Pick either LOOP or LOOPI'''
+        is_loopi = random.random() < self.loopi_prob
+        return self.loopi if is_loopi else self.loop
 
+    def _gen_pieces(self,
+                    cont: GenCont,
+                    model: Model,
+                    program: Program) -> Optional[Pieces]:
+        '''Generate a loop and return its constituent pieces
+
+        This is useful for subclasses that alter the generated loop after the
+        fact.
+
+        As with gen(), if this function succeeds, it will modify program and
+        may modify model.
+
+        '''
         # A loop or loopi sequence has a loop/loopi instruction, at least one
         # body instruction (the last of which must be a straight line
         # instruction) and then needs a following trampoline. That means we
@@ -420,9 +444,7 @@ class Loop(SnippetGen):
         if model.loop_depth == Model.max_loop_depth:
             return None
 
-        # Decide whether to generate LOOP or LOOPI
-        is_loopi = random.random() < self.loopi_prob
-        insn = self.loopi if is_loopi else self.loop
+        insn = self._pick_loop_insn()
 
         # Pick a loop count
         op0_type = insn.operands[0].op_type
@@ -437,7 +459,6 @@ class Loop(SnippetGen):
 
         # Generate the head instruction (which runs once, unconditionally) and
         # clone model and program to add it
-        hd_addr = model.pc
         enc_bodysize = op1_type.op_val_to_enc_val(bodysize, model.pc)
         assert enc_bodysize is not None
         hd_insn = ProgInsn(insn, [iter_opval, enc_bodysize], None)
@@ -480,9 +501,6 @@ class Loop(SnippetGen):
         assert body_fuel > 0
         fuel_afterwards = model.fuel - num_iters * body_fuel
 
-        snippet = LoopSnippet(hd_addr, hd_insn, body_snippet)
-        snippet.insert_into_program(program)
-
         # Update model to take the loop body into account. If we know we have
         # exactly one iteration through the body, we can just take body_model.
         # Otherwise, we merge the two after "teleporting" model to the loop
@@ -499,5 +517,22 @@ class Loop(SnippetGen):
             # between model and body_model, but we actually want it to be what
             # we computed before.
             model.fuel = fuel_afterwards
+
+        return (lshape, hd_insn, body_snippet, model)
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        hd_addr = model.pc
+        pieces = self._gen_pieces(cont, model, program)
+        if pieces is None:
+            return None
+
+        shape, hd_insn, body_snippet, model = pieces
+
+        snippet = LoopSnippet(hd_addr, hd_insn, body_snippet)
+        snippet.insert_into_program(program)
 
         return (snippet, False, model)

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -20,6 +20,7 @@ from .gens.loop import Loop
 from .gens.straight_line_insn import StraightLineInsn
 
 from .gens.bad_insn import BadInsn
+from .gens.bad_zero_loop import BadZeroLoop
 
 
 class SnippetGens:
@@ -31,7 +32,8 @@ class SnippetGens:
         StraightLineInsn,
 
         ECall,
-        BadInsn
+        BadInsn,
+        BadZeroLoop
     ]
 
     def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:


### PR DESCRIPTION
To do this, we add a new snippet generator to the RIG called
`BadZeroLoop`. This derives from `Loop` (the normal generator for loops)
and uses the subclass to generate a valid loop, before altering the
head instruction to be invalid.

Note: This PR has two patches. The first fixes a minor bug in the ISS, where we crashed on a `LOOPI` with zero iteration count. What should happen is the behaviour we already had for `LOOP`: stop with an architectural "bad instruction" error.