### PR TITLE
[dv] fix tl error coverage

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -84,7 +84,6 @@ class tl_errors_cg_wrap;
   // This covergroup sampled all kinds of TL error cases.
   covergroup tl_errors_cg (string name)
       with function sample(bit unmapped_err,
-                           bit csr_aligned_err,
                            bit csr_size_err,
                            bit mem_byte_access_err,
                            bit mem_wo_err,
@@ -95,7 +94,6 @@ class tl_errors_cg_wrap;
 
     // these cp should be disabled (set weight to 0), when they're not applicable for the block
     cp_unmapped_err: coverpoint unmapped_err;
-    cp_csr_aligned_err: coverpoint csr_aligned_err;
     cp_csr_size_err: coverpoint csr_size_err;
     cp_mem_byte_access_err: coverpoint mem_byte_access_err;
     cp_mem_wo_err: coverpoint mem_wo_err;
@@ -113,13 +111,12 @@ class tl_errors_cg_wrap;
 
   // Function: sample
   function void sample(bit unmapped_err,
-                       bit csr_aligned_err,
                        bit csr_size_err,
                        bit mem_byte_access_err,
                        bit mem_wo_err,
                        bit mem_ro_err,
                        bit tl_protocol_err);
-    tl_errors_cg.sample(unmapped_err, csr_aligned_err, csr_size_err, mem_byte_access_err,
+    tl_errors_cg.sample(unmapped_err, csr_size_err, mem_byte_access_err,
                         mem_wo_err, mem_ro_err, tl_protocol_err);
   endfunction : sample
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -355,7 +355,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       "intr_test":                  run_intr_test_vseq(num_times);
       "alert_test":                 run_alert_test_vseq(num_times);
       "tl_errors":                  run_tl_errors_vseq(num_times);
-      "tl_intg_err":                run_tl_intg_err_vseq(num_times);
+      // Each iteration only sends 1 item with TL integrity error. Increase to send at least
+      // 10 x num_times integrity errors
+      "tl_intg_err":                run_tl_intg_err_vseq(10 * num_times);
       "stress_all_with_rand_reset": run_stress_all_with_rand_reset_vseq(num_times);
       "same_csr_outstanding":       run_same_csr_outstanding_vseq(num_times);
       "shadow_reg_errors":          run_shadow_reg_errors(num_times);

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -50,23 +50,6 @@ virtual task tl_access_unmapped_addr(string ral_name);
   end
 endtask
 
-virtual task tl_write_csr_word_unaligned_addr(string ral_name);
-  addr_range_t loc_mem_ranges[$] = updated_mem_ranges[ral_name];
-  repeat ($urandom_range(10, 100)) begin
-    if (cfg.under_reset) return;
-    `create_tl_access_error_case(
-        tl_write_csr_word_unaligned_addr,
-        opcode inside {tlul_pkg::PutFullData, tlul_pkg::PutPartialData};
-        foreach (loc_mem_ranges[i]) {
-          !((addr & csr_addr_mask[ral_name])
-              inside {[loc_mem_ranges[i].start_addr : loc_mem_ranges[i].end_addr]});
-        }
-        addr[1:0] != 2'b00;,
-        ,
-        p_sequencer.tl_sequencer_hs[ral_name])
-  end
-endtask
-
 virtual task tl_write_less_than_csr_width(string ral_name);
   uvm_reg all_csrs[$];
 
@@ -242,7 +225,6 @@ virtual task run_tl_errors_vseq_sub(int num_times = 1, bit do_wait_clk = 0, stri
                 1: tl_protocol_err(p_sequencer.tl_sequencer_hs[ral_name]);
                 // only run when csr addresses exist
                 has_csr_addrs: tl_write_less_than_csr_width(ral_name);
-                has_csr_addrs: tl_write_csr_word_unaligned_addr(ral_name);
 
                 // only run when unmapped addr exists
                 cfg.ral_models[ral_name].has_unmapped_addrs: tl_access_unmapped_addr(ral_name);

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -277,4 +277,13 @@ class dv_base_reg_block extends uvm_reg_block;
     return (word_aligned ? get_word_aligned_addr(byte_offset) : byte_offset) + map.get_base_addr();
   endfunction
 
+  // The design ignores the address bits that aren't enabled by addr_mask.
+  // Normalize these ignored bits to enable locating which CSR/mem is at the returned address.
+  function uvm_reg_addr_t get_normalized_addr(uvm_reg_addr_t byte_addr, uvm_reg_map map = null);
+    if (map == null) map = get_default_map();
+    return get_addr_from_offset(.byte_offset(byte_addr & addr_mask[map]),
+                                .word_aligned(1),
+                                .map(map));
+  endfunction
+
 endclass


### PR DESCRIPTION
1. use `get_normalized_addr` function for the address, to fix most of
error cases flagged as unmapped, as it's not normalized address
2. remove CSR unaligned error, which is defined in spec, but CSR size
error already include that
3. add more iteration for tl_intg_err since we only send 1 integrity
error per interation. Will test 200 integrity errors in nightly
regression, instead of just 20-40 of these transactions.

Signed-off-by: Weicai Yang <weicai@google.com>