### PR TITLE
[pinmux] Use regfile async option for wakeup detector CSRs

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -668,7 +668,12 @@
                 }
     },
     { multireg: { name:         "WKUP_DETECTOR_EN",
-                  desc:         "Enables for the wakeup detectors."
+                  desc:         '''
+                                Enables for the wakeup detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -676,6 +681,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "0:0",
                       name: "EN",
@@ -691,7 +697,12 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR",
-                  desc:         "Configuration of wakeup condition detectors."
+                  desc:         '''
+                                Configuration of wakeup condition detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -699,6 +710,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "2:0",
                       name: "MODE",
@@ -754,7 +766,12 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR_CNT_TH",
-                  desc:         "Counter thresholds for wakeup condition detectors."
+                  desc:         '''
+                                Counter thresholds for wakeup condition detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -762,6 +779,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "WkupCntWidth-1:0",
                       name: "TH",
@@ -775,7 +793,10 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR_PADSEL",
-                  desc:         "Pad selects for pad wakeup condition detectors."
+                  desc:         '''
+                                Pad selects for pad wakeup condition detectors.
+                                This register is NOT synced to the AON domain since the muxing mechanism is implemented in the same way as the pinmux muxing matrix.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -798,13 +819,17 @@
 
     },
     { multireg: { name:     "WKUP_CAUSE",
-                  desc:     "Cause registers for wakeup detectors."
+                  desc:     '''
+                            Cause registers for wakeup detectors.
+                            Note that these registers are synced to the always-on clock.
+                            The first write access always completes immediately.
+                            However, read/write accesses following a write will block until that write has completed.
+                            '''
                   count:    "NWkupDetect",
                   swaccess: "rw0c",
                   hwaccess: "hrw",
-                  hwext:    "true",
-                  hwqe:     "true",
                   cname:    "DETECTOR",
+                  async:    "clk_aon_i",
                   fields: [
                     { bits: "0",
                       name: "CAUSE",
@@ -813,10 +838,6 @@
                       '''
                     }
                   ]
-                  // these CSRs live in the slow AON clock domain and
-                  // clearing them will be very slow and the changes
-                  // are not immediately visible.
-                  tags: ["excl:CsrAllTests:CsrExclWriteCheck"]
                 }
 
     },

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -680,7 +680,12 @@
                 }
     },
     { multireg: { name:         "WKUP_DETECTOR_EN",
-                  desc:         "Enables for the wakeup detectors."
+                  desc:         '''
+                                Enables for the wakeup detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -688,6 +693,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "0:0",
                       name: "EN",
@@ -703,7 +709,12 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR",
-                  desc:         "Configuration of wakeup condition detectors."
+                  desc:         '''
+                                Configuration of wakeup condition detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -711,6 +722,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "2:0",
                       name: "MODE",
@@ -766,7 +778,12 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR_CNT_TH",
-                  desc:         "Counter thresholds for wakeup condition detectors."
+                  desc:         '''
+                                Counter thresholds for wakeup condition detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -774,6 +791,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "WkupCntWidth-1:0",
                       name: "TH",
@@ -787,7 +805,10 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR_PADSEL",
-                  desc:         "Pad selects for pad wakeup condition detectors."
+                  desc:         '''
+                                Pad selects for pad wakeup condition detectors.
+                                This register is NOT synced to the AON domain since the muxing mechanism is implemented in the same way as the pinmux muxing matrix.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -810,13 +831,17 @@
 
     },
     { multireg: { name:     "WKUP_CAUSE",
-                  desc:     "Cause registers for wakeup detectors."
+                  desc:     '''
+                            Cause registers for wakeup detectors.
+                            Note that these registers are synced to the always-on clock.
+                            The first write access always completes immediately.
+                            However, read/write accesses following a write will block until that write has completed.
+                            '''
                   count:    "NWkupDetect",
                   swaccess: "rw0c",
                   hwaccess: "hrw",
-                  hwext:    "true",
-                  hwqe:     "true",
                   cname:    "DETECTOR",
+                  async:    "clk_aon_i",
                   fields: [
                     { bits: "0",
                       name: "CAUSE",
@@ -825,10 +850,6 @@
                       '''
                     }
                   ]
-                  // these CSRs live in the slow AON clock domain and
-                  // clearing them will be very slow and the changes
-                  // are not immediately visible.
-                  tags: ["excl:CsrAllTests:CsrExclWriteCheck"]
                 }
 
     },

--- a/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_pkg.sv
@@ -96,7 +96,6 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     logic        q;
-    logic        qe;
   } pinmux_reg2hw_wkup_cause_mreg_t;
 
   typedef struct packed {
@@ -119,35 +118,36 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     logic        d;
+    logic        de;
   } pinmux_hw2reg_wkup_cause_mreg_t;
 
   // Register -> HW type
   typedef struct packed {
-    pinmux_reg2hw_alert_test_reg_t alert_test; // [1431:1430]
-    pinmux_reg2hw_mio_periph_insel_mreg_t [32:0] mio_periph_insel; // [1429:1232]
-    pinmux_reg2hw_mio_outsel_mreg_t [31:0] mio_outsel; // [1231:1040]
-    pinmux_reg2hw_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [1039:592]
-    pinmux_reg2hw_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [591:368]
-    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [31:0] mio_pad_sleep_status; // [367:336]
-    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [31:0] mio_pad_sleep_en; // [335:304]
-    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [31:0] mio_pad_sleep_mode; // [303:240]
-    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [15:0] dio_pad_sleep_status; // [239:224]
-    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [15:0] dio_pad_sleep_en; // [223:208]
-    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [15:0] dio_pad_sleep_mode; // [207:176]
-    pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [175:168]
-    pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [167:128]
-    pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [127:64]
-    pinmux_reg2hw_wkup_detector_padsel_mreg_t [7:0] wkup_detector_padsel; // [63:16]
-    pinmux_reg2hw_wkup_cause_mreg_t [7:0] wkup_cause; // [15:0]
+    pinmux_reg2hw_alert_test_reg_t alert_test; // [1423:1422]
+    pinmux_reg2hw_mio_periph_insel_mreg_t [32:0] mio_periph_insel; // [1421:1224]
+    pinmux_reg2hw_mio_outsel_mreg_t [31:0] mio_outsel; // [1223:1032]
+    pinmux_reg2hw_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [1031:584]
+    pinmux_reg2hw_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [583:360]
+    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [31:0] mio_pad_sleep_status; // [359:328]
+    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [31:0] mio_pad_sleep_en; // [327:296]
+    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [31:0] mio_pad_sleep_mode; // [295:232]
+    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [15:0] dio_pad_sleep_status; // [231:216]
+    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [15:0] dio_pad_sleep_en; // [215:200]
+    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [15:0] dio_pad_sleep_mode; // [199:168]
+    pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [167:160]
+    pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [159:120]
+    pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [119:56]
+    pinmux_reg2hw_wkup_detector_padsel_mreg_t [7:0] wkup_detector_padsel; // [55:8]
+    pinmux_reg2hw_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
   } pinmux_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    pinmux_hw2reg_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [727:312]
-    pinmux_hw2reg_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [311:104]
-    pinmux_hw2reg_mio_pad_sleep_status_mreg_t [31:0] mio_pad_sleep_status; // [103:40]
-    pinmux_hw2reg_dio_pad_sleep_status_mreg_t [15:0] dio_pad_sleep_status; // [39:8]
-    pinmux_hw2reg_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
+    pinmux_hw2reg_mio_pad_attr_mreg_t [31:0] mio_pad_attr; // [735:320]
+    pinmux_hw2reg_dio_pad_attr_mreg_t [15:0] dio_pad_attr; // [319:112]
+    pinmux_hw2reg_mio_pad_sleep_status_mreg_t [31:0] mio_pad_sleep_status; // [111:48]
+    pinmux_hw2reg_dio_pad_sleep_status_mreg_t [15:0] dio_pad_sleep_status; // [47:16]
+    pinmux_hw2reg_wkup_cause_mreg_t [7:0] wkup_cause; // [15:0]
   } pinmux_hw2reg_t;
 
   // Register offsets
