### PR TITLE
 [tlul/intg] move data integrity generation into special submodule 

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -273,9 +273,9 @@ module sram_ctrl
 
   // Compute the correct integrity alongside for the pseudo-random initialization values.
   logic [DataWidth - 1 :0] lfsr_out_integ;
-  prim_secded_39_32_enc u_data_gen (
+  tlul_data_integ_enc u_tlul_data_integ_enc (
     .data_i(lfsr_out),
-    .data_o(lfsr_out_integ)
+    .data_intg_o(lfsr_out_integ)
   );
 
   /////////////////////////////////

--- a/hw/ip/tlul/rtl/tlul_cmd_intg_chk.sv
+++ b/hw/ip/tlul/rtl/tlul_cmd_intg_chk.sv
@@ -17,7 +17,7 @@ module tlul_cmd_intg_chk import tlul_pkg::*; (
 );
 
   logic [1:0] err;
-  logic [1:0] data_err;
+  logic data_err;
   tl_h2d_cmd_intg_t cmd;
   assign cmd = extract_h2d_cmd_intg(tl_i);
 
@@ -28,11 +28,9 @@ module tlul_cmd_intg_chk import tlul_pkg::*; (
     .err_o(err)
   );
 
-  prim_secded_39_32_dec u_data_chk (
-    .data_i({tl_i.a_user.data_intg, DataMaxWidth'(tl_i.a_data)}),
-    .data_o(),
-    .syndrome_o(),
-    .err_o(data_err)
+  tlul_data_integ_dec u_tlul_data_integ_dec (
+    .data_intg_i({tl_i.a_user.data_intg, DataMaxWidth'(tl_i.a_data)}),
+    .data_err_o(data_err)
   );
 
   // error output is transactional, it is up to the instantiating module

--- a/hw/ip/tlul/rtl/tlul_data_integ_dec.sv
+++ b/hw/ip/tlul/rtl/tlul_data_integ_dec.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+/**
+ * Data integrity decoder for bus integrity scheme
+ */
+
+module tlul_data_integ_dec import tlul_pkg::*; (
+  // TL-UL interface
+  input        [DataMaxWidth+DataIntgWidth-1:0] data_intg_i,
+  output logic                                  data_err_o
+);
+
+  logic [1:0] data_err;
+  prim_secded_39_32_dec u_data_chk (
+    .data_i(data_intg_i),
+    .data_o(),
+    .syndrome_o(),
+    .err_o(data_err)
+  );
+
+  assign data_err_o = |data_err;
+
+endmodule : tlul_data_integ_dec

--- a/hw/ip/tlul/rtl/tlul_data_integ_enc.sv
+++ b/hw/ip/tlul/rtl/tlul_data_integ_enc.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+/**
+ * Data integrity encoder for bus integrity scheme
+ */
+
+module tlul_data_integ_enc import tlul_pkg::*; (
+  // TL-UL interface
+  input        [DataMaxWidth-1:0]               data_i,
+  output logic [DataMaxWidth+DataIntgWidth-1:0] data_intg_o
+);
+
+  prim_secded_39_32_enc u_data_gen (
+    .data_i,
+    .data_o(data_intg_o)
+  );
+
+endmodule : tlul_data_integ_enc

--- a/hw/ip/tlul/rtl/tlul_rsp_intg_gen.sv
+++ b/hw/ip/tlul/rtl/tlul_rsp_intg_gen.sv
@@ -35,10 +35,9 @@ module tlul_rsp_intg_gen import tlul_pkg::*; #(
   logic [DataIntgWidth-1:0] data_intg;
   if (EnableDataIntgGen) begin : gen_data_intg
     logic [DataMaxWidth-1:0] unused_data;
-
-    prim_secded_39_32_enc u_data_gen (
+    tlul_data_integ_enc u_tlul_data_integ_enc (
       .data_i(DataMaxWidth'(tl_i.d_data)),
-      .data_o({data_intg, unused_data})
+      .data_intg_o({data_intg, unused_data})
     );
   end else begin : gen_passthrough_data_intg
     assign data_intg = tl_i.d_user.data_intg;

--- a/hw/ip/tlul/trans_intg.core
+++ b/hw/ip/tlul/trans_intg.core
@@ -12,6 +12,8 @@ filesets:
       - lowrisc:prim:secded
       - lowrisc:tlul:headers
     files:
+      - rtl/tlul_data_integ_enc.sv
+      - rtl/tlul_data_integ_dec.sv
       - rtl/tlul_cmd_intg_gen.sv
       - rtl/tlul_cmd_intg_chk.sv
       - rtl/tlul_rsp_intg_gen.sv


### PR DESCRIPTION
This just wraps up the data integrity generation in its own submodule.
See this discussion for context: https://github.com/lowRISC/opentitan/pull/7548#discussion_r682968515