### PR TITLE
[sw/silicon_creator] Remove CsrTest class, update tests

### DIFF
--- a/sw/device/lib/base/testing/mock_csr.h
+++ b/sw/device/lib/base/testing/mock_csr.h
@@ -25,21 +25,6 @@ class MockCsr : public ::mask_rom_test::GlobalMock<MockCsr> {
 
 using MockCsr = testing::StrictMock<internal::MockCsr>;
 
-/**
- * Conveninence fixture for creating CSR tests.
- *
- * This class should be derived by a test fixture (along with `testing::Test`)
- * and used in a `TEST_F` block. Doing so will make the `EXPECT_CSR_*`
- * convenience macros useable.
- *
- * TODO: should this be composable with MmioTest and/or MaskRomTest?
- */
-class CsrTest {
- private:
-  MockCsr csr_;
-  testing::InSequence seq_;
-};
-
 }  // namespace mock_csr
 
 /**

--- a/sw/device/lib/base/testing/mock_csr_test.cc
+++ b/sw/device/lib/base/testing/mock_csr_test.cc
@@ -8,7 +8,10 @@
 #include "sw/device/lib/base/csr.h"
 
 namespace mock_csr_test {
-class MockCsrTest : public ::testing::Test, ::mock_csr::CsrTest {};
+class MockCsrTest : public testing::Test {
+ protected:
+  mock_csr::MockCsr csr_;
+};
 
 TEST_F(MockCsrTest, Read) {
   EXPECT_CSR_READ(CSR_REG_PMPCFG0, 1);

--- a/sw/device/silicon_creator/lib/epmp_unittest.cc
+++ b/sw/device/silicon_creator/lib/epmp_unittest.cc
@@ -10,10 +10,9 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
 #include "sw/device/lib/base/testing/mock_csr.h"
+#include "sw/device/lib/testing/mask_rom_test.h"
 
 namespace epmp_unittest {
-using ::mock_csr::CsrTest;
-using ::testing::Test;
 
 /**
  * Representation of the hardware PMP control register state.
@@ -146,8 +145,9 @@ static uint32_t napot(epmp_region_t region) {
   return (region.start >> 2) | ((region.end - region.start - 1) >> 3);
 }
 
-class EpmpTest : public CsrTest {
+class EpmpTest : public mask_rom_test::MaskRomTest {
  protected:
+  mock_csr::MockCsr csr_;
   /**
    * Default reset value for the PMP CSRs.
    */
@@ -155,7 +155,7 @@ class EpmpTest : public CsrTest {
   epmp_state_t state_ = reset_.State();
 };
 
-class EpmpCheckTest : public Test, public EpmpTest {};
+class EpmpCheckTest : public EpmpTest {};
 
 TEST_F(EpmpCheckTest, Default) {
   // Check CSRs are set as expected.
@@ -193,7 +193,7 @@ TEST_F(EpmpCheckTest, ErrorMseccfg) {
   EXPECT_EQ(epmp_state_check(&state_), kErrorEpmpBadCheck);
 }
 
-class EpmpTorTest : public Test, public EpmpTest {};
+class EpmpTorTest : public EpmpTest {};
 
 TEST_F(EpmpTorTest, Entry0) {
   // Region for entry.
@@ -285,7 +285,7 @@ TEST_F(EpmpTorTest, SharedAddress) {
   EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
 }
 
-class EpmpNa4Test : public Test, public EpmpTest {};
+class EpmpNa4Test : public EpmpTest {};
 
 TEST_F(EpmpNa4Test, Entry0) {
   // Region for entry.
@@ -327,7 +327,7 @@ TEST_F(EpmpNa4Test, Entry15) {
   EXPECT_EQ(epmp_state_check(&state_), kErrorOk);
 }
 
-class EpmpNapotTest : public Test, public EpmpTest {};
+class EpmpNapotTest : public EpmpTest {};
 
 TEST_F(EpmpNapotTest, Entry0) {
   // Region for entry.


### PR DESCRIPTION
This change removes the `CsrTest` class since we don't really need it and updates tests. 

Signed-off-by: Alphan Ulusoy <alphan@google.com>