@@ -665,15 +665,6 @@ package pinmux_reg_pkg;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_14_ATTR_14_RESVAL = 13'h 0;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_15_RESVAL = 13'h 0;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_15_ATTR_15_RESVAL = 13'h 0;
-  parameter logic [7:0] PINMUX_WKUP_CAUSE_RESVAL = 8'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_0_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_1_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_2_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_3_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_4_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_5_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_6_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_7_RESVAL = 1'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -9,6 +9,8 @@
 module pinmux_reg_top (
   input clk_i,
   input rst_ni,
+  input clk_aon_i,
+  input rst_aon_ni,
 
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
@@ -102,6 +104,15 @@ module pinmux_reg_top (
   );
 
   // cdc oversampling signals
+    logic sync_aon_update;
+  prim_pulse_sync u_aon_tgl (
+    .clk_src_i(clk_aon_i),
+    .rst_src_ni(rst_aon_ni),
+    .src_pulse_i(1'b1),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(sync_aon_update)
+  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -1394,107 +1405,147 @@ module pinmux_reg_top (
   logic wkup_detector_en_0_we;
   logic wkup_detector_en_0_qs;
   logic wkup_detector_en_0_wd;
+  logic wkup_detector_en_0_busy;
   logic wkup_detector_en_1_we;
   logic wkup_detector_en_1_qs;
   logic wkup_detector_en_1_wd;
+  logic wkup_detector_en_1_busy;
   logic wkup_detector_en_2_we;
   logic wkup_detector_en_2_qs;
   logic wkup_detector_en_2_wd;
+  logic wkup_detector_en_2_busy;
   logic wkup_detector_en_3_we;
   logic wkup_detector_en_3_qs;
   logic wkup_detector_en_3_wd;
+  logic wkup_detector_en_3_busy;
   logic wkup_detector_en_4_we;
   logic wkup_detector_en_4_qs;
   logic wkup_detector_en_4_wd;
+  logic wkup_detector_en_4_busy;
   logic wkup_detector_en_5_we;
   logic wkup_detector_en_5_qs;
   logic wkup_detector_en_5_wd;
+  logic wkup_detector_en_5_busy;
   logic wkup_detector_en_6_we;
   logic wkup_detector_en_6_qs;
   logic wkup_detector_en_6_wd;
+  logic wkup_detector_en_6_busy;
   logic wkup_detector_en_7_we;
   logic wkup_detector_en_7_qs;
   logic wkup_detector_en_7_wd;
+  logic wkup_detector_en_7_busy;
   logic wkup_detector_0_we;
   logic [2:0] wkup_detector_0_mode_0_qs;
   logic [2:0] wkup_detector_0_mode_0_wd;
+  logic wkup_detector_0_mode_0_busy;
   logic wkup_detector_0_filter_0_qs;
   logic wkup_detector_0_filter_0_wd;
+  logic wkup_detector_0_filter_0_busy;
   logic wkup_detector_0_miodio_0_qs;
   logic wkup_detector_0_miodio_0_wd;
+  logic wkup_detector_0_miodio_0_busy;
   logic wkup_detector_1_we;
   logic [2:0] wkup_detector_1_mode_1_qs;
   logic [2:0] wkup_detector_1_mode_1_wd;
+  logic wkup_detector_1_mode_1_busy;
   logic wkup_detector_1_filter_1_qs;
   logic wkup_detector_1_filter_1_wd;
+  logic wkup_detector_1_filter_1_busy;
   logic wkup_detector_1_miodio_1_qs;
   logic wkup_detector_1_miodio_1_wd;
+  logic wkup_detector_1_miodio_1_busy;
   logic wkup_detector_2_we;
   logic [2:0] wkup_detector_2_mode_2_qs;
   logic [2:0] wkup_detector_2_mode_2_wd;
+  logic wkup_detector_2_mode_2_busy;
   logic wkup_detector_2_filter_2_qs;
   logic wkup_detector_2_filter_2_wd;
+  logic wkup_detector_2_filter_2_busy;
   logic wkup_detector_2_miodio_2_qs;
   logic wkup_detector_2_miodio_2_wd;
+  logic wkup_detector_2_miodio_2_busy;
   logic wkup_detector_3_we;
   logic [2:0] wkup_detector_3_mode_3_qs;
   logic [2:0] wkup_detector_3_mode_3_wd;
+  logic wkup_detector_3_mode_3_busy;
   logic wkup_detector_3_filter_3_qs;
   logic wkup_detector_3_filter_3_wd;
+  logic wkup_detector_3_filter_3_busy;
   logic wkup_detector_3_miodio_3_qs;
   logic wkup_detector_3_miodio_3_wd;
+  logic wkup_detector_3_miodio_3_busy;
   logic wkup_detector_4_we;
   logic [2:0] wkup_detector_4_mode_4_qs;
   logic [2:0] wkup_detector_4_mode_4_wd;
+  logic wkup_detector_4_mode_4_busy;
   logic wkup_detector_4_filter_4_qs;
   logic wkup_detector_4_filter_4_wd;
+  logic wkup_detector_4_filter_4_busy;
   logic wkup_detector_4_miodio_4_qs;
   logic wkup_detector_4_miodio_4_wd;
+  logic wkup_detector_4_miodio_4_busy;
   logic wkup_detector_5_we;
   logic [2:0] wkup_detector_5_mode_5_qs;
   logic [2:0] wkup_detector_5_mode_5_wd;
+  logic wkup_detector_5_mode_5_busy;
   logic wkup_detector_5_filter_5_qs;
   logic wkup_detector_5_filter_5_wd;
+  logic wkup_detector_5_filter_5_busy;
   logic wkup_detector_5_miodio_5_qs;
   logic wkup_detector_5_miodio_5_wd;
+  logic wkup_detector_5_miodio_5_busy;
   logic wkup_detector_6_we;
   logic [2:0] wkup_detector_6_mode_6_qs;
   logic [2:0] wkup_detector_6_mode_6_wd;
+  logic wkup_detector_6_mode_6_busy;
   logic wkup_detector_6_filter_6_qs;
   logic wkup_detector_6_filter_6_wd;
+  logic wkup_detector_6_filter_6_busy;
   logic wkup_detector_6_miodio_6_qs;
   logic wkup_detector_6_miodio_6_wd;
+  logic wkup_detector_6_miodio_6_busy;
   logic wkup_detector_7_we;
   logic [2:0] wkup_detector_7_mode_7_qs;
   logic [2:0] wkup_detector_7_mode_7_wd;
+  logic wkup_detector_7_mode_7_busy;
   logic wkup_detector_7_filter_7_qs;
   logic wkup_detector_7_filter_7_wd;
+  logic wkup_detector_7_filter_7_busy;
   logic wkup_detector_7_miodio_7_qs;
   logic wkup_detector_7_miodio_7_wd;
+  logic wkup_detector_7_miodio_7_busy;
   logic wkup_detector_cnt_th_0_we;
   logic [7:0] wkup_detector_cnt_th_0_qs;
   logic [7:0] wkup_detector_cnt_th_0_wd;
+  logic wkup_detector_cnt_th_0_busy;
   logic wkup_detector_cnt_th_1_we;
   logic [7:0] wkup_detector_cnt_th_1_qs;
   logic [7:0] wkup_detector_cnt_th_1_wd;
+  logic wkup_detector_cnt_th_1_busy;
   logic wkup_detector_cnt_th_2_we;
   logic [7:0] wkup_detector_cnt_th_2_qs;
   logic [7:0] wkup_detector_cnt_th_2_wd;
+  logic wkup_detector_cnt_th_2_busy;
   logic wkup_detector_cnt_th_3_we;
   logic [7:0] wkup_detector_cnt_th_3_qs;
   logic [7:0] wkup_detector_cnt_th_3_wd;
+  logic wkup_detector_cnt_th_3_busy;
   logic wkup_detector_cnt_th_4_we;
   logic [7:0] wkup_detector_cnt_th_4_qs;
   logic [7:0] wkup_detector_cnt_th_4_wd;
+  logic wkup_detector_cnt_th_4_busy;
   logic wkup_detector_cnt_th_5_we;
   logic [7:0] wkup_detector_cnt_th_5_qs;
   logic [7:0] wkup_detector_cnt_th_5_wd;
+  logic wkup_detector_cnt_th_5_busy;
   logic wkup_detector_cnt_th_6_we;
   logic [7:0] wkup_detector_cnt_th_6_qs;
   logic [7:0] wkup_detector_cnt_th_6_wd;
+  logic wkup_detector_cnt_th_6_busy;
   logic wkup_detector_cnt_th_7_we;
   logic [7:0] wkup_detector_cnt_th_7_qs;
   logic [7:0] wkup_detector_cnt_th_7_wd;
+  logic wkup_detector_cnt_th_7_busy;
   logic wkup_detector_padsel_0_we;
   logic [5:0] wkup_detector_padsel_0_qs;
   logic [5:0] wkup_detector_padsel_0_wd;
@@ -1519,24 +1570,31 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_7_we;
   logic [5:0] wkup_detector_padsel_7_qs;
   logic [5:0] wkup_detector_padsel_7_wd;
-  logic wkup_cause_re;
   logic wkup_cause_we;
   logic wkup_cause_cause_0_qs;
   logic wkup_cause_cause_0_wd;
+  logic wkup_cause_cause_0_busy;
   logic wkup_cause_cause_1_qs;
   logic wkup_cause_cause_1_wd;
+  logic wkup_cause_cause_1_busy;
   logic wkup_cause_cause_2_qs;
   logic wkup_cause_cause_2_wd;
+  logic wkup_cause_cause_2_busy;
   logic wkup_cause_cause_3_qs;
   logic wkup_cause_cause_3_wd;
+  logic wkup_cause_cause_3_busy;
   logic wkup_cause_cause_4_qs;
   logic wkup_cause_cause_4_wd;
+  logic wkup_cause_cause_4_busy;
   logic wkup_cause_cause_5_qs;
   logic wkup_cause_cause_5_wd;
+  logic wkup_cause_cause_5_busy;
   logic wkup_cause_cause_6_qs;
   logic wkup_cause_cause_6_wd;
+  logic wkup_cause_cause_6_busy;
   logic wkup_cause_cause_7_qs;
   logic wkup_cause_cause_7_wd;
+  logic wkup_cause_cause_7_busy;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -12525,217 +12583,185 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_en
   // R[wkup_detector_en_0]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_en_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[0].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_en_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_0_busy),
+    .src_qs_o     (wkup_detector_en_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[0].q)
   );
 
   // Subregister 1 of Multireg wkup_detector_en
   // R[wkup_detector_en_1]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_en_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[1].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_en_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_1_busy),
+    .src_qs_o     (wkup_detector_en_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[1].q)
   );
 
   // Subregister 2 of Multireg wkup_detector_en
   // R[wkup_detector_en_2]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_en_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[2].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_en_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_2_busy),
+    .src_qs_o     (wkup_detector_en_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[2].q)
   );
 
   // Subregister 3 of Multireg wkup_detector_en
   // R[wkup_detector_en_3]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_en_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[3].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_en_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_3_busy),
+    .src_qs_o     (wkup_detector_en_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[3].q)
   );
 
   // Subregister 4 of Multireg wkup_detector_en
   // R[wkup_detector_en_4]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_en_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[4].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_en_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_4_busy),
+    .src_qs_o     (wkup_detector_en_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[4].q)
   );
 
   // Subregister 5 of Multireg wkup_detector_en
   // R[wkup_detector_en_5]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_en_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[5].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_en_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_5_busy),
+    .src_qs_o     (wkup_detector_en_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[5].q)
   );
 
   // Subregister 6 of Multireg wkup_detector_en
   // R[wkup_detector_en_6]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_en_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[6].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_en_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_6_busy),
+    .src_qs_o     (wkup_detector_en_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[6].q)
   );
 
   // Subregister 7 of Multireg wkup_detector_en
   // R[wkup_detector_en_7]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_en_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[7].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_en_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_7_busy),
+    .src_qs_o     (wkup_detector_en_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[7].q)
   );
 
 
@@ -12744,80 +12770,68 @@ module pinmux_reg_top (
   // R[wkup_detector_0]: V(False)
 
   // F[mode_0]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_0_mode_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_0_mode_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[0].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_0_mode_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_0_mode_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_0_mode_0_busy),
+    .src_qs_o     (wkup_detector_0_mode_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[0].mode.q)
   );
 
 
   // F[filter_0]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_filter_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_0_filter_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[0].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_0_filter_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_0_filter_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_0_filter_0_busy),
+    .src_qs_o     (wkup_detector_0_filter_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[0].filter.q)
   );
 
 
   // F[miodio_0]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_miodio_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_0_miodio_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[0].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_0_miodio_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_0_miodio_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_0_miodio_0_busy),
+    .src_qs_o     (wkup_detector_0_miodio_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[0].miodio.q)
   );
 
 
@@ -12825,80 +12839,68 @@ module pinmux_reg_top (
   // R[wkup_detector_1]: V(False)
 
   // F[mode_1]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_1_mode_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_1_mode_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[1].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_1_mode_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_1_mode_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_1_mode_1_busy),
+    .src_qs_o     (wkup_detector_1_mode_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[1].mode.q)
   );
 
 
   // F[filter_1]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_filter_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_1_filter_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[1].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_1_filter_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_1_filter_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_1_filter_1_busy),
+    .src_qs_o     (wkup_detector_1_filter_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[1].filter.q)
   );
 
 
   // F[miodio_1]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_miodio_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_1_miodio_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[1].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_1_miodio_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_1_miodio_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_1_miodio_1_busy),
+    .src_qs_o     (wkup_detector_1_miodio_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[1].miodio.q)
   );
 
 
