### PR TITLE
[aes] Use separate subreg prims for fields of shadowed control reg

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -18,6 +18,7 @@ filesets:
       - rtl/aes_reg_pkg.sv
       - rtl/aes_pkg.sv
       - rtl/aes_reg_top.sv
+      - rtl/aes_ctrl_reg_shadowed.sv
       - rtl/aes_core.sv
       - rtl/aes_ctr.sv
       - rtl/aes_control.sv

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -348,6 +348,7 @@
         desc:  '''
           Select encryption(0) or decryption(1) operation of AES unit.
         '''
+        tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_operation"]
       }
       { bits: "6:1",
         name: "MODE",
@@ -395,6 +396,7 @@
             '''
           }
         ]
+        tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_mode"]
       }
       { bits: "9:7",
         name: "KEY_LEN",
@@ -426,6 +428,7 @@
             '''
           }
         ]
+        tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_key_len"]
       }
       { bits: "10",
         name: "MANUAL_OPERATION",
@@ -438,6 +441,7 @@
           In manual mode (1), the AES unit i) only starts to encrypt/decrypt after receiving a start trigger (see Trigger Register), and ii) overwrites previous output data irrespective of whether it has been read out or not.
           This mode is useful if software needs full control over the AES unit.
         '''
+        tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_manual_operation"]
       }
       { bits: "11",
         name: "FORCE_ZERO_MASKS",
@@ -448,13 +452,13 @@
           To completely disable the masking, the second key share (KEY_SHARE1_0 - KEY_SHARE1_7) must be zero as well.
           Only applicable if both the Masking parameter and the SecAllowForcingMasks parameter are set to one.
         '''
