### PR TITLE
[prim] Add non-linear out option to prim_lfsr

### DIFF
--- a/hw/ip/prim/prim_lfsr.core
+++ b/hw/ip/prim/prim_lfsr.core
@@ -9,6 +9,7 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:prim:assert
+      - lowrisc:prim:cipher_pkg
     files:
       - rtl/prim_lfsr.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This follows AES's example and just uses the prince sbox on the output
of the LFSR.

Signed-off-by: Timothy Chen <timothytim@google.com>