### PR TITLE
[dv] Add checking status CSRs after intg error is triggered

### DIFF
--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -218,9 +218,9 @@ Some examples:
   integrity. The bad packet is created by corrupting upto 3 bits either in the integrity
   (ECC) fields (`a_user.cmd_intg`, `a_user.d_intg`), or in their corresponding command /
   data payload itself. The sequence then verifies that the DUT not only returns an error
-  response (with `d_error` = 1), but also triggers a fatal alert. The list of CSRs that
-  are impacted by this alert event, maintained in `cfg.tl_intg_alert_fields`, are also
-  checked for correctness.
+  response (with `d_error` = 1), but also triggers a fatal alert and updates status CSRs
+  such as `ERR_CODE`. The list of CSRs that are impacted by this alert event, maintained
+  in `cfg.tl_intg_alert_fields`, are also checked for correctness.
 * **task run_stress_all_with_rand_reset_vseq**: This task runs 3 parallel threads,
   which are ip_stress_all_vseq, run_tl_errors_vseq and reset sequence. After
   reset occurs, the other threads will be killed and then all the CSRs will be read

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -304,11 +304,19 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
 
         `uvm_info(`gfn, "expected fatal alert is triggered", UVM_LOW)
 
-        // This is a fatal alert and design keeps sending it until reset is issued.
-        // Check alerts are triggered for a few times
-        repeat ($urandom_range(5, 20)) begin
-          wait_alert_trigger(cfg.tl_intg_alert_name, .wait_complete(1));
-        end
+        // Check both alert and CSR status update
+        fork
+          // This is a fatal alert and design keeps sending it until reset is issued.
+          // Check alerts are triggered for a few times
+          repeat ($urandom_range(5, 20)) begin
+            wait_alert_trigger(cfg.tl_intg_alert_name, .wait_complete(1));
+          end
+          // Check corresponding CSR status is updated correctly
+          foreach (cfg.tl_intg_alert_fields[csr_field]) begin
+            bit [BUS_DW-1:0] exp_val = cfg.tl_intg_alert_fields[csr_field];
+            csr_rd_check(.ptr(csr_field), .compare_value(exp_val));
+          end
+        join
       end
     join
 


### PR DESCRIPTION
explicitly check error status CSRs after intg error occurs instead of relying the following
csr_rw seq to verify status CSRs are updated.

Signed-off-by: Weicai Yang <weicai@google.com>