### PR TITLE
[csrng/doc] usage note update for internal state access

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -116,7 +116,7 @@
             bits: "7:4",
             name: "SW_APP_ENABLE",
             desc: '''
-                  Setting this field to 0xA will enable reading from the GENBITS register.
+                  Setting this field to 0xA will enable reading from the !!GENBITS register.
                   This application interface for software (register based) will be enabled
                   only if the efuse_sw_app_enable input is set.
                   '''
@@ -216,10 +216,12 @@
                   Setting this field will set the number for which internal state can be
                   selected for a read access. Up to 16 internal state values can be chosen
                   from this register. The actual number of valid internal state fields
-                  is set by NHwApps plus 1 software app. For those selections that point
+                  is set by parameter NHwApps plus 1 software app. For those selections that point
                   to reserved locations (greater than NHwApps plus 1), the returned value
                   will be zero. Writing this register will also reset the internal read
-                  pointer for the INT_STATE_VAL register.
+                  pointer for the !!INT_STATE_VAL register.
+                  Note: This register should be read back after being written to ensure
+                  that the !!INT_STATE_VAL read back is accurate.
                   '''
         },
       ]
@@ -238,7 +240,7 @@
                 Reading this register will dump out the contents of the selected internal state field.
                 Since the internal state field is 448 bits wide, it will require 14 reads from this
                 register to gather the entire field. Once 14 reads have been done, the internal read
-                pointer (selects 32 bits of the 448 bit field) will reset to zero. The INT_STATE_NUM
+                pointer (selects 32 bits of the 448 bit field) will reset to zero. The !!INT_STATE_NUM
                 can be re-written at this time (internal read pointer is also reset), and then
                 another internal state field can be read.
                 Also, the life cycle state must be one where the signal "lc_hw_debug_en" is asserted


### PR DESCRIPTION
Due to worst case tile link timings, a timing window exists that will return the wrong internal state data.
The best resolution is to read the INT_STATE_NUM back after writing it.
A note has been added to the hjson register description.
Fixes #7703.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>