### PR TITLE
[spi_device] Refactor SRAM inteface

### DIFF
--- a/hw/ip/spi_device/rtl/spi_fwmode.sv
+++ b/hw/ip/spi_device/rtl/spi_fwmode.sv
@@ -31,13 +31,14 @@ module spi_fwmode
   output logic      txf_underflow_o,
 
   // SRAM interface
-  output logic              fwm_req_o,
-  output logic              fwm_write_o,
-  output logic [SramAw-1:0] fwm_addr_o,
-  output logic [SramDw-1:0] fwm_wdata_o,
-  input                     fwm_rvalid_i,
-  input        [SramDw-1:0] fwm_rdata_i,
-  input        [1:0]        fwm_rerror_i,
+  output logic       fwm_req_o,
+  output logic       fwm_write_o,
+  output sram_addr_t fwm_addr_o,
+  output sram_data_t fwm_wdata_o,
+  output sram_strb_t fwm_wstrb_o,
+  input              fwm_rvalid_i,
+  input  sram_data_t fwm_rdata_i,
+  input  sram_err_t  fwm_rerror_i,
 
   // Serial to Parallel
   input             rx_data_valid_i,
@@ -253,6 +254,7 @@ module spi_fwmode
   );
 
   // Arbiter for FIFOs : Connecting between SRAM Ctrls and SRAM interface
+  assign fwm_wstrb_o = '1;
   prim_sram_arbiter #(
     .N            (2),  // RXF, TXF
     .SramDw       (SramDw),

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -120,13 +120,8 @@ module spi_readcmd
   input sel_datapath_e sel_dp_i,
 
   // SRAM access
-  output logic       sram_req_o,
-  output logic       sram_we_o,
-  output sram_addr_t sram_addr_o,
-  output sram_data_t sram_wdata_o,
-  input              sram_rvalid_i,
-  input  sram_data_t sram_rdata_i,
-  input  sram_err_t  sram_rerror_i,
+  output sram_l2m_t  sram_l2m_o,
+  input  sram_m2l_t  sram_m2l_i,
 
   // Interface: SPI to Parallel
   input               s2p_valid_i,
@@ -190,7 +185,7 @@ module spi_readcmd
   assign mailbox_assumed_o = 1'b 0;
 
   sram_err_t unused_sram_rerr;
-  assign unused_sram_rerr = sram_rerror_i;
+  assign unused_sram_rerr = sram_m2l_i.rerror;
 
   // TODO: Implement cmd_info
   logic unused_cmd_info_idx;
@@ -672,13 +667,8 @@ module spi_readcmd
     .mailbox_hit_i (addr_in_mailbox),
     .sfdp_hit_i    (sel_dp_i == DpReadSFDP),
 
-    .sram_req_o,
-    .sram_we_o,
-    .sram_addr_o,
-    .sram_wdata_o,
-    .sram_rvalid_i,
-    .sram_rdata_i,
-    .sram_rerror_i,
+    .sram_l2m_o,
+    .sram_m2l_i,
 
     // FIFO
     .fifo_rvalid_o (unused_fifo_rvalid),


### PR DESCRIPTION
This commit bundles the SRAM signals in SPI_DEVICE HWIP into two data
structures, `sram_l1m_t` and `sram_m2l_t`. These bundles help the
SPI_DEVICE top to be well organized and clean.

In addition to the bundles, this commit defines the strobe for SRAM
write data. The strobe for FWMode and Read Command are tied to 1 as of
now. The SPI Flash Upload submodule is going to use the strobe to upload
the payload data in a byte granularity.