### PR TITLE
[otbn] Two small spec improvements

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -178,6 +178,7 @@
       fields: [
         { bits: "0",
           name: "bad_data_addr"
+          resval: 0,
           desc: '''
             A DMEM read or write occurred with an out of bounds or unaligned
             address.
@@ -185,11 +186,13 @@
         }
         { bits: "1",
           name: "bad_insn_addr"
+          resval: 0,
           desc: '''
             An IMEM read occurred with an out of bounds or unaligned address.
           '''
         }
         { bits: "2",
+          resval: 0,
           name: "call_stack"
           desc: '''
             A instruction tried to pop from an empty call stack or push to a
@@ -197,6 +200,7 @@
           '''
         }
         { bits: "3",
+          resval: 0,
           name: "illegal_insn"
           desc: '''
             One of the following happened:
@@ -208,6 +212,7 @@
         }
         { bits: "4",
           name: "loop"
+          resval: 0,
           desc: '''
             One of the following happened:
             <ul>
@@ -224,14 +229,17 @@
         }
         { bits: "5",
           name: "fatal_imem"
+          resval: 0,
           desc: "A fatal error was seen on an instruction fetch."
         }
         { bits: "6",
           name: "fatal_dmem"
+          resval: 0,
           desc: "A fatal error was seen on a DMEM read."
         }
         { bits: "7",
           name: "fatal_reg"
+          resval: 0,
           desc: "A fatal error was seen on a GPR or WDR read."
         }
       ]
@@ -317,6 +325,7 @@
       fields: [
         { bits: "31:0",
           name: "insn_cnt",
+          resval: 0,
           desc: '''
             The number of instructions executed in the current or last OTBN run.
             Saturates at 2^32-1. The counter is reset to zero when a new operation

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -281,17 +281,17 @@
         { bits: "1",
           name: "imem_error",
           resval: 0,
-          desc: "Set on any ECC error in IMEM"
+          desc: "Set on any integrity error in IMEM"
         }
         { bits: "2",
           name: "dmem_error",
           resval: 0,
-          desc: "Set on any ECC error in DMEM"
+          desc: "Set on any integrity error in DMEM"
         }
         { bits: "3",
           name: "reg_error",
           resval: 0,
-          desc: "Set on any ECC error in a register file"
+          desc: "Set on any integrity error in a register file"
         }
       ]
     } // register : fatal_alert_cause

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -167,6 +167,7 @@ package otbn_reg_pkg;
   parameter logic [0:0] OTBN_CMD_RESVAL = 1'h 0;
   parameter logic [0:0] OTBN_STATUS_RESVAL = 1'h 0;
   parameter logic [31:0] OTBN_INSN_CNT_RESVAL = 32'h 0;
+  parameter logic [31:0] OTBN_INSN_CNT_INSN_CNT_RESVAL = 32'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] OTBN_IMEM_OFFSET = 16'h 4000;


### PR DESCRIPTION
* Add zero reset values to bus-accessible registers
* Use integrity error in spec

We could also use the reset value for the instruction count register, which is made available as parameter, in the RTL instead of hard-coding "0" there. I'm not really convinced that this is even a good idea, so I left it as-is for now.