### PR TITLE
[dv/pwrmgr] Allow 0-wait clk en to valid changes

### DIFF
--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -46,9 +46,9 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   constraint cycles_before_otp_done_base_c {cycles_before_otp_done inside {[0 : 4]};}
   constraint cycles_before_lc_done_base_c {cycles_before_lc_done inside {[0 : 4]};}
   constraint cycles_before_wakeup_c {cycles_before_wakeup inside {[2 : 6]};}
-  constraint cycles_before_core_clk_en_c {cycles_before_core_clk_en inside {[2 : 6]};}
-  constraint cycles_before_io_clk_en_c {cycles_before_io_clk_en inside {[2 : 6]};}
-  constraint cycles_before_usb_clk_en_c {cycles_before_usb_clk_en inside {[2 : 6]};}
+  constraint cycles_before_core_clk_en_c {cycles_before_core_clk_en inside {[0 : 6]};}
+  constraint cycles_before_io_clk_en_c {cycles_before_io_clk_en inside {[0 : 6]};}
+  constraint cycles_before_usb_clk_en_c {cycles_before_usb_clk_en inside {[0 : 6]};}
   constraint cycles_before_main_pd_n_c {cycles_before_main_pd_n inside {[2 : 6]};}
 
   bit do_pwrmgr_init = 1'b1;

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -8,7 +8,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
 
   `uvm_object_new
 
-  rand ibex_pkg::crash_dump_t cpu_dump;
+  rand ibex_pkg::crash_dump_t  cpu_dump;
   rand logic [NumHwResets-1:0] rstreqs;
   rand logic [NumSwResets-1:0] sw_rst_regen;
   rand logic [NumSwResets-1:0] sw_rst_ctrl_n;
@@ -105,12 +105,12 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
       csr_wr(.ptr(ral.sw_rst_regen), .value(sw_rst_regen));
       `uvm_info(`gfn, $sformatf("sw_rst_regen set to 0x%0h", sw_rst_regen), UVM_LOW)
       csr_rd_check(.ptr(ral.sw_rst_regen), .compare_value(sw_rst_regen),
-                    .err_msg("Expected sw_rst_regen to reflect rw0c"));
+                   .err_msg("Expected sw_rst_regen to reflect rw0c"));
 
       // Check sw_rst_regen can not be set to all ones again because it is rw0c.
       csr_wr(.ptr(ral.sw_rst_regen), .value('1));
       csr_rd_check(.ptr(ral.sw_rst_regen), .compare_value(sw_rst_regen),
-                    .err_msg("Expected sw_rst_regen block raising individual bits because rw0c"));
+                   .err_msg("Expected sw_rst_regen block raising individual bits because rw0c"));
 
       // Check that the regen disabled bits block corresponding updated to ctrl_n.
       csr_wr(.ptr(ral.sw_rst_ctrl_n), .value(sw_rst_regen));
@@ -118,8 +118,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
                    .err_msg("Expected sw_rst_ctrl_n not to change"));
 
       csr_wr(.ptr(ral.sw_rst_ctrl_n), .value(sw_rst_ctrl_n));
-      `uvm_info(`gfn, $sformatf(
-                "Attempted to set sw_rst_ctrl_n to 0x%0x", sw_rst_ctrl_n), UVM_LOW)
+      `uvm_info(`gfn, $sformatf("Attempted to set sw_rst_ctrl_n to 0x%0x", sw_rst_ctrl_n), UVM_LOW)
       exp_ctrl_n = ~sw_rst_regen | sw_rst_ctrl_n;
       // And check that the reset outputs match the actual ctrl_n settings.
       // Allow for domain crossing delay.


### PR DESCRIPTION
Clock disable to invalid transitions can take 0 delay cycles in the AST.
Change the ast responder to allow 0 cycles on both enable and disable
transitions.
Undo the macros in the pwrmgr ast SVAs, since verdi seems to disable
some features unless the assertion is explicitly named.

Signed-off-by: Guillermo Maturana <maturana@google.com>