### PR TITLE
[tools/uvmdvgen] Fix path in testplan inclusion

### DIFF
--- a/util/uvmdvgen/index.md.tpl
+++ b/util/uvmdvgen/index.md.tpl
@@ -131,4 +131,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/${name}/dv/${name}_sim_cfg.hjson
 ${'##'} Testplan
 <!-- TODO: uncomment the line below after adding the testplan.
 Please make sure the testplan is added to `/util/build_docs.py`. -->
-{{</* incGenFromIpDesc "../../data/${name}_testplan.hjson" "testplan" */>}
+{{</* incGenFromIpDesc "/hw/ip/${name}/data/${name}_testplan.hjson" "testplan" */>}


### PR DESCRIPTION
Avoid parent paths "..".

Signed-off-by: Guillermo Maturana <maturana@google.com>