### PR TITLE
[otbn,dv] Bad Load/Store and Edge Store Snippets

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -6,6 +6,7 @@ gen-weights:
   # Generators that can continue the program
   Branch: 0.1
   CallStackRW: 0.1
+  EdgeLoadStore: 0.1
   Jump: 0.1
   Loop: 0.1
   LoopDupEnd: 0.01

--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -19,6 +19,7 @@ gen-weights:
   BadBNMovr: 1
   BadCallStackRW: 1
   BadDeepLoop: 1
+  BadLoadStore: 1
   BadInsn: 1
   BadGiantLoop: 1
   BadZeroLoop: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
@@ -1,0 +1,293 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional
+
+from shared.operand import ImmOperandType, RegOperandType, OptionOperandType
+from shared.insn_yaml import Insn, InsnsFile
+
+from ..config import Config
+from ..model import Model
+from ..program import ProgInsn, Program
+
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
+
+
+class BadLoadStore(SnippetGen):
+    '''A snippet generator that generates random lw/sw instructions
+
+    Generated instructions are out of bounds, therefore end the
+    program.
+
+    '''
+
+    ends_program = True
+
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__()
+
+        self.insns = []
+        self.weights = []
+
+        self.lw = self._get_named_insn(insns_file, 'lw')
+
+        # LW has three operands: grd, offset, grs
+        if not (len(self.lw.operands) == 3 and
+                isinstance(self.lw.operands[0].op_type, RegOperandType) and
+                self.lw.operands[0].op_type.reg_type == 'gpr' and
+                self.lw.operands[0].op_type.is_dest() and
+                isinstance(self.lw.operands[1].op_type, ImmOperandType) and
+                isinstance(self.lw.operands[2].op_type, RegOperandType) and
+                self.lw.operands[2].op_type.reg_type == 'gpr' and
+                not self.lw.operands[2].op_type.is_dest()):
+            raise RuntimeError('LW instruction from instructions file is '
+                               'not the shape expected by the BadLoadStore'
+                               'generator.')
+
+        self.sw = self._get_named_insn(insns_file, 'sw')
+
+        # SW Instruction Checks
+        # SW has three operands: grs1, offset, grs2
+        if not (len(self.sw.operands) == 3 and
+                isinstance(self.sw.operands[0].op_type, RegOperandType) and
+                self.sw.operands[0].op_type.reg_type == 'gpr' and
+                not self.sw.operands[0].op_type.is_dest() and
+                isinstance(self.sw.operands[1].op_type, ImmOperandType) and
+                isinstance(self.sw.operands[2].op_type, RegOperandType) and
+                self.sw.operands[2].op_type.reg_type == 'gpr' and
+                not self.sw.operands[2].op_type.is_dest()):
+            raise RuntimeError('SW instruction from instructions file is '
+                               'not the shape expected by the BadLoadStore'
+                               'generator.')
+
+        self.bnlid = self._get_named_insn(insns_file, 'bn.lid')
+
+        # BN.LID Instruction Checks
+        # bn.lid expects the operands: grd, grs1, offset, grs1_inc, grd_inc
+        if len(self.bnlid.operands) != 5:
+            raise RuntimeError('Unexpected number of operands for bn.lid')
+
+        if not (isinstance(self.bnlid.operands[0].op_type, RegOperandType) and
+                (self.bnlid.operands[0].op_type.reg_type == 'gpr' and
+                not self.bnlid.operands[0].op_type.is_dest() and
+                isinstance(self.bnlid.operands[1].op_type, RegOperandType) and
+                self.bnlid.operands[1].op_type.reg_type == 'gpr' and
+                not self.bnlid.operands[1].op_type.is_dest() and
+                isinstance(self.bnlid.operands[2].op_type, ImmOperandType) and
+                self.bnlid.operands[2].op_type.signed and
+                isinstance(self.bnlid.operands[3].op_type, OptionOperandType) and
+                isinstance(self.bnlid.operands[4].op_type, OptionOperandType))):
+            raise RuntimeError('BN.LID instruction from instructions file is '
+                               'not the shape expected by the BadLoadStore'
+                               'generator.')
+        self.bnsid = self._get_named_insn(insns_file, 'bn.sid')
+
+        # BN.SID Instruction Checks
+
+        # bn.sid expects the operands: grs1, grs2, offset, grs1_inc,
+        # grs2_inc
+        if len(self.bnsid.operands) != 5:
+            raise RuntimeError('Unexpected number of operands for bn.sid')
+
+        if not (isinstance(self.bnsid.operands[0].op_type, RegOperandType) and
+                self.bnsid.operands[0].op_type.reg_type == 'gpr' and
+                not self.bnsid.operands[0].op_type.is_dest() and
+                isinstance(self.bnsid.operands[1].op_type, RegOperandType) and
+                self.bnsid.operands[1].op_type.reg_type == 'gpr' and
+                not self.bnsid.operands[1].op_type.is_dest() and
+                isinstance(self.bnsid.operands[2].op_type, ImmOperandType) and
+                self.bnsid.operands[2].op_type.signed and
+                isinstance(self.bnsid.operands[3].op_type, OptionOperandType) and
+                isinstance(self.bnsid.operands[4].op_type, OptionOperandType)):
+            raise RuntimeError('BN.LID instruction from instructions file is '
+                               'not the shape expected by the BadLoadStore'
+                               'generator.')
+
+        for insn in [self.sw, self.bnsid, self.lw, self.bnlid]:
+            weight = cfg.insn_weights.get(insn.mnemonic)
+            if weight > 0:
+                self.weights.append(weight)
+                self.insns.append(insn)
+
+        # Check that at least one instruction has a positive weight
+        assert len(self.insns) == len(self.weights)
+        if not self.weights:
+            self.disabled = True
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        weights = self.weights
+        prog_insn = None
+        while prog_insn is None:
+            idx = random.choices(range(len(self.insns)), weights=weights)[0]
+            # At least one weight should be positive. This is guaranteed so
+            # long as fill_insn doesn't fail for absolutely everything. We know
+            # that doesn't happen, because we have some instructions (such as
+            # addi) where it will not fail.
+            assert weights[idx] > 0
+
+            # Try to fill out the instruction. On failure, clear the weight for
+            # this index and go around again. We take the copy here, rather
+            # than outside the loop, because we don't expect this to happen
+            # very often.
+            prog_insn = self.fill_insn(self.insns[idx], model)
+            if prog_insn is None:
+                weights = self.weights.copy()
+                weights[idx] = 0
+                continue
+
+        snippet = ProgSnippet(model.pc, [prog_insn])
+        snippet.insert_into_program(program)
+
+        return (snippet, True, model)
+
+    def fill_insn(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
+        '''Try to pick one of BN.XID or XW instructions
+
+        '''
+
+        # Special-case BN load/store instructions by mnemonic. These use
+        # complicated indirect addressing, so it's probably more sensible to
+        # give them special code.
+        if insn.mnemonic in ['bn.lid', 'bn.sid']:
+            return self._fill_bn_xid(insn, model)
+        if insn.mnemonic in ['lw', 'sw']:
+            return self._fill_xw(insn, model)
+
+        return None
+
+    def _fill_xw(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
+
+        grd_op_type = self.lw.operands[0].op_type
+        imm_op_type = self.lw.operands[1].op_type
+
+        # Determine the offset range for XW
+        offset_rng = imm_op_type.get_op_val_range(model.pc)
+        assert offset_rng is not None
+
+        # Max/Min Offsets for XW (-2048, 2047)
+        min_offset, max_offset = offset_rng
+
+        # Get known registers
+        known_regs = model.regs_with_known_vals('gpr')
+
+        # We have two options for this generator: Barely OOB or OOB
+        barely_oob = []
+        oob = []
+
+        for reg_idx, u_reg_val in known_regs:
+            reg_val = u_reg_val - (1 << 32) if u_reg_val >> 31 else u_reg_val
+            # We can reach to barely OOB by adding max_offset to smallest val
+            # or adding min_offset (which is negative) to biggest possible val
+            if reg_val - model.dmem_size in range(-max_offset, -min_offset):
+                barely_oob.append((reg_idx, reg_val))
+            # Negative OOB
+            if reg_val + min_offset < 0:
+                oob.append((reg_idx, reg_val))
+            # Positive OOB
+            if reg_val + max_offset > model.dmem_size:
+                oob.append((reg_idx, reg_val))
+
+        if random.random() < 0.2 and barely_oob:
+            idx, val = random.choice(barely_oob)
+            tgt_addr = model.dmem_size
+        elif oob:
+            idx, val = random.choice(oob)
+            if val + min_offset < 0:
+                tgt_addr = random.randrange(val + min_offset, -1)
+            else:
+                tgt_addr = random.randrange(model.dmem_size, val + max_offset)
+        else:
+            return None
+
+        imm_val = tgt_addr - val
+
+        # Check if the final target address is in OOB region
+        assert imm_val + val < 0 or imm_val + val >= model.dmem_size
+
+        offset_val = imm_op_type.op_val_to_enc_val(imm_val, model.pc)
+        assert offset_val is not None
+
+        # Get the chosen base register index as grs1 operand.
+        op_val_grs1 = idx
+        assert op_val_grs1 is not None
+
+        if insn.mnemonic == 'lw':
+            # Pick grd randomly. Since we can write to any register
+            # (including x0) this should always succeed.
+            op_val_grd = model.pick_operand_value(grd_op_type)
+            assert op_val_grd is not None
+
+            op_val = [op_val_grd, offset_val, op_val_grs1]
+
+        elif insn.mnemonic == 'sw':
+            # Any known register is okay for grs2 operand since it will be
+            # guaranteed to have an out of bounds address to store the value from
+            # We definitely have a known register (x0), so this should never fail
+            op_val_grs2 = random.choice(known_regs)[0]
+
+            op_val = [op_val_grs2, offset_val, op_val_grs1]
+
+        return ProgInsn(insn, op_val, ('dmem', 4096))
+
+    def _fill_bn_xid(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
+        '''Fill out a BN.LID or BN.SID instruction'''
+
+        bn_imm_op_type = self.bnlid.operands[2].op_type
+
+        # Determine the offset range for BN.XID
+        bn_offset_rng = bn_imm_op_type.get_op_val_range(model.pc)
+        assert bn_offset_rng is not None
+
+        # Max/Min Offsets for BN.XID (-512 * 32, 511 * 32)
+        min_offset, max_offset = bn_offset_rng
+
+        # Get known registers
+        known_regs = model.regs_with_known_vals('gpr')
+
+        idx, u_val = random.choice(known_regs)
+        val = u_val - (1 << 32) if u_val >> 31 else u_val
+        tgt_addr = random.randrange(val + min_offset, val + max_offset, 32)
+
+        # Check if randomized tgt_addr is in OOB region.
+        if tgt_addr >> 12:
+            bn_imm_val = tgt_addr - val
+        # If randomized tgt_addr is not in OOB region, make sure bn_imm_val is
+        # big enough. So that the new resulting tgt_addr will definitely
+        # be in OOB region.
+        else:
+            bn_imm_val = tgt_addr + model.dmem_size - val
+
+        # Check if the final target address is in OOB region
+        assert bn_imm_val + val < 0 or bn_imm_val + val >= model.dmem_size
+
+        bn_offset_val = bn_imm_op_type.op_val_to_enc_val(bn_imm_val, model.pc)
+        assert bn_offset_val is not None
+
+        # Get the chosen base register index as grs1 operand.
+        op_val_grs1 = idx
+        assert op_val_grs1 is not None
+
+        if insn.mnemonic == 'bn.lid':
+            # Pick grd randomly. Since we can write to any register
+            # (including x0) this should always succeed.
+            op_val_grd = model.pick_operand_value(self.bnlid.operands[0].op_type)
+            assert op_val_grd is not None
+
+            op_val = [op_val_grd, op_val_grs1, bn_offset_val, 0, 0]
+
+        elif insn.mnemonic == 'bn.sid':
+            # Any known register is okay for grs2 operand since it will be
+            # guaranteed to have an out of bounds address to store the value from.
+            # We definitely have a known register (x0), so this should never fail
+            op_val_grs2 = random.choice(known_regs)[0]
+
+            op_val = [op_val_grs1, op_val_grs2, bn_offset_val, 0, 0]
+
+        return ProgInsn(insn, op_val, ('dmem', 4096))

--- a/hw/ip/otbn/dv/rig/rig/gens/edge_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/edge_load_store.py
@@ -1,0 +1,222 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional
+
+from shared.operand import ImmOperandType, RegOperandType, OptionOperandType
+from shared.insn_yaml import Insn, InsnsFile
+
+from ..config import Config
+from ..model import Model
+from ..program import ProgInsn, Program
+
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
+
+
+class EdgeLoadStore(SnippetGen):
+    '''A snippet generator that generates random stores that try to
+    hit edge cases.
+
+    '''
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__()
+
+        self.insns = []
+        self.weights = []
+
+        self.sw = self._get_named_insn(insns_file, 'sw')
+
+        # SW Instruction Checks
+        # SW has three operands: grs1, offset, grs2
+        if not (len(self.sw.operands) == 3 and
+                isinstance(self.sw.operands[0].op_type, RegOperandType) and
+                self.sw.operands[0].op_type.reg_type == 'gpr' and
+                not self.sw.operands[0].op_type.is_dest() and
+                isinstance(self.sw.operands[1].op_type, ImmOperandType) and
+                isinstance(self.sw.operands[2].op_type, RegOperandType) and
+                self.sw.operands[2].op_type.reg_type == 'gpr' and
+                not self.sw.operands[2].op_type.is_dest()):
+            raise RuntimeError('SW instruction from instructions file is '
+                               'not the shape expected by the BadLoadStore'
+                               'generator.')
+
+        self.bnsid = self._get_named_insn(insns_file, 'bn.sid')
+
+        # BN.SID Instruction Checks
+        # bn.sid expects the operands: grs1, grs2, offset, grs1_inc,
+        # grs2_inc20512
+        if len(self.bnsid.operands) != 5:
+            raise RuntimeError('Unexpected number of operands for bn.sid')
+
+        if not (isinstance(self.bnsid.operands[0].op_type, RegOperandType) and
+                self.bnsid.operands[0].op_type.reg_type == 'gpr' and
+                not self.bnsid.operands[0].op_type.is_dest() and
+                isinstance(self.bnsid.operands[1].op_type, RegOperandType) and
+                self.bnsid.operands[1].op_type.reg_type == 'gpr' and
+                not self.bnsid.operands[1].op_type.is_dest() and
+                isinstance(self.bnsid.operands[2].op_type, ImmOperandType) and
+                self.bnsid.operands[2].op_type.signed and
+                isinstance(self.bnsid.operands[3].op_type, OptionOperandType) and
+                isinstance(self.bnsid.operands[4].op_type, OptionOperandType)):
+            raise RuntimeError('BN.LID instruction from instructions file is '
+                               'not the shape expected by the BadLoadStore'
+                               'generator.')
+
+        for insn in [self.sw, self.bnsid]:
+            weight = cfg.insn_weights.get(insn.mnemonic)
+            if weight > 0:
+                self.weights.append(weight)
+                self.insns.append(insn)
+
+        # Check that at least one instruction has a positive weight
+        assert len(self.insns) == len(self.weights)
+        if not self.weights:
+            self.disabled = True
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        # Return None if this is the last instruction in the current gap
+        # because we need to either jump or do an ECALL to avoid getting stuck.
+        if program.get_insn_space_at(model.pc) <= 1:
+            return None
+
+        weights = self.weights
+        chosen_insn = random.choices(self.insns, weights=weights)[0]
+
+        prog_insn = self.fill_insn(chosen_insn, model)
+        if prog_insn is None:
+            return None
+
+        snippet = ProgSnippet(model.pc, [prog_insn])
+        snippet.insert_into_program(program)
+        model.update_for_insn(prog_insn)
+        model.pc += 4
+        return (snippet, False, model)
+
+    def fill_insn(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
+        '''Try to pick one of BN.SID or SW instructions
+
+        '''
+
+        # Special-case BN store instruction by mnemonic. These use
+        # complicated indirect addressing, so it's probably more sensible to
+        # give them special code.
+        if insn.mnemonic in ['bn.sid']:
+            return self._fill_bn_sid(insn, model)
+        if insn.mnemonic in ['sw']:
+            return self._fill_sw(insn, model)
+
+        return None
+
+    def _fill_sw(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
+
+        imm_op_type = self.sw.operands[1].op_type
+
+        # Determine the offset range for SW
+        offset_rng = imm_op_type.get_op_val_range(model.pc)
+        assert offset_rng is not None
+
+        # Max/Min Offsets for SW (-2048, 2047)
+        min_offset, max_offset = offset_rng
+
+        # Get known registers
+        known_regs = model.regs_with_known_vals('gpr')
+
+        base = []
+
+        for reg_idx, u_reg_val in known_regs:
+            reg_val = u_reg_val - (1 << 32) if u_reg_val >> 31 else u_reg_val
+            if model.dmem_size - reg_val - 4 in range(min_offset, max_offset + 1):
+                base.append((reg_idx, reg_val))
+
+        if not base:
+            return None
+
+        # Pick a random register among known registers that are constrained above
+        idx, value = random.choice(base)
+
+        imm_val = model.dmem_size - 4 - value
+
+        addr = imm_val + value
+        assert addr == model.dmem_size - 4
+
+        offset_val = imm_op_type.op_val_to_enc_val(imm_val, model.pc)
+        assert offset_val is not None
+
+        # Get the chosen base register index as grs1 operand.
+        op_val_grs1 = idx
+        assert op_val_grs1 is not None
+
+        # Any known register is okay for grs2 operand since it will be
+        # guaranteed to have an out of bounds address to store the value from.
+        # We definitely ave a known register (x0), so this should never fail
+        op_val_grs2 = random.choice(known_regs[0])
+
+        op_val = [op_val_grs2, offset_val, op_val_grs1]
+
+        return ProgInsn(insn, op_val, ('dmem', addr))
+
+    def _fill_bn_sid(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
+        '''Fill out a BN.SID instruction'''
+
+        bn_imm_op_type = self.bnsid.operands[2].op_type
+
+        # Determine the offset range for BN.SID
+        bn_offset_rng = bn_imm_op_type.get_op_val_range(model.pc)
+        assert bn_offset_rng is not None
+
+        # Max/Min Offsets for BN.SID (-512 * 32, 511 * 32)
+        min_offset, max_offset = bn_offset_rng
+
+        # Get known registers
+        known_regs = model.regs_with_known_vals('gpr')
+
+        base = []
+        valid_grs2s = []
+        known_wdrs = model.regs_with_known_vals('wdr')
+        if not known_wdrs:
+            return None
+
+        # Choose not too big not too little register values
+        # Also find a register for grd and grs2 operands
+        for reg_idx, u_reg_val in known_regs:
+            reg_val = u_reg_val - (1 << 32) if u_reg_val >> 31 else u_reg_val
+            if ((model.dmem_size - reg_val - 32
+                 in range(min_offset, max_offset + 1) and not reg_val % 32)):
+                base.append((reg_idx, reg_val))
+            if reg_val < 32 and reg_val in known_wdrs[0]:
+                valid_grs2s.append(reg_idx)
+
+        if not valid_grs2s:
+            return None
+
+        if not base:
+            return None
+
+        # Pick a random register among known registers
+        idx, value = random.choice(base)
+        bn_imm_val = model.dmem_size - 32 - value
+        addr = bn_imm_val + value
+        assert addr == model.dmem_size - 32
+
+        bn_offset_val = bn_imm_op_type.op_val_to_enc_val(bn_imm_val, model.pc)
+        assert bn_offset_val is not None
+
+        # Get the chosen base register index as grs1 operand.
+        op_val_grs1 = idx
+        assert op_val_grs1 is not None
+
+        # Any known register is okay for grs2 operand since it will be
+        # guaranteed to have an out of bounds address to store the value from.
+        # We definitely have a known register (x0), so this should never fail
+        op_val_grs2 = random.choice(valid_grs2s)
+
+        op_val = [op_val_grs1, op_val_grs2, bn_offset_val, 0, 0]
+
+        return ProgInsn(insn, op_val, ('dmem', addr))

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -28,6 +28,7 @@ from .gens.bad_bnmovr import BadBNMovr
 from .gens.bad_deep_loop import BadDeepLoop
 from .gens.bad_insn import BadInsn
 from .gens.bad_giant_loop import BadGiantLoop
+from .gens.bad_load_store import BadLoadStore
 from .gens.bad_zero_loop import BadZeroLoop
 
 
@@ -50,6 +51,7 @@ class SnippetGens:
         BadDeepLoop,
         BadInsn,
         BadGiantLoop,
+        BadLoadStore,
         BadZeroLoop
     ]
 

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -17,10 +17,11 @@ from .gens.branch import Branch
 from .gens.call_stack_rw import CallStackRW, BadCallStackRW
 from .gens.ecall import ECall
 from .gens.jump import Jump
+from .gens.edge_load_store import EdgeLoadStore
+from .gens.known_wdr import KnownWDR
 from .gens.loop import Loop
 from .gens.loop_dup_end import LoopDupEnd
 from .gens.small_val import SmallVal
-from .gens.known_wdr import KnownWDR
 from .gens.straight_line_insn import StraightLineInsn
 
 from .gens.bad_at_end import BadAtEnd
@@ -37,6 +38,7 @@ class SnippetGens:
     _CLASSES = [
         Branch,
         CallStackRW,
+        EdgeLoadStore,
         Jump,
         Loop,
         LoopDupEnd,


### PR DESCRIPTION
Bad load-store generates out of bounds addresses and generates
an error. Edge store generates store instructions at the edge
address of memory.

Resolves #7658 

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>