### PR TITLE
[dv] reduce seeds for CSR tests

### DIFF
--- a/hw/dv/tools/dvsim/tests/csr_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/csr_tests.hjson
@@ -22,6 +22,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_hw_reset"]
       en_run_modes: ["csr_tests_mode"]
+      reseed: 5
     }
 
     {
@@ -29,6 +30,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_rw"]
       en_run_modes: ["csr_tests_mode"]
+      reseed: 20
     }
 
     {
@@ -36,6 +38,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_bit_bash"]
       en_run_modes: ["csr_tests_mode"]
+      reseed: 5
     }
 
     {
@@ -43,6 +46,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+csr_aliasing"]
       en_run_modes: ["csr_tests_mode"]
+      reseed: 5
     }
 
     {
@@ -50,6 +54,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+run_same_csr_outstanding"]
       en_run_modes: ["csr_tests_mode"]
+      reseed: 20
     }
 
     {
@@ -57,6 +62,7 @@
       build_mode: "cover_reg_top"
       run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000"]
       en_run_modes: ["csr_tests_mode"]
+      reseed: 20
     }
   ]
 

--- a/hw/dv/tools/dvsim/tests/mem_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/mem_tests.hjson
@@ -13,6 +13,7 @@
       name: mem_tests_mode
       uvm_test_seq: "{name}_common_vseq"
       run_opts: ["+en_scb=0"]
+      reseed: 5
     }
   ]
 

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -127,7 +127,6 @@
       // Append stub cpu mode to csr_tests_mode, run with 20 reseeds.
       name: csr_tests_mode
       en_run_modes: ["stub_cpu_mode"]
-      reseed: 20
     }
     {
       // Append stub cpu mode to mem_tests_mode, run with 20 reseeds.


### PR DESCRIPTION
For very direct sequence like bit_bash, reduce to 5 seeds,
for others, reduce to 20.
Tried on uart and spi_device, coverage didn't drop with this change

Signed-off-by: Weicai Yang <weicai@google.com>