### PR TITLE
[hw/otp] Add EN_ENTROPY_SRC_FW_OVER default value

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -64,6 +64,10 @@
                     name:  "EN_ENTROPY_SRC_FW_READ",
                     value: "0xA5",
                 },
+                {
+                    name: "EN_ENTROPY_SRC_FW_OVER",
+                    value: "0xA5",
+                }
             ],
         }
         {


### PR DESCRIPTION
Add default EN_ENTROPY_SRC_FW_OVER value for RMA OTP configuration.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>