@@ -12906,80 +12908,68 @@ module pinmux_reg_top (
   // R[wkup_detector_2]: V(False)
 
   // F[mode_2]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_2_mode_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_2_mode_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[2].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_2_mode_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_2_mode_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_2_mode_2_busy),
+    .src_qs_o     (wkup_detector_2_mode_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[2].mode.q)
   );
 
 
   // F[filter_2]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_filter_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_2_filter_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[2].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_2_filter_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_2_filter_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_2_filter_2_busy),
+    .src_qs_o     (wkup_detector_2_filter_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[2].filter.q)
   );
 
 
   // F[miodio_2]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_miodio_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_2_miodio_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[2].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_2_miodio_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_2_miodio_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_2_miodio_2_busy),
+    .src_qs_o     (wkup_detector_2_miodio_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[2].miodio.q)
   );
 
 
@@ -12987,80 +12977,68 @@ module pinmux_reg_top (
   // R[wkup_detector_3]: V(False)
 
   // F[mode_3]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_3_mode_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_3_mode_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[3].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_3_mode_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_3_mode_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_3_mode_3_busy),
+    .src_qs_o     (wkup_detector_3_mode_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[3].mode.q)
   );
 
 
   // F[filter_3]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_filter_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_3_filter_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[3].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_3_filter_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_3_filter_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_3_filter_3_busy),
+    .src_qs_o     (wkup_detector_3_filter_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[3].filter.q)
   );
 
 
   // F[miodio_3]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_miodio_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_3_miodio_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[3].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_3_miodio_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_3_miodio_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_3_miodio_3_busy),
+    .src_qs_o     (wkup_detector_3_miodio_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[3].miodio.q)
   );
 
 
@@ -13068,80 +13046,68 @@ module pinmux_reg_top (
   // R[wkup_detector_4]: V(False)
 
   // F[mode_4]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_4_mode_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_4_mode_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[4].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_4_mode_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_4_mode_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_4_mode_4_busy),
+    .src_qs_o     (wkup_detector_4_mode_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[4].mode.q)
   );
 
 
   // F[filter_4]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_filter_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_4_filter_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[4].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_4_filter_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_4_filter_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_4_filter_4_busy),
+    .src_qs_o     (wkup_detector_4_filter_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[4].filter.q)
   );
 
 
   // F[miodio_4]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_miodio_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_4_miodio_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[4].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_4_miodio_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_4_miodio_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_4_miodio_4_busy),
+    .src_qs_o     (wkup_detector_4_miodio_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[4].miodio.q)
   );
 
 
@@ -13149,80 +13115,68 @@ module pinmux_reg_top (
   // R[wkup_detector_5]: V(False)
 
   // F[mode_5]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_5_mode_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_5_mode_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[5].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_5_mode_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_5_mode_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_5_mode_5_busy),
+    .src_qs_o     (wkup_detector_5_mode_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[5].mode.q)
   );
 
 
   // F[filter_5]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_filter_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_5_filter_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[5].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_5_filter_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_5_filter_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_5_filter_5_busy),
+    .src_qs_o     (wkup_detector_5_filter_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[5].filter.q)
   );
 
 
   // F[miodio_5]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_miodio_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_5_miodio_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[5].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_5_miodio_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_5_miodio_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_5_miodio_5_busy),
+    .src_qs_o     (wkup_detector_5_miodio_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[5].miodio.q)
   );
 
 
@@ -13230,80 +13184,68 @@ module pinmux_reg_top (
   // R[wkup_detector_6]: V(False)
 
   // F[mode_6]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_6_mode_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_6_mode_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[6].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_6_mode_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_6_mode_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_6_mode_6_busy),
+    .src_qs_o     (wkup_detector_6_mode_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[6].mode.q)
   );
 
 
   // F[filter_6]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_filter_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_6_filter_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[6].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_6_filter_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_6_filter_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_6_filter_6_busy),
+    .src_qs_o     (wkup_detector_6_filter_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[6].filter.q)
   );
 
 
   // F[miodio_6]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_miodio_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_6_miodio_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[6].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_6_miodio_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_6_miodio_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_6_miodio_6_busy),
+    .src_qs_o     (wkup_detector_6_miodio_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[6].miodio.q)
   );
 
 
@@ -13311,80 +13253,68 @@ module pinmux_reg_top (
   // R[wkup_detector_7]: V(False)
 
   // F[mode_7]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_7_mode_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_7_mode_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[7].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_7_mode_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_7_mode_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_7_mode_7_busy),
+    .src_qs_o     (wkup_detector_7_mode_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[7].mode.q)
   );
 
 
   // F[filter_7]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_filter_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_7_filter_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[7].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_7_filter_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_7_filter_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_7_filter_7_busy),
+    .src_qs_o     (wkup_detector_7_filter_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[7].filter.q)
   );
 
 
   // F[miodio_7]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_miodio_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_7_miodio_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[7].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_7_miodio_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_7_miodio_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_7_miodio_7_busy),
+    .src_qs_o     (wkup_detector_7_miodio_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[7].miodio.q)
   );
 
 
@@ -13393,217 +13323,185 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_0]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_cnt_th_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[0].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_cnt_th_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_0_busy),
+    .src_qs_o     (wkup_detector_cnt_th_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[0].q)
   );
 
   // Subregister 1 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_1]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_cnt_th_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[1].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_cnt_th_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_1_busy),
+    .src_qs_o     (wkup_detector_cnt_th_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[1].q)
   );
 
   // Subregister 2 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_2]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_cnt_th_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[2].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_cnt_th_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_2_busy),
+    .src_qs_o     (wkup_detector_cnt_th_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[2].q)
   );
 
   // Subregister 3 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_3]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_cnt_th_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[3].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_cnt_th_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_3_busy),
+    .src_qs_o     (wkup_detector_cnt_th_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[3].q)
   );
 
   // Subregister 4 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_4]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_cnt_th_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[4].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_cnt_th_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_4_busy),
+    .src_qs_o     (wkup_detector_cnt_th_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[4].q)
   );
 
   // Subregister 5 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_5]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_cnt_th_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[5].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_cnt_th_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_5_busy),
+    .src_qs_o     (wkup_detector_cnt_th_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[5].q)
   );
 
   // Subregister 6 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_6]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_cnt_th_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[6].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_cnt_th_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_6_busy),
+    .src_qs_o     (wkup_detector_cnt_th_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[6].q)
   );
 
   // Subregister 7 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_7]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_cnt_th_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[7].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_cnt_th_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_7_busy),
+    .src_qs_o     (wkup_detector_cnt_th_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[7].q)
   );
 
 
@@ -13827,125 +13725,181 @@ module pinmux_reg_top (
 
 
   // Subregister 0 of Multireg wkup_cause
-  // R[wkup_cause]: V(True)
+  // R[wkup_cause]: V(False)
 
   // F[cause_0]: 0:0
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_0 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_0_wd),
-    .d      (hw2reg.wkup_cause[0].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[0].qe),
-    .q      (reg2hw.wkup_cause[0].q),
-    .qs     (wkup_cause_cause_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_0_wd),
+    .dst_de_i     (hw2reg.wkup_cause[0].de),
+    .dst_d_i      (hw2reg.wkup_cause[0].d),
+    .src_busy_o   (wkup_cause_cause_0_busy),
+    .src_qs_o     (wkup_cause_cause_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[0].q)
   );
 
 
   // F[cause_1]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_1 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_1_wd),
-    .d      (hw2reg.wkup_cause[1].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[1].qe),
-    .q      (reg2hw.wkup_cause[1].q),
-    .qs     (wkup_cause_cause_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_1_wd),
+    .dst_de_i     (hw2reg.wkup_cause[1].de),
+    .dst_d_i      (hw2reg.wkup_cause[1].d),
+    .src_busy_o   (wkup_cause_cause_1_busy),
+    .src_qs_o     (wkup_cause_cause_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[1].q)
   );
 
 
   // F[cause_2]: 2:2
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_2 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_2_wd),
-    .d      (hw2reg.wkup_cause[2].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[2].qe),
-    .q      (reg2hw.wkup_cause[2].q),
-    .qs     (wkup_cause_cause_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_2_wd),
+    .dst_de_i     (hw2reg.wkup_cause[2].de),
+    .dst_d_i      (hw2reg.wkup_cause[2].d),
+    .src_busy_o   (wkup_cause_cause_2_busy),
+    .src_qs_o     (wkup_cause_cause_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[2].q)
   );
 
 
   // F[cause_3]: 3:3
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_3 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_3_wd),
-    .d      (hw2reg.wkup_cause[3].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[3].qe),
-    .q      (reg2hw.wkup_cause[3].q),
-    .qs     (wkup_cause_cause_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_3_wd),
+    .dst_de_i     (hw2reg.wkup_cause[3].de),
+    .dst_d_i      (hw2reg.wkup_cause[3].d),
+    .src_busy_o   (wkup_cause_cause_3_busy),
+    .src_qs_o     (wkup_cause_cause_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[3].q)
   );
 
 
   // F[cause_4]: 4:4
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_4 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_4_wd),
-    .d      (hw2reg.wkup_cause[4].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[4].qe),
-    .q      (reg2hw.wkup_cause[4].q),
-    .qs     (wkup_cause_cause_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_4_wd),
+    .dst_de_i     (hw2reg.wkup_cause[4].de),
+    .dst_d_i      (hw2reg.wkup_cause[4].d),
+    .src_busy_o   (wkup_cause_cause_4_busy),
+    .src_qs_o     (wkup_cause_cause_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[4].q)
   );
 
 
   // F[cause_5]: 5:5
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_5 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_5_wd),
-    .d      (hw2reg.wkup_cause[5].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[5].qe),
-    .q      (reg2hw.wkup_cause[5].q),
-    .qs     (wkup_cause_cause_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_5_wd),
+    .dst_de_i     (hw2reg.wkup_cause[5].de),
+    .dst_d_i      (hw2reg.wkup_cause[5].d),
+    .src_busy_o   (wkup_cause_cause_5_busy),
+    .src_qs_o     (wkup_cause_cause_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[5].q)
   );
 
 
   // F[cause_6]: 6:6
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_6 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_6_wd),
-    .d      (hw2reg.wkup_cause[6].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[6].qe),
-    .q      (reg2hw.wkup_cause[6].q),
-    .qs     (wkup_cause_cause_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_6_wd),
+    .dst_de_i     (hw2reg.wkup_cause[6].de),
+    .dst_d_i      (hw2reg.wkup_cause[6].d),
+    .src_busy_o   (wkup_cause_cause_6_busy),
+    .src_qs_o     (wkup_cause_cause_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[6].q)
   );
 
 
   // F[cause_7]: 7:7
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_7 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_7_wd),
-    .d      (hw2reg.wkup_cause[7].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[7].qe),
-    .q      (reg2hw.wkup_cause[7].q),
-    .qs     (wkup_cause_cause_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_7_wd),
+    .dst_de_i     (hw2reg.wkup_cause[7].de),
+    .dst_d_i      (hw2reg.wkup_cause[7].d),
+    .src_busy_o   (wkup_cause_cause_7_busy),
+    .src_qs_o     (wkup_cause_cause_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[7].q)
   );
 
 
