### PR TITLE
[sw/silicon_creator] Cleanup mock_sec_mmio.h, update tests

### DIFF
--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -28,33 +28,27 @@ class MockSecMmio : public GlobalMock<MockSecMmio> {
 using MockSecMmio = testing::StrictMock<internal::MockSecMmio>;
 
 /**
- * Expect a read to the device `dev` at the given offset, returning the given
+ * Expect a sec_mmio read at the given address, returning the given
  * 32-bit value.
  *
- * The value may be given as an integer, a pointer to little-endian data,
- * or a `std::initializer_list<BitField>`.
- *
- * This expectation is sequenced with all other `EXPECT_SEC_READ` and
- * `EXPECT_SEC_WRITE` calls.
+ * @param addr Read address.
+ * @param ...  The value to return. May be an integer, a pointer to
+ * little-endian data, or a `std::initializer_list<BitField>`.
  */
-#define EXPECT_SEC_READ32(mmio, addr, ...) \
-  EXPECT_CALL(mmio, Read32(addr))          \
+#define EXPECT_SEC_READ32(addr, ...)                                  \
+  EXPECT_CALL(::mask_rom_test::MockSecMmio::Instance(), Read32(addr)) \
       .WillOnce(testing::Return(mock_mmio::ToInt<uint32_t>(__VA_ARGS__)))
 
 /**
- * Expect a write to the given offset with the given 32-bit value.
+ * Expect a sec_mmio write to the given address with the given 32-bit value.
  *
- * The value may be given as an integer, a pointer to little-endian data,
- * or a `std::initializer_list<BitField>`.
- *
- * This function is only available in tests using a fixture that derives
- * `MmioTest`.
- *
- * This expectation is sequenced with all other `EXPECT_SEC_READ` and
- * `EXPECT_SEC_WRITE` calls.
+ * @param addr Write address.
+ * @param ...  Expected value to be written. May be an integer, a pointer to
+ * little-endian data, or a `std::initializer_list<BitField>`.
  */
-#define EXPECT_SEC_WRITE32(mmio, addr, ...) \
-  EXPECT_CALL(mmio, Write32(addr, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)));
+#define EXPECT_SEC_WRITE32(addr, ...)                   \
+  EXPECT_CALL(::mask_rom_test::MockSecMmio::Instance(), \
+              Write32(addr, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)));
 
 extern "C" {
 

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -32,20 +32,20 @@ class OtpReadTest : public OtpTest {
 };
 
 TEST_F(OtpReadTest, Read32) {
-  EXPECT_SEC_READ32(mmio_, base_ + offset_, 0x00010203);
+  EXPECT_SEC_READ32(base_ + offset_, 0x00010203);
 
   EXPECT_EQ(otp_read32(0), 0x00010203);
 }
 
 TEST_F(OtpReadTest, Read64) {
-  EXPECT_SEC_READ32(mmio_, base_ + offset_ + 8, 0x04050607);
-  EXPECT_SEC_READ32(mmio_, base_ + offset_ + 4, 0x08090A0B);
+  EXPECT_SEC_READ32(base_ + offset_ + 8, 0x04050607);
+  EXPECT_SEC_READ32(base_ + offset_ + 4, 0x08090A0B);
 
   EXPECT_EQ(otp_read64(4), 0x0405060708090A0B);
 }
 
 TEST_F(OtpReadTest, ReadLen32) {
-  EXPECT_SEC_READ32(mmio_, base_ + offset_, 0x08090A0B);
+  EXPECT_SEC_READ32(base_ + offset_, 0x08090A0B);
 
   uint32_t value = 0;
   otp_read(0, &value, 1);
@@ -53,8 +53,8 @@ TEST_F(OtpReadTest, ReadLen32) {
 }
 
 TEST_F(OtpReadTest, ReadLen64) {
-  EXPECT_SEC_READ32(mmio_, base_ + offset_, 0x0C0D0E0F);
-  EXPECT_SEC_READ32(mmio_, base_ + offset_ + 4, 0x08090A0B);
+  EXPECT_SEC_READ32(base_ + offset_, 0x0C0D0E0F);
+  EXPECT_SEC_READ32(base_ + offset_ + 4, 0x08090A0B);
 
   std::array<uint32_t, 2> buf;
   otp_read(0, buf.data(), 2);
@@ -63,7 +63,7 @@ TEST_F(OtpReadTest, ReadLen64) {
 
 TEST_F(OtpReadTest, ReadLenN) {
   for (int val = 0; val < 16; ++val) {
-    EXPECT_SEC_READ32(mmio_, base_ + offset_ + val * sizeof(uint32_t), val);
+    EXPECT_SEC_READ32(base_ + offset_ + val * sizeof(uint32_t), val);
   }
 
   std::array<uint32_t, 16> arr;


### PR DESCRIPTION
This change slightly simplifies the `EXPECT_SEC_READ32` and `EXPECT_SEC_WRITE32` macros in `mock_sec_mmio.h` by removing the first argument and using the `Instance()` method instead.

@moidx and @cfrantz, if we are happy with this change I can do the same for abs_mmio.

Signed-off-by: Alphan Ulusoy <alphan@google.com>