### PR TITLE
[otbn,lint] Waive unused sec_wipe signals

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -96,6 +96,10 @@ module otbn
   otbn_reg2hw_t reg2hw;
   otbn_hw2reg_t hw2reg;
 
+  // TODO: Connect up sec_wipe signals
+  logic unused_sec_wipe;
+  assign unused_sec_wipe = ^{reg2hw.sec_wipe};
+
   // Bus device windows, as specified in otbn.hjson
   typedef enum logic {
     TlWinImem = 1'b0,


### PR DESCRIPTION
These cause lint errors. Since it's going to be a bit of time until we
connect them up properly, waive them for now.
