### PR TITLE
[dv] Switch cip_base_scoreboard logging to convert2string

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -138,7 +138,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endtask
 
   task process_tl_a_item(string ral_name, tl_seq_item item);
-    `uvm_info(`gfn, $sformatf("received tl a_chan item:\n%0s", item.sprint()), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("received tl a_chan item: %0s", item.convert2string()), UVM_HIGH)
 
     if (cfg.en_scb_tl_err_chk) begin
       if (predict_tl_err(item, AddrChannel, ral_name)) return;
@@ -153,7 +153,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endtask
 
   task process_tl_d_item(string ral_name, tl_seq_item item);
-    `uvm_info(`gfn, $sformatf("received tl d_chan item:\n%0s", item.sprint()), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("received tl d_chan item: %0s", item.convert2string()), UVM_HIGH)
 
     if (cfg.en_scb_tl_err_chk) begin
       // check tl packet integrity


### PR DESCRIPTION
This changes the output format to a single line, which should be
easier to grep.

Following up on a review comment from @sriyerg here: https://github.com/lowRISC/opentitan/pull/7101#discussion_r674967177