### PR TITLE
[dv/clkmgr] Fix some test failures

### DIFF
--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -10,6 +10,10 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   );
   `uvm_object_utils(clkmgr_base_vseq)
 
+  // The extra cycles to wait after reset before starting any test, required so some CSRs (notably
+  // hints_status) are properly set when inputs go through synchronizers.
+  localparam int POST_APPLY_RESET_CYCLES = 10;
+
   typedef enum {LcTxTSelOn, LcTxTSelOff, LcTxTSelOther} lc_tx_t_sel_e;
 
   // This simplifies the constraint blocks.
@@ -118,6 +122,10 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     cfg.main_clk_rst_vif.drive_rst_pin(1);
     cfg.io_clk_rst_vif.drive_rst_pin(1);
     cfg.usb_clk_rst_vif.drive_rst_pin(1);
+  endtask
+
+  task post_apply_reset(string reset_kind = "HARD");
+    cfg.io_clk_rst_vif.wait_clks(POST_APPLY_RESET_CYCLES);
   endtask
 
   // setup basic clkmgr features

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -8,10 +8,18 @@
 // will be disabled, but the others will remain enabled. Then all units are made idle to check 
 // that status matches hints. Prior to the next round this raises all hints to avoid units whose
 // clock is off but are not idle.
+//
+// Notice one of the otbn transactional units is on the io_div4 clock, so there are some extra
+// cycles of synchronization.
+
 class clkmgr_trans_vseq extends clkmgr_base_vseq;
   `uvm_object_utils(clkmgr_trans_vseq)
 
   `uvm_object_new
+
+  // This delay in io_clk cycles is needed to allow updates to the hints_status CSR to go through
+  // synchronizers.
+  localparam int IO_DIV4_SYNC_CYCLES = 8;
 
   rand bit [NUM_TRANS-1:0] initial_hints;
 
@@ -28,20 +36,22 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
       `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", initial_hints), UVM_MEDIUM)
       csr_wr(.ptr(ral.clk_hints), .value(initial_hints));
 
-      cfg.clk_rst_vif.wait_clks(5);
+      // Extra wait because of clk_io_div4 synchronizers.
+      cfg.io_clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES);
       // We expect the status to be determined by hints and idle.
       csr_rd(.ptr(ral.clk_hints_status), .value(value));
-      `DV_CHECK_EQ(value, initial_hints | ~idle, "Busy units have status high")
+      `DV_CHECK_EQ(value, initial_hints | ~idle, $sformatf(
+                   "Busy units have status high: hints=0x%x, idle=0x%x", initial_hints, idle))
 
       // Clearing idle should make hint_status match hints.
       cfg.clkmgr_vif.update_idle('1);
-      cfg.clk_rst_vif.wait_clks(2);
+      cfg.io_clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES);
       csr_rd(.ptr(ral.clk_hints_status), .value(value));
       `DV_CHECK_EQ(value, initial_hints, "All idle: units status matches hints")
 
       // Now set all hints, and the status should also be all ones.
       csr_wr(.ptr(ral.clk_hints), .value('1));
-      cfg.clk_rst_vif.wait_clks(2);
+      cfg.io_clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES);
       csr_rd(.ptr(ral.clk_hints_status), .value(value));
       // We expect all units to be on.
       `DV_CHECK_EQ(value, '1, "All idle and all hints high: units status should be high")


### PR DESCRIPTION
Fix clkmgr_trans, adding extra cycles before checking the hints_status
CSR to account for the added clk_io_div4 transactional unit.
Fix clkmgr_csr_mem_rw_with_rand_reset to handle divided clock checks
when io_rst_n becomes active.

Signed-off-by: Guillermo Maturana <maturana@google.com>