### PR TITLE
[dv/clkmgr] Add jitter and clk_status tests

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -21,6 +21,7 @@
             - Clears each unit's `clk_hints` bit, which has no effect until
               the unit becomes idle.
             - Sets the unit's `idle_i` bit, which should disable the clock.
+            - Writes both values of the `jitter_enable` CSR.
 
             **Stimulus**:
             - CSR writes to `clk_enables` and `clk_hints`.
@@ -36,6 +37,8 @@
               - If the hint disables it and the unit is idle, the clock stops.
             - For transactional units the CSR `clk_hints_status` is checked
               to correspond to `clk_hints` once the units are idle.
+            - Check in scoreboard the `jitter_en_o` output tracks updates of the
+              `jitter_enable` CSR.
             '''
       milestone: V1
       tests: ["clkmgr_smoke"]
@@ -137,40 +140,45 @@
     }
     {
       name: clk_status
-      desc: '''Test clk_status output.
+      desc: '''
+            This tests the `pwr_o.clk_status` output port.
 
-            The clk_status is set in response to ip_clk_en. Of particular
-            interest is the case where the usb clock is disabled by pwrmgr in
-            active state. When a low power transition occurs it is possible
-            clk_status may not be set to all off. See
-            https://github.com/lowRISC/opentitan/issues/6504.
+            The `pwr_o.clk_status` output must track the `pwr_i.ip_clk_en`
+            input once the clock outputs are enabled when ip_clk_en is active,
+            or disabled when ip_clk_en goes inactive.
 
             **Stimulus**:
-            - Send low transition on ip_clk_en with the usb clock disabled.
+            - Randomize the `pwr_i.ip_clk_en` setting.
+            - Randomize the various pwrmgr clock controls per settings in
+              the pwrmgr `control` CSR.
+            - This will trigger cases where the usb clock is inactive with
+              `ip_clk_en` enabled.
 
             **Check**:
-            - The clk_status eventually drops.
+            - The sequence checks that `pwr_o.clk_status` tracks
+              `pwr_i.ip_clk_en`.
             '''
       milestone: V2
-      tests: []
+      tests: ["clkmgr_clk_status"]
     }
     {
       name: jitter
       desc: '''
             This tests the jitter functionality.
 
-            The jitter functionality is implemented by the AST block,
-            but controlled by the `jitter` CSR in this block. This CSR
+            The jitter functionality is implemented by the AST block, but
+            controlled by the `jitter_enable` CSR in this block. This CSR
             directly drives the `jitter_en_o` output pin.
 
             **Stimulus**:
-            - CSR write to `jitter`.
+            - CSR write to `jitter_enable`.
 
             **Check**:
-            - The `jitter_en_o` output pin reflects the `jitter` CSR.
+            - The `jitter_en_o` output pin reflects the `jitter_enable` CSR.
+              Test is implemented in the scoreboard, and runs always.
             '''
       milestone: V2
-      tests: []
+      tests: ["clkmgr_smoke"]
     }
     {
       name: stress

--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -67,6 +67,10 @@
       name: clkmgr_trans
       uvm_test_seq: clkmgr_trans_vseq
     }
+    {
+      name: clkmgr_clk_status
+      uvm_test_seq: clkmgr_clk_status_vseq
+    }
     // TODO: add more tests here
   ]
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -18,6 +18,7 @@ filesets:
       - clkmgr_env.sv: {is_include_file: true}
       - seq_lib/clkmgr_vseq_list.sv: {is_include_file: true}
       - seq_lib/clkmgr_base_vseq.sv: {is_include_file: true}
+      - seq_lib/clkmgr_clk_status_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_extclk_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_peri_vseq.sv: {is_include_file: true}

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -59,11 +59,10 @@ interface clkmgr_if (
   } clk_hints_t;
 
   // The CSR values from the testbench side.
-  clk_enables_t        clk_enables;
-  clk_hints_t          clk_hints;
-  clk_hints_t          clk_hints_status;
-  lc_ctrl_pkg::lc_tx_t extclk_sel;
-  logic                jitter_enable;
+  clk_enables_t        clk_enables_csr;
+  clk_hints_t          clk_hints_csr;
+  lc_ctrl_pkg::lc_tx_t extclk_sel_csr;
+  logic                jitter_enable_csr;
 
   // The expected and actual divided io clocks.
   logic                exp_clk_io_div2;
