### PR TITLE
[otbn] Make stalling more explicit in instruction definitions

### DIFF
--- a/hw/ip/otbn/doc/isa.md
+++ b/hw/ip/otbn/doc/isa.md
@@ -61,6 +61,9 @@ Memory loads are represented as `DMEM.load_u32(addr)`, `DMEM.load_u256(addr)`.
 Memory stores are represented as `DMEM.store_u32(addr, value)` and `DMEM.store_u256(addr, value)`.
 In all cases, memory values are interpreted as unsigned integers and, as for register accesses, the instruction descriptions are written to ensure that any value stored to memory is representable.
 
+Some instructions can stall for one or more cycles (those instructions that access memory, CSRs or WSRs).
+To represent this precisely in the pseudo-code, and the simulator reference model, such instructions execute a `yield` statement to stall the processor for a cycle.
+
 There are a few other helper functions, defined here to avoid having to inline their bodies into each instruction.
 ```python3
 def from_2s_complement(n: int) -> int:

--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -5,7 +5,7 @@
 '''Code to load instruction words into a simulator'''
 
 import struct
-from typing import List
+from typing import List, Optional, Iterator
 
 from .err_bits import ILLEGAL_INSN
 from .isa import INSNS_FILE, DecodeError, OTBNInsn
@@ -35,8 +35,9 @@ class IllegalInsn(OTBNInsn):
         # disassembling the underlying DummyInsn.
         self._disasm = (pc, '?? 0x{:08x}'.format(raw))
 
-    def execute(self, state: OTBNState) -> None:
+    def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
         state.stop_at_end_of_cycle(ILLEGAL_INSN)
+        return None
 
 
 def _decode_word(pc: int, word: int) -> OTBNInsn:

--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -60,9 +60,6 @@ class Dmem:
         self.data = [uninit] * num_words
         self.trace = []  # type: List[TraceDmemStore]
 
-        self._load_begun = False
-        self._load_ready = False
-
     def _get_u32s(self, idx: int) -> List[int]:
         '''Return the value at idx as 8 uint32's
 
@@ -229,23 +226,10 @@ class Dmem:
         # And write back
         self._set_u32s(idxW, u32s)
 
-    def commit(self, stalled: bool) -> None:
-        if self._load_begun:
-            self._load_begun = False
-            self._load_ready = True
-        else:
-            self._load_ready = False
-
+    def commit(self) -> None:
         for item in self.trace:
             self._commit_store(item)
         self.trace = []
 
     def abort(self) -> None:
         self.trace = []
-
-    def in_progress_load_complete(self) -> bool:
-        '''Returns true if a previously started load has completed'''
-        return self._load_ready
-
-    def begin_load(self) -> None:
-        self._load_begun = True

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterator, Optional, Tuple
 
 from shared.insn_yaml import Insn, DummyInsn, load_insns_yaml
 
@@ -79,15 +79,13 @@ class OTBNInsn:
         # it can't hurt to check).
         self._disasm = None  # type: Optional[Tuple[int, str]]
 
-    def pre_execute(self, state: OTBNState) -> bool:
-        '''Performs any actions required before instruction can execute.
+    def execute(self, state: OTBNState) -> Optional[Iterator[None]]:
+        '''Execute the instruction
 
-        Return True if instruction is clear to execute. Returning False will
-        stall the simulator for a step.
+        This may yield (returning an iterator object) if the instruction has
+        stalled the processor and will take multiple cycles.
+
         '''
-        return True
-
-    def execute(self, state: OTBNState) -> None:
         raise NotImplementedError('OTBNInsn.execute')
 
     def disassemble(self, pc: int) -> str:
@@ -106,20 +104,6 @@ class OTBNInsn:
         '''Interpret the signed value as a 2's complement u32'''
         assert -(1 << 31) <= value < (1 << 31)
         return (1 << 32) + value if value < 0 else value
-
-
-class OTBNLDInsn(OTBNInsn):
-    '''A general class for any load instruction providing appropriate stalls'''
-
-    def pre_execute(self, state: OTBNState) -> bool:
-        if state.dmem.in_progress_load_complete():
-            # Load has been started and now complete, execution can proceed
-            return True
-
-        # Load not complete so begin a new load
-        state.dmem.begin_load()
-        # Load stalls when it begins
-        return False
 
 
 class RV32RegReg(OTBNInsn):

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -35,8 +35,8 @@ class OTBNState:
         self.dmem = Dmem()
 
         # Stalling support: Instructions can indicate they should stall by
-        # returning false from OTBNInsn.pre_execute. For non instruction related
-        # stalls setting self.non_insn_stall will produce a stall.
+        # yielding in OTBNInsn.execute. For non instruction related stalls,
+        # setting self.non_insn_stall will produce a stall.
         #
         # As a special case, we stall until the URND reseed is completed then
         # stall for one more cycle before fetching the first instruction (to
@@ -127,13 +127,12 @@ class OTBNState:
             self.non_insn_stall = False
             self.ext_regs.commit()
 
-        self.dmem.commit(sim_stalled)
-
-        # If we're stalled, there's nothing more to do: we only commit when we
-        # finish our stall cycles.
+        # If we're stalled, there's nothing more to do: we only commit the rest
+        # of the architectural state when we finish our stall cycles.
         if sim_stalled:
             return
 
+        self.dmem.commit()
         self.gprs.commit()
         self.pc = self.get_next_pc()
         self._pc_next_override = None

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -254,9 +254,7 @@ class OTBNState:
         self.loop_step()
         self.gprs.post_insn()
 
-        self._err_bits |= (self.gprs.err_bits() |
-                           self.dmem.err_bits() |
-                           self.loop_stack.err_bits())
+        self._err_bits |= self.gprs.err_bits() | self.loop_stack.err_bits()
         if self._err_bits:
             self.pending_halt = True
 


### PR DESCRIPTION
This comes in two commits, but the interesting one is the second:

> This is prompted by the fact that we couldn't properly model things
> like faulting calls to `BN.LID`. We need to do some of the instruction
> body on the first cycle (to spot that an address is bogus). However,
> we can't run everything on the first cycle. For example accesses of
> the `RND` WSR/CSR can't do their work until the data is available, and
> this data isn't supplied by the Python simulator.
> 
> Solve the problem by splitting the execution over multiple calls to
> the `execute()` method, passing some opaque continuation object as a
> "`cont`" argument.

We're going to need something like this to un-block @ctopal, who is trying to generate faulting BN.LID and LW instructions at the moment.