### PR TITLE
[otbn,dv] Fix Non-Spec Coverage Point in BN.XID

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -790,10 +790,8 @@ The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.SID`).
   Tracked as `oob_addr_neg_cross`.
 - Misaligned address tracking.
   Track loads from addresses that are in range for the size of the memory.
-  Crossing the possible misalignments for operand_a and offset would give a big cross (`32^2 = 1024`).
-  Instead, we split those alignments into 3 bins: 0, 1-30 and 31.
-  Crossing them gives 9 combinations, tracked as `part_align_cross`.
-  We also track all possible alignments of the sum as `addr_align_cross`.
+  We track all possible alignments of the sum as `addr_align_cross`.
+  The reason for not tracking offset and register value misalignments seperately is because the offset would always be shifted by 5 bits, which makes it always aligned.
 - See an invalid instruction with both increments specified
   Tracked in `enc_bnxid_cg` as a bin of `incd_inc1_cross`.
 - See `grd` greater than 31, giving an illegal instruction error
@@ -822,10 +820,8 @@ The instruction-specific covergroup is `insn_bn_xid_cg` (shared with `BN.LID`).
   Tracked as `oob_addr_neg_cross`.
 - Misaligned address tracking.
   Track stores to addresses that are in range for the size of the memory.
-  Crossing the possible misalignments for operand_a and offset would give a big cross (`32^2 = 1024`).
-  Instead, we split those alignments into 3 bins: 0, 1-30 and 31.
-  Crossing them gives 9 combinations, tracked as `part_align_cross`.
-  We also track all possible alignments of the sum as `addr_align_cross`.
+  We track all possible alignments of the sum as `addr_align_cross`.
+  The reason for not tracking offset and register value misalignments seperately is because the offset would always be shifted by 5 bits, which makes it always aligned.
 - See an invalid instruction with both increments specified
   Tracked in `enc_bnxid_cg` as a bin of `incd_inc1_cross`.
 - See `grd` greater than 31, giving an illegal instruction error

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -1489,24 +1489,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     `DEF_MNEM_CROSS(oob_addr_neg)
 
     // Misaligned address tracking (see DV document for why we have these exact crosses)
-    grs1_align_cp:
-      coverpoint operand_a[4:0] {
-         bins zero = {0};
-         bins middling = {[1:30]};
-         bins high = {31};
-      }
-    offset_align_cp:
-      coverpoint offset[4:0] {
-         bins zero = {0};
-         bins middling = {[1:30]};
-         bins high = {31};
-      }
-    addr_align_cp: coverpoint operand_a[4:0] + offset[4:0];
+    addr_align_cp: coverpoint operand_a[4:0];
 
-    part_align_cross:
-      cross mnemonic_cp, grs1_align_cp, offset_align_cp
-        iff ((0 <= ($signed(operand_a) + $signed(offset))) &&
-             (($signed(operand_a) + $signed(offset)) + 32 <= DmemSizeByte));
     addr_align_cross:
       cross mnemonic_cp, addr_align_cp
         iff ((0 <= ($signed(operand_a) + $signed(offset))) &&


### PR DESCRIPTION
This commit removes coverage points for misaligned offsets since
it is specified in the ISA that the first 5-bits of the offset
operand would always be 0 for BN.LID and BN.SID instructions.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>