### PR TITLE
[prim_lfsr] Do not shadow |state| variable

### DIFF
--- a/hw/ip/prim/rtl/prim_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_lfsr.sv
@@ -415,36 +415,39 @@ module prim_lfsr #(
 // the code below is not meant to be synthesized,
 // but it is intended to be used in simulation and FPV
 `ifndef SYNTHESIS
-  function automatic logic[LfsrDw-1:0] compute_next_state(logic[LfsrDw-1:0]    lfsrcoeffs,
-                                                          logic[EntropyDw-1:0] entropy,
-                                                          logic[LfsrDw-1:0]    state);
+  function automatic logic [LfsrDw-1:0] compute_next_state(logic [LfsrDw-1:0]    lfsrcoeffs,
+                                                           logic [EntropyDw-1:0] entropy,
+                                                           logic [LfsrDw-1:0]    current_state);
     logic state0;
+    logic [LfsrDw-1:0] next_state;
+
+    next_state = current_state;
 
     // Galois XOR
     if (64'(LfsrType) == 64'("GAL_XOR")) begin
-      if (state == 0) begin
-        state = DefaultSeed;
+      if (next_state == 0) begin
+        next_state = DefaultSeed;
       end else begin
-        state0 = state[0];
-        state = state >> 1;
-        if (state0) state ^= lfsrcoeffs;
-        state ^= LfsrDw'(entropy);
+        state0 = next_state[0];
+        next_state = next_state >> 1;
+        if (state0) next_state ^= lfsrcoeffs;
+        next_state ^= LfsrDw'(entropy);
       end
     // Fibonacci XNOR
     end else if (64'(LfsrType) == "FIB_XNOR") begin
-      if (&state) begin
-        state = DefaultSeed;
+      if (&next_state) begin
+        next_state = DefaultSeed;
       end else begin
-        state0 = ~(^(state & lfsrcoeffs));
-        state = state << 1;
-        state[0] = state0;
-        state ^= LfsrDw'(entropy);
+        state0 = ~(^(next_state & lfsrcoeffs));
+        next_state = next_state << 1;
+        next_state[0] = state0;
+        next_state ^= LfsrDw'(entropy);
       end
     end else begin
       $error("unknown lfsr type");
     end
 
-    return state;
+    return next_state;
   endfunction : compute_next_state
 
   // check whether next state is computed correctly


### PR DESCRIPTION
A variable called `state` is used inside a function (with function
scope), and also in the module with module scope. This makes the
variable in the function shadow the one in the module. Verilator reports
this as lint warning. Since we build the OTBN smoke test in a way that
fails on warnings, we get a failing CI run for the OTBN smoke test.

This commit renames the variable inside the function to avoid the
shadowing.

```
%Warning-VARHIDDEN: ../src/lowrisc_prim_lfsr_0.1/rtl/prim_lfsr.sv:420:80: Declaration of signal hides declaration in upper scope: 'state'
  420 |                                                           logic[LfsrDw-1:0]    state);
      |                                                                                ^~~~~
                    ../src/lowrisc_prim_lfsr_0.1/rtl/prim_lfsr.sv:377:26: ... Location of original declaration
  377 |   logic [StateOutDw-1:0] state;
      |                          ^~~~~
                    ... Use "/* verilator lint_off VARHIDDEN */" and lint_on around source to disable this message.
```