### PR TITLE
[dv/otp_ctrl] fixed process_tl_access in scoreboard

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -487,8 +487,8 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     dv_base_reg dv_reg;
     bit         do_read_check = 1;
     bit         write         = item.is_write();
-    uvm_reg_addr_t csr_addr   = ral.get_word_aligned_addr(item.a_addr);
-    bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
+    uvm_reg_addr_t csr_addr   = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    bit [TL_AW-1:0] addr_mask = cfg.ral_models[ral_name].get_addr_mask();
 
     bit addr_phase_read   = (!write && channel == AddrChannel);
     bit addr_phase_write  = (write && channel == AddrChannel);
@@ -497,7 +497,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
-      csr = ral.default_map.get_reg_by_offset(csr_addr);
+      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
       `downcast(dv_reg, csr)
     // SW CFG window


### PR DESCRIPTION
Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

Fix for: `otp_ctrl_scoreboard::process_tl_access` calls main RAL for querying the register according to its name instead of the appropriate RAL (`cfg.ral_models[ral_name]`).