### PR TITLE
[dv/prim_alert/esc] Improvements for prim_alert/esc_tb

### DIFF
--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_cover.cfg
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_cover.cfg
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
++module prim_alert_sender
++module prim_alert_receiver
+begin tgl(portsonly)
+  +module prim_alert_sender
+  +module prim_alert_receiver
+end

--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -63,4 +63,10 @@
       tests: ["prim_alert_smoke"]
     }
   ]
+  overrides: [
+    {
+      name: vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_alert/data/prim_alert_cover.cfg"
+    }
+  ]
 }

--- a/hw/ip/prim/dv/prim_esc/data/prim_esc_cover.cfg
+++ b/hw/ip/prim/dv/prim_esc/data/prim_esc_cover.cfg
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
++module prim_esc_sender
++module prim_esc_receiver
+begin tgl(portsonly)
+  +module prim_esc_sender
+  +module prim_esc_receiver
+end

--- a/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
@@ -38,4 +38,11 @@
       tests: ["prim_esc_test"]
     }
   ]
+
+  overrides: [
+    {
+      name: vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/ip/prim/dv/prim_esc/data/prim_esc_cover.cfg"
+    }
+  ]
 }

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -36,6 +36,7 @@
              "{proj_root}/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/pattgen/dv/pattgen_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson",
+             "{proj_root}/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_lfsr/prim_lfsr_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_present/prim_present_sim_cfg.hjson",
              "{proj_root}/hw/ip/prim/dv/prim_prince/prim_prince_sim_cfg.hjson",

--- a/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_dv_lint_cfgs.hjson
@@ -110,6 +110,11 @@
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
                   rel_path: "hw/ip/prim/dv/prim_alert/lint/{tool}"
              },
+             {    name: prim_esc
+                  fusesoc_core: lowrisc:dv:prim_esc_sim
+                  import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+                  rel_path: "hw/ip/prim/dv/prim_esc/lint/{tool}"
+             },
              {    name: prim_lfsr
                   fusesoc_core: lowrisc:dv:prim_lfsr_sim
                   import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]


### PR DESCRIPTION
This PR adds the following items:
1). prim_alert/esc_tb: override vcs_cov_cfg_file with its own prim_alert/esc_cover.cfg
2). prim_esc_tb: add to nightly regression and lint regression.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>