### PR TITLE
[otbn,dv] Add support for "giant loops" to RIG

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -12,4 +12,5 @@ gen-weights:
   # Generators that end the program
   ECall: 1
   BadInsn: 1
+  BadGiantLoop: 1
   BadZeroLoop: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_giant_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_giant_loop.py
@@ -1,0 +1,103 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional
+
+from shared.insn_yaml import InsnsFile
+
+from .loop import Loop
+from ..config import Config
+from ..model import Model
+from ..program import ProgInsn, Program
+from ..snippet import LoopSnippet
+from ..snippet_gen import GenCont, GenRet
+
+
+class BadGiantLoop(Loop):
+    '''A generator for loops with end addresses that don't lie in memory
+
+    This generator has "ends_program = True", but doesn't end the program in
+    itself. Instead, it sets up a loop with an endpoint that doesn't fit in
+    memory (so the loop body will never actually terminate) and then generates
+    a sequence for the rest of the program, to go inside the body. OTBN will
+    complete its operation without popping the loop off the stack.
+
+    '''
+
+    ends_program = True
+
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__(cfg, insns_file)
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        # We need space for at least 2 instructions here: one for the loop head
+        # instruction and one for the minimal body (which might contain an
+        # ECALL, for example)
+        space_here = program.get_insn_space_at(model.pc)
+        if space_here < 2:
+            return None
+
+        # Similarly, the smallest possible loop will take 2 instructions
+        if program.space < 2:
+            return None
+
+        # And we don't want to overflow the loop stack
+        if model.loop_depth == Model.max_loop_depth:
+            return None
+
+        insn = self._pick_loop_insn()
+        iters_op_type = insn.operands[0].op_type
+        bodysize_op_type = insn.operands[1].op_type
+
+        bodysize_range = bodysize_op_type.get_op_val_range(model.pc)
+        assert bodysize_range is not None
+
+        bodysize_min, bodysize_max = bodysize_range
+
+        # Adjust bodysize_min to make sure we pick an end address that's larger
+        # than IMEM (and check that we can represent the result).
+        bodysize_min = max(bodysize_min, (program.imem_size - model.pc) // 4)
+        if bodysize_max < bodysize_min:
+            return None
+
+        # Pick bodysize, preferring the endpoints
+        x = random.random()
+        if x < 0.4:
+            bodysize = bodysize_min
+        elif x < 0.8:
+            bodysize = bodysize_max
+        else:
+            bodysize = random.randint(bodysize_min, bodysize_max)
+
+        enc_bodysize = bodysize_op_type.op_val_to_enc_val(bodysize, model.pc)
+        assert enc_bodysize is not None
+
+        # Now pick the number of iterations (not that the number actually
+        # matters)
+        iters = self._pick_iterations(iters_op_type, bodysize, model)
+        if iters is None:
+            return None
+
+        iters_opval, num_iters = iters
+        hd_addr = model.pc
+        hd_insn = ProgInsn(insn, [iters_opval, enc_bodysize], None)
+
+        body_model = self._setup_body(hd_insn, model, program)
+
+        # At this point, all the "loop related work" is done: we've entered the
+        # loop body (from which we can never leave). Now call the continuation
+        # with a flag to say that we'd like the generation to complete.
+        body_snippet, end_model = cont(body_model, program, True)
+
+        # Because we passed end=True to cont, the snippet from the continuation
+        # is not None.
+        assert body_snippet is not None
+
+        loop_snippet = LoopSnippet(hd_addr, hd_insn, body_snippet)
+        return (loop_snippet, True, end_model)

--- a/hw/ip/otbn/dv/rig/rig/gens/branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch.py
@@ -187,7 +187,7 @@ class Branch(SnippetGen):
         model0.fuel = branch_fuel - 1
         prog0.space = branch_space
 
-        snippet0, model0 = cont(model0, prog0)
+        snippet0, model0 = cont(model0, prog0, False)
         # If snippet0 is None then we didn't manage to generate anything, but
         # that's fine. model0 will be unchanged and we just have an empty
         # sequence on the fall-through side of the branch.
@@ -213,7 +213,7 @@ class Branch(SnippetGen):
         prog1.space = branch_space
         model1.fuel = branch_fuel - 1
 
-        snippet1, model1 = cont(model1, prog1)
+        snippet1, model1 = cont(model1, prog1, False)
         # If snippet1 is None, we didn't manage to generate anything here
         # either. As before, that's fine.
 

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -355,7 +355,7 @@ class Loop(SnippetGen):
                 bogus_tail_insns = [bogus_insn] * (tail_len + 1)
                 prog0.add_insns(tail_start, bogus_tail_insns)
 
-                head_snippet, model = cont(model, prog0)
+                head_snippet, model = cont(model, prog0, False)
 
                 # Generation of the head might have failed, but that's actually
                 # ok: we'll just start the loop body with the jump to the tail.

--- a/hw/ip/otbn/dv/rig/rig/snippet_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gen.py
@@ -19,10 +19,10 @@ from .snippet import Snippet
 
 # The return type of a single generator. This is a tuple (snippet, done,
 # model). snippet is a generated snippet. done is true if the processor has
-# just executed an ECALL instruction. model is a Model object representing the
-# state of the processor after executing the code in the snippet(s). The PC of
-# the model will be the next instruction to be executed unless done is true, in
-# which case it still points at the ECALL.
+# just executed an instruction that causes it to stop. model is a Model object
+# representing the state of the processor after executing the code in the
+# snippet(s). The PC of the model will be the next instruction to be executed
+# unless done is true, in which case it still points at the final instruction.
 GenRet = Tuple[Snippet, bool, Model]
 
 # An "internal" return type for generators that never cause termination.
@@ -35,7 +35,8 @@ GensRet = Tuple[Optional[Snippet], Model]
 
 # A continuation type that allows a generator to recursively generate some more
 # stuff. If the boolean argument is true, the continuation will try to generate
-# a snippet that causes OTBN to stop.
+# a snippet that causes OTBN to stop. In this case, the Snippet term in the
+# GensRet will not be None.
 GenCont = Callable[[Model, Program, bool], GensRet]
 
 

--- a/hw/ip/otbn/dv/rig/rig/snippet_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gen.py
@@ -34,8 +34,9 @@ SimpleGenRet = Tuple[Snippet, Model]
 GensRet = Tuple[Optional[Snippet], Model]
 
 # A continuation type that allows a generator to recursively generate some more
-# stuff.
-GenCont = Callable[[Model, Program], GensRet]
+# stuff. If the boolean argument is true, the continuation will try to generate
+# a snippet that causes OTBN to stop.
+GenCont = Callable[[Model, Program, bool], GensRet]
 
 
 class SnippetGen:

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -20,6 +20,7 @@ from .gens.loop import Loop
 from .gens.straight_line_insn import StraightLineInsn
 
 from .gens.bad_insn import BadInsn
+from .gens.bad_giant_loop import BadGiantLoop
 from .gens.bad_zero_loop import BadZeroLoop
 
 
@@ -33,6 +34,7 @@ class SnippetGens:
 
         ECall,
         BadInsn,
+        BadGiantLoop,
         BadZeroLoop
     ]
 
