### PR TITLE
[aes] Add support for key sideload

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:ip:tlul
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
+      - lowrisc:ip:keymgr_pkg
     files:
       - rtl/aes_reg_pkg.sv
       - rtl/aes_pkg.sv

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -157,6 +157,12 @@
       act:     "req"
       package: "edn_pkg"
     }
+    { struct:  "hw_key_req"
+      type:    "uni"
+      name:    "keymgr_key"
+      act:     "rcv"
+      package: "keymgr_pkg"
+    }
   ],
   alert_list: [
     //{ name: "informative",
@@ -431,6 +437,14 @@
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_key_len"]
       }
       { bits: "10",
+        name: "SIDELOAD",
+        resval: "0",
+        desc: '''
+          Controls whether the AES unit uses the key provided by the key manager via key sideload interface (1) or the key provided by software via Initial Key Registers KEY_SHARE1_0 - KEY_SHARE1_7 (0).
+        '''
+        tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_sideload"]
+      }
+      { bits: "11",
         name: "MANUAL_OPERATION",
         resval: "0"
         desc:  '''
@@ -443,7 +457,7 @@
         '''
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_manual_operation"]
       }
-      { bits: "11",
+      { bits: "12",
         name: "FORCE_ZERO_MASKS",
         resval: "0"
         desc:  '''

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -17,6 +17,7 @@ module tb;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire edn_req;
+  keymgr_pkg::hw_key_req_t keymgr_key;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -25,9 +26,12 @@ module tb;
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
 
-    // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
+  // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
   `DV_EDN_IF_CONNECT
   `DV_ALERT_IF_CONNECT
+
+  // for now drive a static key marked as invalid
+  assign keymgr_key = keymgr_pkg::HW_KEY_REQ_DEFAULT;
 
   // dut
   aes #(
@@ -45,6 +49,7 @@ module tb;
     .rst_edn_ni       ( edn_rst_n                     ),
     .edn_o            ( edn_if.req                    ),
     .edn_i            ( {edn_if.ack, edn_if.d_data}   ),
+    .keymgr_key_i     ( keymgr_key                    ),
 
     .tl_i             ( tl_if.h2d                     ),
     .tl_o             ( tl_if.d2h                     ),

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -52,6 +52,9 @@ module aes
   output edn_pkg::edn_req_t                         edn_o,
   input  edn_pkg::edn_rsp_t                         edn_i,
 
+  // Key manager (keymgr) key sideload interface
+  input  keymgr_pkg::hw_key_req_t                   keymgr_key_i,
+
   // Bus interface
   input  tlul_pkg::tl_h2d_t                         tl_i,
   output tlul_pkg::tl_d2h_t                         tl_o,
@@ -165,6 +168,8 @@ module aes
     .entropy_masking_req_o  ( entropy_masking_req  ),
     .entropy_masking_ack_i  ( entropy_masking_ack  ),
     .entropy_masking_i      ( edn_data             ),
+
+    .keymgr_key_i           ( keymgr_key_i         ),
 
     .lc_escalate_en_i       ( lc_escalate_en       ),
 

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -29,6 +29,7 @@ module aes_ctrl_reg_shadowed
   output aes_op_e   operation_o,
   output aes_mode_e mode_o,
   output key_len_e  key_len_o,
+  output logic      sideload_o,
   output logic      manual_operation_o,
   output logic      force_zero_masks_o,
 
@@ -48,11 +49,13 @@ module aes_ctrl_reg_shadowed
   logic      err_update_operation;
   logic      err_update_mode;
   logic      err_update_key_len;
+  logic      err_update_sideload;
   logic      err_update_manual_operation;
   logic      err_update_force_zero_masks;
   logic      err_storage_operation;
   logic      err_storage_mode;
   logic      err_storage_key_len;
+  logic      err_storage_sideload;
   logic      err_storage_manual_operation;
   logic      err_storage_force_zero_masks;
 
@@ -61,8 +64,8 @@ module aes_ctrl_reg_shadowed
 
   // Get and forward write enable. Writes are only allowed if the module is idle.
   assign qe_o = reg2hw_ctrl_i.operation.qe & reg2hw_ctrl_i.mode.qe &
-      reg2hw_ctrl_i.key_len.qe & reg2hw_ctrl_i.manual_operation.qe &
-      reg2hw_ctrl_i.force_zero_masks.qe;
+      reg2hw_ctrl_i.key_len.qe & reg2hw_ctrl_i.sideload.qe &
+      reg2hw_ctrl_i.manual_operation.qe & reg2hw_ctrl_i.force_zero_masks.qe;
 
   // Get and resolve values from register interface.
   assign ctrl_wd.operation = aes_op_e'(reg2hw_ctrl_i.operation.q);
@@ -89,6 +92,7 @@ module aes_ctrl_reg_shadowed
     endcase
   end
 
+  assign ctrl_wd.sideload = reg2hw_ctrl_i.sideload.q;
   assign ctrl_wd.manual_operation = reg2hw_ctrl_i.manual_operation.q;
 
   // SecAllowForcingMasks forbids forcing the masks. Forcing the masks to zero is only
@@ -161,6 +165,26 @@ module aes_ctrl_reg_shadowed
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
+    .RESVAL  (AES_CTRL_SHADOWED_SIDELOAD_RESVAL)
+  ) u_ctrl_reg_shadowed_sideload (
+    .clk_i,
+    .rst_ni,
+    .rst_shadowed_ni,
+    .re         (reg2hw_ctrl_i.sideload.re),
+    .we         (we_i),
+    .wd         (ctrl_wd.sideload),
+    .de         (1'b0),
+    .d          ('0),
+    .qe         (),
+    .q          (hw2reg_ctrl_o.sideload.d),
+    .qs         (),
+    .err_update (err_update_sideload),
+    .err_storage(err_storage_sideload)
+  );
+
+  prim_subreg_shadow #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessWO),
     .RESVAL  (AES_CTRL_SHADOWED_MANUAL_OPERATION_RESVAL)
   ) u_ctrl_reg_shadowed_manual_operation (
     .clk_i,
@@ -200,15 +224,16 @@ module aes_ctrl_reg_shadowed
 
   // Collect alerts.
   assign err_update_o = err_update_operation | err_update_mode | err_update_key_len |
-      err_update_manual_operation | err_update_force_zero_masks;
+      err_update_sideload | err_update_manual_operation | err_update_force_zero_masks;
   assign err_storage_o = err_storage_operation | err_storage_mode | err_storage_key_len |
-      err_storage_manual_operation | err_storage_force_zero_masks;
+      err_storage_sideload | err_storage_manual_operation | err_storage_force_zero_masks;
 
   // Generate shorter references.
   // Doing that here as opposed to in aes_core avoids several Verilator lint errors.
   assign operation_o        = aes_op_e'(hw2reg_ctrl_o.operation.d);
   assign mode_o             = aes_mode_e'(hw2reg_ctrl_o.mode.d);
   assign key_len_o          = key_len_e'(hw2reg_ctrl_o.key_len.d);
+  assign sideload_o         = hw2reg_ctrl_o.sideload.d;
   assign manual_operation_o = hw2reg_ctrl_o.manual_operation.d;
   assign force_zero_masks_o = hw2reg_ctrl_o.force_zero_masks.d;
 

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -257,11 +257,12 @@ typedef enum logic [AddRKSelWidth-1:0] {
   ADD_RK_FINAL = MUX3_SEL_2
 } add_rk_sel_e;
 
-parameter int KeyInitSelNum = 2;
-parameter int KeyInitSelWidth = Mux2SelWidth;
+parameter int KeyInitSelNum = 3;
+parameter int KeyInitSelWidth = Mux3SelWidth;
 typedef enum logic [KeyInitSelWidth-1:0] {
-  KEY_INIT_INPUT = MUX2_SEL_0,
-  KEY_INIT_CLEAR = MUX2_SEL_1
+  KEY_INIT_INPUT  = MUX3_SEL_0,
+  KEY_INIT_KEYMGR = MUX3_SEL_1,
+  KEY_INIT_CLEAR  = MUX3_SEL_2
 } key_init_sel_e;
 
 parameter int IVSelNum = 6;
@@ -327,6 +328,7 @@ typedef enum logic [Sp2VWidth-1:0] {
 typedef struct packed {
   logic      force_zero_masks;
   logic      manual_operation;
+  logic      sideload;
   key_len_e  key_len;
   aes_mode_e mode;
   aes_op_e   operation;
@@ -335,6 +337,7 @@ typedef struct packed {
 parameter ctrl_reg_t CTRL_RESET = '{
   force_zero_masks: aes_reg_pkg::AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_RESVAL,
   manual_operation: aes_reg_pkg::AES_CTRL_SHADOWED_MANUAL_OPERATION_RESVAL,
+  sideload:         aes_reg_pkg::AES_CTRL_SHADOWED_SIDELOAD_RESVAL,
   key_len:          key_len_e'(aes_reg_pkg::AES_CTRL_SHADOWED_KEY_LEN_RESVAL),
   mode:             aes_mode_e'(aes_reg_pkg::AES_CTRL_SHADOWED_MODE_RESVAL),
   operation:        aes_op_e'(aes_reg_pkg::AES_CTRL_SHADOWED_OPERATION_RESVAL)

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -75,6 +75,11 @@ package aes_reg_pkg;
       logic        q;
       logic        qe;
       logic        re;
+    } sideload;
+    struct packed {
+      logic        q;
+      logic        qe;
+      logic        re;
     } manual_operation;
     struct packed {
       logic        q;
@@ -137,6 +142,9 @@ package aes_reg_pkg;
     } key_len;
     struct packed {
       logic        d;
+    } sideload;
+    struct packed {
+      logic        d;
     } manual_operation;
     struct packed {
       logic        d;
@@ -195,25 +203,25 @@ package aes_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aes_reg2hw_alert_test_reg_t alert_test; // [949:946]
-    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [945:682]
-    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [681:418]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [417:286]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [285:154]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [153:22]
-    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [21:5]
+    aes_reg2hw_alert_test_reg_t alert_test; // [951:948]
+    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [947:684]
+    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [683:420]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [419:288]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [287:156]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [155:24]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [23:5]
     aes_reg2hw_trigger_reg_t trigger; // [4:1]
     aes_reg2hw_status_reg_t status; // [0:0]
   } aes_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    aes_hw2reg_key_share0_mreg_t [7:0] key_share0; // [933:678]
-    aes_hw2reg_key_share1_mreg_t [7:0] key_share1; // [677:422]
-    aes_hw2reg_iv_mreg_t [3:0] iv; // [421:294]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [293:162]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [161:34]
-    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [33:22]
+    aes_hw2reg_key_share0_mreg_t [7:0] key_share0; // [934:679]
+    aes_hw2reg_key_share1_mreg_t [7:0] key_share1; // [678:423]
+    aes_hw2reg_iv_mreg_t [3:0] iv; // [422:295]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [294:163]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [162:35]
+    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [34:22]
     aes_hw2reg_trigger_reg_t trigger; // [21:14]
     aes_hw2reg_status_reg_t status; // [13:0]
   } aes_hw2reg_t;
@@ -304,10 +312,11 @@ package aes_reg_pkg;
   parameter logic [31:0] AES_DATA_OUT_2_DATA_OUT_2_RESVAL = 32'h 0;
   parameter logic [31:0] AES_DATA_OUT_3_RESVAL = 32'h 0;
   parameter logic [31:0] AES_DATA_OUT_3_DATA_OUT_3_RESVAL = 32'h 0;
-  parameter logic [11:0] AES_CTRL_SHADOWED_RESVAL = 12'h c0;
+  parameter logic [12:0] AES_CTRL_SHADOWED_RESVAL = 13'h c0;
   parameter logic [0:0] AES_CTRL_SHADOWED_OPERATION_RESVAL = 1'h 0;
   parameter logic [5:0] AES_CTRL_SHADOWED_MODE_RESVAL = 6'h 20;
   parameter logic [2:0] AES_CTRL_SHADOWED_KEY_LEN_RESVAL = 3'h 1;
+  parameter logic [0:0] AES_CTRL_SHADOWED_SIDELOAD_RESVAL = 1'h 0;
   parameter logic [0:0] AES_CTRL_SHADOWED_MANUAL_OPERATION_RESVAL = 1'h 0;
   parameter logic [0:0] AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_RESVAL = 1'h 0;
 

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -175,6 +175,8 @@ module aes_reg_top (
   logic [5:0] ctrl_shadowed_mode_wd;
   logic [2:0] ctrl_shadowed_key_len_qs;
   logic [2:0] ctrl_shadowed_key_len_wd;
+  logic ctrl_shadowed_sideload_qs;
+  logic ctrl_shadowed_sideload_wd;
   logic ctrl_shadowed_manual_operation_qs;
   logic ctrl_shadowed_manual_operation_wd;
   logic ctrl_shadowed_force_zero_masks_qs;
@@ -758,7 +760,21 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_key_len_qs)
   );
 
-  //   F[manual_operation]: 10:10
+  //   F[sideload]: 10:10
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_ctrl_shadowed_sideload (
+    .re     (ctrl_shadowed_re),
+    .we     (ctrl_shadowed_we),
+    .wd     (ctrl_shadowed_sideload_wd),
+    .d      (hw2reg.ctrl_shadowed.sideload.d),
+    .qre    (reg2hw.ctrl_shadowed.sideload.re),
+    .qe     (reg2hw.ctrl_shadowed.sideload.qe),
+    .q      (reg2hw.ctrl_shadowed.sideload.q),
+    .qs     (ctrl_shadowed_sideload_qs)
+  );
+
+  //   F[manual_operation]: 11:11
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_manual_operation (
@@ -772,7 +788,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_manual_operation_qs)
   );
 
-  //   F[force_zero_masks]: 11:11
+  //   F[force_zero_masks]: 12:12
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_force_zero_masks (
@@ -1232,9 +1248,11 @@ module aes_reg_top (
 
   assign ctrl_shadowed_key_len_wd = reg_wdata[9:7];
 
-  assign ctrl_shadowed_manual_operation_wd = reg_wdata[10];
+  assign ctrl_shadowed_sideload_wd = reg_wdata[10];
 
-  assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[11];
+  assign ctrl_shadowed_manual_operation_wd = reg_wdata[11];
+
+  assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[12];
   assign trigger_we = addr_hit[30] & reg_we & !reg_error;
 
   assign trigger_start_wd = reg_wdata[0];
@@ -1370,8 +1388,9 @@ module aes_reg_top (
         reg_rdata_next[0] = ctrl_shadowed_operation_qs;
         reg_rdata_next[6:1] = ctrl_shadowed_mode_qs;
         reg_rdata_next[9:7] = ctrl_shadowed_key_len_qs;
-        reg_rdata_next[10] = ctrl_shadowed_manual_operation_qs;
-        reg_rdata_next[11] = ctrl_shadowed_force_zero_masks_qs;
+        reg_rdata_next[10] = ctrl_shadowed_sideload_qs;
+        reg_rdata_next[11] = ctrl_shadowed_manual_operation_qs;
+        reg_rdata_next[12] = ctrl_shadowed_force_zero_masks_qs;
       end
 
       addr_hit[30]: begin

--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -13,8 +13,10 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:prim:lc_sync
       - lowrisc:prim:msb_extend
+      - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:kmac_pkg
+      - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:rom_ctrl_pkg
     files:
       - rtl/keymgr_reg_top.sv

--- a/hw/ip/keymgr/keymgr_pkg.core
+++ b/hw/ip/keymgr/keymgr_pkg.core
@@ -10,8 +10,6 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:ip:edn_pkg
-      - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:ip:flash_ctrl_pkg
     files:
       - rtl/keymgr_reg_pkg.sv
       - rtl/keymgr_pkg.sv

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4739,6 +4739,18 @@
           index: 5
         }
         {
+          name: keymgr_key
+          struct: hw_key_req
+          package: keymgr_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: aes
+          default: ""
+          top_signame: keymgr_aes_key
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -5176,6 +5188,10 @@
           act: req
           width: 1
           inst_name: keymgr
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: keymgr_aes_key
           index: -1
         }
         {
@@ -7033,6 +7049,10 @@
       otp_ctrl.otp_keymgr_key:
       [
         keymgr.otp_key
+      ]
+      keymgr.aes_key:
+      [
+        aes.keymgr_key
       ]
       keymgr.kmac_key:
       [
@@ -16178,6 +16198,18 @@
         index: 5
       }
       {
+        name: keymgr_key
+        struct: hw_key_req
+        package: keymgr_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: aes
+        default: ""
+        top_signame: keymgr_aes_key
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -16312,6 +16344,10 @@
         act: req
         width: 1
         inst_name: keymgr
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: keymgr_aes_key
         index: -1
       }
       {
@@ -18987,6 +19023,17 @@
         act: req
         suffix: ""
         default: "'0"
+      }
+      {
+        package: keymgr_pkg
+        struct: hw_key_req
+        signame: keymgr_aes_key
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: keymgr_pkg::HW_KEY_REQ_DEFAULT
       }
       {
         package: keymgr_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -752,7 +752,8 @@
 
       // KeyMgr Sideload & KDF function
       'otp_ctrl.otp_keymgr_key' : ['keymgr.otp_key'],
-      'keymgr.kmac_key'         : ['kmac.keymgr_key']
+      'keymgr.aes_key'          : ['aes.keymgr_key'],
+      'keymgr.kmac_key'         : ['kmac.keymgr_key'],
 
       // KMAC Application Interface
       'kmac.app'                : ['keymgr.kmac_data',    // Keymgr needs to be at index 0

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -552,6 +552,7 @@ module top_earlgrey #(
   otp_ctrl_pkg::otbn_otp_key_req_t       otp_ctrl_otbn_otp_key_req;
   otp_ctrl_pkg::otbn_otp_key_rsp_t       otp_ctrl_otbn_otp_key_rsp;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
+  keymgr_pkg::hw_key_req_t       keymgr_aes_key;
   keymgr_pkg::hw_key_req_t       keymgr_kmac_key;
   kmac_pkg::app_req_t [2:0] kmac_app_req;
   kmac_pkg::app_rsp_t [2:0] kmac_app_rsp;
@@ -2007,6 +2008,7 @@ module top_earlgrey #(
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .edn_o(edn0_edn_req[5]),
       .edn_i(edn0_edn_rsp[5]),
+      .keymgr_key_i(keymgr_aes_key),
       .tl_i(aes_tl_req),
       .tl_o(aes_tl_rsp),
 
@@ -2101,7 +2103,7 @@ module top_earlgrey #(
       // Inter-module signals
       .edn_o(edn0_edn_req[0]),
       .edn_i(edn0_edn_rsp[0]),
-      .aes_key_o(),
+      .aes_key_o(keymgr_aes_key),
       .kmac_key_o(keymgr_kmac_key),
       .otbn_key_o(),
       .kmac_data_o(kmac_app_req[0]),


### PR DESCRIPTION
This PR adds key sideload support in AES. It follows the example of KMAC: to enable sideload, a new `SIDELOAD` bit in the main control register needs to be set and the key coming in from keymgr needs to be marked as valid. Otherwise AES won't start in normal/automatic mode.