### PR TITLE
[entropycomplex/rtl] exclude writes to test reg

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -271,6 +271,8 @@
       desc: "Hardware detection of error conditions status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      tags: [ // The internal HW can modify the error code registers
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0",
           name: "SFIFO_CMD_ERR",

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -248,6 +248,8 @@
       desc: "Hardware detection of error conditions status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      tags: [ // The internal HW can modify the error code registers
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0",
           name: "SFIFO_RESCMD_ERR",

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1119,6 +1119,8 @@
       desc: "Hardware detection of error conditions status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      tags: [ // The internal HW can modify the error code registers
+              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0",
           name: "SFIFO_ESRNG_ERR",

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -15,7 +15,7 @@ class entropy_src_smoke_test extends entropy_src_base_test;
     cfg.route_software_pct          = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
-    
+
     // To correctly model ast/rng behavior, back-to-back entropy is not allowed
     cfg.m_rng_agent_cfg.zero_delays = 0;
 


### PR DESCRIPTION
For all entropy blocks, the CSR tests will be excluded from writing the ERR_CODE_TEST register.
Specific sequenced tests will need to be created to test this register.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>