### PR TITLE
[dv/alert_handler] Fix alert int err and reduce a uvm_info in nightly regression

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -242,7 +242,7 @@ class dv_base_reg extends uvm_reg;
       end else if (shadow_wr_staged || (shadow_fatal_lock && rw.path != UVM_BACKDOOR)) begin
         `uvm_info(`gfn, $sformatf(
             "skip predict %s: due to shadow_reg_first_wr=%0b, shadow_fatal_lock=%0b",
-            get_name(), shadow_wr_staged, shadow_fatal_lock), UVM_LOW)
+            get_name(), shadow_wr_staged, shadow_fatal_lock), UVM_HIGH)
         return;
       end
     end

--- a/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -79,7 +79,7 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
       automatic int index = i;
       fork
         forever begin
-          bit alert_en;
+          bit alert_en, loc_alert_en;
           alert_esc_seq_item act_item;
           alert_fifo[index].get(act_item);
           alert_en = ral.alert_en_shadowed[index].get_mirrored_value();
@@ -90,12 +90,12 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
               process_alert_sig(index, 0);
             // alert integrity fail
             end else if (act_item.alert_esc_type == AlertEscIntFail) begin
-              bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_shadowed[2].get_mirrored_value();
-              if (loc_alert_en[LocalAlertIntFail]) process_alert_sig(index, 1, LocalAlertIntFail);
+              loc_alert_en = ral.loc_alert_en_shadowed[LocalAlertIntFail].get_mirrored_value();
+              if (loc_alert_en) process_alert_sig(index, 1, LocalAlertIntFail);
             end else if (act_item.alert_esc_type == AlertEscPingTrans &&
                          act_item.ping_timeout) begin
-              bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_shadowed[0].get_mirrored_value();
-              if (loc_alert_en[LocalAlertPingFail]) begin
+              loc_alert_en = ral.loc_alert_en_shadowed[LocalAlertPingFail].get_mirrored_value();
+              if (loc_alert_en) begin
                 process_alert_sig(index, 1, LocalAlertPingFail);
                 `uvm_info(`gfn, $sformatf("alert %0d ping timeout, timeout_cyc reg is %0d",
                           index, ral.ping_timeout_cyc_shadowed.get_mirrored_value()), UVM_LOW);
@@ -121,12 +121,12 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           // escalation integrity fail
           end else if (act_item.alert_esc_type == AlertEscIntFail ||
                (act_item.esc_handshake_sta == EscIntFail && !act_item.ping_timeout)) begin
-            bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_shadowed[3].get_mirrored_value();
-            if (loc_alert_en[LocalEscIntFail]) process_alert_sig(index, 1, LocalEscIntFail);
+            bit loc_alert_en = ral.loc_alert_en_shadowed[LocalEscIntFail].get_mirrored_value();
+            if (loc_alert_en) process_alert_sig(index, 1, LocalEscIntFail);
           // escalation ping timeout
           end else if (act_item.alert_esc_type == AlertEscPingTrans && act_item.ping_timeout) begin
-            bit [TL_DW-1:0] loc_alert_en = ral.loc_alert_en_shadowed[1].get_mirrored_value();
-            if (loc_alert_en[LocalEscPingFail]) begin
+            bit loc_alert_en = ral.loc_alert_en_shadowed[LocalEscPingFail].get_mirrored_value();
+            if (loc_alert_en) begin
               process_alert_sig(index, 1, LocalEscPingFail);
               `uvm_info(`gfn, $sformatf("esc %0d ping timeout, timeout_cyc reg is %0d",
                         index, ral.ping_timeout_cyc_shadowed.get_mirrored_value()), UVM_LOW);


### PR DESCRIPTION
Two commits in this PR：
1).  fixes regression error about sig_int_error. The issue is we
indexed twice in scb when trying to locate the correct local alert.

2). Change the verbosity of a uvm_info in dv_base_reg to avoid massive print in the nightly
regression.