### PR TITLE
[tlul_adapter_sram] Fix minor bugs in byte write logic

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -91,7 +91,8 @@ module tlul_adapter_sram import tlul_pkg::*; #(
   tl_h2d_t tl_i_int;
   tl_d2h_t tl_o_int;
   tlul_sram_byte #(
-    .EnableIntg(ByteAccess & CmdIntgCheck & !ErrOnWrite)
+    .EnableIntg(ByteAccess & CmdIntgCheck & !ErrOnWrite),
+    .Outstanding(Outstanding)
   ) u_sram_byte (
     .clk_i,
     .rst_ni,
@@ -269,11 +270,6 @@ module tlul_adapter_sram import tlul_pkg::*; #(
     end
   end
 
-  // TODO: The logic below is incomplete.  If the adapter detects a write is NOT
-  // the full word, it must read back the other parts of the data from memory and
-  // re-generate the integrity.
-  // Since that will cause back-pressure to the upstream agent and likely substantial
-  // change into this module, it is left to a different PR.
   always_comb begin
     wmask_intg  = '0;
     wdata_intg  = '0;


### PR DESCRIPTION
Split out from #7218.

----------------------

This fixes a few bugs in the byte write logic and adds a workaround for potential RAW hazards that can occur when the byte write logic is employed together with `prim_ram_1p_scr`.

This workaround should be removed once the DV environment of `sram_ctrl` is able to handle these corner cases (#7461).

Signed-off-by: Michael Schaffner <msf@google.com>