@@ -16202,7 +16156,6 @@ module pinmux_reg_top (
   assign wkup_detector_padsel_7_we = addr_hit[412] & reg_we & !reg_error;
 
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
-  assign wkup_cause_re = addr_hit[413] & reg_re & !reg_error;
   assign wkup_cause_we = addr_hit[413] & reg_we & !reg_error;
 
   assign wkup_cause_cause_0_wd = reg_wdata[0];
@@ -17960,6 +17913,113 @@ module pinmux_reg_top (
   always_comb begin
     reg_busy = '0;
     unique case (1'b1)
+      addr_hit[381]: begin
+        reg_busy = wkup_detector_en_0_busy;
+      end
+      addr_hit[382]: begin
+        reg_busy = wkup_detector_en_1_busy;
+      end
+      addr_hit[383]: begin
+        reg_busy = wkup_detector_en_2_busy;
+      end
+      addr_hit[384]: begin
+        reg_busy = wkup_detector_en_3_busy;
+      end
+      addr_hit[385]: begin
+        reg_busy = wkup_detector_en_4_busy;
+      end
+      addr_hit[386]: begin
+        reg_busy = wkup_detector_en_5_busy;
+      end
+      addr_hit[387]: begin
+        reg_busy = wkup_detector_en_6_busy;
+      end
+      addr_hit[388]: begin
+        reg_busy = wkup_detector_en_7_busy;
+      end
+      addr_hit[389]: begin
+        reg_busy =
+          wkup_detector_0_mode_0_busy |
+          wkup_detector_0_filter_0_busy |
+          wkup_detector_0_miodio_0_busy;
+      end
+      addr_hit[390]: begin
+        reg_busy =
+          wkup_detector_1_mode_1_busy |
+          wkup_detector_1_filter_1_busy |
+          wkup_detector_1_miodio_1_busy;
+      end
+      addr_hit[391]: begin
+        reg_busy =
+          wkup_detector_2_mode_2_busy |
+          wkup_detector_2_filter_2_busy |
+          wkup_detector_2_miodio_2_busy;
+      end
+      addr_hit[392]: begin
+        reg_busy =
+          wkup_detector_3_mode_3_busy |
+          wkup_detector_3_filter_3_busy |
+          wkup_detector_3_miodio_3_busy;
+      end
+      addr_hit[393]: begin
+        reg_busy =
+          wkup_detector_4_mode_4_busy |
+          wkup_detector_4_filter_4_busy |
+          wkup_detector_4_miodio_4_busy;
+      end
+      addr_hit[394]: begin
+        reg_busy =
+          wkup_detector_5_mode_5_busy |
+          wkup_detector_5_filter_5_busy |
+          wkup_detector_5_miodio_5_busy;
+      end
+      addr_hit[395]: begin
+        reg_busy =
+          wkup_detector_6_mode_6_busy |
+          wkup_detector_6_filter_6_busy |
+          wkup_detector_6_miodio_6_busy;
+      end
+      addr_hit[396]: begin
+        reg_busy =
+          wkup_detector_7_mode_7_busy |
+          wkup_detector_7_filter_7_busy |
+          wkup_detector_7_miodio_7_busy;
+      end
+      addr_hit[397]: begin
+        reg_busy = wkup_detector_cnt_th_0_busy;
+      end
+      addr_hit[398]: begin
+        reg_busy = wkup_detector_cnt_th_1_busy;
+      end
+      addr_hit[399]: begin
+        reg_busy = wkup_detector_cnt_th_2_busy;
+      end
+      addr_hit[400]: begin
+        reg_busy = wkup_detector_cnt_th_3_busy;
+      end
+      addr_hit[401]: begin
+        reg_busy = wkup_detector_cnt_th_4_busy;
+      end
+      addr_hit[402]: begin
+        reg_busy = wkup_detector_cnt_th_5_busy;
+      end
+      addr_hit[403]: begin
+        reg_busy = wkup_detector_cnt_th_6_busy;
+      end
+      addr_hit[404]: begin
+        reg_busy = wkup_detector_cnt_th_7_busy;
+      end
+      addr_hit[413]: begin
+        reg_busy =
+          wkup_cause_cause_0_busy |
+          wkup_cause_cause_1_busy |
+          wkup_cause_cause_2_busy |
+          wkup_cause_cause_3_busy |
+          wkup_cause_cause_4_busy |
+          wkup_cause_cause_5_busy |
+          wkup_cause_cause_6_busy |
+          wkup_cause_cause_7_busy;
+      end
       default: begin
         reg_busy  = '0;
       end

--- a/hw/ip/pinmux/rtl/pinmux_wkup.sv
+++ b/hw/ip/pinmux/rtl/pinmux_wkup.sv
@@ -2,71 +2,22 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
+module pinmux_wkup
+  import pinmux_pkg::*;
+  import pinmux_reg_pkg::*;
+#(
   parameter int Cycles = 4
 ) (
-  input                    clk_i,
-  input                    rst_ni,
-  // Always on clock / reset
-  input                    clk_aon_i,
-  input                    rst_aon_ni,
-  // These signals get synchronized to the
-  // slow AON clock within this module.
-  // Note that wkup_en_i is assumed to be level encoded.
-  input                    wkup_en_i,
-  input                    filter_en_i,
-  input wkup_mode_e        wkup_mode_i,
-  input [WkupCntWidth-1:0] wkup_cnt_th_i,
-  input                    pin_value_i,
-  // Signals to/from cause register.
-  // They are synched to/from the AON clock internally
-  input                    wkup_cause_valid_i,
-  input                    wkup_cause_data_i,
-  output                   wkup_cause_data_o,
-  // This signal is running on the AON clock
-  // and is held high as long as the cause register
-  // has not been cleared.
-  output logic             aon_wkup_req_o
+  input                                 clk_i,
+  input                                 rst_ni,
+  input                                 wkup_en_i,
+  input                                 filter_en_i,
+  input  wkup_mode_e                    wkup_mode_i,
+  input              [WkupCntWidth-1:0] wkup_cnt_th_i,
+  input                                 pin_value_i,
+  // Wakeup request pulse signal
+  output logic                          aon_wkup_pulse_o
 );
-
-  ///////////////////////////
-  // Input Synchronization //
-  ///////////////////////////
-
-  // Synchronize configuration to slow clock
-  wkup_mode_e aon_wkup_mode_q;
-  logic aon_filter_en_q;
-  logic aon_wkup_en_d, aon_wkup_en_q;
-  logic [WkupCntWidth-1:0] aon_wkup_cnt_th_q;
-
-  prim_flop_2sync #(
-    .Width(1)
-  ) i_prim_flop_2sync_config (
-    .clk_i  ( clk_aon_i      ),
-    .rst_ni ( rst_aon_ni     ),
-    .d_i    ( wkup_en_i     ),
-    .q_o    ( aon_wkup_en_d )
-  );
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : p_sync
-    if (!rst_aon_ni) begin
-      aon_wkup_en_q     <= 1'b0;
-      aon_wkup_mode_q   <= Posedge;
-      aon_filter_en_q   <= 1'b0;
-      aon_wkup_cnt_th_q <= '0;
-    end else begin
-      aon_wkup_en_q <= aon_wkup_en_d;
-      // latch these when going into sleep. note that these
-      // config signals should be stable at this point, since
-      // SW has configured them many cycles ago. hence no
-      // explicit multibit consistency check is performed.
-      if (aon_wkup_en_d & !aon_wkup_en_q) begin
-        aon_wkup_mode_q   <= wkup_mode_i;
-        aon_filter_en_q   <= filter_en_i;
-        aon_wkup_cnt_th_q <= wkup_cnt_th_i;
-      end
-    end
-  end
 
   ////////////////////////////
   // Optional Signal Filter //
@@ -75,123 +26,76 @@ module pinmux_wkup import pinmux_pkg::*; import pinmux_reg_pkg::*; #(
   // This uses a lower value for filtering than GPIO since
   // the always-on clock is slower. This can be disabled,
   // in which case the signal is just combinationally bypassed.
-  logic aon_filter_out, aon_filter_out_d, aon_filter_out_q;
+  logic filter_out, filter_out_d, filter_out_q;
   prim_filter #(
     .Cycles(Cycles)
-  ) i_prim_filter (
-    .clk_i    ( clk_aon_i       ),
-    .rst_ni   ( rst_aon_ni      ),
-    .enable_i ( aon_filter_en_q ),
-    .filter_i ( pin_value_i     ),
-    .filter_o ( aon_filter_out  )
+  ) u_prim_filter (
+    .clk_i,
+    .rst_ni,
+    .enable_i(filter_en_i),
+    .filter_i(pin_value_i),
+    .filter_o(filter_out)
   );
 
   // Run this through a 2 stage synchronizer to
   // prevent metastability.
   prim_flop_2sync #(
     .Width(1)
-  ) i_prim_flop_2sync_filter (
-    .clk_i  ( clk_aon_i  ),
-    .rst_ni ( rst_aon_ni ),
-    .d_i    ( aon_filter_out ),
-    .q_o    ( aon_filter_out_d )
+  ) u_prim_flop_2sync_filter (
+    .clk_i,
+    .rst_ni,
+    .d_i(filter_out),
+    .q_o(filter_out_d)
   );
 
   //////////////////////
   // Pattern Matching //
   //////////////////////
 
-  logic aon_rising, aon_falling;
-  assign aon_falling = ~aon_filter_out_d &  aon_filter_out_q;
-  assign aon_rising  =  aon_filter_out_d & ~aon_filter_out_q;
+  logic rising, falling;
+  assign falling = ~filter_out_d & filter_out_q;
+  assign rising  = filter_out_d & ~filter_out_q;
 
-  logic aon_cnt_en, aon_cnt_eq_th;
-  logic [WkupCntWidth-1:0] aon_cnt_d, aon_cnt_q;
-  assign aon_cnt_d = (aon_cnt_eq_th) ? '0                :
-                     (aon_cnt_en)    ?  aon_cnt_q + 1'b1 : '0;
+  logic cnt_en, cnt_eq_th;
+  logic [WkupCntWidth-1:0] cnt_d, cnt_q;
+  assign cnt_d     = (cnt_eq_th) ? '0 : (cnt_en) ? cnt_q + 1'b1 : '0;
 
-  assign aon_cnt_eq_th = aon_cnt_q == aon_wkup_cnt_th_q;
+  assign cnt_eq_th = (cnt_q == wkup_cnt_th_i);
 
-  logic aon_wkup_pulse;
   always_comb begin : p_mode
