### PR TITLE
[csrng/rtl] bug fix for uninstantiate cmd with adata

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -905,6 +905,7 @@ module csrng_core import csrng_pkg::*; #(
          ((instant_req && flag0_q) ||
           reseed_req ||
           update_req ||
+          uninstant_req ||
           (generate_req && flag0_q));
 
   //-------------------------------------


### PR DESCRIPTION
When an uninstantiate command is issued that has additional data, the internal adata packer needs to be reset or residual data will cause a failure.
Normally the uninstantiate command will not have adata, but per spec it is currently not restricted as such.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>