### PR TITLE
[formal/conn] Move from top_earlgrey to chip_earlgrey_asic

### DIFF
--- a/hw/formal/formal_conn.sh
+++ b/hw/formal/formal_conn.sh
@@ -23,10 +23,10 @@
 
 set -e
 
-CORE_PATH=systems:top_earlgrey
+CORE_PATH=systems:chip_earlgrey_asic
 REPO_PATH=$(readlink -f ../..)
 
-export DUT_TOP="top_earlgrey"
+export DUT_TOP="chip_earlgrey_asic"
 gui="-batch -command exit"  # default Batch mode
 tool="jg"
 export COV=0

--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  name: top_earlgrey
+  name: chip_earlgrey_asic
 
   import_cfgs: [// common server configuration for results upload
                 "{proj_root}/hw/formal/tools/dvsim/common_conn_cfg.hjson"]
 
-  fusesoc_core: lowrisc:systems:top_earlgrey
+  fusesoc_core: lowrisc:systems:chip_earlgrey_asic:0.1
 
   csv_path: "{proj_root}/hw/top_earlgrey/formal/conn_csvs/top_earlgrey_conn.csv"
 

--- a/hw/top_earlgrey/formal/conn_csvs/top_earlgrey_conn.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/top_earlgrey_conn.csv
@@ -5,43 +5,41 @@
 # Run these checks with
 #  cd hw/top_earlgrey/formal
 #  ../../../util/dvsim/dvsim.py chip_conn_cfg.hjson
-#
-# TODO: use chip_earlgrey_asic once the ast compile error fixed
 
 ,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
 
 # clkmgr idle connectivity
-CONNECTION,CLKMGR_IDLE0,u_clkmgr_aon,idle_i[0],u_aes,idle_o
-CONNECTION,CLKMGR_IDLE1,u_clkmgr_aon,idle_i[1],u_hmac,idle_o
-CONNECTION,CLKMGR_IDLE2,u_clkmgr_aon,idle_i[2],u_kmac,idle_o
-CONNECTION,CLKMGR_IDLE3,u_clkmgr_aon,idle_i[3],u_otbn,idle_o
+CONNECTION,CLKMGR_IDLE0,top_earlgrey.u_clkmgr_aon,idle_i[0],top_earlgrey.u_aes,idle_o
+CONNECTION,CLKMGR_IDLE1,top_earlgrey.u_clkmgr_aon,idle_i[1],top_earlgrey.u_hmac,idle_o
+CONNECTION,CLKMGR_IDLE2,top_earlgrey.u_clkmgr_aon,idle_i[2],top_earlgrey.u_kmac,idle_o
+CONNECTION,CLKMGR_IDLE3,top_earlgrey.u_clkmgr_aon,idle_i[3],top_earlgrey.u_otbn,idle_o
 # clkmgr peri clock connectivity
-CONNECTION,CLKMGR_PERI_CLK0_GPIO,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_gpio,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_SPI_DEVICE,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_spi_device,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_SPI_HOST0,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_spi_host0,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_SPI_HOST1,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_spi_host1,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_I2C0,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_i2c0,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_I2C1,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_i2c1,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_I2C2,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_i2c2,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_PATTGEN,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_pattgen,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_USBDEV,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_usbdev,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_ADC_CTRL_AON,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_adc_ctrl_aon,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_SRAM_CTRL_RET_AON,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_sram_ctrl_ret_aon,clk_i
-CONNECTION,CLKMGR_PERI_CLK0_SRAM_CTRL_RET_AON_OTP,u_clkmgr_aon,clocks_o.clk_io_div4_peri,u_sram_ctrl_ret_aon,clk_otp_i
-CONNECTION,CLKMGR_PERI_CLK1_SPI_DEVICE,u_clkmgr_aon,clocks_o.clk_io_div2_peri,u_spi_device,scan_clk_i
-CONNECTION,CLKMGR_PERI_CLK1_SPI_HOST0,u_clkmgr_aon,clocks_o.clk_io_peri,u_spi_host0,clk_core_i
-CONNECTION,CLKMGR_PERI_CLK1_SPI_HOST1,u_clkmgr_aon,clocks_o.clk_io_div2_peri,u_spi_host1,clk_core_i
-CONNECTION,CLKMGR_PERI_CLK2_USBDEV,u_clkmgr_aon,clocks_o.clk_usb_peri,u_usbdev,clk_usb_48mhz_i
+CONNECTION,CLKMGR_PERI_CLK0_GPIO,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_gpio,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_SPI_DEVICE,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_spi_device,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_SPI_HOST0,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_spi_host0,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_SPI_HOST1,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_spi_host1,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_I2C0,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_i2c0,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_I2C1,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_i2c1,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_I2C2,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_i2c2,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_PATTGEN,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_pattgen,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_USBDEV,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_usbdev,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_ADC_CTRL_AON,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_adc_ctrl_aon,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_SRAM_CTRL_RET_AON,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_sram_ctrl_ret_aon,clk_i
+CONNECTION,CLKMGR_PERI_CLK0_SRAM_CTRL_RET_AON_OTP,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_peri,top_earlgrey.u_sram_ctrl_ret_aon,clk_otp_i
+CONNECTION,CLKMGR_PERI_CLK1_SPI_DEVICE,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div2_peri,top_earlgrey.u_spi_device,scan_clk_i
+CONNECTION,CLKMGR_PERI_CLK1_SPI_HOST0,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_peri,top_earlgrey.u_spi_host0,clk_core_i
+CONNECTION,CLKMGR_PERI_CLK1_SPI_HOST1,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div2_peri,top_earlgrey.u_spi_host1,clk_core_i
+CONNECTION,CLKMGR_PERI_CLK2_USBDEV,top_earlgrey.u_clkmgr_aon,clocks_o.clk_usb_peri,top_earlgrey.u_usbdev,clk_usb_48mhz_i
 # clkmgr trans clock connectivity
