### PR TITLE
[otbn] Always run OTBN smoke test in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -416,7 +416,6 @@ jobs:
 - job: otbn_standalone_tests
   displayName: Run OTBN Smoke Test
   dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.hasOTBNChanges'], '1'))
   pool:
     vmImage: ubuntu-18.04
   timeoutInMinutes: 10


### PR DESCRIPTION
The OTBN smoke test tests OTBN (as the name implies), but also depends
on other IP blocks/primitives in OpenTitan. Changes to those blocks can
hence fail the test, even if no OTBN changes were made.

Currently, we only run the OTBN smoke test if OTBN changes have been
detected. #7694 is a good example that this heuristic isn't reliable:
a PR went in making changes to prim_lfsr. The PR CI passed because the
OTBN test wasn't executed, and then master CI failed (because there we
always run the OTBN tests), leading to a broken master tree.

This commit removes the condition on the test and always runs it.