### PR TITLE
[otbn] Rewrite case in bignum ALU to make all branches reachable

### DIFF
--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -418,10 +418,10 @@ module otbn_alu_bignum
   always_comb begin
     unique case (operation_i.sel_flag)
       FlagC:   selection_flag_o = selected_flags.C;
-      FlagL:   selection_flag_o = selected_flags.L;
       FlagM:   selection_flag_o = selected_flags.M;
-      FlagZ:   selection_flag_o = selected_flags.Z;
-      default: selection_flag_o = selected_flags.C;
+      FlagL:   selection_flag_o = selected_flags.L;
+      // FlagZ case
+      default: selection_flag_o = selected_flags.Z;
     endcase
   end
 


### PR DESCRIPTION
`operation_i.sel_flag` has type `flag_e`, which has 4 possible values (the
four different flags: C, M, L and Z). The default case is only
reachable in simulation if the `operation_i.sel_flag` is `'x`, which
doesn't happen and gives a coverage hole.

In other situations, there might be non-X situations where the case
statement might have picked the default. For example, the enum might
have had 5 items, so there would be 3 invalid bit patterns. In this
case, we'd have to be careful about changing the behaviour of the
default case. That doesn't apply here.

Also, reorder the case items to match the ordering of the
enum (originally, there was disagreement in the code about whether M
or L came first: apparently, this file supported the losing side!)
