### PR TITLE
[sca] Add initial implementation of SHA3 SCA program

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -56,7 +56,7 @@ index 50bee15fa..8f5976a83 100644
 --- a/sw/device/sca/aes_serial.c
 +++ b/sw/device/sca/aes_serial.c
 @@ -203,21 +203,13 @@ int main(void) {
-   sca_init();
+   sca_init(kScaTriggerSourceAes);
    sca_get_uart(&uart1);
  
 -  LOG_INFO("Running AES serial");

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -55,14 +55,11 @@ diff --git a/sw/device/sca/aes_serial.c b/sw/device/sca/aes_serial.c
 index 50bee15fa..8f5976a83 100644
 --- a/sw/device/sca/aes_serial.c
 +++ b/sw/device/sca/aes_serial.c
-@@ -203,21 +203,13 @@ int main(void) {
-   sca_init(kScaTriggerSourceAes);
+@@ -203,18 +203,13 @@ int main(void) {
+   sca_init(kScaTriggerSourceAes, kScaPeripheralAes);
    sca_get_uart(&uart1);
  
 -  LOG_INFO("Running AES serial");
--
--  LOG_INFO("Disabling entropy complex and unneeded clocks to reduce noise.");
--  sca_reduce_noise();
 -
 -  LOG_INFO("Initializing simple serial interface to capture board.");
    simple_serial_init(uart1);
@@ -81,7 +78,7 @@ diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
 index 1c74eb0ee..cc087c4b9 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
-@@ -50,7 +50,6 @@ enum {
+@@ -56,7 +56,6 @@ enum {
    kRvTimerHart = kTopEarlgreyPlicTargetIbex0,
  };
  
@@ -89,7 +86,7 @@ index 1c74eb0ee..cc087c4b9 100644
  static dif_uart_t uart1;
  static dif_gpio_t gpio;
  static dif_rv_timer_t timer;
-@@ -72,16 +71,9 @@ static void sca_init_uart(void) {
+@@ -78,16 +77,9 @@ static void sca_init_uart(void) {
        (dif_uart_params_t){
            .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
        },
@@ -107,26 +104,30 @@ index 1c74eb0ee..cc087c4b9 100644
  }
  
  /**
-@@ -137,42 +129,16 @@ void sca_init(void) {
- }
- 
- void sca_reduce_noise() {
--  // Disable/stopping functionality not yet provided by EDN and CSRNG DIFs.
--  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
--                      EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
--  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
--                      EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
--  mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
--                      CSRNG_CTRL_REG_OFFSET, CSRNG_CTRL_REG_RESVAL);
--
--  // Disable entropy source through DIF.
--  const dif_entropy_src_params_t entropy_params = {
--      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
--  };
--  dif_entropy_src_t entropy;
--  IGNORE_RESULT(dif_entropy_src_init(entropy_params, &entropy) ==
--                kDifEntropySrcOk);
--  IGNORE_RESULT(dif_entropy_src_disable(&entropy) == kDifEntropySrcOk);
+@@ -147,32 +147,11 @@ void handler_irq_timer(void) {
+  * @param disable Set of peripherals to disable.
+  */
+ void sca_disable_peripherals(sca_peripherals_t disable) {
+-  if (disable & kScaPeripheralEdn) {
+-    // TODO(#5465): Replace with `dif_edn_stop()` when it is implemented.
+-    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
+-                        EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
+-    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
+-                        EDN_CTRL_REG_OFFSET, EDN_CTRL_REG_RESVAL);
+-  }
+-  if (disable & kScaPeripheralCsrng) {
+-    // TODO(#7837): Replace with `dif_csrng_stop()` when it is implemented.
+-    mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
+-                        CSRNG_CTRL_REG_OFFSET, CSRNG_CTRL_REG_RESVAL);
+-  }
+-  if (disable & kScaPeripheralEntropy) {
+-    const dif_entropy_src_params_t entropy_params = {
+-        .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
+-    };
+-    dif_entropy_src_t entropy;
+-    IGNORE_RESULT(dif_entropy_src_init(entropy_params, &entropy));
+-    IGNORE_RESULT(dif_entropy_src_disable(&entropy));
+-  }
 -
    // Disable HMAC, KMAC, OTBN and USB clocks through CLKMGR DIF.
    const dif_clkmgr_params_t clkmgr_params = {
@@ -135,22 +136,28 @@ index 1c74eb0ee..cc087c4b9 100644
 -      .last_hintable_clock = CLKMGR_CLK_HINTS_STATUS_CLK_MAIN_OTBN_VAL_BIT};
 +      .last_hintable_clock = CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT};
    dif_clkmgr_t clkmgr;
-   IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr) == kDifClkmgrOk);
-   IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-                     &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
-                     kDifClkmgrToggleDisabled) == kDifClkmgrOk);
--  IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--                    &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT,
--                    kDifClkmgrToggleDisabled) == kDifClkmgrOk);
--  IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--                    &clkmgr, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
--                    kDifClkmgrToggleDisabled) == kDifClkmgrOk);
--  IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--                    &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT,
--                    kDifClkmgrToggleDisabled) == kDifClkmgrOk);
-   IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
-                     &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
-                     kDifClkmgrToggleDisabled) == kDifClkmgrOk);
+   IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr));
+
+@@ -182,19 +165,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
+         &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
+         kDifClkmgrToggleDisabled));
+   }
+-  if (disable & kScaPeripheralKmac) {
+-    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
+-        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT,
+-        kDifClkmgrToggleDisabled));
+-  }
+-  if (disable & kScaPeripheralOtbn) {
+-    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
+-        &clkmgr, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
+-        kDifClkmgrToggleDisabled));
+-    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
+-        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT,
+-        kDifClkmgrToggleDisabled));
+-  }
+   if (disable & kScaPeripheralUsb) {
+     IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
+         &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
 diff --git a/sw/device/tests/dif/dif_aes_smoketest.c b/sw/device/tests/dif/dif_aes_smoketest.c
 index 70c3baaf9..5d69301e2 100644
 --- a/sw/device/tests/dif/dif_aes_smoketest.c

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -200,7 +200,7 @@ static void init_aes(void) {
 int main(void) {
   const dif_uart_t *uart1;
 
-  sca_init();
+  sca_init(kScaTriggerSourceAes);
   sca_get_uart(&uart1);
 
   LOG_INFO("Running AES serial");

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -200,13 +200,10 @@ static void init_aes(void) {
 int main(void) {
   const dif_uart_t *uart1;
 
-  sca_init(kScaTriggerSourceAes);
+  sca_init(kScaTriggerSourceAes, kScaPeripheralAes);
   sca_get_uart(&uart1);
 
   LOG_INFO("Running AES serial");
-
-  LOG_INFO("Disabling entropy complex and unneeded clocks to reduce noise.");
-  sca_reduce_noise();
 
   LOG_INFO("Initializing simple serial interface to capture board.");
   simple_serial_init(uart1);

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -15,9 +15,43 @@
  */
 
 /**
- * Initializes the peripherals (pinmux, uart, gpio, and timer) used by SCA code.
+ * Trigger sources.
+ *
+ * The trigger signal for a peripheral is based on its clkmgr_aon_idle signal.
+ * These values must match the values in chiplevel.sv.tpl.
  */
-void sca_init(void);
+typedef enum sca_trigger_source {
+  /**
+   * Use AES for capture trigger.
+   *
+   * The trigger signal will go high 40 cycles after `dif_aes_trigger()` is
+   * called and remain high until the operation is complete.
+   */
+  kScaTriggerSourceAes,
+  /**
+   * Use HMAC for capture trigger.
+   */
+  kScaTriggerSourceHmac,
+  /**
+   * Use KMAC for capture trigger.
+   */
+  kScaTriggerSourceKmac,
+  /**
+   * Use OTBN (IO_DIV4 clock) for capture trigger.
+   */
+  kScaTriggerSourceOtbnIoDiv4,
+  /**
+   * Use OTBN for capture trigger.
+   */
+  kScaTriggerSourceOtbn,
+} sca_trigger_source_t;
+
+/**
+ * Initializes the peripherals (pinmux, uart, gpio, and timer) used by SCA code.
+ *
+ * @param trigger Peripheral to use for the trigger signal.
+ */
+void sca_init(sca_trigger_source_t trigger);
 
 /**
  * Disables the entropy complex and clocks of IPs not needed for SCA to reduce
@@ -40,10 +74,8 @@ void sca_get_uart(const dif_uart_t **uart_out);
  * Sets capture trigger high.
  *
  * The actual trigger signal used for capture is a combination (logical AND) of:
- * - GPIO15 enabled here, and
- * - the busy signal of the AES unit. This signal will go high 40 cycles
- *   after aes_manual_trigger() is executed below and remain high until
- *   the operation has finished.
+ * - the trigger gate enabled here, and
+ * - the busy signal of the peripheral of interest.
  */
 void sca_set_trigger_high(void);
 

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -47,21 +47,67 @@ typedef enum sca_trigger_source {
 } sca_trigger_source_t;
 
 /**
+ * Peripherals.
+ *
+ * Constants below are bitmasks that can be used to specify a set of
+ * peripherals.
+ *
+ * See also: `sca_peripherals_t`.
+ */
+typedef enum sca_peripheral {
+  /**
+   * EDN.
+   */
+  kScaPeripheralEdn = 1 << 0,
+  /**
+   * CSRNG.
+   */
+  kScaPeripheralCsrng = 1 << 1,
+  /**
+   * Entropy source.
+   */
+  kScaPeripheralEntropy = 1 << 2,
+  /**
+   * AES.
+   */
+  kScaPeripheralAes = 1 << 3,
+  /**
+   * HMAC.
+   */
+  kScaPeripheralHmac = 1 << 4,
+  /**
+   * KMAC.
+   */
+  kScaPeripheralKmac = 1 << 5,
+  /**
+   * OTBN.
+   */
+  kScaPeripheralOtbn = 1 << 6,
+  /**
+   * USB.
+   */
+  kScaPeripheralUsb = 1 << 7,
+} sca_peripheral_t;
+
+/**
+ * A set of peripherals.
+ *
+ * This type is used for specifying which peripherals should be enabled when
+ * calling `sca_init()`. Remaining peripherals will be disabled to reduce noise
+ * during SCA.
+ *
+ * See also: `sca_peripheral_t`, `sca_init()`.
+ */
+typedef uint32_t sca_peripherals_t;
+
+/**
  * Initializes the peripherals (pinmux, uart, gpio, and timer) used by SCA code.
  *
  * @param trigger Peripheral to use for the trigger signal.
+ * @param enable Set of peripherals to enable. Remaining peripherals will
+ * be disabled to reduce noise during SCA.
  */
-void sca_init(sca_trigger_source_t trigger);
-
-/**
- * Disables the entropy complex and clocks of IPs not needed for SCA to reduce
- * noise in the power traces.
- *
- * We can only disable the entropy complex as AES features a parameter to skip
- * PRNG reseeding for SCA experiments. Without this parameter, AES would simply
- * get stalled with a disabled entropy complex.
- */
-void sca_reduce_noise(void);
+void sca_init(sca_trigger_source_t trigger, sca_peripherals_t enable);
 
 /**
  * Returns a handle to the intialized UART device.

--- a/sw/device/sca/meson.build
+++ b/sw/device/sca/meson.build
@@ -4,63 +4,83 @@
 
 subdir('lib')
 
-foreach device_name, device_lib : sw_lib_arch_core_devices
-  aes_serial_elf = executable(
-    'aes_serial_' + device_name,
-    sources: ['aes_serial.c'],
-    name_suffix: 'elf',
-    dependencies: [
-      device_lib,
-      riscv_crt,
-      sw_lib_dif_aes,
-      sw_lib_mmio,
-      sw_lib_runtime_hart,
-      sw_lib_runtime_log,
-      sw_sca_lib_prng,
-      sw_sca_lib_sca,
-      sw_sca_lib_simple_serial,
-    ],
-  )
+# Dictionary for SCA programs.
+sca_programs = {
+  # 'program_name': {
+  #   'dependency': dependency_name,
+  # },
+}
 
-  target_name = 'aes_serial_@0@_' + device_name
+aes_serial = declare_dependency(
+  sources: ['aes_serial.c'],
+  dependencies: [
+    sw_lib_dif_aes,
+  ],
+)
+sca_programs += {
+  'aes_serial': {
+    'dependency': aes_serial,
+  },
+}
 
-  aes_serial_dis = custom_target(
-    target_name.format('dis'),
-    input: aes_serial_elf,
-    kwargs: elf_to_dis_custom_target_args,
-  )
+foreach sca_program_name, sca_program_info: sca_programs
+  foreach device_name, device_lib : sw_lib_arch_core_devices
+    sca_program_elf = executable(
+      '@0@_@1@'.format(sca_program_name, device_name),
+      name_suffix: 'elf',
+      dependencies: [
+        device_lib,
+        riscv_crt,
+        sw_lib_mmio,
+        sw_lib_runtime_hart,
+        sw_lib_runtime_log,
+        sw_sca_lib_prng,
+        sw_sca_lib_sca,
+        sw_sca_lib_simple_serial,
+        sca_program_info['dependency'],
+      ]
+    )
 
-  aes_serial_bin = custom_target(
-    target_name.format('bin'),
-    input: aes_serial_elf,
-    kwargs: elf_to_bin_custom_target_args,
-  )
+    target_name = sca_program_name + '_@0@_' + device_name
 
-  aes_serial_vmem32 = custom_target(
-    target_name.format('vmem32'),
-    input: aes_serial_bin,
-    kwargs: bin_to_vmem32_custom_target_args,
-  )
+    sca_program_dis = custom_target(
+      target_name.format('dis'),
+      input: sca_program_elf,
+      kwargs: elf_to_dis_custom_target_args,
+    )
 
-  aes_serial_vmem64 = custom_target(
-    target_name.format('vmem64'),
-    input: aes_serial_bin,
-    kwargs: bin_to_vmem64_custom_target_args,
-  )
+    sca_program_bin = custom_target(
+      target_name.format('bin'),
+      input: sca_program_elf,
+      kwargs: elf_to_bin_custom_target_args,
+    )
 
-  custom_target(
-    target_name.format('export'),
-    command: export_target_command,
-    depend_files: [export_target_depend_files,],
-    input: [
-      aes_serial_elf,
-      aes_serial_dis,
-      aes_serial_bin,
-      aes_serial_vmem32,
-      aes_serial_vmem64,
-    ],
-    output: target_name.format('export'),
-    build_always_stale: true,
-    build_by_default: true,
-  )
+    sca_program_vmem32 = custom_target(
+      target_name.format('vmem32'),
+      input: sca_program_bin,
+      kwargs: bin_to_vmem32_custom_target_args,
+    )
+
+    sca_program_vmem64 = custom_target(
+      target_name.format('vmem64'),
+      input: sca_program_bin,
+      kwargs: bin_to_vmem64_custom_target_args,
+    )
+
+    custom_target(
+      target_name.format('export'),
+      command: export_target_command,
+      depend_files: [export_target_depend_files,],
+      input: [
+        sca_program_elf,
+        sca_program_dis,
+        sca_program_bin,
+        sca_program_vmem32,
+        sca_program_vmem64,
+      ],
+      output: target_name.format('export'),
+      build_always_stale: true,
+      build_by_default: true,
+    )
+  endforeach
 endforeach

--- a/sw/device/sca/meson.build
+++ b/sw/device/sca/meson.build
@@ -23,6 +23,21 @@ sca_programs += {
   },
 }
 
+sha3_serial = declare_dependency(
+  sources: [
+    'sha3_serial.c',
+    hw_ip_kmac_reg_h,
+  ],
+  dependencies: [
+    sw_lib_dif_kmac,
+  ],
+)
+sca_programs += {
+  'sha3_serial': {
+    'dependency': sha3_serial,
+  },
+}
+
 foreach sca_program_name, sca_program_info: sca_programs
   foreach device_name, device_lib : sw_lib_arch_core_devices
     sca_program_elf = executable(

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -1,0 +1,187 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/sca/lib/prng.h"
+#include "sw/device/sca/lib/sca.h"
+#include "sw/device/sca/lib/simple_serial.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "kmac_regs.h"
+
+/**
+ * OpenTitan program for side-channel analysis of the absorb step of a KMAC128
+ * operation using a 128-bit key.
+ *
+ * This program implements the following simple serial commands:
+ *   - Set key ('k')*,
+ *   - Absorb ('p')*,
+ *   - Version ('v')+,
+ *   - Seed PRNG ('s')+,
+ * Commands marked with * are implemented in this file. Those marked with + are
+ * implemented in the simple serial library. See
+ * https://wiki.newae.com/SimpleSerial for details on the protocol.
+ */
+
+enum {
+  /**
+   * Key length in bytes.
+   */
+  kKeyLength = 16,
+  /**
+   * Message length in bytes.
+   */
+  kMessageLength = 16,
+};
+
+/**
+ * A handle to KMAC.
+ */
+static dif_kmac_t kmac;
+
+/**
+ * KMAC key.
+ *
+ * Used for caching the key in the 'k' (set key) command packet until it is used
+ * when handling a 'p' (absorb) command.
+ */
+static dif_kmac_key_t kmac_key;
+
+/**
+ * Blocks until KMAC is idle.
+ */
+static void kmac_block_until_idle(void) {
+  // TODO(#7842): Remove when `dif_kmac_get_status()` is implemented.
+  uint32_t reg;
+  do {
+    reg = mmio_region_read32(kmac.params.base_addr, KMAC_STATUS_REG_OFFSET);
+  } while (!bitfield_bit32_read(reg, KMAC_STATUS_SHA3_IDLE_BIT));
+}
+
+/**
+ * Resets KMAC to idle state.
+ */
+static void kmac_reset(void) {
+  // TODO(#7842): Remove when `dif_kmac_reset()` is implemented.
+  mmio_region_write32(
+      kmac.params.base_addr, KMAC_CMD_REG_OFFSET,
+      bitfield_field32_write(0, KMAC_CMD_CMD_FIELD, KMAC_CMD_CMD_VALUE_DONE));
+  kmac_block_until_idle();
+}
+
+/**
+ * Issues a process command to KMAC and waits until absorb step is complete.
+ */
+static void kmac_absorb_end(void) {
+  // TODO(#7841, #7842): Remove when we finalize the way we capture traces.
+  uint32_t reg = 0;
+  reg = bitfield_field32_write(reg, KMAC_CMD_CMD_FIELD,
+                               KMAC_CMD_CMD_VALUE_PROCESS);
+  mmio_region_write32(kmac.params.base_addr, KMAC_CMD_REG_OFFSET, reg);
+
+  do {
+    reg = mmio_region_read32(kmac.params.base_addr, KMAC_STATUS_REG_OFFSET);
+  } while (!bitfield_bit32_read(reg, KMAC_STATUS_SHA3_SQUEEZE_BIT));
+}
+
+/**
+ * Initializes the KMAC peripheral.
+ *
+ * This function configures KMAC to use software entropy.
+ */
+static void kmac_init(void) {
+  dif_kmac_params_t params = {
+      .base_addr = mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR),
+  };
+  CHECK(dif_kmac_init(params, &kmac) == kDifKmacOk);
+
+  dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_seed = 0xffff,
+      .entropy_fast_process = true,
+  };
+  CHECK(dif_kmac_configure(&kmac, config) == kDifKmacOk);
+
+  kmac_block_until_idle();
+}
+
+/**
+ * Simple serial 'k' (set key) command handler.
+ *
+ * This function simply caches the provided key in the static `kmac_key`
+ * variable so that it can be used in subsequent operations. This function does
+ * not use key shares to simplify side-channel analysis. The key must be
+ * `kKeyLength` bytes long.
+ *
+ * @param key Key. Must be `kKeyLength` bytes long.
+ * @param key_len Key length. Must be equal to `kKeyLength`.
+ * @return Result of the operation.
+ */
+static void sha3_serial_set_key(const uint8_t *key, size_t key_len) {
+  SS_CHECK(key_len == kKeyLength);
+
+  kmac_key = (dif_kmac_key_t){
+      .length = kDifKmacKeyLen128,
+  };
+  memcpy(kmac_key.share0, key, kKeyLength);
+}
+
+/**
+ * Simple serial 'p' (absorb) command handler.
+ *
+ * Absorbs the given message using KMAC128 without a customization string.
+ *
+ * @param msg Message.
+ * @param msg_len Message length.
+ */
+static void sha3_serial_single_absorb(const uint8_t *msg, size_t msg_len) {
+  SS_CHECK(msg_len == kMessageLength);
+
+  SS_CHECK(dif_kmac_mode_kmac_start(&kmac, kDifKmacModeKmacLen128, 0, &kmac_key,
+                                    NULL) == kDifKmacOk);
+
+  // TODO(#7841): Consider delaying the absorb step until triggered manually to
+  // be able to use `sca_call_and_sleep()`.
+  sca_set_trigger_high();
+  SS_CHECK(dif_kmac_absorb(&kmac, msg, msg_len, NULL) == kDifKmacOk);
+  // Note: Performing the squeeze step after this call using HW directly would
+  // produce incorrect results. See `dif_kmac_mode_kmac_start()` and
+  // `dif_kmac_squeeze()`.
+  kmac_absorb_end();
+  sca_set_trigger_low();
+
+  // Reset before the next absorb since KMAC must be idle before starting
+  // another absorb.
+  kmac_reset();
+}
+
+/**
+ * Main function.
+ *
+ * Initializes peripherals and processes simple serial packets received over
+ * UART.
+ */
+int main(void) {
+  const dif_uart_t *uart1;
+
+  sca_init(kScaTriggerSourceKmac, kScaPeripheralKmac);
+
+  LOG_INFO("Running sha3_serial");
+
+  LOG_INFO("Initializing simple serial interface to capture board.");
+  sca_get_uart(&uart1);
+  simple_serial_init(uart1);
+  simple_serial_register_handler('k', sha3_serial_set_key);
+  simple_serial_register_handler('p', sha3_serial_single_absorb);
+
+  LOG_INFO("Initializing the KMAC peripheral.");
+  kmac_init();
+
+  LOG_INFO("Starting simple serial packet handling.");
+  while (true) {
+    simple_serial_process_packet();
+  }
+}


### PR DESCRIPTION
This PR adds a program for SHA3/KMAC SCA. I also improved `meson.build` a bit and refactored the code for trigger selection and disabling peripherals, which will hopefully make it easier to add new programs in the future. I'll create a separate PR in lowRISC/ot-sca for the capture scripts. I also had to write some static functions for controlling KMAC to unblock this PR but these can be moved to the KMAC DIF library later.

I'm not sure what the attack(s) will look like but I guess we could approach this in two ways:
1. Performing a `SHA3(key | message)` operation (@moidx's suggestion), or
2. Loading the key to KMAC and performing a `KMAC` operation.

I went with the latter to exclude key loads from traces. That being said, (1) can also be easily implemented as a separate command handler if needed.

This change does not include a batch capture command and the current capture speed is ~100 traces/s. This is how traces look like:
![Screen Shot 2021-08-14 at 00 09 51](https://user-images.githubusercontent.com/57949550/129433587-3fa27e00-89b3-4465-bb9b-b9d98a74a177.png)

The trigger is high for \~48 us but the traces are a bit longer to include the idle state as well. @eunchan told me that he would expect this operation (absorb with a 16 byte key and message) to take 3\~4 us at 100 MHz. Since CW310 runs at 10 MHz and we also have some overhead due to DIFs, the length of the trigger seems to match our expectations.

Another thing to note is that since the KMAC operations require the CPU for FIFO writes, we cannot use `sca_call_and_sleep` as we did for AES and traces will have some additional noise as a result. I'm not sure if we can do something in HW to improve this for SCA.

Also, we have been calling this `sha3_serial` so far but maybe we should call it `kmac_serial` since it uses the KMAC peripheral. Please let me know what you think.