-CONNECTION,CLKMGR_AES,u_clkmgr_aon,clocks_o.clk_main_aes,u_aes,clk_i
-CONNECTION,CLKMGR_AES_EDN,u_clkmgr_aon,clocks_o.clk_main_aes,u_aes,clk_edn_i
-CONNECTION,CLKMGR_HMAC,u_clkmgr_aon,clocks_o.clk_main_hmac,u_hmac,clk_i
-CONNECTION,CLKMGR_KMAC,u_clkmgr_aon,clocks_o.clk_main_kmac,u_kmac,clk_i
-CONNECTION,CLKMGR_KMAC_EDN,u_clkmgr_aon,clocks_o.clk_main_kmac,u_kmac,clk_edn_i
-CONNECTION,CLKMGR_OTBN,u_clkmgr_aon,clocks_o.clk_main_otbn,u_otbn,clk_i
-CONNECTION,CLKMGR_OTBN_EDN,u_clkmgr_aon,clocks_o.clk_main_otbn,u_otbn,clk_edn_i
+CONNECTION,CLKMGR_AES,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_aes,top_earlgrey.u_aes,clk_i
+CONNECTION,CLKMGR_AES_EDN,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_aes,top_earlgrey.u_aes,clk_edn_i
+CONNECTION,CLKMGR_HMAC,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_hmac,top_earlgrey.u_hmac,clk_i
+CONNECTION,CLKMGR_KMAC,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_kmac,top_earlgrey.u_kmac,clk_i
+CONNECTION,CLKMGR_KMAC_EDN,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_kmac,top_earlgrey.u_kmac,clk_edn_i
+CONNECTION,CLKMGR_OTBN,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_otbn,top_earlgrey.u_otbn,clk_i
+CONNECTION,CLKMGR_OTBN_EDN,top_earlgrey.u_clkmgr_aon,clocks_o.clk_main_otbn,top_earlgrey.u_otbn,clk_edn_i
 # pwrmgr rstmgr connections
-CONNECTION,CLKMGR_RST_LC_REQ,u_pwrmgr_aon,pwr_rst_o.rst_lc_req,u_rstmgr_aon,pwr_i.rst_lc_req
-CONNECTION,CLKMGR_RST_SYS_REQ,u_pwrmgr_aon,pwr_rst_o.rst_sys_req,u_rstmgr_aon,pwr_i.rst_sys_req
-CONNECTION,CLKMGR_RST_LC_SRC_N,u_pwrmgr_aon,pwr_rst_i.rst_lc_src_n,u_rstmgr_aon,pwr_o.rst_lc_src_n
-CONNECTION,CLKMGR_RST_SYS_SRC_N,u_pwrmgr_aon,pwr_rst_i.rst_sys_src_n,u_rstmgr_aon,pwr_o.rst_sys_src_n
+CONNECTION,CLKMGR_RST_LC_REQ,top_earlgrey.u_pwrmgr_aon,pwr_rst_o.rst_lc_req,top_earlgrey.u_rstmgr_aon,pwr_i.rst_lc_req
+CONNECTION,CLKMGR_RST_SYS_REQ,top_earlgrey.u_pwrmgr_aon,pwr_rst_o.rst_sys_req,top_earlgrey.u_rstmgr_aon,pwr_i.rst_sys_req
+CONNECTION,CLKMGR_RST_LC_SRC_N,top_earlgrey.u_pwrmgr_aon,pwr_rst_i.rst_lc_src_n,top_earlgrey.u_rstmgr_aon,pwr_o.rst_lc_src_n
+CONNECTION,CLKMGR_RST_SYS_SRC_N,top_earlgrey.u_pwrmgr_aon,pwr_rst_i.rst_sys_src_n,top_earlgrey.u_rstmgr_aon,pwr_o.rst_sys_src_n


### PR DESCRIPTION
This PR moves formal connectivity test top-level: from `top_earlgrey` to
`chip_earlgrey_asic`. This will help check the connectivity of blocks
like AST and Pinumx.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>