### PR TITLE
[dv/kmac] assorted regression fixes

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1222,6 +1222,14 @@ class kmac_scoreboard extends cip_base_scoreboard #(
                               // latched by the flushing logic.
                               // We can also increment the fifo_rd_ptr and increment
                               // num_blocks_filled as a result.
+                              //
+                              // We need to also check the exact timestep that this code starts
+                              // executing, so insert a zero delay.
+                              #0;
+                              if (fifo_wr_ptr > fifo_rd_ptr) begin
+                                do_increment = 1;
+                                incr_fifo_wr_in_flush = 1;
+                              end
                               @(fifo_wr_ptr);
                               incr_fifo_wr_in_flush = 1;
                               do_increment = 1;

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -151,8 +151,8 @@ class kmac_smoke_vseq extends kmac_base_vseq;
           //
           // We disable all error case subprocesses once the valid data transfer has finished as
           // to not cause spurious issues later on in the simulation.
+          `uvm_info(`gfn, "starting kmac_app requests", UVM_HIGH)
           begin : send_kmac_req
-            `uvm_info(`gfn, "starting kmac_app requests", UVM_HIGH)
             send_kmac_app_req(app_mode);
             disable invalid_msgfifo_wr;
             disable sw_cmd_in_app;
@@ -198,7 +198,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
             end
           end : check_invalid_key_err
         join
-        if (process_key_err_before_app_done) begin
+        if (kmac_err_type != kmac_pkg::ErrNone && process_key_err_before_app_done) begin
           continue;
         end else begin
           // Wait until the KMAC engine has completely finished
@@ -294,6 +294,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
       // Drop the sideloaded key if it was provided to the DUT.
       if (kmac_en && (en_sideload || provide_sideload_key)) begin
+        `uvm_info(`gfn, "dropping sideload key", UVM_HIGH)
         cfg.sideload_vif.drive_sideload_key(0);
       end
 


### PR DESCRIPTION
this PR contains 2 fixes for nightlies:

- first patch is to fix a small bug in `kmac_smoke_vseq` that would
  cause App operations with errors disabled to sometimes behave like
  errors were enabled

- second patch is to fix a small bug in the scb that would cause us to
  inadvertently miss an update to `fifo_rd_ptr` if the `fifo_wr_ptr` got
  updated on the same timestep that the scb started to wait for the
  msgfifo to flush

Signed-off-by: Udi Jonnalagadda <udij@google.com>