### PR TITLE
[dv] Update Xcelium cover ccf

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -144,12 +144,12 @@
   cover_reg_top_vcs_cov_cfg_file: "-cm_hier {dv_root}/tools/vcs/cover_reg_top.cfg"
 
   // Project defaults for Xcelium
-  xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover.ccf"
-  xcelium_cov_refine_files: []
+  xcelium_cov_cfg_file: "{{build_mode}_xcelium_cov_cfg_file}"
   xcelium_unr_cfg_file:  "{dv_root}/tools/xcelium/unr.cfg"
-  xcelium_common_excl_file: ["{dv_root}/tools/xcelium/exclude.tcl"]
+  xcelium_common_excl_file: "{dv_root}/tools/xcelium/exclude.tcl"
+  xcelium_cov_refine_files: []
 
   // Build-specific coverage cfg files for Xcelium.
-  // default_xcelium_cov_cfg_file: "-covfile {dv_root}/tools/xcelium/cover.ccf"
-  // cover_reg_top_xcelium_cov_cfg_file: "-covfile {dv_root}/tools/xcelium/cover_reg_top.ccf"
+  default_xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover.ccf"
+  cover_reg_top_xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover_reg_top.ccf"
 }

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -174,7 +174,10 @@
                    // Limit the scope of coverage collection to the DUT.
                    "-covdut {dut}",
                    // Set the coverage configuration file
