### PR TITLE
[dv/kmac] update kmac_base_vseq

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -721,6 +721,9 @@ class kmac_base_vseq extends cip_base_vseq #(
 
       // Wait a long time for hashing to finish, then check that `kmac_done` is set
       if (cfg.enable_masking) begin
+        // If masked, wait for some time past the max latency of the EDN agent in case
+        // an EDN request is sent right as CmdProcess is seen by the KMAC.
+        cfg.edn_clk_rst_vif.wait_clks(2 * cfg.m_edn_pull_agent_cfg.device_delay_max);
         cfg.clk_rst_vif.wait_clks(1000);
       end else begin
         cfg.clk_rst_vif.wait_clks(150);


### PR DESCRIPTION
this PR updates how the kmac_base_vseq waits after sending CmdProcess
and before reading out `intr_state.kmac_done`, by waiting for twice the
length of the max delay period of the EDN agent, to account for cases in
the masked version where EDN request is sent at the same time as
CmdProcess.

Signed-off-by: Udi Jonnalagadda <udij@google.com>