### PR TITLE
[dvsim] Minor fixes to coverage extraction

### DIFF
--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -612,21 +612,16 @@ class CovReport(Deploy):
     def post_finish(self, status):
         """Extract the coverage results summary for the dashboard.
 
-        If that fails for some reason, report the job as a failure.
+        If the extraction fails, an appropriate exception is raised, which must
+        be caught by the caller to mark the job as a failure.
         """
 
         if self.dry_run or status != 'P':
             return
 
-        results, self.cov_total, ex_msg = get_cov_summary_table(
+        results, self.cov_total = get_cov_summary_table(
             self.cov_report_txt, self.sim_cfg.tool)
 
-        if ex_msg:
-            self.launcher.fail_msg += ex_msg
-            log.error(ex_msg)
-            return
-
-        # Succeeded in obtaining the coverage data.
         colalign = (("center", ) * len(results[0]))
         self.cov_results = tabulate(results,
                                     headers="firstrow",

--- a/util/dvsim/LocalLauncher.py
+++ b/util/dvsim/LocalLauncher.py
@@ -80,7 +80,7 @@ class LocalLauncher(Launcher):
         self.exit_code = self.process.returncode
         status, err_msg = self._check_status()
         self._post_finish(status, err_msg)
-        return status
+        return self.status
 
     def kill(self):
         '''Kill the running process.
@@ -104,9 +104,9 @@ class LocalLauncher(Launcher):
                                             context=[]))
 
     def _post_finish(self, status, err_msg):
-        super()._post_finish(status, err_msg)
         self._close_process()
         self.process = None
+        super()._post_finish(status, err_msg)
 
     def _close_process(self):
         '''Close the file descriptors associated with the process.'''

--- a/util/dvsim/LsfLauncher.py
+++ b/util/dvsim/LsfLauncher.py
@@ -119,10 +119,6 @@ class LsfLauncher(Launcher):
     def __init__(self, deploy):
         super().__init__(deploy)
 
-        # Set the status. Only update after the job is done - i.e. status will
-        # transition from None to P/F/K.
-        self.status = None
-
         # Maintain the job script output as an instance variable for polling
         # and cleanup.
         self.bsub_out = None
@@ -390,7 +386,6 @@ class LsfLauncher(Launcher):
     def _post_finish(self, status, err_msg):
         if self.bsub_out_fd:
             self.bsub_out_fd.close()
-        self.status = status
         if self.exit_code is None:
             self.exit_code = 0 if status == 'P' else 1
         super()._post_finish(status, err_msg)


### PR DESCRIPTION
The issue was reported by @rasmus-madsen - if the cleanup tasks in
Deploy::post_finish() fails, it attempts append the error message to a
Launcher class member called `fail_msg` which has not been created,
causing the dvsim invocation to bomb improperly.

A bigger issue here is not factoring in the failure of the cleanup tasks 
to determine whether a job completed successfully or not, especially 
when run locally (i.e. when the `LocalLauncher` is used). This PR fixes
both of these issues. The job `status` is made a member of the 
`Launcher` class which is returned to the Scheduler at the end. Cleanup 
tasks are run regardless of the job's outcome, but now that invocation
is updated to catch any exceptions thrown, so that the `status` can be 
updated if they fail for whatever reason. 

In addition, a minor change in the Xcelium coverage extraction code
fixes the issue of some coverage metrics not showing up correctly.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>