### PR TITLE
[dv/kmac] loosen timing requirements in kmac vseq

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -241,6 +241,9 @@ class kmac_smoke_vseq extends kmac_base_vseq;
           write_msg(output_len_enc);
         end
 
+        // wait for some cycles after writing message to let internal state settle
+        cfg.clk_rst_vif.wait_clks($urandom_range(5, 10));
+
         // issue an incorrect SW command, this will be dropped internally,
         // so need to send the correct command afterwards.
         if (kmac_err_type == kmac_pkg::ErrSwCmdSequence &&


### PR DESCRIPTION
This PR loosens the timing requirements in
`kmac_base_vseq::wait_for_kmac_done()` task.

The task is currently implemented using `csr_spinwait`, which puts a lot
of timing-related pressure on the scoreboard (especially with
zero_delays enabled), and doesn't necessarily add much to the quality of
verification.

This task is updated to now use a "before" and "after" CSR read, with a
long wait in between to allow the KMAC to finish hashing, rather than
send out a CSR request every few cycles with `csr_spinwait`.

Signed-off-by: Udi Jonnalagadda <udij@google.com>