### PR TITLE
[dv] Add Aes, Otbn sideload seq

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -409,6 +409,24 @@
   end
 `endif
 
+// This macro converts a string input from plusarg to an enum variable
+// ENUM_: the name of enum type
+// PLUSARG_: the name of the plusargs, which is also the name of the enum variable
+// CHECK_EXIST_: set to 1, `$value$plusargs()` should return true
+`ifndef DV_GET_ENUM_PLUSARG
+`define DV_GET_ENUM_PLUSARG(ENUM_, PLUSARG_, CHECK_EXIST_ = 0, ID_ = `gfn) \
+  begin \
+    string str; \
+    if ($value$plusargs("``PLUSARG_``=%0s", str)) begin \
+      if (!uvm_enum_wrapper#(ENUM_)::from_name(str, PLUSARG_)) begin \
+        `uvm_fatal(ID_, $sformatf("Cannot find %s from enum ``ENUM_``", PLUSARG_.name)) \
+      end \
+    end else if (CHECK_EXIST_) begin \
+      `uvm_fatal(ID_, "Can't find plusargs ``PLUSARG_``") \
+    end \
+  end
+`endif
+
 // Enable / disable assertions at a module hierarchy identified by LABEL_.
 //
 // This goes in conjunction with `DV_ASSERT_CTRL() macro above, but is invoked in the entity that is

--- a/hw/ip/keymgr/dv/env/keymgr_env.core
+++ b/hw/ip/keymgr/dv/env/keymgr_env.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:cip_lib
       - lowrisc:dv:kmac_app_agent
       - lowrisc:ip:keymgr
+      - lowrisc:ip:kmac_pkg
     files:
       - keymgr_env_pkg.sv
       - keymgr_if.sv
@@ -24,6 +25,7 @@ filesets:
       - seq_lib/keymgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_sideload_vseq.sv: {is_include_file: true}
+      - seq_lib/keymgr_sideload_one_intf_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_random_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_cfg_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/keymgr_direct_to_disabled_vseq.sv: {is_include_file: true}

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -26,6 +26,7 @@ package keymgr_env_pkg;
 
   typedef virtual keymgr_if keymgr_vif;
   typedef bit [keymgr_pkg::Shares-1:0][keymgr_pkg::KeyWidth-1:0] key_shares_t;
+  typedef bit [keymgr_pkg::Shares-1:0][kmac_pkg::AppDigestW-1:0] kmac_digests_t;
   typedef enum {
     IntrOpDone,
     NumKeyMgrIntr

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -206,7 +206,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
         end
       end
       UpdateHwOut: begin
-        key_shares_t key_shares = {item.rsp_digest_share1, item.rsp_digest_share0};
+        kmac_digests_t key_shares = {item.rsp_digest_share1, item.rsp_digest_share0};
         bit good_key = (get_err_code() == 0);
         keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
             `gmv(ral.control.dest_sel));
@@ -897,6 +897,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     case (dest)
       keymgr_pkg::Kmac: exp.KeyID = keymgr_pkg::RndCnstKmacSeedDefault;
       keymgr_pkg::Aes:  exp.KeyID = keymgr_pkg::RndCnstAesSeedDefault;
+      keymgr_pkg::Otbn: exp.KeyID = keymgr_pkg::RndCnstOtbnSeedDefault;
       keymgr_pkg::None: exp.KeyID = keymgr_pkg::RndCnstNoneSeedDefault;
       default: `uvm_fatal(`gfn, $sformatf("Unexpected dest_sel: %0s", dest.name))
     endcase

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Enable OpGenHwOut to test sideload key to a selected interface
+class keymgr_sideload_one_intf_vseq extends keymgr_smoke_vseq;
+  `uvm_object_utils(keymgr_sideload_one_intf_vseq)
+  `uvm_object_new
+
+  keymgr_pkg::keymgr_key_dest_e sideload_dest;
+  // also test HW sideload
+  constraint gen_operation_c {
+    gen_operation == keymgr_pkg::OpGenHwOut;
+  }
+  constraint key_dest_c {
+    key_dest == sideload_dest;
+  }
+  function void pre_randomize();
+    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, 1)
+    super.pre_randomize();
+  endfunction
+endclass : keymgr_sideload_one_intf_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_vseq_list.sv
@@ -6,6 +6,7 @@
 `include "keymgr_smoke_vseq.sv"
 `include "keymgr_common_vseq.sv"
 `include "keymgr_sideload_vseq.sv"
+`include "keymgr_sideload_one_intf_vseq.sv"
 `include "keymgr_random_vseq.sv"
 `include "keymgr_cfg_regwen_vseq.sv"
 `include "keymgr_direct_to_disabled_vseq.sv"

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -58,6 +58,24 @@
     }
 
     {
+      name: keymgr_sideload_kmac
+      uvm_test_seq: keymgr_sideload_one_intf_vseq
+      run_opts: ["+sideload_dest=Kmac"]
+    }
+
+    {
+      name: keymgr_sideload_aes
+      uvm_test_seq: keymgr_sideload_one_intf_vseq
+      run_opts: ["+sideload_dest=Aes"]
+    }
+
+    {
+      name: keymgr_sideload_otbn
+      uvm_test_seq: keymgr_sideload_one_intf_vseq
+      run_opts: ["+sideload_dest=Otbn"]
+    }
+
+    {
       name: keymgr_random
       uvm_test_seq: keymgr_random_vseq
     }

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -46,6 +46,7 @@ module tb;
     .clk_edn_i            (edn_clk    ),
     .rst_edn_ni           (edn_rst_n  ),
     .aes_key_o            (keymgr_if.aes_key),
+    .otbn_key_o           (keymgr_if.otbn_key),
     .kmac_key_o           (keymgr_if.kmac_key),
     .kmac_data_o          (keymgr_kmac_intf.kmac_data_req),
     .kmac_data_i          (keymgr_kmac_intf.kmac_data_rsp),


### PR DESCRIPTION
2 commits in this PR
1. Add macro DV_GET_ENUM_PLUSARG
This macro converts a string input from plusarg to an enum variable

2. [dv] Add Aes, Otbn sideload seq
Create 3 individual tests for 3 sideload interface
Update key size, otbn uses 384 bits, for others, use 256

Will add assertion checks for aes, otbn key in next PR