### PR TITLE
[rv_core_ibex] Add register exclude tag

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -615,6 +615,8 @@
             desc: "Current state for watchdog NMI"
           },
         ]
+        tags: [// nmi could be updated by HW
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
       },
 
       { name: "ERR_STATUS",


### PR DESCRIPTION
- Skip checking nmi_state as it can be randomly triggered through the
  interrupt test registers in aon_timer.

Signed-off-by: Timothy Chen <timothytim@google.com>