-    aon_wkup_pulse = 1'b0;
-    aon_cnt_en     = 1'b0;
-    if (aon_wkup_en_q) begin
-      unique case (aon_wkup_mode_q)
-        Negedge:   aon_wkup_pulse = aon_falling;
-        Edge:      aon_wkup_pulse = aon_rising | aon_falling;
+    aon_wkup_pulse_o = 1'b0;
+    cnt_en           = 1'b0;
+    if (wkup_en_i) begin
+      unique case (wkup_mode_i)
+        Negedge: begin
+          aon_wkup_pulse_o = falling;
+        end
+        Edge: begin
+          aon_wkup_pulse_o = rising | falling;
+        end
         HighTimed: begin
-          aon_cnt_en = aon_filter_out_d;
-          aon_wkup_pulse = aon_cnt_eq_th;
+          cnt_en = filter_out_d;
+          aon_wkup_pulse_o = cnt_eq_th;
         end
         LowTimed: begin
-          aon_cnt_en = ~aon_filter_out_d;
-          aon_wkup_pulse = aon_cnt_eq_th;
+          cnt_en = ~filter_out_d;
+          aon_wkup_pulse_o = cnt_eq_th;
         end
         // Default to rising
-        default:   aon_wkup_pulse = aon_rising;
+        default: begin
+          aon_wkup_pulse_o = rising;
+        end
       endcase
     end
   end
 
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : p_aon_pattern
-    if (!rst_aon_ni) begin
-      aon_filter_out_q <= 1'b0;
-      aon_cnt_q        <= '0;
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_aon_pattern
+    if (!rst_ni) begin
+      filter_out_q <= 1'b0;
+      cnt_q        <= '0;
     end else begin
-      aon_filter_out_q <= aon_filter_out_d;
-      aon_cnt_q        <= aon_cnt_d;
-    end
-  end
-
-  ////////////////////
-  // Cause register //
-  ////////////////////
-
-  // to AON domain
-  logic aon_wkup_cause_valid, aon_wkup_cause_data;
-  logic aon_wkup_cause_d, aon_wkup_cause_q;
-
-  prim_flop_2sync #(
-    .Width(1)
-  ) i_prim_flop_2sync_cause_in (
-    .clk_i  ( clk_aon_i  ),
-    .rst_ni ( rst_aon_ni ),
-    .d_i    ( wkup_cause_data_i   ),
-    .q_o    ( aon_wkup_cause_data )
-  );
-
-  prim_pulse_sync i_prim_pulse_sync_cause (
-    .clk_src_i   ( clk_i                ),
-    .rst_src_ni  ( rst_ni               ),
-    .src_pulse_i ( wkup_cause_valid_i   ),
-    .clk_dst_i   ( clk_aon_i            ),
-    .rst_dst_ni  ( rst_aon_ni           ),
-    .dst_pulse_o ( aon_wkup_cause_valid )
-  );
-
-  // note that aon_wkup_pulse will not be asserted when not in sleep mode
-  assign aon_wkup_cause_d = (aon_wkup_cause_valid) ? aon_wkup_cause_q & aon_wkup_cause_data :
-                                                     aon_wkup_cause_q | aon_wkup_pulse;
-
-  // output to power manager
-  assign aon_wkup_req_o = aon_wkup_cause_q;
-
-  // output to CSR
-  prim_flop_2sync #(
-    .Width(1)
-  ) i_prim_flop_2sync_cause_out (
-    .clk_i,
-    .rst_ni,
-    .d_i    ( aon_wkup_cause_q  ),
-    .q_o    ( wkup_cause_data_o )
-  );
-
-  always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : p_aon_cause
-    if (!rst_aon_ni) begin
-      aon_wkup_cause_q <= 1'b0;
-    end else begin
-      aon_wkup_cause_q <= aon_wkup_cause_d;
+      filter_out_q <= filter_out_d;
+      cnt_q        <= cnt_d;
     end
   end
 

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -676,7 +676,12 @@
                 }
     },
     { multireg: { name:         "WKUP_DETECTOR_EN",
-                  desc:         "Enables for the wakeup detectors."
+                  desc:         '''
+                                Enables for the wakeup detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -684,6 +689,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "0:0",
                       name: "EN",
@@ -699,7 +705,12 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR",
-                  desc:         "Configuration of wakeup condition detectors."
+                  desc:         '''
+                                Configuration of wakeup condition detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -707,6 +718,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "2:0",
                       name: "MODE",
@@ -762,7 +774,12 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR_CNT_TH",
-                  desc:         "Counter thresholds for wakeup condition detectors."
+                  desc:         '''
+                                Counter thresholds for wakeup condition detectors.
+                                Note that these registers are synced to the always-on clock.
+                                The first write access always completes immediately.
+                                However, read/write accesses following a write will block until that write has completed.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -770,6 +787,7 @@
                   regwen:       "WKUP_DETECTOR_REGWEN",
                   regwen_multi: "true",
                   cname:        "DETECTOR",
+                  async:        "clk_aon_i",
                   fields: [
                     { bits: "WkupCntWidth-1:0",
                       name: "TH",
@@ -783,7 +801,10 @@
 
     },
     { multireg: { name:         "WKUP_DETECTOR_PADSEL",
-                  desc:         "Pad selects for pad wakeup condition detectors."
+                  desc:         '''
+                                Pad selects for pad wakeup condition detectors.
+                                This register is NOT synced to the AON domain since the muxing mechanism is implemented in the same way as the pinmux muxing matrix.
+                                '''
                   count:        "NWkupDetect",
                   compact:      "false",
                   swaccess:     "rw",
@@ -806,13 +827,17 @@
 
     },
     { multireg: { name:     "WKUP_CAUSE",
-                  desc:     "Cause registers for wakeup detectors."
+                  desc:     '''
+                            Cause registers for wakeup detectors.
+                            Note that these registers are synced to the always-on clock.
+                            The first write access always completes immediately.
+                            However, read/write accesses following a write will block until that write has completed.
+                            '''
                   count:    "NWkupDetect",
                   swaccess: "rw0c",
                   hwaccess: "hrw",
-                  hwext:    "true",
-                  hwqe:     "true",
                   cname:    "DETECTOR",
+                  async:    "clk_aon_i",
                   fields: [
                     { bits: "0",
                       name: "CAUSE",
@@ -821,10 +846,6 @@
                       '''
                     }
                   ]
-                  // these CSRs live in the slow AON clock domain and
-                  // clearing them will be very slow and the changes
-                  // are not immediately visible.
-                  tags: ["excl:CsrAllTests:CsrExclWriteCheck"]
                 }
 
     },

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_pkg.sv
@@ -96,7 +96,6 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     logic        q;
-    logic        qe;
   } pinmux_reg2hw_wkup_cause_mreg_t;
 
   typedef struct packed {
@@ -119,35 +118,36 @@ package pinmux_reg_pkg;
 
   typedef struct packed {
     logic        d;
+    logic        de;
   } pinmux_hw2reg_wkup_cause_mreg_t;
 
   // Register -> HW type
   typedef struct packed {
-    pinmux_reg2hw_alert_test_reg_t alert_test; // [2120:2119]
-    pinmux_reg2hw_mio_periph_insel_mreg_t [55:0] mio_periph_insel; // [2118:1783]
-    pinmux_reg2hw_mio_outsel_mreg_t [46:0] mio_outsel; // [1782:1454]
-    pinmux_reg2hw_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1453:796]
-    pinmux_reg2hw_dio_pad_attr_mreg_t [23:0] dio_pad_attr; // [795:460]
-    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [459:413]
-    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [46:0] mio_pad_sleep_en; // [412:366]
-    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [46:0] mio_pad_sleep_mode; // [365:272]
-    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [23:0] dio_pad_sleep_status; // [271:248]
-    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [23:0] dio_pad_sleep_en; // [247:224]
-    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [23:0] dio_pad_sleep_mode; // [223:176]
-    pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [175:168]
-    pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [167:128]
-    pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [127:64]
-    pinmux_reg2hw_wkup_detector_padsel_mreg_t [7:0] wkup_detector_padsel; // [63:16]
-    pinmux_reg2hw_wkup_cause_mreg_t [7:0] wkup_cause; // [15:0]
+    pinmux_reg2hw_alert_test_reg_t alert_test; // [2112:2111]
+    pinmux_reg2hw_mio_periph_insel_mreg_t [55:0] mio_periph_insel; // [2110:1775]
+    pinmux_reg2hw_mio_outsel_mreg_t [46:0] mio_outsel; // [1774:1446]
+    pinmux_reg2hw_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1445:788]
+    pinmux_reg2hw_dio_pad_attr_mreg_t [23:0] dio_pad_attr; // [787:452]
+    pinmux_reg2hw_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [451:405]
+    pinmux_reg2hw_mio_pad_sleep_en_mreg_t [46:0] mio_pad_sleep_en; // [404:358]
+    pinmux_reg2hw_mio_pad_sleep_mode_mreg_t [46:0] mio_pad_sleep_mode; // [357:264]
+    pinmux_reg2hw_dio_pad_sleep_status_mreg_t [23:0] dio_pad_sleep_status; // [263:240]
+    pinmux_reg2hw_dio_pad_sleep_en_mreg_t [23:0] dio_pad_sleep_en; // [239:216]
+    pinmux_reg2hw_dio_pad_sleep_mode_mreg_t [23:0] dio_pad_sleep_mode; // [215:168]
+    pinmux_reg2hw_wkup_detector_en_mreg_t [7:0] wkup_detector_en; // [167:160]
+    pinmux_reg2hw_wkup_detector_mreg_t [7:0] wkup_detector; // [159:120]
+    pinmux_reg2hw_wkup_detector_cnt_th_mreg_t [7:0] wkup_detector_cnt_th; // [119:56]
+    pinmux_reg2hw_wkup_detector_padsel_mreg_t [7:0] wkup_detector_padsel; // [55:8]
+    pinmux_reg2hw_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
   } pinmux_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    pinmux_hw2reg_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1072:462]
-    pinmux_hw2reg_dio_pad_attr_mreg_t [23:0] dio_pad_attr; // [461:150]
-    pinmux_hw2reg_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [149:56]
-    pinmux_hw2reg_dio_pad_sleep_status_mreg_t [23:0] dio_pad_sleep_status; // [55:8]
-    pinmux_hw2reg_wkup_cause_mreg_t [7:0] wkup_cause; // [7:0]
+    pinmux_hw2reg_mio_pad_attr_mreg_t [46:0] mio_pad_attr; // [1080:470]
+    pinmux_hw2reg_dio_pad_attr_mreg_t [23:0] dio_pad_attr; // [469:158]
+    pinmux_hw2reg_mio_pad_sleep_status_mreg_t [46:0] mio_pad_sleep_status; // [157:64]
+    pinmux_hw2reg_dio_pad_sleep_status_mreg_t [23:0] dio_pad_sleep_status; // [63:16]
+    pinmux_hw2reg_wkup_cause_mreg_t [7:0] wkup_cause; // [15:0]
   } pinmux_hw2reg_t;
 
   // Register offsets
