### PR TITLE
[opentitantool] Add support for Ultradebug

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -10,11 +10,16 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+thiserror = "1.0"
 lazy_static = "1.4.0"
 regex = "1"
 nix = "0.17.0"
 bitflags = "1.0"
 log = "0.4"
+# TODO(cfrantz): work with cr1901 to release 0.3.0.
+safe-ftdi = { git = "https://github.com/cr1901/safe-ftdi" }
 
+serde = { version="1", features=["serde_derive"] }
+serde_json = "1"
 erased-serde = "0.3.12"
 opentitantool_derive = {path = "opentitantool_derive"}

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -9,6 +9,7 @@ use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
+pub mod ultradebug;
 pub mod verilator;
 
 bitflags! {

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use safe_ftdi as ftdi;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::io::gpio::Gpio;
+use crate::transport::ultradebug::mpsse;
+use crate::transport::ultradebug::Ultradebug;
+
+/// Represents the Ultradebug GPIO pins.
+pub struct UltradebugGpio {
+    pub device: Rc<RefCell<mpsse::Context>>,
+}
+
+impl UltradebugGpio {
+    /// Request the upstream SPI bus to tristate so ultradebug may drive the SPI bus (platforms-ultradebug only).
+    pub const PIN_SPI_ZB: u32 = 4;
+    /// Reset the chip attached to ultradebug.
+    pub const PIN_RESET_B: u32 = 5;
+    /// Request bootstrap mode on the chip attached to ultradebug.
+    pub const PIN_BOOTSTRAP: u32 = 6;
+    /// Reset the target system attached to ultradebug (platforms-ultradebug only).
+    pub const PIN_TGT_RESET: u32 = 7;
+
+    pub fn open(ultradebug: &Ultradebug) -> Result<Self> {
+        Ok(UltradebugGpio {
+            device: ultradebug.mpsse(ftdi::Interface::B)?,
+        })
+    }
+}
+
+impl Gpio for UltradebugGpio {
+    /// Reads the value of the the GPIO pin `id`.
+    fn read(&self, id: u32) -> Result<bool> {
+        let bits = self.device.borrow_mut().gpio_get()?;
+        Ok(bits & (1 << id) != 0)
+    }
+
+    /// Sets the value of the GPIO pin `id` to `value`.
+    fn write(&self, id: u32, value: bool) -> Result<()> {
+        self.device.borrow_mut().gpio_set(id, value)
+    }
+}

--- a/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
@@ -1,0 +1,127 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+
+use safe_ftdi as ftdi;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::io::gpio::Gpio;
+use crate::io::spi::Target;
+use crate::io::uart::Uart;
+use crate::transport::{Capabilities, Capability, Transport};
+
+pub mod gpio;
+pub mod mpsse;
+pub mod spi;
+pub mod uart;
+
+#[derive(Default)]
+pub struct Ultradebug {
+    pub usb_vid: Option<u16>,
+    pub usb_pid: Option<u16>,
+    pub usb_serial: Option<String>,
+    internal: RefCell<Internal>,
+}
+
+#[derive(Default)]
+struct Internal {
+    // A ref-counted pointer to an MPSSE context for FTDI interface B.  This is needed because
+    // interface B contains both the SPI and GPIO functions on ultradebug.
+    pub mpsse_b: Option<Rc<RefCell<mpsse::Context>>>,
+}
+
+impl Ultradebug {
+    pub const VID_GOOGLE: u16 = 0x18d1;
+    pub const PID_ULTRADEBUG: u16 = 0x0304;
+
+    /// Create a new `Ultradebug` struct, optionally specifying the USB vid/pid/serial number.
+    pub fn new(usb_vid: Option<u16>, usb_pid: Option<u16>, usb_serial: Option<String>) -> Self {
+        Ultradebug {
+            usb_vid,
+            usb_pid,
+            usb_serial,
+            ..Default::default()
+        }
+    }
+
+    /// Construct an `ftdi::Device` for the specified `interface` on the Ultradebug device.
+    pub fn from_interface(&self, interface: ftdi::Interface) -> Result<ftdi::Device> {
+        Ok(ftdi::Device::from_description_serial(
+            interface,
+            self.usb_vid.unwrap_or(Ultradebug::VID_GOOGLE),
+            self.usb_pid.unwrap_or(Ultradebug::PID_ULTRADEBUG),
+            None,
+            self.usb_serial.clone(),
+        )?)
+    }
+
+    // Create an instance of an MPSSE context bound to Ultradebug interface B.
+    // This is both the SPI and GPIO block on ultradebug.
+    fn mpsse_interface_b(&self) -> Result<Rc<RefCell<mpsse::Context>>> {
+        let mut internal = self.internal.borrow_mut();
+        if internal.mpsse_b.is_none() {
+            let device = self.from_interface(ftdi::Interface::B)?;
+            // Read and write timeouts:
+            device.set_timeouts(5000, 5000);
+
+            // Create a new MPSSE context and configure it
+            let mut mpdev = mpsse::Context::new(device)?;
+            mpdev.gpio_direction.insert(
+                mpsse::GpioDirection::OUT_0 |   // Clock out
+                mpsse::GpioDirection::OUT_1 |   // Master out
+                                                // Pin 2 is Master In
+                mpsse::GpioDirection::OUT_3 |   // Chip select
+                mpsse::GpioDirection::OUT_4 |   // SPI_ZB
+                mpsse::GpioDirection::OUT_5 |   // RESET_B
+                mpsse::GpioDirection::OUT_6 |   // BOOTSTRAP
+                mpsse::GpioDirection::OUT_7, // TGT_RESET
+            );
+
+            let _ = mpdev.gpio_get()?;
+            // Clear the low 3 bits as they are mapped to the SPI pins.
+            // The SPI chip select is managed like a normal GPIO.
+            // We don't need to change the GPIOs immediately; it is sufficient
+            // to cache the value before the next GPIO operation.
+            mpdev.gpio_value &= 0xF8;
+            internal.mpsse_b = Some(Rc::new(RefCell::new(mpdev)));
+        }
+        Ok(Rc::clone(internal.mpsse_b.as_ref().unwrap()))
+    }
+
+    /// Construct an `mpsse::Context` for the requested interface.
+    pub fn mpsse(&self, interface: ftdi::Interface) -> Result<Rc<RefCell<mpsse::Context>>> {
+        match interface {
+            // Note: we may want to be able to create an MPSSE for interface A in the future.
+            // There are enough IOs for a second SPI bus or for JTAG or I2C busses.
+            // For now, only interface B is supported.
+            ftdi::Interface::B => self.mpsse_interface_b(),
+            _ => {
+                bail!(
+                    "I don't know how to create an MPSSE context for interface {:?}",
+                    interface
+                );
+            }
+        }
+    }
+}
+
+impl Transport for Ultradebug {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::UART | Capability::GPIO | Capability::SPI)
+    }
+
+    fn uart(&self) -> Result<Box<dyn Uart>> {
+        Ok(Box::new(uart::UltradebugUart::open(&self)?))
+    }
+
+    fn gpio(&self) -> Result<Box<dyn Gpio>> {
+        Ok(Box::new(gpio::UltradebugGpio::open(&self)?))
+    }
+
+    fn spi(&self) -> Result<Box<dyn Target>> {
+        Ok(Box::new(spi::UltradebugSpi::open(&self)?))
+    }
+}