-                   "-covfile {xcelium_cov_cfg_file}"]
+                   "-covfile {xcelium_cov_cfg_file}",
+                   // Don't warn about the switches we set that will be default in future releases.
+                   "-nowarn COVDEF",
+                  ]
       run_opts:   [// Put the coverage model (*.ucm) and the database (*.ucd) together.
                    "-covmodeldir {cov_db_test_dir}",
                    // Coverage database output location.

--- a/hw/dv/tools/vcs/common_cov_excl.el
+++ b/hw/dv/tools/vcs/common_cov_excl.el
@@ -2,11 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Baesd on our Comportable IP spec, these TL pins are reserved / unused and hence, tied off.
-
+// Based on our Comportable IP spec, these TL pins are reserved / unused and hence, tied off.
 INSTANCE: tb.dut
+Toggle tl_i.a_param "logic tl_i.a_param[2:0]"
+Toggle tl_o.d_param "logic tl_o.d_param[2:0]"
 Toggle tl_o.d_opcode [1] "logic tl_o.d_opcode[2:0]"
 Toggle tl_o.d_opcode [2] "logic tl_o.d_opcode[2:0]"
-Toggle tl_o.d_param "logic tl_o.d_param[2:0]"
 Toggle tl_o.d_sink "logic tl_o.d_sink[0:0]"
-Toggle tl_i.a_param "logic tl_i.a_param[2:0]"

--- a/hw/dv/tools/xcelium/common.ccf
+++ b/hw/dv/tools/xcelium/common.ccf
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Common coverage commands that apply to all DUTs.
+//
+// This coverge config file is provided by Xcelium and is located at:
+// ${XCELIUM_HOME}/tools/icc/include/all_coverage.ccf
+// Xcelium recommends including it, since it bundles together the common set of commands that enable
+// coverage collection on various design elements, that are otherwise turned off by default. We
+// maintain it locally with minor amends.
+
+// Enables expression coverage of various Verilog operators.
+set_expr_coverable_operators -all -event_or
+
+// Enables expression coverage of operators in various conditions and assignments.
+set_expr_coverable_statements -all
+
+// Enables scoring of Verilog modules compiled with -v/-y or -libcell option but continues to
+// disable the scoring of Verilog modules defined with the 'celldefine compiler directive.
+set_libcell_scoring
+
+// Enables scoring of block and expression coverage for functions and tasks defined directly inside
+// SystemVerilog packages.
+set_subprogram_scoring -svpackage
+
+// Enables scoring of SystemVerilog continuous assignments, which is by disabled by default.
+set_assign_scoring
+
+// Scores branches together with block coverage.
+set_branch_scoring
+
+// Scores statements within a block.
+set_statement_scoring
+
+// Enables expression coverage for expression containing structs (packed and unpacked).
+set_expr_scoring -struct
+
+// Enables Toggle scoring and reporting of SystemVerilog enumerations and multidimensional static
+// arrays , vectors, packed union, modport and generate blocks.
+set_toggle_scoring -sv_enum enable_mda -sv_struct_with_enum -sv_modport -sv_mda 16 -sv_mda_of_struct -sv_generate -sv_packed_union
+
+// Enables scoring of reset states and transitions for identified FSMs.
+set_fsm_reset_scoring
+
+// Enables scoring of immediate assertions inside a class in a package and assertions inside AMS
+// modules.
+select_functional  -ams_control  -imm_asrt_class_package
+
+// Improve the scoping and naming of covergroup instances.
+set_covergroup -new_instance_reporting
+
+// Enable toggle coverage only on ports.
+set_toggle_portsonly
+
+// Enable scoring of FSM arcs (state transitions).
+set_fsm_arc_scoring

--- a/hw/dv/tools/xcelium/common_toggle_excl
+++ b/hw/dv/tools/xcelium/common_toggle_excl
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Baesd on our Comportable IP spec, these TL pins are reserved / unused.
+//
+// Add this to the ccf with the following command:
+// set_toggle_excludefile ${dv_root}/tools/xcelium/common_toggle_excl
+//
+// It is not being added right now because it is not working.
+// TODO: Work with AE to understand how can this be achieved.
+-ere module ${DUT_TOP}\.*tl_i\.a_user\.rsvd
+-ere module ${DUT_TOP}\.*tl_i\.a_param
+-ere module ${DUT_TOP}\.*tl_o\.d_param
+-ere module ${DUT_TOP}\.*tl_o\.d_sink

--- a/hw/dv/tools/xcelium/cov_merge.tcl
+++ b/hw/dv/tools/xcelium/cov_merge.tcl
@@ -8,14 +8,14 @@
 # using the env var 'cov_db_dirs' (which is a space separated list of directories).
 # Append each of these directories with /* wildcard at the end to allow the tool to
 # find all available test databases.
-set cov_db_dirs_env [string trim $::env(cov_db_dirs) " \""]
+set cov_db_dirs_env [string trim $::env(cov_db_dirs) " \"'"]
 foreach i $cov_db_dirs_env { append cov_db_dirs "[string trim $i]/* "; }
 puts "Input coverage directories:\n$cov_db_dirs"
 
 # Set the output directory for the merged database using the env var 'cov_merge_db_dir'.
 # The supplied env var may have quotes or spaces that needs to be trimmed.
 puts "Output directory for merged coverage:"
-set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \""]
+set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
 
 # Run the merge command.
 merge $cov_db_dirs -out $cov_merge_db_dir -overwrite

--- a/hw/dv/tools/xcelium/cov_report.tcl
+++ b/hw/dv/tools/xcelium/cov_report.tcl
@@ -6,11 +6,11 @@
 
 # Set the input merged coverage database directory using the env var 'cov_merge_db_dir'.
 # The supplied env var may have quotes or spaces that needs to be trimmed.
-set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \""]
+set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
 
 # Set the output directory for the reports database using the env var 'cov_report_dir'.
 # The supplied env var may have quotes or spaces that needs to be trimmed.
-set cov_report_dir [string trim $::env(cov_report_dir) " \""]
+set cov_report_dir [string trim $::env(cov_report_dir) " \"'"]
 
 # Set the DUT name.
 set dut [string trim $::env(DUT_TOP)]

--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -2,20 +2,19 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Enable scoring of continuous assignments, branch and statements.
-set_assign_scoring
-set_branch_scoring
-set_statement_scoring
+// Include our common coverage CCF.
+include_ccf ${dv_root}/tools/xcelium/common.ccf
 
