### PR TITLE
[dv] Fix testplan links in the generated regression reports

### DIFF
--- a/doc/project/development_stages.md
+++ b/doc/project/development_stages.md
@@ -95,33 +95,33 @@ The verification stages can be applied to simulation-based DV and formal propert
 
 The first verification stage is **Initial Work**.
 This indicates the period of time between the beginning of verification planning and the testbench up and running.
-The testbench is still being created, scoreboards implemented, DV document and DV plan being written, nightly regressions running, etc.
-Once the verification environment is available for writing tests, with a DV plan written including a testplan and a functional coverage plan, it has completed the Initial Work stage.
+The testbench is still being created, scoreboards implemented, DV document and testplan being written, nightly regressions running, etc.
+Once the verification environment is available for writing tests, with a testplan written including a testplan and a functional coverage plan, it has completed the Initial Work stage.
 
 The second verification stage is **Under Test**.
 In this stage, the verification environment is available but not all tests in the testplan are are completed and the coverpoints are not implemented.
-Once all of the items in the DV plan are implemented, it exits this stage.
+Once all of the items in the testplan are implemented, it exits this stage.
 
 The third verification stage is **Testing Complete**.
-In this phase, no changes are expected on the DV plan, no changes expected on the testbench, and no new tests are expected except to close coverage on the design.
+In this phase, no changes are expected on the testplan, no changes expected on the testbench, and no new tests are expected except to close coverage on the design.
 Once all coverage metrics have been met, waivers checked, the verification moves into its final stage: **Verification Complete**.
 
 **Stages for simulation-based DV**:
 
 | **Stage** | **Name** | **Definition** |
 | --- | --- | --- |
