### PR TITLE
[sw/silicon_creator] Check life cycle state when choosing the rsa_verify implementation

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -74,6 +74,7 @@ enum module_ {
   X(kErrorSigverifyBadExponent,       ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadKey,            ERROR_(3, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadOtpValue,       ERROR_(4, kModuleSigverify, kInternal)), \
+  X(kErrorSigverifyBadLcState,        ERROR_(5, kModuleSigverify, kInternal)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
   X(kErrorManifestBadLength,          ERROR_(1, kModuleManifest, kInternal)), \
   X(kErrorManifestBadEntryPoint,      ERROR_(2, kModuleManifest, kInternal)), \

--- a/sw/device/silicon_creator/lib/sigverify.h
+++ b/sw/device/silicon_creator/lib/sigverify.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify_rsa_key.h"
 
@@ -32,16 +33,21 @@ inline uint32_t sigverify_rsa_key_id_get(
 /**
  * Verifies an RSASSA-PKCS1-v1_5 signature.
  *
+ * The actual implementation that is used (software or OTBN) is determined by
+ * the life cycle state of the device and the OTP value.
+ *
  * @param signed_message Message whose signature is to be verified.
  * @param signed_message_len Length of the signed message in bytes.
  * @param signature Signature to be verified.
  * @param key Signer's RSA public key.
+ * @param lc_state Life cycle state of the device.
  * @return Result of the operation.
  */
 rom_error_t sigverify_rsa_verify(const void *signed_message,
                                  size_t signed_message_len,
                                  const sigverify_rsa_buffer_t *signature,
-                                 const sigverify_rsa_key_t *key);
+                                 const sigverify_rsa_key_t *key,
+                                 lifecycle_state_t lc_state);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/sigverify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify_functest.c
@@ -124,18 +124,18 @@ static const sigverify_rsa_key_t kKeyExp3 = {
 
 rom_error_t sigverify_test_exp_3(void) {
   return sigverify_rsa_verify(&kMessage, sizeof(kMessage) - 1, &kSignatureExp3,
-                              &kKeyExp3);
+                              &kKeyExp3, kLcStateRma);
 }
 
 rom_error_t sigverify_test_exp_65537(void) {
   return sigverify_rsa_verify(&kMessage, sizeof(kMessage) - 1,
-                              &kSignatureExp65537, &kKeyExp65537);
+                              &kSignatureExp65537, &kKeyExp65537, kLcStateRma);
 }
 
 rom_error_t sigverify_test_negative(void) {
   // Signature verification should fail when using the wrong signature.
   if (sigverify_rsa_verify(&kMessage, sizeof(kMessage) - 1, &kSignatureExp65537,
-                           &kKeyExp3) == kErrorOk) {
+                           &kKeyExp3, kLcStateRma) == kErrorOk) {
     return kErrorUnknown;
   }
   return kErrorOk;

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -134,8 +134,9 @@ rom_error_t mask_rom_boot(void) {
     RETURN_IF_ERROR(manifest_signed_region_get(manifest, &signed_region));
     RETURN_IF_ERROR(sigverify_rsa_key_get(
         sigverify_rsa_key_id_get(&manifest->modulus), lc_state, &key));
-    RETURN_IF_ERROR(sigverify_rsa_verify(
-        signed_region.start, signed_region.length, &manifest->signature, key));
+    RETURN_IF_ERROR(sigverify_rsa_verify(signed_region.start,
+                                         signed_region.length,
+                                         &manifest->signature, key, lc_state));
 
     //  // Manifest Failure (check Boot Policy)
     //  // **Open Q:** Does this need different logic to the check after

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -491,7 +491,7 @@ TEST_P(SigverifyRsaVerify, Ibex) {
       .WillOnce(Return(kHardenedBoolTrue));
 
   EXPECT_EQ(sigverify_rsa_verify(kMessage.data(), kMessage.size(),
-                                 &GetParam().sig, GetParam().key),
+                                 &GetParam().sig, GetParam().key, kLcStateProd),
             kErrorOk);
 }
 


### PR DESCRIPTION
This PR adds a life cycle check before reading from OTP to determine the rsa_verify implementation to use (OTBN or SW):
* During manufacturing (TEST_UNLOCKED*), software implementation is used by default without any reads from OTP since it may not have been programmed yet.
* After manufacturing (PROD, PROD_END, DEV, RMA), the implementation to use is determined by the OTP value .

Signed-off-by: Alphan Ulusoy <alphan@google.com>