### PR TITLE
[dv/dvsim] Add "testfile" grading option

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -155,8 +155,10 @@
                      "+urg+lic+wait",
                      // Lists all the tests that covered a given object.
                      "-show tests",
-                     // Enable test grading.
-                     "-grade index",
+                     // Enable test grading using the "index" scheme, and the
+                     // generation of the list of contributing tests with
+                     // "testfile".
+                     "-grade index testfile",
                      // Use simple ratio of total covered bins over total bins across cps & crs,
                      "-group ratio",
                      // Compute overall coverage for per-instance covergroups individually rather


### PR DESCRIPTION
Add "testfile" for the coverage reports to contain the list of
tests that contribute to coverage. This enables a better way
to determine the number of reseeds per test.

Signed-off-by: Guillermo Maturana <maturana@google.com>