### PR TITLE
[flash_ctrl/dv] Adding info partitions MP configurations

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -30,6 +30,18 @@ package flash_ctrl_env_pkg;
   parameter uint FlashSizeBytes           = FlashNumPages * flash_ctrl_pkg::WordsPerPage *
                                             flash_ctrl_pkg::DataWidth / 8;
 
+  // Number of bytes in each of the flash pages.
+  parameter uint BytesPerPage = FlashSizeBytes / FlashNumPages;
+
+  // Num of bytes in each of the flash banks for each of the flash partitions.
+  parameter uint BytesPerBank = FlashSizeBytes / flash_ctrl_pkg::NumBanks;
+
+  parameter uint InfoTypeBytes [flash_ctrl_pkg::InfoTypes] = '{
+    flash_ctrl_pkg::InfoTypeSize[0] * BytesPerPage,
+    flash_ctrl_pkg::InfoTypeSize[1] * BytesPerPage,
+    flash_ctrl_pkg::InfoTypeSize[2] * BytesPerPage
+  };
+
   parameter uint FlashNumBusWords         = FlashSizeBytes / top_pkg::TL_DBW;
   parameter uint FlashNumBusWordsPerBank  = FlashNumBusWords / flash_ctrl_pkg::NumBanks;
   parameter uint FlashNumBusWordsPerPage  = FlashNumBusWordsPerBank / flash_ctrl_pkg::PagesPerBank;
@@ -82,10 +94,16 @@ package flash_ctrl_env_pkg;
     bit           read_en;    // enable reads
     bit           program_en; // enable write
     bit           erase_en;   // enable erase
-    flash_part_e  partition;  // info or data
     uint          num_pages;  // 0:NumPages % start_page
     uint          start_page; // 0:NumPages-1
   } flash_mp_region_cfg_t;
+
+  typedef struct packed {
+    bit           en;         // enable this page
+    bit           read_en;    // enable reads
+    bit           program_en; // enable write
+    bit           erase_en;   // enable erase
+  } flash_bank_mp_info_page_cfg_t;
 
   typedef struct packed {
     flash_dv_part_e partition;  // data or one of the info partitions

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -18,6 +18,10 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // This enables memory protection regions to overlap.
   bit allow_mp_region_overlap;
 
+  // Weights for enable bits for each of the flash banks information partitions memory protection
+  //  configuration registers.
+  uint mp_info_page_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+
   // When this knob is NOT FlashOpInvalid (default) the selected operation will be the only
   //  operation to run in the test (FlashOpRead, FlashOpProgram, FlashOpErase).
   flash_ctrl_pkg::flash_op_e flash_only_op;
@@ -27,7 +31,6 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint mp_region_read_en_pc;
   uint mp_region_program_en_pc;
   uint mp_region_erase_en_pc;
-  uint mp_region_data_partition_pc;
   uint mp_region_max_pages;
 
   // Knob to control bank level erasability.
@@ -37,6 +40,13 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint default_region_read_en_pc;
   uint default_region_program_en_pc;
   uint default_region_erase_en_pc;
+
+  // Weights to enable read / program and erase for each information partition page.
+  // For each of the information partitions in each of the banks there is a single variable to
+  //  control all of this partition pages.
+  uint mp_info_page_read_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_program_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_erase_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
 
   // Control the number of flash ops.
   uint max_flash_ops_per_cfg;
@@ -110,7 +120,6 @@ class flash_ctrl_seq_cfg extends uvm_object;
     mp_region_read_en_pc = 50;
     mp_region_program_en_pc = 50;
     mp_region_erase_en_pc = 50;
-    mp_region_data_partition_pc = 50;
     mp_region_max_pages = 32;
 
     bank_erase_en_pc = 50;
@@ -118,6 +127,13 @@ class flash_ctrl_seq_cfg extends uvm_object;
     default_region_read_en_pc    = 50;
     default_region_program_en_pc = 50;
     default_region_erase_en_pc   = 50;
+
+    foreach (mp_info_page_en_pc[i, j]) begin
+      mp_info_page_en_pc[i][j] = 50;
+      mp_info_page_read_en_pc[i][j] = 50;
+      mp_info_page_program_en_pc[i][j] = 50;
+      mp_info_page_erase_en_pc[i][j] = 50;
+    end
 
     flash_only_op = FlashOpInvalid;
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
@@ -20,6 +20,14 @@ class flash_ctrl_rand_ops_vseq extends flash_ctrl_rand_ops_base_vseq;
     // Don't enable any memory protection.
     cfg.seq_cfg.num_en_mp_regions = 0;
 
+    // Enable access to all information partitions.
+    foreach (cfg.seq_cfg.mp_info_page_en_pc[i, j]) begin
+      cfg.seq_cfg.mp_info_page_en_pc[i][j] = 100;
+      cfg.seq_cfg.mp_info_page_read_en_pc[i][j] = 100;
+      cfg.seq_cfg.mp_info_page_program_en_pc[i][j] = 100;
+      cfg.seq_cfg.mp_info_page_erase_en_pc[i][j] = 100;
+    end
+
     // Enable default region read/program and erasability.
     cfg.seq_cfg.default_region_read_en_pc = 100;
     cfg.seq_cfg.default_region_program_en_pc = 100;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_smoke_vseq.sv
@@ -22,6 +22,11 @@ class flash_ctrl_smoke_vseq extends flash_ctrl_rand_ops_base_vseq;
     // Don't enable any memory protection.
     cfg.seq_cfg.num_en_mp_regions = 0;
 
+    // Don't enable access to any of information partitions.
+    foreach (cfg.seq_cfg.mp_info_page_en_pc[i, j]) begin
+      cfg.seq_cfg.mp_info_page_en_pc[i][j] = 0;
+    end
+
     // Enable default region read/program and erasability.
     cfg.seq_cfg.default_region_read_en_pc = 100;
     cfg.seq_cfg.default_region_program_en_pc = 100;


### PR DESCRIPTION
Hi,
In this PR some additions been made to control and enable access to information partitions.

1.  Constraint added to operation address in **flash_ctrl_rand_ops_base_vseq** to be more relevant to selected partition.
2.  Added in **flash_ctrl_rand_ops_base_vseq** and **flash_ctrl_seq_cfg** separate configuration control of information partition memory protection, very similar to already exist **mp_region_cfg**.
3.  Added some fields to **flash_ctrl_env_pkg** for the above.
4.  Added default confoguration of info partitions to **flash_ctrl_rand_ops_vseq** and **flash_ctrl_smoke_vseq** to enable access in the 1st and disable in the second.

Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>