@@ -214,6 +216,8 @@ class SnippetGens:
 
         '''
         snippets, next_model = self._gens(model, program, end)
+        # If end was True, there must be at least one instruction
+        assert snippets or not end
         snippet = Snippet.merge_list(snippets) if snippets else None
         return (snippet, next_model)
 

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -203,17 +203,17 @@ class SnippetGens:
 
     def gens(self,
              model: Model,
-             program: Program) -> Tuple[Optional[Snippet], Model]:
+             program: Program,
+             end: bool) -> Tuple[Optional[Snippet], Model]:
         '''Try to generate snippets to continue program
 
         This will try to run down model.fuel and program.size. When it runs out
         of one or the other, it stops and returns any snippet it generated plus
-        the updated model.
+        the updated model. If end is true, the generated snippet should cause
+        OTBN to stop.
 
         '''
-        snippets, next_model = self._gens(model, program, False)
-        # _gens() only sets next_model to None if finish is True.
-        assert next_model is not None
+        snippets, next_model = self._gens(model, program, end)
         snippet = Snippet.merge_list(snippets) if snippets else None
         return (snippet, next_model)
 
@@ -239,7 +239,7 @@ class SnippetGens:
         tail_fuel = model.fuel - head_fuel
 
         model.fuel = head_fuel
-        head, model = self.gens(model, program)
+        head, model = self.gens(model, program, False)
         # Add the rest of the fuel to the tank
         model.fuel += tail_fuel
 


### PR DESCRIPTION
These are loops that have an end address above the top of IMEM.
They'll never actually complete, so we generate a sequence of
instructions that *does* complete to go inside them.

This PR has a staging commit that comes before, slightly changing the signature of the continuation function to make this possible.