### PR TITLE
[dv/prim_esc] fix regression error

### DIFF
--- a/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
@@ -21,7 +21,7 @@
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 1
+  reseed: 5
 
   // List of test specifications.
   tests: [

--- a/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
+++ b/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
@@ -123,7 +123,7 @@ module prim_esc_tb;
     $display("Escalation esc_p/n integrity sequence passed!");
 
     // 3). Escalation reverse ping request timeout sequence.
-    main_clk.wait_clks($urandom_range(0, 20));
+    main_clk.wait_clks($urandom_range(1, 20));
     ping_req = 1;
     fork
       begin


### PR DESCRIPTION
This PR fxe a corner case where ping_req is issued at the same cycle as
esc_req goes low with signal integrity error.
The prim_esc_receiver ignored the ping request because the esc_req was
set low at the same cycle.

Also add a few more iterations to reach higher coverage.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>