### PR TITLE
[dv/top_earlgrey] Bind SVA between pwrmgr and AST

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -14,6 +14,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:dv:chip_test
+      - lowrisc:dv:pwrmgr_sva
       - lowrisc:dv:xbar_main_bind
       - lowrisc:dv:xbar_peri_bind
       - lowrisc:dv:xbar_test

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -24,7 +24,8 @@
   ral_spec: "{proj_root}/hw/top_earlgrey/data/top_earlgrey.hjson"
 
   // Add additional tops for simulation.
-  sim_tops: ["xbar_main_bind",
+  sim_tops: ["pwrmgr_bind",
+             "xbar_main_bind",
              "xbar_peri_bind"]
 
   // Import additional common sim cfg files.


### PR DESCRIPTION
Reuse the pwrmgr IP level SVA for full chip.

Signed-off-by: Guillermo Maturana <maturana@google.com>