### PR TITLE
[formal/conn] Fix top_earlgrey reset

### DIFF
--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -35,7 +35,7 @@ if {$env(DUT_TOP) == "top_earlgrey"} {
   clock clk_io_i
   clock clk_usb_i
   clock clk_aon_i
-  reset -expr {rst_ni}
+  reset -expr {por_n_i}
 }
 
 #-------------------------------------------------------------------------

--- a/hw/top_earlgrey/formal/conn_csvs/top_earlgrey_conn.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/top_earlgrey_conn.csv
@@ -2,6 +2,10 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 #
+# Run these checks with
+#  cd hw/top_earlgrey/formal
+#  ../../../util/dvsim/dvsim.py chip_conn_cfg.hjson
+#
 # TODO: use chip_earlgrey_asic once the ast compile error fixed
 
 ,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,


### PR DESCRIPTION
The top_earlgrey rst_ni was replaced by por_n_i.
Added a comment in the csv file describing how to run it.

Signed-off-by: Guillermo Maturana <maturana@google.com>