### PR TITLE
[dv] Constrain TLUL to 24Mhz or higher

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -46,6 +46,14 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   rand clk_freq_mhz_e clk_freq_mhz;
   rand clk_freq_mhz_e clk_freqs_mhz[string];
 
+  // TODO(#7647), only run with 24Mhz or higher
+  constraint clk_freq_mhz_c {
+    clk_freq_mhz >= ClkFreq24Mhz;
+    foreach (clk_freqs_mhz[i]) {
+      clk_freqs_mhz[i] >= ClkFreq24Mhz;
+    }
+  }
+
   `uvm_object_param_utils_begin(dv_base_env_cfg #(RAL_T))
     `uvm_field_int   (is_active,   UVM_DEFAULT)
     `uvm_field_int   (en_scb,      UVM_DEFAULT)

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -38,6 +38,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     tl_intg_alert_name = "fatal_bus_integ_error";
     super.initialize(csr_base_addr);
 
+    // OTP can run with 6Mhz, disable this constraint which limits freq >= 24Mhz
+    clk_freq_mhz_c.constraint_mode(0);
+
     // create push_pull agent config obj
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin
       string cfg_name = $sformatf("sram_pull_agent_cfg[%0d]", i);


### PR DESCRIPTION
relate to #7647
Temporarily fix many regression failures due to using 6Mhz

Signed-off-by: Weicai Yang <weicai@google.com>