+        tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_force_zero_masks"]
       }
     ]
     tags: [// Updated by the HW.
            // Updates based on writes to this reg (reset test possible).
            // Exclude from write-read checks.
-           "excl:CsrNonInitTests:CsrExclWriteCheck",
-           "shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed"]
+           "excl:CsrNonInitTests:CsrExclWriteCheck"]
   },
   { name: "TRIGGER",
     desc: '''

--- a/hw/ip/aes/dv/env/seq_lib/aes_alert_reset_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_alert_reset_vseq.sv
@@ -31,14 +31,19 @@ class aes_alert_reset_vseq extends aes_base_vseq;
             cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
             if (cfg.error_types.mal_inject && (cfg.flip_rst == Flip_bits)) begin
               void'(randomize(mal_error)  with { $countones(mal_error) > 1; });
-              if (!uvm_hdl_check_path("tb.dut.u_aes_core.u_ctrl_reg_shadowed.committed_q")) begin
+              if (!uvm_hdl_check_path(
+                  "tb.dut.u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_mode.committed_q"
+                  )) begin
                 `uvm_fatal(`gfn, $sformatf("\n\t ----| PATH NOT FOUND"))
               end else begin
                 $assertoff(0, "tb.dut.u_aes_core.AesModeValid");
                 $assertoff(0, "tb.dut.u_aes_core.u_aes_control.AesModeValid");
-                void'(uvm_hdl_force("tb.dut.u_aes_core.u_ctrl_reg_shadowed.committed_q[6:1]", mal_error));
+                void'(uvm_hdl_force(
+                    "tb.dut.u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_mode.committed_q",
+                    mal_error));
                 wait(!cfg.clk_rst_vif.rst_n);
-                void'(uvm_hdl_release("tb.dut.u_aes_core.u_ctrl_reg_shadowed.committed_q[6:1]"));
+                void'(uvm_hdl_release(
+                    "tb.dut.u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_mode.committed_q"));
                 // turn assertions back on
                 $asserton(0, "tb.dut.u_aes_core.AesModeValid");
                 $asserton(0, "tb.dut.u_aes_core.u_aes_control.AesModeValid");

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -1,0 +1,210 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// AES shadowed control register
+//
+// This module implements the AES shadowed control register. The main differences compared
+// to implementing the register as part of the auto-generated aes_reg_top.sv are:
+//
+// 1. The hardware can block updates to the control register from software.
+//    Whenever the module is busy, control register writes are ignored.
+// 2. Invalid values written by software are resolved to valid configurations.
+
+`include "prim_assert.sv"
+
+module aes_ctrl_reg_shadowed
+  import aes_pkg::*;
+  import aes_reg_pkg::*;
+#(
+  parameter bit AES192Enable         = 1,
+  parameter bit SecAllowForcingMasks = 0
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+
+  // Main control
+  output logic      qe_o, // software wants to write
+  input  logic      we_i, // hardware grants software write
+  output aes_op_e   operation_o,
+  output aes_mode_e mode_o,
+  output key_len_e  key_len_o,
+  output logic      manual_operation_o,
+  output logic      force_zero_masks_o,
+
+  // Alerts
+  output logic err_update_o,
+  output logic err_storage_o,
+
+  // Bus interface
+  input  aes_reg2hw_ctrl_shadowed_reg_t reg2hw_ctrl_i,
+  output aes_hw2reg_ctrl_shadowed_reg_t hw2reg_ctrl_o
+);
+
+  // Signals
+  ctrl_reg_t ctrl_wd;
+  aes_mode_e mode;
+  key_len_e  key_len;
+  logic      err_update_operation;
+  logic      err_update_mode;
+  logic      err_update_key_len;
+  logic      err_update_manual_operation;
+  logic      err_update_force_zero_masks;
+  logic      err_storage_operation;
+  logic      err_storage_mode;
+  logic      err_storage_key_len;
+  logic      err_storage_manual_operation;
+  logic      err_storage_force_zero_masks;
+
+  // Unused signals
+  logic unused_force_zero_masks;
+
+  // Get and forward write enable. Writes are only allowed if the module is idle.
+  assign qe_o = reg2hw_ctrl_i.operation.qe & reg2hw_ctrl_i.mode.qe &
+      reg2hw_ctrl_i.key_len.qe & reg2hw_ctrl_i.manual_operation.qe &
+      reg2hw_ctrl_i.force_zero_masks.qe;
+
+  // Get and resolve values from register interface.
+  assign ctrl_wd.operation = aes_op_e'(reg2hw_ctrl_i.operation.q);
+
+  assign mode = aes_mode_e'(reg2hw_ctrl_i.mode.q);
+  always_comb begin : mode_get
+    unique case (mode)
+      AES_ECB: ctrl_wd.mode = AES_ECB;
+      AES_CBC: ctrl_wd.mode = AES_CBC;
+      AES_CFB: ctrl_wd.mode = AES_CFB;
+      AES_OFB: ctrl_wd.mode = AES_OFB;
+      AES_CTR: ctrl_wd.mode = AES_CTR;
+      default: ctrl_wd.mode = AES_NONE; // unsupported values are mapped to AES_NONE
+    endcase
+  end
+
+  assign key_len = key_len_e'(reg2hw_ctrl_i.key_len.q);
+  always_comb begin : key_len_get
+    unique case (key_len)
+      AES_128: ctrl_wd.key_len = AES_128;
+      AES_256: ctrl_wd.key_len = AES_256;
+      AES_192: ctrl_wd.key_len = AES192Enable ? AES_192 : AES_256;
+      default: ctrl_wd.key_len = AES_256; // unsupported values are mapped to AES_256
+    endcase
+  end
+
+  assign ctrl_wd.manual_operation = reg2hw_ctrl_i.manual_operation.q;
+
+  // SecAllowForcingMasks forbids forcing the masks. Forcing the masks to zero is only
+  // useful for SCA.
+  assign ctrl_wd.force_zero_masks = SecAllowForcingMasks ? reg2hw_ctrl_i.force_zero_masks.q : 1'b0;
+  assign unused_force_zero_masks = SecAllowForcingMasks ? 1'b0 : reg2hw_ctrl_i.force_zero_masks.q;
+
+  // Instantiate one shadowed register primitive per field. An update error in a field should
+  // only prevent the update of the affected field.
+  prim_subreg_shadow #(
+    .DW      ($bits(aes_op_e)),
+    .SwAccess(prim_subreg_pkg::SwAccessWO),
+    .RESVAL  (AES_CTRL_SHADOWED_OPERATION_RESVAL)
+  ) u_ctrl_reg_shadowed_operation (
+    .clk_i,
+    .rst_ni,
+    .re         (reg2hw_ctrl_i.operation.re),
+    .we         (we_i),
+    .wd         (ctrl_wd.operation),
+    .de         (1'b0),
+    .d          ('0),
+    .qe         (),
+    .q          (hw2reg_ctrl_o.operation.d),
+    .qs         (),
+    .err_update (err_update_operation),
+    .err_storage(err_storage_operation)
+  );
+
+  prim_subreg_shadow #(
+    .DW      ($bits(aes_mode_e)),
+    .SwAccess(prim_subreg_pkg::SwAccessWO),
+    .RESVAL  (AES_CTRL_SHADOWED_MODE_RESVAL)
+  ) u_ctrl_reg_shadowed_mode (
+    .clk_i,
+    .rst_ni,
+    .re         (reg2hw_ctrl_i.mode.re),
+    .we         (we_i),
+    .wd         ({ctrl_wd.mode}),
+    .de         (1'b0),
+    .d          ('0),
+    .qe         (),
+    .q          (hw2reg_ctrl_o.mode.d),
+    .qs         (),
+    .err_update (err_update_mode),
+    .err_storage(err_storage_mode)
+  );
+
+  prim_subreg_shadow #(
+    .DW      ($bits(key_len_e)),
+    .SwAccess(prim_subreg_pkg::SwAccessWO),
+    .RESVAL  (AES_CTRL_SHADOWED_KEY_LEN_RESVAL)
+  ) u_ctrl_reg_shadowed_key_len (
+    .clk_i,
+    .rst_ni,
+    .re         (reg2hw_ctrl_i.key_len.re),
+    .we         (we_i),
+    .wd         ({ctrl_wd.key_len}),
+    .de         (1'b0),
+    .d          ('0),
+    .qe         (),
+    .q          (hw2reg_ctrl_o.key_len.d),
+    .qs         (),
+    .err_update (err_update_key_len),
+    .err_storage(err_storage_key_len)
+  );
+
+  prim_subreg_shadow #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessWO),
+    .RESVAL  (AES_CTRL_SHADOWED_MANUAL_OPERATION_RESVAL)
+  ) u_ctrl_reg_shadowed_manual_operation (
+    .clk_i,
+    .rst_ni,
+    .re         (reg2hw_ctrl_i.manual_operation.re),
+    .we         (we_i),
+    .wd         (ctrl_wd.manual_operation),
+    .de         (1'b0),
+    .d          ('0),
+    .qe         (),
+    .q          (hw2reg_ctrl_o.manual_operation.d),
+    .qs         (),
+    .err_update (err_update_manual_operation),
+    .err_storage(err_storage_manual_operation)
+  );
+
+  prim_subreg_shadow #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessWO),
+    .RESVAL  (AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_RESVAL)
+  ) u_ctrl_reg_shadowed_force_zero_masks (
+    .clk_i,
+    .rst_ni,
+    .re         (reg2hw_ctrl_i.force_zero_masks.re),
+    .we         (we_i),
+    .wd         (ctrl_wd.force_zero_masks),
+    .de         (1'b0),
+    .d          ('0),
+    .qe         (),
+    .q          (hw2reg_ctrl_o.force_zero_masks.d),
+    .qs         (),
+    .err_update (err_update_force_zero_masks),
+    .err_storage(err_storage_force_zero_masks)
+  );
+
+  // Collect alerts.
+  assign err_update_o = err_update_operation | err_update_mode | err_update_key_len |
+      err_update_manual_operation | err_update_force_zero_masks;
+  assign err_storage_o = err_storage_operation | err_storage_mode | err_storage_key_len |
+      err_storage_manual_operation | err_storage_force_zero_masks;
+
+  // Generate shorter references.
+  // Doing that here as opposed to in aes_core avoids several Verilator lint errors.
+  assign operation_o        = aes_op_e'(hw2reg_ctrl_o.operation.d);
+  assign mode_o             = aes_mode_e'(hw2reg_ctrl_o.mode.d);
+  assign key_len_o          = key_len_e'(hw2reg_ctrl_o.key_len.d);
+  assign manual_operation_o = hw2reg_ctrl_o.manual_operation.d;
+  assign force_zero_masks_o = hw2reg_ctrl_o.force_zero_masks.d;
+
+endmodule


### PR DESCRIPTION
An update error in a particular field should only prevent the update of that field. Updates to other fields should still be applied.

This fixes lowRISC/OpenTitan#7417.

@cindychip DV is currently failing with the following error:
```
* `Job returned non-zero exit code` has 1 failures:
    * Test default has 1 failures.
        * default\
         Log opentitan/scratch/aes-shadow-reg-rework/aes-sim-vcs/default/build.log

                    <%def name="make_ral_pkg(dv_base_prefix, reg_width, reg_block_path, rb, esc_if_name)">\
                  File "/home/pirmin/ot/opentitan/util/reggen/uvm_reg_base.sv.tpl", line 521, in render_instantiate_register
                    assert 0
                AssertionError:
                
                ERROR: ext shadow_reg does not have tags for shadowed_reg_path!
                Error: RAL pkg generation failed:
                Command '['opentitan/util/regtool.py', '-s', '-t', '.', 'opentitan/hw/ip/aes/data/aes.hjson']' returned non-zero exit status 1.
                ERROR: Setup failed : "python3 opentitan/hw/dv/tools/ralgen/ralgen.py opentitan/scratch/aes-shadow-reg-rework/aes-sim-vcs/default/sim-vcs/
generated/lowrisc_dv_aes_env-ral_0.1/ral_input.yml" exited with an error code. See stderr for details.
                make: *** [opentitan/hw/dv/tools/dvsim/sim.mk:26: gen_sv_flist] Error 1
```
I think the problem now is that `uvm_reg_base.sv.tpl` still expects one `shadow_reg_path` tag for the whole register. But if I am not misunderstood, we have to provide one tag per field as every field is now implemented by a separate subreg. Would you mind to take a look please?