@@ -903,15 +903,6 @@ package pinmux_reg_pkg;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_22_ATTR_22_RESVAL = 13'h 0;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_23_RESVAL = 13'h 0;
   parameter logic [12:0] PINMUX_DIO_PAD_ATTR_23_ATTR_23_RESVAL = 13'h 0;
-  parameter logic [7:0] PINMUX_WKUP_CAUSE_RESVAL = 8'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_0_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_1_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_2_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_3_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_4_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_5_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_6_RESVAL = 1'h 0;
-  parameter logic [0:0] PINMUX_WKUP_CAUSE_CAUSE_7_RESVAL = 1'h 0;
 
   // Register index
   typedef enum int {

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -9,6 +9,8 @@
 module pinmux_reg_top (
   input clk_i,
   input rst_ni,
+  input clk_aon_i,
+  input rst_aon_ni,
 
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
@@ -102,6 +104,15 @@ module pinmux_reg_top (
   );
 
   // cdc oversampling signals
+    logic sync_aon_update;
+  prim_pulse_sync u_aon_tgl (
+    .clk_src_i(clk_aon_i),
+    .rst_src_ni(rst_aon_ni),
+    .src_pulse_i(1'b1),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(sync_aon_update)
+  );
 
   assign reg_rdata = reg_rdata_next ;
   assign reg_error = (devmode_i & addrmiss) | wr_err | intg_err;
@@ -2037,107 +2048,147 @@ module pinmux_reg_top (
   logic wkup_detector_en_0_we;
   logic wkup_detector_en_0_qs;
   logic wkup_detector_en_0_wd;
+  logic wkup_detector_en_0_busy;
   logic wkup_detector_en_1_we;
   logic wkup_detector_en_1_qs;
   logic wkup_detector_en_1_wd;
+  logic wkup_detector_en_1_busy;
   logic wkup_detector_en_2_we;
   logic wkup_detector_en_2_qs;
   logic wkup_detector_en_2_wd;
+  logic wkup_detector_en_2_busy;
   logic wkup_detector_en_3_we;
   logic wkup_detector_en_3_qs;
   logic wkup_detector_en_3_wd;
+  logic wkup_detector_en_3_busy;
   logic wkup_detector_en_4_we;
   logic wkup_detector_en_4_qs;
   logic wkup_detector_en_4_wd;
+  logic wkup_detector_en_4_busy;
   logic wkup_detector_en_5_we;
   logic wkup_detector_en_5_qs;
   logic wkup_detector_en_5_wd;
+  logic wkup_detector_en_5_busy;
   logic wkup_detector_en_6_we;
   logic wkup_detector_en_6_qs;
   logic wkup_detector_en_6_wd;
+  logic wkup_detector_en_6_busy;
   logic wkup_detector_en_7_we;
   logic wkup_detector_en_7_qs;
   logic wkup_detector_en_7_wd;
+  logic wkup_detector_en_7_busy;
   logic wkup_detector_0_we;
   logic [2:0] wkup_detector_0_mode_0_qs;
   logic [2:0] wkup_detector_0_mode_0_wd;
+  logic wkup_detector_0_mode_0_busy;
   logic wkup_detector_0_filter_0_qs;
   logic wkup_detector_0_filter_0_wd;
+  logic wkup_detector_0_filter_0_busy;
   logic wkup_detector_0_miodio_0_qs;
   logic wkup_detector_0_miodio_0_wd;
+  logic wkup_detector_0_miodio_0_busy;
   logic wkup_detector_1_we;
   logic [2:0] wkup_detector_1_mode_1_qs;
   logic [2:0] wkup_detector_1_mode_1_wd;
+  logic wkup_detector_1_mode_1_busy;
   logic wkup_detector_1_filter_1_qs;
   logic wkup_detector_1_filter_1_wd;
+  logic wkup_detector_1_filter_1_busy;
   logic wkup_detector_1_miodio_1_qs;
   logic wkup_detector_1_miodio_1_wd;
+  logic wkup_detector_1_miodio_1_busy;
   logic wkup_detector_2_we;
   logic [2:0] wkup_detector_2_mode_2_qs;
   logic [2:0] wkup_detector_2_mode_2_wd;
+  logic wkup_detector_2_mode_2_busy;
   logic wkup_detector_2_filter_2_qs;
   logic wkup_detector_2_filter_2_wd;
+  logic wkup_detector_2_filter_2_busy;
   logic wkup_detector_2_miodio_2_qs;
   logic wkup_detector_2_miodio_2_wd;
+  logic wkup_detector_2_miodio_2_busy;
   logic wkup_detector_3_we;
   logic [2:0] wkup_detector_3_mode_3_qs;
   logic [2:0] wkup_detector_3_mode_3_wd;
+  logic wkup_detector_3_mode_3_busy;
   logic wkup_detector_3_filter_3_qs;
   logic wkup_detector_3_filter_3_wd;
+  logic wkup_detector_3_filter_3_busy;
   logic wkup_detector_3_miodio_3_qs;
   logic wkup_detector_3_miodio_3_wd;
+  logic wkup_detector_3_miodio_3_busy;
   logic wkup_detector_4_we;
   logic [2:0] wkup_detector_4_mode_4_qs;
   logic [2:0] wkup_detector_4_mode_4_wd;
+  logic wkup_detector_4_mode_4_busy;
   logic wkup_detector_4_filter_4_qs;
   logic wkup_detector_4_filter_4_wd;
+  logic wkup_detector_4_filter_4_busy;
   logic wkup_detector_4_miodio_4_qs;
   logic wkup_detector_4_miodio_4_wd;
+  logic wkup_detector_4_miodio_4_busy;
   logic wkup_detector_5_we;
   logic [2:0] wkup_detector_5_mode_5_qs;
   logic [2:0] wkup_detector_5_mode_5_wd;
+  logic wkup_detector_5_mode_5_busy;
   logic wkup_detector_5_filter_5_qs;
   logic wkup_detector_5_filter_5_wd;
+  logic wkup_detector_5_filter_5_busy;
   logic wkup_detector_5_miodio_5_qs;
   logic wkup_detector_5_miodio_5_wd;
+  logic wkup_detector_5_miodio_5_busy;
   logic wkup_detector_6_we;
   logic [2:0] wkup_detector_6_mode_6_qs;
   logic [2:0] wkup_detector_6_mode_6_wd;
+  logic wkup_detector_6_mode_6_busy;
   logic wkup_detector_6_filter_6_qs;
   logic wkup_detector_6_filter_6_wd;
+  logic wkup_detector_6_filter_6_busy;
   logic wkup_detector_6_miodio_6_qs;
   logic wkup_detector_6_miodio_6_wd;
+  logic wkup_detector_6_miodio_6_busy;
   logic wkup_detector_7_we;
   logic [2:0] wkup_detector_7_mode_7_qs;
   logic [2:0] wkup_detector_7_mode_7_wd;
+  logic wkup_detector_7_mode_7_busy;
   logic wkup_detector_7_filter_7_qs;
   logic wkup_detector_7_filter_7_wd;
+  logic wkup_detector_7_filter_7_busy;
   logic wkup_detector_7_miodio_7_qs;
   logic wkup_detector_7_miodio_7_wd;
+  logic wkup_detector_7_miodio_7_busy;
   logic wkup_detector_cnt_th_0_we;
   logic [7:0] wkup_detector_cnt_th_0_qs;
   logic [7:0] wkup_detector_cnt_th_0_wd;
+  logic wkup_detector_cnt_th_0_busy;
   logic wkup_detector_cnt_th_1_we;
   logic [7:0] wkup_detector_cnt_th_1_qs;
   logic [7:0] wkup_detector_cnt_th_1_wd;
+  logic wkup_detector_cnt_th_1_busy;
   logic wkup_detector_cnt_th_2_we;
   logic [7:0] wkup_detector_cnt_th_2_qs;
   logic [7:0] wkup_detector_cnt_th_2_wd;
+  logic wkup_detector_cnt_th_2_busy;
   logic wkup_detector_cnt_th_3_we;
   logic [7:0] wkup_detector_cnt_th_3_qs;
   logic [7:0] wkup_detector_cnt_th_3_wd;
+  logic wkup_detector_cnt_th_3_busy;
   logic wkup_detector_cnt_th_4_we;
   logic [7:0] wkup_detector_cnt_th_4_qs;
   logic [7:0] wkup_detector_cnt_th_4_wd;
+  logic wkup_detector_cnt_th_4_busy;
   logic wkup_detector_cnt_th_5_we;
   logic [7:0] wkup_detector_cnt_th_5_qs;
   logic [7:0] wkup_detector_cnt_th_5_wd;
+  logic wkup_detector_cnt_th_5_busy;
   logic wkup_detector_cnt_th_6_we;
   logic [7:0] wkup_detector_cnt_th_6_qs;
   logic [7:0] wkup_detector_cnt_th_6_wd;
+  logic wkup_detector_cnt_th_6_busy;
   logic wkup_detector_cnt_th_7_we;
   logic [7:0] wkup_detector_cnt_th_7_qs;
   logic [7:0] wkup_detector_cnt_th_7_wd;
+  logic wkup_detector_cnt_th_7_busy;
   logic wkup_detector_padsel_0_we;
   logic [5:0] wkup_detector_padsel_0_qs;
   logic [5:0] wkup_detector_padsel_0_wd;
@@ -2162,24 +2213,31 @@ module pinmux_reg_top (
   logic wkup_detector_padsel_7_we;
   logic [5:0] wkup_detector_padsel_7_qs;
   logic [5:0] wkup_detector_padsel_7_wd;
-  logic wkup_cause_re;
   logic wkup_cause_we;
   logic wkup_cause_cause_0_qs;
   logic wkup_cause_cause_0_wd;
+  logic wkup_cause_cause_0_busy;
   logic wkup_cause_cause_1_qs;
   logic wkup_cause_cause_1_wd;
+  logic wkup_cause_cause_1_busy;
   logic wkup_cause_cause_2_qs;
   logic wkup_cause_cause_2_wd;
+  logic wkup_cause_cause_2_busy;
   logic wkup_cause_cause_3_qs;
   logic wkup_cause_cause_3_wd;
+  logic wkup_cause_cause_3_busy;
   logic wkup_cause_cause_4_qs;
   logic wkup_cause_cause_4_wd;
+  logic wkup_cause_cause_4_busy;
   logic wkup_cause_cause_5_qs;
   logic wkup_cause_cause_5_wd;
+  logic wkup_cause_cause_5_busy;
   logic wkup_cause_cause_6_qs;
   logic wkup_cause_cause_6_wd;
+  logic wkup_cause_cause_6_busy;
   logic wkup_cause_cause_7_qs;
   logic wkup_cause_cause_7_wd;
+  logic wkup_cause_cause_7_busy;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -18673,217 +18731,185 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_en
   // R[wkup_detector_en_0]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_en_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[0].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_en_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_0_busy),
+    .src_qs_o     (wkup_detector_en_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[0].q)
   );
 
   // Subregister 1 of Multireg wkup_detector_en
   // R[wkup_detector_en_1]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_en_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[1].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_en_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_1_busy),
+    .src_qs_o     (wkup_detector_en_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[1].q)
   );
 
   // Subregister 2 of Multireg wkup_detector_en
   // R[wkup_detector_en_2]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_en_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[2].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_en_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_2_busy),
+    .src_qs_o     (wkup_detector_en_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[2].q)
   );
 
   // Subregister 3 of Multireg wkup_detector_en
   // R[wkup_detector_en_3]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_en_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[3].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_en_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_3_busy),
+    .src_qs_o     (wkup_detector_en_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[3].q)
   );
 
   // Subregister 4 of Multireg wkup_detector_en
   // R[wkup_detector_en_4]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_en_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[4].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_en_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_4_busy),
+    .src_qs_o     (wkup_detector_en_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[4].q)
   );
 
   // Subregister 5 of Multireg wkup_detector_en
   // R[wkup_detector_en_5]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_en_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[5].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_en_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_5_busy),
