### PR TITLE
[dv/otp_ctrl] reconnecting dut signals to otp_ctrl_if instead of cons…

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_ast_inputs_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_ast_inputs_cfg.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+// Configuration values for DUT input signals
+//
+//
+// This class randomizes values for DUT signal inputs
+// and sets constraints on these values.
+//
+// This class will be instantiated inside otp_ctrl_env_cfg object, and will connect
+// to it's otp_ctrl_vif signals and drive them each reset event
+//
+// The constraints can be hardened and softened as needed in
+// closed-source environment.
+// In order to override these constraints, please inherit this class
+// and set a type override in the closed source environment
+
+class otp_ctrl_ast_inputs_cfg extends uvm_object;
+  `uvm_object_utils(otp_ctrl_ast_inputs_cfg);
+  `uvm_object_new
+
+  //  Group: Variables
+  rand otp_ast_rsp_t        otp_ast_pwr_seq_h;
+  rand logic [otp_ctrl_pkg::OtpTestCtrlWidth-1:0] otp_test_ctrl;
+  rand lc_ctrl_pkg::lc_tx_t scanmode;
+  rand logic                scan_en, scan_rst_n;
+
+  //  Group: Constraints
+  constraint dut_values_c {
+    otp_test_ctrl            == 8'h0;
+  }
+
+endclass: otp_ctrl_ast_inputs_cfg

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.core
@@ -15,6 +15,7 @@ filesets:
     files:
       - otp_ctrl_env_pkg.sv
       - otp_ctrl_if.sv
