### PR TITLE
[dv/hmac] fix regression error

### DIFF
--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -122,7 +122,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
   virtual task wr_key(bit [TL_DW-1:0] key[]);
     // pity we cant loop here
     foreach (key[i]) begin
-      ral.key[i].set(key[7]);
+      ral.key[i].set(key[i]);
       csr_update(.csr(ral.key[i]));
       `uvm_info(`gfn, $sformatf("key[%0d] = 0x%0h", i, key[i]), UVM_HIGH)
     end


### PR DESCRIPTION
This PR fixes a regression error that hardcoded the key input instead of
using the loop index i.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>