### PR TITLE
[otbn,dv] Remove unused import from RIG's config.py

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/config.py
+++ b/hw/ip/otbn/dv/rig/rig/config.py
@@ -6,8 +6,7 @@ import os
 import random
 from typing import Dict, List, Optional, Set
 
-from shared.yaml_parse_helpers import (check_str, check_keys, check_list,
-                                       load_yaml)
+from shared.yaml_parse_helpers import check_str, check_keys, load_yaml
 
 
 class Weights:


### PR DESCRIPTION
I seem to have added it mistakenly in fddf0d0 in January(!). Oops.
