### PR TITLE
[rstmgr/sysrst_ctrl] This fixes an autogenerated constant name

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -43,7 +43,7 @@ uint32_t rstmgr_reason_get(void) {
   REASON_ASSERT(
       kRstmgrReasonSysrstCtrl,
       RSTMGR_RESET_INFO_HW_REQ_OFFSET +
-          kTopEarlgreyPowerManagerResetRequestsSysrstCtrlAonAonGscRst);
+          kTopEarlgreyPowerManagerResetRequestsSysrstCtrlAonAonSysrstCtrlRstReq);
   REASON_ASSERT(
       kRstmgrReasonWatchdog,
       RSTMGR_RESET_INFO_HW_REQ_OFFSET +


### PR DESCRIPTION
This somehow slipped through CI in https://github.com/lowRISC/opentitan/pull/7829.

Signed-off-by: Michael Schaffner <msf@opentitan.org>