### PR TITLE
[otp_ctrl] Fix partition default value vector size in template

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -248,9 +248,8 @@ package otp_ctrl_part_pkg;
   };
 
   // OTP invalid partition default for buffered partitions.
-  parameter logic [16383:0] PartInvDefault = 16384'({
+  parameter logic [15359:0] PartInvDefault = 15360'({
     704'({
-      1024'h0, // unallocated space
       320'hDAAF8720F255C5C84D1D9C10648A878DB1D5ABE9610E8395490EC23C0A1EDCCE280E8ECA88CEA2E9,
       384'h9470329E17324EDB1E2960279AB8F882A991BEA2CF16541724A52D80A891BCD52BE973D4C5752E3A6912899150240B3A
     }),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
@@ -193,9 +193,9 @@ package otp_ctrl_part_pkg;
   };
   % endif
 % endfor
-<% offset =  int(otp_mmap.config["otp"]["depth"]) * int(otp_mmap.config["otp"]["width"]) %>
+<% offset =  int(otp_mmap.config["partitions"][-1]["offset"]) + int(otp_mmap.config["partitions"][-1]["size"]) %>
   // OTP invalid partition default for buffered partitions.
-  parameter logic [${int(otp_mmap.config["otp"]["depth"])*int(otp_mmap.config["otp"]["width"])*8-1}:0] PartInvDefault = ${int(otp_mmap.config["otp"]["depth"])*int(otp_mmap.config["otp"]["width"])*8}'({
+  parameter logic [${offset * 8 - 1}:0] PartInvDefault = ${offset * 8}'({
   % for k, part in enumerate(otp_mmap.config["partitions"][::-1]):
     ${int(part["size"])*8}'({
     % for item in part["items"][::-1]:


### PR DESCRIPTION
The OTP memory map can now have a total size that is smaller than what is physically available. 
Some of the templating logic hence needs to be updated to work correctly.

Signed-off-by: Michael Schaffner <msf@google.com>