-| V0 | Initial Work | Testbench being developed, not functional; DV plan being written; decided which methodology to use (sim-based DV, FPV, or both). |
-| V1 | Under Test | <ul> <li> Documentation: <ul> <li> [DV document]({{< relref "doc/ug/dv_methodology#documentation" >}}) available, <li> [DV plan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed <li> [functional coverage plan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed </ul> <li> Testbench: <ul> <li> DUT instantiated with major interfaces hooked up <li> All available interface assertion monitors hooked up <li> X / unknown checks on DUT outputs added <li> Skeleton environment created with UVCs <li> TLM connections made from interface monitors to the scoreboard </ul> <li> Tests (written and passing): <ul> <li> Sanity test accessing basic functionality <li> CSR / mem test suite </ul> <li> Regressions: Sanity and nightly regression set up</ul> |
-| V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV document completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces hooked up and exercised <li> all assertions written and enabled </ul> <li> UVM environment: fully developed with end-to-end checks in scoreboard <li> Tests (written and passing): all tests planned for in the DV plan  <li> Functional coverage (written): all covergroups planned for in the DV plan <li> Regression: all tests passing in nightly regression with multiple seeds (> 90%)  <li> Coverage: 90% code coverage across the board, 100% functional coverpoints covered and 75% crosses covered</ul></ul> |
+| V0 | Initial Work | Testbench being developed, not functional; testplan being written; decided which methodology to use (sim-based DV, FPV, or both). |
+| V1 | Under Test | <ul> <li> Documentation: <ul> <li> [DV document]({{< relref "doc/ug/dv_methodology#documentation" >}}) available, <li> [Testplan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed </ul> <li> Testbench: <ul> <li> DUT instantiated with major interfaces hooked up <li> All available interface assertion monitors hooked up <li> X / unknown checks on DUT outputs added <li> Skeleton environment created with UVCs <li> TLM connections made from interface monitors to the scoreboard </ul> <li> Tests (written and passing): <ul> <li> Sanity test accessing basic functionality <li> CSR / mem test suite </ul> <li> Regressions: Sanity and nightly regression set up</ul> |
+| V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV document completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces hooked up and exercised <li> all assertions written and enabled </ul> <li> UVM environment: fully developed with end-to-end checks in scoreboard <li> Tests (written and passing): all tests planned for in the testplan  <li> Functional coverage (written): all covergroups planned for in the testplan <li> Regression: all tests passing in nightly regression with multiple seeds (> 90%)  <li> Coverage: 90% code coverage across the board, 100% functional coverpoints covered and 75% crosses covered</ul></ul> |
 | V3 | Verification Complete | <ul> <li> Design Issues: all bugs addressed <li> Tests (written and passing): all tests including newly added post-V2 tests (if any) <li> Regression: all tests with all seeds passing <li> Coverage: 100% code and 100% functional coverage with waivers </ul> </ul> |
 
 **Stages for FPV approaches**:
 
 | **Stage** | **Name** | **Definition** |
 | --- | --- | --- |
-| V0 | Initial Work | Testbench being developed, not functional; DV plan being written; decided which methodology to use (sim-based DV, FPV, or both). |
-| V1 | Under Test | <ul> <li> Documentation: <ul> <li> [DV document]({{< relref "doc/ug/dv_methodology#documentation" >}}) available, [DV plan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed </ul> <li> Testbench: <ul> <li> Formal testbench with DUT bound to assertion module(s) <li> All available interface assertion monitors hooked up <li> X / unknown assertions on DUT outputs added </ul> <li> Assertions (written and proven): <ul> <li> All functional properties identified and described in DV plan <li> Assertions for main functional path implemented and passing (sanity check)<li> Each input and each output is part of at least one assertion</ul> <li> Regressions: Sanity and nightly regression set up</ul> |
-| V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV document completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces have assertions checking the protocol <li> all functional assertions written and enabled <li> assumptions for FPV specified and reviewed </ul> <li> Tests (written and passing): all tests planned for in the DV plan <li> Regression: 90% of properties proven in nightly regression <li> Coverage: 90% code coverage and 75% logic cone of influence (COI) coverage </ul> |
+| V0 | Initial Work | Testbench being developed, not functional; testplan being written; decided which methodology to use (sim-based DV, FPV, or both). |
+| V1 | Under Test | <ul> <li> Documentation: <ul> <li> [DV document]({{< relref "doc/ug/dv_methodology#documentation" >}}) available, [Testplan]({{< relref "doc/ug/dv_methodology#documentation" >}}) completed and reviewed </ul> <li> Testbench: <ul> <li> Formal testbench with DUT bound to assertion module(s) <li> All available interface assertion monitors hooked up <li> X / unknown assertions on DUT outputs added </ul> <li> Assertions (written and proven): <ul> <li> All functional properties identified and described in testplan <li> Assertions for main functional path implemented and passing (sanity check)<li> Each input and each output is part of at least one assertion</ul> <li> Regressions: Sanity and nightly regression set up</ul> |
+| V2 | Testing Complete | <ul> <li> Documentation: <ul> <li> DV document completely written </ul> <li> Design Issues: <ul> <li> all high priority bugs addressed <li> low priority bugs root-caused </ul> <li> Testbench: <ul> <li> all interfaces have assertions checking the protocol <li> all functional assertions written and enabled <li> assumptions for FPV specified and reviewed </ul> <li> Tests (written and passing): all tests planned for in the testplan <li> Regression: 90% of properties proven in nightly regression <li> Coverage: 90% code coverage and 75% logic cone of influence (COI) coverage </ul> |
 | V3 | Verification Complete | <ul> <li> Design Issues: all bugs addressed <li> Assertions (written and proven): all assertions including newly added post-V2 assertions (if any) <li> Regression: 100% of properties proven (with reviewed assumptions) <li> Coverage: 100% code coverage and 100% COI coverage</ul> |
 
 ## Device Interface Function Stages (S)
@@ -163,7 +163,7 @@ Generally, this process would involve:
 *   Specification and RTL are re-reviewed for readability, consistency, and code coverage standards
 *   All design items are complete, reviewed against committed specification
 *   All lint and CDC errors and warnings are waived, waivers reviewed
-*   DV plan is re-reviewed for completeness
+*   Testplan is re-reviewed for completeness
 *   All test items are confirmed complete
 *   All code coverage items are completed or waived
 *   Performance requirements are reviewed, performance metrics met

--- a/doc/ug/dv_methodology/index.md
+++ b/doc/ug/dv_methodology/index.md
@@ -63,7 +63,6 @@ The testplan is parsed into a data structure that serves the following purposes:
 
 *  Provide the ability to insert the testplan and coverage plan as tables into the DV document itself, so that all of the required information is in one place
 *  Annotate the nightly regression results to allow us to track our progress towards executing the testplan and coverage collection
-  *  this feature is not yet available and is [under active development](#pending-work-items)
 
 The [testplanner]({{< relref "util/dvsim/doc/testplanner.md" >}}) tool provides some additional information on the Hjson testplan anatomy and some of the features and constructs supported.
 The [build_docs]({{< relref "README.md#documentation" >}}) tool works in conjunction with the `testplanner` tool to enable its insertion into the DV document as a table.

--- a/hw/dv/doc/dv_doc_template.md
+++ b/hw/dv/doc/dv_doc_template.md
@@ -14,7 +14,7 @@ applicable. Once done, remove this comment before making a PR. -->
 ## Goals
 * **DV**
   * Verify all FOO IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -115,6 +115,6 @@ $ cd hw/ip/foo/dv
 $ make TEST_NAME=foo_smoke
 ```
 
-## DV plan
-<!-- TODO: uncomment the line below after adding the DV plan -->
-{{</* testplan "hw/ip/foo/data/foo_testplan.hjson" */>}}
+## Testplan
+<!-- TODO: uncomment the line below after adding the testplan -->
+{{</* incGenFromIpDesc "../../data/foo_testplan.hjson" "testplan" */>}}

--- a/hw/ip/adc_ctrl/doc/checklist.md
+++ b/hw/ip/adc_ctrl/doc/checklist.md
@@ -116,7 +116,7 @@ Review        | Signoff date            | Not Started |
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
 Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [ADC_CTRL DV document]({{<relref "dv/index.md" >}})
-Documentation | [TESTPLAN_COMPLETED][]                | Not Started | [ADC_CTRL DV Plan]({{<relref "dv/index.md#testplan" >}})
+Documentation | [TESTPLAN_COMPLETED][]                | Not Started | [ADC_CTRL Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Not Started |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Not Started |

--- a/hw/ip/adc_ctrl/doc/dv/index.md
+++ b/hw/ip/adc_ctrl/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "ADC_CTRL DV document"
 ## Goals
 * **DV**
   * Verify all ADC_CTRL IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -104,5 +104,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson -i adc_ctrl_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/adc_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/aes/doc/dv/index.md
+++ b/hw/ip/aes/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "AES DV document"
 ## Goals
 * **DV**
   * Verify all AES IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP.
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP.
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -156,5 +156,5 @@ Here's how to run a basic test without DPI calls:
 ```console
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/aes/dv/aes_sim_cfg.hjson -i aes_wakeup
 ```
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/aes_testplan.hjson" "testplan" >}}

--- a/hw/ip/alert_handler/doc/dv/index.md
+++ b/hw/ip/alert_handler/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "ALERT_HANDLER DV document"
 ## Goals
 * **DV**
   * Verify all ALERT_HANDLER IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
   * Verify transmitter and receiver pairs for alert and escalator
@@ -111,5 +111,5 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/$CHIP/ip/alert_handler/dv/alert_han
 ```
 In this run command, $CHIP can be top_earlgrey, etc.
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/alert_handler_testplan.hjson" "testplan" >}}

--- a/hw/ip/aon_timer/doc/checklist.md
+++ b/hw/ip/aon_timer/doc/checklist.md
@@ -110,7 +110,7 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [AON Timer DV Plan]()
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [AON Timer DV document]()
 Documentation | [TESTPLAN_COMPLETED][]                | Not Started | [AON Timer Testplan]()
 Testbench     | [TB_TOP_CREATED][]                    | Not Started |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Not Started |

--- a/hw/ip/aon_timer/doc/dv/index.md
+++ b/hw/ip/aon_timer/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "AON Timer DV Document"
 ## Goals
 * **DV**
   * Verify the always-on timer (*AON Timer*) by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -134,5 +134,5 @@ To run a basic smoke test, go to the top of the repository and run:
 $ util/dvsim/dvsim.py hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson -i aon_timer_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/aon_timer_testplan.hjson" "testplan" >}}

--- a/hw/ip/clkmgr/doc/checklist.md
+++ b/hw/ip/clkmgr/doc/checklist.md
@@ -116,7 +116,7 @@ Review        | Signoff date            | Not Started |
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
 Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [CLKMGR DV document]({{<relref "dv" >}})
-Documentation | [TESTPLAN_COMPLETED][]                | Done        | [CLKMGR Testplan]({{<relref "dv/index.md#dv-plan" >}})
+Documentation | [TESTPLAN_COMPLETED][]                | Done        | [CLKMGR Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/clkmgr/doc/dv/index.md
+++ b/hw/ip/clkmgr/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "CLKMGR DV document"
 ## Goals
 * **DV**
   * Verify all CLKMGR IP features by running dynamic simulations with a SV/UVM based testbench.
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules.
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules.
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench.
   * Verify clock gating assertions.
@@ -158,5 +158,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson -i clkmgr_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/clkmgr_testplan.hjson" "testplan" >}}

--- a/hw/ip/csrng/doc/dv/index.md
+++ b/hw/ip/csrng/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "CSRNG DV document"
 ## Goals
 * **DV**
   * Verify all CSRNG IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -100,5 +100,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/csrng/dv/csrng_sim_cfg.hjson -i csrng_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/csrng_testplan.hjson" "testplan" >}}

--- a/hw/ip/edn/doc/dv/index.md
+++ b/hw/ip/edn/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "EDN DV document"
 ## Goals
 * **DV**
   * Verify all EDN IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -102,5 +102,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/edn/dv/edn_sim_cfg.hjson -i edn_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/edn_testplan.hjson" "testplan" >}}

--- a/hw/ip/entropy_src/doc/dv/index.md
+++ b/hw/ip/entropy_src/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "ENTROPY_SRC DV document"
 ## Goals
 * **DV**
   * Verify all ENTROPY_SRC IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -99,5 +99,5 @@ $ cd hw/ip/entropy_src/dv
 $ make TEST_NAME=entropy_src_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/entropy_src_testplan.hjson" "testplan" >}}

--- a/hw/ip/flash_ctrl/doc/dv/index.md
+++ b/hw/ip/flash_ctrl/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "FLASH_CTRL DV document"
 ## Goals
 * **DV**
   * Verify all `flash_ctrl` IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -127,5 +127,5 @@ $ cd $REPO_TOP
 $ ./util/dvsim/dvsim.py hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson -i flash_ctrl_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/flash_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/gpio/doc/dv/index.md
+++ b/hw/ip/gpio/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "GPIO DV document"
 ## Goals
 * **DV**
   * Verify all GPIO IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -112,5 +112,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/gpio/dv/gpio_sim_cfg.hjson -i gpio_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/gpio_testplan.hjson" "testplan" >}}

--- a/hw/ip/hmac/doc/dv/index.md
+++ b/hw/ip/hmac/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "HMAC DV document"
 ## Goals
 * **DV**
   * Verify all HMAC IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -142,5 +142,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/hmac/dv/hmac_sim_cfg.hjson -i hmac_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/hmac_testplan.hjson" "testplan" >}}

--- a/hw/ip/i2c/doc/dv/index.md
+++ b/hw/ip/i2c/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "I2C DV document"
 ## Goals
 * **DV**
   * Verify all I2C IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -97,5 +97,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/i2c/dv/i2c_sim_cfg.hjson -i i2c_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/i2c_testplan.hjson" "testplan" >}}

--- a/hw/ip/keymgr/doc/dv/index.md
+++ b/hw/ip/keymgr/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "KEYMGR DV document"
 ## Goals
 * **DV**
   * Verify all KEYMGR IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -104,5 +104,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson -i keymgr_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/keymgr_testplan.hjson" "testplan" >}}

--- a/hw/ip/kmac/doc/dv/index.md
+++ b/hw/ip/kmac/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "KMAC DV document"
 ## Goals
 * **DV**
   * Verify all KMAC IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -151,6 +151,6 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/kmac/dv/kmac_sim_cfg.hjson -i kmac_smoke
 ```
 
-## DV plan
-<!-- TODO: uncomment the line below after adding the DV plan -->
+## Testplan
+<!-- TODO: uncomment the line below after adding the Testplan -->
 {{</* testplan "hw/ip/kmac/data/kmac_testplan.hjson" */>}}

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "LC_CTRL DV document"
 ## Goals
 * **DV**
   * Verify all LC_CTRL IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -104,5 +104,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson -i lc_ctrl_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/lc_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "OTBN DV document"
 ## Goals
 * **DV**
   * Verify the OTBN processor by running dynamic simulations with a SV/UVM based testbench
-  * These simulations are grouped in tests listed in the [DV plan](#dv-plan) below.
+  * These simulations are grouped in tests listed in the [testplan](#testplan) below.
   * Close code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
@@ -888,5 +888,5 @@ To run a basic smoke test, go to the top of the repository and run:
 $ util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/otbn_testplan.hjson" "testplan" >}}

--- a/hw/ip/otp_ctrl/doc/checklist.md
+++ b/hw/ip/otp_ctrl/doc/checklist.md
@@ -116,7 +116,7 @@ Review        | Signoff date            | Not Started |
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
 Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [OTP_CTRL DV document]({{<relref "dv" >}})
-Documentation | [TESTPLAN_COMPLETED][]                | Done        | [OTP_CTRL Testplan]({{<relref "dv/index.md#dv-plan" >}})
+Documentation | [TESTPLAN_COMPLETED][]                | Done        | [OTP_CTRL Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
 Testbench     | [SIM_TB_ENV_CREATED][]                | Done        |

--- a/hw/ip/otp_ctrl/doc/dv/index.md
+++ b/hw/ip/otp_ctrl/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "OTP_CTRL DV document"
 ## Goals
 * **DV**
   * Verify all OTP_CTRL IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -145,5 +145,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson -i otp_ctrl_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/otp_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/pattgen/doc/dv/index.md
+++ b/hw/ip/pattgen/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "PATTGEN DV document"
 ## Goals
 * **DV**
   * Verify all PATTGEN IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -98,5 +98,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson -i pattgen_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/pattgen_testplan.hjson" "testplan" >}}

--- a/hw/ip/pinmux/doc/dv/index.md
+++ b/hw/ip/pinmux/doc/dv/index.md
@@ -38,5 +38,5 @@ Due to there are large number of peripheral and muxed inputs, the symbolic varia
 In the pinmux_assert_fpv module, we declared two symbolic variables `mio_sel_i` and `periph_sel_i` to represent the index for muxed and peripheral IO.
 Detailed explanation is listed in the [Symbolic Variables]({{< relref "hw/formal/README.md#symbolic-variables" >}}) section.
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/pinmux_fpv_testplan.hjson" "testplan" >}}

--- a/hw/ip/pwm/doc/dv/index.md
+++ b/hw/ip/pwm/doc/dv/index.md
@@ -14,7 +14,7 @@ applicable. Once done, remove this comment before making a PR. -->
 ## Goals
 * **DV**
   * Verify all PWM IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -115,5 +115,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/pwm/dv/pwm_sim_cfg.hjson -i pwm_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/pwm_testplan.hjson" "testplan" >}}

--- a/hw/ip/pwrmgr/doc/dv/index.md
+++ b/hw/ip/pwrmgr/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "PWRMGR DV document"
 ## Goals
 * **DV**
   * Verify all PWRMGR IP features by running dynamic simulations with a SV/UVM based testbench.
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules.
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules.
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench.
 
@@ -57,7 +57,7 @@ It can be created manually by invoking [`regtool`]({{< relref "util/reggen/READM
 
 ### Stimulus strategy
 The sequences are closely related to the testplan's testpoints.
-Testpoints and coverage are described in more detail in the [testplan](#dv-plan).
+Testpoints and coverage are described in more detail in the [testplan](#testplan).
 #### Test sequences
 All test sequences reside in `hw/ip/pwrmgr/dv/env/seq_lib`, and extend `pwrmgr_base_vseq`.
 The `pwrmgr_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
@@ -218,5 +218,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson -i pwrmgr_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/pwrmgr_testplan.hjson" "testplan" >}}

--- a/hw/ip/rom_ctrl/doc/dv/index.md
+++ b/hw/ip/rom_ctrl/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "ROM Controller DV document"
 ## Goals
 * **DV**
   * Verify all `rom_ctrl` IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -87,5 +87,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson -i rom_ctrl_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/rom_ctrl_testplan.hjson" "testplan" >}}

--- a/hw/ip/rstmgr/doc/dv/index.md
+++ b/hw/ip/rstmgr/doc/dv/index.md
@@ -14,7 +14,7 @@ applicable. Once done, remove this comment before making a PR. -->
 ## Goals
 * **DV**
   * Verify all RSTMGR IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -80,7 +80,7 @@ It can be created manually by invoking [`regtool`]({{< relref "util/reggen/READM
 [Describe reference models in use if applicable, example: SHA256/HMAC]
 
 ### Stimulus strategy
-The following test sequences and covergroupsare described in more detail in the testplan at `hw/ip/pwrmgr/data/rstmgr_testplan.hjson`, and also included [below](#dv-plan).
+The following test sequences and covergroupsare described in more detail in the testplan at `hw/ip/pwrmgr/data/rstmgr_testplan.hjson`, and also included [below](#testplan).
 
 #### Test sequences
 The test sequences reside in `hw/ip/rstmgr/dv/env/seq_lib`.
@@ -121,7 +121,7 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson -i rstmgr_smoke
 ```
 
-## DV plan
+## Testplan
 <!-- TODO: uncomment the line below after adding the testplan.
 Please make sure the testplan is added to `/util/build_docs.py`. -->
 {{</* incGenFromIpDesc "hw/ip/rstmgr/data/rstmgr_testplan.hjson" "testplan" */>}}

--- a/hw/ip/rv_plic/doc/dv/index.md
+++ b/hw/ip/rv_plic/doc/dv/index.md
@@ -47,5 +47,5 @@ interrupt source and interrupt target.
 Detailed explanation is listed in the
 [Symbolic Variables]({{< relref "/hw/formal/README.md#symbolic-variables" >}}) section.
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/rv_plic_fpv_testplan.hjson" "testplan" >}}

--- a/hw/ip/rv_timer/doc/dv/index.md
+++ b/hw/ip/rv_timer/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "RV_TIMER DV document"
 ## Goals
 * **DV**
   * Verify all RV_TIMER IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -101,5 +101,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/rv_timer/dv/rv_timer_sim_cfg.hjson -i rv_timer_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/rv_timer_testplan.hjson" "testplan" >}}

--- a/hw/ip/spi_device/doc/dv/index.md
+++ b/hw/ip/spi_device/doc/dv/index.md
@@ -6,7 +6,7 @@ title: "SPI Device DV document"
 ## Goals
 * **DV**
   * Verify all SPI Device IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -102,5 +102,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson -i spi_device_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/spi_device_testplan.hjson" "testplan" >}}

--- a/hw/ip/spi_host/doc/dv/index.md
+++ b/hw/ip/spi_host/doc/dv/index.md
@@ -1,11 +1,11 @@
 ---
-title: "SPI_HOST DV Plan"
+title: "SPI_HOST DV Document"
 ---
 
 ## Goals
 * **DV**
   * Verify all SPI_HOST IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run tests that exercise all testpoint in the [DV plan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run tests that exercise all testpoints in the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -15,11 +15,11 @@ title: "SPI_HOST DV Plan"
 * [Simulation results](https://reports.opentitan.org/hw/ip/spi_host/dv/latest/results.html)
 
 ## Design features
-For detailed information on SPI_HOST design features, please see the 
+For detailed information on SPI_HOST design features, please see the
 [SPI_HOST HWIP technical specification]({{< relref "hw/ip/spi_host/doc" >}}).
 
 ## Testbench architecture
-SPI_HOST testbench has been constructed based on the 
+SPI_HOST testbench has been constructed based on the
 [CIP testbench architecture]({{< relref "hw/dv/sv/cip_lib/doc" >}}).
 
 ### Block diagram
@@ -54,7 +54,7 @@ All common types and methods defined at the package level can be found in
 TODO
 ```
 ### TL_agent
-SPI_HOST testbench instantiates (already handled in CIP base env) 
+SPI_HOST testbench instantiates (already handled in CIP base env)
 [tl_agent]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
 which provides the ability to drive and independently monitor random traffic via TL host interface into SPI_HOST device.
 Transactions will be sampled by the monitor and passed on to the predictor in the scoreboard.
@@ -86,7 +86,7 @@ Some of the most commonly used tasks / functions are as follows:
 
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
-the list of functional coverpoints can be found under covergroups in the [DV plan](#testplan)
+the list of functional coverpoints can be found under covergroups in the [testplan](#testplan)
 
 
 ### Self-checking strategy

--- a/hw/ip/sram_ctrl/doc/dv/index.md
+++ b/hw/ip/sram_ctrl/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "SRAM_CTRL DV document"
 ## Goals
 * **DV**
   * Verify all SRAM_CTRL IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -202,5 +202,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/sram_ctrl/dv/sram_ctrl_sim_cfg.hjson -i sram_ctrl_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/sram_ctrl_base_testplan.hjson" "testplan" >}}

--- a/hw/ip/tlul/doc/dv/index.md
+++ b/hw/ip/tlul/doc/dv/index.md
@@ -6,7 +6,7 @@ title: "TLUL XBAR DV document"
 ## Goals
 * **DV**
   * Verify all TLUL XBAR IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -112,5 +112,5 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/$CHIP/ip/$XBAR_IP/dv/autogen/${XBAR
 ```
 In this run command, $XBAR_IP can be xbar_main, xbar_peri, etc. $CHIP can be top_earlgrey, etc.
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/tlul_testplan.hjson" "testplan" >}}

--- a/hw/ip/uart/doc/dv/index.md
+++ b/hw/ip/uart/doc/dv/index.md
@@ -6,7 +6,7 @@ title: "UART DV document"
 ## Goals
 * **DV**
   * Verify all UART IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -99,5 +99,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/uart/dv/uart_sim_cfg.hjson -i uart_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/uart_testplan.hjson" "testplan" >}}

--- a/hw/ip/usbdev/doc/dv/index.md
+++ b/hw/ip/usbdev/doc/dv/index.md
@@ -5,7 +5,7 @@ title: "USBDEV DV document"
 ## Goals
 * **DV**
   * Verify all USBDEV IP features by running dynamic simulations with a SV/UVM based testbench.
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules.
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules.
     * Note that code and functional coverage goals are TBD due to pending evaluation of where / how to source a USB20 UVM VIP.
     * The decision is trending towards hooking up a cocotb (Python) based open source USB20 compliance test suite with this UVM environment.
 * **FPV**
@@ -97,5 +97,5 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/usbdev/dv/usbdev_sim_cfg.hjson -i usbdev_smoke
 ```
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/usbdev_testplan.hjson" "testplan" >}}

--- a/hw/top_earlgrey/doc/dv/index.md
+++ b/hw/top_earlgrey/doc/dv/index.md
@@ -130,7 +130,7 @@ The basic UART transmit and receive test can be run with the following command:
 ```console
 $ ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i chip_uart_tx_rx
 ```
-For a list of available tests  to run, please see the 'Tests' column in the [DV plan]({{< relref "#dv_plan" >}}) below.
+For a list of available tests  to run, please see the 'Tests' column in the [testplan]({{< relref "#testplan" >}}) below.
 
 ## Regressions
 
@@ -140,5 +140,5 @@ For a list of available tests  to run, please see the 'Tests' column in the [DV 
 
 ### Nightly
 
-## DV plan
+## Testplan
 {{< incGenFromIpDesc "../../data/chip_testplan.hjson" "testplan" >}}

--- a/hw/top_earlgrey/ip/xbar/doc/checklist.md
+++ b/hw/top_earlgrey/ip/xbar/doc/checklist.md
@@ -142,7 +142,7 @@ Review        | Signoff date                          | Done        | 2019-11-04
 [XBAR DV document]:                   {{<relref "/hw/ip/tlul/doc/dv">}}
 [XBAR Testplan]:                      {{<relref "/hw/ip/tlul/doc/dv/index.md#testplan">}}
 
-[DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv-plan-draft-completed" >}}
+[DV_DOC_DRAFT_COMPLETED]:             {{<relref "/doc/project/checklist.md#dv-doc-draft-completed" >}}
 [TESTPLAN_COMPLETED]:                 {{<relref "/doc/project/checklist.md#testplan-completed" >}}
 [TB_TOP_CREATED]:                     {{<relref "/doc/project/checklist.md#tb-top-created" >}}
 [PRELIMINARY_ASSERTION_CHECKS_ADDED]: {{<relref "/doc/project/checklist.md#preliminary-assertion-checks-added" >}}

--- a/site/docs/assets/scss/_markdown.scss
+++ b/site/docs/assets/scss/_markdown.scss
@@ -134,7 +134,7 @@ table.hw-project-dashboard {
     td {
         vertical-align: middle;
 
-        &.dv-plan, &.version {
+        &.dv-doc, &.version {
             text-align: center;
         }
 

--- a/site/docs/layouts/shortcodes/dashboard.html
+++ b/site/docs/layouts/shortcodes/dashboard.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <th>Design Spec</th>
-      <th>DV Plan</th>
+      <th>DV Document</th>
       <th><a href="{{ relref . "doc/project/development_stages#versioning" }}">Version</a></th>
       <th colspan="4"><a href="{{ relref . "doc/project/development_stages#life-stages" }}">Development Stage</a></th>
       <th>Notes</th>

--- a/util/dashboard/dashboard_validate.py
+++ b/util/dashboard/dashboard_validate.py
@@ -36,7 +36,7 @@ field_required = {
 field_optional = {
     'design_spec':
     ['s', "path to the design specification, relative to repo root"],
-    'dv_doc': ['s', "path to the DV plan, relative to repo root"],
+    'dv_doc': ['s', "path to the DV document, relative to repo root"],
     'hw_checklist': ['s', "path to the hw_checklist, relative to repo root"],
     'sw_checklist': ['s', "path to the sw_checklist, relative to repo root"],
     'design_stage': ['s', "design stage of module"],

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -75,8 +75,8 @@ def get_linked_design_spec(obj):
     return result
 
 
-# Provide the link to the DV plan.
-def get_linked_dv_plan(obj):
+# Provide the link to the DV document.
+def get_linked_dv_doc(obj):
     if 'dv_doc' in obj:
         return "<span title='DV Document'><a href=\"{}\">DV</a></span>".format(
             get_doc_url(obj['_ip_desc_hjson_dir'], obj['dv_doc']))
@@ -229,8 +229,8 @@ def print_version1_format(obj, outfile):
     genout(outfile, "      <tr>\n")
     genout(outfile, "        <td class=\"fixleft\">" +
                     get_linked_design_spec(obj) + "</td>\n")
-    genout(outfile, "        <td class=\"dv-plan\">" +
-                    get_linked_dv_plan(obj) + "</td>\n")
+    genout(outfile, "        <td class=\"dv-doc\">" +
+                    get_linked_dv_doc(obj) + "</td>\n")
     genout(outfile, "        <td class=\"version\">" +
                     get_linked_version(obj) + "</td>\n")
 
@@ -261,8 +261,8 @@ def print_multiversion_format(obj, outfile):
         if len(revisions) == 1:
             outstr += "        <td class='fixleft'>"
             outstr += get_linked_design_spec(obj) + "</td>\n"
-            outstr += "        <td class='dv-plan'>"
-            outstr += get_linked_dv_plan(obj) + "</td>\n"
+            outstr += "        <td class='dv-doc'>"
+            outstr += get_linked_dv_doc(obj) + "</td>\n"
         # Print out the module name in the first entry only
         elif i == 0:
             outstr += "        <td class='fixleft' rowspan='{}'>".format(
@@ -270,7 +270,7 @@ def print_multiversion_format(obj, outfile):
             outstr += get_linked_design_spec(obj) + "</td>\n"
             outstr += "        <td class='hw-stage' rowspan='{}'>".format(
                 len(revisions))
-            outstr += get_linked_dv_plan(obj) + "</td>\n"
+            outstr += get_linked_dv_doc(obj) + "</td>\n"
 
         # Version
         outstr += "        <td class=\"version\">"
@@ -306,18 +306,18 @@ def gen_specboard_html(hjson_path, rel_hjson_path, outfile):
     else:
         log.error("hjson file import failed")
 
-    # create design spec and DV plan references, check for existence below
+    # create design spec and DV doc references, check for existence below
     design_spec_md = re.sub(r'/data/', '/doc/',
                             re.sub(r'\.prj\.hjson', '.md', str(hjson_path)))
-    dv_plan_md = re.sub(
-        r'/data/', '/doc/',
-        re.sub(r'\.prj\.hjson', '_dv_plan.md', str(hjson_path)))
+    dv_doc_md = re.sub(
+        r'/data/', '/doc/dv',
+        re.sub(r'\.prj\.hjson', 'index.md', str(hjson_path)))
     design_spec_html = re.sub(
         r'/data/', '/doc/',
         re.sub(r'\.prj\.hjson', '.html', str(rel_hjson_path)))
-    dv_plan_html = re.sub(
-        r'/data/', '/doc/',
-        re.sub(r'\.prj\.hjson', '_dv_plan.html', str(rel_hjson_path)))
+    dv_doc_html = re.sub(
+        r'/data/', '/doc/dv',
+        re.sub(r'\.prj\.hjson', 'index.html', str(rel_hjson_path)))
 
     # yapf: disable
     genout(outfile, "      <tr>\n")
@@ -329,9 +329,9 @@ def gen_specboard_html(hjson_path, rel_hjson_path, outfile):
                "design spec</a>\n")
     else:
         genout(outfile, "        <td>&nbsp;</td>\n")
-    if os.path.exists(dv_plan_md):
+    if os.path.exists(dv_doc_md):
         genout(outfile, "        <td class=\"fixleft\"><a href=\"" +
-               html.escape(dv_plan_html) + "\">" +
+               html.escape(dv_doc_html) + "\">" +
                "DV document</a>\n")
     else:
         genout(outfile, "        <td>&nbsp;</td>\n")

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -621,7 +621,7 @@ class SimCfg(FlowCfg):
             else:
                 testplan = "https://{}/{}".format(self.doc_server,
                                                   self.rel_path)
-                testplan = testplan.replace("/dv", "/doc/dv_plan/#testplan")
+                testplan = testplan.replace("/dv", "/doc/dv/#testplan")
 
             results_str += f"### [Testplan]({testplan})\n"
 

--- a/util/uvmdvgen/README.md
+++ b/util/uvmdvgen/README.md
@@ -63,7 +63,7 @@ optional arguments:
   -eo [hw/ip/<ip>], --env-outdir [hw/ip/<ip>]
                         Path to place the full tetsbench code. It creates 3
                         directories - dv, data and doc. The DV document and the
-                        DV plan Hjson files are placed in the doc and data
+                        testplan Hjson files are placed in the doc and data
                         directories respectively. These are to be merged into
                         the IP's root directory (with the existing data and
                         doc directories). Under dv, it creates 3 sub-

--- a/util/uvmdvgen/index.md.tpl
+++ b/util/uvmdvgen/index.md.tpl
@@ -14,7 +14,7 @@ applicable. Once done, remove this comment before making a PR. -->
 ${'##'} Goals
 * **DV**
   * Verify all ${name.upper()} IP features by running dynamic simulations with a SV/UVM based testbench
-  * Develop and run all tests based on the [DV plan](#dv-plan) below towards closing code and functional coverage on the IP and all of its sub-modules
+  * Develop and run all tests based on the [testplan](#testplan) below towards closing code and functional coverage on the IP and all of its sub-modules
 * **FPV**
   * Verify TileLink device protocol compliance with an SVA based testbench
 
@@ -128,7 +128,7 @@ Here's how to run a smoke test:
 $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/${name}/dv/${name}_sim_cfg.hjson -i ${name}_smoke
 ```
 
-${'##'} DV plan
+${'##'} Testplan
 <!-- TODO: uncomment the line below after adding the testplan.
 Please make sure the testplan is added to `/util/build_docs.py`. -->
-{{</* incGenFromIpDesc "hw/ip/${name}/data/${name}_testplan.hjson" "testplan" */>}
+{{</* incGenFromIpDesc "../../data/${name}_testplan.hjson" "testplan" */>}

--- a/util/uvmdvgen/uvmdvgen.py
+++ b/util/uvmdvgen/uvmdvgen.py
@@ -107,7 +107,7 @@ def main():
         "--env-outdir",
         metavar="[hw/ip/<ip>]",
         help="""Path to place the full testbench code. It creates 3 directories
-        - dv, data, and doc. The DV plan and the testplan Hjson files are placed
+        - dv, data, and doc. The DV doc and the testplan Hjson files are placed
         in the doc and data directories respectively. These are to be merged
         into the IP's root directory (with the existing data and doc
         directories). Under dv, it creates 3 sub-directories - env, tb, and


### PR DESCRIPTION
The link to the testplan in the generated regression reports is broken. Example, try clicking on the 'Testplan' link in the page below:
https://reports.opentitan.org/hw/ip/aes/dv/latest/results.html

The first commit fixes the path in the dvsim codebase. The second renames 'dv plan' to 'testplan' in all of the DV documents. 