### PR TITLE
[otbn,dv] Finesse "barely_oob_addr_cp" to make it possible to hit

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -383,7 +383,7 @@ The instruction-specific covergroup is `insn_xw_cg` (shared with `SW`).
   Tracked as `top_addr_cross`.
 - Load from an invalid address (aligned but above the top of memory)
   Tracked as `oob_addr_cross`.
-- Load from a "barely invalid" address (aligned but overlapping the top of memory)
+- Load from a "barely invalid" address (just above the top of memory)
   Tracked as `barely_oob_addr_cross`.
 - Misaligned address tracking.
   Track loads from addresses that are in range for the size of the memory.

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -1128,11 +1128,9 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                  ((($signed(operand_a) + $signed(offset)) & 32'h3) == 0))
     `DEF_MNEM_CROSS(oob_addr)
 
-    // Load from a "barely invalid" address (aligned but overlapping the top of memory)
-    `DEF_SEEN_CP(barely_oob_addr_cp,
-                 ($signed(operand_a) + $signed(offset) > DmemSizeByte - 4) &&
-                 ($signed(operand_a) + $signed(offset) < DmemSizeByte) &&
-                 ((($signed(operand_a) + $signed(offset)) & 32'h3) == 0))
+    // Load from a "barely invalid" address (the smallest aligned address that's above the top of
+    // memory)
+    `DEF_SEEN_CP(barely_oob_addr_cp, $signed(operand_a) + $signed(offset) == DmemSizeByte)
     `DEF_MNEM_CROSS(barely_oob_addr)
 
     // Cross the different possible address alignments for otherwise valid addresses


### PR DESCRIPTION
I'd been overly clever here and was looking for an aligned address
where the base pointed at a valid byte of memory but the top fell off
the top of memory. Unfortunately, aligned addresses are multiples of
4, and the load/store width is also 4 bytes, which means this isn't
actually possible!

Repurpose the coverage point for "just above the top of memory", which
might be worth seeing.

@ctopal: Thanks for spotting this! Does the result look a bit more sensible?