### PR TITLE
[otbn,dv] Double the number of otbn_single runs

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -134,7 +134,7 @@ name:
       name: "otbn_single"
       uvm_test_seq: "otbn_single_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
-      reseed: 50
+      reseed: 100
     }
 
     // This test runs 10 binaries each time, so we give it a reseed value


### PR DESCRIPTION
Since lots of the interesting corner cases cause (architecturally
defined) errors, we have to do lots of OTBN runs to see them all. It
turns out that the setup/teardown costs of a simulation aren't too
significant compared to the time spent running instructions, so
there's no real benefit to packing multiple runs into a single
simulation. And, obviously, debugging is easier with just a single
binary.

So bump up the number of `otbn_single` runs, to see more of the weird
error cases :-)
