### PR TITLE
[prim_xor2/lint] Add waiver for .* use in generated prim

### DIFF
--- a/hw/ip/prim/lint/prim_xor2.waiver
+++ b/hw/ip/prim/lint/prim_xor2.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_xor2
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_xor2.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim_xor2.core
+++ b/hw/ip/prim/prim_xor2.core
@@ -22,6 +22,8 @@ filesets:
     depend:
       # common waivers
       - lowrisc:lint:common
+    files:
+      - lint/prim_xor2.waiver
     file_type: waiver
 
   files_veriblelint_waiver:


### PR DESCRIPTION
Signed-off-by: Michael Schaffner <msf@google.com>