### PR TITLE
[dv/sram] update KDI timing

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -31,9 +31,9 @@ package sram_ctrl_env_pkg;
   // 1 bit for valid, SramKeyWidth bits for the key, SramNonceWidth bits for the nonce.
   parameter int KDI_DATA_SIZE = 1 + otp_ctrl_pkg::SramKeyWidth + otp_ctrl_pkg::SramNonceWidth;
 
-  // after a kDI transaction is copmleted, it needs 4 cycles in the SRAM clock domain
+  // after a KDI transaction is completed, it needs 2 cycles in the SRAM clock domain
   // to be properly synchronized and propagated through the DUT
-  parameter int KDI_PROPAGATION_CYCLES = 4;
+  parameter int KDI_PROPAGATION_CYCLES = 2;
 
   // a LC escalation request needs 3 cycles to be fully propagated through the DUT
   parameter int LC_ESCALATION_PROPAGATION_CYCLES = 3;


### PR DESCRIPTION
this PR updates KDI timing from 4 to 2 cycles, and updates related
timing in the scoreboard.

Should also address CI failures in #7756.

Signed-off-by: Udi Jonnalagadda <udij@google.com>