### PR TITLE
[dv] Update TLUL and EDN frequency

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
+++ b/hw/dv/sv/dv_lib/dv_base_env_cfg.sv
@@ -43,14 +43,13 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
   // clk_rst_vif and clk_freq_mhz can be found from the associative arrays
   virtual clk_rst_if  clk_rst_vif;
   virtual clk_rst_if  clk_rst_vifs[string];
-  rand clk_freq_mhz_e clk_freq_mhz;
-  rand clk_freq_mhz_e clk_freqs_mhz[string];
+  rand uint clk_freq_mhz;
+  rand uint clk_freqs_mhz[string];
 
-  // TODO(#7647), only run with 24Mhz or higher
   constraint clk_freq_mhz_c {
-    clk_freq_mhz >= ClkFreq24Mhz;
+    `DV_COMMON_CLK_CONSTRAINT(clk_freq_mhz)
     foreach (clk_freqs_mhz[i]) {
-      clk_freqs_mhz[i] >= ClkFreq24Mhz;
+      `DV_COMMON_CLK_CONSTRAINT(clk_freqs_mhz[i])
     }
   }
 
@@ -82,7 +81,7 @@ class dv_base_env_cfg #(type RAL_T = dv_base_reg_block) extends uvm_object;
 
     // add items to clk_freqs_mhz before randomizing it
     foreach (ral_model_names[i]) begin
-      clk_freqs_mhz[ral_model_names[i]] = ClkFreq24Mhz;
+      clk_freqs_mhz[ral_model_names[i]] = 0;
     end
   endfunction
 

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -510,3 +510,18 @@
 `endif
 
 `endif // UVM
+
+// Macros for constrain clk with common frequencies
+// constrain clock to run at 24Mhz - 100Mhz and use higher weights on 24, 25, 48, 50, 100
+`ifndef DV_COMMON_CLK_CONSTRAINT
+`define DV_COMMON_CLK_CONSTRAINT(FREQ_) \
+  FREQ_ dist { \
+    [24:25] :/ 2, \
+    [26:47] :/ 1, \
+    [48:50] :/ 2, \
+    [51:95] :/ 1, \
+    96      :/ 1, \
+    [97:99] :/ 1, \
+    100     :/ 1  \
+  };
+`endif

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -44,16 +44,6 @@ package dv_utils_pkg;
     Device
   } if_mode_e;
 
-  // speed for the clock
-  typedef enum int {
-    ClkFreq6Mhz   = 6,
-    ClkFreq24Mhz  = 24,
-    ClkFreq25Mhz  = 25,
-    ClkFreq48Mhz  = 48,
-    ClkFreq50Mhz  = 50,
-    ClkFreq100Mhz = 100
-  } clk_freq_mhz_e;
-
   // compare operator types
   typedef enum {
     CompareOpEq,
@@ -85,6 +75,14 @@ package dv_utils_pkg;
     HostReqWriteOnly = 2,
     HostReqReadWrite = 3
   } host_req_type_e;
+
+  // Enum representing clock frequency difference on 2 clocks
+  typedef enum bit [1:0] {
+    ClkFreqDiffNone,
+    ClkFreqDiffSmall,
+    ClkFreqDiffBig,
+    ClkFreqDiffAny
+  } clk_freq_diff_e;
 
   string msg_id = "dv_utils_pkg";
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -2,6 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`define OTP_CLK_CONSTRAINT(FREQ_) \
+  FREQ_ dist { \
+    6       :/ 2, \
+    [24:25] :/ 2, \
+    [26:47] :/ 1, \
+    [48:50] :/ 2, \
+    [51:95] :/ 1, \
+    96      :/ 1, \
+    [97:99] :/ 1, \
+    100     :/ 1  \
+  };
+
 class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block));
 
   // ext component cfgs