-// Only collect toggle coverage on the DUT ports.
-deselect_coverage -toggle -instance tb.dut.*...
-set_toggle_portsonly
+// Black-box pre-verified IPs from coverage collection.
+deselect_coverage -betfs -module pins_if
+deselect_coverage -betfs -module clk_rst_if
+deselect_coverage -betfs -module prim_alert_sender...
+deselect_coverage -betfs -module prim_prince...
+deselect_coverage -betfs -module prim_lfsr...
 
-// Enable toggle scoring of MDAs and structs.
-set_toggle_scoring -sv_mda -sv_mda_of_struct
-
-// Filter glitches.
-set_toggle_strobe 0ps
-
-//  Filter unreachable/statically constant blocks
-set_com -log
+// Only collect toggle coverage on the DUT and the black-boxed IP (above) ports.
+deselect_coverage -toggle -module ${DUT_TOP}...
+select_coverage -toggle -module ${DUT_TOP}
+select_coverage -toggle -module prim_alert_sender
+select_coverage -toggle -module prim_prince
+select_coverage -toggle -module prim_lfsr

--- a/hw/dv/tools/xcelium/cover_reg_top.ccf
+++ b/hw/dv/tools/xcelium/cover_reg_top.ccf
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Include our common coverage CCF.
+include_ccf ${dv_root}/tools/xcelium/common.ccf
+
+// Only collect code coverage on the *_reg_top instance.
+deselect_coverage -betfs -module ${DUT_TOP}...
+select_coverage -befs -module *_reg_top...
+
+// TODO: The intent below is to only enable coverage on the DUT's TL interfaces (tests using this
+// ccf file are meant to fully exercise the TL interfaces, but they do not verify the rest of the
+// functionality of the block). We enable coverage on all DUT ports but exclude ports that do not
+// contain tl_i or tl_o in the port name using a separate excludefile that supports regexes.
+select_coverage -toggle -module ${DUT_TOP}
+set_toggle_excludefile ${dv_root}/tools/xcelium/cover_reg_top_toggle_excl

--- a/hw/dv/tools/xcelium/cover_reg_top_toggle_excl
+++ b/hw/dv/tools/xcelium/cover_reg_top_toggle_excl
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Exclude all but the TL ports of the DUT.
+// TODO: This does not work.
+-ere module ^((?!tl_i$|tl_o$).)*$

--- a/hw/dv/tools/xcelium/exclude.tcl
+++ b/hw/dv/tools/xcelium/exclude.tcl
@@ -2,10 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.parity'
-exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.parity_en'
+exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.rsvd'
 exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_param'
 exclude -inst $::env(DUT_TOP) -toggle 'tl_o.d_param'
 exclude -inst $::env(DUT_TOP) -toggle 'tl_o.d_sink'
-exclude -inst $::env(DUT_TOP) -toggle 'tl_o.d_user'
-exclude -inst $::env(DUT_TOP) -toggle 'tl_i.a_user.rsvd1'


### PR DESCRIPTION
- THis black-boxes pre-verified IPs for Xcelium, which should improve
the coverage numbers.
- This is in-line with our existing VCS cover.cfg file.

The commit relies on the following tool versions:

Xcelium: 21.03.005
VManager: 21.03.003

In addition, it mandates the following env var to be exported to the
execition environment:
XCELIUM_HOME: path/to/xcelium/install/root/dir

The following updates are made to the Xcelium coverage cfg file
(hw/dv/tools/xcelium/cover.ccf):
- Include the common ccf recommended in the Xcelium user guide, which
enables some options.
- Black-box pre-verified modules from coverage collection, but re-enable
the toggles on its ports
- Use env vars in the ccf file instead of hardcoding RTL path
hierarchies.
- Remove commands that are already present in the Xcelium provided ccf
file.
- Improves the covergroup naming

Signed-off-by: Srikrishna Iyer <sriyer@google.com>