### PR TITLE
[usb/top] Remove AND gates on non-AON domain and rename 3.3V signal

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -244,8 +244,8 @@ module pinmux
     // input signals for resume detection
     .usb_dp_async_alw_i(dio_to_periph_o[TargetCfg.usb_dp_idx]),
     .usb_dn_async_alw_i(dio_to_periph_o[TargetCfg.usb_dn_idx]),
-    .usb_dppullup_en_alw_i(dio_oe_o[TargetCfg.usb_dp_pullup_idx]),
-    .usb_dnpullup_en_alw_i(dio_oe_o[TargetCfg.usb_dn_pullup_idx]),
+    .usb_dppullup_en_alw_i(dio_out_o[TargetCfg.usb_dp_pullup_idx]),
+    .usb_dnpullup_en_alw_i(dio_out_o[TargetCfg.usb_dn_pullup_idx]),
 
     // tie this to something from usbdev to indicate its out of reset
     .usb_out_of_rst_upwr_i(usb_out_of_rst_i),

--- a/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_usb_diff_rx.sv
@@ -13,7 +13,7 @@ module prim_generic_usb_diff_rx #(
   input wire         input_pi,      // differential input
   input wire         input_ni,      // differential input
   input              input_en_i,    // input buffer enable
-  input              core_pok_i,    // core power indication at VCC level
+  input              core_pok_h_i,  // core power indication at VCC level
   input              pullup_p_en_i, // pullup enable for P
   input              pullup_n_en_i, // pullup enable for N
   input [CalibW-1:0] calibration_i, // calibration input
@@ -29,6 +29,6 @@ module prim_generic_usb_diff_rx #(
   assign unused_calibration = calibration_i;
   assign unused_pullup_p_en = pullup_p_en_i;
   assign unused_pullup_n_en = pullup_n_en_i;
-  assign unused_core_pok = core_pok_i;
+  assign unused_core_pok = core_pok_h_i;
 
 endmodule : prim_generic_usb_diff_rx

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -1059,8 +1059,8 @@ module usbdev
   assign cio_rx_enable_en_o  = 1'b1;
 
   // Pullup
-  assign cio_dp_pullup_o     = 1'b1;
-  assign cio_dn_pullup_o     = 1'b1;
+  assign cio_dp_pullup_o     = cio_dp_pullup_en_o;
+  assign cio_dn_pullup_o     = cio_dn_pullup_en_o;
 
   /////////////////////////////////////////
   // SOF Reference for Clock Calibration //

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -728,11 +728,11 @@ module chip_earlgrey_asic (
 
   // Pullups
   logic usb_pullup_p_en, usb_pullup_n_en;
-  assign usb_pullup_p_en = dio_out[DioUsbdevDpPullup] & dio_oe[DioUsbdevDpPullup];
-  assign usb_pullup_n_en = dio_out[DioUsbdevDnPullup] & dio_oe[DioUsbdevDnPullup];
+  assign usb_pullup_p_en = dio_out[DioUsbdevDpPullup];
+  assign usb_pullup_n_en = dio_out[DioUsbdevDnPullup];
 
   logic usb_rx_enable;
-  assign usb_rx_enable = dio_out[DioUsbdevRxEnable] & dio_oe[DioUsbdevRxEnable];
+  assign usb_rx_enable = dio_out[DioUsbdevRxEnable];
 
   logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal;
 
@@ -746,7 +746,7 @@ module chip_earlgrey_asic (
     .input_pi      ( USB_P                 ),
     .input_ni      ( USB_N                 ),
     .input_en_i    ( usb_rx_enable         ),
-    .core_pok_i    ( ast_pwst_h.aon_pok    ),
+    .core_pok_h_i  ( ast_pwst_h.aon_pok    ),
     .pullup_p_en_i ( usb_pullup_p_en       ),
     .pullup_n_en_i ( usb_pullup_n_en       ),
     .calibration_i ( usb_io_pu_cal         ),
@@ -781,12 +781,15 @@ module chip_earlgrey_asic (
     dio_oe[DioUsbdevSuspend],
     dio_attr[DioUsbdevSuspend],
     // Rx enable
+    dio_oe[DioUsbdevRxEnable],
     dio_attr[DioUsbdevRxEnable],
     // D is used as an input only
     dio_out[DioUsbdevD],
     dio_oe[DioUsbdevD],
     dio_attr[DioUsbdevD],
     // Pullup/down
+    dio_oe[DioUsbdevDpPullup],
+    dio_oe[DioUsbdevDnPullup],
     dio_attr[DioUsbdevDpPullup],
     dio_attr[DioUsbdevDnPullup]
   };

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -576,11 +576,11 @@ module chip_${top["name"]}_${target["name"]} (
 
   // Pullups
   logic usb_pullup_p_en, usb_pullup_n_en;
-  assign usb_pullup_p_en = dio_out[DioUsbdevDpPullup] & dio_oe[DioUsbdevDpPullup];
-  assign usb_pullup_n_en = dio_out[DioUsbdevDnPullup] & dio_oe[DioUsbdevDnPullup];
+  assign usb_pullup_p_en = dio_out[DioUsbdevDpPullup];
+  assign usb_pullup_n_en = dio_out[DioUsbdevDnPullup];
 
   logic usb_rx_enable;
-  assign usb_rx_enable = dio_out[DioUsbdevRxEnable] & dio_oe[DioUsbdevRxEnable];
+  assign usb_rx_enable = dio_out[DioUsbdevRxEnable];
 
   logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal;
 
@@ -594,7 +594,7 @@ module chip_${top["name"]}_${target["name"]} (
     .input_pi      ( USB_P                 ),
     .input_ni      ( USB_N                 ),
     .input_en_i    ( usb_rx_enable         ),
-    .core_pok_i    ( ast_pwst_h.aon_pok    ),
+    .core_pok_h_i  ( ast_pwst_h.aon_pok    ),
     .pullup_p_en_i ( usb_pullup_p_en       ),
     .pullup_n_en_i ( usb_pullup_n_en       ),
     .calibration_i ( usb_io_pu_cal         ),
@@ -629,12 +629,15 @@ module chip_${top["name"]}_${target["name"]} (
     dio_oe[DioUsbdevSuspend],
     dio_attr[DioUsbdevSuspend],
     // Rx enable
+    dio_oe[DioUsbdevRxEnable],
     dio_attr[DioUsbdevRxEnable],
     // D is used as an input only
     dio_out[DioUsbdevD],
     dio_oe[DioUsbdevD],
     dio_attr[DioUsbdevD],
     // Pullup/down
+    dio_oe[DioUsbdevDpPullup],
+    dio_oe[DioUsbdevDnPullup],
     dio_attr[DioUsbdevDpPullup],
     dio_attr[DioUsbdevDnPullup]
   };


### PR DESCRIPTION
Fix #7802

Signed-off-by: Michael Schaffner <msf@opentitan.org>