### PR TITLE
[sram_ctrl_ret_aon] Remove en_ifetch chicken bit from retention RAM

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3521,7 +3521,6 @@
           width: 1
           default: "'0"
           inst_name: sram_ctrl_ret_aon
-          top_signame: sram_ctrl_ret_aon_otp_en_sram_ifetch
           index: -1
         }
         {
@@ -6894,7 +6893,6 @@
       lc_ctrl.otp_manuf_state
       keymgr.otp_device_id
       sram_ctrl_main.otp_en_sram_ifetch
-      sram_ctrl_ret_aon.otp_en_sram_ifetch
     ]
     external:
     {
@@ -14916,7 +14914,6 @@
         width: 1
         default: "'0"
         inst_name: sram_ctrl_ret_aon
-        top_signame: sram_ctrl_ret_aon_otp_en_sram_ifetch
         index: -1
       }
       {
@@ -19914,15 +19911,6 @@
         package: otp_ctrl_pkg
         struct: otp_en
         signame: sram_ctrl_main_otp_en_sram_ifetch
-        width: 1
-        type: uni
-        end_idx: -1
-        default: "'0"
-      }
-      {
-        package: otp_ctrl_pkg
-        struct: otp_en
-        signame: sram_ctrl_ret_aon_otp_en_sram_ifetch
         width: 1
         type: uni
         end_idx: -1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -913,7 +913,6 @@
         'lc_ctrl.otp_manuf_state',
         'keymgr.otp_device_id',
         'sram_ctrl_main.otp_en_sram_ifetch',
-        'sram_ctrl_ret_aon.otp_en_sram_ifetch'
     ],
 
     // ext is to create port in the top.

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -712,7 +712,6 @@ module top_earlgrey #(
   otp_ctrl_pkg::otp_manuf_state_t       lc_ctrl_otp_manuf_state;
   otp_ctrl_pkg::otp_device_id_t       keymgr_otp_device_id;
   otp_ctrl_pkg::otp_en_t       sram_ctrl_main_otp_en_sram_ifetch;
-  otp_ctrl_pkg::otp_en_t       sram_ctrl_ret_aon_otp_en_sram_ifetch;
 
   // define mixed connection to port
   assign edn0_edn_req[2] = ast_edn_req_i;
@@ -752,7 +751,6 @@ module top_earlgrey #(
   assign entropy_src_otp_en_entropy_src_fw_read = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_read;
   assign entropy_src_otp_en_entropy_src_fw_over = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_over;
   assign sram_ctrl_main_otp_en_sram_ifetch = otp_ctrl_otp_hw_cfg.data.en_sram_ifetch;
-  assign sram_ctrl_ret_aon_otp_en_sram_ifetch = otp_ctrl_otp_hw_cfg.data.en_sram_ifetch;
   assign lc_ctrl_otp_device_id = otp_ctrl_otp_hw_cfg.data.device_id;
   assign lc_ctrl_otp_manuf_state = otp_ctrl_otp_hw_cfg.data.manuf_state;
   assign keymgr_otp_device_id = otp_ctrl_otp_hw_cfg.data.device_id;
@@ -1900,7 +1898,7 @@ module top_earlgrey #(
       .cfg_i(ast_ram_1p_cfg),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),
-      .otp_en_sram_ifetch_i(sram_ctrl_ret_aon_otp_en_sram_ifetch),
+      .otp_en_sram_ifetch_i('0),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_ret_aon_ram_tl_req),

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -243,7 +243,6 @@ module top_${top["name"]} #(
   assign entropy_src_otp_en_entropy_src_fw_read = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_read;
   assign entropy_src_otp_en_entropy_src_fw_over = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_over;
   assign sram_ctrl_main_otp_en_sram_ifetch = otp_ctrl_otp_hw_cfg.data.en_sram_ifetch;
-  assign sram_ctrl_ret_aon_otp_en_sram_ifetch = otp_ctrl_otp_hw_cfg.data.en_sram_ifetch;
   assign lc_ctrl_otp_device_id = otp_ctrl_otp_hw_cfg.data.device_id;
   assign lc_ctrl_otp_manuf_state = otp_ctrl_otp_hw_cfg.data.manuf_state;
   assign keymgr_otp_device_id = otp_ctrl_otp_hw_cfg.data.device_id;


### PR DESCRIPTION
The retention RAM ifetch feature had already been disabled via the parameter. This commit removes the physical connection of the OTP chicken bits as well.

Fix #7107

Signed-off-by: Michael Schaffner <msf@google.com>