### PR TITLE
[dv/prim_alert] Improvement on prim_alert tb

### DIFF
--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "prim_alert"
+  testpoints: [
+    {
+      name: prim_alert_request_test
+      desc: '''Verify alert request from prim_alert_sender.
+
+            - Send an alert request by driving `alert_req` pin to 1.
+            - Verify that `alert_ack` signal is set and the alert handshake completes.
+            - If the alert is fatal, verify if the alert continuous fires until a reset is
+              issued.
+            '''
+      milestone: V1
+      tests: ["prim_async_alert",
+              "prim_async_fatal_alert",
+              "prim_sync_alert",
+              "prim_sync_fatal_alert"]
+    }
+
+    {
+      name: prim_alert_test
+      desc: '''Verify alert test request from prim_alert_sender.
+
+             - Send an alert test request by driving `alert_test` pin to 1.
+             - Verify that alert handshake completes and `alert_ack` signal stays low.
+            '''
+      milestone: V1
+      tests: ["prim_async_alert",
+              "prim_async_fatal_alert",
+              "prim_sync_alert",
+              "prim_sync_fatal_alert"]
+    }
+
+    {
+      name: prim_alert_ping_request_test
+      desc: '''Verify ping request from prim_alert_sender.
+
+             - Send a ping request by driving `ping_req` pin to 1.
+             - Verify that `ping_ok` signal is set and ping handshake completes.
+             Because ping reqeust is level trigger, in order to cover toggle coverage for
+             `alert_tx.ping_p/n` the above sequence will run twice.
+            '''
+      milestone: V1
+      tests: ["prim_async_alert",
+              "prim_async_fatal_alert",
+              "prim_sync_alert",
+              "prim_sync_fatal_alert"]
+    }
+
+    {
+      name: prim_alert_integrity_errors_test
+      desc: '''Verify the integrity errors from the prim_alert_sender and prim_alert_receiver pair.
+
+            1). `Ack_p/n` integrity error:
+                - Send an alert reqeust by driving `alert_req` pin to 1.
+                - Force `ack_p` signal to stay low to trigger an integrity error.
+                - Verify that prim_alert_receiver can identify the integrity error by setting
+                  `integ_fail_o` output to 1.
+            2). `Ping_p/n` integrity error:
+                - Send a ping request by driving `ping_req` to 1.
+                - Force `ping_n` signal to 1 to trigger an integrity error.
+                - Verify that prim_alert_receiver can identify the integrity error by setting
+                  `integ_fail_o` output to 1.
+            '''
+      milestone: V1
+      tests: ["prim_async_alert",
+              "prim_async_fatal_alert",
+              "prim_sync_alert",
+              "prim_sync_fatal_alert"]
+    }
+
+  ]
+}

