### PR TITLE
[keymgr] Handle keymgr disable during reset -> init transition

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -392,8 +392,9 @@ module keymgr_ctrl import keymgr_pkg::*; (
       // reseed entropy
       StCtrlEntropyReseed: begin
         prng_reseed_req_o = 1'b1;
+
         if (prng_reseed_ack_i) begin
-          state_d = StCtrlRandom;
+          state_d = en_i ? StCtrlRandom : StCtrlWipe;
         end
       end
 
@@ -403,7 +404,7 @@ module keymgr_ctrl import keymgr_pkg::*; (
         random_req = 1'b1;
 
         if (random_ack) begin
-          state_d = StCtrlRootKey;
+          state_d = en_i ? StCtrlRootKey : StCtrlWipe;
         end
       end
 


### PR DESCRIPTION
Also handle keymgr disable during the initial arc.
Note however, it is possible for the operation to complete at the
same time keymgr_en dropping low.  To the keymgr, this does not seem
like an error because the operation is "done".

Fixes #5922

Signed-off-by: Timothy Chen <timothytim@google.com>