@@ -72,15 +71,15 @@ interface clkmgr_if (
   logic                actual_clk_io_div4;
 
   function automatic void update_extclk_sel(lc_ctrl_pkg::lc_tx_t value);
-    extclk_sel = value;
+    extclk_sel_csr = value;
   endfunction
 
   function automatic void update_clk_enables(clk_enables_t value);
-    clk_enables = value;
+    clk_enables_csr = value;
   endfunction
 
   function automatic void update_clk_hints(clk_hints_t value);
-    clk_hints = value;
+    clk_hints_csr = value;
   endfunction
 
   function automatic void update_idle(bit [NUM_TRANS-1:0] value);
@@ -109,6 +108,10 @@ interface clkmgr_if (
 
   function automatic logic get_clk_status();
     return pwr_o.clk_status;
+  endfunction
+
+  function automatic void update_jitter_enable(bit value);
+    jitter_enable_csr = value;
   endfunction
 
   function automatic void update_exp_clk_io_divs(logic exp_div2_value, logic actual_div2_value,
@@ -145,9 +148,11 @@ interface clkmgr_if (
   logic [PIPELINE_DEPTH-1:0] ip_clk_en_div4_ffs;
   always @(posedge clocks_o.clk_io_div4_powerup or negedge rst_io_n) begin
     if (rst_io_n) begin
-      clk_enable_div4_ffs <= {clk_enable_div4_ffs[PIPELINE_DEPTH-2:0], clk_enables.io_div4_peri_en};
+      clk_enable_div4_ffs <= {
+        clk_enable_div4_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.io_div4_peri_en
+      };
       clk_hint_otbn_div4_ffs <= {
-        clk_hint_otbn_div4_ffs[PIPELINE_DEPTH-2:0], clk_hints[TransOtbnIoDiv4]
+        clk_hint_otbn_div4_ffs[PIPELINE_DEPTH-2:0], clk_hints_csr[TransOtbnIoDiv4]
       };
       ip_clk_en_div4_ffs <= {ip_clk_en_div4_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
     end else begin
@@ -167,8 +172,10 @@ interface clkmgr_if (
   logic [PIPELINE_DEPTH-1:0] ip_clk_en_div2_ffs;
   always @(posedge clocks_o.clk_io_div2_powerup or negedge rst_io_n) begin
     if (rst_io_n) begin
-      clk_enable_div2_ffs <= {clk_enable_div2_ffs[PIPELINE_DEPTH-2:0], clk_enables.io_div2_peri_en};
-      ip_clk_en_div2_ffs  <= {ip_clk_en_div2_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
+      clk_enable_div2_ffs <= {
+        clk_enable_div2_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.io_div2_peri_en
+      };
+      ip_clk_en_div2_ffs <= {ip_clk_en_div2_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
     end else begin
       clk_enable_div2_ffs <= '0;
       ip_clk_en_div2_ffs  <= '0;
@@ -183,7 +190,7 @@ interface clkmgr_if (
   logic [PIPELINE_DEPTH-1:0] ip_clk_en_io_ffs;
   always @(posedge clocks_o.clk_io_powerup or negedge rst_io_n) begin
     if (rst_io_n) begin
-      clk_enable_io_ffs <= {clk_enable_io_ffs[PIPELINE_DEPTH-2:0], clk_enables.io_peri_en};
+      clk_enable_io_ffs <= {clk_enable_io_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.io_peri_en};
       ip_clk_en_io_ffs  <= {ip_clk_en_io_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
     end else begin
       clk_enable_io_ffs <= '0;
@@ -199,7 +206,7 @@ interface clkmgr_if (
   logic [PIPELINE_DEPTH-1:0] ip_clk_en_usb_ffs;
   always @(posedge clocks_o.clk_usb_powerup or negedge rst_usb_n) begin
     if (rst_usb_n) begin
-      clk_enable_usb_ffs <= {clk_enable_usb_ffs[PIPELINE_DEPTH-2:0], clk_enables.usb_peri_en};
+      clk_enable_usb_ffs <= {clk_enable_usb_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.usb_peri_en};
       ip_clk_en_usb_ffs  <= {ip_clk_en_usb_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
     end else begin
       clk_enable_usb_ffs <= '0;
@@ -216,7 +223,7 @@ interface clkmgr_if (
   logic [PIPELINE_DEPTH-1:0]                trans_clk_en_ffs;
   always @(posedge clocks_o.clk_main_powerup or negedge rst_main_n) begin
     if (rst_main_n) begin
-      clk_hints_ffs <= {clk_hints_ffs[PIPELINE_DEPTH-2:0], clk_hints};
+      clk_hints_ffs <= {clk_hints_ffs[PIPELINE_DEPTH-2:0], clk_hints_csr};
       trans_clk_en_ffs <= {trans_clk_en_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
     end else begin
       clk_hints_ffs <= '0;
@@ -229,13 +236,6 @@ interface clkmgr_if (
     input idle_i;
   endclocking
 
-  clocking extclk_cb @(posedge clk);
-    input extclk_sel;
-    input lc_dft_en_i;
-    input ast_clk_byp_req;
-    input lc_clk_byp_req;
-  endclocking
-
   // Pipelining and clocking block for external clock bypass. The divisor control is
   // triggered by an ast ack, which goes through synchronizers.
   logic step_down_ff;
@@ -246,8 +246,14 @@ interface clkmgr_if (
       step_down_ff <= 1'b0;
     end
   end
-  clocking step_down_cb @(posedge clk);
+
+  clocking clk_cb @(posedge clk);
+    input extclk_sel_csr;
+    input lc_dft_en_i;
+    input ast_clk_byp_req;
+    input lc_clk_byp_req;
     input step_down = step_down_ff;
+    input jitter_enable_csr;
   endclocking
 
   clocking div_clks_cb @(posedge clocks_o.clk_io_powerup);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This tests the transitions of clk_status under various scenarios:
+// - Transitions with ip_clk_en going active, assuming the usb clock is either active or inactive.
+// - Transitions with ip_clk_en going inactive, and assumming any subset of the clocks
+//   remain enabled (per controls in pwrmgr `control` CSR).
+class clkmgr_clk_status_vseq extends clkmgr_base_vseq;
+  `uvm_object_utils(clkmgr_clk_status_vseq)
+
+  `uvm_object_new
+
+  rand logic usb_clk_en_active;
+
+  // If usb_clk_en_active is off we stop the incoming usb clock.
+  task control_clocks();
+    if (usb_clk_en_active) cfg.usb_clk_rst_vif.start_clk();
+    else cfg.usb_clk_rst_vif.stop_clk();
+  endtask
+
+  function string create_failure_report();
+    return $sformatf(
+        "With ip_clk_en=%b, usb_clk_en_active=%b, clk_status is unexpectedly %b",
+        ip_clk_en,
+        usb_clk_en_active,
+        cfg.clkmgr_vif.pwr_o.clk_status
+    );
+  endfunction
+
+  task body();
+    update_csrs_with_reset_values();
+    for (int i = 0; i < num_trans; ++i) begin
+      cfg.clk_rst_vif.wait_clks(4);
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
+      control_clocks();
+      cfg.clk_rst_vif.wait_clks(10);
+      // If some units were not idle, make them so.
+      idle = '1;
+      // Wait for idle to percolate.
+      cfg.clk_rst_vif.wait_clks(10);
+      `DV_CHECK_EQ(cfg.clkmgr_vif.pwr_o.clk_status, ip_clk_en, create_failure_report())
+      // And set it back to a more common value for stress tests.
+      ip_clk_en = 1'b1;
+      usb_clk_en_active = 1'b1;
+      cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
+      control_clocks();
+      cfg.clk_rst_vif.wait_clks(10);
+    end
+  endtask : body
+endclass : clkmgr_clk_status_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "clkmgr_base_vseq.sv"
+`include "clkmgr_clk_status_vseq.sv"
 `include "clkmgr_common_vseq.sv"
 `include "clkmgr_extclk_vseq.sv"
 `include "clkmgr_peri_vseq.sv"

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_if.sv
@@ -33,7 +33,9 @@ interface pwrmgr_clock_enables_if (
 
   sequence usbActiveTransition_S;
     logic prev_en;
-    (1'b1, prev_en = usb_clk_en_active_i) ##1 usb_clk_en == prev_en;
+    (1'b1,
+    prev_en = usb_clk_en_active_i
+    ) ##1 usb_clk_en == prev_en;
   endsequence
 
   `ASSERT(CoreClkPwrUp_A, transitionUp_S |=> core_clk_en == 1'b1, clk_i, reset_or_disable)


### PR DESCRIPTION
Check that jitter CSR triggers an update of the jitter output port.
Add a test for the clk_status output to the pwrmgr: special attention
to what happens when the usb clock is off when the fast fsm is active.

Signed-off-by: Guillermo Maturana <maturana@google.com>