### PR TITLE
[rtl/prim_alert_sender] Allow ping_req to stay high without error

### DIFF
--- a/hw/ip/prim/rtl/prim_esc_sender.sv
+++ b/hw/ip/prim/rtl/prim_esc_sender.sv
@@ -114,7 +114,7 @@ module prim_esc_sender
       Idle: begin
         if (esc_req_i) begin
           state_d = CheckEscRespHi;
-        end else if (ping_req_i) begin
+        end else if (ping_req_d & ~ping_req_q) begin
           state_d = CheckPingResp0;
         end
         // any assertion of the response signal


### PR DESCRIPTION
This PR fixes issue #7483 where Michael proposed a fix to eliminate a
ping_req corner case.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>