--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -17,6 +17,9 @@
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:prim_alert_sim:0.1
 
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson"
+
   // Import additional common sim cfg files.
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
@@ -41,10 +44,10 @@
   // List of test specifications.
   tests: [
     {
-      name: prim_alert_smoke
+      name: prim_async_alert
     }
     {
-      name: prim_fatal_alert
+      name: prim_async_fatal_alert
       build_mode: fatal_alert
     }
     {
@@ -60,7 +63,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["prim_alert_smoke"]
+      tests: ["prim_async_alert"]
     }
   ]
   overrides: [

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -4,26 +4,12 @@
 //
 // Testbench module for prim_alert_sender and prim_alert_receiver pair.
 //
-// This direct test has four test sequences:
-// 1). Alert request sequence:
-//     Send an alert request by driving `alert_req` pin to 1.
-//     Check `alert_ack` signal is set and check alert handshake is completed.
-//     If the alert is fatal, the alert should continuous firing until a reset is issued. To check
-//     this property, the sequence waits a random number of clock cycles, then check if alert is
-//     still firing.
-// 2). Ping request sequence:
-//     Send a ping request by driving `ping_req` pin to 1.
-//     Check `ping_ok` signal is set and ping handshake is completed.
-// 3). Ack_p/n integrity check sequence:
-//     Send an alert reqeust by driving `alert_req` pin to 1.
-//     Force `ack_p` signal to stay low to trigger an integrity error.
-//     Check if `integ_fail_o` output is set to 1.
-// 4). Ping_p/n integrity check sequence:
-//     Send a ping request by driving `ping_req` to 1.
-//     Because ping request is level triggered and sequence 2) has driven ping request once, in
-//     this sequence, ping request will reset `ping_p` signal to 0, and set `ping_n` to 1.
-//     Then force `ping_n` signal to stay low to trigger an integrity error.
-//     Check if `integ_fail_o` output is set to 1.
+// This direct test has five test sequences:
+// 1). Alert request sequence.
+// 2). Alert test sequence.
+// 3). Ping request sequence.
+// 4). `Ack_p/n` integrity check sequence.
+// 5). `Ping_p/n` integrity check sequence.
 //
 // This direct sequence did not drive `ack_p/n` to trigger integrity error because this sequence is
 // covered in alert_handler IP level test.
@@ -48,6 +34,10 @@ module prim_alert_tb;
 
   localparam time ClkPeriod  = 10000;
   localparam int  WaitCycle = IsAsync ? 3 : 1;
+
+  // Minimal cycles to wait between each sequence.
+  // The main concern here is the minimal wait cycles between each handshake.
+  localparam int  MinHandshakeWait = 2 + WaitCycle;
 
   typedef enum bit [3:0]{
     AlertSet,
@@ -115,6 +105,7 @@ module prim_alert_tb;
 
   logic error = 0;
 
+  // `Alert`, `Ack`, and `Ping` are all differential signal pairs with postfix `_p` and `_n`.
   function automatic void check_diff_pair(bit exp_p, alert_signal_pair_e signal_pair);
     bit exp_n = ~exp_p;
     bit act_p, act_n;
@@ -152,6 +143,8 @@ module prim_alert_tb;
     end
   endfunction
 
+  // Check `alert`, `ack`, and `ping` differential pairs with given alert_handshake stage and
+  // expected ping value.
   function automatic void check_alert_rxtx(alert_handshake_e alert_handshake, bit exp_ping);
     case (alert_handshake)
       AlertSet: begin
@@ -178,6 +171,13 @@ module prim_alert_tb;
     check_diff_pair(exp_ping, PingPair);
   endfunction
 
+  // Verify the alert handshake protocol with the following pattern:
+  // 1). alert_p = 1, alert_n = 0;
+  // 2). ack_p = 1, ack_n = 0;
+  // 3). ack_p = 0, ack_n = 1;
+  // 4). alert_p = 0, alert_n = 1;
+  // There is a fixed cycles of delay between each sequence depending on if the alert is sync or
+  // async mode.
   task automatic check_alert_handshake(bit exp_ping_value);
     check_alert_rxtx(AlertSet, exp_ping_value);
     main_clk.wait_clks(WaitCycle);
@@ -200,7 +200,7 @@ module prim_alert_tb;
     main_clk.set_active();
     main_clk.apply_reset();
 
-    // Check alert request.
+    // Sequence 1). Alert request sequence.
     main_clk.wait_clks($urandom_range(0, 10));
     alert_req = 1;
     fork
@@ -223,29 +223,59 @@ module prim_alert_tb;
       check_alert_handshake(.exp_ping_value(0));
       main_clk.apply_reset();
     end
-    $display("Alert request sequence passed!");
+    $display("Alert request sequence finished!");
 
-    // Check ping request.
-    // Wait at least two cycles between each alert handshake.
-    main_clk.wait_clks($urandom_range(2, 10));
-    ping_req = 1;
-    fork
-      begin
-        main_clk.wait_clks(1);
-        check_diff_pair(1, PingPair);
-        main_clk.wait_clks(WaitCycle);
-        check_alert_handshake(.exp_ping_value(1));
-      end
-      begin
-        wait (ping_ok == 1);
-        ping_req = 0;
+    // Sequence 2). Alert test sequence.
+    main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
+    alert_test = 1;
+    fork : isolation_fork
+      begin: isolation_fork
+        fork
+          begin
+            main_clk.wait_clks(1);
+            alert_test = 0;
+            check_alert_handshake(.exp_ping_value(0));
+            // wait random clocks to ensure alert_ack is not set after alert handshake finishes.
+            main_clk.wait_clks($urandom_range(10, 20));
+          end
+          forever begin
+            main_clk.wait_clks(1);
+            if (alert_ack == 1) begin
+              $error("Alert ack should not set high during alert_test sequence!");
+              error = 1;
+            end
+          end
+        join_any
+        disable fork;
       end
     join
-    $display("Ping request sequence passed!");
+    $display("Alert test sequence finished!");
 
-    // Check alert_rx.ack_p/n signal integrity error from the alert_receiver side.
+    // Sequence 3) Ping request sequence.
+    // Loop the ping request twice to cover the alert_rx.ping_p/n toggle coverage.
+    for (int i = 0; i < 2; i++) begin
+      // Ping is level triggered, so the two exp_ping value should be 1 and 0.
+      automatic bit exp_ping = (i == 0);
+      main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
+      ping_req = 1;
+      fork
+        begin
+          main_clk.wait_clks(1);
+          check_diff_pair(exp_ping, PingPair);
+          main_clk.wait_clks(WaitCycle);
+          check_alert_handshake(.exp_ping_value(exp_ping));
+        end
+        begin
+          wait (ping_ok == 1);
+          ping_req = 0;
+        end
+      join
+      $display($sformatf("Ping request sequence[%0d] finished!", i));
+    end
+
+    // Sequence 4) `Ack_p/n` integrity check sequence.
     // Note that alert_tx signal interigy errors are verified in alert_handler testbench.
-    main_clk.wait_clks($urandom_range(2, 10));
+    main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
     alert_req = 1;
 
     $assertoff(0, prim_alert_tb.i_alert_receiver.AckDiffOk_A);
@@ -253,18 +283,26 @@ module prim_alert_tb;
     wait (integ_fail == 1);
     alert_req = 0;
     release i_alert_receiver.alert_rx_o.ack_p;
-    $display("Ack signal integrity error sequence passed!");
 
-    // Check alert_rx.ping_p/n signal integrity error from the alert_receiver side.
-    main_clk.wait_clks($urandom_range(2, 10));
+    // Wait until async or sync signal propogate from alert to ack.
+    main_clk.wait_clks(WaitCycle);
+    $asserton(0, prim_alert_tb.i_alert_receiver.AckDiffOk_A);
+    $display("Ack signal integrity error sequence finished!");
+
+    // Sequence 5) `Ping_p/n` integrity check sequence.
+    main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
     ping_req = 1;
 
     $assertoff(0, prim_alert_tb.i_alert_receiver.PingDiffOk_A);
-    force i_alert_receiver.alert_rx_o.ping_n = 0;
+    force i_alert_receiver.alert_rx_o.ping_n = 1;
     wait (integ_fail == 1);
     ping_req = 0;
     release i_alert_receiver.alert_rx_o.ping_p;
-    $display("Ping signal integrity error sequence passed!");
+
+    // Ping is the first signal of the handshake, so we can directly turn on the assertion once the
+    // forced ping signal is released.
+    $asserton(0, prim_alert_tb.i_alert_receiver.PingDiffOk_A);
+    $display("Ping signal integrity error sequence finished!");
 
     dv_test_status_pkg::dv_test_status(.passed(!error));
     $finish();


### PR DESCRIPTION
This PR improves prim_alert testbench:
1). Add a testplan
2). Add two seuqences to reach 100% on toggle coverage
3). Add more comments.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>