@@ -34,14 +46,18 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
   `uvm_object_new
 
+  constraint clk_freq_mhz_c {
+    `OTP_CLK_CONSTRAINT(clk_freq_mhz)
+    foreach (clk_freqs_mhz[i]) {
+      `OTP_CLK_CONSTRAINT(clk_freqs_mhz[i])
+    }
+  }
+
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
     has_edn = 1;
     tl_intg_alert_name = "fatal_bus_integ_error";
     super.initialize(csr_base_addr);
-
-    // OTP can run with 6Mhz, disable this constraint which limits freq >= 24Mhz
-    clk_freq_mhz_c.constraint_mode(0);
 
     // create push_pull agent config obj
     for (int i = 0; i < NumSramKeyReqSlots; i++) begin
@@ -82,3 +98,5 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
   endfunction
 
 endclass
+
+`undef OTP_CLK_CONSTRAINT

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -20,8 +20,11 @@ class sram_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(sram_ctrl_regs_reg_blo
   mem_bkdr_util mem_bkdr_util_h;
 
   // otp clk freq
-  rand dv_utils_pkg::clk_freq_mhz_e otp_freq_mhz;
+  rand uint otp_freq_mhz;
 
+  constraint otp_freq_mhz_c {
+    `DV_COMMON_CLK_CONSTRAINT(otp_freq_mhz)
+  }
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = sram_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_error";

--- a/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
+++ b/hw/ip/uart/dv/env/seq_lib/uart_base_vseq.sv
@@ -35,7 +35,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
   constraint baud_rate_c {
     // when the uart frequency is very close to core freq, disable noise filter and glitch,
     // otherwise, not enough timing margin to predict status correctly in scb
-    if (baud_rate == BaudRate1p5Mbps && p_sequencer.cfg.clk_freq_mhz == ClkFreq24Mhz) {
+    if (baud_rate == BaudRate1p5Mbps && p_sequencer.cfg.clk_freq_mhz < 48) {
       en_noise_filter == 0;
       uart_period_glitch_pct == 0;
     }
@@ -72,7 +72,7 @@ class uart_base_vseq extends cip_base_vseq #(.CFG_T               (uart_env_cfg)
     // we skip writting some CSRs at the last 1-2 uart cycles, when baud rate is 1.5Mbps, uart
     // cycle is small, need to reduce the TL delay, so that the write doesn't happen at the
     // ignore period
-    if (baud_rate == BaudRate1p5Mbps && p_sequencer.cfg.clk_freq_mhz == ClkFreq24Mhz) begin
+    if (baud_rate == BaudRate1p5Mbps && p_sequencer.cfg.clk_freq_mhz < 48) begin
       if (cfg.m_tl_agent_cfg.d_ready_delay_max > 5) cfg.m_tl_agent_cfg.d_ready_delay_max = 5;
     end
 

--- a/hw/ip/uart/dv/env/uart_env_cov.sv
+++ b/hw/ip/uart/dv/env/uart_env_cov.sv
@@ -16,12 +16,14 @@ class uart_env_cov extends cip_base_env_cov #(.CFG_T(uart_env_cfg));
 
   // Cover all combinations of 2 different clocks
   covergroup baud_rate_w_core_clk_cg with function sample(baud_rate_e baud_rate,
-                                                          clk_freq_mhz_e clk_freq);
+                                                          int clk_freq);
     cp_baud_rate: coverpoint baud_rate;
-    cp_clk_freq:  coverpoint clk_freq;
+    cp_clk_freq:  coverpoint clk_freq {
+      bins freqs[] = {24, 25, 48, 50, 100};
+    }
     cross cp_baud_rate, cp_clk_freq {
       ignore_bins unsupported = binsof(cp_baud_rate) intersect {BaudRate1p5Mbps} &&
-                                binsof(cp_clk_freq)  intersect {ClkFreq24Mhz};
+                                binsof(cp_clk_freq)  intersect {24};
     }
   endgroup
 

--- a/hw/ip/uart/dv/env/uart_env_pkg.sv
+++ b/hw/ip/uart/dv/env/uart_env_pkg.sv
@@ -69,7 +69,7 @@ package uart_env_pkg;
   // if uart baud rate is 1500_000 and IO is 24Mhz, NCO is 'h1_0000, which is over the NCO width
   // use NCO = 'hffff for this case since the error is tolerable. Refer to #4263
   `define CALC_NCO(baud_rate, nco_width, clk_freq_mhz) \
-    (baud_rate == BaudRate1p5Mbps && clk_freq_mhz == ClkFreq24Mhz) ? 16'hffff : \
+    (baud_rate == BaudRate1p5Mbps && clk_freq_mhz == 24) ? 16'hffff : \
         (longint'(baud_rate) * (2**(nco_width+4))) / (clk_freq_mhz * 1000_000)
 
   // calculate the nco

--- a/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_cfg.sv
@@ -5,22 +5,22 @@
 class usbdev_env_cfg extends cip_base_env_cfg #(.RAL_T(usbdev_reg_block));
 
   virtual clk_rst_if  usb_clk_rst_vif;
-  rand clk_freq_mhz_e usb_clk_freq_mhz;
+  rand uint usb_clk_freq_mhz;
 
   // Reset kinds for USB
   string reset_kinds[] = {"HARD", "TL_IF", "USB_IF"};
 
   // Constrain USB to be at 48MHz based on spec
   constraint usb_clk_freq_mhz_c {
-    usb_clk_freq_mhz == dv_utils_pkg::ClkFreq48Mhz;
+    usb_clk_freq_mhz == 48;
   }
 
   // ext component cfgs
   rand usb20_agent_cfg m_usb20_agent_cfg;
 
   `uvm_object_utils_begin(usbdev_env_cfg)
-    `uvm_field_object(m_usb20_agent_cfg,                UVM_DEFAULT)
-    `uvm_field_enum  (clk_freq_mhz_e, usb_clk_freq_mhz, UVM_DEFAULT)
+    `uvm_field_object(m_usb20_agent_cfg,  UVM_DEFAULT)
+    `uvm_field_int   (usb_clk_freq_mhz,   UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -71,7 +71,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   // TODO: Fixing core clk freq to 50MHz for now.
   // Need to find a way to pass this to the SW test.
   constraint clk_freq_mhz_c {
-    clk_freq_mhz == dv_utils_pkg::ClkFreq50Mhz;
+    clk_freq_mhz == 50;
   }
 
   `uvm_object_new


### PR DESCRIPTION
As discussed at #7647, update 2 things

1. change enum to int have more flexibility
2. add constraint to randomize clock frequency for TLUL clock and EDN
clock in this range {24:100}, but have high distributions for these
frequencies (24Mhz, 25Mhz, 48Mhz, 50Mhz and 100Mhz).

2nd commit is to fix all TB to remove the enum

Signed-off-by: Weicai Yang <weicai@google.com>
