### PR TITLE
[otbn,dv] Fix logic in "deep loop" generator

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
@@ -52,7 +52,7 @@ class BadDeepLoop(SnippetGen):
             guess = random.randint(bodysize_range[0], bodysize_range[1])
             last_insn_addr = pc + 4 * guess
             if ((last_insn_addr >= program.imem_size or
-                 program.get_insn_space_at(last_insn_addr) != 0)):
+                 program.get_insn_space_at(last_insn_addr) == 0)):
                 bodysize = guess
                 break
 


### PR DESCRIPTION
This generator tries to generate a deep stack of nested loops, until
it blows the HW stack. Since we don't actually want to complete any of
these loops, it's supposed to pick `bodysize`s so that the loops end on
addresses that are out of range or have already got instructions. The
trick is that, because we never go back to code that we've visited
before, this ensures the loops will never complete.

Unfortunately, I got the check backwards! Interestingly, it doesn't
matter most of the time, but it *does* cause explosions if `guess == 1`.

Fixes #7760.