### PR TITLE
[otbn, dv] Snippet Generator for Known WDR Values

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -9,6 +9,7 @@ gen-weights:
   Loop: 0.1
   SmallVal: 0.05
   StraightLineInsn: 1.0
+  KnownWDR: 0.05
 
   # Generators that end the program
   ECall: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/known_wdr.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/known_wdr.py
@@ -1,0 +1,125 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import List, Optional
+
+from shared.operand import EnumOperandType, ImmOperandType, RegOperandType
+from shared.insn_yaml import InsnsFile
+
+from ..config import Config
+from ..model import Model
+from ..program import ProgInsn, Program
+
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
+
+
+class KnownWDR(SnippetGen):
+    '''A snippet generator that generates known values (all zeros or all ones
+    for now) for WDRs.
+
+    '''
+
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__()
+
+        self.bn_xor = self._get_named_insn(insns_file, 'bn.xor')
+        self.bn_not = self._get_named_insn(insns_file, 'bn.not')
+        
+        # BN.XOR has six operands: wrd, wrs1, wrs2, shift_type, shift_value
+        # and flag_group
+        if not (len(self.bn_xor.operands) == 6 and
+                isinstance(self.bn_xor.operands[0].op_type, RegOperandType) and
+                self.bn_xor.operands[0].op_type.reg_type == 'wdr' and
+                self.bn_xor.operands[0].op_type.is_dest() and
+                isinstance(self.bn_xor.operands[1].op_type, RegOperandType) and
+                self.bn_xor.operands[1].op_type.reg_type == 'wdr' and
+                not self.bn_xor.operands[1].op_type.is_dest() and
+                isinstance(self.bn_xor.operands[2].op_type, RegOperandType) and
+                self.bn_xor.operands[2].op_type.reg_type == 'wdr' and
+                not self.bn_xor.operands[2].op_type.is_dest() and
+                isinstance(self.bn_xor.operands[4].op_type, ImmOperandType)):
+            raise RuntimeError('BN.XOR instruction from instructions file is '
+                               'not the shape expected by the KnownWDR generator.')
+
+        self.wrd_op_type = self.bn_xor.operands[0].op_type
+        self.wrs_op_type = self.bn_xor.operands[1].op_type
+        self.imm_op_type = self.bn_xor.operands[4].op_type
+        assert self.imm_op_type.shift == 3
+
+        if not (isinstance(self.bn_not.operands[0].op_type, RegOperandType) and
+                self.bn_not.operands[0].op_type.reg_type == 'wdr' and
+                self.bn_not.operands[0].op_type.is_dest() and
+                isinstance(self.bn_not.operands[1].op_type, RegOperandType) and
+                self.bn_not.operands[1].op_type.reg_type == 'wdr' and
+                not self.bn_not.operands[1].op_type.is_dest() and
+                isinstance(self.bn_not.operands[2].op_type, EnumOperandType) and
+                isinstance(self.bn_not.operands[3].op_type, ImmOperandType)):
+            raise RuntimeError('BN.NOT instruction from instructions file is '
+                               'not the shape expected by KnownWDR generator. ')
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+        # Return None if this one of the last two instructions in the current gap
+        # because we need to either jump or do an ECALL to avoid getting stuck
+        # after executing both bn.xor and bn.not
+        if program.get_insn_space_at(model.pc) <= 3:
+            return None
+
+        # The bn.xor-bn.not pair takes 2 instructions
+        if program.space < 2:
+            return None
+
+        if model.fuel < 2:
+            return None
+
+        # Picks a random operand value for wrd.
+        wrd_val_xor = model.pick_operand_value(self.wrd_op_type)
+        if wrd_val_xor is None:
+                return None
+
+        # Picks a random operand value. It shouldn't matter because
+        # in the end, we will feed the same value as wrs2 and XORing
+        # would result with wrd becoming 0.
+        wrs_val_xor = model.pick_operand_value(self.wrs_op_type)
+        if wrs_val_xor is None:
+                return None
+
+        # Assertion is always true because ImmOperand has width embedded in it
+        shift_bits = self.imm_op_type.op_val_to_enc_val(0, model.pc)
+        assert shift_bits is not None
+
+        # Value of shift_type does not matter since shift_bits are hardcoded to 0
+        shift_type = model.pick_operand_value(self.bn_xor.operands[3].op_type)
+        assert shift_type is not None
+
+        # This value does not matter for this application
+        flg_group = model.pick_operand_value(self.bn_xor.operands[5].op_type)
+        assert flg_group is not None
+
+        # Result of this insn can be written to any register.
+        wrd_val_not = model.pick_operand_value(self.wrd_op_type)
+        if wrd_val_not is None:
+                return None
+
+        op_vals_xor = [wrd_val_xor, wrs_val_xor, wrs_val_xor, shift_type,
+                       shift_bits, flg_group]
+
+        op_vals_not = [wrd_val_not, wrd_val_xor, shift_type, shift_bits, flg_group]
+
+        prog_bn_xor = ProgInsn(self.bn_xor, op_vals_xor, None)
+        prog_bn_not = ProgInsn(self.bn_not, op_vals_not, None)
+
+        snippet = ProgSnippet(model.pc, [prog_bn_xor, prog_bn_not])
+        snippet.insert_into_program(program)
+
+        model.update_for_insn(prog_bn_xor)
+        model.update_for_insn(prog_bn_not)
+
+        model.pc += 8
+
+        return (snippet, False, model)

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -18,6 +18,7 @@ from .gens.ecall import ECall
 from .gens.jump import Jump
 from .gens.loop import Loop
 from .gens.small_val import SmallVal
+from .gens.known_wdr import KnownWDR
 from .gens.straight_line_insn import StraightLineInsn
 
 from .gens.bad_deep_loop import BadDeepLoop
@@ -34,6 +35,7 @@ class SnippetGens:
         Loop,
         SmallVal,
         StraightLineInsn,
+        KnownWDR,
 
         ECall,
         BadDeepLoop,


### PR DESCRIPTION
This commit includes a snippet generator that helps model know
some WDR values (starts with all 1s at the moment). Also model
now updates when it sees bn.not and bn.xor instructions.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>