### PR TITLE
[dv/kmac] update App digest width in DV

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_item.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_item.sv
@@ -16,9 +16,9 @@ class kmac_app_item extends uvm_sequence_item;
   rand byte byte_data_q[$];
 
   // response digest/error
-  rand bit [KeyWidth-1:0] rsp_digest_share0;
-  rand bit [KeyWidth-1:0] rsp_digest_share1;
-  rand bit                rsp_error;
+  rand bit [kmac_pkg::AppDigestW-1:0] rsp_digest_share0;
+  rand bit [kmac_pkg::AppDigestW-1:0] rsp_digest_share1;
+  rand bit                            rsp_error;
 
   rand bit                is_kmac_rsp_err;
   rand int unsigned       rsp_delay;

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -168,8 +168,8 @@ class kmac_scoreboard extends cip_base_scoreboard #(
   byte kmac_app_msg[$];
 
   // output digest from KMAC_APP intf (256 bits each)
-  bit [keymgr_pkg::KeyWidth-1:0] kmac_app_digest_share0;
-  bit [keymgr_pkg::KeyWidth-1:0] kmac_app_digest_share1;
+  bit [kmac_pkg::AppDigestW-1:0] kmac_app_digest_share0;
+  bit [kmac_pkg::AppDigestW-1:0] kmac_app_digest_share1;
 
   // output digests
   bit [7:0] digest_share0[];

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_vseq.sv
@@ -21,8 +21,8 @@ class kmac_app_vseq extends kmac_sideload_vseq;
 
   constraint kmac_app_c {
     if (en_app) {
-      // application interface outputs 256-bit digest (32 bytes)
-      output_len == 32;
+      // application interface outputs 384-bit digest (48 bytes)
+      output_len == kmac_pkg::AppDigestW / 8;
 
       // LC_CTRL uses 128-bit strength, KeyMgr and OTP_CTRL use 256-bit strength
       if (app_mode == AppLc) {

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -135,7 +135,7 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
       // Check data sent to keymgr
       if (cfg.rom_ctrl_vif.keymgr_data.valid) begin
         `DV_CHECK_EQ(keymgr_complete, 1'b0, "Spurious keymgr signal")
-        `DV_CHECK_EQ(cfg.rom_ctrl_vif.keymgr_data.data, kmac_digest, "Incorrect keymgr digest")
+        `DV_CHECK_EQ(cfg.rom_ctrl_vif.keymgr_data.data, kmac_digest[DIGEST_SIZE-1:0], "Incorrect keymgr digest")
         keymgr_complete = 1'b1;
       end
     end


### PR DESCRIPTION
This PR updates the output width of the Application interface digest to
`kmac_pkg::AppDigestW`, as there were still a few places in the
codebase missing this update.

Signed-off-by: Udi Jonnalagadda <udij@google.com>