### PR TITLE
[dvsim] Separate publish report from dvsim flow [PART4]

### DIFF
--- a/util/dvsim/OneShotCfg.py
+++ b/util/dvsim/OneShotCfg.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from Deploy import CompileOneShot
 from FlowCfg import FlowCfg
 from Modes import BuildModes, Modes
-from utils import rm_path
+from utils import purge_latest_report_dirs, rm_path
 
 
 class OneShotCfg(FlowCfg):
@@ -114,6 +114,7 @@ class OneShotCfg(FlowCfg):
         assert self.scratch_path
         log.info("Purging scratch path %s", self.scratch_path)
         rm_path(self.scratch_path)
+        purge_latest_report_dirs(os.path.join(self.scratch_base_path, "reports"))
 
     def _create_objects(self):
         # Create build and run modes objects

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -19,7 +19,7 @@ from Modes import BuildModes, Modes, Regressions, RunModes, Tests
 from SimResults import SimResults
 from tabulate import tabulate
 from Testplan import Testplan
-from utils import VERBOSE, rm_path
+from utils import VERBOSE, purge_latest_report_dirs, mk_path, mk_symlink, rm_path
 
 
 # This affects the bucketizer failure report.
@@ -248,6 +248,7 @@ class SimCfg(FlowCfg):
         assert self.scratch_path
         log.info("Purging scratch path %s", self.scratch_path)
         rm_path(self.scratch_path)
+        purge_latest_report_dirs(os.path.join(self.scratch_base_path, "reports"))
 
     def _create_objects(self):
         # Create build and run modes objects
@@ -659,6 +660,14 @@ class SimCfg(FlowCfg):
                     results_str += self.cov_report_deploy.cov_results
                     self.results_summary[
                         "Coverage"] = self.cov_report_deploy.cov_total
+
+                    # Copy cov_report to the report directory and create a
+                    # symlink to the latest directory.
+                    dest_target_dir = os.path.join(self.results_path, "cov_report")
+                    dest_symlink_dir = os.path.join(self.symlink_path, "cov_report")
+                    mk_path(dest_symlink_dir)
+                    shutil.copytree(self.cov_report_dir, dest_target_dir)
+                    mk_symlink(dest_target_dir, dest_symlink_dir)
                 else:
                     self.results_summary["Coverage"] = "--"
 

--- a/util/dvsim/utils.py
+++ b/util/dvsim/utils.py
@@ -528,6 +528,14 @@ def print_msg_list(msg_list_title, msg_list, max_msg_count=-1):
     return md_results
 
 
+def purge_latest_report_dirs(path):
+    ''' Find and remove directories named `latest` under the given path'''
+
+    for subdir, dirs, files in os.walk(path):
+        for dirname in dirs:
+            if (dirname == "latest"):
+                rm_path(os.path.join(subdir, dirname))
+
 def rm_path(path, ignore_error=False):
     '''Removes the specified path if it exists.
 


### PR DESCRIPTION
This pr includes two changes:
1). --purge switch: adds a logic to remove all `latest` reports, so if
for some reason the dvsim failed without generate the latest reports,
the publish report script won't upload any results to the website.

2). move the cov_report to the reports directory so we can publish them
in the separate script.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>