### PR TITLE
[dif/alert_handler] Remove artificial alert # limit (attempt 2) to fix #3826

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/lib/dif/dif_alert_handler_unittest.cc
@@ -58,13 +58,9 @@ TEST_P(InitTest, NullArgs) {
   EXPECT_EQ(dif_alert_handler_init(params, nullptr), kDifAlertHandlerBadArg);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    InitTestSignalCounts, InitTest,
-    testing::Values(1, 2, 12, 16
-                    // TODO: Enable these parameters once we can support them.
-                    // See: #3826
-                    // 24, 32,
-                    ));
+INSTANTIATE_TEST_SUITE_P(InitTestSignalCounts, InitTest,
+                         testing::Values(1, 2, 12, 16, 24, 32, 64,
+                                         ALERT_HANDLER_PARAM_N_ALERTS));
 
 class ConfigTest : public AlertTest {
   // We provide our own dev_ member variable in this fixture, in order to
@@ -748,12 +744,12 @@ class CauseTest : public AlertTest {};
 TEST_F(CauseTest, IsCause) {
   bool flag;
 
-  EXPECT_READ32(ALERT_HANDLER_ALERT_CAUSE_0_REG_OFFSET, {{0, true}, {5, true}});
+  EXPECT_READ32(ALERT_HANDLER_ALERT_CAUSE_5_REG_OFFSET, {{0, true}});
   EXPECT_EQ(dif_alert_handler_alert_is_cause(&handler_, 5, &flag),
             kDifAlertHandlerOk);
   EXPECT_TRUE(flag);
 
-  EXPECT_READ32(ALERT_HANDLER_ALERT_CAUSE_0_REG_OFFSET, {{0, true}, {5, true}});
+  EXPECT_READ32(ALERT_HANDLER_ALERT_CAUSE_6_REG_OFFSET, {{0, false}});
   EXPECT_EQ(dif_alert_handler_alert_is_cause(&handler_, 6, &flag),
             kDifAlertHandlerOk);
   EXPECT_FALSE(flag);


### PR DESCRIPTION
Issue #3826 mentioned the need to support more than 16 alerts. PR #4054 first attempted to do this, but was rendered obsolete after PR #6136 made changes to the Alert Handler RTL. Specifically, alert enable and class CSRs that were once packed are now multiregs, which simplifies configuring any number of alerts. This PR finally fixes #3826 with the most up to date version of the alert handler RTL. However, this PR **does not** fix the alert handler to pass all unit tests that were temporarily disabled (commented out) in PR #6136. That fix is coming in a future PR.