### PR TITLE
[sw/silicon_creator] Add reset reason enum to rstmgr driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -29,11 +29,59 @@ typedef struct RstMgrAlertInfo {
 extern rstmgr_alert_info_t rstmgr_alert_info;
 
 /**
- * Get the reason for the last reset.
+ * Reset reason bitfield indices.
+ *
+ * Note that the reset reasons are not necessarily mutually exclusive.
+ */
+typedef enum rstmgr_reason {
+  /**
+   * Power on reset (POR).
+   */
+  kRstmgrReasonPowerOn = 0,
+
+  /**
+   * Low power exit (LOW_POWER_EXIT).
+   */
+  kRstmgrReasonLowPowerExit = 1,
+
+  /**
+   * Non-debug module (NDM).
+   */
+  kRstmgrReasonNonDebugModule = 2,
+
+  /**
+   * Hardware requests (HW_REQ).
+   */
+  kRstmgrReasonSysrstCtrl = 3,
+  kRstmgrReasonWatchdog = 4,
+  kRstmgrReasonEscalation = 5,
+
+  /**
+   * Last used bit index (inclusive).
+   */
+  kRstmgrReasonLast = 5,
+} rstmgr_reason_t;
+
+/**
+ * Get the reason(s) for the last reset.
+ *
+ * The reset reason is a bitfield. Individual bits may be extracted using
+ * the indices provided by the `rstmgr_reason_t` enumeration. The reset
+ * reasons are not necessarily mutually exclusive.
  *
  * This function also captures alert information into `rstmgr_alert_info`.
  */
 uint32_t rstmgr_reason_get(void);
+
+/**
+ * Clear the reset reason(s) set in the given mask.
+ *
+ * A value of all ones will clear all the reset reasons while zero will
+ * leave the register unchanged.
+ *
+ * @param reasons A mask containing the bit fields to clear.
+ */
+void rstmgr_reason_clear(uint32_t reasons);
 
 /**
  * Enable capturing of alert info in the event of an alert escalation.

--- a/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
@@ -43,6 +43,12 @@ TEST_F(RstmgrTest, GetResetReason) {
               ElementsAre(1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
+TEST_F(RstmgrTest, ClearResetReason) {
+  uint32_t mask = 1u << kRstmgrReasonPowerOn;
+  EXPECT_ABS_WRITE32(base_ + RSTMGR_RESET_INFO_REG_OFFSET, mask);
+  rstmgr_reason_clear(mask);
+}
+
 TEST_F(RstmgrTest, EnableAlertInfo) {
   EXPECT_ABS_WRITE32(base_ + RSTMGR_ALERT_INFO_CTRL_REG_OFFSET, 1);
   rstmgr_alert_info_enable();


### PR DESCRIPTION
This attempts to both centralize the definitions of the reset reason
bitfields and also make them slightly more robust. In particular
this change should catch modifications to the layout of the HW_REQ
field at compilation time.

This change also adds the `rstmgr_reason_clear` function that can
be used to clear reset reasons that have already been processed.

Signed-off-by: Michael Munday <mike.munday@lowrisc.org>