### PR TITLE
[dv] Change tl_intg_alert_field to associative array

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -16,7 +16,8 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   // If there is a bit in an "alert cause" register that will be set by a corrupt bus access, this
   // should be the name of that field (with syntax "reg.field"). Used by cip_base_scoreboard to
   // update the relevant field in the RAL model if it sees an error.
-  string              tl_intg_alert_field = "";
+  // Format: tl_intg_alert_fields[ral.a_reg.a_field] = value
+  uvm_reg_data_t      tl_intg_alert_fields[dv_base_reg_field];
   // Enables TL integrity generation & checking with *_user bits.
   // Assume ALL TL agents have integrity check enabled or disabled altogether.
   bit                 en_tl_intg_gen = 1;
@@ -48,7 +49,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
     `uvm_field_aa_object_string(m_tl_agent_cfgs,   UVM_DEFAULT)
     `uvm_field_aa_object_string(m_alert_agent_cfg, UVM_DEFAULT)
     `uvm_field_int             (num_interrupts,    UVM_DEFAULT)
- `uvm_object_utils_end
+  `uvm_object_utils_end
 
   `uvm_object_new
 

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -495,40 +495,13 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   endfunction
 
   virtual function void update_tl_alert_field_prediction();
-    string        regname;
-    string        fldname;
-    string        name_components[$];
-    uvm_reg       register;
-    uvm_reg_field field;
+    foreach (cfg.tl_intg_alert_fields[field]) begin
+      uvm_reg_data_t value = cfg.tl_intg_alert_fields[field];
+      `DV_CHECK_FATAL(field, "field is Null in tl_intg_alert_fields")
 
-    if (cfg.tl_intg_alert_field == "") begin
-      // No field configured. Return immediately.
-      return;
+      // Set the field
+      `DV_CHECK_FATAL(field.predict(.value(value), .kind(UVM_PREDICT_READ)));
     end
-
-    // Split the string into register and field name.
-    str_utils_pkg::str_split(.s(cfg.tl_intg_alert_field),
-                             .result(name_components),
-                             .delim("."),
-                             .strip_whitespaces(1'b0));
-    `DV_CHECK_EQ_FATAL(name_components.size(), 2,
-                       $sformatf("tl_intg_alert_field must have form REG.FIELD. It is `%0s'.",
-                                 cfg.tl_intg_alert_field))
-
-    regname = name_components[0];
-    fldname = name_components[1];
-
-    register = ral.get_reg_by_name(regname);
-    `DV_CHECK_FATAL(register,
-                    $sformatf("No register called %0s (from tl_intg_alert_field)", regname))
-
-    field = register.get_field_by_name(fldname);
-    `DV_CHECK_FATAL(field,
-                    $sformatf("No field called %0s in the %0s register (from tl_intg_alert_field)",
-                              fldname, regname))
-
-    // Set the field
-    `DV_CHECK_FATAL(field.predict(.value(1), .kind(UVM_PREDICT_READ)));
   endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -180,8 +180,8 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     list_of_alerts = aes_env_pkg::LIST_OF_ALERTS;
     has_edn = 1;
-    tl_intg_alert_field = "status.alert_fatal_fault";
     super.initialize(csr_base_addr);
+    tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;
   endfunction
 
 endclass

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -19,6 +19,8 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
     tl_intg_alert_name = "fatal_fault_err";
     has_edn = 1;
     super.initialize(csr_base_addr);
+    tl_intg_alert_fields[ral.err_code.invalid_states] = 1;
+    tl_intg_alert_fields[ral.fault_status.regfile_intg] = 1;
 
     m_keymgr_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_keymgr_kmac_agent_cfg");
     m_keymgr_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -53,11 +53,11 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     // Tell the CIP base code what alert we generate if we see a TL fault and the field in the
     // FATAL_ALERT_CAUSE register that it should expect to see get set.
     tl_intg_alert_name = "fatal";
-    tl_intg_alert_field = "fatal_alert_cause.bus_integrity_error";
 
     model_agent_cfg = otbn_model_agent_cfg::type_id::create("model_agent_cfg");
 
     super.initialize(csr_base_addr);
+    tl_intg_alert_fields[ral.fatal_alert_cause.bus_integrity_error] = 1;
   endfunction
 
 endclass

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -32,7 +32,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
     m_kmac_agent_cfg.start_default_device_seq = 1'b1;
 
     // Tell the CIP base code what bit gets set if we see a TL fault.
-    tl_intg_alert_field = "fatal_alert_cause.integrity_error";
+    tl_intg_alert_fields[ral.fatal_alert_cause.integrity_error] = 1;
   endfunction
 
 endclass


### PR DESCRIPTION
Format is tl_intg_alert_fields[reg_name] = field_name;

TL intg error may trigger more than CSR changes. For example,
It triggers Keymgr to update these 2 fields
    tl_intg_alert_fields[ral.err_code.invalid_states] = value1;
    tl_intg_alert_fields[ral.fault_status.regfile_intg] = value2;

Signed-off-by: Weicai Yang <weicai@google.com>