### PR TITLE
[sw, rstmgr] Fix broken reference

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -40,9 +40,10 @@ uint32_t rstmgr_reason_get(void) {
   REASON_ASSERT(kRstmgrReasonLowPowerExit,
                 RSTMGR_RESET_INFO_LOW_POWER_EXIT_BIT);
   REASON_ASSERT(kRstmgrReasonNonDebugModule, RSTMGR_RESET_INFO_NDM_RESET_BIT);
-  REASON_ASSERT(kRstmgrReasonSysrstCtrl,
-                RSTMGR_RESET_INFO_HW_REQ_OFFSET +
-                    kTopEarlgreyPowerManagerResetRequestsSysrstCtrlAonGscRst);
+  REASON_ASSERT(
+      kRstmgrReasonSysrstCtrl,
+      RSTMGR_RESET_INFO_HW_REQ_OFFSET +
+          kTopEarlgreyPowerManagerResetRequestsSysrstCtrlAonAonGscRst);
   REASON_ASSERT(
       kRstmgrReasonWatchdog,
       RSTMGR_RESET_INFO_HW_REQ_OFFSET +


### PR DESCRIPTION
This reference got missed in 80b2ce5f6e3d1e39540f3b46b885991d7382c47b and currently breaks CI.