+    .src_qs_o     (wkup_detector_en_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[5].q)
   );
 
   // Subregister 6 of Multireg wkup_detector_en
   // R[wkup_detector_en_6]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_en_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[6].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_en_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_6_busy),
+    .src_qs_o     (wkup_detector_en_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[6].q)
   );
 
   // Subregister 7 of Multireg wkup_detector_en
   // R[wkup_detector_en_7]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_en_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_en_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_en[7].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_en_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_en_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_en_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_en_7_busy),
+    .src_qs_o     (wkup_detector_en_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_en[7].q)
   );
 
 
@@ -18892,80 +18918,68 @@ module pinmux_reg_top (
   // R[wkup_detector_0]: V(False)
 
   // F[mode_0]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_0_mode_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_0_mode_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[0].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_0_mode_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_0_mode_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_0_mode_0_busy),
+    .src_qs_o     (wkup_detector_0_mode_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[0].mode.q)
   );
 
 
   // F[filter_0]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_filter_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_0_filter_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[0].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_0_filter_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_0_filter_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_0_filter_0_busy),
+    .src_qs_o     (wkup_detector_0_filter_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[0].filter.q)
   );
 
 
   // F[miodio_0]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_miodio_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_0_miodio_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[0].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_0_miodio_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_0_miodio_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_0_miodio_0_busy),
+    .src_qs_o     (wkup_detector_0_miodio_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[0].miodio.q)
   );
 
 
@@ -18973,80 +18987,68 @@ module pinmux_reg_top (
   // R[wkup_detector_1]: V(False)
 
   // F[mode_1]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_1_mode_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_1_mode_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[1].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_1_mode_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_1_mode_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_1_mode_1_busy),
+    .src_qs_o     (wkup_detector_1_mode_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[1].mode.q)
   );
 
 
   // F[filter_1]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_filter_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_1_filter_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[1].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_1_filter_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_1_filter_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_1_filter_1_busy),
+    .src_qs_o     (wkup_detector_1_filter_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[1].filter.q)
   );
 
 
   // F[miodio_1]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_miodio_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_1_miodio_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[1].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_1_miodio_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_1_miodio_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_1_miodio_1_busy),
+    .src_qs_o     (wkup_detector_1_miodio_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[1].miodio.q)
   );
 
 
@@ -19054,80 +19056,68 @@ module pinmux_reg_top (
   // R[wkup_detector_2]: V(False)
 
   // F[mode_2]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_2_mode_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_2_mode_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[2].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_2_mode_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_2_mode_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_2_mode_2_busy),
+    .src_qs_o     (wkup_detector_2_mode_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[2].mode.q)
   );
 
 
   // F[filter_2]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_filter_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_2_filter_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[2].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_2_filter_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_2_filter_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_2_filter_2_busy),
+    .src_qs_o     (wkup_detector_2_filter_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[2].filter.q)
   );
 
 
   // F[miodio_2]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_miodio_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_2_miodio_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[2].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_2_miodio_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_2_miodio_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_2_miodio_2_busy),
+    .src_qs_o     (wkup_detector_2_miodio_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[2].miodio.q)
   );
 
 
@@ -19135,80 +19125,68 @@ module pinmux_reg_top (
   // R[wkup_detector_3]: V(False)
 
   // F[mode_3]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_3_mode_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_3_mode_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[3].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_3_mode_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_3_mode_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_3_mode_3_busy),
+    .src_qs_o     (wkup_detector_3_mode_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[3].mode.q)
   );
 
 
   // F[filter_3]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_filter_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_3_filter_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[3].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_3_filter_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_3_filter_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_3_filter_3_busy),
+    .src_qs_o     (wkup_detector_3_filter_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[3].filter.q)
   );
 
 
   // F[miodio_3]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_miodio_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_3_miodio_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[3].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_3_miodio_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_3_miodio_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_3_miodio_3_busy),
+    .src_qs_o     (wkup_detector_3_miodio_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[3].miodio.q)
   );
 
 
@@ -19216,80 +19194,68 @@ module pinmux_reg_top (
   // R[wkup_detector_4]: V(False)
 
   // F[mode_4]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_4_mode_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_4_mode_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[4].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_4_mode_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_4_mode_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_4_mode_4_busy),
+    .src_qs_o     (wkup_detector_4_mode_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[4].mode.q)
   );
 
 
   // F[filter_4]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_filter_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_4_filter_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[4].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_4_filter_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_4_filter_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_4_filter_4_busy),
+    .src_qs_o     (wkup_detector_4_filter_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[4].filter.q)
   );
 
 
   // F[miodio_4]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_miodio_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_4_miodio_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[4].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_4_miodio_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_4_miodio_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_4_miodio_4_busy),
+    .src_qs_o     (wkup_detector_4_miodio_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[4].miodio.q)
   );
 
 
@@ -19297,80 +19263,68 @@ module pinmux_reg_top (
   // R[wkup_detector_5]: V(False)
 
   // F[mode_5]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_5_mode_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_5_mode_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[5].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_5_mode_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_5_mode_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_5_mode_5_busy),
+    .src_qs_o     (wkup_detector_5_mode_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[5].mode.q)
   );
 
 
   // F[filter_5]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_filter_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_5_filter_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[5].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_5_filter_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_5_filter_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_5_filter_5_busy),
+    .src_qs_o     (wkup_detector_5_filter_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[5].filter.q)
   );
 
 
   // F[miodio_5]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_miodio_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_5_miodio_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[5].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_5_miodio_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_5_miodio_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_5_miodio_5_busy),
+    .src_qs_o     (wkup_detector_5_miodio_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[5].miodio.q)
   );
 
 
@@ -19378,80 +19332,68 @@ module pinmux_reg_top (
   // R[wkup_detector_6]: V(False)
 
   // F[mode_6]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_6_mode_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_6_mode_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[6].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_6_mode_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_6_mode_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_6_mode_6_busy),
+    .src_qs_o     (wkup_detector_6_mode_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[6].mode.q)
   );
 
 
   // F[filter_6]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_filter_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_6_filter_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[6].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_6_filter_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_6_filter_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_6_filter_6_busy),
+    .src_qs_o     (wkup_detector_6_filter_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[6].filter.q)
   );
 
 
   // F[miodio_6]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_miodio_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_6_miodio_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[6].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_6_miodio_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_6_miodio_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_6_miodio_6_busy),
+    .src_qs_o     (wkup_detector_6_miodio_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[6].miodio.q)
   );
 
 
@@ -19459,80 +19401,68 @@ module pinmux_reg_top (
   // R[wkup_detector_7]: V(False)
 
   // F[mode_7]: 2:0
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_7_mode_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_7_mode_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[7].mode.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_7_mode_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_7_mode_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_7_mode_7_busy),
+    .src_qs_o     (wkup_detector_7_mode_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[7].mode.q)
   );
 
 
   // F[filter_7]: 3:3
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_filter_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_7_filter_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[7].filter.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_7_filter_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_7_filter_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_7_filter_7_busy),
+    .src_qs_o     (wkup_detector_7_filter_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[7].filter.q)
   );
 
 
   // F[miodio_7]: 4:4
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_miodio_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_7_miodio_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector[7].miodio.q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_7_miodio_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_7_miodio_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_7_miodio_7_busy),
+    .src_qs_o     (wkup_detector_7_miodio_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector[7].miodio.q)
   );
 
 
@@ -19541,217 +19471,185 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_0]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_0_we & wkup_detector_regwen_0_qs),
-    .wd     (wkup_detector_cnt_th_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[0].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_0_we & wkup_detector_regwen_0_qs),
+    .src_wd_i     (wkup_detector_cnt_th_0_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_0_busy),
+    .src_qs_o     (wkup_detector_cnt_th_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[0].q)
   );
 
   // Subregister 1 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_1]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_1_we & wkup_detector_regwen_1_qs),
-    .wd     (wkup_detector_cnt_th_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[1].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_1_we & wkup_detector_regwen_1_qs),
+    .src_wd_i     (wkup_detector_cnt_th_1_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_1_busy),
+    .src_qs_o     (wkup_detector_cnt_th_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[1].q)
   );
 
   // Subregister 2 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_2]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_2 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_2_we & wkup_detector_regwen_2_qs),
-    .wd     (wkup_detector_cnt_th_2_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[2].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_2_we & wkup_detector_regwen_2_qs),
+    .src_wd_i     (wkup_detector_cnt_th_2_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_2_busy),
+    .src_qs_o     (wkup_detector_cnt_th_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[2].q)
   );
 
   // Subregister 3 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_3]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_3 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_3_we & wkup_detector_regwen_3_qs),
-    .wd     (wkup_detector_cnt_th_3_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[3].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_3_we & wkup_detector_regwen_3_qs),
+    .src_wd_i     (wkup_detector_cnt_th_3_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_3_busy),
+    .src_qs_o     (wkup_detector_cnt_th_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[3].q)
   );
 
   // Subregister 4 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_4]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_4 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_4_we & wkup_detector_regwen_4_qs),
-    .wd     (wkup_detector_cnt_th_4_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[4].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_4_we & wkup_detector_regwen_4_qs),
+    .src_wd_i     (wkup_detector_cnt_th_4_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_4_busy),
+    .src_qs_o     (wkup_detector_cnt_th_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[4].q)
   );
 
   // Subregister 5 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_5]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_5 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_5_we & wkup_detector_regwen_5_qs),
-    .wd     (wkup_detector_cnt_th_5_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[5].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_5_we & wkup_detector_regwen_5_qs),
+    .src_wd_i     (wkup_detector_cnt_th_5_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_5_busy),
+    .src_qs_o     (wkup_detector_cnt_th_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[5].q)
   );
 
   // Subregister 6 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_6]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_6 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_6_we & wkup_detector_regwen_6_qs),
