### PR TITLE
[otbn,dv] Alter "loopy" configuration to see maximal loop depth

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/README.md
+++ b/hw/ip/otbn/dv/rig/rig/configs/README.md
@@ -71,3 +71,16 @@ The valid keys for these YAML files are:
 
   As an even shorter shorthand, a one-item list whose only item is a
   string can be replaced by just that string.
+
+- ranges:
+
+  A dictionary of maximum or minimum values, keyed with names like
+  `max-FOO` or `min-FOO`, respectively.
+
+  Supported names:
+
+  - `max-loop-iters`: Used by the Loop generator to constrain the
+    maximum number of loop iterations that it will pick.
+  - `max-loop-tail-insns`: Used by the Loop generator to constrain the
+    maximum number of straight-line instructions it will generate as
+    part of a loop's tail.

--- a/hw/ip/otbn/dv/rig/rig/configs/loopy.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/loopy.yml
@@ -3,10 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # An example custom configuration that generates lots of loops (100
-# times as many as the default config)
+# times as many as the default config), but constrains them not to
+# take too long. We also force the generator not to make long loop
+# tails (the straight-line code that appears up to and including the
+# last instruction of the loop). The idea is that we'll be much more
+# likely to get deeply nested loops this way.
 
 inherit: base
 
 gen-weights:
   Loop: 100
 
+ranges:
+  max-loop-iters: 2
+  max-loop-tail-insns: 4


### PR DESCRIPTION
This lets us hit the `FullToEmpty_C` cover assertion in the loop
interface, which wants to see a loop of maximal depth, followed by the
loop stack becoming completely empty again.
