### PR TITLE
[dv/kmac] update error_cg

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -265,7 +265,18 @@
     {
       name: error_cg
       desc: '''
-            Covers that all errors have been seen by the KMAC.
+            Covers all error scenarios:
+            - ErrKeyNotValid: covers that secret key is invalid when KeyMgr initiates App operation
+            - ErrSwPushedMsgFifo: covers that SW writes the msgfifo while App interface is active
+            - ErrSwIssuedCmdInAppActive: covers that SW writes all possible commands to the KMAC
+                                         while App interface is active
+            - ErrWaitTimerExpired: covers that the KMAC timed out while waiting for EDN entropy
+            - ErrIncorrectEntropyMode: covers that incorrect entropy modes are detected by the KMAC
+            - ErrUnexpectedModeStrength: covers that 128-bit strength is seen for SHA3, and all but
+                                         128/256 bit strengths are seen for XOF functions
+            - ErrIncorrectFunctionName: covers that the function name is configured incorrectly
+                                        when KMAC mode is enabled
+            - ErrSwCmdSequence: covers that SW issues commands to the KMAC out of order
             '''
     }
   ]

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2398,6 +2398,11 @@ class kmac_scoreboard extends cip_base_scoreboard #(
       void'(ral.err_code.predict(.value(TL_DW'(kmac_err)), .kind(UVM_PREDICT_DIRECT)));
     end
 
+    // collect coverage
+    if (cfg.en_cov) begin
+      cov.error_cg.sample(kmac_err.code, unchecked_kmac_cmd, hash_mode, strength);
+    end
+
     kmac_err = '{valid: 1'b0,
                  code: kmac_pkg::ErrNone,
                  info: '0};


### PR DESCRIPTION
this PR updates the `error_cg`to collect coverage on newly added IP
errors, and makes the corresponding documentation more clear as to what
coverage is being collected for each type of error.

Signed-off-by: Udi Jonnalagadda <udij@google.com>