### PR TITLE
[dv/clkmgr] Adjust wait cycles in smoke test

### DIFF
--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -14,6 +14,10 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   // hints_status) are properly set when inputs go through synchronizers.
   localparam int POST_APPLY_RESET_CYCLES = 10;
 
+  // This delay in io_clk cycles is needed to allow updates to the hints_status CSR to go through
+  // synchronizers.
+  localparam int IO_DIV4_SYNC_CYCLES = 8;
+
   typedef enum {
     LcTxTSelOn,
     LcTxTSelOff,

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -74,7 +74,7 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
       idle[trans] = 1'b1;
       cfg.clkmgr_vif.update_idle(idle);
       // Some cycles for the logic to settle.
-      cfg.clk_rst_vif.wait_clks(3);
+      cfg.clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES);
       csr_rd(.ptr(descriptor.value_bit), .value(bit_value));
       if (!cfg.under_reset) begin
         `DV_CHECK_EQ(bit_value, 1'b0, $sformatf(

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -17,10 +17,6 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-  // This delay in io_clk cycles is needed to allow updates to the hints_status CSR to go through
-  // synchronizers.
-  localparam int IO_DIV4_SYNC_CYCLES = 8;
-
   rand bit [NUM_TRANS-1:0] initial_hints;
 
   task body();


### PR DESCRIPTION
The smoke test needs to wait enough time for `idle` inputs to update
hints_status CSR. Use the wait count from the trans sequence.

Signed-off-by: Guillermo Maturana <maturana@google.com>