### PR TITLE
[otbn,dv] Generate RIG json with -o, not stdout

### DIFF
--- a/hw/ip/otbn/dv/rig/otbn-rig
+++ b/hw/ip/otbn/dv/rig/otbn-rig
@@ -71,10 +71,10 @@ def gen_main(args: argparse.Namespace) -> int:
     ser_data = init_data.as_json()
     ser_snippet = snippet.to_json()
     ser = [ser_data, ser_snippet, end_addr]
-    json.dump(ser, sys.stdout)
+    json.dump(ser, args.output)
     # Add a newline at end of output: json.dump doesn't, and it makes a
     # bit of a mess of some consoles.
-    sys.stdout.write('\n')
+    args.output.write('\n')
 
     return 0
 
@@ -160,6 +160,11 @@ def main() -> int:
                      help='Reset address. Defaults to 0.')
     gen.add_argument('--config', type=str, default='default',
                      help='Configuration to use')
+    gen.add_argument('--output', '-o',
+                     metavar='out',
+                     type=argparse.FileType('w', encoding='UTF-8'),
+                     default=sys.stdout,
+                     help='Output filename')
     gen.set_defaults(func=gen_main)
 
     asm.add_argument('--output', '-o',

--- a/hw/ip/otbn/dv/uvm/gen-binaries.py
+++ b/hw/ip/otbn/dv/uvm/gen-binaries.py
@@ -183,7 +183,7 @@ def write_ninja(handle: TextIO, build_smoke: bool, rig_count: int,
 
     if rig_count:
         handle.write('rule rig-gen\n'
-                     '  command = {rig} gen --size {size} --seed $seed >$out\n'
+                     '  command = {rig} gen --size {size} --seed $seed -o $out\n'
                      .format(rig=otbn_rig, size=size))
 
     handle.write('rule rig-asm\n'


### PR DESCRIPTION
No real change, but it means you can add debug prints to the RIG
without breaking the build. (Before, they'd get mixed in with the
json, causing havoc with the next step)
