### PR TITLE
[vcformal/script] Downgrade Error to Warning

### DIFF
--- a/hw/formal/tools/vcformal/parse-formal-report.py
+++ b/hw/formal/tools/vcformal/parse-formal-report.py
@@ -124,7 +124,7 @@ def get_cov_results(logpath, dut_name):
                     cov_results[key] = item[0] + " %"
                 else:
                     cov_results[key] = "N/A"
-                    log.error("Parse %s coverage error. Expect one matching value, get %s",
+                    log.warning("Parse %s coverage error. Expect one matching value, get %s",
                               key, item)
             return cov_results
 


### PR DESCRIPTION
For result parsing script, if we could not find coverage data, it used
to report an error and exit the dvsim. But now we want to downgrade to
warning, so dvsim can still execute.

Request by @ayann-snps :)

Signed-off-by: Cindy Chen <chencindy@opentitan.org>