### PR TITLE
[topgen] Add missing memory attributes

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5575,7 +5575,9 @@
         rom:
         {
           label: rom
-          swaccess: rx
+          swaccess: ro
+          exec: True
+          byte_write: False
           size: 0x4000
         }
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -549,9 +549,11 @@
       base_addrs: {rom: "0x00008000", regs: "0x411e0000"}
       memory: {
         rom: {
-          label:    "rom",
-          swaccess: "rx",
-          size:     "0x4000"
+          label:      "rom",
+          swaccess:   "ro",
+          exec:       "True",
+          byte_write: "False",
+          size:       "0x4000"
         }
       },
       param_decl: {

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -365,9 +365,11 @@
       base_addrs: {rom: "0x00008000", regs: "0x411e0000"}
       memory: {
         rom: {
-          label:    "rom",
-          swaccess: "rx",
-          size:     "0x4000"
+          label:      "rom",
+          swaccess:   "ro",
+          exec:       "True",
+          byte_write: "False",
+          size:       "0x4000"
         }
       }
     },

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -2,6 +2,7 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 <%!
+# TODO(#4709): Remove this function, once the old way of defining memories has been deprecated.
 def memory_to_flags(memory):
     memory_type = memory["type"]
     memory_access = memory.get("swaccess", "rw")
@@ -17,6 +18,21 @@ def memory_to_flags(memory):
         flags_str += "x"
 
     return flags_str
+
+def flags(mem):
+    swaccess = mem["swaccess"]
+    exec = mem["exec"]
+    sw_to_flags = {
+        'rw': 'rw',
+        'ro': 'r'
+    }
+    assert swaccess in sw_to_flags
+
+    flags_str = sw_to_flags[swaccess]
+    if exec:
+        flags_str += "x"
+
+    return flags_str
 %>\
 
 /**
@@ -27,8 +43,8 @@ def memory_to_flags(memory):
 MEMORY {
 % for m in top["module"]:
   % if "memory" in m:
-    % for key, val in m["memory"].items():
-  ${val["label"]}(${val["swaccess"]}) : ORIGIN = ${m["base_addrs"][key]}, LENGTH = ${val["size"]}
+    % for key, mem in m["memory"].items():
+  ${mem["label"]}(${flags(mem)}) : ORIGIN = ${m["base_addrs"][key]}, LENGTH = ${mem["size"]}
     % endfor
   % endif
 % endfor

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -214,7 +214,9 @@ module_added = {
 
 memory_required = {
     'label': ['s', 'region label for the linker script'],
-    'swaccess': ['s', 'access attributes for the linker script'],
+    'swaccess': ['s', 'access attributes for the memory region (ro, rw)'],
+    'exec': ['pb', 'executable region indication for the linker script'],
+    'byte_write': ['pb', 'indicate whether the memory supports byte write accesses'],
     'size': ['d', 'memory region size in bytes for the linker script, '
                   'xbar and RTL parameterisations'],
 }
@@ -797,7 +799,7 @@ def check_modules(top, prefix):
                     error += 1
                 # make sure the linker region access attribute is valid
                 attr = value.get('swaccess', 'unknown attribute')
-                if attr not in ['r', 'rw', 'rx', 'rwx']:
+                if attr not in ['ro', 'rw']:
                     log.error('{} {} swaccess attribute {} of memory region {} '
                               'is not valid'.format(prefix, modname, attr, intf))
                     error += 1


### PR DESCRIPTION
This adds the `byte_write` memory attribute to the memory config section, and changes the allowed `swaccess` attributes to be compatible with the existing reggen environment. I.e., reggen and the associated DV classes do not understand the linker attributes `r`, `w`, `rwx` etc, but use the labels `ro`, `wo`, `rw` instead. We therefore align the allowed label values with the ones understood by the reggen environment, and add a remapping function to the linker script template, alongside with an additional key `exec` in the memory config that indicates whether a region is executable or not.

Signed-off-by: Michael Schaffner <msf@google.com>