### PR TITLE
[otbn, dv] Negative Out of Bound Address

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -383,6 +383,8 @@ The instruction-specific covergroup is `insn_xw_cg` (shared with `SW`).
   Tracked as `top_addr_cross`.
 - Load from an invalid address (aligned but above the top of memory)
   Tracked as `oob_addr_cross`.
+- Load from a calculated negative invalid address (aligned but unsigned address exceeds the top of memory)
+  Tracked as `oob_addr_neg_cross`.
 - Load from a "barely invalid" address (just above the top of memory)
   Tracked as `barely_oob_addr_cross`.
 - Misaligned address tracking.
@@ -405,6 +407,8 @@ The instruction-specific covergroup is `insn_xw_cg` (shared with `LW`).
   Tracked as `top_addr_cross`.
 - Store to an invalid address (aligned but above the top of memory)
   Tracked as `oob_addr_cross`.
+- Store to a calculated negative invalid address (aligned but unsigned address exceeds the top of memory)
+  Tracked as `oob_addr_neg_cross`.
 - Store to a "barely invalid" address (aligned but overlapping the top of memory)
   Tracked as `barely_oob_addr_cross`.
 - Misaligned address tracking.
@@ -782,6 +786,8 @@ The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.SID`).
   Tracked as `top_addr_cross`.
 - Load from an invalid address (aligned but above the top of memory)
   Tracked as `oob_addr_cross`.
+- Load from a calculated negative invalid address (aligned but unsigned address exceeds the top of memory)
+  Tracked as `oob_addr_neg_cross`.
 - Misaligned address tracking.
   Track loads from addresses that are in range for the size of the memory.
   Crossing the possible misalignments for operand_a and offset would give a big cross (`32^2 = 1024`).
@@ -812,6 +818,8 @@ The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.LID`).
   Tracked as `top_addr_cross`.
 - Store to an invalid address (aligned but above the top of memory)
   Tracked as `oob_addr_cross`.
+- Store to a calculated negative invalid address (aligned but unsigned address exceeds the top of memory)
+  Tracked as `oob_addr_neg_cross`.
 - Misaligned address tracking.
   Track stores to addresses that are in range for the size of the memory.
   Crossing the possible misalignments for operand_a and offset would give a big cross (`32^2 = 1024`).

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -1127,6 +1127,11 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                  ($signed(operand_a) + $signed(offset) > DmemSizeByte - 4) &&
                  ((($signed(operand_a) + $signed(offset)) & 32'h3) == 0))
     `DEF_MNEM_CROSS(oob_addr)
+    // Load from a negative invalid address (aligned but unsigned address exceeds the top of memory)
+    `DEF_SEEN_CP(oob_addr_neg_cp,
+                 ($signed(operand_a) + $signed(offset) < 0) &&
+                 ((($signed(operand_a) + $signed(offset)) & 32'h3) == 0))
+    `DEF_MNEM_CROSS(oob_addr_neg)
 
     // Load from a "barely invalid" address (the smallest aligned address that's above the top of
     // memory)
@@ -1477,6 +1482,11 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
                  ($signed(operand_a) + $signed(offset) > DmemSizeByte - 32) &&
                  ((($signed(operand_a) + $signed(offset)) & 32'd31) == 0))
     `DEF_MNEM_CROSS(oob_addr)
+    // Load from a negative invalid address (aligned but unsigned address exceeds the top of memory)
+    `DEF_SEEN_CP(oob_addr_neg_cp,
+                 ($signed(operand_a) + $signed(offset) < 0) &&
+                 ((($signed(operand_a) + $signed(offset)) & 32'h3) == 0))
+    `DEF_MNEM_CROSS(oob_addr_neg)
 
     // Misaligned address tracking (see DV document for why we have these exact crosses)
     grs1_align_cp:


### PR DESCRIPTION
This commit adds a coverage point for negative out of bound address
that could be calculated in lw/sw instructions

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>