### PR TITLE
[dv/gpio] fix intr_test regression failure

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -33,6 +33,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   // knobs to lock shadow register write access if fatal storage error occurred
   bit do_lock_shadow_reg = 1'b1;
 
+  // knobs to turn on `csr_wr` task's `predict` switch in intr_test sequence
+  bit do_predict_csr_wr = 1'b0;
+
   // csr queues
   dv_base_reg all_csrs[$];
   dv_base_reg intr_state_csrs[$];
@@ -390,7 +393,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       foreach (intr_csrs[i]) begin
         uvm_reg_data_t data = $urandom();
         `uvm_info(`gfn, $sformatf("Write %s: 0x%0h", intr_csrs[i].`gfn, data), UVM_MEDIUM)
-        csr_wr(.ptr(intr_csrs[i]), .value(data));
+        csr_wr(.ptr(intr_csrs[i]), .value(data), .predict(do_predict_csr_wr));
       end
 
       // Read all intr related csr and check interrupt pins

--- a/hw/ip/gpio/dv/env/seq_lib/gpio_common_vseq.sv
+++ b/hw/ip/gpio/dv/env/seq_lib/gpio_common_vseq.sv
@@ -10,6 +10,14 @@ class gpio_common_vseq extends gpio_base_vseq;
     num_trans inside {[1:3]};
   }
 
+  virtual task pre_start();
+    super.pre_start();
+    // GPIO scoreboard is cycle accurate and will only update `intr_state` mirrored value only at
+    // the address phase of the next read operation. This is too late for intr_test. So we turn on
+    // `predict` switch in `csr_wr` task to avoid this issue.
+    if (common_seq_type == "intr_test")  do_predict_csr_wr = 1;
+  endtask
+
   virtual task dut_init(string reset_kind = "HARD");
     // Implement gpio pulldown for csr tests for avoiding comparison
     // mismatch for DATA_IN register checks


### PR DESCRIPTION
This PR fixes intr_test failure in gpio.
The root cause is the recent change in `intr_test` procedure.
We used to:
1). write all interrupt related registers.
2). read all interrupt related registers, and compare the value with
mirrored vale from scb prediction.

The recent changes step 2).
Now 2). Get mirrored value from RAL, then read all interrupt registers
and compare the read value with stored mirrored value.

This change makes sense but does not work for GPIO, because GPIO
scoreboard has a cycle accurate model and it won't update intr_state
values until next TL read's address phase.

To solve this issue, we turn on auto-predict in csr_wr for gpio
intr_test sequence.

Thanks Weicai for helping out with this issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>