+      - otp_ctrl_ast_inputs_cfg.sv: {is_include_file: true}
       - otp_ctrl_env_cfg.sv: {is_include_file: true}
       - otp_ctrl_env_cov.sv: {is_include_file: true}
       - otp_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -18,6 +18,7 @@ class otp_ctrl_env #(
 
   `uvm_component_new
 
+
   push_pull_agent#(.DeviceDataWidth(SRAM_DATA_SIZE))  m_sram_pull_agent[NumSramKeyReqSlots];
   push_pull_agent#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent;
   push_pull_agent#(.DeviceDataWidth(FLASH_DATA_SIZE)) m_flash_addr_pull_agent;
@@ -67,6 +68,7 @@ class otp_ctrl_env #(
     if (!uvm_config_db#(otp_ctrl_vif)::get(this, "", "otp_ctrl_vif", cfg.otp_ctrl_vif)) begin
       `uvm_fatal(`gfn, "failed to get otp_ctrl_vif from uvm_config_db")
     end
+
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -93,6 +95,9 @@ class otp_ctrl_env #(
           scoreboard.flash_data_fifo.analysis_export);
       m_lc_prog_pull_agent.monitor.analysis_port.connect(scoreboard.lc_prog_fifo.analysis_export);
     end
+
+    // connect the DUT cfg instance to the handle in the otp_ctrl_vif
+    this.cfg.otp_ctrl_vif.dut_cfg = this.cfg.dut_cfg;
   endfunction
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -18,7 +18,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   // ext interfaces
   otp_ctrl_vif otp_ctrl_vif;
-
   bit backdoor_clear_mem;
 
   // This value is updated in sequence when backdoor inject ECC error
@@ -26,6 +25,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   // Check ECC errors
   otp_ecc_err_e ecc_chk_err [NumPart] = '{default:OtpNoEccErr};
+
+  // values for otp_ctrl_if signals connected to DUT
+  rand otp_ctrl_ast_inputs_cfg dut_cfg;
 
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end
@@ -71,6 +73,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
     // only support 1 outstanding TL items in tlul_adapter
     m_tl_agent_cfg.max_outstanding_req = 1;
+
+    // create the inputs cfg instance
+    dut_cfg = otp_ctrl_ast_inputs_cfg::type_id::create("dut_cfg");
   endfunction
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -238,6 +238,7 @@ package otp_ctrl_env_pkg;
   endfunction
 
   // package sources
+  `include "otp_ctrl_ast_inputs_cfg.sv"
   `include "otp_ctrl_env_cfg.sv"
   `include "otp_ctrl_env_cov.sv"
   `include "otp_ctrl_virtual_sequencer.sv"

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -63,6 +63,12 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   // Internal veriable to track which sw partitions have ECC reg error.
   bit [1:0] force_sw_parts_ecc_reg;
 
+  // DUT configuration object
+  otp_ctrl_ast_inputs_cfg dut_cfg;
+
+  // for DV macros ID
+  string msg_id = "otp_ctrl_if";
+
   // Lc_err could trigger during LC program, so check intr and status after lc_req is finished.
   // Lc_err takes one clock cycle to propogate to intr signal. So avoid intr check if it happens
   // during the transition.
@@ -94,12 +100,16 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     lc_dft_en_i                = lc_ctrl_pkg::Off;    // drive it in specific task
     lc_escalate_en_i           = lc_ctrl_pkg::Off;    // drive it in specific task
     pwr_otp_init_i             = 0;
-    // Unused signals in open sourced OTP memory
-    otp_ast_pwr_seq_h_i        = $urandom();
-    scan_en_i                  = $urandom();
-    scan_rst_ni                = $urandom();
-    scanmode_i                 = $urandom();
-    otp_test_ctrl_i            = 0;
+
+    // `DV_CHECK_RANDOMIZE_FATAL won't work inside an interface as an interface doesn't
+    // have a `get_full_name` method
+    `DV_CHECK_RANDOMIZE_FATAL(dut_cfg, ,msg_id)
+    //Unused signals in open sourced OTP memory
+    otp_ast_pwr_seq_h_i        = dut_cfg.otp_ast_pwr_seq_h;
+    scan_en_i                  = dut_cfg.scan_en;
+    scan_rst_ni                = dut_cfg.scan_rst_n;
+    scanmode_i                 = dut_cfg.scanmode;
+    otp_test_ctrl_i            = dut_cfg.otp_test_ctrl;
   endtask
 
   task automatic drive_pwr_otp_init(logic val);

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -101,7 +101,7 @@ module tb;
     .alert_tx_o                 (alert_tx   ),
     // ast
     .otp_ast_pwr_seq_o          (ast_req),
-    .otp_ast_pwr_seq_h_i        (ast_req),
+    .otp_ast_pwr_seq_h_i        (otp_ctrl_if.otp_ast_pwr_seq_h_i),
     .otp_alert_o                (otp_ctrl_if.otp_alert_o),
     // pwrmgr
     .pwr_otp_i                  (otp_ctrl_if.pwr_otp_init_i),
@@ -133,7 +133,7 @@ module tb;
     //scan
     .scan_en_i                  (otp_ctrl_if.scan_en_i),
     .scan_rst_ni                (otp_ctrl_if.scan_rst_ni),
-    .scanmode_i                 (lc_ctrl_pkg::Off),
+    .scanmode_i                 (otp_ctrl_if.scanmode_i),
 
     // Test-related GPIO output
     .cio_test_o                 (),


### PR DESCRIPTION
…tants

Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

This PR reverts the connections of the OS TB (and thus cancels PR #6954) and reconnects them back to otp_ctrl_if's signals which are controlled via a new DUT config object.

In order to be able to tie specific signals from closed-source environment to specific values that are relevant only for closed-source simulation (e.g. scanmode_i == lc_ctrl_pkg::Off etc.), we had to somehow manipulate otp_ctrl_if's signals in a configurable way which is controlled by the closed-source environment. 

We came up with 3 solutions, 2 of them worked:
1. Randomizing values in `otp_ctrl_env_cfg` and setting them to `otp_ctrl_if` signals in in `post_randomize` - **didn't work** since the handle to `otp_ctrl_if` inside `otp_ctrl_env_cfg` turns to a valid pointer only after `dv_base_test` finishes it's `build_phase`, and `otp_ctrl_env_cfg::post_randomize` happens **during** `dv_base_test::build_phase` https://github.com/lowRISC/opentitan/blob/b915a39cd0edbf00ffeebc94ee737c4db0077f3f/hw/dv/sv/dv_lib/dv_base_test.sv#L28-L32
Hence in this point of the build `otp_ctrl_env_cfg::otp_ctrl_vif` still points to `null`.

2. Adding the desired values to `otp_ctrl_env` as constrained random variables - works fine, easily extendible in closed source environment, however has 2 issues:

- Conceptual - We don't think that random variables should be in the `env` component. This is why `cfg` objects exist. 
- Technical - values passing from `otp_ctrl_env` directly to `cfg.otp_ctrl_vif` will only be done once in a simulation (at `otp_ctrl_env::start_of_simulation_phase`), but otp_ctrl_if initialized these values every `rst_ni` event  using the `init` task that does not have access to the desired values in `otp_ctrl_env`: 
https://github.com/lowRISC/opentitan/blob/b915a39cd0edbf00ffeebc94ee737c4db0077f3f/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv#L188-L193
So we rather come up with a solution which makes minimal changes to otp_ctrl_if's code and allows it to correctly randomize the values we want in the `init` task.

3. **Chosen Solution** - Creating a DUT config object (`otp_ctrl_dut_cfg`), similar to the UVM env config object. 
It will hold the values and set their constraints. `otp_ctrl_env` will hold an instance of this config object and create & randomize it in its `build_phase`, and it will pass it to `cfg::otp_ctrl_vif` as a handle in it's `connect_phase`. 
Thus, `otp_ctrl_if` will get access to the desired values for its signals, and also be able to randomize them itself every `init` invocation.

For overriding & extending the DUT config constraints, the closed source environment will create its own DUT config class which will extend `otp_ctrl_dut_cfg` (e.g. `class partner_otp_ctrl_dut_cfg extends otp_ctrl_dut_cfg;`), and in order to use it instead of `otp_ctrl_dut_cfg` it will override its type in `partner_otp_ctrl_base_test::build_phase`. For example: `otp_ctrl_dut_cfg::type_id::set_type_override(partner_otp_ctrl_dut_config::get_type())`

Although solution No. 3 seems to add more code, we think it's builds nicely upon the existing environment, conceptually better 
 and has less technical issues than solution No. 2 while having the same extendibility for closed-source environment of solution No. 2 ( + a single type override).
