### PR TITLE
[keymgr/dv] Support sideload clear

### DIFF
--- a/hw/ip/keymgr/data/keymgr_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_testplan.hjson
@@ -85,7 +85,8 @@
             Verify the sideload data and status for correctness.
             '''
       milestone: V2
-      tests: ["keymgr_sideload"]
+      tests: ["keymgr_sideload", "keymgr_sideload_kmac",
+              "keymgr_sideload_aes", "keymgr_sideload_otbn"]
     }
     {
       name: init_n_start

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -547,8 +547,17 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
         end
       end
       "reseed_interval_shadowed": begin
-        if (addr_phase_write)
-          cfg.keymgr_vif.edn_interval = `gmv(ral.reseed_interval_shadowed.val);
+        if (addr_phase_write) cfg.keymgr_vif.edn_interval = `gmv(ral.reseed_interval_shadowed.val);
+      end
+      "sideload_clear": begin
+        if (addr_phase_write) begin
+          fork
+            begin
+              cfg.clk_rst_vif.wait_clks(1);
+              cfg.keymgr_vif.clear_sideload_key(`gmv(ral.sideload_clear.val));
+            end
+          join_none
+        end
       end
       default: begin
         if (!uvm_re_match("sw_share*", csr.get_name())) begin // sw_share

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Enable OpGenHwOut to test sideload key to a selected interface
-class keymgr_sideload_one_intf_vseq extends keymgr_smoke_vseq;
+class keymgr_sideload_one_intf_vseq extends keymgr_sideload_vseq;
   `uvm_object_utils(keymgr_sideload_one_intf_vseq)
   `uvm_object_new
 
@@ -12,9 +12,15 @@ class keymgr_sideload_one_intf_vseq extends keymgr_smoke_vseq;
   constraint gen_operation_c {
     gen_operation == keymgr_pkg::OpGenHwOut;
   }
+
   constraint key_dest_c {
     key_dest == sideload_dest;
   }
+
+  constraint do_clear_sideload_c {
+   do_clear_sideload == 1;
+  }
+
   function void pre_randomize();
     `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, 1)
     super.pre_randomize();

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_vseq.sv
@@ -7,8 +7,32 @@ class keymgr_sideload_vseq extends keymgr_smoke_vseq;
   `uvm_object_utils(keymgr_sideload_vseq)
   `uvm_object_new
 
+  rand bit do_clear_sideload;
+  rand bit [2:0] clear_dest;
+
   // also test HW sideload
   constraint gen_operation_c {
     gen_operation inside {keymgr_pkg::OpGenId, keymgr_pkg::OpGenSwOut, keymgr_pkg::OpGenHwOut};
   }
+
+  constraint clear_dest_c {
+    clear_dest dist {[0:3] :/ 4,
+                     // reserved value, clear all sideload
+                     [4:$] :/ 1};
+  }
+
+  virtual task keymgr_operations(bit advance_state = $urandom_range(0, 1),
+                                 int num_gen_op    = $urandom_range(1, 4),
+                                 bit clr_output    = $urandom_range(0, 1),
+                                 bit wait_done     = 1);
+    super.keymgr_operations(advance_state, num_gen_op, clr_output, wait_done);
+
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_clear_sideload)
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(clear_dest)
+    if (do_clear_sideload) begin
+      `uvm_info(`gfn, $sformatf("Clear sideload with value %0d", clear_dest), UVM_MEDIUM)
+      csr_wr(.ptr(ral.sideload_clear), .value(clear_dest));
+    end
+  endtask : keymgr_operations
+
 endclass : keymgr_sideload_vseq


### PR DESCRIPTION
In sequences, randomize `sideload_clear` after gen-hw-out
In checkers, check each sideload interface key not matching if it's
cleared

Signed-off-by: Weicai Yang <weicai@google.com>