### PR TITLE
[otbn,dv] Add the "BadAtEnd" generator to RIG

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -13,6 +13,7 @@ gen-weights:
 
   # Generators that end the program
   ECall: 1
+  BadAtEnd: 1
   BadDeepLoop: 1
   BadInsn: 1
   BadGiantLoop: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_at_end.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_at_end.py
@@ -1,0 +1,123 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import List, Optional, Tuple
+
+from shared.insn_yaml import InsnsFile
+
+from .branch import Branch
+from .jump import Jump
+from .loop import Loop
+from ..config import Config
+from ..program import ProgInsn, Program
+from ..model import Model
+from ..snippet_gen import GenCont, GenRet
+
+
+class BadAtEnd(Loop):
+    '''A snippet generator that generates a loop/branch/jump at end of a loop
+
+    This works by overriding the _gen_tail method of the Loop generator and
+    replacing the last instruction that we would have generated with a loop,
+    branch or jump instruction.
+
+    '''
+
+    ends_program = True
+
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__(cfg, insns_file)
+        self.branch_gen = Branch(cfg, insns_file)
+        self.jump_gen = Jump(cfg, insns_file)
+
+    def pick_weight(self,
+                    model: Model,
+                    program: Program) -> float:
+        # Only try this if we've got a reasonable amount of room.
+        room = min(model.fuel, program.space)
+        assert 0 < room
+        return (1.0 if room > 50 else 0.0)
+
+    def _gen_tail(self,
+                  num_insns: int,
+                  model: Model,
+                  program: Program) -> Optional[Tuple[List[ProgInsn], Model]]:
+        assert num_insns > 0
+        old_model = model.copy()
+        ret = super()._gen_tail(num_insns, model, program)
+        if ret is None:
+            return None
+
+        insns, model = ret
+        assert len(insns) == num_insns
+
+        # We need a model to represent the state just before the last
+        # instruction. Of course, we can't "unwind" the state update that we
+        # just did. However, a merge between the initial state and the end
+        # state gives a sound (if very imprecise!) approximation.
+        #
+        # Since the Model.merge() method expects the two models to have the
+        # same PC (which is the usual situation when implementing phi nodes),
+        # we also have to teleport old_model into the right place!
+        old_model.pc = model.pc
+        model.merge(old_model)
+
+        # Pick a new instruction to replace the last one we generated. Start by
+        # shuffling the numbers from 0..2, which will represent Branch, Loop,
+        # Jump respectively. The idea is that we want to try them in an
+        # arbitrary order, but don't want to fail completely if one of the
+        # other generators might have worked.
+        types = list(range(3))
+        random.shuffle(types)
+        for lbj in types:
+            if lbj == 0:
+                # Loop! Pick an loop head (with an arbitrary "100" for
+                # space_here and without setting up program properly: it
+                # doesn't really matter). Pass False as the "check" argument:
+                # we don't want to check anything about whether the implied
+                # loop overlaps with existing code.
+                retL = self._pick_head(100, False, model, program)
+                if retL is not None:
+                    tail_insn, _ = retL
+                    break
+            elif lbj == 1:
+                # Branch!
+                retB = self.branch_gen.gen_head(model, program)
+                if retB is not None:
+                    tail_insn, _ = retB
+                    break
+            else:
+                assert lbj == 2
+                # Jump!
+                retJ = self.jump_gen.gen_tgt(model, program, None)
+                if retJ is not None:
+                    tail_insn, _, _ = retJ
+
+        if tail_insn is None:
+            return
+
+        insns[-1] = tail_insn
+        return (insns, model)
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+        # Run the Loop generator, but with our _gen_tail, which means we'll put
+        # an unexpected jump/branch/loop at the end of the body.
+        ret = super().gen(cont, model, program)
+        if ret is None:
+            return None
+
+        # If the Loop generator returned success, that's great! However, we
+        # need to fix things up a bit for the changes we've made. Specifically,
+        # the "done" flag should be true (since this is supposed to cause a
+        # fault) and the final PC should be 4 less, pointing just before the
+        # last instruction in the loop.
+        snippet, done, model = ret
+        assert not done
+
+        model.pc -= 4
+        return (snippet, True, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
@@ -154,7 +154,7 @@ class BadDeepLoop(SnippetGen):
         model.pc += 4
         model.loop_depth += 1
 
-        body_snippet = None
+        body_snippet = None  # type: Optional[Snippet]
 
         if space_here <= 2:
             # If we've run out of space in front of us, jump somewhere else to
@@ -169,7 +169,7 @@ class BadDeepLoop(SnippetGen):
             # TODO: Can this fail?
             assert jump_ret is not None
 
-            jump_snippet, model = jump_ret
+            jump_insn, jump_snippet, model = jump_ret
             assert model.pc == gap_lo
             body_snippet = jump_snippet
 

--- a/hw/ip/otbn/dv/rig/rig/gens/branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch.py
@@ -80,16 +80,10 @@ class Branch(SnippetGen):
         return (pc + 4 if fall_thru else
                 program.pick_branch_target(pc, 1, off_min, off_max))
 
-    def gen(self,
-            cont: GenCont,
-            model: Model,
-            program: Program) -> Optional[GenRet]:
-        # Return None if this is the last instruction in the current gap
-        # because we need to either jump or do an ECALL to avoid getting stuck
-        # (just like the StraightLineInsn generator)
-        if program.get_insn_space_at(model.pc) <= 1:
-            return None
-
+    def gen_head(self,
+                 model: Model,
+                 program: Program) -> Optional[Tuple[ProgInsn, int]]:
+        '''Generate the actual branch instruction'''
         # Decide whether to generate BEQ or BNE.
         is_beq = random.random() < self.beq_prob
 
@@ -121,7 +115,23 @@ class Branch(SnippetGen):
         off_enc = off_op.op_type.op_val_to_enc_val(tgt_addr, model.pc)
         assert off_enc is not None
 
-        branch_insn = ProgInsn(insn, [grs1, grs2, off_enc], None)
+        return (ProgInsn(insn, [grs1, grs2, off_enc], None), tgt_addr)
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+        # Return None if this is the last instruction in the current gap
+        # because we need to either jump or do an ECALL to avoid getting stuck
+        # (just like the StraightLineInsn generator)
+        if program.get_insn_space_at(model.pc) <= 1:
+            return None
+
+        ret = self.gen_head(model, program)
+        if ret is None:
+            return None
+
+        branch_insn, tgt_addr = ret
 
         if tgt_addr == model.pc + 4:
             # If tgt_addr equals model.pc + 4, this actually behaves like a

--- a/hw/ip/otbn/dv/rig/rig/gens/branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch.py
@@ -230,7 +230,7 @@ class Branch(SnippetGen):
             if jump_ret is None:
                 return None
 
-            jmp_snippet, model0 = jump_ret
+            jmp_insn, jmp_snippet, model0 = jump_ret
             snippet0 = Snippet.cons_option(snippet0, jmp_snippet)
         else:
             # Add the jump to go from branch 1 to branch 0
@@ -240,7 +240,7 @@ class Branch(SnippetGen):
             if jump_ret is None:
                 return None
 
-            jmp_snippet, model1 = jump_ret
+            jmp_insn, jmp_snippet, model1 = jump_ret
             snippet1 = Snippet.cons_option(snippet1, jmp_snippet)
 
         assert model0.pc == model1.pc

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -13,7 +13,7 @@ from .straight_line_insn import StraightLineInsn
 from ..config import Config
 from ..program import ProgInsn, Program
 from ..model import Model
-from ..snippet import LoopSnippet, Snippet
+from ..snippet import LoopSnippet, ProgSnippet, Snippet
 from ..snippet_gen import GenCont, GenRet, SimpleGenRet, SnippetGen
 
 
@@ -401,8 +401,12 @@ class Loop(SnippetGen):
         if tail_ret is None:
             return None
 
-        tail_snippet, model = tail_ret
+        tail_insns, model = tail_ret
         assert model.pc == match_addr
+        assert len(tail_insns) == tail_len
+
+        tail_snippet = ProgSnippet(tail_start, tail_insns)
+        tail_snippet.insert_into_program(program)
 
         snippet = Snippet.cons_option(head_snippet, tail_snippet)
 

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -376,7 +376,7 @@ class Loop(SnippetGen):
                 if jump_ret is None:
                     return None
 
-                jump_snippet, model = jump_ret
+                jump_insn, jump_snippet, model = jump_ret
                 assert model.pc == tail_start
 
                 head_snippet = Snippet.cons_option(head_snippet, jump_snippet)

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -21,6 +21,7 @@ from .gens.small_val import SmallVal
 from .gens.known_wdr import KnownWDR
 from .gens.straight_line_insn import StraightLineInsn
 
+from .gens.bad_at_end import BadAtEnd
 from .gens.bad_deep_loop import BadDeepLoop
 from .gens.bad_insn import BadInsn
 from .gens.bad_giant_loop import BadGiantLoop
@@ -38,6 +39,7 @@ class SnippetGens:
         KnownWDR,
 
         ECall,
+        BadAtEnd,
         BadDeepLoop,
         BadInsn,
         BadGiantLoop,


### PR DESCRIPTION
The main commit is the last one in the series: the other two are refactorings to make that easier. The message for the last commit is:

> This generates a branch, jump or loop as the last instruction in a
> loop.
> 
> To do this, we also factor out the gen_head method in the Branch
> generator. This is the bit that generates the actual branch
> instruction, which is what we need for BadAtEnd.
> 
> Similarly, we factor out a _pick_head method in the Loop generator.
> This is in charge of picking the LOOP/LOOPI instruction (it also
> returns some auxiliary information about loop shape that we need).
> 