### PR TITLE
Copy all bitstreams into distribution

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -610,6 +610,7 @@ jobs:
     - sw_build
     - chip_earlgrey_verilator
     - chip_earlgrey_nexysvideo
+    - chip_earlgrey_cw310
   condition: and(eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
   steps:
   - template: ci/install-package-dependencies.yml
@@ -620,6 +621,7 @@ jobs:
         - sw_build_nexysvideo
         - chip_earlgrey_verilator
         - chip_earlgrey_nexysvideo
+        - chip_earlgrey_cw310
         - chip_englishbreakfast_verilator
   - bash: |
       . util/build_consts.sh

--- a/util/make_distribution.sh
+++ b/util/make_distribution.sh
@@ -27,7 +27,7 @@ readonly DIST_ARTIFACTS=(
   'sw/otbn/*.elf'
   'sw/host/spiflash/spiflash'
   'hw/top_earlgrey/Vchip_earlgrey_verilator'
-  'hw/top_earlgrey/lowrisc_systems_chip_earlgrey_nexysvideo_0.1.bit'
+  'hw/top_earlgrey/lowrisc_systems_chip_earlgrey_*.bit'
 )
 
 DIST_DIR="$OBJ_DIR/$OT_VERSION"


### PR DESCRIPTION
We provide a "release" distribution of all build artifacts, which we
didn't update to include the CW310 bitstream. Add it as well to help
users who are looking for a bitstream from CI.