### PR TITLE
[dv/common] Exclude assertion coverage from IP level testbench

### DIFF
--- a/hw/dv/tools/vcs/common_cov_excl.el
+++ b/hw/dv/tools/vcs/common_cov_excl.el
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Exclude below TL toggle coverage as these pins won't be changed in the comportable IPs.
-
-// Exclude alert_sender as it is fully verified in FPV. Note that user might also need to exclude
-// prim_diff_decode module, but it is not listed here because modules other than prim_alert_sender
-// might instantiate this prim_diff_decode as well.
+// Baesd on our Comportable IP spec, these TL pins are reserved / unused and hence, tied off.
 
 INSTANCE: tb.dut
 Toggle tl_o.d_opcode [1] "logic tl_o.d_opcode[2:0]"

--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -19,3 +19,14 @@ begin tgl
   +module prim_prince
   +module prim_lfsr
 end
+
+begin assert
+  // These three assertions in prim_lc_sync check when `lc_ctrl_pkg::lc_tx_e` input is neither `On`
+  // or `Off`, it is interrupted to the correct `On` or `Off` after one clock cycle. This behavior
+  // is implemented outside of IP level design thus these assertions are not covered in IP level
+  // testbenchs.
+  // TODO: check these assertions in top-level or FPV.
+  -assert PrimLcSyncCheckTransients_A
+  -assert PrimLcSyncCheckTransients0_A
+  -assert PrimLcSyncCheckTransients1_A
+end

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -67,9 +67,9 @@ module tb;
   initial begin
     // these SVA checks the keymgr_en is either Off or On, we will use more than these 2 values.
     // If it's not On, it should be off
-    $assertoff(0, tb.dut.u_lc_keymgr_en_sync.CheckTransients_A);
-    $assertoff(0, tb.dut.u_lc_keymgr_en_sync.CheckTransients0_A);
-    $assertoff(0, tb.dut.u_lc_keymgr_en_sync.CheckTransients1_A);
+    $assertoff(0, tb.dut.u_lc_keymgr_en_sync.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_lc_keymgr_en_sync.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_lc_keymgr_en_sync.PrimLcSyncCheckTransients1_A);
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -191,23 +191,23 @@ module tb;
     // These SVA checks the lc_escalate_en is either Off or On, we will use more than these
     // 2 values.
     // If it's not Off, it should be On.
-    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients_A);
-    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients0_A);
-    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.CheckTransients1_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.PrimLcSyncCheckTransients1_A);
 
     // These SVA checks the lc_sync_seed_hw_rd_en is either Off or On, we will use more than these
     // 2 values.
     // If it's not On, it should be Off.
-    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients_A);
-    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients0_A);
-    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.CheckTransients1_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.PrimLcSyncCheckTransients1_A);
 
     // These SVA checks the lc_check_byp_en is either Off or On, we will use more than these
     // 2 values.
     // If it's not On, it should be Off.
-    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients_A);
-    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients0_A);
-    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.CheckTransients1_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients1_A);
 
     // DV forced otp_cmd_i to reach invalid state, thus violate the assertions
     $assertoff(0, tb.dut.gen_partitions[2].gen_buffered.u_part_buf.OtpErrorState_A);

--- a/hw/ip/prim/rtl/prim_lc_sync.sv
+++ b/hw/ip/prim/rtl/prim_lc_sync.sv
@@ -68,20 +68,22 @@ module prim_lc_sync #(
 
   // If the multibit signal is in a transient state, we expect it
   // to be stable again within one clock cycle.
-  `ASSERT(CheckTransients_A,
+  // DV will exclude these three assertions by name, thus added a module name prefix to make it
+  // harder to accidentally replicate in other modules.
+  `ASSERT(PrimLcSyncCheckTransients_A,
       !(lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off})
       |=>
       (lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off}))
 
   // If a signal departs from passive state, we expect it to move to the active state
   // with only one transient cycle in between.
-  `ASSERT(CheckTransients0_A,
+  `ASSERT(PrimLcSyncCheckTransients0_A,
       $past(lc_en_i == lc_ctrl_pkg::Off) &&
       !(lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off})
       |=>
       (lc_en_i == lc_ctrl_pkg::On))
 
-  `ASSERT(CheckTransients1_A,
+  `ASSERT(PrimLcSyncCheckTransients1_A,
       $past(lc_en_i == lc_ctrl_pkg::On) &&
       !(lc_en_i inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off})
       |=>


### PR DESCRIPTION
This PR excludes three prim_lc_sync assertions that are not covered in
block level.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>