### PR TITLE
[xbar/dv] Remove d_user constraint and exclusion for *_user

### DIFF
--- a/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
+++ b/hw/dv/sv/tl_agent/seq_lib/tl_device_seq.sv
@@ -78,7 +78,6 @@ class tl_device_seq #(type REQ_T = tl_seq_item) extends dv_base_seq #(
               rsp.d_opcode == tlul_pkg::AccessAck;
             }
             rsp.d_size == rsp.a_size;
-            rsp.d_user == '0; // TODO: Not defined yet, tie it to zero
             rsp.d_source == rsp.a_source;
             d_error dist {0 :/ (100 - d_error_pct), 1 :/ d_error_pct};
         })) begin

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
@@ -11,8 +11,6 @@
 // due to VCS issue (fixed at VCS/2020.12), can't move this part into begin...end (tgl) or after.
 -node tb.dut tl_*.a_param
 -node tb.dut tl_*.d_param
--node tb.dut tl_*.d_user
--node tb.dut tl_*.a_user.*
 -node tb.dut tl_*.d_opcode[2:1]
 
 // [UNR] these device address bits are always 0

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
@@ -11,8 +11,6 @@
 // due to VCS issue (fixed at VCS/2020.12), can't move this part into begin...end (tgl) or after.
 -node tb.dut tl_*.a_param
 -node tb.dut tl_*.d_param
--node tb.dut tl_*.d_user
--node tb.dut tl_*.a_user.*
 -node tb.dut tl_*.d_opcode[2:1]
 
 // [UNR] these device address bits are always 0

--- a/util/tlgen/xbar_cover.cfg.tpl
+++ b/util/tlgen/xbar_cover.cfg.tpl
@@ -34,8 +34,6 @@
 // due to VCS issue (fixed at VCS/2020.12), can't move this part into begin...end (tgl) or after.
 -node tb.dut tl_*.a_param
 -node tb.dut tl_*.d_param
--node tb.dut tl_*.d_user
--node tb.dut tl_*.a_user.*
 -node tb.dut tl_*.d_opcode[2:1]
 
 // [UNR] these device address bits are always 0


### PR DESCRIPTION
a/d_user contains integrity info now

Signed-off-by: Weicai Yang <weicai@google.com>