--- a/sw/host/opentitanlib/src/transport/ultradebug/mpsse.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mpsse.rs
@@ -1,0 +1,556 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use bitflags::bitflags;
+use log;
+use safe_ftdi as ftdi;
+use thiserror::Error;
+
+use std::time::{Duration, Instant};
+
+pub const MPSSE_WRCLK_FALLING: u8 = 0x01;
+pub const MPSSE_RDCLK_FALLING: u8 = 0x04;
+pub const MPSSE_DIR_LSB_FIRST: u8 = 0x08;
+pub const MPSSE_WRITE_DATA: u8 = 0x10;
+pub const MPSSE_READ_DATA: u8 = 0x20;
+pub const MPSSE_SET_LOW_GPIO: u8 = 0x80;
+pub const MPSSE_SET_HIGH_GPIO: u8 = 0x82;
+pub const MPSSE_GET_LOW_GPIO: u8 = 0x81;
+pub const MPSSE_GET_HIGH_GPIO: u8 = 0x83;
+pub const MPSSE_SET_CLKDIV: u8 = 0x86;
+pub const MPSSE_DISABLE_DIVBY5: u8 = 0x8A;
+pub const MPSSE_INVALID_COMMAND: u8 = 0xAA;
+pub const MPSSE_CLOCK_FREQUENCY: u32 = 12_000_000;
+
+bitflags! {
+    /// Gpio direction for output pinds on an FTDI interface.
+    pub struct GpioDirection: u8 {
+        const OUT_0 = 0x01;
+        const OUT_1 = 0x02;
+        const OUT_2 = 0x04;
+        const OUT_3 = 0x08;
+        const OUT_4 = 0x10;
+        const OUT_5 = 0x20;
+        const OUT_6 = 0x40;
+        const OUT_7 = 0x80;
+    }
+}
+
+/// ClockEdge defines how data will be driven or sampled on the FTDI device.
+#[derive(Debug, Clone, Copy)]
+pub enum ClockEdge {
+    Rising,
+    Falling,
+}
+
+/// BitDirection determines in which order the bits will be shifted in/out on
+/// a serial interface.
+#[derive(Debug, Clone, Copy)]
+pub enum BitDirection {
+    LsbFirst,
+    MsbFirst,
+}
+
+/// DataShiftOptions determines the full set of serial options for a data
+/// in/out operation.
+#[derive(Debug)]
+pub struct DataShiftOptions {
+    pub read_clock_edge: ClockEdge,
+    pub write_clock_edge: ClockEdge,
+    pub bit_direction: BitDirection,
+    pub write_data: bool,
+    pub read_data: bool,
+}
+
+impl DataShiftOptions {
+    /// Transform a `DataShiftOptions` structure into an MPSSE opcode.
+    pub fn as_opcode(&self) -> u8 {
+        let mut opcode = 0u8;
+        opcode |= match self.read_clock_edge {
+            ClockEdge::Rising => 0,
+            ClockEdge::Falling => MPSSE_RDCLK_FALLING,
+        };
+        opcode |= match self.write_clock_edge {
+            ClockEdge::Rising => 0,
+            ClockEdge::Falling => MPSSE_WRCLK_FALLING,
+        };
+        opcode |= match self.bit_direction {
+            BitDirection::LsbFirst => MPSSE_DIR_LSB_FIRST,
+            BitDirection::MsbFirst => 0,
+        };
+        opcode |= match self.write_data {
+            false => 0,
+            true => MPSSE_WRITE_DATA,
+        };
+        opcode |= match self.read_data {
+            false => 0,
+            true => MPSSE_READ_DATA,
+        };
+        opcode
+    }
+}
+
+impl Default for DataShiftOptions {
+    fn default() -> Self {
+        DataShiftOptions {
+            read_clock_edge: ClockEdge::Rising,
+            write_clock_edge: ClockEdge::Rising,
+            bit_direction: BitDirection::MsbFirst,
+            write_data: false,
+            read_data: false,
+        }
+    }
+}
+
+/// MPSSE `Command`s are used to configure the device, set or get GPIOs or
+/// perform serial data transfers.
+pub enum Command<'rd, 'wr> {
+    ReadData(DataShiftOptions, &'rd mut [u8]),
+    WriteData(DataShiftOptions, &'wr [u8]),
+    TransactData(DataShiftOptions, &'wr [u8], DataShiftOptions, &'rd mut [u8]),
+    SetLowGpio(GpioDirection, u8),
+    GetLowGpio(&'rd mut u8),
+    SetClockDivisor(u16),
+    DisableDivBy5,
+    InvalidCommand,
+}
+
+impl Command<'_, '_> {
+    const MAX_LENGTH: usize = 65536;
+
+    /// Calculate the response length for this `Command`.
+    pub fn response_length(&self) -> usize {
+        match self {
+            Command::ReadData(_, buf) => buf.len(),
+            Command::TransactData(_, _, _, buf) => buf.len(),
+            Command::GetLowGpio(_) => 1,
+            Command::WriteData(_, _)
+            | Command::SetLowGpio(_, _)
+            | Command::SetClockDivisor(_)
+            | Command::DisableDivBy5
+            | Command::InvalidCommand => 0,
+        }
+    }
+
+    /// Extend a `Vec<u8>` with the low-level representation of this `Command`.
+    pub fn extend(&self, buf: &mut Vec<u8>) -> Result<()> {
+        match self {
+            Command::ReadData(options, data) => {
+                if data.len() > Command::MAX_LENGTH {
+                    bail!(Error::InvalidDataLength(data.len()));
+                }
+                buf.push(options.as_opcode());
+                buf.extend_from_slice(&((data.len() - 1) as u16).to_le_bytes());
+            }
+            Command::WriteData(options, data) => {
+                if data.len() > Command::MAX_LENGTH {
+                    bail!(Error::InvalidDataLength(data.len()));
+                }
+                buf.push(options.as_opcode());
+                buf.extend_from_slice(&((data.len() - 1) as u16).to_le_bytes());
+                buf.extend(data.iter());
+            }
+            Command::TransactData(woptions, wdata, roptions, rdata) => {
+                if wdata.len() > Command::MAX_LENGTH || wdata.len() != rdata.len() {
+                    bail!(Error::InvalidDataLength(wdata.len()));
+                }
+                buf.push(woptions.as_opcode() | roptions.as_opcode());
+                buf.extend_from_slice(&((wdata.len() - 1) as u16).to_le_bytes());
+                buf.extend(wdata.iter());
+            }
+            Command::SetLowGpio(direction, value) => {
+                buf.push(MPSSE_SET_LOW_GPIO);
+                buf.push(*value);
+                buf.push(direction.bits());
+            }
+            Command::GetLowGpio(_) => {
+                buf.push(MPSSE_GET_LOW_GPIO);
+            }
+            Command::SetClockDivisor(divisor) => {
+                buf.push(MPSSE_SET_CLKDIV);
+                buf.extend_from_slice(&divisor.to_le_bytes());
+            }
+            Command::DisableDivBy5 => {
+                buf.push(MPSSE_DISABLE_DIVBY5);
+            }
+            Command::InvalidCommand => {
+                buf.push(MPSSE_INVALID_COMMAND);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("timeout waiting for MPSSE")]
+    MpsseTimeout,
+    #[error("unknown MPSSE error: {0:02x} {1:02x}")]
+    MpsseUnknown(u8, u8),
+    #[error("Invalid GPIO pin: {0}")]
+    InvalidGpioPin(u32),
+    #[error("Invalid GPIO direction: {0}")]
+    InvalidGpioDirection(u32),
+    #[error("Invalid data length: {0}")]
+    InvalidDataLength(usize),
+}
+
+/// An MPSSE `Context` is the high-level interface to an MPSSE FTDI interface.
+pub struct Context {
+    // The FTDI interface/device.
+    pub device: ftdi::Device,
+    // The maximum clock frequency the device can operate at.
+    pub max_clock_frequency: u32,
+    // The current clock frequency the device is operating at.
+    pub clock_frequency: u32,
+    // The input/output pin direction of the GPIO pins.
+    pub gpio_direction: GpioDirection,
+    // The current value of the GPIO pins.
+    pub gpio_value: u8,
+    // The receive timeout of the last read operation in a command sequence.
+    pub receive_timeout: Duration,
+}
+
+impl Context {
+    /// Create a new MPSSE `Context` given an FTDI device.
+    pub fn new(device: ftdi::Device) -> Result<Self> {
+        device.set_event_char(0, false)?;
+        device.set_error_char(0, false)?;
+        device.set_latency_timer(1)?;
+        device.set_bitmode(0, ftdi::BitMode::Reset)?;
+        device.set_bitmode(0, ftdi::BitMode::Mpsse)?;
+        // Give the device some time to configure itself.
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut context = Context {
+            device,
+            max_clock_frequency: MPSSE_CLOCK_FREQUENCY / 2,
+            clock_frequency: MPSSE_CLOCK_FREQUENCY / 2,
+            gpio_direction: GpioDirection::empty(),
+            gpio_value: 0,
+            receive_timeout: Duration::from_millis(100),
+        };
+        context.set_clock_frequency(context.clock_frequency)?;
+        Ok(context)
+    }
+
+    fn read_timeout(&self, rxbuf: &mut [u8], timeout: Duration) -> Result<u32> {
+        let deadline = Instant::now() + timeout;
+        let mut rxlen = 0;
+        while rxlen < rxbuf.len() {
+            if Instant::now() > deadline {
+                return Err(Error::MpsseTimeout.into());
+            }
+            let n = self.device.read_data(&mut rxbuf[rxlen..])?;
+            rxlen += n as usize;
+        }
+        Ok(rxlen as u32)
+    }
+
+    fn read_status(&self) -> Result<()> {
+        let mut buf = [0u8; 2];
+        let n = self.device.read_data(&mut buf)?;
+        if n > 0 {
+            Err(Error::MpsseUnknown(buf[0], buf[1]).into())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Execute a slice of `commands` on the target FTDI device.
+    pub fn execute(&self, commands: &mut [Command]) -> Result<()> {
+        // Build up a transmit buffer from the slice of commands.
+        // The buffer contains both MPSSE opcodes and data.
+        // Calculate the size of the receive buffer needed.
+        let mut txbuf = Vec::new();
+        let mut rxlen = 0;
+        for command in commands.iter() {
+            command.extend(&mut txbuf)?;
+            rxlen += command.response_length();
+        }
+
+        // Transmit and receive simultaneously.
+        // When the transmit buffer is exhausted, we issue a read with a
+        // timeout to consume the available data or return a timeout error.
+        let mut rxbuf = vec![0u8; rxlen];
+        let mut txlen = 0;
+        rxlen = 0;
+        while txlen < txbuf.len() || rxlen < rxbuf.len() {
+            if txlen < txbuf.len() {
+                let n = self.device.write_data(&txbuf[txlen..])?;
+                txlen += n as usize;
+            }
+            if rxlen < rxbuf.len() {
+                let n = if txlen < txbuf.len() {
+                    self.device.read_data(&mut rxbuf[rxlen..])?
+                } else {
+                    self.read_timeout(&mut rxbuf[rxlen..], self.receive_timeout)?
+                };
+                rxlen += n as usize;
+            }
+        }
+
+        // Redistribute the received data into the buffers specified in
+        // the slice of commands.
+        let mut pos = 0usize;
+        for command in commands.iter_mut() {
+            let len = command.response_length();
+            match command {
+                Command::ReadData(_, buf) => {
+                    buf.copy_from_slice(&rxbuf[pos..(pos + len)]);
+                }
+                Command::TransactData(_, _, _, buf) => {
+                    buf.copy_from_slice(&rxbuf[pos..(pos + len)]);
+                }
+                Command::GetLowGpio(value) => {
+                    **value = rxbuf[pos];
+                }
+                _ => {}
+            }
+            pos += len;
+        }
+
+        // Check for errors
+        self.read_status()
+    }
+
+    /// Get the GPIO state on the target FTDI device.
+    pub fn gpio_get(&mut self) -> Result<u8> {
+        let mut value = 0u8;
+        let command = Command::GetLowGpio(&mut value);
+        self.execute(&mut [command])?;
+        log::debug!("gpio_get {:x}", value);
+        self.gpio_value = value;
+        Ok(value)
+    }
+
+    /// Set the GPIO state of an individual pin on the FTDI device.
+    pub fn gpio_set(&mut self, pin: u32, high: bool) -> Result<()> {
+        let dir = GpioDirection::from_bits(1 << pin).ok_or(Error::InvalidGpioPin(pin))?;
+        if (dir & self.gpio_direction).bits() == 0 {
+            return Err(Error::InvalidGpioDirection(pin).into());
+        }
+        if high {
+            self.gpio_value |= 1 << pin;
+        } else {
+            self.gpio_value &= !(1 << pin);
+        }
+        log::debug!(
+            "gpio_set dir={:x} value={:x}",
+            self.gpio_direction.bits(),
+            self.gpio_value
+        );
+        let command = Command::SetLowGpio(self.gpio_direction, self.gpio_value);
+        self.execute(&mut [command])
+    }
+
+    /// Set the clock frequency for serial opertions on the FTDI device.
+    pub fn set_clock_frequency(&mut self, frequency: u32) -> Result<()> {
+        let base = self.max_clock_frequency;
+        let divisor = base / frequency - 1;
+        let actual = base / (divisor + 1);
+        log::debug!(
+            "mpsse: requested clock frequency {}.  actual={}",
+            frequency,
+            actual
+        );
+        self.execute(&mut [Command::SetClockDivisor(divisor as u16)])?;
+        self.clock_frequency = actual;
+        Ok(())
+    }
+
+    /// Send an invalid command to the FTDI device (this is typically used in a debugging
+    /// context to ensure synchronization with the FTDI device).
+    pub fn invalid_command(&self) -> Result<()> {
+        self.execute(&mut [Command::InvalidCommand])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // Checks the read/write opcodes generated by DataShiftOptions.
+    fn test_data_shift_options() {
+        let opt = DataShiftOptions {
+            read_clock_edge: ClockEdge::Rising,
+            read_data: true,
+            ..Default::default()
+        };
+        assert_eq!(opt.as_opcode(), 0x20);
+
+        let opt = DataShiftOptions {
+            read_clock_edge: ClockEdge::Falling,
+            read_data: true,
+            ..Default::default()
+        };
+        assert_eq!(opt.as_opcode(), 0x24);
+
+        let opt = DataShiftOptions {
+            read_clock_edge: ClockEdge::Falling,
+            read_data: true,
+            bit_direction: BitDirection::LsbFirst,
+            ..Default::default()
+        };
+        assert_eq!(opt.as_opcode(), 0x2c);
+
+        let opt = DataShiftOptions {
+            write_clock_edge: ClockEdge::Rising,
+            write_data: true,
+            ..Default::default()
+        };
+        assert_eq!(opt.as_opcode(), 0x10);
+
+        let opt = DataShiftOptions {
+            write_clock_edge: ClockEdge::Falling,
+            write_data: true,
+            ..Default::default()
+        };
+        assert_eq!(opt.as_opcode(), 0x11);
+
+        let opt = DataShiftOptions {
+            read_clock_edge: ClockEdge::Rising,
+            write_clock_edge: ClockEdge::Falling,
+            read_data: true,
+            write_data: true,
+            ..Default::default()
+        };
+        assert_eq!(opt.as_opcode(), 0x31);
+    }
+
+    #[test]
+    // Checks the construction of a ReadData command.
+    fn test_command_read_data() -> Result<()> {
+        let mut read_buf = [0u8; 8];
+        let opt = DataShiftOptions {
+            read_clock_edge: ClockEdge::Rising,
+            read_data: true,
+            ..Default::default()
+        };
+
+        let command = Command::ReadData(opt, &mut read_buf);
+        assert_eq!(command.response_length(), 8);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode followed by little endian representation of (length-1).
+        assert_eq!(&low_level_command, &[0x20, 7, 0]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of a WriteData command.
+    fn test_command_write_data() -> Result<()> {
+        let write_buf = [1u8, 2, 3, 4, 5];
+        let opt = DataShiftOptions {
+            write_clock_edge: ClockEdge::Falling,
+            write_data: true,
+            ..Default::default()
+        };
+
+        let command = Command::WriteData(opt, &write_buf);
+        assert_eq!(command.response_length(), 0);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode followed by little endian representation of (length-1) followed by data.
+        assert_eq!(&low_level_command, &[0x11, 4, 0, 1, 2, 3, 4, 5]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of a TransactData command.
+    fn test_command_transact_data() -> Result<()> {
+        let write_buf = [1u8, 2, 3, 4, 5];
+        let write_opt = DataShiftOptions {
+            write_clock_edge: ClockEdge::Falling,
+            write_data: true,
+            ..Default::default()
+        };
+        let mut read_buf = [0u8; 5];
+        let read_opt = DataShiftOptions {
+            read_clock_edge: ClockEdge::Rising,
+            read_data: true,
+            ..Default::default()
+        };
+
+        let command = Command::TransactData(write_opt, &write_buf, read_opt, &mut read_buf);
+        assert_eq!(command.response_length(), 5);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode followed by little endian representation of (length-1) followed by data.
+        assert_eq!(&low_level_command, &[0x31, 4, 0, 1, 2, 3, 4, 5]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of a SetLowGpio command.
+    fn test_set_gpio() -> Result<()> {
+        let direction = GpioDirection::OUT_0 | GpioDirection::OUT_1;
+        let command = Command::SetLowGpio(direction, 0x5a);
+        assert_eq!(command.response_length(), 0);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode followed by gpio value followed by gpio direction.
+        assert_eq!(&low_level_command, &[0x80, 0x5a, 0x3]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of a GetLowGpio command.
+    fn test_get_gpio() -> Result<()> {
+        let mut value = 0u8;
+        let command = Command::GetLowGpio(&mut value);
+        assert_eq!(command.response_length(), 1);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode only.
+        assert_eq!(&low_level_command, &[0x81]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of a SetClockDivisor command.
+    fn test_set_clock_divisor() -> Result<()> {
+        let command = Command::SetClockDivisor(0x1234);
+        assert_eq!(command.response_length(), 0);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode followed by the little-endian representation of the divisor.
+        assert_eq!(&low_level_command, &[0x86, 0x34, 0x12]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of a DisableDivBy5 command.
+    fn test_disable_div_by_five() -> Result<()> {
+        let command = Command::DisableDivBy5;
+        assert_eq!(command.response_length(), 0);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode only.
+        assert_eq!(&low_level_command, &[0x8a]);
+        Ok(())
+    }
+
+    #[test]
+    // Checks the construction of an InvalidCommand command.
+    fn test_invalid_command() -> Result<()> {
+        let command = Command::InvalidCommand;
+        assert_eq!(command.response_length(), 0);
+
+        let mut low_level_command = Vec::new();
+        command.extend(&mut low_level_command)?;
+        // opcode only.
+        assert_eq!(&low_level_command, &[0xaa]);
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
@@ -1,0 +1,150 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use log;
+use safe_ftdi as ftdi;
+use std::cell::RefCell;
+use std::rc::Rc;
+use thiserror::Error;
+
+use crate::io::spi::{ClockPolarity, Target, Transfer, TransferMode};
+use crate::transport::ultradebug::mpsse;
+use crate::transport::ultradebug::Ultradebug;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Invalid word size: {0}")]
+    InvalidWordSize(u32),
+    #[error("Invalid speed: {0}")]
+    InvalidSpeed(u32),
+}
+
+/// Represents the Ultradebug SPI device.
+pub struct UltradebugSpi {
+    pub device: Rc<RefCell<mpsse::Context>>,
+    pub mode: TransferMode,
+    pub speed: u32,
+}
+
+impl UltradebugSpi {
+    pub const PIN_CLOCK: u32 = 0;
+    pub const PIN_MOSI: u32 = 1;
+    pub const PIN_MISO: u32 = 2;
+    pub const PIN_CHIP_SELECT: u32 = 3;
+    pub const PIN_SPI_ZB: u32 = 4;
+    pub fn open(ultradebug: &Ultradebug) -> Result<Self> {
+        let mpsse = ultradebug.mpsse(ftdi::Interface::B)?;
+        // Note: platforms ultradebugs tristate their SPI lines
+        // unless SPI_ZB is driven low.  Non-platforms ultradebugs
+        // don't use SPI_ZB, so this is safe for both types of devices.
+        log::debug!("Setting SPI_ZB");
+        mpsse
+            .borrow_mut()
+            .gpio_set(UltradebugSpi::PIN_SPI_ZB, false)?;
+
+        let clock_frequency = mpsse.borrow().clock_frequency;
+        Ok(UltradebugSpi {
+            device: mpsse,
+            mode: TransferMode::Mode0,
+            speed: clock_frequency,
+        })
+    }
+}
+
+impl Target for UltradebugSpi {
+    fn get_transfer_mode(&self) -> Result<TransferMode> {
+        Ok(self.mode)
+    }
+    fn set_transfer_mode(&mut self, mode: TransferMode) -> Result<()> {
+        self.mode = mode;
+        Ok(())
+    }
+
+    fn get_bits_per_word(&self) -> Result<u32> {
+        Ok(8)
+    }
+    fn set_bits_per_word(&mut self, bits_per_word: u32) -> Result<()> {
+        match bits_per_word {
+            8 => Ok(()),
+            _ => Err(Error::InvalidWordSize(bits_per_word).into()),
+        }
+    }
+
+    fn get_max_speed(&self) -> Result<u32> {
+        Ok(self.device.borrow().max_clock_frequency)
+    }
+    fn set_max_speed(&mut self, frequency: u32) -> Result<()> {
+        let mut device = self.device.borrow_mut();
+        device.set_clock_frequency(frequency)
+    }
+
+    fn get_max_transfer_count(&self) -> usize {
+        // Arbitrary value: number of `Transfers` that can be in a single transaction.
+        42
+    }
+
+    fn max_chunk_size(&self) -> usize {
+        // Size of the FTDI read buffer.  We can't perform a read larger than this;
+        // the FTDI device simply won't read any more.
+        65536
+    }
+
+    fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
+        let (rdedge, wredge) = match self.mode.polarity() {
+            ClockPolarity::IdleLow => (mpsse::ClockEdge::Rising, mpsse::ClockEdge::Falling),
+            ClockPolarity::IdleHigh => (mpsse::ClockEdge::Falling, mpsse::ClockEdge::Rising),
+        };
+
+        let mut command = Vec::new();
+        let device = self.device.borrow();
+        let chip_select = 1u8 << UltradebugSpi::PIN_CHIP_SELECT;
+        // Assert CS# (drive low).
+        command.push(mpsse::Command::SetLowGpio(
+            device.gpio_direction,
+            device.gpio_value & !chip_select,
+        ));
+        // Translate SPI Read/Write Transactions into MPSSE Commands.
+        for transfer in transaction.iter_mut() {
+            command.push(match transfer {
+                Transfer::Read(buf) => mpsse::Command::ReadData(
+                    mpsse::DataShiftOptions {
+                        read_clock_edge: rdedge,
+                        read_data: true,
+                        ..Default::default()
+                    },
+                    buf,
+                ),
+                Transfer::Write(buf) => mpsse::Command::WriteData(
+                    mpsse::DataShiftOptions {
+                        write_clock_edge: wredge,
+                        write_data: true,
+                        ..Default::default()
+                    },
+                    buf,
+                ),
+                Transfer::Both(wbuf, rbuf) => mpsse::Command::TransactData(
+                    mpsse::DataShiftOptions {
+                        write_clock_edge: wredge,
+                        write_data: true,
+                        ..Default::default()
+                    },
+                    wbuf,
+                    mpsse::DataShiftOptions {
+                        read_clock_edge: rdedge,
+                        read_data: true,
+                        ..Default::default()
+                    },
+                    rbuf,
+                ),
+            });
+        }
+        // Release CS# (allow to float high).
+        command.push(mpsse::Command::SetLowGpio(
+            device.gpio_direction,
+            device.gpio_value | chip_select,
+        ));
+        device.execute(&mut command)
+    }
+}

--- a/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
@@ -1,0 +1,79 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use safe_ftdi as ftdi;
+use std::io::{Error, ErrorKind};
+use std::io::{Read, Write};
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::transport::ultradebug::Ultradebug;
+
+/// Represents the Ultradebug UART.
+pub struct UltradebugUart {
+    device: ftdi::Device,
+    baudrate: u32,
+}
+
+impl UltradebugUart {
+    pub fn open(ultradebug: &Ultradebug) -> Result<Self> {
+        let device = ultradebug.from_interface(ftdi::Interface::C)?;
+        device.set_bitmode(0, ftdi::BitMode::Reset)?;
+        device.set_baudrate(115200)?;
+        // Read and write timeouts:
+        device.set_timeouts(5000, 5000);
+        Ok(UltradebugUart {
+            device,
+            baudrate: 115200,
+        })
+    }
+}
+
+impl Uart for UltradebugUart {
+    fn get_baudrate(&self) -> u32 {
+        self.baudrate
+    }
+
+    fn set_baudrate(&mut self, baudrate: u32) -> Result<()> {
+        self.device.set_baudrate(baudrate)?;
+        self.baudrate = baudrate;
+        Ok(())
+    }
+
+    fn read_timeout(&mut self, buf: &mut [u8], _timeout: Duration) -> Result<usize> {
+        // Note: my recollection is that there is no way to set a read timeout
+        // for the UART.  If there are no characters ready, the FTDI device
+        // simply returns a zero-length read.
+        Ok(self.read(buf)?)
+    }
+}
+
+impl Read for UltradebugUart {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self
+            .device
+            .read_data(buf)
+            .map_err(|e| Error::new(ErrorKind::Other, e))?;
+        Ok(n as usize)
+    }
+}
+
+impl Write for UltradebugUart {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut total = 0usize;
+        while total < buf.len() {
+            let n = self
+                .device
+                .write_data(&buf[total..])
+                .map_err(|e| Error::new(ErrorKind::Other, e))?;
+            total += n as usize;
+        }
+        Ok(total)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
1. Create an interface for the UART (ultradebug ftdi interface C).
2. Create an interface for GPIOs (ultradebug ftdi interface B).
3. Create an interface for SPI (ultradebug ftdi interface B).
4. Create an MPSSE command executor to drive SPI transactions.

Signed-off-by: Chris Frantz <cfrantz@google.com>