### PR TITLE
[keymgr/dv] Truncate kmac digest for key/SW output

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -181,7 +181,9 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
     case (update_result)
       UpdateInternalKey: begin
-        current_internal_key[current_cdi] = {item.rsp_digest_share1, item.rsp_digest_share0};
+        // digest is 384 bits wide while internal key is only 256, need to truncate it
+        current_internal_key[current_cdi] = {item.rsp_digest_share1[keymgr_pkg::KeyWidth-1:0],
+                                             item.rsp_digest_share0[keymgr_pkg::KeyWidth-1:0]};
         cfg.keymgr_vif.store_internal_key(current_internal_key[current_cdi], current_state,
                                           current_cdi);
 
@@ -191,7 +193,9 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
       UpdateSwOut: begin
         bit [keymgr_pkg::Shares-1:0][DIGEST_SHARE_WORD_NUM-1:0][TL_DW-1:0] sw_share_output;
 
-        sw_share_output = {item.rsp_digest_share1, item.rsp_digest_share0};
+        // digest is 384 bits wide while SW output is only 256, need to truncate it
+        sw_share_output = {item.rsp_digest_share1[keymgr_pkg::KeyWidth-1:0],
+                           item.rsp_digest_share0[keymgr_pkg::KeyWidth-1:0]};
         foreach (sw_share_output[i, j]) begin
           string csr_name = $sformatf("sw_share%0d_output_%0d", i, j);
           uvm_reg csr = ral.get_reg_by_name(csr_name);


### PR DESCRIPTION
Digest is 384 bits wide while SW output is only 256.

This will fix CI falures in #7646. Thanks @udinator for finding this issue.

Signed-off-by: Weicai Yang <weicai@google.com>