-    .wd     (wkup_detector_cnt_th_6_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[6].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_6_we & wkup_detector_regwen_6_qs),
+    .src_wd_i     (wkup_detector_cnt_th_6_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_6_busy),
+    .src_qs_o     (wkup_detector_cnt_th_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[6].q)
   );
 
   // Subregister 7 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_7]: V(False)
 
-  prim_subreg #(
+  prim_subreg_async #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_7 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (wkup_detector_cnt_th_7_we & wkup_detector_regwen_7_qs),
-    .wd     (wkup_detector_cnt_th_7_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.wkup_detector_cnt_th[7].q),
-
-    // to register interface (read)
-    .qs     (wkup_detector_cnt_th_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_detector_cnt_th_7_we & wkup_detector_regwen_7_qs),
+    .src_wd_i     (wkup_detector_cnt_th_7_wd),
+    .dst_de_i     (1'b0),
+    .dst_d_i      ('0),
+    .src_busy_o   (wkup_detector_cnt_th_7_busy),
+    .src_qs_o     (wkup_detector_cnt_th_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_detector_cnt_th[7].q)
   );
 
 
@@ -19975,125 +19873,181 @@ module pinmux_reg_top (
 
 
   // Subregister 0 of Multireg wkup_cause
-  // R[wkup_cause]: V(True)
+  // R[wkup_cause]: V(False)
 
   // F[cause_0]: 0:0
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_0 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_0_wd),
-    .d      (hw2reg.wkup_cause[0].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[0].qe),
-    .q      (reg2hw.wkup_cause[0].q),
-    .qs     (wkup_cause_cause_0_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_0_wd),
+    .dst_de_i     (hw2reg.wkup_cause[0].de),
+    .dst_d_i      (hw2reg.wkup_cause[0].d),
+    .src_busy_o   (wkup_cause_cause_0_busy),
+    .src_qs_o     (wkup_cause_cause_0_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[0].q)
   );
 
 
   // F[cause_1]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_1 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_1_wd),
-    .d      (hw2reg.wkup_cause[1].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[1].qe),
-    .q      (reg2hw.wkup_cause[1].q),
-    .qs     (wkup_cause_cause_1_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_1_wd),
+    .dst_de_i     (hw2reg.wkup_cause[1].de),
+    .dst_d_i      (hw2reg.wkup_cause[1].d),
+    .src_busy_o   (wkup_cause_cause_1_busy),
+    .src_qs_o     (wkup_cause_cause_1_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[1].q)
   );
 
 
   // F[cause_2]: 2:2
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_2 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_2_wd),
-    .d      (hw2reg.wkup_cause[2].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[2].qe),
-    .q      (reg2hw.wkup_cause[2].q),
-    .qs     (wkup_cause_cause_2_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_2_wd),
+    .dst_de_i     (hw2reg.wkup_cause[2].de),
+    .dst_d_i      (hw2reg.wkup_cause[2].d),
+    .src_busy_o   (wkup_cause_cause_2_busy),
+    .src_qs_o     (wkup_cause_cause_2_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[2].q)
   );
 
 
   // F[cause_3]: 3:3
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_3 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_3_wd),
-    .d      (hw2reg.wkup_cause[3].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[3].qe),
-    .q      (reg2hw.wkup_cause[3].q),
-    .qs     (wkup_cause_cause_3_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_3_wd),
+    .dst_de_i     (hw2reg.wkup_cause[3].de),
+    .dst_d_i      (hw2reg.wkup_cause[3].d),
+    .src_busy_o   (wkup_cause_cause_3_busy),
+    .src_qs_o     (wkup_cause_cause_3_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[3].q)
   );
 
 
   // F[cause_4]: 4:4
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_4 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_4_wd),
-    .d      (hw2reg.wkup_cause[4].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[4].qe),
-    .q      (reg2hw.wkup_cause[4].q),
-    .qs     (wkup_cause_cause_4_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_4_wd),
+    .dst_de_i     (hw2reg.wkup_cause[4].de),
+    .dst_d_i      (hw2reg.wkup_cause[4].d),
+    .src_busy_o   (wkup_cause_cause_4_busy),
+    .src_qs_o     (wkup_cause_cause_4_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[4].q)
   );
 
 
   // F[cause_5]: 5:5
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_5 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_5_wd),
-    .d      (hw2reg.wkup_cause[5].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[5].qe),
-    .q      (reg2hw.wkup_cause[5].q),
-    .qs     (wkup_cause_cause_5_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_5_wd),
+    .dst_de_i     (hw2reg.wkup_cause[5].de),
+    .dst_d_i      (hw2reg.wkup_cause[5].d),
+    .src_busy_o   (wkup_cause_cause_5_busy),
+    .src_qs_o     (wkup_cause_cause_5_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[5].q)
   );
 
 
   // F[cause_6]: 6:6
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_6 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_6_wd),
-    .d      (hw2reg.wkup_cause[6].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[6].qe),
-    .q      (reg2hw.wkup_cause[6].q),
-    .qs     (wkup_cause_cause_6_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_6_wd),
+    .dst_de_i     (hw2reg.wkup_cause[6].de),
+    .dst_d_i      (hw2reg.wkup_cause[6].d),
+    .src_busy_o   (wkup_cause_cause_6_busy),
+    .src_qs_o     (wkup_cause_cause_6_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[6].q)
   );
 
 
   // F[cause_7]: 7:7
-  prim_subreg_ext #(
-    .DW    (1)
+  prim_subreg_async #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
   ) u_wkup_cause_cause_7 (
-    .re     (wkup_cause_re),
-    .we     (wkup_cause_we),
-    .wd     (wkup_cause_cause_7_wd),
-    .d      (hw2reg.wkup_cause[7].d),
-    .qre    (),
-    .qe     (reg2hw.wkup_cause[7].qe),
-    .q      (reg2hw.wkup_cause[7].q),
-    .qs     (wkup_cause_cause_7_qs)
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_we_i     (wkup_cause_we),
+    .src_wd_i     (wkup_cause_cause_7_wd),
+    .dst_de_i     (hw2reg.wkup_cause[7].de),
+    .dst_d_i      (hw2reg.wkup_cause[7].d),
+    .src_busy_o   (wkup_cause_cause_7_busy),
+    .src_qs_o     (wkup_cause_cause_7_qs),
+    .dst_qe_o     (),
+    .q            (reg2hw.wkup_cause[7].q)
   );
 
 
@@ -23377,7 +23331,6 @@ module pinmux_reg_top (
   assign wkup_detector_padsel_7_we = addr_hit[604] & reg_we & !reg_error;
 
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
-  assign wkup_cause_re = addr_hit[605] & reg_re & !reg_error;
   assign wkup_cause_we = addr_hit[605] & reg_we & !reg_error;
 
   assign wkup_cause_cause_0_wd = reg_wdata[0];
@@ -25925,6 +25878,113 @@ module pinmux_reg_top (
   always_comb begin
     reg_busy = '0;
     unique case (1'b1)
+      addr_hit[573]: begin
+        reg_busy = wkup_detector_en_0_busy;
+      end
+      addr_hit[574]: begin
+        reg_busy = wkup_detector_en_1_busy;
+      end
+      addr_hit[575]: begin
+        reg_busy = wkup_detector_en_2_busy;
+      end
+      addr_hit[576]: begin
+        reg_busy = wkup_detector_en_3_busy;
+      end
+      addr_hit[577]: begin
+        reg_busy = wkup_detector_en_4_busy;
+      end
+      addr_hit[578]: begin
+        reg_busy = wkup_detector_en_5_busy;
+      end
+      addr_hit[579]: begin
+        reg_busy = wkup_detector_en_6_busy;
+      end
+      addr_hit[580]: begin
+        reg_busy = wkup_detector_en_7_busy;
+      end
+      addr_hit[581]: begin
+        reg_busy =
+          wkup_detector_0_mode_0_busy |
+          wkup_detector_0_filter_0_busy |
+          wkup_detector_0_miodio_0_busy;
+      end
+      addr_hit[582]: begin
+        reg_busy =
+          wkup_detector_1_mode_1_busy |
+          wkup_detector_1_filter_1_busy |
+          wkup_detector_1_miodio_1_busy;
+      end
+      addr_hit[583]: begin
+        reg_busy =
+          wkup_detector_2_mode_2_busy |
+          wkup_detector_2_filter_2_busy |
+          wkup_detector_2_miodio_2_busy;
+      end
+      addr_hit[584]: begin
+        reg_busy =
+          wkup_detector_3_mode_3_busy |
+          wkup_detector_3_filter_3_busy |
+          wkup_detector_3_miodio_3_busy;
+      end
+      addr_hit[585]: begin
+        reg_busy =
+          wkup_detector_4_mode_4_busy |
+          wkup_detector_4_filter_4_busy |
+          wkup_detector_4_miodio_4_busy;
+      end
+      addr_hit[586]: begin
+        reg_busy =
+          wkup_detector_5_mode_5_busy |
+          wkup_detector_5_filter_5_busy |
+          wkup_detector_5_miodio_5_busy;
+      end
+      addr_hit[587]: begin
+        reg_busy =
+          wkup_detector_6_mode_6_busy |
+          wkup_detector_6_filter_6_busy |
+          wkup_detector_6_miodio_6_busy;
+      end
+      addr_hit[588]: begin
+        reg_busy =
+          wkup_detector_7_mode_7_busy |
+          wkup_detector_7_filter_7_busy |
+          wkup_detector_7_miodio_7_busy;
+      end
+      addr_hit[589]: begin
+        reg_busy = wkup_detector_cnt_th_0_busy;
+      end
+      addr_hit[590]: begin
+        reg_busy = wkup_detector_cnt_th_1_busy;
+      end
+      addr_hit[591]: begin
+        reg_busy = wkup_detector_cnt_th_2_busy;
+      end
+      addr_hit[592]: begin
+        reg_busy = wkup_detector_cnt_th_3_busy;
+      end
+      addr_hit[593]: begin
+        reg_busy = wkup_detector_cnt_th_4_busy;
+      end
+      addr_hit[594]: begin
+        reg_busy = wkup_detector_cnt_th_5_busy;
+      end
+      addr_hit[595]: begin
+        reg_busy = wkup_detector_cnt_th_6_busy;
+      end
+      addr_hit[596]: begin
+        reg_busy = wkup_detector_cnt_th_7_busy;
+      end
+      addr_hit[605]: begin
+        reg_busy =
+          wkup_cause_cause_0_busy |
+          wkup_cause_cause_1_busy |
+          wkup_cause_cause_2_busy |
+          wkup_cause_cause_3_busy |
+          wkup_cause_cause_4_busy |
+          wkup_cause_cause_5_busy |
+          wkup_cause_cause_6_busy |
+          wkup_cause_cause_7_busy;
+      end
       default: begin
         reg_busy  = '0;
       end


### PR DESCRIPTION
This switches over to the new regfile CDC option such that the CDCs do not have to be explicitly coded anymore in the wakeup detectors.

Signed-off-by: Michael Schaffner <msf@google.com>