### PR TITLE
[prim_subreg] This dependency was missing in some core files

### DIFF
--- a/hw/ip/alert_handler/alert_handler_reg.core
+++ b/hw/ip/alert_handler/alert_handler_reg.core
@@ -8,6 +8,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:tlul:headers
+      - lowrisc:prim:subreg
       - "fileset_top    ? (lowrisc:systems:alert_handler_reg)"
       - "fileset_topgen ? (lowrisc:systems:topgen-reg-only)"
     files:

--- a/hw/ip/pwrmgr/pwrmgr_reg.core
+++ b/hw/ip/pwrmgr/pwrmgr_reg.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:tlul:headers
+      - lowrisc:prim:subreg
       - "fileset_top    ? (lowrisc:systems:pwrmgr_reg)"
       - "fileset_topgen ? (lowrisc:systems:topgen-reg-only)"
     files:


### PR DESCRIPTION
This missing dependency seems to cause issues for some lint targets:
https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/summary.html

```
Tool Errors
IOError: [Errno 2] No such file or directory: '/usr/local/google/home/msf/scratch-nightlies/master/lc_ctrl-lint-ascentlint/default/lint-ascentlint/ascentlint.rpt'

  ERR  [#59034] : on line 542 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 568 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 594 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 620 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 648 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 674 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 700 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 726 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 815 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 842 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 874 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 908 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 935 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 962 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 989 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 1018 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 1050 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 1082 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 1114 in file ../src/lowrisc_ip_alert_handler_reg_0.1/rtl/alert_handler_reg_top.sv

  ERR  [#59034] : on line 164 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 191 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 251 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 277 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 303 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 329 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 355 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 381 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 408 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 435 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 464 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 493 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 520 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 549 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 578 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59034] : on line 605 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv

  ERR  [#59097] : on line 9 in file ../src/lowrisc_ip_pwrmgr_reg_0.1/rtl/pwrmgr_reg_top.sv


```

Signed-off-by: Michael Schaffner <msf@google.com>