### PR TITLE
[reggen] Disallow internal shadow registers from hardware write.

### DIFF
--- a/util/reggen/field.py
+++ b/util/reggen/field.py
@@ -71,6 +71,8 @@ class Field:
                  reg_resval: Optional[int],
                  reg_width: int,
                  params: ReggenParams,
+                 hwext: bool,
+                 shadowed: bool,
                  raw: object) -> 'Field':
         where = 'field {} of {} register'.format(field_idx, reg_name)
         rd = check_keys(raw, where,
@@ -107,6 +109,11 @@ class Field:
             hwaccess = HWAccess(where, raw_hwaccess)
         else:
             hwaccess = default_hwaccess
+
+        # Currently internal shadow registers do not support hw write type
+        if not hwext and shadowed and hwaccess.allows_write():
+            raise ValueError('Internal Shadow registers do not currently support '
+                             'hardware write')
 
         bits = Bits.from_raw(where, reg_width, params, rd['bits'])
 

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -267,6 +267,8 @@ class Register(RegBase):
                                  resval,
                                  reg_width,
                                  params,
+                                 hwext,
+                                 shadowed,
                                  rf)
                   for idx, rf in enumerate(raw_fields)]
 


### PR DESCRIPTION
- When the shadow registers were first conceived it was mostly
  treated as a software RW register, we did not give a ton
  of thought as to how HW writes should behave.

- Currently, HW writes follow the same rules as softawre writes,
  ie, they need to be written twice before the value takes effect.
  This seems very odd and may not be the ideal behavior.

- Instead of quickly hacking the shadow regs to a different behavior,
  for now disable this combination and see if there is a real usecase
  for it.

Signed-off-by: Timothy Chen <timothytim@google.com>