### PR TITLE
[reggen] Refactor regfile CDC handling

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -130,265 +130,77 @@ module adc_ctrl_reg_top (
   logic alert_test_we;
   logic alert_test_wd;
   logic adc_en_ctl_we;
-  logic adc_en_ctl_adc_enable_qs;
-  logic adc_en_ctl_adc_enable_wd;
-  logic adc_en_ctl_adc_enable_busy;
-  logic adc_en_ctl_oneshot_mode_qs;
-  logic adc_en_ctl_oneshot_mode_wd;
-  logic adc_en_ctl_oneshot_mode_busy;
+  logic [1:0] adc_en_ctl_qs;
+  logic adc_en_ctl_busy;
   logic adc_pd_ctl_we;
-  logic adc_pd_ctl_lp_mode_qs;
-  logic adc_pd_ctl_lp_mode_wd;
-  logic adc_pd_ctl_lp_mode_busy;
-  logic [3:0] adc_pd_ctl_pwrup_time_qs;
-  logic [3:0] adc_pd_ctl_pwrup_time_wd;
-  logic adc_pd_ctl_pwrup_time_busy;
-  logic [23:0] adc_pd_ctl_wakeup_time_qs;
-  logic [23:0] adc_pd_ctl_wakeup_time_wd;
-  logic adc_pd_ctl_wakeup_time_busy;
+  logic [31:0] adc_pd_ctl_qs;
+  logic adc_pd_ctl_busy;
   logic adc_lp_sample_ctl_we;
   logic [7:0] adc_lp_sample_ctl_qs;
-  logic [7:0] adc_lp_sample_ctl_wd;
   logic adc_lp_sample_ctl_busy;
   logic adc_sample_ctl_we;
   logic [15:0] adc_sample_ctl_qs;
-  logic [15:0] adc_sample_ctl_wd;
   logic adc_sample_ctl_busy;
   logic adc_fsm_rst_we;
-  logic adc_fsm_rst_qs;
-  logic adc_fsm_rst_wd;
+  logic [0:0] adc_fsm_rst_qs;
   logic adc_fsm_rst_busy;
   logic adc_chn0_filter_ctl_0_we;
-  logic [9:0] adc_chn0_filter_ctl_0_min_v_0_qs;
-  logic [9:0] adc_chn0_filter_ctl_0_min_v_0_wd;
-  logic adc_chn0_filter_ctl_0_min_v_0_busy;
-  logic adc_chn0_filter_ctl_0_cond_0_qs;
-  logic adc_chn0_filter_ctl_0_cond_0_wd;
-  logic adc_chn0_filter_ctl_0_cond_0_busy;
-  logic [9:0] adc_chn0_filter_ctl_0_max_v_0_qs;
-  logic [9:0] adc_chn0_filter_ctl_0_max_v_0_wd;
-  logic adc_chn0_filter_ctl_0_max_v_0_busy;
-  logic adc_chn0_filter_ctl_0_en_0_qs;
-  logic adc_chn0_filter_ctl_0_en_0_wd;
-  logic adc_chn0_filter_ctl_0_en_0_busy;
+  logic [31:0] adc_chn0_filter_ctl_0_qs;
+  logic adc_chn0_filter_ctl_0_busy;
   logic adc_chn0_filter_ctl_1_we;
-  logic [9:0] adc_chn0_filter_ctl_1_min_v_1_qs;
-  logic [9:0] adc_chn0_filter_ctl_1_min_v_1_wd;
-  logic adc_chn0_filter_ctl_1_min_v_1_busy;
-  logic adc_chn0_filter_ctl_1_cond_1_qs;
-  logic adc_chn0_filter_ctl_1_cond_1_wd;
-  logic adc_chn0_filter_ctl_1_cond_1_busy;
-  logic [9:0] adc_chn0_filter_ctl_1_max_v_1_qs;
-  logic [9:0] adc_chn0_filter_ctl_1_max_v_1_wd;
-  logic adc_chn0_filter_ctl_1_max_v_1_busy;
-  logic adc_chn0_filter_ctl_1_en_1_qs;
-  logic adc_chn0_filter_ctl_1_en_1_wd;
-  logic adc_chn0_filter_ctl_1_en_1_busy;
+  logic [31:0] adc_chn0_filter_ctl_1_qs;
+  logic adc_chn0_filter_ctl_1_busy;
   logic adc_chn0_filter_ctl_2_we;
-  logic [9:0] adc_chn0_filter_ctl_2_min_v_2_qs;
-  logic [9:0] adc_chn0_filter_ctl_2_min_v_2_wd;
-  logic adc_chn0_filter_ctl_2_min_v_2_busy;
-  logic adc_chn0_filter_ctl_2_cond_2_qs;
-  logic adc_chn0_filter_ctl_2_cond_2_wd;
-  logic adc_chn0_filter_ctl_2_cond_2_busy;
-  logic [9:0] adc_chn0_filter_ctl_2_max_v_2_qs;
-  logic [9:0] adc_chn0_filter_ctl_2_max_v_2_wd;
-  logic adc_chn0_filter_ctl_2_max_v_2_busy;
-  logic adc_chn0_filter_ctl_2_en_2_qs;
-  logic adc_chn0_filter_ctl_2_en_2_wd;
-  logic adc_chn0_filter_ctl_2_en_2_busy;
+  logic [31:0] adc_chn0_filter_ctl_2_qs;
+  logic adc_chn0_filter_ctl_2_busy;
   logic adc_chn0_filter_ctl_3_we;
-  logic [9:0] adc_chn0_filter_ctl_3_min_v_3_qs;
-  logic [9:0] adc_chn0_filter_ctl_3_min_v_3_wd;
-  logic adc_chn0_filter_ctl_3_min_v_3_busy;
-  logic adc_chn0_filter_ctl_3_cond_3_qs;
-  logic adc_chn0_filter_ctl_3_cond_3_wd;
-  logic adc_chn0_filter_ctl_3_cond_3_busy;
-  logic [9:0] adc_chn0_filter_ctl_3_max_v_3_qs;
-  logic [9:0] adc_chn0_filter_ctl_3_max_v_3_wd;
-  logic adc_chn0_filter_ctl_3_max_v_3_busy;
-  logic adc_chn0_filter_ctl_3_en_3_qs;
-  logic adc_chn0_filter_ctl_3_en_3_wd;
-  logic adc_chn0_filter_ctl_3_en_3_busy;
+  logic [31:0] adc_chn0_filter_ctl_3_qs;
+  logic adc_chn0_filter_ctl_3_busy;
   logic adc_chn0_filter_ctl_4_we;
-  logic [9:0] adc_chn0_filter_ctl_4_min_v_4_qs;
-  logic [9:0] adc_chn0_filter_ctl_4_min_v_4_wd;
-  logic adc_chn0_filter_ctl_4_min_v_4_busy;
-  logic adc_chn0_filter_ctl_4_cond_4_qs;
-  logic adc_chn0_filter_ctl_4_cond_4_wd;
-  logic adc_chn0_filter_ctl_4_cond_4_busy;
-  logic [9:0] adc_chn0_filter_ctl_4_max_v_4_qs;
-  logic [9:0] adc_chn0_filter_ctl_4_max_v_4_wd;
-  logic adc_chn0_filter_ctl_4_max_v_4_busy;
-  logic adc_chn0_filter_ctl_4_en_4_qs;
-  logic adc_chn0_filter_ctl_4_en_4_wd;
-  logic adc_chn0_filter_ctl_4_en_4_busy;
+  logic [31:0] adc_chn0_filter_ctl_4_qs;
+  logic adc_chn0_filter_ctl_4_busy;
   logic adc_chn0_filter_ctl_5_we;
-  logic [9:0] adc_chn0_filter_ctl_5_min_v_5_qs;
-  logic [9:0] adc_chn0_filter_ctl_5_min_v_5_wd;
-  logic adc_chn0_filter_ctl_5_min_v_5_busy;
-  logic adc_chn0_filter_ctl_5_cond_5_qs;
-  logic adc_chn0_filter_ctl_5_cond_5_wd;
-  logic adc_chn0_filter_ctl_5_cond_5_busy;
-  logic [9:0] adc_chn0_filter_ctl_5_max_v_5_qs;
-  logic [9:0] adc_chn0_filter_ctl_5_max_v_5_wd;
-  logic adc_chn0_filter_ctl_5_max_v_5_busy;
-  logic adc_chn0_filter_ctl_5_en_5_qs;
-  logic adc_chn0_filter_ctl_5_en_5_wd;
-  logic adc_chn0_filter_ctl_5_en_5_busy;
+  logic [31:0] adc_chn0_filter_ctl_5_qs;
+  logic adc_chn0_filter_ctl_5_busy;
   logic adc_chn0_filter_ctl_6_we;
-  logic [9:0] adc_chn0_filter_ctl_6_min_v_6_qs;
-  logic [9:0] adc_chn0_filter_ctl_6_min_v_6_wd;
-  logic adc_chn0_filter_ctl_6_min_v_6_busy;
-  logic adc_chn0_filter_ctl_6_cond_6_qs;
-  logic adc_chn0_filter_ctl_6_cond_6_wd;
-  logic adc_chn0_filter_ctl_6_cond_6_busy;
-  logic [9:0] adc_chn0_filter_ctl_6_max_v_6_qs;
-  logic [9:0] adc_chn0_filter_ctl_6_max_v_6_wd;
-  logic adc_chn0_filter_ctl_6_max_v_6_busy;
-  logic adc_chn0_filter_ctl_6_en_6_qs;
-  logic adc_chn0_filter_ctl_6_en_6_wd;
-  logic adc_chn0_filter_ctl_6_en_6_busy;
+  logic [31:0] adc_chn0_filter_ctl_6_qs;
+  logic adc_chn0_filter_ctl_6_busy;
   logic adc_chn0_filter_ctl_7_we;
-  logic [9:0] adc_chn0_filter_ctl_7_min_v_7_qs;
-  logic [9:0] adc_chn0_filter_ctl_7_min_v_7_wd;
-  logic adc_chn0_filter_ctl_7_min_v_7_busy;
-  logic adc_chn0_filter_ctl_7_cond_7_qs;
-  logic adc_chn0_filter_ctl_7_cond_7_wd;
-  logic adc_chn0_filter_ctl_7_cond_7_busy;
-  logic [9:0] adc_chn0_filter_ctl_7_max_v_7_qs;
-  logic [9:0] adc_chn0_filter_ctl_7_max_v_7_wd;
-  logic adc_chn0_filter_ctl_7_max_v_7_busy;
-  logic adc_chn0_filter_ctl_7_en_7_qs;
-  logic adc_chn0_filter_ctl_7_en_7_wd;
-  logic adc_chn0_filter_ctl_7_en_7_busy;
+  logic [31:0] adc_chn0_filter_ctl_7_qs;
+  logic adc_chn0_filter_ctl_7_busy;
   logic adc_chn1_filter_ctl_0_we;
-  logic [9:0] adc_chn1_filter_ctl_0_min_v_0_qs;
-  logic [9:0] adc_chn1_filter_ctl_0_min_v_0_wd;
-  logic adc_chn1_filter_ctl_0_min_v_0_busy;
-  logic adc_chn1_filter_ctl_0_cond_0_qs;
-  logic adc_chn1_filter_ctl_0_cond_0_wd;
-  logic adc_chn1_filter_ctl_0_cond_0_busy;
-  logic [9:0] adc_chn1_filter_ctl_0_max_v_0_qs;
-  logic [9:0] adc_chn1_filter_ctl_0_max_v_0_wd;
-  logic adc_chn1_filter_ctl_0_max_v_0_busy;
-  logic adc_chn1_filter_ctl_0_en_0_qs;
-  logic adc_chn1_filter_ctl_0_en_0_wd;
-  logic adc_chn1_filter_ctl_0_en_0_busy;
+  logic [31:0] adc_chn1_filter_ctl_0_qs;
+  logic adc_chn1_filter_ctl_0_busy;
   logic adc_chn1_filter_ctl_1_we;
-  logic [9:0] adc_chn1_filter_ctl_1_min_v_1_qs;
-  logic [9:0] adc_chn1_filter_ctl_1_min_v_1_wd;
-  logic adc_chn1_filter_ctl_1_min_v_1_busy;
-  logic adc_chn1_filter_ctl_1_cond_1_qs;
-  logic adc_chn1_filter_ctl_1_cond_1_wd;
-  logic adc_chn1_filter_ctl_1_cond_1_busy;
-  logic [9:0] adc_chn1_filter_ctl_1_max_v_1_qs;
-  logic [9:0] adc_chn1_filter_ctl_1_max_v_1_wd;
-  logic adc_chn1_filter_ctl_1_max_v_1_busy;
-  logic adc_chn1_filter_ctl_1_en_1_qs;
-  logic adc_chn1_filter_ctl_1_en_1_wd;
-  logic adc_chn1_filter_ctl_1_en_1_busy;
+  logic [31:0] adc_chn1_filter_ctl_1_qs;
+  logic adc_chn1_filter_ctl_1_busy;
   logic adc_chn1_filter_ctl_2_we;
-  logic [9:0] adc_chn1_filter_ctl_2_min_v_2_qs;
-  logic [9:0] adc_chn1_filter_ctl_2_min_v_2_wd;
-  logic adc_chn1_filter_ctl_2_min_v_2_busy;
-  logic adc_chn1_filter_ctl_2_cond_2_qs;
-  logic adc_chn1_filter_ctl_2_cond_2_wd;
-  logic adc_chn1_filter_ctl_2_cond_2_busy;
-  logic [9:0] adc_chn1_filter_ctl_2_max_v_2_qs;
-  logic [9:0] adc_chn1_filter_ctl_2_max_v_2_wd;
-  logic adc_chn1_filter_ctl_2_max_v_2_busy;
-  logic adc_chn1_filter_ctl_2_en_2_qs;
-  logic adc_chn1_filter_ctl_2_en_2_wd;
-  logic adc_chn1_filter_ctl_2_en_2_busy;
+  logic [31:0] adc_chn1_filter_ctl_2_qs;
+  logic adc_chn1_filter_ctl_2_busy;
   logic adc_chn1_filter_ctl_3_we;
-  logic [9:0] adc_chn1_filter_ctl_3_min_v_3_qs;
-  logic [9:0] adc_chn1_filter_ctl_3_min_v_3_wd;
-  logic adc_chn1_filter_ctl_3_min_v_3_busy;
-  logic adc_chn1_filter_ctl_3_cond_3_qs;
-  logic adc_chn1_filter_ctl_3_cond_3_wd;
-  logic adc_chn1_filter_ctl_3_cond_3_busy;
-  logic [9:0] adc_chn1_filter_ctl_3_max_v_3_qs;
-  logic [9:0] adc_chn1_filter_ctl_3_max_v_3_wd;
-  logic adc_chn1_filter_ctl_3_max_v_3_busy;
-  logic adc_chn1_filter_ctl_3_en_3_qs;
-  logic adc_chn1_filter_ctl_3_en_3_wd;
-  logic adc_chn1_filter_ctl_3_en_3_busy;
+  logic [31:0] adc_chn1_filter_ctl_3_qs;
+  logic adc_chn1_filter_ctl_3_busy;
   logic adc_chn1_filter_ctl_4_we;
-  logic [9:0] adc_chn1_filter_ctl_4_min_v_4_qs;
-  logic [9:0] adc_chn1_filter_ctl_4_min_v_4_wd;
-  logic adc_chn1_filter_ctl_4_min_v_4_busy;
-  logic adc_chn1_filter_ctl_4_cond_4_qs;
-  logic adc_chn1_filter_ctl_4_cond_4_wd;
-  logic adc_chn1_filter_ctl_4_cond_4_busy;
-  logic [9:0] adc_chn1_filter_ctl_4_max_v_4_qs;
-  logic [9:0] adc_chn1_filter_ctl_4_max_v_4_wd;
-  logic adc_chn1_filter_ctl_4_max_v_4_busy;
-  logic adc_chn1_filter_ctl_4_en_4_qs;
-  logic adc_chn1_filter_ctl_4_en_4_wd;
-  logic adc_chn1_filter_ctl_4_en_4_busy;
+  logic [31:0] adc_chn1_filter_ctl_4_qs;
+  logic adc_chn1_filter_ctl_4_busy;
   logic adc_chn1_filter_ctl_5_we;
-  logic [9:0] adc_chn1_filter_ctl_5_min_v_5_qs;
-  logic [9:0] adc_chn1_filter_ctl_5_min_v_5_wd;
-  logic adc_chn1_filter_ctl_5_min_v_5_busy;
-  logic adc_chn1_filter_ctl_5_cond_5_qs;
-  logic adc_chn1_filter_ctl_5_cond_5_wd;
-  logic adc_chn1_filter_ctl_5_cond_5_busy;
-  logic [9:0] adc_chn1_filter_ctl_5_max_v_5_qs;
-  logic [9:0] adc_chn1_filter_ctl_5_max_v_5_wd;
-  logic adc_chn1_filter_ctl_5_max_v_5_busy;
-  logic adc_chn1_filter_ctl_5_en_5_qs;
-  logic adc_chn1_filter_ctl_5_en_5_wd;
-  logic adc_chn1_filter_ctl_5_en_5_busy;
+  logic [31:0] adc_chn1_filter_ctl_5_qs;
+  logic adc_chn1_filter_ctl_5_busy;
   logic adc_chn1_filter_ctl_6_we;
-  logic [9:0] adc_chn1_filter_ctl_6_min_v_6_qs;
-  logic [9:0] adc_chn1_filter_ctl_6_min_v_6_wd;
-  logic adc_chn1_filter_ctl_6_min_v_6_busy;
-  logic adc_chn1_filter_ctl_6_cond_6_qs;
-  logic adc_chn1_filter_ctl_6_cond_6_wd;
-  logic adc_chn1_filter_ctl_6_cond_6_busy;
-  logic [9:0] adc_chn1_filter_ctl_6_max_v_6_qs;
-  logic [9:0] adc_chn1_filter_ctl_6_max_v_6_wd;
-  logic adc_chn1_filter_ctl_6_max_v_6_busy;
-  logic adc_chn1_filter_ctl_6_en_6_qs;
-  logic adc_chn1_filter_ctl_6_en_6_wd;
-  logic adc_chn1_filter_ctl_6_en_6_busy;
+  logic [31:0] adc_chn1_filter_ctl_6_qs;
+  logic adc_chn1_filter_ctl_6_busy;
   logic adc_chn1_filter_ctl_7_we;
-  logic [9:0] adc_chn1_filter_ctl_7_min_v_7_qs;
-  logic [9:0] adc_chn1_filter_ctl_7_min_v_7_wd;
-  logic adc_chn1_filter_ctl_7_min_v_7_busy;
-  logic adc_chn1_filter_ctl_7_cond_7_qs;
-  logic adc_chn1_filter_ctl_7_cond_7_wd;
-  logic adc_chn1_filter_ctl_7_cond_7_busy;
-  logic [9:0] adc_chn1_filter_ctl_7_max_v_7_qs;
-  logic [9:0] adc_chn1_filter_ctl_7_max_v_7_wd;
-  logic adc_chn1_filter_ctl_7_max_v_7_busy;
-  logic adc_chn1_filter_ctl_7_en_7_qs;
-  logic adc_chn1_filter_ctl_7_en_7_wd;
-  logic adc_chn1_filter_ctl_7_en_7_busy;
-  logic [1:0] adc_chn_val_0_adc_chn_value_ext_0_qs;
-  logic adc_chn_val_0_adc_chn_value_ext_0_busy;
-  logic [9:0] adc_chn_val_0_adc_chn_value_0_qs;
-  logic adc_chn_val_0_adc_chn_value_0_busy;
-  logic [1:0] adc_chn_val_0_adc_chn_value_intr_ext_0_qs;
-  logic adc_chn_val_0_adc_chn_value_intr_ext_0_busy;
-  logic [9:0] adc_chn_val_0_adc_chn_value_intr_0_qs;
-  logic adc_chn_val_0_adc_chn_value_intr_0_busy;
-  logic [1:0] adc_chn_val_1_adc_chn_value_ext_1_qs;
-  logic adc_chn_val_1_adc_chn_value_ext_1_busy;
-  logic [9:0] adc_chn_val_1_adc_chn_value_1_qs;
-  logic adc_chn_val_1_adc_chn_value_1_busy;
-  logic [1:0] adc_chn_val_1_adc_chn_value_intr_ext_1_qs;
-  logic adc_chn_val_1_adc_chn_value_intr_ext_1_busy;
-  logic [9:0] adc_chn_val_1_adc_chn_value_intr_1_qs;
-  logic adc_chn_val_1_adc_chn_value_intr_1_busy;
+  logic [31:0] adc_chn1_filter_ctl_7_qs;
+  logic adc_chn1_filter_ctl_7_busy;
+  logic [27:0] adc_chn_val_0_qs;
+  logic adc_chn_val_0_busy;
+  logic [27:0] adc_chn_val_1_qs;
+  logic adc_chn_val_1_busy;
   logic adc_wakeup_ctl_we;
   logic [7:0] adc_wakeup_ctl_qs;
-  logic [7:0] adc_wakeup_ctl_wd;
   logic adc_wakeup_ctl_busy;
   logic filter_status_we;
   logic [7:0] filter_status_qs;
-  logic [7:0] filter_status_wd;
   logic filter_status_busy;
   logic adc_intr_ctl_we;
   logic [8:0] adc_intr_ctl_qs;
@@ -412,6 +224,989 @@ module adc_ctrl_reg_top (
   logic adc_intr_status_cc_discon_wd;
   logic adc_intr_status_oneshot_qs;
   logic adc_intr_status_oneshot_wd;
+  // Define register CDC handling.
+  // CDC handling is done on a per-reg instead of per-field boundary.
+
+  logic  aon_adc_en_ctl_adc_enable_qs_int;
+  logic  aon_adc_en_ctl_oneshot_mode_qs_int;
+  logic [1:0] aon_adc_en_ctl_d;
+  logic [1:0] aon_adc_en_ctl_wdata;
+  logic aon_adc_en_ctl_we;
+  logic unused_aon_adc_en_ctl_wdata;
+
+  always_comb begin
+    aon_adc_en_ctl_d = '0;
+    aon_adc_en_ctl_d[0] = aon_adc_en_ctl_adc_enable_qs_int;
+    aon_adc_en_ctl_d[1] = aon_adc_en_ctl_oneshot_mode_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(2),
+    .ResetVal(2'h0),
+    .BitMask(2'h3)
+  ) u_adc_en_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_en_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[1:0]),
+    .src_busy_o   (adc_en_ctl_busy),
+    .src_qs_o     (adc_en_ctl_qs), // for software read back
+    .dst_d_i      (aon_adc_en_ctl_d),
+    .dst_we_o     (aon_adc_en_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_en_ctl_wdata)
+  );
+  assign unused_aon_adc_en_ctl_wdata = ^aon_adc_en_ctl_wdata;
+
+  logic  aon_adc_pd_ctl_lp_mode_qs_int;
+  logic [3:0]  aon_adc_pd_ctl_pwrup_time_qs_int;
+  logic [23:0]  aon_adc_pd_ctl_wakeup_time_qs_int;
+  logic [31:0] aon_adc_pd_ctl_d;
+  logic [31:0] aon_adc_pd_ctl_wdata;
+  logic aon_adc_pd_ctl_we;
+  logic unused_aon_adc_pd_ctl_wdata;
+
+  always_comb begin
+    aon_adc_pd_ctl_d = '0;
+    aon_adc_pd_ctl_d[0] = aon_adc_pd_ctl_lp_mode_qs_int;
+    aon_adc_pd_ctl_d[7:4] = aon_adc_pd_ctl_pwrup_time_qs_int;
+    aon_adc_pd_ctl_d[31:8] = aon_adc_pd_ctl_wakeup_time_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h64060),
+    .BitMask(32'hfffffff1)
+  ) u_adc_pd_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_pd_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_pd_ctl_busy),
+    .src_qs_o     (adc_pd_ctl_qs), // for software read back
+    .dst_d_i      (aon_adc_pd_ctl_d),
+    .dst_we_o     (aon_adc_pd_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_pd_ctl_wdata)
+  );
+  assign unused_aon_adc_pd_ctl_wdata = ^aon_adc_pd_ctl_wdata;
+
+  logic [7:0]  aon_adc_lp_sample_ctl_qs_int;
+  logic [7:0] aon_adc_lp_sample_ctl_d;
+  logic [7:0] aon_adc_lp_sample_ctl_wdata;
+  logic aon_adc_lp_sample_ctl_we;
+  logic unused_aon_adc_lp_sample_ctl_wdata;
+
+  always_comb begin
+    aon_adc_lp_sample_ctl_d = '0;
+    aon_adc_lp_sample_ctl_d = aon_adc_lp_sample_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h4),
+    .BitMask(8'hff)
+  ) u_adc_lp_sample_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_lp_sample_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (adc_lp_sample_ctl_busy),
+    .src_qs_o     (adc_lp_sample_ctl_qs), // for software read back
+    .dst_d_i      (aon_adc_lp_sample_ctl_d),
+    .dst_we_o     (aon_adc_lp_sample_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_lp_sample_ctl_wdata)
+  );
+  assign unused_aon_adc_lp_sample_ctl_wdata = ^aon_adc_lp_sample_ctl_wdata;
+
+  logic [15:0]  aon_adc_sample_ctl_qs_int;
+  logic [15:0] aon_adc_sample_ctl_d;
+  logic [15:0] aon_adc_sample_ctl_wdata;
+  logic aon_adc_sample_ctl_we;
+  logic unused_aon_adc_sample_ctl_wdata;
+
+  always_comb begin
+    aon_adc_sample_ctl_d = '0;
+    aon_adc_sample_ctl_d = aon_adc_sample_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h9b),
+    .BitMask(16'hffff)
+  ) u_adc_sample_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_sample_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (adc_sample_ctl_busy),
+    .src_qs_o     (adc_sample_ctl_qs), // for software read back
+    .dst_d_i      (aon_adc_sample_ctl_d),
+    .dst_we_o     (aon_adc_sample_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_sample_ctl_wdata)
+  );
+  assign unused_aon_adc_sample_ctl_wdata = ^aon_adc_sample_ctl_wdata;
+
+  logic  aon_adc_fsm_rst_qs_int;
+  logic [0:0] aon_adc_fsm_rst_d;
+  logic [0:0] aon_adc_fsm_rst_wdata;
+  logic aon_adc_fsm_rst_we;
+  logic unused_aon_adc_fsm_rst_wdata;
+
+  always_comb begin
+    aon_adc_fsm_rst_d = '0;
+    aon_adc_fsm_rst_d = aon_adc_fsm_rst_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_adc_fsm_rst_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_fsm_rst_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (adc_fsm_rst_busy),
+    .src_qs_o     (adc_fsm_rst_qs), // for software read back
+    .dst_d_i      (aon_adc_fsm_rst_d),
+    .dst_we_o     (aon_adc_fsm_rst_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_fsm_rst_wdata)
+  );
+  assign unused_aon_adc_fsm_rst_wdata = ^aon_adc_fsm_rst_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_0_min_v_0_qs_int;
+  logic  aon_adc_chn0_filter_ctl_0_cond_0_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_0_max_v_0_qs_int;
+  logic  aon_adc_chn0_filter_ctl_0_en_0_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_0_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_0_wdata;
+  logic aon_adc_chn0_filter_ctl_0_we;
+  logic unused_aon_adc_chn0_filter_ctl_0_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_0_d = '0;
+    aon_adc_chn0_filter_ctl_0_d[11:2] = aon_adc_chn0_filter_ctl_0_min_v_0_qs_int;
+    aon_adc_chn0_filter_ctl_0_d[12] = aon_adc_chn0_filter_ctl_0_cond_0_qs_int;
+    aon_adc_chn0_filter_ctl_0_d[27:18] = aon_adc_chn0_filter_ctl_0_max_v_0_qs_int;
+    aon_adc_chn0_filter_ctl_0_d[31] = aon_adc_chn0_filter_ctl_0_en_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_0_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_0_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_0_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_0_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_0_wdata = ^aon_adc_chn0_filter_ctl_0_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_1_min_v_1_qs_int;
+  logic  aon_adc_chn0_filter_ctl_1_cond_1_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_1_max_v_1_qs_int;
+  logic  aon_adc_chn0_filter_ctl_1_en_1_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_1_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_1_wdata;
+  logic aon_adc_chn0_filter_ctl_1_we;
+  logic unused_aon_adc_chn0_filter_ctl_1_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_1_d = '0;
+    aon_adc_chn0_filter_ctl_1_d[11:2] = aon_adc_chn0_filter_ctl_1_min_v_1_qs_int;
+    aon_adc_chn0_filter_ctl_1_d[12] = aon_adc_chn0_filter_ctl_1_cond_1_qs_int;
+    aon_adc_chn0_filter_ctl_1_d[27:18] = aon_adc_chn0_filter_ctl_1_max_v_1_qs_int;
+    aon_adc_chn0_filter_ctl_1_d[31] = aon_adc_chn0_filter_ctl_1_en_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_1_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_1_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_1_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_1_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_1_wdata = ^aon_adc_chn0_filter_ctl_1_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_2_min_v_2_qs_int;
+  logic  aon_adc_chn0_filter_ctl_2_cond_2_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_2_max_v_2_qs_int;
+  logic  aon_adc_chn0_filter_ctl_2_en_2_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_2_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_2_wdata;
+  logic aon_adc_chn0_filter_ctl_2_we;
+  logic unused_aon_adc_chn0_filter_ctl_2_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_2_d = '0;
+    aon_adc_chn0_filter_ctl_2_d[11:2] = aon_adc_chn0_filter_ctl_2_min_v_2_qs_int;
+    aon_adc_chn0_filter_ctl_2_d[12] = aon_adc_chn0_filter_ctl_2_cond_2_qs_int;
+    aon_adc_chn0_filter_ctl_2_d[27:18] = aon_adc_chn0_filter_ctl_2_max_v_2_qs_int;
+    aon_adc_chn0_filter_ctl_2_d[31] = aon_adc_chn0_filter_ctl_2_en_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_2_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_2_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_2_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_2_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_2_wdata = ^aon_adc_chn0_filter_ctl_2_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_3_min_v_3_qs_int;
+  logic  aon_adc_chn0_filter_ctl_3_cond_3_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_3_max_v_3_qs_int;
+  logic  aon_adc_chn0_filter_ctl_3_en_3_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_3_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_3_wdata;
+  logic aon_adc_chn0_filter_ctl_3_we;
+  logic unused_aon_adc_chn0_filter_ctl_3_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_3_d = '0;
+    aon_adc_chn0_filter_ctl_3_d[11:2] = aon_adc_chn0_filter_ctl_3_min_v_3_qs_int;
+    aon_adc_chn0_filter_ctl_3_d[12] = aon_adc_chn0_filter_ctl_3_cond_3_qs_int;
+    aon_adc_chn0_filter_ctl_3_d[27:18] = aon_adc_chn0_filter_ctl_3_max_v_3_qs_int;
+    aon_adc_chn0_filter_ctl_3_d[31] = aon_adc_chn0_filter_ctl_3_en_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_3_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_3_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_3_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_3_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_3_wdata = ^aon_adc_chn0_filter_ctl_3_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_4_min_v_4_qs_int;
+  logic  aon_adc_chn0_filter_ctl_4_cond_4_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_4_max_v_4_qs_int;
+  logic  aon_adc_chn0_filter_ctl_4_en_4_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_4_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_4_wdata;
+  logic aon_adc_chn0_filter_ctl_4_we;
+  logic unused_aon_adc_chn0_filter_ctl_4_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_4_d = '0;
+    aon_adc_chn0_filter_ctl_4_d[11:2] = aon_adc_chn0_filter_ctl_4_min_v_4_qs_int;
+    aon_adc_chn0_filter_ctl_4_d[12] = aon_adc_chn0_filter_ctl_4_cond_4_qs_int;
+    aon_adc_chn0_filter_ctl_4_d[27:18] = aon_adc_chn0_filter_ctl_4_max_v_4_qs_int;
+    aon_adc_chn0_filter_ctl_4_d[31] = aon_adc_chn0_filter_ctl_4_en_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_4_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_4_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_4_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_4_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_4_wdata = ^aon_adc_chn0_filter_ctl_4_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_5_min_v_5_qs_int;
+  logic  aon_adc_chn0_filter_ctl_5_cond_5_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_5_max_v_5_qs_int;
+  logic  aon_adc_chn0_filter_ctl_5_en_5_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_5_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_5_wdata;
+  logic aon_adc_chn0_filter_ctl_5_we;
+  logic unused_aon_adc_chn0_filter_ctl_5_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_5_d = '0;
+    aon_adc_chn0_filter_ctl_5_d[11:2] = aon_adc_chn0_filter_ctl_5_min_v_5_qs_int;
+    aon_adc_chn0_filter_ctl_5_d[12] = aon_adc_chn0_filter_ctl_5_cond_5_qs_int;
+    aon_adc_chn0_filter_ctl_5_d[27:18] = aon_adc_chn0_filter_ctl_5_max_v_5_qs_int;
+    aon_adc_chn0_filter_ctl_5_d[31] = aon_adc_chn0_filter_ctl_5_en_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_5_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_5_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_5_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_5_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_5_wdata = ^aon_adc_chn0_filter_ctl_5_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_6_min_v_6_qs_int;
+  logic  aon_adc_chn0_filter_ctl_6_cond_6_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_6_max_v_6_qs_int;
+  logic  aon_adc_chn0_filter_ctl_6_en_6_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_6_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_6_wdata;
+  logic aon_adc_chn0_filter_ctl_6_we;
+  logic unused_aon_adc_chn0_filter_ctl_6_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_6_d = '0;
+    aon_adc_chn0_filter_ctl_6_d[11:2] = aon_adc_chn0_filter_ctl_6_min_v_6_qs_int;
+    aon_adc_chn0_filter_ctl_6_d[12] = aon_adc_chn0_filter_ctl_6_cond_6_qs_int;
+    aon_adc_chn0_filter_ctl_6_d[27:18] = aon_adc_chn0_filter_ctl_6_max_v_6_qs_int;
+    aon_adc_chn0_filter_ctl_6_d[31] = aon_adc_chn0_filter_ctl_6_en_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_6_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_6_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_6_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_6_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_6_wdata = ^aon_adc_chn0_filter_ctl_6_wdata;
+
+  logic [9:0]  aon_adc_chn0_filter_ctl_7_min_v_7_qs_int;
+  logic  aon_adc_chn0_filter_ctl_7_cond_7_qs_int;
+  logic [9:0]  aon_adc_chn0_filter_ctl_7_max_v_7_qs_int;
+  logic  aon_adc_chn0_filter_ctl_7_en_7_qs_int;
+  logic [31:0] aon_adc_chn0_filter_ctl_7_d;
+  logic [31:0] aon_adc_chn0_filter_ctl_7_wdata;
+  logic aon_adc_chn0_filter_ctl_7_we;
+  logic unused_aon_adc_chn0_filter_ctl_7_wdata;
+
+  always_comb begin
+    aon_adc_chn0_filter_ctl_7_d = '0;
+    aon_adc_chn0_filter_ctl_7_d[11:2] = aon_adc_chn0_filter_ctl_7_min_v_7_qs_int;
+    aon_adc_chn0_filter_ctl_7_d[12] = aon_adc_chn0_filter_ctl_7_cond_7_qs_int;
+    aon_adc_chn0_filter_ctl_7_d[27:18] = aon_adc_chn0_filter_ctl_7_max_v_7_qs_int;
+    aon_adc_chn0_filter_ctl_7_d[31] = aon_adc_chn0_filter_ctl_7_en_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn0_filter_ctl_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn0_filter_ctl_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn0_filter_ctl_7_busy),
+    .src_qs_o     (adc_chn0_filter_ctl_7_qs), // for software read back
+    .dst_d_i      (aon_adc_chn0_filter_ctl_7_d),
+    .dst_we_o     (aon_adc_chn0_filter_ctl_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn0_filter_ctl_7_wdata)
+  );
+  assign unused_aon_adc_chn0_filter_ctl_7_wdata = ^aon_adc_chn0_filter_ctl_7_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_0_min_v_0_qs_int;
+  logic  aon_adc_chn1_filter_ctl_0_cond_0_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_0_max_v_0_qs_int;
+  logic  aon_adc_chn1_filter_ctl_0_en_0_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_0_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_0_wdata;
+  logic aon_adc_chn1_filter_ctl_0_we;
+  logic unused_aon_adc_chn1_filter_ctl_0_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_0_d = '0;
+    aon_adc_chn1_filter_ctl_0_d[11:2] = aon_adc_chn1_filter_ctl_0_min_v_0_qs_int;
+    aon_adc_chn1_filter_ctl_0_d[12] = aon_adc_chn1_filter_ctl_0_cond_0_qs_int;
+    aon_adc_chn1_filter_ctl_0_d[27:18] = aon_adc_chn1_filter_ctl_0_max_v_0_qs_int;
+    aon_adc_chn1_filter_ctl_0_d[31] = aon_adc_chn1_filter_ctl_0_en_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_0_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_0_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_0_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_0_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_0_wdata = ^aon_adc_chn1_filter_ctl_0_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_1_min_v_1_qs_int;
+  logic  aon_adc_chn1_filter_ctl_1_cond_1_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_1_max_v_1_qs_int;
+  logic  aon_adc_chn1_filter_ctl_1_en_1_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_1_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_1_wdata;
+  logic aon_adc_chn1_filter_ctl_1_we;
+  logic unused_aon_adc_chn1_filter_ctl_1_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_1_d = '0;
+    aon_adc_chn1_filter_ctl_1_d[11:2] = aon_adc_chn1_filter_ctl_1_min_v_1_qs_int;
+    aon_adc_chn1_filter_ctl_1_d[12] = aon_adc_chn1_filter_ctl_1_cond_1_qs_int;
+    aon_adc_chn1_filter_ctl_1_d[27:18] = aon_adc_chn1_filter_ctl_1_max_v_1_qs_int;
+    aon_adc_chn1_filter_ctl_1_d[31] = aon_adc_chn1_filter_ctl_1_en_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_1_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_1_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_1_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_1_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_1_wdata = ^aon_adc_chn1_filter_ctl_1_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_2_min_v_2_qs_int;
+  logic  aon_adc_chn1_filter_ctl_2_cond_2_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_2_max_v_2_qs_int;
+  logic  aon_adc_chn1_filter_ctl_2_en_2_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_2_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_2_wdata;
+  logic aon_adc_chn1_filter_ctl_2_we;
+  logic unused_aon_adc_chn1_filter_ctl_2_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_2_d = '0;
+    aon_adc_chn1_filter_ctl_2_d[11:2] = aon_adc_chn1_filter_ctl_2_min_v_2_qs_int;
+    aon_adc_chn1_filter_ctl_2_d[12] = aon_adc_chn1_filter_ctl_2_cond_2_qs_int;
+    aon_adc_chn1_filter_ctl_2_d[27:18] = aon_adc_chn1_filter_ctl_2_max_v_2_qs_int;
+    aon_adc_chn1_filter_ctl_2_d[31] = aon_adc_chn1_filter_ctl_2_en_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_2_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_2_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_2_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_2_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_2_wdata = ^aon_adc_chn1_filter_ctl_2_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_3_min_v_3_qs_int;
+  logic  aon_adc_chn1_filter_ctl_3_cond_3_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_3_max_v_3_qs_int;
+  logic  aon_adc_chn1_filter_ctl_3_en_3_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_3_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_3_wdata;
+  logic aon_adc_chn1_filter_ctl_3_we;
+  logic unused_aon_adc_chn1_filter_ctl_3_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_3_d = '0;
+    aon_adc_chn1_filter_ctl_3_d[11:2] = aon_adc_chn1_filter_ctl_3_min_v_3_qs_int;
+    aon_adc_chn1_filter_ctl_3_d[12] = aon_adc_chn1_filter_ctl_3_cond_3_qs_int;
+    aon_adc_chn1_filter_ctl_3_d[27:18] = aon_adc_chn1_filter_ctl_3_max_v_3_qs_int;
+    aon_adc_chn1_filter_ctl_3_d[31] = aon_adc_chn1_filter_ctl_3_en_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_3_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_3_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_3_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_3_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_3_wdata = ^aon_adc_chn1_filter_ctl_3_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_4_min_v_4_qs_int;
+  logic  aon_adc_chn1_filter_ctl_4_cond_4_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_4_max_v_4_qs_int;
+  logic  aon_adc_chn1_filter_ctl_4_en_4_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_4_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_4_wdata;
+  logic aon_adc_chn1_filter_ctl_4_we;
+  logic unused_aon_adc_chn1_filter_ctl_4_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_4_d = '0;
+    aon_adc_chn1_filter_ctl_4_d[11:2] = aon_adc_chn1_filter_ctl_4_min_v_4_qs_int;
+    aon_adc_chn1_filter_ctl_4_d[12] = aon_adc_chn1_filter_ctl_4_cond_4_qs_int;
+    aon_adc_chn1_filter_ctl_4_d[27:18] = aon_adc_chn1_filter_ctl_4_max_v_4_qs_int;
+    aon_adc_chn1_filter_ctl_4_d[31] = aon_adc_chn1_filter_ctl_4_en_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_4_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_4_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_4_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_4_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_4_wdata = ^aon_adc_chn1_filter_ctl_4_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_5_min_v_5_qs_int;
+  logic  aon_adc_chn1_filter_ctl_5_cond_5_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_5_max_v_5_qs_int;
+  logic  aon_adc_chn1_filter_ctl_5_en_5_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_5_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_5_wdata;
+  logic aon_adc_chn1_filter_ctl_5_we;
+  logic unused_aon_adc_chn1_filter_ctl_5_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_5_d = '0;
+    aon_adc_chn1_filter_ctl_5_d[11:2] = aon_adc_chn1_filter_ctl_5_min_v_5_qs_int;
+    aon_adc_chn1_filter_ctl_5_d[12] = aon_adc_chn1_filter_ctl_5_cond_5_qs_int;
+    aon_adc_chn1_filter_ctl_5_d[27:18] = aon_adc_chn1_filter_ctl_5_max_v_5_qs_int;
+    aon_adc_chn1_filter_ctl_5_d[31] = aon_adc_chn1_filter_ctl_5_en_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_5_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_5_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_5_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_5_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_5_wdata = ^aon_adc_chn1_filter_ctl_5_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_6_min_v_6_qs_int;
+  logic  aon_adc_chn1_filter_ctl_6_cond_6_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_6_max_v_6_qs_int;
+  logic  aon_adc_chn1_filter_ctl_6_en_6_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_6_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_6_wdata;
+  logic aon_adc_chn1_filter_ctl_6_we;
+  logic unused_aon_adc_chn1_filter_ctl_6_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_6_d = '0;
+    aon_adc_chn1_filter_ctl_6_d[11:2] = aon_adc_chn1_filter_ctl_6_min_v_6_qs_int;
+    aon_adc_chn1_filter_ctl_6_d[12] = aon_adc_chn1_filter_ctl_6_cond_6_qs_int;
+    aon_adc_chn1_filter_ctl_6_d[27:18] = aon_adc_chn1_filter_ctl_6_max_v_6_qs_int;
+    aon_adc_chn1_filter_ctl_6_d[31] = aon_adc_chn1_filter_ctl_6_en_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_6_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_6_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_6_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_6_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_6_wdata = ^aon_adc_chn1_filter_ctl_6_wdata;
+
+  logic [9:0]  aon_adc_chn1_filter_ctl_7_min_v_7_qs_int;
+  logic  aon_adc_chn1_filter_ctl_7_cond_7_qs_int;
+  logic [9:0]  aon_adc_chn1_filter_ctl_7_max_v_7_qs_int;
+  logic  aon_adc_chn1_filter_ctl_7_en_7_qs_int;
+  logic [31:0] aon_adc_chn1_filter_ctl_7_d;
+  logic [31:0] aon_adc_chn1_filter_ctl_7_wdata;
+  logic aon_adc_chn1_filter_ctl_7_we;
+  logic unused_aon_adc_chn1_filter_ctl_7_wdata;
+
+  always_comb begin
+    aon_adc_chn1_filter_ctl_7_d = '0;
+    aon_adc_chn1_filter_ctl_7_d[11:2] = aon_adc_chn1_filter_ctl_7_min_v_7_qs_int;
+    aon_adc_chn1_filter_ctl_7_d[12] = aon_adc_chn1_filter_ctl_7_cond_7_qs_int;
+    aon_adc_chn1_filter_ctl_7_d[27:18] = aon_adc_chn1_filter_ctl_7_max_v_7_qs_int;
+    aon_adc_chn1_filter_ctl_7_d[31] = aon_adc_chn1_filter_ctl_7_en_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'h8ffc1ffc)
+  ) u_adc_chn1_filter_ctl_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_chn1_filter_ctl_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (adc_chn1_filter_ctl_7_busy),
+    .src_qs_o     (adc_chn1_filter_ctl_7_qs), // for software read back
+    .dst_d_i      (aon_adc_chn1_filter_ctl_7_d),
+    .dst_we_o     (aon_adc_chn1_filter_ctl_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_chn1_filter_ctl_7_wdata)
+  );
+  assign unused_aon_adc_chn1_filter_ctl_7_wdata = ^aon_adc_chn1_filter_ctl_7_wdata;
+
+  logic [1:0]  aon_adc_chn_val_0_adc_chn_value_ext_0_qs_int;
+  logic [9:0]  aon_adc_chn_val_0_adc_chn_value_0_qs_int;
+  logic [1:0]  aon_adc_chn_val_0_adc_chn_value_intr_ext_0_qs_int;
+  logic [9:0]  aon_adc_chn_val_0_adc_chn_value_intr_0_qs_int;
+  logic [27:0] aon_adc_chn_val_0_d;
+
+  always_comb begin
+    aon_adc_chn_val_0_d = '0;
+    aon_adc_chn_val_0_d[1:0] = aon_adc_chn_val_0_adc_chn_value_ext_0_qs_int;
+    aon_adc_chn_val_0_d[11:2] = aon_adc_chn_val_0_adc_chn_value_0_qs_int;
+    aon_adc_chn_val_0_d[17:16] = aon_adc_chn_val_0_adc_chn_value_intr_ext_0_qs_int;
+    aon_adc_chn_val_0_d[27:18] = aon_adc_chn_val_0_adc_chn_value_intr_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(28),
+    .ResetVal(28'h0),
+    .BitMask(28'hfff0fff)
+  ) u_adc_chn_val_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     ('0),
+    .src_re_i     ('0),
+    .src_wd_i     ('0),
+    .src_busy_o   (adc_chn_val_0_busy),
+    .src_qs_o     (adc_chn_val_0_qs), // for software read back
+    .dst_d_i      (aon_adc_chn_val_0_d),
+    .dst_we_o     (),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     ()
+  );
+
+  logic [1:0]  aon_adc_chn_val_1_adc_chn_value_ext_1_qs_int;
+  logic [9:0]  aon_adc_chn_val_1_adc_chn_value_1_qs_int;
+  logic [1:0]  aon_adc_chn_val_1_adc_chn_value_intr_ext_1_qs_int;
+  logic [9:0]  aon_adc_chn_val_1_adc_chn_value_intr_1_qs_int;
+  logic [27:0] aon_adc_chn_val_1_d;
+
+  always_comb begin
+    aon_adc_chn_val_1_d = '0;
+    aon_adc_chn_val_1_d[1:0] = aon_adc_chn_val_1_adc_chn_value_ext_1_qs_int;
+    aon_adc_chn_val_1_d[11:2] = aon_adc_chn_val_1_adc_chn_value_1_qs_int;
+    aon_adc_chn_val_1_d[17:16] = aon_adc_chn_val_1_adc_chn_value_intr_ext_1_qs_int;
+    aon_adc_chn_val_1_d[27:18] = aon_adc_chn_val_1_adc_chn_value_intr_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(28),
+    .ResetVal(28'h0),
+    .BitMask(28'hfff0fff)
+  ) u_adc_chn_val_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     ('0),
+    .src_re_i     ('0),
+    .src_wd_i     ('0),
+    .src_busy_o   (adc_chn_val_1_busy),
+    .src_qs_o     (adc_chn_val_1_qs), // for software read back
+    .dst_d_i      (aon_adc_chn_val_1_d),
+    .dst_we_o     (),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     ()
+  );
+
+  logic [7:0]  aon_adc_wakeup_ctl_qs_int;
+  logic [7:0] aon_adc_wakeup_ctl_d;
+  logic [7:0] aon_adc_wakeup_ctl_wdata;
+  logic aon_adc_wakeup_ctl_we;
+  logic unused_aon_adc_wakeup_ctl_wdata;
+
+  always_comb begin
+    aon_adc_wakeup_ctl_d = '0;
+    aon_adc_wakeup_ctl_d = aon_adc_wakeup_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_adc_wakeup_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (adc_wakeup_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (adc_wakeup_ctl_busy),
+    .src_qs_o     (adc_wakeup_ctl_qs), // for software read back
+    .dst_d_i      (aon_adc_wakeup_ctl_d),
+    .dst_we_o     (aon_adc_wakeup_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_adc_wakeup_ctl_wdata)
+  );
+  assign unused_aon_adc_wakeup_ctl_wdata = ^aon_adc_wakeup_ctl_wdata;
+
+  logic [7:0]  aon_filter_status_qs_int;
+  logic [7:0] aon_filter_status_d;
+  logic [7:0] aon_filter_status_wdata;
+  logic aon_filter_status_we;
+  logic unused_aon_filter_status_wdata;
+
+  always_comb begin
+    aon_filter_status_d = '0;
+    aon_filter_status_d = aon_filter_status_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_filter_status_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (filter_status_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (filter_status_busy),
+    .src_qs_o     (filter_status_qs), // for software read back
+    .dst_d_i      (aon_filter_status_d),
+    .dst_we_o     (aon_filter_status_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_filter_status_wdata)
+  );
+  assign unused_aon_filter_status_wdata = ^aon_filter_status_wdata;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -503,183 +1298,215 @@ module adc_ctrl_reg_top (
   // R[adc_en_ctl]: V(False)
 
   //   F[adc_enable]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_en_ctl_adc_enable (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_en_ctl_we),
-    .src_wd_i     (adc_en_ctl_adc_enable_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_en_ctl_adc_enable_busy),
-    .src_qs_o     (adc_en_ctl_adc_enable_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_en_ctl.adc_enable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_en_ctl_we),
+    .wd     (aon_adc_en_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_en_ctl.adc_enable.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_en_ctl_adc_enable_qs_int)
   );
 
 
   //   F[oneshot_mode]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_en_ctl_oneshot_mode (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_en_ctl_we),
-    .src_wd_i     (adc_en_ctl_oneshot_mode_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_en_ctl_oneshot_mode_busy),
-    .src_qs_o     (adc_en_ctl_oneshot_mode_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_en_ctl.oneshot_mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_en_ctl_we),
+    .wd     (aon_adc_en_ctl_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_en_ctl.oneshot_mode.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_en_ctl_oneshot_mode_qs_int)
   );
 
 
   // R[adc_pd_ctl]: V(False)
 
   //   F[lp_mode]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_pd_ctl_lp_mode (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_pd_ctl_we),
-    .src_wd_i     (adc_pd_ctl_lp_mode_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_pd_ctl_lp_mode_busy),
-    .src_qs_o     (adc_pd_ctl_lp_mode_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_pd_ctl.lp_mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_pd_ctl_we),
+    .wd     (aon_adc_pd_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_pd_ctl.lp_mode.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_pd_ctl_lp_mode_qs_int)
   );
 
 
   //   F[pwrup_time]: 7:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h6)
   ) u_adc_pd_ctl_pwrup_time (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_pd_ctl_we),
-    .src_wd_i     (adc_pd_ctl_pwrup_time_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_pd_ctl_pwrup_time_busy),
-    .src_qs_o     (adc_pd_ctl_pwrup_time_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_pd_ctl.pwrup_time.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_pd_ctl_we),
+    .wd     (aon_adc_pd_ctl_wdata[7:4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_pd_ctl.pwrup_time.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_pd_ctl_pwrup_time_qs_int)
   );
 
 
   //   F[wakeup_time]: 31:8
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (24),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (24'h640)
   ) u_adc_pd_ctl_wakeup_time (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_pd_ctl_we),
-    .src_wd_i     (adc_pd_ctl_wakeup_time_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_pd_ctl_wakeup_time_busy),
-    .src_qs_o     (adc_pd_ctl_wakeup_time_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_pd_ctl.wakeup_time.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_pd_ctl_we),
+    .wd     (aon_adc_pd_ctl_wdata[31:8]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_pd_ctl.wakeup_time.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_pd_ctl_wakeup_time_qs_int)
   );
 
 
   // R[adc_lp_sample_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h4)
   ) u_adc_lp_sample_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_lp_sample_ctl_we),
-    .src_wd_i     (adc_lp_sample_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_lp_sample_ctl_busy),
-    .src_qs_o     (adc_lp_sample_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_lp_sample_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_lp_sample_ctl_we),
+    .wd     (aon_adc_lp_sample_ctl_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_lp_sample_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_lp_sample_ctl_qs_int)
   );
 
 
   // R[adc_sample_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h9b)
   ) u_adc_sample_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_sample_ctl_we),
-    .src_wd_i     (adc_sample_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_sample_ctl_busy),
-    .src_qs_o     (adc_sample_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_sample_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_sample_ctl_we),
+    .wd     (aon_adc_sample_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_sample_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_sample_ctl_qs_int)
   );
 
 
   // R[adc_fsm_rst]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_fsm_rst (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_fsm_rst_we),
-    .src_wd_i     (adc_fsm_rst_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_fsm_rst_busy),
-    .src_qs_o     (adc_fsm_rst_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_fsm_rst.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_fsm_rst_we),
+    .wd     (aon_adc_fsm_rst_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_fsm_rst.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_fsm_rst_qs_int)
   );
 
 
@@ -688,90 +1515,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_0]: V(False)
 
   // F[min_v_0]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_0_min_v_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_0_we),
-    .src_wd_i     (adc_chn0_filter_ctl_0_min_v_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_0_min_v_0_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_0_min_v_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[0].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_0_we),
+    .wd     (aon_adc_chn0_filter_ctl_0_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[0].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_0_min_v_0_qs_int)
   );
 
 
   // F[cond_0]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_0_cond_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_0_we),
-    .src_wd_i     (adc_chn0_filter_ctl_0_cond_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_0_cond_0_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_0_cond_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[0].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_0_we),
+    .wd     (aon_adc_chn0_filter_ctl_0_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[0].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_0_cond_0_qs_int)
   );
 
 
   // F[max_v_0]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_0_max_v_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_0_we),
-    .src_wd_i     (adc_chn0_filter_ctl_0_max_v_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_0_max_v_0_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_0_max_v_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[0].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_0_we),
+    .wd     (aon_adc_chn0_filter_ctl_0_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[0].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_0_max_v_0_qs_int)
   );
 
 
   // F[en_0]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_0_en_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_0_we),
-    .src_wd_i     (adc_chn0_filter_ctl_0_en_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_0_en_0_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_0_en_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[0].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_0_we),
+    .wd     (aon_adc_chn0_filter_ctl_0_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[0].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_0_en_0_qs_int)
   );
 
 
@@ -779,90 +1622,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_1]: V(False)
 
   // F[min_v_1]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_1_min_v_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_1_we),
-    .src_wd_i     (adc_chn0_filter_ctl_1_min_v_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_1_min_v_1_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_1_min_v_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[1].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_1_we),
+    .wd     (aon_adc_chn0_filter_ctl_1_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[1].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_1_min_v_1_qs_int)
   );
 
 
   // F[cond_1]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_1_cond_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_1_we),
-    .src_wd_i     (adc_chn0_filter_ctl_1_cond_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_1_cond_1_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_1_cond_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[1].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_1_we),
+    .wd     (aon_adc_chn0_filter_ctl_1_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[1].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_1_cond_1_qs_int)
   );
 
 
   // F[max_v_1]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_1_max_v_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_1_we),
-    .src_wd_i     (adc_chn0_filter_ctl_1_max_v_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_1_max_v_1_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_1_max_v_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[1].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_1_we),
+    .wd     (aon_adc_chn0_filter_ctl_1_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[1].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_1_max_v_1_qs_int)
   );
 
 
   // F[en_1]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_1_en_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_1_we),
-    .src_wd_i     (adc_chn0_filter_ctl_1_en_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_1_en_1_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_1_en_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[1].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_1_we),
+    .wd     (aon_adc_chn0_filter_ctl_1_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[1].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_1_en_1_qs_int)
   );
 
 
@@ -870,90 +1729,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_2]: V(False)
 
   // F[min_v_2]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_2_min_v_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_2_we),
-    .src_wd_i     (adc_chn0_filter_ctl_2_min_v_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_2_min_v_2_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_2_min_v_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[2].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_2_we),
+    .wd     (aon_adc_chn0_filter_ctl_2_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[2].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_2_min_v_2_qs_int)
   );
 
 
   // F[cond_2]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_2_cond_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_2_we),
-    .src_wd_i     (adc_chn0_filter_ctl_2_cond_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_2_cond_2_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_2_cond_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[2].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_2_we),
+    .wd     (aon_adc_chn0_filter_ctl_2_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[2].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_2_cond_2_qs_int)
   );
 
 
   // F[max_v_2]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_2_max_v_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_2_we),
-    .src_wd_i     (adc_chn0_filter_ctl_2_max_v_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_2_max_v_2_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_2_max_v_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[2].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_2_we),
+    .wd     (aon_adc_chn0_filter_ctl_2_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[2].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_2_max_v_2_qs_int)
   );
 
 
   // F[en_2]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_2_en_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_2_we),
-    .src_wd_i     (adc_chn0_filter_ctl_2_en_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_2_en_2_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_2_en_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[2].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_2_we),
+    .wd     (aon_adc_chn0_filter_ctl_2_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[2].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_2_en_2_qs_int)
   );
 
 
@@ -961,90 +1836,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_3]: V(False)
 
   // F[min_v_3]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_3_min_v_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_3_we),
-    .src_wd_i     (adc_chn0_filter_ctl_3_min_v_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_3_min_v_3_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_3_min_v_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[3].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_3_we),
+    .wd     (aon_adc_chn0_filter_ctl_3_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[3].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_3_min_v_3_qs_int)
   );
 
 
   // F[cond_3]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_3_cond_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_3_we),
-    .src_wd_i     (adc_chn0_filter_ctl_3_cond_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_3_cond_3_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_3_cond_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[3].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_3_we),
+    .wd     (aon_adc_chn0_filter_ctl_3_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[3].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_3_cond_3_qs_int)
   );
 
 
   // F[max_v_3]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_3_max_v_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_3_we),
-    .src_wd_i     (adc_chn0_filter_ctl_3_max_v_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_3_max_v_3_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_3_max_v_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[3].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_3_we),
+    .wd     (aon_adc_chn0_filter_ctl_3_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[3].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_3_max_v_3_qs_int)
   );
 
 
   // F[en_3]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_3_en_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_3_we),
-    .src_wd_i     (adc_chn0_filter_ctl_3_en_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_3_en_3_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_3_en_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[3].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_3_we),
+    .wd     (aon_adc_chn0_filter_ctl_3_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[3].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_3_en_3_qs_int)
   );
 
 
@@ -1052,90 +1943,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_4]: V(False)
 
   // F[min_v_4]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_4_min_v_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_4_we),
-    .src_wd_i     (adc_chn0_filter_ctl_4_min_v_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_4_min_v_4_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_4_min_v_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[4].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_4_we),
+    .wd     (aon_adc_chn0_filter_ctl_4_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[4].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_4_min_v_4_qs_int)
   );
 
 
   // F[cond_4]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_4_cond_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_4_we),
-    .src_wd_i     (adc_chn0_filter_ctl_4_cond_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_4_cond_4_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_4_cond_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[4].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_4_we),
+    .wd     (aon_adc_chn0_filter_ctl_4_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[4].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_4_cond_4_qs_int)
   );
 
 
   // F[max_v_4]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_4_max_v_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_4_we),
-    .src_wd_i     (adc_chn0_filter_ctl_4_max_v_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_4_max_v_4_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_4_max_v_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[4].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_4_we),
+    .wd     (aon_adc_chn0_filter_ctl_4_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[4].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_4_max_v_4_qs_int)
   );
 
 
   // F[en_4]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_4_en_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_4_we),
-    .src_wd_i     (adc_chn0_filter_ctl_4_en_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_4_en_4_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_4_en_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[4].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_4_we),
+    .wd     (aon_adc_chn0_filter_ctl_4_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[4].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_4_en_4_qs_int)
   );
 
 
@@ -1143,90 +2050,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_5]: V(False)
 
   // F[min_v_5]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_5_min_v_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_5_we),
-    .src_wd_i     (adc_chn0_filter_ctl_5_min_v_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_5_min_v_5_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_5_min_v_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[5].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_5_we),
+    .wd     (aon_adc_chn0_filter_ctl_5_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[5].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_5_min_v_5_qs_int)
   );
 
 
   // F[cond_5]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_5_cond_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_5_we),
-    .src_wd_i     (adc_chn0_filter_ctl_5_cond_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_5_cond_5_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_5_cond_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[5].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_5_we),
+    .wd     (aon_adc_chn0_filter_ctl_5_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[5].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_5_cond_5_qs_int)
   );
 
 
   // F[max_v_5]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_5_max_v_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_5_we),
-    .src_wd_i     (adc_chn0_filter_ctl_5_max_v_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_5_max_v_5_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_5_max_v_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[5].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_5_we),
+    .wd     (aon_adc_chn0_filter_ctl_5_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[5].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_5_max_v_5_qs_int)
   );
 
 
   // F[en_5]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_5_en_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_5_we),
-    .src_wd_i     (adc_chn0_filter_ctl_5_en_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_5_en_5_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_5_en_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[5].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_5_we),
+    .wd     (aon_adc_chn0_filter_ctl_5_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[5].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_5_en_5_qs_int)
   );
 
 
@@ -1234,90 +2157,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_6]: V(False)
 
   // F[min_v_6]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_6_min_v_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_6_we),
-    .src_wd_i     (adc_chn0_filter_ctl_6_min_v_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_6_min_v_6_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_6_min_v_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[6].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_6_we),
+    .wd     (aon_adc_chn0_filter_ctl_6_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[6].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_6_min_v_6_qs_int)
   );
 
 
   // F[cond_6]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_6_cond_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_6_we),
-    .src_wd_i     (adc_chn0_filter_ctl_6_cond_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_6_cond_6_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_6_cond_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[6].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_6_we),
+    .wd     (aon_adc_chn0_filter_ctl_6_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[6].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_6_cond_6_qs_int)
   );
 
 
   // F[max_v_6]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_6_max_v_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_6_we),
-    .src_wd_i     (adc_chn0_filter_ctl_6_max_v_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_6_max_v_6_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_6_max_v_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[6].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_6_we),
+    .wd     (aon_adc_chn0_filter_ctl_6_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[6].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_6_max_v_6_qs_int)
   );
 
 
   // F[en_6]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_6_en_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_6_we),
-    .src_wd_i     (adc_chn0_filter_ctl_6_en_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_6_en_6_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_6_en_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[6].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_6_we),
+    .wd     (aon_adc_chn0_filter_ctl_6_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[6].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_6_en_6_qs_int)
   );
 
 
@@ -1325,90 +2264,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn0_filter_ctl_7]: V(False)
 
   // F[min_v_7]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_7_min_v_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_7_we),
-    .src_wd_i     (adc_chn0_filter_ctl_7_min_v_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_7_min_v_7_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_7_min_v_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[7].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_7_we),
+    .wd     (aon_adc_chn0_filter_ctl_7_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[7].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_7_min_v_7_qs_int)
   );
 
 
   // F[cond_7]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_7_cond_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_7_we),
-    .src_wd_i     (adc_chn0_filter_ctl_7_cond_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_7_cond_7_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_7_cond_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[7].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_7_we),
+    .wd     (aon_adc_chn0_filter_ctl_7_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[7].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_7_cond_7_qs_int)
   );
 
 
   // F[max_v_7]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn0_filter_ctl_7_max_v_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_7_we),
-    .src_wd_i     (adc_chn0_filter_ctl_7_max_v_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_7_max_v_7_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_7_max_v_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[7].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_7_we),
+    .wd     (aon_adc_chn0_filter_ctl_7_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[7].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_7_max_v_7_qs_int)
   );
 
 
   // F[en_7]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn0_filter_ctl_7_en_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn0_filter_ctl_7_we),
-    .src_wd_i     (adc_chn0_filter_ctl_7_en_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn0_filter_ctl_7_en_7_busy),
-    .src_qs_o     (adc_chn0_filter_ctl_7_en_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn0_filter_ctl[7].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn0_filter_ctl_7_we),
+    .wd     (aon_adc_chn0_filter_ctl_7_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn0_filter_ctl[7].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn0_filter_ctl_7_en_7_qs_int)
   );
 
 
@@ -1418,90 +2373,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_0]: V(False)
 
   // F[min_v_0]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_0_min_v_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_0_we),
-    .src_wd_i     (adc_chn1_filter_ctl_0_min_v_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_0_min_v_0_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_0_min_v_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[0].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_0_we),
+    .wd     (aon_adc_chn1_filter_ctl_0_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[0].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_0_min_v_0_qs_int)
   );
 
 
   // F[cond_0]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_0_cond_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_0_we),
-    .src_wd_i     (adc_chn1_filter_ctl_0_cond_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_0_cond_0_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_0_cond_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[0].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_0_we),
+    .wd     (aon_adc_chn1_filter_ctl_0_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[0].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_0_cond_0_qs_int)
   );
 
 
   // F[max_v_0]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_0_max_v_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_0_we),
-    .src_wd_i     (adc_chn1_filter_ctl_0_max_v_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_0_max_v_0_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_0_max_v_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[0].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_0_we),
+    .wd     (aon_adc_chn1_filter_ctl_0_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[0].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_0_max_v_0_qs_int)
   );
 
 
   // F[en_0]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_0_en_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_0_we),
-    .src_wd_i     (adc_chn1_filter_ctl_0_en_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_0_en_0_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_0_en_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[0].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_0_we),
+    .wd     (aon_adc_chn1_filter_ctl_0_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[0].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_0_en_0_qs_int)
   );
 
 
@@ -1509,90 +2480,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_1]: V(False)
 
   // F[min_v_1]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_1_min_v_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_1_we),
-    .src_wd_i     (adc_chn1_filter_ctl_1_min_v_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_1_min_v_1_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_1_min_v_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[1].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_1_we),
+    .wd     (aon_adc_chn1_filter_ctl_1_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[1].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_1_min_v_1_qs_int)
   );
 
 
   // F[cond_1]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_1_cond_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_1_we),
-    .src_wd_i     (adc_chn1_filter_ctl_1_cond_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_1_cond_1_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_1_cond_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[1].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_1_we),
+    .wd     (aon_adc_chn1_filter_ctl_1_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[1].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_1_cond_1_qs_int)
   );
 
 
   // F[max_v_1]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_1_max_v_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_1_we),
-    .src_wd_i     (adc_chn1_filter_ctl_1_max_v_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_1_max_v_1_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_1_max_v_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[1].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_1_we),
+    .wd     (aon_adc_chn1_filter_ctl_1_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[1].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_1_max_v_1_qs_int)
   );
 
 
   // F[en_1]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_1_en_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_1_we),
-    .src_wd_i     (adc_chn1_filter_ctl_1_en_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_1_en_1_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_1_en_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[1].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_1_we),
+    .wd     (aon_adc_chn1_filter_ctl_1_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[1].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_1_en_1_qs_int)
   );
 
 
@@ -1600,90 +2587,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_2]: V(False)
 
   // F[min_v_2]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_2_min_v_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_2_we),
-    .src_wd_i     (adc_chn1_filter_ctl_2_min_v_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_2_min_v_2_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_2_min_v_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[2].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_2_we),
+    .wd     (aon_adc_chn1_filter_ctl_2_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[2].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_2_min_v_2_qs_int)
   );
 
 
   // F[cond_2]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_2_cond_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_2_we),
-    .src_wd_i     (adc_chn1_filter_ctl_2_cond_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_2_cond_2_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_2_cond_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[2].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_2_we),
+    .wd     (aon_adc_chn1_filter_ctl_2_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[2].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_2_cond_2_qs_int)
   );
 
 
   // F[max_v_2]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_2_max_v_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_2_we),
-    .src_wd_i     (adc_chn1_filter_ctl_2_max_v_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_2_max_v_2_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_2_max_v_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[2].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_2_we),
+    .wd     (aon_adc_chn1_filter_ctl_2_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[2].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_2_max_v_2_qs_int)
   );
 
 
   // F[en_2]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_2_en_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_2_we),
-    .src_wd_i     (adc_chn1_filter_ctl_2_en_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_2_en_2_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_2_en_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[2].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_2_we),
+    .wd     (aon_adc_chn1_filter_ctl_2_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[2].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_2_en_2_qs_int)
   );
 
 
@@ -1691,90 +2694,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_3]: V(False)
 
   // F[min_v_3]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_3_min_v_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_3_we),
-    .src_wd_i     (adc_chn1_filter_ctl_3_min_v_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_3_min_v_3_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_3_min_v_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[3].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_3_we),
+    .wd     (aon_adc_chn1_filter_ctl_3_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[3].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_3_min_v_3_qs_int)
   );
 
 
   // F[cond_3]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_3_cond_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_3_we),
-    .src_wd_i     (adc_chn1_filter_ctl_3_cond_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_3_cond_3_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_3_cond_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[3].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_3_we),
+    .wd     (aon_adc_chn1_filter_ctl_3_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[3].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_3_cond_3_qs_int)
   );
 
 
   // F[max_v_3]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_3_max_v_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_3_we),
-    .src_wd_i     (adc_chn1_filter_ctl_3_max_v_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_3_max_v_3_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_3_max_v_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[3].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_3_we),
+    .wd     (aon_adc_chn1_filter_ctl_3_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[3].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_3_max_v_3_qs_int)
   );
 
 
   // F[en_3]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_3_en_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_3_we),
-    .src_wd_i     (adc_chn1_filter_ctl_3_en_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_3_en_3_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_3_en_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[3].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_3_we),
+    .wd     (aon_adc_chn1_filter_ctl_3_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[3].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_3_en_3_qs_int)
   );
 
 
@@ -1782,90 +2801,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_4]: V(False)
 
   // F[min_v_4]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_4_min_v_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_4_we),
-    .src_wd_i     (adc_chn1_filter_ctl_4_min_v_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_4_min_v_4_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_4_min_v_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[4].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_4_we),
+    .wd     (aon_adc_chn1_filter_ctl_4_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[4].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_4_min_v_4_qs_int)
   );
 
 
   // F[cond_4]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_4_cond_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_4_we),
-    .src_wd_i     (adc_chn1_filter_ctl_4_cond_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_4_cond_4_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_4_cond_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[4].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_4_we),
+    .wd     (aon_adc_chn1_filter_ctl_4_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[4].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_4_cond_4_qs_int)
   );
 
 
   // F[max_v_4]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_4_max_v_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_4_we),
-    .src_wd_i     (adc_chn1_filter_ctl_4_max_v_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_4_max_v_4_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_4_max_v_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[4].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_4_we),
+    .wd     (aon_adc_chn1_filter_ctl_4_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[4].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_4_max_v_4_qs_int)
   );
 
 
   // F[en_4]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_4_en_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_4_we),
-    .src_wd_i     (adc_chn1_filter_ctl_4_en_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_4_en_4_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_4_en_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[4].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_4_we),
+    .wd     (aon_adc_chn1_filter_ctl_4_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[4].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_4_en_4_qs_int)
   );
 
 
@@ -1873,90 +2908,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_5]: V(False)
 
   // F[min_v_5]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_5_min_v_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_5_we),
-    .src_wd_i     (adc_chn1_filter_ctl_5_min_v_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_5_min_v_5_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_5_min_v_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[5].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_5_we),
+    .wd     (aon_adc_chn1_filter_ctl_5_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[5].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_5_min_v_5_qs_int)
   );
 
 
   // F[cond_5]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_5_cond_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_5_we),
-    .src_wd_i     (adc_chn1_filter_ctl_5_cond_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_5_cond_5_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_5_cond_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[5].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_5_we),
+    .wd     (aon_adc_chn1_filter_ctl_5_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[5].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_5_cond_5_qs_int)
   );
 
 
   // F[max_v_5]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_5_max_v_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_5_we),
-    .src_wd_i     (adc_chn1_filter_ctl_5_max_v_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_5_max_v_5_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_5_max_v_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[5].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_5_we),
+    .wd     (aon_adc_chn1_filter_ctl_5_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[5].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_5_max_v_5_qs_int)
   );
 
 
   // F[en_5]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_5_en_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_5_we),
-    .src_wd_i     (adc_chn1_filter_ctl_5_en_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_5_en_5_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_5_en_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[5].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_5_we),
+    .wd     (aon_adc_chn1_filter_ctl_5_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[5].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_5_en_5_qs_int)
   );
 
 
@@ -1964,90 +3015,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_6]: V(False)
 
   // F[min_v_6]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_6_min_v_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_6_we),
-    .src_wd_i     (adc_chn1_filter_ctl_6_min_v_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_6_min_v_6_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_6_min_v_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[6].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_6_we),
+    .wd     (aon_adc_chn1_filter_ctl_6_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[6].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_6_min_v_6_qs_int)
   );
 
 
   // F[cond_6]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_6_cond_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_6_we),
-    .src_wd_i     (adc_chn1_filter_ctl_6_cond_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_6_cond_6_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_6_cond_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[6].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_6_we),
+    .wd     (aon_adc_chn1_filter_ctl_6_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[6].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_6_cond_6_qs_int)
   );
 
 
   // F[max_v_6]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_6_max_v_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_6_we),
-    .src_wd_i     (adc_chn1_filter_ctl_6_max_v_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_6_max_v_6_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_6_max_v_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[6].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_6_we),
+    .wd     (aon_adc_chn1_filter_ctl_6_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[6].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_6_max_v_6_qs_int)
   );
 
 
   // F[en_6]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_6_en_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_6_we),
-    .src_wd_i     (adc_chn1_filter_ctl_6_en_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_6_en_6_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_6_en_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[6].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_6_we),
+    .wd     (aon_adc_chn1_filter_ctl_6_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[6].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_6_en_6_qs_int)
   );
 
 
@@ -2055,90 +3122,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn1_filter_ctl_7]: V(False)
 
   // F[min_v_7]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_7_min_v_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_7_we),
-    .src_wd_i     (adc_chn1_filter_ctl_7_min_v_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_7_min_v_7_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_7_min_v_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[7].min_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_7_we),
+    .wd     (aon_adc_chn1_filter_ctl_7_wdata[11:2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[7].min_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_7_min_v_7_qs_int)
   );
 
 
   // F[cond_7]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_7_cond_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_7_we),
-    .src_wd_i     (adc_chn1_filter_ctl_7_cond_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_7_cond_7_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_7_cond_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[7].cond.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_7_we),
+    .wd     (aon_adc_chn1_filter_ctl_7_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[7].cond.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_7_cond_7_qs_int)
   );
 
 
   // F[max_v_7]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
   ) u_adc_chn1_filter_ctl_7_max_v_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_7_we),
-    .src_wd_i     (adc_chn1_filter_ctl_7_max_v_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_7_max_v_7_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_7_max_v_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[7].max_v.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_7_we),
+    .wd     (aon_adc_chn1_filter_ctl_7_wdata[27:18]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[7].max_v.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_7_max_v_7_qs_int)
   );
 
 
   // F[en_7]: 31:31
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_adc_chn1_filter_ctl_7_en_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_chn1_filter_ctl_7_we),
-    .src_wd_i     (adc_chn1_filter_ctl_7_en_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_chn1_filter_ctl_7_en_7_busy),
-    .src_qs_o     (adc_chn1_filter_ctl_7_en_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_chn1_filter_ctl[7].en.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_chn1_filter_ctl_7_we),
+    .wd     (aon_adc_chn1_filter_ctl_7_wdata[31]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_chn1_filter_ctl[7].en.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn1_filter_ctl_7_en_7_qs_int)
   );
 
 
@@ -2148,90 +3231,106 @@ module adc_ctrl_reg_top (
   // R[adc_chn_val_0]: V(False)
 
   // F[adc_chn_value_ext_0]: 1:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_0_adc_chn_value_ext_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value_ext.de),
-    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value_ext.d),
-    .src_busy_o   (adc_chn_val_0_adc_chn_value_ext_0_busy),
-    .src_qs_o     (adc_chn_val_0_adc_chn_value_ext_0_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[0].adc_chn_value_ext.de),
+    .d      (hw2reg.adc_chn_val[0].adc_chn_value_ext.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_0_adc_chn_value_ext_0_qs_int)
   );
 
 
   // F[adc_chn_value_0]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_0_adc_chn_value_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value.de),
-    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value.d),
-    .src_busy_o   (adc_chn_val_0_adc_chn_value_0_busy),
-    .src_qs_o     (adc_chn_val_0_adc_chn_value_0_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[0].adc_chn_value.de),
+    .d      (hw2reg.adc_chn_val[0].adc_chn_value.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_0_adc_chn_value_0_qs_int)
   );
 
 
   // F[adc_chn_value_intr_ext_0]: 17:16
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_0_adc_chn_value_intr_ext_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.de),
-    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.d),
-    .src_busy_o   (adc_chn_val_0_adc_chn_value_intr_ext_0_busy),
-    .src_qs_o     (adc_chn_val_0_adc_chn_value_intr_ext_0_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.de),
+    .d      (hw2reg.adc_chn_val[0].adc_chn_value_intr_ext.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_0_adc_chn_value_intr_ext_0_qs_int)
   );
 
 
   // F[adc_chn_value_intr_0]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_0_adc_chn_value_intr_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[0].adc_chn_value_intr.de),
-    .dst_d_i      (hw2reg.adc_chn_val[0].adc_chn_value_intr.d),
-    .src_busy_o   (adc_chn_val_0_adc_chn_value_intr_0_busy),
-    .src_qs_o     (adc_chn_val_0_adc_chn_value_intr_0_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[0].adc_chn_value_intr.de),
+    .d      (hw2reg.adc_chn_val[0].adc_chn_value_intr.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_0_adc_chn_value_intr_0_qs_int)
   );
 
 
@@ -2239,137 +3338,161 @@ module adc_ctrl_reg_top (
   // R[adc_chn_val_1]: V(False)
 
   // F[adc_chn_value_ext_1]: 1:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_1_adc_chn_value_ext_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value_ext.de),
-    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value_ext.d),
-    .src_busy_o   (adc_chn_val_1_adc_chn_value_ext_1_busy),
-    .src_qs_o     (adc_chn_val_1_adc_chn_value_ext_1_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[1].adc_chn_value_ext.de),
+    .d      (hw2reg.adc_chn_val[1].adc_chn_value_ext.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_1_adc_chn_value_ext_1_qs_int)
   );
 
 
   // F[adc_chn_value_1]: 11:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_1_adc_chn_value_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value.de),
-    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value.d),
-    .src_busy_o   (adc_chn_val_1_adc_chn_value_1_busy),
-    .src_qs_o     (adc_chn_val_1_adc_chn_value_1_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[1].adc_chn_value.de),
+    .d      (hw2reg.adc_chn_val[1].adc_chn_value.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_1_adc_chn_value_1_qs_int)
   );
 
 
   // F[adc_chn_value_intr_ext_1]: 17:16
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (2'h0)
   ) u_adc_chn_val_1_adc_chn_value_intr_ext_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.de),
-    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.d),
-    .src_busy_o   (adc_chn_val_1_adc_chn_value_intr_ext_1_busy),
-    .src_qs_o     (adc_chn_val_1_adc_chn_value_intr_ext_1_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.de),
+    .d      (hw2reg.adc_chn_val[1].adc_chn_value_intr_ext.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_1_adc_chn_value_intr_ext_1_qs_int)
   );
 
 
   // F[adc_chn_value_intr_1]: 27:18
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (10'h0)
   ) u_adc_chn_val_1_adc_chn_value_intr_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (1'b0),
-    .src_wd_i     ('0),
-    .dst_de_i     (hw2reg.adc_chn_val[1].adc_chn_value_intr.de),
-    .dst_d_i      (hw2reg.adc_chn_val[1].adc_chn_value_intr.d),
-    .src_busy_o   (adc_chn_val_1_adc_chn_value_intr_1_busy),
-    .src_qs_o     (adc_chn_val_1_adc_chn_value_intr_1_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.adc_chn_val[1].adc_chn_value_intr.de),
+    .d      (hw2reg.adc_chn_val[1].adc_chn_value_intr.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_adc_chn_val_1_adc_chn_value_intr_1_qs_int)
   );
 
 
 
   // R[adc_wakeup_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_adc_wakeup_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (adc_wakeup_ctl_we),
-    .src_wd_i     (adc_wakeup_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (adc_wakeup_ctl_busy),
-    .src_qs_o     (adc_wakeup_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.adc_wakeup_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_adc_wakeup_ctl_we),
+    .wd     (aon_adc_wakeup_ctl_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.adc_wakeup_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_adc_wakeup_ctl_qs_int)
   );
 
 
   // R[filter_status]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (8'h0)
   ) u_filter_status (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (filter_status_we),
-    .src_wd_i     (filter_status_wd),
-    .dst_de_i     (hw2reg.filter_status.de),
-    .dst_d_i      (hw2reg.filter_status.d),
-    .src_busy_o   (filter_status_busy),
-    .src_qs_o     (filter_status_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.filter_status.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_filter_status_we),
+    .wd     (aon_filter_status_wdata[7:0]),
+
+    // from internal hardware
+    .de     (hw2reg.filter_status.de),
+    .d      (hw2reg.filter_status.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.filter_status.q),
+
+    // to register interface (read)
+    .qs     (aon_filter_status_qs_int)
   );
 
 
@@ -2725,175 +3848,101 @@ module adc_ctrl_reg_top (
   assign alert_test_wd = reg_wdata[0];
   assign adc_en_ctl_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign adc_en_ctl_adc_enable_wd = reg_wdata[0];
 
-  assign adc_en_ctl_oneshot_mode_wd = reg_wdata[1];
   assign adc_pd_ctl_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign adc_pd_ctl_lp_mode_wd = reg_wdata[0];
 
-  assign adc_pd_ctl_pwrup_time_wd = reg_wdata[7:4];
 
-  assign adc_pd_ctl_wakeup_time_wd = reg_wdata[31:8];
   assign adc_lp_sample_ctl_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign adc_lp_sample_ctl_wd = reg_wdata[7:0];
   assign adc_sample_ctl_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign adc_sample_ctl_wd = reg_wdata[15:0];
   assign adc_fsm_rst_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign adc_fsm_rst_wd = reg_wdata[0];
   assign adc_chn0_filter_ctl_0_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_0_min_v_0_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_0_cond_0_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_0_max_v_0_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_0_en_0_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_1_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_1_min_v_1_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_1_cond_1_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_1_max_v_1_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_1_en_1_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_2_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_2_min_v_2_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_2_cond_2_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_2_max_v_2_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_2_en_2_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_3_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_3_min_v_3_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_3_cond_3_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_3_max_v_3_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_3_en_3_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_4_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_4_min_v_4_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_4_cond_4_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_4_max_v_4_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_4_en_4_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_5_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_5_min_v_5_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_5_cond_5_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_5_max_v_5_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_5_en_5_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_6_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_6_min_v_6_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_6_cond_6_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_6_max_v_6_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_6_en_6_wd = reg_wdata[31];
   assign adc_chn0_filter_ctl_7_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign adc_chn0_filter_ctl_7_min_v_7_wd = reg_wdata[11:2];
 
-  assign adc_chn0_filter_ctl_7_cond_7_wd = reg_wdata[12];
 
-  assign adc_chn0_filter_ctl_7_max_v_7_wd = reg_wdata[27:18];
 
-  assign adc_chn0_filter_ctl_7_en_7_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_0_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_0_min_v_0_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_0_cond_0_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_0_max_v_0_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_0_en_0_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_1_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_1_min_v_1_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_1_cond_1_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_1_max_v_1_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_1_en_1_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_2_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_2_min_v_2_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_2_cond_2_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_2_max_v_2_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_2_en_2_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_3_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_3_min_v_3_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_3_cond_3_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_3_max_v_3_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_3_en_3_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_4_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_4_min_v_4_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_4_cond_4_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_4_max_v_4_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_4_en_4_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_5_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_5_min_v_5_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_5_cond_5_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_5_max_v_5_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_5_en_5_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_6_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_6_min_v_6_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_6_cond_6_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_6_max_v_6_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_6_en_6_wd = reg_wdata[31];
   assign adc_chn1_filter_ctl_7_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign adc_chn1_filter_ctl_7_min_v_7_wd = reg_wdata[11:2];
 
-  assign adc_chn1_filter_ctl_7_cond_7_wd = reg_wdata[12];
 
-  assign adc_chn1_filter_ctl_7_max_v_7_wd = reg_wdata[27:18];
 
-  assign adc_chn1_filter_ctl_7_en_7_wd = reg_wdata[31];
   assign adc_wakeup_ctl_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign adc_wakeup_ctl_wd = reg_wdata[7:0];
   assign filter_status_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign filter_status_wd = reg_wdata[7:0];
   assign adc_intr_ctl_we = addr_hit[29] & reg_we & !reg_error;
 
   assign adc_intr_ctl_wd = reg_wdata[8:0];
@@ -2938,162 +3987,80 @@ module adc_ctrl_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[0] = adc_en_ctl_adc_enable_qs;
-        reg_rdata_next[1] = adc_en_ctl_oneshot_mode_qs;
+        reg_rdata_next = DW'(adc_en_ctl_qs);
       end
-
       addr_hit[5]: begin
-        reg_rdata_next[0] = adc_pd_ctl_lp_mode_qs;
-        reg_rdata_next[7:4] = adc_pd_ctl_pwrup_time_qs;
-        reg_rdata_next[31:8] = adc_pd_ctl_wakeup_time_qs;
+        reg_rdata_next = DW'(adc_pd_ctl_qs);
       end
-
       addr_hit[6]: begin
-        reg_rdata_next[7:0] = adc_lp_sample_ctl_qs;
+        reg_rdata_next = DW'(adc_lp_sample_ctl_qs);
       end
-
       addr_hit[7]: begin
-        reg_rdata_next[15:0] = adc_sample_ctl_qs;
+        reg_rdata_next = DW'(adc_sample_ctl_qs);
       end
-
       addr_hit[8]: begin
-        reg_rdata_next[0] = adc_fsm_rst_qs;
+        reg_rdata_next = DW'(adc_fsm_rst_qs);
       end
-
       addr_hit[9]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_0_min_v_0_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_0_cond_0_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_0_max_v_0_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_0_en_0_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_0_qs);
       end
-
       addr_hit[10]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_1_min_v_1_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_1_cond_1_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_1_max_v_1_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_1_en_1_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_1_qs);
       end
-
       addr_hit[11]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_2_min_v_2_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_2_cond_2_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_2_max_v_2_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_2_en_2_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_2_qs);
       end
-
       addr_hit[12]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_3_min_v_3_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_3_cond_3_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_3_max_v_3_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_3_en_3_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_3_qs);
       end
-
       addr_hit[13]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_4_min_v_4_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_4_cond_4_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_4_max_v_4_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_4_en_4_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_4_qs);
       end
-
       addr_hit[14]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_5_min_v_5_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_5_cond_5_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_5_max_v_5_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_5_en_5_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_5_qs);
       end
-
       addr_hit[15]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_6_min_v_6_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_6_cond_6_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_6_max_v_6_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_6_en_6_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_6_qs);
       end
-
       addr_hit[16]: begin
-        reg_rdata_next[11:2] = adc_chn0_filter_ctl_7_min_v_7_qs;
-        reg_rdata_next[12] = adc_chn0_filter_ctl_7_cond_7_qs;
-        reg_rdata_next[27:18] = adc_chn0_filter_ctl_7_max_v_7_qs;
-        reg_rdata_next[31] = adc_chn0_filter_ctl_7_en_7_qs;
+        reg_rdata_next = DW'(adc_chn0_filter_ctl_7_qs);
       end
-
       addr_hit[17]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_0_min_v_0_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_0_cond_0_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_0_max_v_0_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_0_en_0_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_0_qs);
       end
-
       addr_hit[18]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_1_min_v_1_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_1_cond_1_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_1_max_v_1_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_1_en_1_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_1_qs);
       end
-
       addr_hit[19]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_2_min_v_2_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_2_cond_2_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_2_max_v_2_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_2_en_2_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_2_qs);
       end
-
       addr_hit[20]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_3_min_v_3_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_3_cond_3_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_3_max_v_3_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_3_en_3_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_3_qs);
       end
-
       addr_hit[21]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_4_min_v_4_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_4_cond_4_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_4_max_v_4_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_4_en_4_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_4_qs);
       end
-
       addr_hit[22]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_5_min_v_5_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_5_cond_5_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_5_max_v_5_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_5_en_5_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_5_qs);
       end
-
       addr_hit[23]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_6_min_v_6_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_6_cond_6_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_6_max_v_6_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_6_en_6_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_6_qs);
       end
-
       addr_hit[24]: begin
-        reg_rdata_next[11:2] = adc_chn1_filter_ctl_7_min_v_7_qs;
-        reg_rdata_next[12] = adc_chn1_filter_ctl_7_cond_7_qs;
-        reg_rdata_next[27:18] = adc_chn1_filter_ctl_7_max_v_7_qs;
-        reg_rdata_next[31] = adc_chn1_filter_ctl_7_en_7_qs;
+        reg_rdata_next = DW'(adc_chn1_filter_ctl_7_qs);
       end
-
       addr_hit[25]: begin
-        reg_rdata_next[1:0] = adc_chn_val_0_adc_chn_value_ext_0_qs;
-        reg_rdata_next[11:2] = adc_chn_val_0_adc_chn_value_0_qs;
-        reg_rdata_next[17:16] = adc_chn_val_0_adc_chn_value_intr_ext_0_qs;
-        reg_rdata_next[27:18] = adc_chn_val_0_adc_chn_value_intr_0_qs;
+        reg_rdata_next = DW'(adc_chn_val_0_qs);
       end
-
       addr_hit[26]: begin
-        reg_rdata_next[1:0] = adc_chn_val_1_adc_chn_value_ext_1_qs;
-        reg_rdata_next[11:2] = adc_chn_val_1_adc_chn_value_1_qs;
-        reg_rdata_next[17:16] = adc_chn_val_1_adc_chn_value_intr_ext_1_qs;
-        reg_rdata_next[27:18] = adc_chn_val_1_adc_chn_value_intr_1_qs;
+        reg_rdata_next = DW'(adc_chn_val_1_qs);
       end
-
       addr_hit[27]: begin
-        reg_rdata_next[7:0] = adc_wakeup_ctl_qs;
+        reg_rdata_next = DW'(adc_wakeup_ctl_qs);
       end
-
       addr_hit[28]: begin
-        reg_rdata_next[7:0] = filter_status_qs;
+        reg_rdata_next = DW'(filter_status_qs);
       end
-
       addr_hit[29]: begin
         reg_rdata_next[8:0] = adc_intr_ctl_qs;
       end
@@ -3127,15 +4094,10 @@ module adc_ctrl_reg_top (
     reg_busy_sel = '0;
     unique case (1'b1)
       addr_hit[4]: begin
-        reg_busy_sel =
-          adc_en_ctl_adc_enable_busy |
-          adc_en_ctl_oneshot_mode_busy;
+        reg_busy_sel = adc_en_ctl_busy;
       end
       addr_hit[5]: begin
-        reg_busy_sel =
-          adc_pd_ctl_lp_mode_busy |
-          adc_pd_ctl_pwrup_time_busy |
-          adc_pd_ctl_wakeup_time_busy;
+        reg_busy_sel = adc_pd_ctl_busy;
       end
       addr_hit[6]: begin
         reg_busy_sel = adc_lp_sample_ctl_busy;
@@ -3147,130 +4109,58 @@ module adc_ctrl_reg_top (
         reg_busy_sel = adc_fsm_rst_busy;
       end
       addr_hit[9]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_0_min_v_0_busy |
-          adc_chn0_filter_ctl_0_cond_0_busy |
-          adc_chn0_filter_ctl_0_max_v_0_busy |
-          adc_chn0_filter_ctl_0_en_0_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_0_busy;
       end
       addr_hit[10]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_1_min_v_1_busy |
-          adc_chn0_filter_ctl_1_cond_1_busy |
-          adc_chn0_filter_ctl_1_max_v_1_busy |
-          adc_chn0_filter_ctl_1_en_1_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_1_busy;
       end
       addr_hit[11]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_2_min_v_2_busy |
-          adc_chn0_filter_ctl_2_cond_2_busy |
-          adc_chn0_filter_ctl_2_max_v_2_busy |
-          adc_chn0_filter_ctl_2_en_2_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_2_busy;
       end
       addr_hit[12]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_3_min_v_3_busy |
-          adc_chn0_filter_ctl_3_cond_3_busy |
-          adc_chn0_filter_ctl_3_max_v_3_busy |
-          adc_chn0_filter_ctl_3_en_3_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_3_busy;
       end
       addr_hit[13]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_4_min_v_4_busy |
-          adc_chn0_filter_ctl_4_cond_4_busy |
-          adc_chn0_filter_ctl_4_max_v_4_busy |
-          adc_chn0_filter_ctl_4_en_4_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_4_busy;
       end
       addr_hit[14]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_5_min_v_5_busy |
-          adc_chn0_filter_ctl_5_cond_5_busy |
-          adc_chn0_filter_ctl_5_max_v_5_busy |
-          adc_chn0_filter_ctl_5_en_5_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_5_busy;
       end
       addr_hit[15]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_6_min_v_6_busy |
-          adc_chn0_filter_ctl_6_cond_6_busy |
-          adc_chn0_filter_ctl_6_max_v_6_busy |
-          adc_chn0_filter_ctl_6_en_6_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_6_busy;
       end
       addr_hit[16]: begin
-        reg_busy_sel =
-          adc_chn0_filter_ctl_7_min_v_7_busy |
-          adc_chn0_filter_ctl_7_cond_7_busy |
-          adc_chn0_filter_ctl_7_max_v_7_busy |
-          adc_chn0_filter_ctl_7_en_7_busy;
+        reg_busy_sel = adc_chn0_filter_ctl_7_busy;
       end
       addr_hit[17]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_0_min_v_0_busy |
-          adc_chn1_filter_ctl_0_cond_0_busy |
-          adc_chn1_filter_ctl_0_max_v_0_busy |
-          adc_chn1_filter_ctl_0_en_0_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_0_busy;
       end
       addr_hit[18]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_1_min_v_1_busy |
-          adc_chn1_filter_ctl_1_cond_1_busy |
-          adc_chn1_filter_ctl_1_max_v_1_busy |
-          adc_chn1_filter_ctl_1_en_1_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_1_busy;
       end
       addr_hit[19]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_2_min_v_2_busy |
-          adc_chn1_filter_ctl_2_cond_2_busy |
-          adc_chn1_filter_ctl_2_max_v_2_busy |
-          adc_chn1_filter_ctl_2_en_2_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_2_busy;
       end
       addr_hit[20]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_3_min_v_3_busy |
-          adc_chn1_filter_ctl_3_cond_3_busy |
-          adc_chn1_filter_ctl_3_max_v_3_busy |
-          adc_chn1_filter_ctl_3_en_3_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_3_busy;
       end
       addr_hit[21]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_4_min_v_4_busy |
-          adc_chn1_filter_ctl_4_cond_4_busy |
-          adc_chn1_filter_ctl_4_max_v_4_busy |
-          adc_chn1_filter_ctl_4_en_4_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_4_busy;
       end
       addr_hit[22]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_5_min_v_5_busy |
-          adc_chn1_filter_ctl_5_cond_5_busy |
-          adc_chn1_filter_ctl_5_max_v_5_busy |
-          adc_chn1_filter_ctl_5_en_5_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_5_busy;
       end
       addr_hit[23]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_6_min_v_6_busy |
-          adc_chn1_filter_ctl_6_cond_6_busy |
-          adc_chn1_filter_ctl_6_max_v_6_busy |
-          adc_chn1_filter_ctl_6_en_6_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_6_busy;
       end
       addr_hit[24]: begin
-        reg_busy_sel =
-          adc_chn1_filter_ctl_7_min_v_7_busy |
-          adc_chn1_filter_ctl_7_cond_7_busy |
-          adc_chn1_filter_ctl_7_max_v_7_busy |
-          adc_chn1_filter_ctl_7_en_7_busy;
+        reg_busy_sel = adc_chn1_filter_ctl_7_busy;
       end
       addr_hit[25]: begin
-        reg_busy_sel =
-          adc_chn_val_0_adc_chn_value_ext_0_busy |
-          adc_chn_val_0_adc_chn_value_0_busy |
-          adc_chn_val_0_adc_chn_value_intr_ext_0_busy |
-          adc_chn_val_0_adc_chn_value_intr_0_busy;
+        reg_busy_sel = adc_chn_val_0_busy;
       end
       addr_hit[26]: begin
-        reg_busy_sel =
-          adc_chn_val_1_adc_chn_value_ext_1_busy |
-          adc_chn_val_1_adc_chn_value_1_busy |
-          adc_chn_val_1_adc_chn_value_intr_ext_1_busy |
-          adc_chn_val_1_adc_chn_value_intr_1_busy;
+        reg_busy_sel = adc_chn_val_1_busy;
       end
       addr_hit[27]: begin
         reg_busy_sel = adc_wakeup_ctl_busy;
@@ -3283,7 +4173,6 @@ module adc_ctrl_reg_top (
       end
     endcase
   end
-
 
 
   // Unused signal tieoff

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -1443,7 +1443,6 @@ module aes_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -5979,7 +5979,6 @@ module alert_handler_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -356,7 +356,6 @@ module clkmgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -1814,7 +1814,6 @@ module csrng_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -1094,7 +1094,6 @@ module edn_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -3183,7 +3183,6 @@ module entropy_src_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -12343,7 +12343,6 @@ module flash_ctrl_core_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -774,7 +774,6 @@ module gpio_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -1243,7 +1243,6 @@ module hmac_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -3221,7 +3221,6 @@ module i2c_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -2903,7 +2903,6 @@ module keymgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -2610,7 +2610,6 @@ module kmac_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -1160,7 +1160,6 @@ module lc_ctrl_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -890,7 +890,6 @@ module otbn_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -1794,7 +1794,6 @@ module otp_ctrl_core_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -871,7 +871,6 @@ module pattgen_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -1402,148 +1402,76 @@ module pinmux_reg_top (
   logic wkup_detector_regwen_7_qs;
   logic wkup_detector_regwen_7_wd;
   logic wkup_detector_en_0_we;
-  logic wkup_detector_en_0_qs;
-  logic wkup_detector_en_0_wd;
+  logic [0:0] wkup_detector_en_0_qs;
   logic wkup_detector_en_0_busy;
   logic wkup_detector_en_1_we;
-  logic wkup_detector_en_1_qs;
-  logic wkup_detector_en_1_wd;
+  logic [0:0] wkup_detector_en_1_qs;
   logic wkup_detector_en_1_busy;
   logic wkup_detector_en_2_we;
-  logic wkup_detector_en_2_qs;
-  logic wkup_detector_en_2_wd;
+  logic [0:0] wkup_detector_en_2_qs;
   logic wkup_detector_en_2_busy;
   logic wkup_detector_en_3_we;
-  logic wkup_detector_en_3_qs;
-  logic wkup_detector_en_3_wd;
+  logic [0:0] wkup_detector_en_3_qs;
   logic wkup_detector_en_3_busy;
   logic wkup_detector_en_4_we;
-  logic wkup_detector_en_4_qs;
-  logic wkup_detector_en_4_wd;
+  logic [0:0] wkup_detector_en_4_qs;
   logic wkup_detector_en_4_busy;
   logic wkup_detector_en_5_we;
-  logic wkup_detector_en_5_qs;
-  logic wkup_detector_en_5_wd;
+  logic [0:0] wkup_detector_en_5_qs;
   logic wkup_detector_en_5_busy;
   logic wkup_detector_en_6_we;
-  logic wkup_detector_en_6_qs;
-  logic wkup_detector_en_6_wd;
+  logic [0:0] wkup_detector_en_6_qs;
   logic wkup_detector_en_6_busy;
   logic wkup_detector_en_7_we;
-  logic wkup_detector_en_7_qs;
-  logic wkup_detector_en_7_wd;
+  logic [0:0] wkup_detector_en_7_qs;
   logic wkup_detector_en_7_busy;
   logic wkup_detector_0_we;
-  logic [2:0] wkup_detector_0_mode_0_qs;
-  logic [2:0] wkup_detector_0_mode_0_wd;
-  logic wkup_detector_0_mode_0_busy;
-  logic wkup_detector_0_filter_0_qs;
-  logic wkup_detector_0_filter_0_wd;
-  logic wkup_detector_0_filter_0_busy;
-  logic wkup_detector_0_miodio_0_qs;
-  logic wkup_detector_0_miodio_0_wd;
-  logic wkup_detector_0_miodio_0_busy;
+  logic [4:0] wkup_detector_0_qs;
+  logic wkup_detector_0_busy;
   logic wkup_detector_1_we;
-  logic [2:0] wkup_detector_1_mode_1_qs;
-  logic [2:0] wkup_detector_1_mode_1_wd;
-  logic wkup_detector_1_mode_1_busy;
-  logic wkup_detector_1_filter_1_qs;
-  logic wkup_detector_1_filter_1_wd;
-  logic wkup_detector_1_filter_1_busy;
-  logic wkup_detector_1_miodio_1_qs;
-  logic wkup_detector_1_miodio_1_wd;
-  logic wkup_detector_1_miodio_1_busy;
+  logic [4:0] wkup_detector_1_qs;
+  logic wkup_detector_1_busy;
   logic wkup_detector_2_we;
-  logic [2:0] wkup_detector_2_mode_2_qs;
-  logic [2:0] wkup_detector_2_mode_2_wd;
-  logic wkup_detector_2_mode_2_busy;
-  logic wkup_detector_2_filter_2_qs;
-  logic wkup_detector_2_filter_2_wd;
-  logic wkup_detector_2_filter_2_busy;
-  logic wkup_detector_2_miodio_2_qs;
-  logic wkup_detector_2_miodio_2_wd;
-  logic wkup_detector_2_miodio_2_busy;
+  logic [4:0] wkup_detector_2_qs;
+  logic wkup_detector_2_busy;
   logic wkup_detector_3_we;
-  logic [2:0] wkup_detector_3_mode_3_qs;
-  logic [2:0] wkup_detector_3_mode_3_wd;
-  logic wkup_detector_3_mode_3_busy;
-  logic wkup_detector_3_filter_3_qs;
-  logic wkup_detector_3_filter_3_wd;
-  logic wkup_detector_3_filter_3_busy;
-  logic wkup_detector_3_miodio_3_qs;
-  logic wkup_detector_3_miodio_3_wd;
-  logic wkup_detector_3_miodio_3_busy;
+  logic [4:0] wkup_detector_3_qs;
+  logic wkup_detector_3_busy;
   logic wkup_detector_4_we;
-  logic [2:0] wkup_detector_4_mode_4_qs;
-  logic [2:0] wkup_detector_4_mode_4_wd;
-  logic wkup_detector_4_mode_4_busy;
-  logic wkup_detector_4_filter_4_qs;
-  logic wkup_detector_4_filter_4_wd;
-  logic wkup_detector_4_filter_4_busy;
-  logic wkup_detector_4_miodio_4_qs;
-  logic wkup_detector_4_miodio_4_wd;
-  logic wkup_detector_4_miodio_4_busy;
+  logic [4:0] wkup_detector_4_qs;
+  logic wkup_detector_4_busy;
   logic wkup_detector_5_we;
-  logic [2:0] wkup_detector_5_mode_5_qs;
-  logic [2:0] wkup_detector_5_mode_5_wd;
-  logic wkup_detector_5_mode_5_busy;
-  logic wkup_detector_5_filter_5_qs;
-  logic wkup_detector_5_filter_5_wd;
-  logic wkup_detector_5_filter_5_busy;
-  logic wkup_detector_5_miodio_5_qs;
-  logic wkup_detector_5_miodio_5_wd;
-  logic wkup_detector_5_miodio_5_busy;
+  logic [4:0] wkup_detector_5_qs;
+  logic wkup_detector_5_busy;
   logic wkup_detector_6_we;
-  logic [2:0] wkup_detector_6_mode_6_qs;
-  logic [2:0] wkup_detector_6_mode_6_wd;
-  logic wkup_detector_6_mode_6_busy;
-  logic wkup_detector_6_filter_6_qs;
-  logic wkup_detector_6_filter_6_wd;
-  logic wkup_detector_6_filter_6_busy;
-  logic wkup_detector_6_miodio_6_qs;
-  logic wkup_detector_6_miodio_6_wd;
-  logic wkup_detector_6_miodio_6_busy;
+  logic [4:0] wkup_detector_6_qs;
+  logic wkup_detector_6_busy;
   logic wkup_detector_7_we;
-  logic [2:0] wkup_detector_7_mode_7_qs;
-  logic [2:0] wkup_detector_7_mode_7_wd;
-  logic wkup_detector_7_mode_7_busy;
-  logic wkup_detector_7_filter_7_qs;
-  logic wkup_detector_7_filter_7_wd;
-  logic wkup_detector_7_filter_7_busy;
-  logic wkup_detector_7_miodio_7_qs;
-  logic wkup_detector_7_miodio_7_wd;
-  logic wkup_detector_7_miodio_7_busy;
+  logic [4:0] wkup_detector_7_qs;
+  logic wkup_detector_7_busy;
   logic wkup_detector_cnt_th_0_we;
   logic [7:0] wkup_detector_cnt_th_0_qs;
-  logic [7:0] wkup_detector_cnt_th_0_wd;
   logic wkup_detector_cnt_th_0_busy;
   logic wkup_detector_cnt_th_1_we;
   logic [7:0] wkup_detector_cnt_th_1_qs;
-  logic [7:0] wkup_detector_cnt_th_1_wd;
   logic wkup_detector_cnt_th_1_busy;
   logic wkup_detector_cnt_th_2_we;
   logic [7:0] wkup_detector_cnt_th_2_qs;
-  logic [7:0] wkup_detector_cnt_th_2_wd;
   logic wkup_detector_cnt_th_2_busy;
   logic wkup_detector_cnt_th_3_we;
   logic [7:0] wkup_detector_cnt_th_3_qs;
-  logic [7:0] wkup_detector_cnt_th_3_wd;
   logic wkup_detector_cnt_th_3_busy;
   logic wkup_detector_cnt_th_4_we;
   logic [7:0] wkup_detector_cnt_th_4_qs;
-  logic [7:0] wkup_detector_cnt_th_4_wd;
   logic wkup_detector_cnt_th_4_busy;
   logic wkup_detector_cnt_th_5_we;
   logic [7:0] wkup_detector_cnt_th_5_qs;
-  logic [7:0] wkup_detector_cnt_th_5_wd;
   logic wkup_detector_cnt_th_5_busy;
   logic wkup_detector_cnt_th_6_we;
   logic [7:0] wkup_detector_cnt_th_6_qs;
-  logic [7:0] wkup_detector_cnt_th_6_wd;
   logic wkup_detector_cnt_th_6_busy;
   logic wkup_detector_cnt_th_7_we;
   logic [7:0] wkup_detector_cnt_th_7_qs;
-  logic [7:0] wkup_detector_cnt_th_7_wd;
   logic wkup_detector_cnt_th_7_busy;
   logic wkup_detector_padsel_0_we;
   logic [5:0] wkup_detector_padsel_0_qs;
@@ -1570,30 +1498,955 @@ module pinmux_reg_top (
   logic [5:0] wkup_detector_padsel_7_qs;
   logic [5:0] wkup_detector_padsel_7_wd;
   logic wkup_cause_we;
-  logic wkup_cause_cause_0_qs;
-  logic wkup_cause_cause_0_wd;
-  logic wkup_cause_cause_0_busy;
-  logic wkup_cause_cause_1_qs;
-  logic wkup_cause_cause_1_wd;
-  logic wkup_cause_cause_1_busy;
-  logic wkup_cause_cause_2_qs;
-  logic wkup_cause_cause_2_wd;
-  logic wkup_cause_cause_2_busy;
-  logic wkup_cause_cause_3_qs;
-  logic wkup_cause_cause_3_wd;
-  logic wkup_cause_cause_3_busy;
-  logic wkup_cause_cause_4_qs;
-  logic wkup_cause_cause_4_wd;
-  logic wkup_cause_cause_4_busy;
-  logic wkup_cause_cause_5_qs;
-  logic wkup_cause_cause_5_wd;
-  logic wkup_cause_cause_5_busy;
-  logic wkup_cause_cause_6_qs;
-  logic wkup_cause_cause_6_wd;
-  logic wkup_cause_cause_6_busy;
-  logic wkup_cause_cause_7_qs;
-  logic wkup_cause_cause_7_wd;
-  logic wkup_cause_cause_7_busy;
+  logic [7:0] wkup_cause_qs;
+  logic wkup_cause_busy;
+  // Define register CDC handling.
+  // CDC handling is done on a per-reg instead of per-field boundary.
+
+  logic  aon_wkup_detector_en_0_qs_int;
+  logic [0:0] aon_wkup_detector_en_0_d;
+  logic [0:0] aon_wkup_detector_en_0_wdata;
+  logic aon_wkup_detector_en_0_we;
+  logic unused_aon_wkup_detector_en_0_wdata;
+  logic aon_wkup_detector_en_0_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_0_d = '0;
+    aon_wkup_detector_en_0_d = aon_wkup_detector_en_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_0_qs),
+    .src_we_i     (wkup_detector_en_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_0_busy),
+    .src_qs_o     (wkup_detector_en_0_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_0_d),
+    .dst_we_o     (aon_wkup_detector_en_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_0_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_0_wdata)
+  );
+  assign unused_aon_wkup_detector_en_0_wdata = ^aon_wkup_detector_en_0_wdata;
+
+  logic  aon_wkup_detector_en_1_qs_int;
+  logic [0:0] aon_wkup_detector_en_1_d;
+  logic [0:0] aon_wkup_detector_en_1_wdata;
+  logic aon_wkup_detector_en_1_we;
+  logic unused_aon_wkup_detector_en_1_wdata;
+  logic aon_wkup_detector_en_1_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_1_d = '0;
+    aon_wkup_detector_en_1_d = aon_wkup_detector_en_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_1_qs),
+    .src_we_i     (wkup_detector_en_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_1_busy),
+    .src_qs_o     (wkup_detector_en_1_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_1_d),
+    .dst_we_o     (aon_wkup_detector_en_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_1_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_1_wdata)
+  );
+  assign unused_aon_wkup_detector_en_1_wdata = ^aon_wkup_detector_en_1_wdata;
+
+  logic  aon_wkup_detector_en_2_qs_int;
+  logic [0:0] aon_wkup_detector_en_2_d;
+  logic [0:0] aon_wkup_detector_en_2_wdata;
+  logic aon_wkup_detector_en_2_we;
+  logic unused_aon_wkup_detector_en_2_wdata;
+  logic aon_wkup_detector_en_2_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_2_d = '0;
+    aon_wkup_detector_en_2_d = aon_wkup_detector_en_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_2_qs),
+    .src_we_i     (wkup_detector_en_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_2_busy),
+    .src_qs_o     (wkup_detector_en_2_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_2_d),
+    .dst_we_o     (aon_wkup_detector_en_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_2_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_2_wdata)
+  );
+  assign unused_aon_wkup_detector_en_2_wdata = ^aon_wkup_detector_en_2_wdata;
+
+  logic  aon_wkup_detector_en_3_qs_int;
+  logic [0:0] aon_wkup_detector_en_3_d;
+  logic [0:0] aon_wkup_detector_en_3_wdata;
+  logic aon_wkup_detector_en_3_we;
+  logic unused_aon_wkup_detector_en_3_wdata;
+  logic aon_wkup_detector_en_3_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_3_d = '0;
+    aon_wkup_detector_en_3_d = aon_wkup_detector_en_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_3_qs),
+    .src_we_i     (wkup_detector_en_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_3_busy),
+    .src_qs_o     (wkup_detector_en_3_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_3_d),
+    .dst_we_o     (aon_wkup_detector_en_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_3_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_3_wdata)
+  );
+  assign unused_aon_wkup_detector_en_3_wdata = ^aon_wkup_detector_en_3_wdata;
+
+  logic  aon_wkup_detector_en_4_qs_int;
+  logic [0:0] aon_wkup_detector_en_4_d;
+  logic [0:0] aon_wkup_detector_en_4_wdata;
+  logic aon_wkup_detector_en_4_we;
+  logic unused_aon_wkup_detector_en_4_wdata;
+  logic aon_wkup_detector_en_4_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_4_d = '0;
+    aon_wkup_detector_en_4_d = aon_wkup_detector_en_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_4_qs),
+    .src_we_i     (wkup_detector_en_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_4_busy),
+    .src_qs_o     (wkup_detector_en_4_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_4_d),
+    .dst_we_o     (aon_wkup_detector_en_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_4_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_4_wdata)
+  );
+  assign unused_aon_wkup_detector_en_4_wdata = ^aon_wkup_detector_en_4_wdata;
+
+  logic  aon_wkup_detector_en_5_qs_int;
+  logic [0:0] aon_wkup_detector_en_5_d;
+  logic [0:0] aon_wkup_detector_en_5_wdata;
+  logic aon_wkup_detector_en_5_we;
+  logic unused_aon_wkup_detector_en_5_wdata;
+  logic aon_wkup_detector_en_5_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_5_d = '0;
+    aon_wkup_detector_en_5_d = aon_wkup_detector_en_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_5_qs),
+    .src_we_i     (wkup_detector_en_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_5_busy),
+    .src_qs_o     (wkup_detector_en_5_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_5_d),
+    .dst_we_o     (aon_wkup_detector_en_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_5_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_5_wdata)
+  );
+  assign unused_aon_wkup_detector_en_5_wdata = ^aon_wkup_detector_en_5_wdata;
+
+  logic  aon_wkup_detector_en_6_qs_int;
+  logic [0:0] aon_wkup_detector_en_6_d;
+  logic [0:0] aon_wkup_detector_en_6_wdata;
+  logic aon_wkup_detector_en_6_we;
+  logic unused_aon_wkup_detector_en_6_wdata;
+  logic aon_wkup_detector_en_6_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_6_d = '0;
+    aon_wkup_detector_en_6_d = aon_wkup_detector_en_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_6_qs),
+    .src_we_i     (wkup_detector_en_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_6_busy),
+    .src_qs_o     (wkup_detector_en_6_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_6_d),
+    .dst_we_o     (aon_wkup_detector_en_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_6_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_6_wdata)
+  );
+  assign unused_aon_wkup_detector_en_6_wdata = ^aon_wkup_detector_en_6_wdata;
+
+  logic  aon_wkup_detector_en_7_qs_int;
+  logic [0:0] aon_wkup_detector_en_7_d;
+  logic [0:0] aon_wkup_detector_en_7_wdata;
+  logic aon_wkup_detector_en_7_we;
+  logic unused_aon_wkup_detector_en_7_wdata;
+  logic aon_wkup_detector_en_7_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_7_d = '0;
+    aon_wkup_detector_en_7_d = aon_wkup_detector_en_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_7_qs),
+    .src_we_i     (wkup_detector_en_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_7_busy),
+    .src_qs_o     (wkup_detector_en_7_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_7_d),
+    .dst_we_o     (aon_wkup_detector_en_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_7_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_7_wdata)
+  );
+  assign unused_aon_wkup_detector_en_7_wdata = ^aon_wkup_detector_en_7_wdata;
+
+  logic [2:0]  aon_wkup_detector_0_mode_0_qs_int;
+  logic  aon_wkup_detector_0_filter_0_qs_int;
+  logic  aon_wkup_detector_0_miodio_0_qs_int;
+  logic [4:0] aon_wkup_detector_0_d;
+  logic [4:0] aon_wkup_detector_0_wdata;
+  logic aon_wkup_detector_0_we;
+  logic unused_aon_wkup_detector_0_wdata;
+  logic aon_wkup_detector_0_regwen;
+
+  always_comb begin
+    aon_wkup_detector_0_d = '0;
+    aon_wkup_detector_0_d[2:0] = aon_wkup_detector_0_mode_0_qs_int;
+    aon_wkup_detector_0_d[3] = aon_wkup_detector_0_filter_0_qs_int;
+    aon_wkup_detector_0_d[4] = aon_wkup_detector_0_miodio_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_0_qs),
+    .src_we_i     (wkup_detector_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_0_busy),
+    .src_qs_o     (wkup_detector_0_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_0_d),
+    .dst_we_o     (aon_wkup_detector_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_0_regwen),
+    .dst_wd_o     (aon_wkup_detector_0_wdata)
+  );
+  assign unused_aon_wkup_detector_0_wdata = ^aon_wkup_detector_0_wdata;
+
+  logic [2:0]  aon_wkup_detector_1_mode_1_qs_int;
+  logic  aon_wkup_detector_1_filter_1_qs_int;
+  logic  aon_wkup_detector_1_miodio_1_qs_int;
+  logic [4:0] aon_wkup_detector_1_d;
+  logic [4:0] aon_wkup_detector_1_wdata;
+  logic aon_wkup_detector_1_we;
+  logic unused_aon_wkup_detector_1_wdata;
+  logic aon_wkup_detector_1_regwen;
+
+  always_comb begin
+    aon_wkup_detector_1_d = '0;
+    aon_wkup_detector_1_d[2:0] = aon_wkup_detector_1_mode_1_qs_int;
+    aon_wkup_detector_1_d[3] = aon_wkup_detector_1_filter_1_qs_int;
+    aon_wkup_detector_1_d[4] = aon_wkup_detector_1_miodio_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_1_qs),
+    .src_we_i     (wkup_detector_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_1_busy),
+    .src_qs_o     (wkup_detector_1_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_1_d),
+    .dst_we_o     (aon_wkup_detector_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_1_regwen),
+    .dst_wd_o     (aon_wkup_detector_1_wdata)
+  );
+  assign unused_aon_wkup_detector_1_wdata = ^aon_wkup_detector_1_wdata;
+
+  logic [2:0]  aon_wkup_detector_2_mode_2_qs_int;
+  logic  aon_wkup_detector_2_filter_2_qs_int;
+  logic  aon_wkup_detector_2_miodio_2_qs_int;
+  logic [4:0] aon_wkup_detector_2_d;
+  logic [4:0] aon_wkup_detector_2_wdata;
+  logic aon_wkup_detector_2_we;
+  logic unused_aon_wkup_detector_2_wdata;
+  logic aon_wkup_detector_2_regwen;
+
+  always_comb begin
+    aon_wkup_detector_2_d = '0;
+    aon_wkup_detector_2_d[2:0] = aon_wkup_detector_2_mode_2_qs_int;
+    aon_wkup_detector_2_d[3] = aon_wkup_detector_2_filter_2_qs_int;
+    aon_wkup_detector_2_d[4] = aon_wkup_detector_2_miodio_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_2_qs),
+    .src_we_i     (wkup_detector_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_2_busy),
+    .src_qs_o     (wkup_detector_2_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_2_d),
+    .dst_we_o     (aon_wkup_detector_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_2_regwen),
+    .dst_wd_o     (aon_wkup_detector_2_wdata)
+  );
+  assign unused_aon_wkup_detector_2_wdata = ^aon_wkup_detector_2_wdata;
+
+  logic [2:0]  aon_wkup_detector_3_mode_3_qs_int;
+  logic  aon_wkup_detector_3_filter_3_qs_int;
+  logic  aon_wkup_detector_3_miodio_3_qs_int;
+  logic [4:0] aon_wkup_detector_3_d;
+  logic [4:0] aon_wkup_detector_3_wdata;
+  logic aon_wkup_detector_3_we;
+  logic unused_aon_wkup_detector_3_wdata;
+  logic aon_wkup_detector_3_regwen;
+
+  always_comb begin
+    aon_wkup_detector_3_d = '0;
+    aon_wkup_detector_3_d[2:0] = aon_wkup_detector_3_mode_3_qs_int;
+    aon_wkup_detector_3_d[3] = aon_wkup_detector_3_filter_3_qs_int;
+    aon_wkup_detector_3_d[4] = aon_wkup_detector_3_miodio_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_3_qs),
+    .src_we_i     (wkup_detector_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_3_busy),
+    .src_qs_o     (wkup_detector_3_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_3_d),
+    .dst_we_o     (aon_wkup_detector_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_3_regwen),
+    .dst_wd_o     (aon_wkup_detector_3_wdata)
+  );
+  assign unused_aon_wkup_detector_3_wdata = ^aon_wkup_detector_3_wdata;
+
+  logic [2:0]  aon_wkup_detector_4_mode_4_qs_int;
+  logic  aon_wkup_detector_4_filter_4_qs_int;
+  logic  aon_wkup_detector_4_miodio_4_qs_int;
+  logic [4:0] aon_wkup_detector_4_d;
+  logic [4:0] aon_wkup_detector_4_wdata;
+  logic aon_wkup_detector_4_we;
+  logic unused_aon_wkup_detector_4_wdata;
+  logic aon_wkup_detector_4_regwen;
+
+  always_comb begin
+    aon_wkup_detector_4_d = '0;
+    aon_wkup_detector_4_d[2:0] = aon_wkup_detector_4_mode_4_qs_int;
+    aon_wkup_detector_4_d[3] = aon_wkup_detector_4_filter_4_qs_int;
+    aon_wkup_detector_4_d[4] = aon_wkup_detector_4_miodio_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_4_qs),
+    .src_we_i     (wkup_detector_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_4_busy),
+    .src_qs_o     (wkup_detector_4_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_4_d),
+    .dst_we_o     (aon_wkup_detector_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_4_regwen),
+    .dst_wd_o     (aon_wkup_detector_4_wdata)
+  );
+  assign unused_aon_wkup_detector_4_wdata = ^aon_wkup_detector_4_wdata;
+
+  logic [2:0]  aon_wkup_detector_5_mode_5_qs_int;
+  logic  aon_wkup_detector_5_filter_5_qs_int;
+  logic  aon_wkup_detector_5_miodio_5_qs_int;
+  logic [4:0] aon_wkup_detector_5_d;
+  logic [4:0] aon_wkup_detector_5_wdata;
+  logic aon_wkup_detector_5_we;
+  logic unused_aon_wkup_detector_5_wdata;
+  logic aon_wkup_detector_5_regwen;
+
+  always_comb begin
+    aon_wkup_detector_5_d = '0;
+    aon_wkup_detector_5_d[2:0] = aon_wkup_detector_5_mode_5_qs_int;
+    aon_wkup_detector_5_d[3] = aon_wkup_detector_5_filter_5_qs_int;
+    aon_wkup_detector_5_d[4] = aon_wkup_detector_5_miodio_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_5_qs),
+    .src_we_i     (wkup_detector_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_5_busy),
+    .src_qs_o     (wkup_detector_5_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_5_d),
+    .dst_we_o     (aon_wkup_detector_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_5_regwen),
+    .dst_wd_o     (aon_wkup_detector_5_wdata)
+  );
+  assign unused_aon_wkup_detector_5_wdata = ^aon_wkup_detector_5_wdata;
+
+  logic [2:0]  aon_wkup_detector_6_mode_6_qs_int;
+  logic  aon_wkup_detector_6_filter_6_qs_int;
+  logic  aon_wkup_detector_6_miodio_6_qs_int;
+  logic [4:0] aon_wkup_detector_6_d;
+  logic [4:0] aon_wkup_detector_6_wdata;
+  logic aon_wkup_detector_6_we;
+  logic unused_aon_wkup_detector_6_wdata;
+  logic aon_wkup_detector_6_regwen;
+
+  always_comb begin
+    aon_wkup_detector_6_d = '0;
+    aon_wkup_detector_6_d[2:0] = aon_wkup_detector_6_mode_6_qs_int;
+    aon_wkup_detector_6_d[3] = aon_wkup_detector_6_filter_6_qs_int;
+    aon_wkup_detector_6_d[4] = aon_wkup_detector_6_miodio_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_6_qs),
+    .src_we_i     (wkup_detector_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_6_busy),
+    .src_qs_o     (wkup_detector_6_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_6_d),
+    .dst_we_o     (aon_wkup_detector_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_6_regwen),
+    .dst_wd_o     (aon_wkup_detector_6_wdata)
+  );
+  assign unused_aon_wkup_detector_6_wdata = ^aon_wkup_detector_6_wdata;
+
+  logic [2:0]  aon_wkup_detector_7_mode_7_qs_int;
+  logic  aon_wkup_detector_7_filter_7_qs_int;
+  logic  aon_wkup_detector_7_miodio_7_qs_int;
+  logic [4:0] aon_wkup_detector_7_d;
+  logic [4:0] aon_wkup_detector_7_wdata;
+  logic aon_wkup_detector_7_we;
+  logic unused_aon_wkup_detector_7_wdata;
+  logic aon_wkup_detector_7_regwen;
+
+  always_comb begin
+    aon_wkup_detector_7_d = '0;
+    aon_wkup_detector_7_d[2:0] = aon_wkup_detector_7_mode_7_qs_int;
+    aon_wkup_detector_7_d[3] = aon_wkup_detector_7_filter_7_qs_int;
+    aon_wkup_detector_7_d[4] = aon_wkup_detector_7_miodio_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_7_qs),
+    .src_we_i     (wkup_detector_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_7_busy),
+    .src_qs_o     (wkup_detector_7_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_7_d),
+    .dst_we_o     (aon_wkup_detector_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_7_regwen),
+    .dst_wd_o     (aon_wkup_detector_7_wdata)
+  );
+  assign unused_aon_wkup_detector_7_wdata = ^aon_wkup_detector_7_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_0_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_0_d;
+  logic [7:0] aon_wkup_detector_cnt_th_0_wdata;
+  logic aon_wkup_detector_cnt_th_0_we;
+  logic unused_aon_wkup_detector_cnt_th_0_wdata;
+  logic aon_wkup_detector_cnt_th_0_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_0_d = '0;
+    aon_wkup_detector_cnt_th_0_d = aon_wkup_detector_cnt_th_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_0_qs),
+    .src_we_i     (wkup_detector_cnt_th_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_0_busy),
+    .src_qs_o     (wkup_detector_cnt_th_0_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_0_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_0_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_0_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_0_wdata = ^aon_wkup_detector_cnt_th_0_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_1_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_1_d;
+  logic [7:0] aon_wkup_detector_cnt_th_1_wdata;
+  logic aon_wkup_detector_cnt_th_1_we;
+  logic unused_aon_wkup_detector_cnt_th_1_wdata;
+  logic aon_wkup_detector_cnt_th_1_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_1_d = '0;
+    aon_wkup_detector_cnt_th_1_d = aon_wkup_detector_cnt_th_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_1_qs),
+    .src_we_i     (wkup_detector_cnt_th_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_1_busy),
+    .src_qs_o     (wkup_detector_cnt_th_1_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_1_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_1_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_1_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_1_wdata = ^aon_wkup_detector_cnt_th_1_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_2_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_2_d;
+  logic [7:0] aon_wkup_detector_cnt_th_2_wdata;
+  logic aon_wkup_detector_cnt_th_2_we;
+  logic unused_aon_wkup_detector_cnt_th_2_wdata;
+  logic aon_wkup_detector_cnt_th_2_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_2_d = '0;
+    aon_wkup_detector_cnt_th_2_d = aon_wkup_detector_cnt_th_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_2_qs),
+    .src_we_i     (wkup_detector_cnt_th_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_2_busy),
+    .src_qs_o     (wkup_detector_cnt_th_2_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_2_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_2_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_2_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_2_wdata = ^aon_wkup_detector_cnt_th_2_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_3_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_3_d;
+  logic [7:0] aon_wkup_detector_cnt_th_3_wdata;
+  logic aon_wkup_detector_cnt_th_3_we;
+  logic unused_aon_wkup_detector_cnt_th_3_wdata;
+  logic aon_wkup_detector_cnt_th_3_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_3_d = '0;
+    aon_wkup_detector_cnt_th_3_d = aon_wkup_detector_cnt_th_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_3_qs),
+    .src_we_i     (wkup_detector_cnt_th_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_3_busy),
+    .src_qs_o     (wkup_detector_cnt_th_3_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_3_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_3_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_3_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_3_wdata = ^aon_wkup_detector_cnt_th_3_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_4_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_4_d;
+  logic [7:0] aon_wkup_detector_cnt_th_4_wdata;
+  logic aon_wkup_detector_cnt_th_4_we;
+  logic unused_aon_wkup_detector_cnt_th_4_wdata;
+  logic aon_wkup_detector_cnt_th_4_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_4_d = '0;
+    aon_wkup_detector_cnt_th_4_d = aon_wkup_detector_cnt_th_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_4_qs),
+    .src_we_i     (wkup_detector_cnt_th_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_4_busy),
+    .src_qs_o     (wkup_detector_cnt_th_4_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_4_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_4_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_4_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_4_wdata = ^aon_wkup_detector_cnt_th_4_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_5_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_5_d;
+  logic [7:0] aon_wkup_detector_cnt_th_5_wdata;
+  logic aon_wkup_detector_cnt_th_5_we;
+  logic unused_aon_wkup_detector_cnt_th_5_wdata;
+  logic aon_wkup_detector_cnt_th_5_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_5_d = '0;
+    aon_wkup_detector_cnt_th_5_d = aon_wkup_detector_cnt_th_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_5_qs),
+    .src_we_i     (wkup_detector_cnt_th_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_5_busy),
+    .src_qs_o     (wkup_detector_cnt_th_5_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_5_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_5_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_5_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_5_wdata = ^aon_wkup_detector_cnt_th_5_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_6_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_6_d;
+  logic [7:0] aon_wkup_detector_cnt_th_6_wdata;
+  logic aon_wkup_detector_cnt_th_6_we;
+  logic unused_aon_wkup_detector_cnt_th_6_wdata;
+  logic aon_wkup_detector_cnt_th_6_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_6_d = '0;
+    aon_wkup_detector_cnt_th_6_d = aon_wkup_detector_cnt_th_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_6_qs),
+    .src_we_i     (wkup_detector_cnt_th_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_6_busy),
+    .src_qs_o     (wkup_detector_cnt_th_6_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_6_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_6_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_6_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_6_wdata = ^aon_wkup_detector_cnt_th_6_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_7_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_7_d;
+  logic [7:0] aon_wkup_detector_cnt_th_7_wdata;
+  logic aon_wkup_detector_cnt_th_7_we;
+  logic unused_aon_wkup_detector_cnt_th_7_wdata;
+  logic aon_wkup_detector_cnt_th_7_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_7_d = '0;
+    aon_wkup_detector_cnt_th_7_d = aon_wkup_detector_cnt_th_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_7_qs),
+    .src_we_i     (wkup_detector_cnt_th_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_7_busy),
+    .src_qs_o     (wkup_detector_cnt_th_7_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_7_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_7_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_7_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_7_wdata = ^aon_wkup_detector_cnt_th_7_wdata;
+
+  logic  aon_wkup_cause_cause_0_qs_int;
+  logic  aon_wkup_cause_cause_1_qs_int;
+  logic  aon_wkup_cause_cause_2_qs_int;
+  logic  aon_wkup_cause_cause_3_qs_int;
+  logic  aon_wkup_cause_cause_4_qs_int;
+  logic  aon_wkup_cause_cause_5_qs_int;
+  logic  aon_wkup_cause_cause_6_qs_int;
+  logic  aon_wkup_cause_cause_7_qs_int;
+  logic [7:0] aon_wkup_cause_d;
+  logic [7:0] aon_wkup_cause_wdata;
+  logic aon_wkup_cause_we;
+  logic unused_aon_wkup_cause_wdata;
+
+  always_comb begin
+    aon_wkup_cause_d = '0;
+    aon_wkup_cause_d[0] = aon_wkup_cause_cause_0_qs_int;
+    aon_wkup_cause_d[1] = aon_wkup_cause_cause_1_qs_int;
+    aon_wkup_cause_d[2] = aon_wkup_cause_cause_2_qs_int;
+    aon_wkup_cause_d[3] = aon_wkup_cause_cause_3_qs_int;
+    aon_wkup_cause_d[4] = aon_wkup_cause_cause_4_qs_int;
+    aon_wkup_cause_d[5] = aon_wkup_cause_cause_5_qs_int;
+    aon_wkup_cause_d[6] = aon_wkup_cause_cause_6_qs_int;
+    aon_wkup_cause_d[7] = aon_wkup_cause_cause_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_cause_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (wkup_cause_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_cause_busy),
+    .src_qs_o     (wkup_cause_qs), // for software read back
+    .dst_d_i      (aon_wkup_cause_d),
+    .dst_we_o     (aon_wkup_cause_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_wkup_cause_wdata)
+  );
+  assign unused_aon_wkup_cause_wdata = ^aon_wkup_cause_wdata;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -12582,185 +13435,217 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_en
   // R[wkup_detector_en_0]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_en_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_0_busy),
-    .src_qs_o     (wkup_detector_en_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_0_we & aon_wkup_detector_en_0_regwen),
+    .wd     (aon_wkup_detector_en_0_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[0].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_0_qs_int)
   );
 
   // Subregister 1 of Multireg wkup_detector_en
   // R[wkup_detector_en_1]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_en_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_1_busy),
-    .src_qs_o     (wkup_detector_en_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_1_we & aon_wkup_detector_en_1_regwen),
+    .wd     (aon_wkup_detector_en_1_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[1].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_1_qs_int)
   );
 
   // Subregister 2 of Multireg wkup_detector_en
   // R[wkup_detector_en_2]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_en_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_2_busy),
-    .src_qs_o     (wkup_detector_en_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_2_we & aon_wkup_detector_en_2_regwen),
+    .wd     (aon_wkup_detector_en_2_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[2].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_2_qs_int)
   );
 
   // Subregister 3 of Multireg wkup_detector_en
   // R[wkup_detector_en_3]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_en_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_3_busy),
-    .src_qs_o     (wkup_detector_en_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_3_we & aon_wkup_detector_en_3_regwen),
+    .wd     (aon_wkup_detector_en_3_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[3].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_3_qs_int)
   );
 
   // Subregister 4 of Multireg wkup_detector_en
   // R[wkup_detector_en_4]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_en_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_4_busy),
-    .src_qs_o     (wkup_detector_en_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[4].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_4_we & aon_wkup_detector_en_4_regwen),
+    .wd     (aon_wkup_detector_en_4_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[4].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_4_qs_int)
   );
 
   // Subregister 5 of Multireg wkup_detector_en
   // R[wkup_detector_en_5]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_en_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_5_busy),
-    .src_qs_o     (wkup_detector_en_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[5].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_5_we & aon_wkup_detector_en_5_regwen),
+    .wd     (aon_wkup_detector_en_5_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[5].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_5_qs_int)
   );
 
   // Subregister 6 of Multireg wkup_detector_en
   // R[wkup_detector_en_6]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_en_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_6_busy),
-    .src_qs_o     (wkup_detector_en_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[6].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_6_we & aon_wkup_detector_en_6_regwen),
+    .wd     (aon_wkup_detector_en_6_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[6].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_6_qs_int)
   );
 
   // Subregister 7 of Multireg wkup_detector_en
   // R[wkup_detector_en_7]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_en_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_7_busy),
-    .src_qs_o     (wkup_detector_en_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[7].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_7_we & aon_wkup_detector_en_7_regwen),
+    .wd     (aon_wkup_detector_en_7_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[7].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_7_qs_int)
   );
 
 
@@ -12769,68 +13654,80 @@ module pinmux_reg_top (
   // R[wkup_detector_0]: V(False)
 
   // F[mode_0]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_0_mode_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_0_mode_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_0_mode_0_busy),
-    .src_qs_o     (wkup_detector_0_mode_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[0].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_0_we & aon_wkup_detector_0_regwen),
+    .wd     (aon_wkup_detector_0_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[0].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_0_mode_0_qs_int)
   );
 
 
   // F[filter_0]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_filter_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_0_filter_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_0_filter_0_busy),
-    .src_qs_o     (wkup_detector_0_filter_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[0].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_0_we & aon_wkup_detector_0_regwen),
+    .wd     (aon_wkup_detector_0_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[0].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_0_filter_0_qs_int)
   );
 
 
   // F[miodio_0]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_miodio_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_0_miodio_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_0_miodio_0_busy),
-    .src_qs_o     (wkup_detector_0_miodio_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[0].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_0_we & aon_wkup_detector_0_regwen),
+    .wd     (aon_wkup_detector_0_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[0].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_0_miodio_0_qs_int)
   );
 
 
@@ -12838,68 +13735,80 @@ module pinmux_reg_top (
   // R[wkup_detector_1]: V(False)
 
   // F[mode_1]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_1_mode_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_1_mode_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_1_mode_1_busy),
-    .src_qs_o     (wkup_detector_1_mode_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[1].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_1_we & aon_wkup_detector_1_regwen),
+    .wd     (aon_wkup_detector_1_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[1].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_1_mode_1_qs_int)
   );
 
 
   // F[filter_1]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_filter_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_1_filter_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_1_filter_1_busy),
-    .src_qs_o     (wkup_detector_1_filter_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[1].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_1_we & aon_wkup_detector_1_regwen),
+    .wd     (aon_wkup_detector_1_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[1].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_1_filter_1_qs_int)
   );
 
 
   // F[miodio_1]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_miodio_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_1_miodio_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_1_miodio_1_busy),
-    .src_qs_o     (wkup_detector_1_miodio_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[1].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_1_we & aon_wkup_detector_1_regwen),
+    .wd     (aon_wkup_detector_1_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[1].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_1_miodio_1_qs_int)
   );
 
 
@@ -12907,68 +13816,80 @@ module pinmux_reg_top (
   // R[wkup_detector_2]: V(False)
 
   // F[mode_2]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_2_mode_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_2_mode_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_2_mode_2_busy),
-    .src_qs_o     (wkup_detector_2_mode_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[2].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_2_we & aon_wkup_detector_2_regwen),
+    .wd     (aon_wkup_detector_2_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[2].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_2_mode_2_qs_int)
   );
 
 
   // F[filter_2]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_filter_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_2_filter_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_2_filter_2_busy),
-    .src_qs_o     (wkup_detector_2_filter_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[2].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_2_we & aon_wkup_detector_2_regwen),
+    .wd     (aon_wkup_detector_2_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[2].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_2_filter_2_qs_int)
   );
 
 
   // F[miodio_2]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_miodio_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_2_miodio_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_2_miodio_2_busy),
-    .src_qs_o     (wkup_detector_2_miodio_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[2].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_2_we & aon_wkup_detector_2_regwen),
+    .wd     (aon_wkup_detector_2_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[2].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_2_miodio_2_qs_int)
   );
 
 
@@ -12976,68 +13897,80 @@ module pinmux_reg_top (
   // R[wkup_detector_3]: V(False)
 
   // F[mode_3]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_3_mode_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_3_mode_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_3_mode_3_busy),
-    .src_qs_o     (wkup_detector_3_mode_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[3].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_3_we & aon_wkup_detector_3_regwen),
+    .wd     (aon_wkup_detector_3_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[3].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_3_mode_3_qs_int)
   );
 
 
   // F[filter_3]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_filter_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_3_filter_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_3_filter_3_busy),
-    .src_qs_o     (wkup_detector_3_filter_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[3].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_3_we & aon_wkup_detector_3_regwen),
+    .wd     (aon_wkup_detector_3_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[3].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_3_filter_3_qs_int)
   );
 
 
   // F[miodio_3]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_miodio_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_3_miodio_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_3_miodio_3_busy),
-    .src_qs_o     (wkup_detector_3_miodio_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[3].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_3_we & aon_wkup_detector_3_regwen),
+    .wd     (aon_wkup_detector_3_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[3].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_3_miodio_3_qs_int)
   );
 
 
@@ -13045,68 +13978,80 @@ module pinmux_reg_top (
   // R[wkup_detector_4]: V(False)
 
   // F[mode_4]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_4_mode_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_4_mode_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_4_mode_4_busy),
-    .src_qs_o     (wkup_detector_4_mode_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[4].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_4_we & aon_wkup_detector_4_regwen),
+    .wd     (aon_wkup_detector_4_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[4].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_4_mode_4_qs_int)
   );
 
 
   // F[filter_4]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_filter_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_4_filter_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_4_filter_4_busy),
-    .src_qs_o     (wkup_detector_4_filter_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[4].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_4_we & aon_wkup_detector_4_regwen),
+    .wd     (aon_wkup_detector_4_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[4].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_4_filter_4_qs_int)
   );
 
 
   // F[miodio_4]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_miodio_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_4_miodio_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_4_miodio_4_busy),
-    .src_qs_o     (wkup_detector_4_miodio_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[4].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_4_we & aon_wkup_detector_4_regwen),
+    .wd     (aon_wkup_detector_4_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[4].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_4_miodio_4_qs_int)
   );
 
 
@@ -13114,68 +14059,80 @@ module pinmux_reg_top (
   // R[wkup_detector_5]: V(False)
 
   // F[mode_5]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_5_mode_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_5_mode_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_5_mode_5_busy),
-    .src_qs_o     (wkup_detector_5_mode_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[5].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_5_we & aon_wkup_detector_5_regwen),
+    .wd     (aon_wkup_detector_5_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[5].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_5_mode_5_qs_int)
   );
 
 
   // F[filter_5]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_filter_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_5_filter_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_5_filter_5_busy),
-    .src_qs_o     (wkup_detector_5_filter_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[5].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_5_we & aon_wkup_detector_5_regwen),
+    .wd     (aon_wkup_detector_5_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[5].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_5_filter_5_qs_int)
   );
 
 
   // F[miodio_5]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_miodio_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_5_miodio_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_5_miodio_5_busy),
-    .src_qs_o     (wkup_detector_5_miodio_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[5].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_5_we & aon_wkup_detector_5_regwen),
+    .wd     (aon_wkup_detector_5_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[5].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_5_miodio_5_qs_int)
   );
 
 
@@ -13183,68 +14140,80 @@ module pinmux_reg_top (
   // R[wkup_detector_6]: V(False)
 
   // F[mode_6]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_6_mode_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_6_mode_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_6_mode_6_busy),
-    .src_qs_o     (wkup_detector_6_mode_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[6].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_6_we & aon_wkup_detector_6_regwen),
+    .wd     (aon_wkup_detector_6_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[6].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_6_mode_6_qs_int)
   );
 
 
   // F[filter_6]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_filter_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_6_filter_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_6_filter_6_busy),
-    .src_qs_o     (wkup_detector_6_filter_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[6].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_6_we & aon_wkup_detector_6_regwen),
+    .wd     (aon_wkup_detector_6_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[6].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_6_filter_6_qs_int)
   );
 
 
   // F[miodio_6]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_miodio_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_6_miodio_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_6_miodio_6_busy),
-    .src_qs_o     (wkup_detector_6_miodio_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[6].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_6_we & aon_wkup_detector_6_regwen),
+    .wd     (aon_wkup_detector_6_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[6].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_6_miodio_6_qs_int)
   );
 
 
@@ -13252,68 +14221,80 @@ module pinmux_reg_top (
   // R[wkup_detector_7]: V(False)
 
   // F[mode_7]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_7_mode_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_7_mode_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_7_mode_7_busy),
-    .src_qs_o     (wkup_detector_7_mode_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[7].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_7_we & aon_wkup_detector_7_regwen),
+    .wd     (aon_wkup_detector_7_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[7].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_7_mode_7_qs_int)
   );
 
 
   // F[filter_7]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_filter_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_7_filter_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_7_filter_7_busy),
-    .src_qs_o     (wkup_detector_7_filter_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[7].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_7_we & aon_wkup_detector_7_regwen),
+    .wd     (aon_wkup_detector_7_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[7].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_7_filter_7_qs_int)
   );
 
 
   // F[miodio_7]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_miodio_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_7_miodio_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_7_miodio_7_busy),
-    .src_qs_o     (wkup_detector_7_miodio_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[7].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_7_we & aon_wkup_detector_7_regwen),
+    .wd     (aon_wkup_detector_7_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[7].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_7_miodio_7_qs_int)
   );
 
 
@@ -13322,185 +14303,217 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_0]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_cnt_th_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_0_busy),
-    .src_qs_o     (wkup_detector_cnt_th_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_0_we & aon_wkup_detector_cnt_th_0_regwen),
+    .wd     (aon_wkup_detector_cnt_th_0_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[0].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_0_qs_int)
   );
 
   // Subregister 1 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_1]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_cnt_th_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_1_busy),
-    .src_qs_o     (wkup_detector_cnt_th_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_1_we & aon_wkup_detector_cnt_th_1_regwen),
+    .wd     (aon_wkup_detector_cnt_th_1_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[1].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_1_qs_int)
   );
 
   // Subregister 2 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_2]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_cnt_th_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_2_busy),
-    .src_qs_o     (wkup_detector_cnt_th_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_2_we & aon_wkup_detector_cnt_th_2_regwen),
+    .wd     (aon_wkup_detector_cnt_th_2_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[2].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_2_qs_int)
   );
 
   // Subregister 3 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_3]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_cnt_th_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_3_busy),
-    .src_qs_o     (wkup_detector_cnt_th_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_3_we & aon_wkup_detector_cnt_th_3_regwen),
+    .wd     (aon_wkup_detector_cnt_th_3_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[3].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_3_qs_int)
   );
 
   // Subregister 4 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_4]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_cnt_th_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_4_busy),
-    .src_qs_o     (wkup_detector_cnt_th_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[4].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_4_we & aon_wkup_detector_cnt_th_4_regwen),
+    .wd     (aon_wkup_detector_cnt_th_4_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[4].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_4_qs_int)
   );
 
   // Subregister 5 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_5]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_cnt_th_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_5_busy),
-    .src_qs_o     (wkup_detector_cnt_th_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[5].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_5_we & aon_wkup_detector_cnt_th_5_regwen),
+    .wd     (aon_wkup_detector_cnt_th_5_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[5].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_5_qs_int)
   );
 
   // Subregister 6 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_6]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_cnt_th_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_6_busy),
-    .src_qs_o     (wkup_detector_cnt_th_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[6].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_6_we & aon_wkup_detector_cnt_th_6_regwen),
+    .wd     (aon_wkup_detector_cnt_th_6_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[6].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_6_qs_int)
   );
 
   // Subregister 7 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_7]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_cnt_th_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_7_busy),
-    .src_qs_o     (wkup_detector_cnt_th_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[7].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_7_we & aon_wkup_detector_cnt_th_7_regwen),
+    .wd     (aon_wkup_detector_cnt_th_7_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[7].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_7_qs_int)
   );
 
 
@@ -13727,178 +14740,210 @@ module pinmux_reg_top (
   // R[wkup_cause]: V(False)
 
   // F[cause_0]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_0_wd),
-    .dst_de_i     (hw2reg.wkup_cause[0].de),
-    .dst_d_i      (hw2reg.wkup_cause[0].d),
-    .src_busy_o   (wkup_cause_cause_0_busy),
-    .src_qs_o     (wkup_cause_cause_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[0]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[0].de),
+    .d      (hw2reg.wkup_cause[0].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[0].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_0_qs_int)
   );
 
 
   // F[cause_1]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_1_wd),
-    .dst_de_i     (hw2reg.wkup_cause[1].de),
-    .dst_d_i      (hw2reg.wkup_cause[1].d),
-    .src_busy_o   (wkup_cause_cause_1_busy),
-    .src_qs_o     (wkup_cause_cause_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[1]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[1].de),
+    .d      (hw2reg.wkup_cause[1].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[1].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_1_qs_int)
   );
 
 
   // F[cause_2]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_2_wd),
-    .dst_de_i     (hw2reg.wkup_cause[2].de),
-    .dst_d_i      (hw2reg.wkup_cause[2].d),
-    .src_busy_o   (wkup_cause_cause_2_busy),
-    .src_qs_o     (wkup_cause_cause_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[2]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[2].de),
+    .d      (hw2reg.wkup_cause[2].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[2].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_2_qs_int)
   );
 
 
   // F[cause_3]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_3_wd),
-    .dst_de_i     (hw2reg.wkup_cause[3].de),
-    .dst_d_i      (hw2reg.wkup_cause[3].d),
-    .src_busy_o   (wkup_cause_cause_3_busy),
-    .src_qs_o     (wkup_cause_cause_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[3]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[3].de),
+    .d      (hw2reg.wkup_cause[3].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[3].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_3_qs_int)
   );
 
 
   // F[cause_4]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_4_wd),
-    .dst_de_i     (hw2reg.wkup_cause[4].de),
-    .dst_d_i      (hw2reg.wkup_cause[4].d),
-    .src_busy_o   (wkup_cause_cause_4_busy),
-    .src_qs_o     (wkup_cause_cause_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[4].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[4]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[4].de),
+    .d      (hw2reg.wkup_cause[4].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[4].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_4_qs_int)
   );
 
 
   // F[cause_5]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_5_wd),
-    .dst_de_i     (hw2reg.wkup_cause[5].de),
-    .dst_d_i      (hw2reg.wkup_cause[5].d),
-    .src_busy_o   (wkup_cause_cause_5_busy),
-    .src_qs_o     (wkup_cause_cause_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[5].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[5]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[5].de),
+    .d      (hw2reg.wkup_cause[5].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[5].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_5_qs_int)
   );
 
 
   // F[cause_6]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_6_wd),
-    .dst_de_i     (hw2reg.wkup_cause[6].de),
-    .dst_d_i      (hw2reg.wkup_cause[6].d),
-    .src_busy_o   (wkup_cause_cause_6_busy),
-    .src_qs_o     (wkup_cause_cause_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[6].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[6]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[6].de),
+    .d      (hw2reg.wkup_cause[6].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[6].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_6_qs_int)
   );
 
 
   // F[cause_7]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_7_wd),
-    .dst_de_i     (hw2reg.wkup_cause[7].de),
-    .dst_d_i      (hw2reg.wkup_cause[7].d),
-    .src_busy_o   (wkup_cause_cause_7_busy),
-    .src_qs_o     (wkup_cause_cause_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[7].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[7]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[7].de),
+    .d      (hw2reg.wkup_cause[7].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[7].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_7_qs_int)
   );
 
 
@@ -16029,108 +17074,68 @@ module pinmux_reg_top (
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
   assign wkup_detector_en_0_we = addr_hit[381] & reg_we & !reg_error;
 
-  assign wkup_detector_en_0_wd = reg_wdata[0];
   assign wkup_detector_en_1_we = addr_hit[382] & reg_we & !reg_error;
 
-  assign wkup_detector_en_1_wd = reg_wdata[0];
   assign wkup_detector_en_2_we = addr_hit[383] & reg_we & !reg_error;
 
-  assign wkup_detector_en_2_wd = reg_wdata[0];
   assign wkup_detector_en_3_we = addr_hit[384] & reg_we & !reg_error;
 
-  assign wkup_detector_en_3_wd = reg_wdata[0];
   assign wkup_detector_en_4_we = addr_hit[385] & reg_we & !reg_error;
 
-  assign wkup_detector_en_4_wd = reg_wdata[0];
   assign wkup_detector_en_5_we = addr_hit[386] & reg_we & !reg_error;
 
-  assign wkup_detector_en_5_wd = reg_wdata[0];
   assign wkup_detector_en_6_we = addr_hit[387] & reg_we & !reg_error;
 
-  assign wkup_detector_en_6_wd = reg_wdata[0];
   assign wkup_detector_en_7_we = addr_hit[388] & reg_we & !reg_error;
 
-  assign wkup_detector_en_7_wd = reg_wdata[0];
   assign wkup_detector_0_we = addr_hit[389] & reg_we & !reg_error;
 
-  assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
   assign wkup_detector_1_we = addr_hit[390] & reg_we & !reg_error;
 
-  assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
   assign wkup_detector_2_we = addr_hit[391] & reg_we & !reg_error;
 
-  assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
   assign wkup_detector_3_we = addr_hit[392] & reg_we & !reg_error;
 
-  assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
   assign wkup_detector_4_we = addr_hit[393] & reg_we & !reg_error;
 
-  assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
   assign wkup_detector_5_we = addr_hit[394] & reg_we & !reg_error;
 
-  assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
   assign wkup_detector_6_we = addr_hit[395] & reg_we & !reg_error;
 
-  assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
   assign wkup_detector_7_we = addr_hit[396] & reg_we & !reg_error;
 
-  assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
   assign wkup_detector_cnt_th_0_we = addr_hit[397] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_1_we = addr_hit[398] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_2_we = addr_hit[399] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_3_we = addr_hit[400] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_4_we = addr_hit[401] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_5_we = addr_hit[402] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_6_we = addr_hit[403] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_7_we = addr_hit[404] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
   assign wkup_detector_padsel_0_we = addr_hit[405] & reg_we & !reg_error;
 
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
@@ -16157,21 +17162,13 @@ module pinmux_reg_top (
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
   assign wkup_cause_we = addr_hit[413] & reg_we & !reg_error;
 
-  assign wkup_cause_cause_0_wd = reg_wdata[0];
 
-  assign wkup_cause_cause_1_wd = reg_wdata[1];
 
-  assign wkup_cause_cause_2_wd = reg_wdata[2];
 
-  assign wkup_cause_cause_3_wd = reg_wdata[3];
 
-  assign wkup_cause_cause_4_wd = reg_wdata[4];
 
-  assign wkup_cause_cause_5_wd = reg_wdata[5];
 
-  assign wkup_cause_cause_6_wd = reg_wdata[6];
 
-  assign wkup_cause_cause_7_wd = reg_wdata[7];
 
   // Read data return
   always_comb begin
@@ -17748,117 +18745,77 @@ module pinmux_reg_top (
       end
 
       addr_hit[381]: begin
-        reg_rdata_next[0] = wkup_detector_en_0_qs;
+        reg_rdata_next = DW'(wkup_detector_en_0_qs);
       end
-
       addr_hit[382]: begin
-        reg_rdata_next[0] = wkup_detector_en_1_qs;
+        reg_rdata_next = DW'(wkup_detector_en_1_qs);
       end
-
       addr_hit[383]: begin
-        reg_rdata_next[0] = wkup_detector_en_2_qs;
+        reg_rdata_next = DW'(wkup_detector_en_2_qs);
       end
-
       addr_hit[384]: begin
-        reg_rdata_next[0] = wkup_detector_en_3_qs;
+        reg_rdata_next = DW'(wkup_detector_en_3_qs);
       end
-
       addr_hit[385]: begin
-        reg_rdata_next[0] = wkup_detector_en_4_qs;
+        reg_rdata_next = DW'(wkup_detector_en_4_qs);
       end
-
       addr_hit[386]: begin
-        reg_rdata_next[0] = wkup_detector_en_5_qs;
+        reg_rdata_next = DW'(wkup_detector_en_5_qs);
       end
-
       addr_hit[387]: begin
-        reg_rdata_next[0] = wkup_detector_en_6_qs;
+        reg_rdata_next = DW'(wkup_detector_en_6_qs);
       end
-
       addr_hit[388]: begin
-        reg_rdata_next[0] = wkup_detector_en_7_qs;
+        reg_rdata_next = DW'(wkup_detector_en_7_qs);
       end
-
       addr_hit[389]: begin
-        reg_rdata_next[2:0] = wkup_detector_0_mode_0_qs;
-        reg_rdata_next[3] = wkup_detector_0_filter_0_qs;
-        reg_rdata_next[4] = wkup_detector_0_miodio_0_qs;
+        reg_rdata_next = DW'(wkup_detector_0_qs);
       end
-
       addr_hit[390]: begin
-        reg_rdata_next[2:0] = wkup_detector_1_mode_1_qs;
-        reg_rdata_next[3] = wkup_detector_1_filter_1_qs;
-        reg_rdata_next[4] = wkup_detector_1_miodio_1_qs;
+        reg_rdata_next = DW'(wkup_detector_1_qs);
       end
-
       addr_hit[391]: begin
-        reg_rdata_next[2:0] = wkup_detector_2_mode_2_qs;
-        reg_rdata_next[3] = wkup_detector_2_filter_2_qs;
-        reg_rdata_next[4] = wkup_detector_2_miodio_2_qs;
+        reg_rdata_next = DW'(wkup_detector_2_qs);
       end
-
       addr_hit[392]: begin
-        reg_rdata_next[2:0] = wkup_detector_3_mode_3_qs;
-        reg_rdata_next[3] = wkup_detector_3_filter_3_qs;
-        reg_rdata_next[4] = wkup_detector_3_miodio_3_qs;
+        reg_rdata_next = DW'(wkup_detector_3_qs);
       end
-
       addr_hit[393]: begin
-        reg_rdata_next[2:0] = wkup_detector_4_mode_4_qs;
-        reg_rdata_next[3] = wkup_detector_4_filter_4_qs;
-        reg_rdata_next[4] = wkup_detector_4_miodio_4_qs;
+        reg_rdata_next = DW'(wkup_detector_4_qs);
       end
-
       addr_hit[394]: begin
-        reg_rdata_next[2:0] = wkup_detector_5_mode_5_qs;
-        reg_rdata_next[3] = wkup_detector_5_filter_5_qs;
-        reg_rdata_next[4] = wkup_detector_5_miodio_5_qs;
+        reg_rdata_next = DW'(wkup_detector_5_qs);
       end
-
       addr_hit[395]: begin
-        reg_rdata_next[2:0] = wkup_detector_6_mode_6_qs;
-        reg_rdata_next[3] = wkup_detector_6_filter_6_qs;
-        reg_rdata_next[4] = wkup_detector_6_miodio_6_qs;
+        reg_rdata_next = DW'(wkup_detector_6_qs);
       end
-
       addr_hit[396]: begin
-        reg_rdata_next[2:0] = wkup_detector_7_mode_7_qs;
-        reg_rdata_next[3] = wkup_detector_7_filter_7_qs;
-        reg_rdata_next[4] = wkup_detector_7_miodio_7_qs;
+        reg_rdata_next = DW'(wkup_detector_7_qs);
       end
-
       addr_hit[397]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_0_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_0_qs);
       end
-
       addr_hit[398]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_1_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_1_qs);
       end
-
       addr_hit[399]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_2_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_2_qs);
       end
-
       addr_hit[400]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_3_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_3_qs);
       end
-
       addr_hit[401]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_4_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_4_qs);
       end
-
       addr_hit[402]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_5_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_5_qs);
       end
-
       addr_hit[403]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_6_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_6_qs);
       end
-
       addr_hit[404]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_7_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_7_qs);
       end
-
       addr_hit[405]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_0_qs;
       end
@@ -17892,16 +18849,8 @@ module pinmux_reg_top (
       end
 
       addr_hit[413]: begin
-        reg_rdata_next[0] = wkup_cause_cause_0_qs;
-        reg_rdata_next[1] = wkup_cause_cause_1_qs;
-        reg_rdata_next[2] = wkup_cause_cause_2_qs;
-        reg_rdata_next[3] = wkup_cause_cause_3_qs;
-        reg_rdata_next[4] = wkup_cause_cause_4_qs;
-        reg_rdata_next[5] = wkup_cause_cause_5_qs;
-        reg_rdata_next[6] = wkup_cause_cause_6_qs;
-        reg_rdata_next[7] = wkup_cause_cause_7_qs;
+        reg_rdata_next = DW'(wkup_cause_qs);
       end
-
       default: begin
         reg_rdata_next = '1;
       end
@@ -17943,52 +18892,28 @@ module pinmux_reg_top (
         reg_busy_sel = wkup_detector_en_7_busy;
       end
       addr_hit[389]: begin
-        reg_busy_sel =
-          wkup_detector_0_mode_0_busy |
-          wkup_detector_0_filter_0_busy |
-          wkup_detector_0_miodio_0_busy;
+        reg_busy_sel = wkup_detector_0_busy;
       end
       addr_hit[390]: begin
-        reg_busy_sel =
-          wkup_detector_1_mode_1_busy |
-          wkup_detector_1_filter_1_busy |
-          wkup_detector_1_miodio_1_busy;
+        reg_busy_sel = wkup_detector_1_busy;
       end
       addr_hit[391]: begin
-        reg_busy_sel =
-          wkup_detector_2_mode_2_busy |
-          wkup_detector_2_filter_2_busy |
-          wkup_detector_2_miodio_2_busy;
+        reg_busy_sel = wkup_detector_2_busy;
       end
       addr_hit[392]: begin
-        reg_busy_sel =
-          wkup_detector_3_mode_3_busy |
-          wkup_detector_3_filter_3_busy |
-          wkup_detector_3_miodio_3_busy;
+        reg_busy_sel = wkup_detector_3_busy;
       end
       addr_hit[393]: begin
-        reg_busy_sel =
-          wkup_detector_4_mode_4_busy |
-          wkup_detector_4_filter_4_busy |
-          wkup_detector_4_miodio_4_busy;
+        reg_busy_sel = wkup_detector_4_busy;
       end
       addr_hit[394]: begin
-        reg_busy_sel =
-          wkup_detector_5_mode_5_busy |
-          wkup_detector_5_filter_5_busy |
-          wkup_detector_5_miodio_5_busy;
+        reg_busy_sel = wkup_detector_5_busy;
       end
       addr_hit[395]: begin
-        reg_busy_sel =
-          wkup_detector_6_mode_6_busy |
-          wkup_detector_6_filter_6_busy |
-          wkup_detector_6_miodio_6_busy;
+        reg_busy_sel = wkup_detector_6_busy;
       end
       addr_hit[396]: begin
-        reg_busy_sel =
-          wkup_detector_7_mode_7_busy |
-          wkup_detector_7_filter_7_busy |
-          wkup_detector_7_miodio_7_busy;
+        reg_busy_sel = wkup_detector_7_busy;
       end
       addr_hit[397]: begin
         reg_busy_sel = wkup_detector_cnt_th_0_busy;
@@ -18015,22 +18940,13 @@ module pinmux_reg_top (
         reg_busy_sel = wkup_detector_cnt_th_7_busy;
       end
       addr_hit[413]: begin
-        reg_busy_sel =
-          wkup_cause_cause_0_busy |
-          wkup_cause_cause_1_busy |
-          wkup_cause_cause_2_busy |
-          wkup_cause_cause_3_busy |
-          wkup_cause_cause_4_busy |
-          wkup_cause_cause_5_busy |
-          wkup_cause_cause_6_busy |
-          wkup_cause_cause_7_busy;
+        reg_busy_sel = wkup_cause_busy;
       end
       default: begin
         reg_busy_sel  = '0;
       end
     endcase
   end
-
 
 
   // Unused signal tieoff

--- a/hw/ip/prim/prim_subreg.core
+++ b/hw/ip/prim/prim_subreg.core
@@ -11,6 +11,7 @@ filesets:
       - rtl/prim_subreg_pkg.sv
       - rtl/prim_subreg_arb.sv
       - rtl/prim_subreg_cdc.sv
+      - rtl/prim_reg_cdc.sv
       - rtl/prim_subreg.sv
       - rtl/prim_subreg_async.sv
       - rtl/prim_subreg_ext.sv

--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Component handling register CDC
+
+`include "prim_assert.sv"
+
+module prim_reg_cdc #(
+  parameter int DataWidth = 32,
+  parameter logic [DataWidth-1:0] ResetVal = 32'h0,
+  parameter logic [DataWidth-1:0] BitMask = 32'hFFFFFFFF
+) (
+  input clk_src_i,
+  input rst_src_ni,
+  input clk_dst_i,
+  input rst_dst_ni,
+
+  input src_update_i,
+  input src_regwen_i,
+  input src_we_i,
+  input src_re_i,
+  input [DataWidth-1:0] src_wd_i,
+  output logic src_busy_o,
+  output logic [DataWidth-1:0] src_qs_o,
+  input  [DataWidth-1:0] dst_d_i,
+  output logic dst_we_o,
+  output logic dst_re_o,
+  output logic dst_regwen_o,
+  output logic [DataWidth-1:0] dst_wd_o
+);
+
+  ////////////////////////////
+  // Source domain
+  ////////////////////////////
+  localparam int TxnWidth = 3;
+
+  logic src_ack;
+  logic src_busy_q;
+  logic [DataWidth-1:0] src_q;
+  logic [TxnWidth-1:0] txn_bits_q;
+  logic src_req;
+
+  assign src_req = src_we_i | src_re_i;
+
+  // busy indication back-pressures upstream if the register is accessed
+  // again.  The busy indication is also used as a "commit" indication for
+  // resolving software and hardware write conflicts
+  always_ff @(posedge clk_src_i or negedge rst_src_ni) begin
+    if (!rst_src_ni) begin
+      src_busy_q <= '0;
+    end else if (src_req) begin
+      src_busy_q <= 1'b1;
+    end else if (src_busy_q && src_ack) begin
+      src_busy_q <= 1'b0;
+    end
+  end
+
+  assign src_busy_o = src_busy_q;
+
+  // src_q acts as both the write holding register and the software read back
+  // register.
+  // When software performs a write, the write data is captured in src_q for
+  // CDC purposes.  When not performing a write, the src_q periodically
+  // samples the destination domain using the src_update_i indication.
+  //
+  // To resolve software and hardware conflicts, the process is as follows:
+  // When software issues a write, this module asserts "busy".  While busy,
+  // src_q does not sample the destination value.  Since the
+  // logic has committed to updating based on software command, there is an irreversible
+  // window from which hardware writes are ignored.  Once the busy window completes,
+  // the cdc portion then begins sampling once more.
+  //
+  // This is consistent with prim_subreg_arb where during software / hardware conflicts,
+  // software is always prioritized.  The main difference is the conflict resolution window
+  // is now larger instead of just one destination clock cycle.
+
+  logic busy;
+  assign busy = src_busy_q & !src_ack;
+
+  always_ff @(posedge clk_src_i or negedge rst_src_ni) begin
+    if (!rst_src_ni) begin
+      src_q <= ResetVal;
+      txn_bits_q <= '0;
+    end else if (src_req && !busy) begin
+      src_q <= src_wd_i & BitMask;
+      txn_bits_q <= {src_we_i, src_re_i, src_regwen_i};
+    end else if (src_busy_q && src_ack || src_update_i && !busy) begin
+      // sample data whenever a busy transaction finishes OR
+      // when an update pulse is seen.
+      // TODO: We should add a cover group to test different sync timings
+      // between src_ack and src_update. Ie, there can be 3 scearios:
+      // 1. update one cycle before ack
+      // 2. ack one cycle before update
+      // 3. update / ack on the same cycle
+      // During all 3 cases the read data should be correct
+      src_q <= dst_d_i;
+      txn_bits_q <= '0;
+    end
+  end
+
+  // reserved bits are not used
+  logic unused_wd;
+  assign unused_wd = ^src_wd_i;
+
+  // src_q is always updated in the clk_src domain.
+  // when performing an update to the destination domain, it is guaranteed
+  // to not change by protocol.
+  assign src_qs_o = src_q;
+  assign dst_wd_o = src_q;
+
+  ////////////////////////////
+  // CDC handling
+  ////////////////////////////
+  logic dst_req;
+  prim_sync_reqack u_prim_sync (
+    .clk_src_i,
+    .rst_src_ni,
+    .clk_dst_i,
+    .rst_dst_ni,
+    .req_chk_i(1'b0),
+    // prim_sync_reqack does not natively handle single
+    // pulse requests, so use src_busy to even it out.
+    .src_req_i(src_req | src_busy_q),
+    .src_ack_o(src_ack),
+    .dst_req_o(dst_req),
+    // immediately ack on destination once request is seen
+    .dst_ack_i(dst_req)
+  );
+
+  // Each is valid only when destination request pulse is high
+  assign {dst_we_o, dst_re_o, dst_regwen_o} = txn_bits_q & {TxnWidth{dst_req}};
+
+  `ASSERT_KNOWN(SrcBusyKnown_A, src_busy_o, clk_src_i, !rst_src_ni)
+  `ASSERT_KNOWN(DstReqKnown_A, dst_req, clk_dst_i, !rst_dst_ni)
+
+  // If busy goes high, we must eventually see an ack
+  `ASSERT(HungHandShake_A, $rose(src_busy_o) |-> strong(##[0:$] src_ack), clk_src_i, !rst_src_ni)
+
+  `ifdef SIMULATION
+    logic async_flag;
+    always_ff @(posedge src_req or posedge dst_req or
+      negedge rst_src_ni or negedge rst_dst_ni) begin
+      if (!rst_src_ni && !rst_dst_ni) begin
+        async_flag <= '0;
+      end else if (src_req) begin
+        async_flag <= 1'b1;
+      end else if (dst_req) begin
+        async_flag <= 1'b0;
+      end
+    end
+    `ASSERT(ReqTimeout_A, $rose(async_flag) |-> strong(##[0:3] dst_req), clk_dst_i, !rst_dst_ni)
+  `endif
+
+
+endmodule // prim_subreg_cdc

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -2202,7 +2202,6 @@ module pwm_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -857,7 +857,6 @@ module pwrmgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -789,7 +789,6 @@ module rom_ctrl_regs_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -533,7 +533,6 @@ module rstmgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -1311,7 +1311,6 @@ module rv_core_ibex_cfg_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -177,7 +177,6 @@ module rv_dm_regs_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -4448,7 +4448,6 @@ module rv_plic_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -557,7 +557,6 @@ module rv_timer_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -18309,7 +18309,6 @@ module spi_device_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -1843,7 +1843,6 @@ module spi_host_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -539,7 +539,6 @@ module sram_ctrl_regs_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -134,168 +134,37 @@ module sysrst_ctrl_reg_top (
   logic regwen_wd;
   logic ec_rst_ctl_we;
   logic [15:0] ec_rst_ctl_qs;
-  logic [15:0] ec_rst_ctl_wd;
   logic ec_rst_ctl_busy;
   logic ulp_ac_debounce_ctl_we;
   logic [15:0] ulp_ac_debounce_ctl_qs;
-  logic [15:0] ulp_ac_debounce_ctl_wd;
   logic ulp_ac_debounce_ctl_busy;
   logic ulp_lid_debounce_ctl_we;
   logic [15:0] ulp_lid_debounce_ctl_qs;
-  logic [15:0] ulp_lid_debounce_ctl_wd;
   logic ulp_lid_debounce_ctl_busy;
   logic ulp_pwrb_debounce_ctl_we;
   logic [15:0] ulp_pwrb_debounce_ctl_qs;
-  logic [15:0] ulp_pwrb_debounce_ctl_wd;
   logic ulp_pwrb_debounce_ctl_busy;
   logic ulp_ctl_we;
-  logic ulp_ctl_qs;
-  logic ulp_ctl_wd;
+  logic [0:0] ulp_ctl_qs;
   logic ulp_ctl_busy;
   logic ulp_status_we;
-  logic ulp_status_qs;
-  logic ulp_status_wd;
+  logic [0:0] ulp_status_qs;
   logic ulp_status_busy;
   logic wkup_status_we;
-  logic wkup_status_qs;
-  logic wkup_status_wd;
+  logic [0:0] wkup_status_qs;
   logic wkup_status_busy;
   logic key_invert_ctl_we;
-  logic key_invert_ctl_key0_in_qs;
-  logic key_invert_ctl_key0_in_wd;
-  logic key_invert_ctl_key0_in_busy;
-  logic key_invert_ctl_key0_out_qs;
-  logic key_invert_ctl_key0_out_wd;
-  logic key_invert_ctl_key0_out_busy;
-  logic key_invert_ctl_key1_in_qs;
-  logic key_invert_ctl_key1_in_wd;
-  logic key_invert_ctl_key1_in_busy;
-  logic key_invert_ctl_key1_out_qs;
-  logic key_invert_ctl_key1_out_wd;
-  logic key_invert_ctl_key1_out_busy;
-  logic key_invert_ctl_key2_in_qs;
-  logic key_invert_ctl_key2_in_wd;
-  logic key_invert_ctl_key2_in_busy;
-  logic key_invert_ctl_key2_out_qs;
-  logic key_invert_ctl_key2_out_wd;
-  logic key_invert_ctl_key2_out_busy;
-  logic key_invert_ctl_pwrb_in_qs;
-  logic key_invert_ctl_pwrb_in_wd;
-  logic key_invert_ctl_pwrb_in_busy;
-  logic key_invert_ctl_pwrb_out_qs;
-  logic key_invert_ctl_pwrb_out_wd;
-  logic key_invert_ctl_pwrb_out_busy;
-  logic key_invert_ctl_ac_present_qs;
-  logic key_invert_ctl_ac_present_wd;
-  logic key_invert_ctl_ac_present_busy;
-  logic key_invert_ctl_bat_disable_qs;
-  logic key_invert_ctl_bat_disable_wd;
-  logic key_invert_ctl_bat_disable_busy;
-  logic key_invert_ctl_lid_open_qs;
-  logic key_invert_ctl_lid_open_wd;
-  logic key_invert_ctl_lid_open_busy;
-  logic key_invert_ctl_z3_wakeup_qs;
-  logic key_invert_ctl_z3_wakeup_wd;
-  logic key_invert_ctl_z3_wakeup_busy;
+  logic [11:0] key_invert_ctl_qs;
+  logic key_invert_ctl_busy;
   logic pin_allowed_ctl_we;
-  logic pin_allowed_ctl_bat_disable_0_qs;
-  logic pin_allowed_ctl_bat_disable_0_wd;
-  logic pin_allowed_ctl_bat_disable_0_busy;
-  logic pin_allowed_ctl_ec_rst_l_0_qs;
-  logic pin_allowed_ctl_ec_rst_l_0_wd;
-  logic pin_allowed_ctl_ec_rst_l_0_busy;
-  logic pin_allowed_ctl_pwrb_out_0_qs;
-  logic pin_allowed_ctl_pwrb_out_0_wd;
-  logic pin_allowed_ctl_pwrb_out_0_busy;
-  logic pin_allowed_ctl_key0_out_0_qs;
-  logic pin_allowed_ctl_key0_out_0_wd;
-  logic pin_allowed_ctl_key0_out_0_busy;
-  logic pin_allowed_ctl_key1_out_0_qs;
-  logic pin_allowed_ctl_key1_out_0_wd;
-  logic pin_allowed_ctl_key1_out_0_busy;
-  logic pin_allowed_ctl_key2_out_0_qs;
-  logic pin_allowed_ctl_key2_out_0_wd;
-  logic pin_allowed_ctl_key2_out_0_busy;
-  logic pin_allowed_ctl_z3_wakeup_0_qs;
-  logic pin_allowed_ctl_z3_wakeup_0_wd;
-  logic pin_allowed_ctl_z3_wakeup_0_busy;
-  logic pin_allowed_ctl_flash_wp_l_0_qs;
-  logic pin_allowed_ctl_flash_wp_l_0_wd;
-  logic pin_allowed_ctl_flash_wp_l_0_busy;
-  logic pin_allowed_ctl_bat_disable_1_qs;
-  logic pin_allowed_ctl_bat_disable_1_wd;
-  logic pin_allowed_ctl_bat_disable_1_busy;
-  logic pin_allowed_ctl_ec_rst_l_1_qs;
-  logic pin_allowed_ctl_ec_rst_l_1_wd;
-  logic pin_allowed_ctl_ec_rst_l_1_busy;
-  logic pin_allowed_ctl_pwrb_out_1_qs;
-  logic pin_allowed_ctl_pwrb_out_1_wd;
-  logic pin_allowed_ctl_pwrb_out_1_busy;
-  logic pin_allowed_ctl_key0_out_1_qs;
-  logic pin_allowed_ctl_key0_out_1_wd;
-  logic pin_allowed_ctl_key0_out_1_busy;
-  logic pin_allowed_ctl_key1_out_1_qs;
-  logic pin_allowed_ctl_key1_out_1_wd;
-  logic pin_allowed_ctl_key1_out_1_busy;
-  logic pin_allowed_ctl_key2_out_1_qs;
-  logic pin_allowed_ctl_key2_out_1_wd;
-  logic pin_allowed_ctl_key2_out_1_busy;
-  logic pin_allowed_ctl_z3_wakeup_1_qs;
-  logic pin_allowed_ctl_z3_wakeup_1_wd;
-  logic pin_allowed_ctl_z3_wakeup_1_busy;
-  logic pin_allowed_ctl_flash_wp_l_1_qs;
-  logic pin_allowed_ctl_flash_wp_l_1_wd;
-  logic pin_allowed_ctl_flash_wp_l_1_busy;
+  logic [15:0] pin_allowed_ctl_qs;
+  logic pin_allowed_ctl_busy;
   logic pin_out_ctl_we;
-  logic pin_out_ctl_bat_disable_qs;
-  logic pin_out_ctl_bat_disable_wd;
-  logic pin_out_ctl_bat_disable_busy;
-  logic pin_out_ctl_ec_rst_l_qs;
-  logic pin_out_ctl_ec_rst_l_wd;
-  logic pin_out_ctl_ec_rst_l_busy;
-  logic pin_out_ctl_pwrb_out_qs;
-  logic pin_out_ctl_pwrb_out_wd;
-  logic pin_out_ctl_pwrb_out_busy;
-  logic pin_out_ctl_key0_out_qs;
-  logic pin_out_ctl_key0_out_wd;
-  logic pin_out_ctl_key0_out_busy;
-  logic pin_out_ctl_key1_out_qs;
-  logic pin_out_ctl_key1_out_wd;
-  logic pin_out_ctl_key1_out_busy;
-  logic pin_out_ctl_key2_out_qs;
-  logic pin_out_ctl_key2_out_wd;
-  logic pin_out_ctl_key2_out_busy;
-  logic pin_out_ctl_z3_wakeup_qs;
-  logic pin_out_ctl_z3_wakeup_wd;
-  logic pin_out_ctl_z3_wakeup_busy;
-  logic pin_out_ctl_flash_wp_l_qs;
-  logic pin_out_ctl_flash_wp_l_wd;
-  logic pin_out_ctl_flash_wp_l_busy;
+  logic [7:0] pin_out_ctl_qs;
+  logic pin_out_ctl_busy;
   logic pin_out_value_we;
-  logic pin_out_value_bat_disable_qs;
-  logic pin_out_value_bat_disable_wd;
-  logic pin_out_value_bat_disable_busy;
-  logic pin_out_value_ec_rst_l_qs;
-  logic pin_out_value_ec_rst_l_wd;
-  logic pin_out_value_ec_rst_l_busy;
-  logic pin_out_value_pwrb_out_qs;
-  logic pin_out_value_pwrb_out_wd;
-  logic pin_out_value_pwrb_out_busy;
-  logic pin_out_value_key0_out_qs;
-  logic pin_out_value_key0_out_wd;
-  logic pin_out_value_key0_out_busy;
-  logic pin_out_value_key1_out_qs;
-  logic pin_out_value_key1_out_wd;
-  logic pin_out_value_key1_out_busy;
-  logic pin_out_value_key2_out_qs;
-  logic pin_out_value_key2_out_wd;
-  logic pin_out_value_key2_out_busy;
-  logic pin_out_value_z3_wakeup_qs;
-  logic pin_out_value_z3_wakeup_wd;
-  logic pin_out_value_z3_wakeup_busy;
-  logic pin_out_value_flash_wp_l_qs;
-  logic pin_out_value_flash_wp_l_wd;
-  logic pin_out_value_flash_wp_l_busy;
+  logic [7:0] pin_out_value_qs;
+  logic pin_out_value_busy;
   logic pin_in_value_ac_present_qs;
   logic pin_in_value_ec_rst_l_qs;
   logic pin_in_value_pwrb_in_qs;
@@ -304,254 +173,1296 @@ module sysrst_ctrl_reg_top (
   logic pin_in_value_key2_in_qs;
   logic pin_in_value_lid_open_qs;
   logic key_intr_ctl_we;
-  logic key_intr_ctl_pwrb_in_h2l_qs;
-  logic key_intr_ctl_pwrb_in_h2l_wd;
-  logic key_intr_ctl_pwrb_in_h2l_busy;
-  logic key_intr_ctl_key0_in_h2l_qs;
-  logic key_intr_ctl_key0_in_h2l_wd;
-  logic key_intr_ctl_key0_in_h2l_busy;
-  logic key_intr_ctl_key1_in_h2l_qs;
-  logic key_intr_ctl_key1_in_h2l_wd;
-  logic key_intr_ctl_key1_in_h2l_busy;
-  logic key_intr_ctl_key2_in_h2l_qs;
-  logic key_intr_ctl_key2_in_h2l_wd;
-  logic key_intr_ctl_key2_in_h2l_busy;
-  logic key_intr_ctl_ac_present_h2l_qs;
-  logic key_intr_ctl_ac_present_h2l_wd;
-  logic key_intr_ctl_ac_present_h2l_busy;
-  logic key_intr_ctl_ec_rst_l_h2l_qs;
-  logic key_intr_ctl_ec_rst_l_h2l_wd;
-  logic key_intr_ctl_ec_rst_l_h2l_busy;
-  logic key_intr_ctl_pwrb_in_l2h_qs;
-  logic key_intr_ctl_pwrb_in_l2h_wd;
-  logic key_intr_ctl_pwrb_in_l2h_busy;
-  logic key_intr_ctl_key0_in_l2h_qs;
-  logic key_intr_ctl_key0_in_l2h_wd;
-  logic key_intr_ctl_key0_in_l2h_busy;
-  logic key_intr_ctl_key1_in_l2h_qs;
-  logic key_intr_ctl_key1_in_l2h_wd;
-  logic key_intr_ctl_key1_in_l2h_busy;
-  logic key_intr_ctl_key2_in_l2h_qs;
-  logic key_intr_ctl_key2_in_l2h_wd;
-  logic key_intr_ctl_key2_in_l2h_busy;
-  logic key_intr_ctl_ac_present_l2h_qs;
-  logic key_intr_ctl_ac_present_l2h_wd;
-  logic key_intr_ctl_ac_present_l2h_busy;
-  logic key_intr_ctl_ec_rst_l_l2h_qs;
-  logic key_intr_ctl_ec_rst_l_l2h_wd;
-  logic key_intr_ctl_ec_rst_l_l2h_busy;
+  logic [13:0] key_intr_ctl_qs;
+  logic key_intr_ctl_busy;
   logic key_intr_debounce_ctl_we;
   logic [15:0] key_intr_debounce_ctl_qs;
-  logic [15:0] key_intr_debounce_ctl_wd;
   logic key_intr_debounce_ctl_busy;
   logic auto_block_debounce_ctl_we;
-  logic [15:0] auto_block_debounce_ctl_debounce_timer_qs;
-  logic [15:0] auto_block_debounce_ctl_debounce_timer_wd;
-  logic auto_block_debounce_ctl_debounce_timer_busy;
-  logic auto_block_debounce_ctl_auto_block_enable_qs;
-  logic auto_block_debounce_ctl_auto_block_enable_wd;
-  logic auto_block_debounce_ctl_auto_block_enable_busy;
+  logic [16:0] auto_block_debounce_ctl_qs;
+  logic auto_block_debounce_ctl_busy;
   logic auto_block_out_ctl_we;
-  logic auto_block_out_ctl_key0_out_sel_qs;
-  logic auto_block_out_ctl_key0_out_sel_wd;
-  logic auto_block_out_ctl_key0_out_sel_busy;
-  logic auto_block_out_ctl_key1_out_sel_qs;
-  logic auto_block_out_ctl_key1_out_sel_wd;
-  logic auto_block_out_ctl_key1_out_sel_busy;
-  logic auto_block_out_ctl_key2_out_sel_qs;
-  logic auto_block_out_ctl_key2_out_sel_wd;
-  logic auto_block_out_ctl_key2_out_sel_busy;
-  logic auto_block_out_ctl_key0_out_value_qs;
-  logic auto_block_out_ctl_key0_out_value_wd;
-  logic auto_block_out_ctl_key0_out_value_busy;
-  logic auto_block_out_ctl_key1_out_value_qs;
-  logic auto_block_out_ctl_key1_out_value_wd;
-  logic auto_block_out_ctl_key1_out_value_busy;
-  logic auto_block_out_ctl_key2_out_value_qs;
-  logic auto_block_out_ctl_key2_out_value_wd;
-  logic auto_block_out_ctl_key2_out_value_busy;
+  logic [6:0] auto_block_out_ctl_qs;
+  logic auto_block_out_ctl_busy;
   logic com_sel_ctl_0_we;
-  logic com_sel_ctl_0_key0_in_sel_0_qs;
-  logic com_sel_ctl_0_key0_in_sel_0_wd;
-  logic com_sel_ctl_0_key0_in_sel_0_busy;
-  logic com_sel_ctl_0_key1_in_sel_0_qs;
-  logic com_sel_ctl_0_key1_in_sel_0_wd;
-  logic com_sel_ctl_0_key1_in_sel_0_busy;
-  logic com_sel_ctl_0_key2_in_sel_0_qs;
-  logic com_sel_ctl_0_key2_in_sel_0_wd;
-  logic com_sel_ctl_0_key2_in_sel_0_busy;
-  logic com_sel_ctl_0_pwrb_in_sel_0_qs;
-  logic com_sel_ctl_0_pwrb_in_sel_0_wd;
-  logic com_sel_ctl_0_pwrb_in_sel_0_busy;
-  logic com_sel_ctl_0_ac_present_sel_0_qs;
-  logic com_sel_ctl_0_ac_present_sel_0_wd;
-  logic com_sel_ctl_0_ac_present_sel_0_busy;
+  logic [4:0] com_sel_ctl_0_qs;
+  logic com_sel_ctl_0_busy;
   logic com_sel_ctl_1_we;
-  logic com_sel_ctl_1_key0_in_sel_1_qs;
-  logic com_sel_ctl_1_key0_in_sel_1_wd;
-  logic com_sel_ctl_1_key0_in_sel_1_busy;
-  logic com_sel_ctl_1_key1_in_sel_1_qs;
-  logic com_sel_ctl_1_key1_in_sel_1_wd;
-  logic com_sel_ctl_1_key1_in_sel_1_busy;
-  logic com_sel_ctl_1_key2_in_sel_1_qs;
-  logic com_sel_ctl_1_key2_in_sel_1_wd;
-  logic com_sel_ctl_1_key2_in_sel_1_busy;
-  logic com_sel_ctl_1_pwrb_in_sel_1_qs;
-  logic com_sel_ctl_1_pwrb_in_sel_1_wd;
-  logic com_sel_ctl_1_pwrb_in_sel_1_busy;
-  logic com_sel_ctl_1_ac_present_sel_1_qs;
-  logic com_sel_ctl_1_ac_present_sel_1_wd;
-  logic com_sel_ctl_1_ac_present_sel_1_busy;
+  logic [4:0] com_sel_ctl_1_qs;
+  logic com_sel_ctl_1_busy;
   logic com_sel_ctl_2_we;
-  logic com_sel_ctl_2_key0_in_sel_2_qs;
-  logic com_sel_ctl_2_key0_in_sel_2_wd;
-  logic com_sel_ctl_2_key0_in_sel_2_busy;
-  logic com_sel_ctl_2_key1_in_sel_2_qs;
-  logic com_sel_ctl_2_key1_in_sel_2_wd;
-  logic com_sel_ctl_2_key1_in_sel_2_busy;
-  logic com_sel_ctl_2_key2_in_sel_2_qs;
-  logic com_sel_ctl_2_key2_in_sel_2_wd;
-  logic com_sel_ctl_2_key2_in_sel_2_busy;
-  logic com_sel_ctl_2_pwrb_in_sel_2_qs;
-  logic com_sel_ctl_2_pwrb_in_sel_2_wd;
-  logic com_sel_ctl_2_pwrb_in_sel_2_busy;
-  logic com_sel_ctl_2_ac_present_sel_2_qs;
-  logic com_sel_ctl_2_ac_present_sel_2_wd;
-  logic com_sel_ctl_2_ac_present_sel_2_busy;
+  logic [4:0] com_sel_ctl_2_qs;
+  logic com_sel_ctl_2_busy;
   logic com_sel_ctl_3_we;
-  logic com_sel_ctl_3_key0_in_sel_3_qs;
-  logic com_sel_ctl_3_key0_in_sel_3_wd;
-  logic com_sel_ctl_3_key0_in_sel_3_busy;
-  logic com_sel_ctl_3_key1_in_sel_3_qs;
-  logic com_sel_ctl_3_key1_in_sel_3_wd;
-  logic com_sel_ctl_3_key1_in_sel_3_busy;
-  logic com_sel_ctl_3_key2_in_sel_3_qs;
-  logic com_sel_ctl_3_key2_in_sel_3_wd;
-  logic com_sel_ctl_3_key2_in_sel_3_busy;
-  logic com_sel_ctl_3_pwrb_in_sel_3_qs;
-  logic com_sel_ctl_3_pwrb_in_sel_3_wd;
-  logic com_sel_ctl_3_pwrb_in_sel_3_busy;
-  logic com_sel_ctl_3_ac_present_sel_3_qs;
-  logic com_sel_ctl_3_ac_present_sel_3_wd;
-  logic com_sel_ctl_3_ac_present_sel_3_busy;
+  logic [4:0] com_sel_ctl_3_qs;
+  logic com_sel_ctl_3_busy;
   logic com_det_ctl_0_we;
   logic [31:0] com_det_ctl_0_qs;
-  logic [31:0] com_det_ctl_0_wd;
   logic com_det_ctl_0_busy;
   logic com_det_ctl_1_we;
   logic [31:0] com_det_ctl_1_qs;
-  logic [31:0] com_det_ctl_1_wd;
   logic com_det_ctl_1_busy;
   logic com_det_ctl_2_we;
   logic [31:0] com_det_ctl_2_qs;
-  logic [31:0] com_det_ctl_2_wd;
   logic com_det_ctl_2_busy;
   logic com_det_ctl_3_we;
   logic [31:0] com_det_ctl_3_qs;
-  logic [31:0] com_det_ctl_3_wd;
   logic com_det_ctl_3_busy;
   logic com_out_ctl_0_we;
-  logic com_out_ctl_0_bat_disable_0_qs;
-  logic com_out_ctl_0_bat_disable_0_wd;
-  logic com_out_ctl_0_bat_disable_0_busy;
-  logic com_out_ctl_0_interrupt_0_qs;
-  logic com_out_ctl_0_interrupt_0_wd;
-  logic com_out_ctl_0_interrupt_0_busy;
-  logic com_out_ctl_0_ec_rst_0_qs;
-  logic com_out_ctl_0_ec_rst_0_wd;
-  logic com_out_ctl_0_ec_rst_0_busy;
-  logic com_out_ctl_0_rst_req_0_qs;
-  logic com_out_ctl_0_rst_req_0_wd;
-  logic com_out_ctl_0_rst_req_0_busy;
+  logic [3:0] com_out_ctl_0_qs;
+  logic com_out_ctl_0_busy;
   logic com_out_ctl_1_we;
-  logic com_out_ctl_1_bat_disable_1_qs;
-  logic com_out_ctl_1_bat_disable_1_wd;
-  logic com_out_ctl_1_bat_disable_1_busy;
-  logic com_out_ctl_1_interrupt_1_qs;
-  logic com_out_ctl_1_interrupt_1_wd;
-  logic com_out_ctl_1_interrupt_1_busy;
-  logic com_out_ctl_1_ec_rst_1_qs;
-  logic com_out_ctl_1_ec_rst_1_wd;
-  logic com_out_ctl_1_ec_rst_1_busy;
-  logic com_out_ctl_1_rst_req_1_qs;
-  logic com_out_ctl_1_rst_req_1_wd;
-  logic com_out_ctl_1_rst_req_1_busy;
+  logic [3:0] com_out_ctl_1_qs;
+  logic com_out_ctl_1_busy;
   logic com_out_ctl_2_we;
-  logic com_out_ctl_2_bat_disable_2_qs;
-  logic com_out_ctl_2_bat_disable_2_wd;
-  logic com_out_ctl_2_bat_disable_2_busy;
-  logic com_out_ctl_2_interrupt_2_qs;
-  logic com_out_ctl_2_interrupt_2_wd;
-  logic com_out_ctl_2_interrupt_2_busy;
-  logic com_out_ctl_2_ec_rst_2_qs;
-  logic com_out_ctl_2_ec_rst_2_wd;
-  logic com_out_ctl_2_ec_rst_2_busy;
-  logic com_out_ctl_2_rst_req_2_qs;
-  logic com_out_ctl_2_rst_req_2_wd;
-  logic com_out_ctl_2_rst_req_2_busy;
+  logic [3:0] com_out_ctl_2_qs;
+  logic com_out_ctl_2_busy;
   logic com_out_ctl_3_we;
-  logic com_out_ctl_3_bat_disable_3_qs;
-  logic com_out_ctl_3_bat_disable_3_wd;
-  logic com_out_ctl_3_bat_disable_3_busy;
-  logic com_out_ctl_3_interrupt_3_qs;
-  logic com_out_ctl_3_interrupt_3_wd;
-  logic com_out_ctl_3_interrupt_3_busy;
-  logic com_out_ctl_3_ec_rst_3_qs;
-  logic com_out_ctl_3_ec_rst_3_wd;
-  logic com_out_ctl_3_ec_rst_3_busy;
-  logic com_out_ctl_3_rst_req_3_qs;
-  logic com_out_ctl_3_rst_req_3_wd;
-  logic com_out_ctl_3_rst_req_3_busy;
+  logic [3:0] com_out_ctl_3_qs;
+  logic com_out_ctl_3_busy;
   logic combo_intr_status_we;
-  logic combo_intr_status_combo0_h2l_qs;
-  logic combo_intr_status_combo0_h2l_wd;
-  logic combo_intr_status_combo0_h2l_busy;
-  logic combo_intr_status_combo1_h2l_qs;
-  logic combo_intr_status_combo1_h2l_wd;
-  logic combo_intr_status_combo1_h2l_busy;
-  logic combo_intr_status_combo2_h2l_qs;
-  logic combo_intr_status_combo2_h2l_wd;
-  logic combo_intr_status_combo2_h2l_busy;
-  logic combo_intr_status_combo3_h2l_qs;
-  logic combo_intr_status_combo3_h2l_wd;
-  logic combo_intr_status_combo3_h2l_busy;
+  logic [3:0] combo_intr_status_qs;
+  logic combo_intr_status_busy;
   logic key_intr_status_we;
-  logic key_intr_status_pwrb_h2l_qs;
-  logic key_intr_status_pwrb_h2l_wd;
-  logic key_intr_status_pwrb_h2l_busy;
-  logic key_intr_status_key0_in_h2l_qs;
-  logic key_intr_status_key0_in_h2l_wd;
-  logic key_intr_status_key0_in_h2l_busy;
-  logic key_intr_status_key1_in_h2l_qs;
-  logic key_intr_status_key1_in_h2l_wd;
-  logic key_intr_status_key1_in_h2l_busy;
-  logic key_intr_status_key2_in_h2l_qs;
-  logic key_intr_status_key2_in_h2l_wd;
-  logic key_intr_status_key2_in_h2l_busy;
-  logic key_intr_status_ac_present_h2l_qs;
-  logic key_intr_status_ac_present_h2l_wd;
-  logic key_intr_status_ac_present_h2l_busy;
-  logic key_intr_status_ec_rst_l_h2l_qs;
-  logic key_intr_status_ec_rst_l_h2l_wd;
-  logic key_intr_status_ec_rst_l_h2l_busy;
-  logic key_intr_status_pwrb_l2h_qs;
-  logic key_intr_status_pwrb_l2h_wd;
-  logic key_intr_status_pwrb_l2h_busy;
-  logic key_intr_status_key0_in_l2h_qs;
-  logic key_intr_status_key0_in_l2h_wd;
-  logic key_intr_status_key0_in_l2h_busy;
-  logic key_intr_status_key1_in_l2h_qs;
-  logic key_intr_status_key1_in_l2h_wd;
-  logic key_intr_status_key1_in_l2h_busy;
-  logic key_intr_status_key2_in_l2h_qs;
-  logic key_intr_status_key2_in_l2h_wd;
-  logic key_intr_status_key2_in_l2h_busy;
-  logic key_intr_status_ac_present_l2h_qs;
-  logic key_intr_status_ac_present_l2h_wd;
-  logic key_intr_status_ac_present_l2h_busy;
-  logic key_intr_status_ec_rst_l_l2h_qs;
-  logic key_intr_status_ec_rst_l_l2h_wd;
-  logic key_intr_status_ec_rst_l_l2h_busy;
+  logic [11:0] key_intr_status_qs;
+  logic key_intr_status_busy;
+  // Define register CDC handling.
+  // CDC handling is done on a per-reg instead of per-field boundary.
+
+  logic [15:0]  aon_ec_rst_ctl_qs_int;
+  logic [15:0] aon_ec_rst_ctl_d;
+  logic [15:0] aon_ec_rst_ctl_wdata;
+  logic aon_ec_rst_ctl_we;
+  logic unused_aon_ec_rst_ctl_wdata;
+  logic aon_ec_rst_ctl_regwen;
+
+  always_comb begin
+    aon_ec_rst_ctl_d = '0;
+    aon_ec_rst_ctl_d = aon_ec_rst_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h7d0),
+    .BitMask(16'hffff)
+  ) u_ec_rst_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (ec_rst_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (ec_rst_ctl_busy),
+    .src_qs_o     (ec_rst_ctl_qs), // for software read back
+    .dst_d_i      (aon_ec_rst_ctl_d),
+    .dst_we_o     (aon_ec_rst_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_ec_rst_ctl_regwen),
+    .dst_wd_o     (aon_ec_rst_ctl_wdata)
+  );
+  assign unused_aon_ec_rst_ctl_wdata = ^aon_ec_rst_ctl_wdata;
+
+  logic [15:0]  aon_ulp_ac_debounce_ctl_qs_int;
+  logic [15:0] aon_ulp_ac_debounce_ctl_d;
+  logic [15:0] aon_ulp_ac_debounce_ctl_wdata;
+  logic aon_ulp_ac_debounce_ctl_we;
+  logic unused_aon_ulp_ac_debounce_ctl_wdata;
+  logic aon_ulp_ac_debounce_ctl_regwen;
+
+  always_comb begin
+    aon_ulp_ac_debounce_ctl_d = '0;
+    aon_ulp_ac_debounce_ctl_d = aon_ulp_ac_debounce_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h1f40),
+    .BitMask(16'hffff)
+  ) u_ulp_ac_debounce_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (ulp_ac_debounce_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (ulp_ac_debounce_ctl_busy),
+    .src_qs_o     (ulp_ac_debounce_ctl_qs), // for software read back
+    .dst_d_i      (aon_ulp_ac_debounce_ctl_d),
+    .dst_we_o     (aon_ulp_ac_debounce_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_ulp_ac_debounce_ctl_regwen),
+    .dst_wd_o     (aon_ulp_ac_debounce_ctl_wdata)
+  );
+  assign unused_aon_ulp_ac_debounce_ctl_wdata = ^aon_ulp_ac_debounce_ctl_wdata;
+
+  logic [15:0]  aon_ulp_lid_debounce_ctl_qs_int;
+  logic [15:0] aon_ulp_lid_debounce_ctl_d;
+  logic [15:0] aon_ulp_lid_debounce_ctl_wdata;
+  logic aon_ulp_lid_debounce_ctl_we;
+  logic unused_aon_ulp_lid_debounce_ctl_wdata;
+  logic aon_ulp_lid_debounce_ctl_regwen;
+
+  always_comb begin
+    aon_ulp_lid_debounce_ctl_d = '0;
+    aon_ulp_lid_debounce_ctl_d = aon_ulp_lid_debounce_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h1f40),
+    .BitMask(16'hffff)
+  ) u_ulp_lid_debounce_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (ulp_lid_debounce_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (ulp_lid_debounce_ctl_busy),
+    .src_qs_o     (ulp_lid_debounce_ctl_qs), // for software read back
+    .dst_d_i      (aon_ulp_lid_debounce_ctl_d),
+    .dst_we_o     (aon_ulp_lid_debounce_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_ulp_lid_debounce_ctl_regwen),
+    .dst_wd_o     (aon_ulp_lid_debounce_ctl_wdata)
+  );
+  assign unused_aon_ulp_lid_debounce_ctl_wdata = ^aon_ulp_lid_debounce_ctl_wdata;
+
+  logic [15:0]  aon_ulp_pwrb_debounce_ctl_qs_int;
+  logic [15:0] aon_ulp_pwrb_debounce_ctl_d;
+  logic [15:0] aon_ulp_pwrb_debounce_ctl_wdata;
+  logic aon_ulp_pwrb_debounce_ctl_we;
+  logic unused_aon_ulp_pwrb_debounce_ctl_wdata;
+  logic aon_ulp_pwrb_debounce_ctl_regwen;
+
+  always_comb begin
+    aon_ulp_pwrb_debounce_ctl_d = '0;
+    aon_ulp_pwrb_debounce_ctl_d = aon_ulp_pwrb_debounce_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h1f40),
+    .BitMask(16'hffff)
+  ) u_ulp_pwrb_debounce_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (ulp_pwrb_debounce_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (ulp_pwrb_debounce_ctl_busy),
+    .src_qs_o     (ulp_pwrb_debounce_ctl_qs), // for software read back
+    .dst_d_i      (aon_ulp_pwrb_debounce_ctl_d),
+    .dst_we_o     (aon_ulp_pwrb_debounce_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_ulp_pwrb_debounce_ctl_regwen),
+    .dst_wd_o     (aon_ulp_pwrb_debounce_ctl_wdata)
+  );
+  assign unused_aon_ulp_pwrb_debounce_ctl_wdata = ^aon_ulp_pwrb_debounce_ctl_wdata;
+
+  logic  aon_ulp_ctl_qs_int;
+  logic [0:0] aon_ulp_ctl_d;
+  logic [0:0] aon_ulp_ctl_wdata;
+  logic aon_ulp_ctl_we;
+  logic unused_aon_ulp_ctl_wdata;
+
+  always_comb begin
+    aon_ulp_ctl_d = '0;
+    aon_ulp_ctl_d = aon_ulp_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_ulp_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (ulp_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (ulp_ctl_busy),
+    .src_qs_o     (ulp_ctl_qs), // for software read back
+    .dst_d_i      (aon_ulp_ctl_d),
+    .dst_we_o     (aon_ulp_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_ulp_ctl_wdata)
+  );
+  assign unused_aon_ulp_ctl_wdata = ^aon_ulp_ctl_wdata;
+
+  logic  aon_ulp_status_qs_int;
+  logic [0:0] aon_ulp_status_d;
+  logic [0:0] aon_ulp_status_wdata;
+  logic aon_ulp_status_we;
+  logic unused_aon_ulp_status_wdata;
+
+  always_comb begin
+    aon_ulp_status_d = '0;
+    aon_ulp_status_d = aon_ulp_status_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_ulp_status_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (ulp_status_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (ulp_status_busy),
+    .src_qs_o     (ulp_status_qs), // for software read back
+    .dst_d_i      (aon_ulp_status_d),
+    .dst_we_o     (aon_ulp_status_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_ulp_status_wdata)
+  );
+  assign unused_aon_ulp_status_wdata = ^aon_ulp_status_wdata;
+
+  logic  aon_wkup_status_qs_int;
+  logic [0:0] aon_wkup_status_d;
+  logic [0:0] aon_wkup_status_wdata;
+  logic aon_wkup_status_we;
+  logic unused_aon_wkup_status_wdata;
+
+  always_comb begin
+    aon_wkup_status_d = '0;
+    aon_wkup_status_d = aon_wkup_status_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_status_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (wkup_status_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_status_busy),
+    .src_qs_o     (wkup_status_qs), // for software read back
+    .dst_d_i      (aon_wkup_status_d),
+    .dst_we_o     (aon_wkup_status_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_wkup_status_wdata)
+  );
+  assign unused_aon_wkup_status_wdata = ^aon_wkup_status_wdata;
+
+  logic  aon_key_invert_ctl_key0_in_qs_int;
+  logic  aon_key_invert_ctl_key0_out_qs_int;
+  logic  aon_key_invert_ctl_key1_in_qs_int;
+  logic  aon_key_invert_ctl_key1_out_qs_int;
+  logic  aon_key_invert_ctl_key2_in_qs_int;
+  logic  aon_key_invert_ctl_key2_out_qs_int;
+  logic  aon_key_invert_ctl_pwrb_in_qs_int;
+  logic  aon_key_invert_ctl_pwrb_out_qs_int;
+  logic  aon_key_invert_ctl_ac_present_qs_int;
+  logic  aon_key_invert_ctl_bat_disable_qs_int;
+  logic  aon_key_invert_ctl_lid_open_qs_int;
+  logic  aon_key_invert_ctl_z3_wakeup_qs_int;
+  logic [11:0] aon_key_invert_ctl_d;
+  logic [11:0] aon_key_invert_ctl_wdata;
+  logic aon_key_invert_ctl_we;
+  logic unused_aon_key_invert_ctl_wdata;
+  logic aon_key_invert_ctl_regwen;
+
+  always_comb begin
+    aon_key_invert_ctl_d = '0;
+    aon_key_invert_ctl_d[0] = aon_key_invert_ctl_key0_in_qs_int;
+    aon_key_invert_ctl_d[1] = aon_key_invert_ctl_key0_out_qs_int;
+    aon_key_invert_ctl_d[2] = aon_key_invert_ctl_key1_in_qs_int;
+    aon_key_invert_ctl_d[3] = aon_key_invert_ctl_key1_out_qs_int;
+    aon_key_invert_ctl_d[4] = aon_key_invert_ctl_key2_in_qs_int;
+    aon_key_invert_ctl_d[5] = aon_key_invert_ctl_key2_out_qs_int;
+    aon_key_invert_ctl_d[6] = aon_key_invert_ctl_pwrb_in_qs_int;
+    aon_key_invert_ctl_d[7] = aon_key_invert_ctl_pwrb_out_qs_int;
+    aon_key_invert_ctl_d[8] = aon_key_invert_ctl_ac_present_qs_int;
+    aon_key_invert_ctl_d[9] = aon_key_invert_ctl_bat_disable_qs_int;
+    aon_key_invert_ctl_d[10] = aon_key_invert_ctl_lid_open_qs_int;
+    aon_key_invert_ctl_d[11] = aon_key_invert_ctl_z3_wakeup_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(12),
+    .ResetVal(12'h0),
+    .BitMask(12'hfff)
+  ) u_key_invert_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (key_invert_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[11:0]),
+    .src_busy_o   (key_invert_ctl_busy),
+    .src_qs_o     (key_invert_ctl_qs), // for software read back
+    .dst_d_i      (aon_key_invert_ctl_d),
+    .dst_we_o     (aon_key_invert_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_key_invert_ctl_regwen),
+    .dst_wd_o     (aon_key_invert_ctl_wdata)
+  );
+  assign unused_aon_key_invert_ctl_wdata = ^aon_key_invert_ctl_wdata;
+
+  logic  aon_pin_allowed_ctl_bat_disable_0_qs_int;
+  logic  aon_pin_allowed_ctl_ec_rst_l_0_qs_int;
+  logic  aon_pin_allowed_ctl_pwrb_out_0_qs_int;
+  logic  aon_pin_allowed_ctl_key0_out_0_qs_int;
+  logic  aon_pin_allowed_ctl_key1_out_0_qs_int;
+  logic  aon_pin_allowed_ctl_key2_out_0_qs_int;
+  logic  aon_pin_allowed_ctl_z3_wakeup_0_qs_int;
+  logic  aon_pin_allowed_ctl_flash_wp_l_0_qs_int;
+  logic  aon_pin_allowed_ctl_bat_disable_1_qs_int;
+  logic  aon_pin_allowed_ctl_ec_rst_l_1_qs_int;
+  logic  aon_pin_allowed_ctl_pwrb_out_1_qs_int;
+  logic  aon_pin_allowed_ctl_key0_out_1_qs_int;
+  logic  aon_pin_allowed_ctl_key1_out_1_qs_int;
+  logic  aon_pin_allowed_ctl_key2_out_1_qs_int;
+  logic  aon_pin_allowed_ctl_z3_wakeup_1_qs_int;
+  logic  aon_pin_allowed_ctl_flash_wp_l_1_qs_int;
+  logic [15:0] aon_pin_allowed_ctl_d;
+  logic [15:0] aon_pin_allowed_ctl_wdata;
+  logic aon_pin_allowed_ctl_we;
+  logic unused_aon_pin_allowed_ctl_wdata;
+  logic aon_pin_allowed_ctl_regwen;
+
+  always_comb begin
+    aon_pin_allowed_ctl_d = '0;
+    aon_pin_allowed_ctl_d[0] = aon_pin_allowed_ctl_bat_disable_0_qs_int;
+    aon_pin_allowed_ctl_d[1] = aon_pin_allowed_ctl_ec_rst_l_0_qs_int;
+    aon_pin_allowed_ctl_d[2] = aon_pin_allowed_ctl_pwrb_out_0_qs_int;
+    aon_pin_allowed_ctl_d[3] = aon_pin_allowed_ctl_key0_out_0_qs_int;
+    aon_pin_allowed_ctl_d[4] = aon_pin_allowed_ctl_key1_out_0_qs_int;
+    aon_pin_allowed_ctl_d[5] = aon_pin_allowed_ctl_key2_out_0_qs_int;
+    aon_pin_allowed_ctl_d[6] = aon_pin_allowed_ctl_z3_wakeup_0_qs_int;
+    aon_pin_allowed_ctl_d[7] = aon_pin_allowed_ctl_flash_wp_l_0_qs_int;
+    aon_pin_allowed_ctl_d[8] = aon_pin_allowed_ctl_bat_disable_1_qs_int;
+    aon_pin_allowed_ctl_d[9] = aon_pin_allowed_ctl_ec_rst_l_1_qs_int;
+    aon_pin_allowed_ctl_d[10] = aon_pin_allowed_ctl_pwrb_out_1_qs_int;
+    aon_pin_allowed_ctl_d[11] = aon_pin_allowed_ctl_key0_out_1_qs_int;
+    aon_pin_allowed_ctl_d[12] = aon_pin_allowed_ctl_key1_out_1_qs_int;
+    aon_pin_allowed_ctl_d[13] = aon_pin_allowed_ctl_key2_out_1_qs_int;
+    aon_pin_allowed_ctl_d[14] = aon_pin_allowed_ctl_z3_wakeup_1_qs_int;
+    aon_pin_allowed_ctl_d[15] = aon_pin_allowed_ctl_flash_wp_l_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h2),
+    .BitMask(16'hffff)
+  ) u_pin_allowed_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (pin_allowed_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (pin_allowed_ctl_busy),
+    .src_qs_o     (pin_allowed_ctl_qs), // for software read back
+    .dst_d_i      (aon_pin_allowed_ctl_d),
+    .dst_we_o     (aon_pin_allowed_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_pin_allowed_ctl_regwen),
+    .dst_wd_o     (aon_pin_allowed_ctl_wdata)
+  );
+  assign unused_aon_pin_allowed_ctl_wdata = ^aon_pin_allowed_ctl_wdata;
+
+  logic  aon_pin_out_ctl_bat_disable_qs_int;
+  logic  aon_pin_out_ctl_ec_rst_l_qs_int;
+  logic  aon_pin_out_ctl_pwrb_out_qs_int;
+  logic  aon_pin_out_ctl_key0_out_qs_int;
+  logic  aon_pin_out_ctl_key1_out_qs_int;
+  logic  aon_pin_out_ctl_key2_out_qs_int;
+  logic  aon_pin_out_ctl_z3_wakeup_qs_int;
+  logic  aon_pin_out_ctl_flash_wp_l_qs_int;
+  logic [7:0] aon_pin_out_ctl_d;
+  logic [7:0] aon_pin_out_ctl_wdata;
+  logic aon_pin_out_ctl_we;
+  logic unused_aon_pin_out_ctl_wdata;
+
+  always_comb begin
+    aon_pin_out_ctl_d = '0;
+    aon_pin_out_ctl_d[0] = aon_pin_out_ctl_bat_disable_qs_int;
+    aon_pin_out_ctl_d[1] = aon_pin_out_ctl_ec_rst_l_qs_int;
+    aon_pin_out_ctl_d[2] = aon_pin_out_ctl_pwrb_out_qs_int;
+    aon_pin_out_ctl_d[3] = aon_pin_out_ctl_key0_out_qs_int;
+    aon_pin_out_ctl_d[4] = aon_pin_out_ctl_key1_out_qs_int;
+    aon_pin_out_ctl_d[5] = aon_pin_out_ctl_key2_out_qs_int;
+    aon_pin_out_ctl_d[6] = aon_pin_out_ctl_z3_wakeup_qs_int;
+    aon_pin_out_ctl_d[7] = aon_pin_out_ctl_flash_wp_l_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h2),
+    .BitMask(8'hff)
+  ) u_pin_out_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (pin_out_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (pin_out_ctl_busy),
+    .src_qs_o     (pin_out_ctl_qs), // for software read back
+    .dst_d_i      (aon_pin_out_ctl_d),
+    .dst_we_o     (aon_pin_out_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_pin_out_ctl_wdata)
+  );
+  assign unused_aon_pin_out_ctl_wdata = ^aon_pin_out_ctl_wdata;
+
+  logic  aon_pin_out_value_bat_disable_qs_int;
+  logic  aon_pin_out_value_ec_rst_l_qs_int;
+  logic  aon_pin_out_value_pwrb_out_qs_int;
+  logic  aon_pin_out_value_key0_out_qs_int;
+  logic  aon_pin_out_value_key1_out_qs_int;
+  logic  aon_pin_out_value_key2_out_qs_int;
+  logic  aon_pin_out_value_z3_wakeup_qs_int;
+  logic  aon_pin_out_value_flash_wp_l_qs_int;
+  logic [7:0] aon_pin_out_value_d;
+  logic [7:0] aon_pin_out_value_wdata;
+  logic aon_pin_out_value_we;
+  logic unused_aon_pin_out_value_wdata;
+
+  always_comb begin
+    aon_pin_out_value_d = '0;
+    aon_pin_out_value_d[0] = aon_pin_out_value_bat_disable_qs_int;
+    aon_pin_out_value_d[1] = aon_pin_out_value_ec_rst_l_qs_int;
+    aon_pin_out_value_d[2] = aon_pin_out_value_pwrb_out_qs_int;
+    aon_pin_out_value_d[3] = aon_pin_out_value_key0_out_qs_int;
+    aon_pin_out_value_d[4] = aon_pin_out_value_key1_out_qs_int;
+    aon_pin_out_value_d[5] = aon_pin_out_value_key2_out_qs_int;
+    aon_pin_out_value_d[6] = aon_pin_out_value_z3_wakeup_qs_int;
+    aon_pin_out_value_d[7] = aon_pin_out_value_flash_wp_l_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_pin_out_value_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (pin_out_value_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (pin_out_value_busy),
+    .src_qs_o     (pin_out_value_qs), // for software read back
+    .dst_d_i      (aon_pin_out_value_d),
+    .dst_we_o     (aon_pin_out_value_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_pin_out_value_wdata)
+  );
+  assign unused_aon_pin_out_value_wdata = ^aon_pin_out_value_wdata;
+
+  logic  aon_key_intr_ctl_pwrb_in_h2l_qs_int;
+  logic  aon_key_intr_ctl_key0_in_h2l_qs_int;
+  logic  aon_key_intr_ctl_key1_in_h2l_qs_int;
+  logic  aon_key_intr_ctl_key2_in_h2l_qs_int;
+  logic  aon_key_intr_ctl_ac_present_h2l_qs_int;
+  logic  aon_key_intr_ctl_ec_rst_l_h2l_qs_int;
+  logic  aon_key_intr_ctl_pwrb_in_l2h_qs_int;
+  logic  aon_key_intr_ctl_key0_in_l2h_qs_int;
+  logic  aon_key_intr_ctl_key1_in_l2h_qs_int;
+  logic  aon_key_intr_ctl_key2_in_l2h_qs_int;
+  logic  aon_key_intr_ctl_ac_present_l2h_qs_int;
+  logic  aon_key_intr_ctl_ec_rst_l_l2h_qs_int;
+  logic [13:0] aon_key_intr_ctl_d;
+  logic [13:0] aon_key_intr_ctl_wdata;
+  logic aon_key_intr_ctl_we;
+  logic unused_aon_key_intr_ctl_wdata;
+  logic aon_key_intr_ctl_regwen;
+
+  always_comb begin
+    aon_key_intr_ctl_d = '0;
+    aon_key_intr_ctl_d[0] = aon_key_intr_ctl_pwrb_in_h2l_qs_int;
+    aon_key_intr_ctl_d[1] = aon_key_intr_ctl_key0_in_h2l_qs_int;
+    aon_key_intr_ctl_d[2] = aon_key_intr_ctl_key1_in_h2l_qs_int;
+    aon_key_intr_ctl_d[3] = aon_key_intr_ctl_key2_in_h2l_qs_int;
+    aon_key_intr_ctl_d[4] = aon_key_intr_ctl_ac_present_h2l_qs_int;
+    aon_key_intr_ctl_d[5] = aon_key_intr_ctl_ec_rst_l_h2l_qs_int;
+    aon_key_intr_ctl_d[8] = aon_key_intr_ctl_pwrb_in_l2h_qs_int;
+    aon_key_intr_ctl_d[9] = aon_key_intr_ctl_key0_in_l2h_qs_int;
+    aon_key_intr_ctl_d[10] = aon_key_intr_ctl_key1_in_l2h_qs_int;
+    aon_key_intr_ctl_d[11] = aon_key_intr_ctl_key2_in_l2h_qs_int;
+    aon_key_intr_ctl_d[12] = aon_key_intr_ctl_ac_present_l2h_qs_int;
+    aon_key_intr_ctl_d[13] = aon_key_intr_ctl_ec_rst_l_l2h_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(14),
+    .ResetVal(14'h0),
+    .BitMask(14'h3f3f)
+  ) u_key_intr_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (key_intr_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[13:0]),
+    .src_busy_o   (key_intr_ctl_busy),
+    .src_qs_o     (key_intr_ctl_qs), // for software read back
+    .dst_d_i      (aon_key_intr_ctl_d),
+    .dst_we_o     (aon_key_intr_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_key_intr_ctl_regwen),
+    .dst_wd_o     (aon_key_intr_ctl_wdata)
+  );
+  assign unused_aon_key_intr_ctl_wdata = ^aon_key_intr_ctl_wdata;
+
+  logic [15:0]  aon_key_intr_debounce_ctl_qs_int;
+  logic [15:0] aon_key_intr_debounce_ctl_d;
+  logic [15:0] aon_key_intr_debounce_ctl_wdata;
+  logic aon_key_intr_debounce_ctl_we;
+  logic unused_aon_key_intr_debounce_ctl_wdata;
+  logic aon_key_intr_debounce_ctl_regwen;
+
+  always_comb begin
+    aon_key_intr_debounce_ctl_d = '0;
+    aon_key_intr_debounce_ctl_d = aon_key_intr_debounce_ctl_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(16),
+    .ResetVal(16'h0),
+    .BitMask(16'hffff)
+  ) u_key_intr_debounce_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (key_intr_debounce_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[15:0]),
+    .src_busy_o   (key_intr_debounce_ctl_busy),
+    .src_qs_o     (key_intr_debounce_ctl_qs), // for software read back
+    .dst_d_i      (aon_key_intr_debounce_ctl_d),
+    .dst_we_o     (aon_key_intr_debounce_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_key_intr_debounce_ctl_regwen),
+    .dst_wd_o     (aon_key_intr_debounce_ctl_wdata)
+  );
+  assign unused_aon_key_intr_debounce_ctl_wdata = ^aon_key_intr_debounce_ctl_wdata;
+
+  logic [15:0]  aon_auto_block_debounce_ctl_debounce_timer_qs_int;
+  logic  aon_auto_block_debounce_ctl_auto_block_enable_qs_int;
+  logic [16:0] aon_auto_block_debounce_ctl_d;
+  logic [16:0] aon_auto_block_debounce_ctl_wdata;
+  logic aon_auto_block_debounce_ctl_we;
+  logic unused_aon_auto_block_debounce_ctl_wdata;
+  logic aon_auto_block_debounce_ctl_regwen;
+
+  always_comb begin
+    aon_auto_block_debounce_ctl_d = '0;
+    aon_auto_block_debounce_ctl_d[15:0] = aon_auto_block_debounce_ctl_debounce_timer_qs_int;
+    aon_auto_block_debounce_ctl_d[16] = aon_auto_block_debounce_ctl_auto_block_enable_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(17),
+    .ResetVal(17'h0),
+    .BitMask(17'h1ffff)
+  ) u_auto_block_debounce_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (auto_block_debounce_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[16:0]),
+    .src_busy_o   (auto_block_debounce_ctl_busy),
+    .src_qs_o     (auto_block_debounce_ctl_qs), // for software read back
+    .dst_d_i      (aon_auto_block_debounce_ctl_d),
+    .dst_we_o     (aon_auto_block_debounce_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_auto_block_debounce_ctl_regwen),
+    .dst_wd_o     (aon_auto_block_debounce_ctl_wdata)
+  );
+  assign unused_aon_auto_block_debounce_ctl_wdata = ^aon_auto_block_debounce_ctl_wdata;
+
+  logic  aon_auto_block_out_ctl_key0_out_sel_qs_int;
+  logic  aon_auto_block_out_ctl_key1_out_sel_qs_int;
+  logic  aon_auto_block_out_ctl_key2_out_sel_qs_int;
+  logic  aon_auto_block_out_ctl_key0_out_value_qs_int;
+  logic  aon_auto_block_out_ctl_key1_out_value_qs_int;
+  logic  aon_auto_block_out_ctl_key2_out_value_qs_int;
+  logic [6:0] aon_auto_block_out_ctl_d;
+  logic [6:0] aon_auto_block_out_ctl_wdata;
+  logic aon_auto_block_out_ctl_we;
+  logic unused_aon_auto_block_out_ctl_wdata;
+  logic aon_auto_block_out_ctl_regwen;
+
+  always_comb begin
+    aon_auto_block_out_ctl_d = '0;
+    aon_auto_block_out_ctl_d[0] = aon_auto_block_out_ctl_key0_out_sel_qs_int;
+    aon_auto_block_out_ctl_d[1] = aon_auto_block_out_ctl_key1_out_sel_qs_int;
+    aon_auto_block_out_ctl_d[2] = aon_auto_block_out_ctl_key2_out_sel_qs_int;
+    aon_auto_block_out_ctl_d[4] = aon_auto_block_out_ctl_key0_out_value_qs_int;
+    aon_auto_block_out_ctl_d[5] = aon_auto_block_out_ctl_key1_out_value_qs_int;
+    aon_auto_block_out_ctl_d[6] = aon_auto_block_out_ctl_key2_out_value_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(7),
+    .ResetVal(7'h0),
+    .BitMask(7'h77)
+  ) u_auto_block_out_ctl_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (auto_block_out_ctl_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[6:0]),
+    .src_busy_o   (auto_block_out_ctl_busy),
+    .src_qs_o     (auto_block_out_ctl_qs), // for software read back
+    .dst_d_i      (aon_auto_block_out_ctl_d),
+    .dst_we_o     (aon_auto_block_out_ctl_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_auto_block_out_ctl_regwen),
+    .dst_wd_o     (aon_auto_block_out_ctl_wdata)
+  );
+  assign unused_aon_auto_block_out_ctl_wdata = ^aon_auto_block_out_ctl_wdata;
+
+  logic  aon_com_sel_ctl_0_key0_in_sel_0_qs_int;
+  logic  aon_com_sel_ctl_0_key1_in_sel_0_qs_int;
+  logic  aon_com_sel_ctl_0_key2_in_sel_0_qs_int;
+  logic  aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int;
+  logic  aon_com_sel_ctl_0_ac_present_sel_0_qs_int;
+  logic [4:0] aon_com_sel_ctl_0_d;
+  logic [4:0] aon_com_sel_ctl_0_wdata;
+  logic aon_com_sel_ctl_0_we;
+  logic unused_aon_com_sel_ctl_0_wdata;
+  logic aon_com_sel_ctl_0_regwen;
+
+  always_comb begin
+    aon_com_sel_ctl_0_d = '0;
+    aon_com_sel_ctl_0_d[0] = aon_com_sel_ctl_0_key0_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_d[1] = aon_com_sel_ctl_0_key1_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_d[2] = aon_com_sel_ctl_0_key2_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_d[3] = aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int;
+    aon_com_sel_ctl_0_d[4] = aon_com_sel_ctl_0_ac_present_sel_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_com_sel_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_sel_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_sel_ctl_0_busy),
+    .src_qs_o     (com_sel_ctl_0_qs), // for software read back
+    .dst_d_i      (aon_com_sel_ctl_0_d),
+    .dst_we_o     (aon_com_sel_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_sel_ctl_0_regwen),
+    .dst_wd_o     (aon_com_sel_ctl_0_wdata)
+  );
+  assign unused_aon_com_sel_ctl_0_wdata = ^aon_com_sel_ctl_0_wdata;
+
+  logic  aon_com_sel_ctl_1_key0_in_sel_1_qs_int;
+  logic  aon_com_sel_ctl_1_key1_in_sel_1_qs_int;
+  logic  aon_com_sel_ctl_1_key2_in_sel_1_qs_int;
+  logic  aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int;
+  logic  aon_com_sel_ctl_1_ac_present_sel_1_qs_int;
+  logic [4:0] aon_com_sel_ctl_1_d;
+  logic [4:0] aon_com_sel_ctl_1_wdata;
+  logic aon_com_sel_ctl_1_we;
+  logic unused_aon_com_sel_ctl_1_wdata;
+  logic aon_com_sel_ctl_1_regwen;
+
+  always_comb begin
+    aon_com_sel_ctl_1_d = '0;
+    aon_com_sel_ctl_1_d[0] = aon_com_sel_ctl_1_key0_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_d[1] = aon_com_sel_ctl_1_key1_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_d[2] = aon_com_sel_ctl_1_key2_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_d[3] = aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int;
+    aon_com_sel_ctl_1_d[4] = aon_com_sel_ctl_1_ac_present_sel_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_com_sel_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_sel_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_sel_ctl_1_busy),
+    .src_qs_o     (com_sel_ctl_1_qs), // for software read back
+    .dst_d_i      (aon_com_sel_ctl_1_d),
+    .dst_we_o     (aon_com_sel_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_sel_ctl_1_regwen),
+    .dst_wd_o     (aon_com_sel_ctl_1_wdata)
+  );
+  assign unused_aon_com_sel_ctl_1_wdata = ^aon_com_sel_ctl_1_wdata;
+
+  logic  aon_com_sel_ctl_2_key0_in_sel_2_qs_int;
+  logic  aon_com_sel_ctl_2_key1_in_sel_2_qs_int;
+  logic  aon_com_sel_ctl_2_key2_in_sel_2_qs_int;
+  logic  aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int;
+  logic  aon_com_sel_ctl_2_ac_present_sel_2_qs_int;
+  logic [4:0] aon_com_sel_ctl_2_d;
+  logic [4:0] aon_com_sel_ctl_2_wdata;
+  logic aon_com_sel_ctl_2_we;
+  logic unused_aon_com_sel_ctl_2_wdata;
+  logic aon_com_sel_ctl_2_regwen;
+
+  always_comb begin
+    aon_com_sel_ctl_2_d = '0;
+    aon_com_sel_ctl_2_d[0] = aon_com_sel_ctl_2_key0_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_d[1] = aon_com_sel_ctl_2_key1_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_d[2] = aon_com_sel_ctl_2_key2_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_d[3] = aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int;
+    aon_com_sel_ctl_2_d[4] = aon_com_sel_ctl_2_ac_present_sel_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_com_sel_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_sel_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_sel_ctl_2_busy),
+    .src_qs_o     (com_sel_ctl_2_qs), // for software read back
+    .dst_d_i      (aon_com_sel_ctl_2_d),
+    .dst_we_o     (aon_com_sel_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_sel_ctl_2_regwen),
+    .dst_wd_o     (aon_com_sel_ctl_2_wdata)
+  );
+  assign unused_aon_com_sel_ctl_2_wdata = ^aon_com_sel_ctl_2_wdata;
+
+  logic  aon_com_sel_ctl_3_key0_in_sel_3_qs_int;
+  logic  aon_com_sel_ctl_3_key1_in_sel_3_qs_int;
+  logic  aon_com_sel_ctl_3_key2_in_sel_3_qs_int;
+  logic  aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int;
+  logic  aon_com_sel_ctl_3_ac_present_sel_3_qs_int;
+  logic [4:0] aon_com_sel_ctl_3_d;
+  logic [4:0] aon_com_sel_ctl_3_wdata;
+  logic aon_com_sel_ctl_3_we;
+  logic unused_aon_com_sel_ctl_3_wdata;
+  logic aon_com_sel_ctl_3_regwen;
+
+  always_comb begin
+    aon_com_sel_ctl_3_d = '0;
+    aon_com_sel_ctl_3_d[0] = aon_com_sel_ctl_3_key0_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_d[1] = aon_com_sel_ctl_3_key1_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_d[2] = aon_com_sel_ctl_3_key2_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_d[3] = aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int;
+    aon_com_sel_ctl_3_d[4] = aon_com_sel_ctl_3_ac_present_sel_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_com_sel_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_sel_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (com_sel_ctl_3_busy),
+    .src_qs_o     (com_sel_ctl_3_qs), // for software read back
+    .dst_d_i      (aon_com_sel_ctl_3_d),
+    .dst_we_o     (aon_com_sel_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_sel_ctl_3_regwen),
+    .dst_wd_o     (aon_com_sel_ctl_3_wdata)
+  );
+  assign unused_aon_com_sel_ctl_3_wdata = ^aon_com_sel_ctl_3_wdata;
+
+  logic [31:0]  aon_com_det_ctl_0_qs_int;
+  logic [31:0] aon_com_det_ctl_0_d;
+  logic [31:0] aon_com_det_ctl_0_wdata;
+  logic aon_com_det_ctl_0_we;
+  logic unused_aon_com_det_ctl_0_wdata;
+  logic aon_com_det_ctl_0_regwen;
+
+  always_comb begin
+    aon_com_det_ctl_0_d = '0;
+    aon_com_det_ctl_0_d = aon_com_det_ctl_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff)
+  ) u_com_det_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_det_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_det_ctl_0_busy),
+    .src_qs_o     (com_det_ctl_0_qs), // for software read back
+    .dst_d_i      (aon_com_det_ctl_0_d),
+    .dst_we_o     (aon_com_det_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_det_ctl_0_regwen),
+    .dst_wd_o     (aon_com_det_ctl_0_wdata)
+  );
+  assign unused_aon_com_det_ctl_0_wdata = ^aon_com_det_ctl_0_wdata;
+
+  logic [31:0]  aon_com_det_ctl_1_qs_int;
+  logic [31:0] aon_com_det_ctl_1_d;
+  logic [31:0] aon_com_det_ctl_1_wdata;
+  logic aon_com_det_ctl_1_we;
+  logic unused_aon_com_det_ctl_1_wdata;
+  logic aon_com_det_ctl_1_regwen;
+
+  always_comb begin
+    aon_com_det_ctl_1_d = '0;
+    aon_com_det_ctl_1_d = aon_com_det_ctl_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff)
+  ) u_com_det_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_det_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_det_ctl_1_busy),
+    .src_qs_o     (com_det_ctl_1_qs), // for software read back
+    .dst_d_i      (aon_com_det_ctl_1_d),
+    .dst_we_o     (aon_com_det_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_det_ctl_1_regwen),
+    .dst_wd_o     (aon_com_det_ctl_1_wdata)
+  );
+  assign unused_aon_com_det_ctl_1_wdata = ^aon_com_det_ctl_1_wdata;
+
+  logic [31:0]  aon_com_det_ctl_2_qs_int;
+  logic [31:0] aon_com_det_ctl_2_d;
+  logic [31:0] aon_com_det_ctl_2_wdata;
+  logic aon_com_det_ctl_2_we;
+  logic unused_aon_com_det_ctl_2_wdata;
+  logic aon_com_det_ctl_2_regwen;
+
+  always_comb begin
+    aon_com_det_ctl_2_d = '0;
+    aon_com_det_ctl_2_d = aon_com_det_ctl_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff)
+  ) u_com_det_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_det_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_det_ctl_2_busy),
+    .src_qs_o     (com_det_ctl_2_qs), // for software read back
+    .dst_d_i      (aon_com_det_ctl_2_d),
+    .dst_we_o     (aon_com_det_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_det_ctl_2_regwen),
+    .dst_wd_o     (aon_com_det_ctl_2_wdata)
+  );
+  assign unused_aon_com_det_ctl_2_wdata = ^aon_com_det_ctl_2_wdata;
+
+  logic [31:0]  aon_com_det_ctl_3_qs_int;
+  logic [31:0] aon_com_det_ctl_3_d;
+  logic [31:0] aon_com_det_ctl_3_wdata;
+  logic aon_com_det_ctl_3_we;
+  logic unused_aon_com_det_ctl_3_wdata;
+  logic aon_com_det_ctl_3_regwen;
+
+  always_comb begin
+    aon_com_det_ctl_3_d = '0;
+    aon_com_det_ctl_3_d = aon_com_det_ctl_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(32),
+    .ResetVal(32'h0),
+    .BitMask(32'hffffffff)
+  ) u_com_det_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_det_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[31:0]),
+    .src_busy_o   (com_det_ctl_3_busy),
+    .src_qs_o     (com_det_ctl_3_qs), // for software read back
+    .dst_d_i      (aon_com_det_ctl_3_d),
+    .dst_we_o     (aon_com_det_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_det_ctl_3_regwen),
+    .dst_wd_o     (aon_com_det_ctl_3_wdata)
+  );
+  assign unused_aon_com_det_ctl_3_wdata = ^aon_com_det_ctl_3_wdata;
+
+  logic  aon_com_out_ctl_0_bat_disable_0_qs_int;
+  logic  aon_com_out_ctl_0_interrupt_0_qs_int;
+  logic  aon_com_out_ctl_0_ec_rst_0_qs_int;
+  logic  aon_com_out_ctl_0_rst_req_0_qs_int;
+  logic [3:0] aon_com_out_ctl_0_d;
+  logic [3:0] aon_com_out_ctl_0_wdata;
+  logic aon_com_out_ctl_0_we;
+  logic unused_aon_com_out_ctl_0_wdata;
+  logic aon_com_out_ctl_0_regwen;
+
+  always_comb begin
+    aon_com_out_ctl_0_d = '0;
+    aon_com_out_ctl_0_d[0] = aon_com_out_ctl_0_bat_disable_0_qs_int;
+    aon_com_out_ctl_0_d[1] = aon_com_out_ctl_0_interrupt_0_qs_int;
+    aon_com_out_ctl_0_d[2] = aon_com_out_ctl_0_ec_rst_0_qs_int;
+    aon_com_out_ctl_0_d[3] = aon_com_out_ctl_0_rst_req_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(4),
+    .ResetVal(4'h0),
+    .BitMask(4'hf)
+  ) u_com_out_ctl_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_out_ctl_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[3:0]),
+    .src_busy_o   (com_out_ctl_0_busy),
+    .src_qs_o     (com_out_ctl_0_qs), // for software read back
+    .dst_d_i      (aon_com_out_ctl_0_d),
+    .dst_we_o     (aon_com_out_ctl_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_out_ctl_0_regwen),
+    .dst_wd_o     (aon_com_out_ctl_0_wdata)
+  );
+  assign unused_aon_com_out_ctl_0_wdata = ^aon_com_out_ctl_0_wdata;
+
+  logic  aon_com_out_ctl_1_bat_disable_1_qs_int;
+  logic  aon_com_out_ctl_1_interrupt_1_qs_int;
+  logic  aon_com_out_ctl_1_ec_rst_1_qs_int;
+  logic  aon_com_out_ctl_1_rst_req_1_qs_int;
+  logic [3:0] aon_com_out_ctl_1_d;
+  logic [3:0] aon_com_out_ctl_1_wdata;
+  logic aon_com_out_ctl_1_we;
+  logic unused_aon_com_out_ctl_1_wdata;
+  logic aon_com_out_ctl_1_regwen;
+
+  always_comb begin
+    aon_com_out_ctl_1_d = '0;
+    aon_com_out_ctl_1_d[0] = aon_com_out_ctl_1_bat_disable_1_qs_int;
+    aon_com_out_ctl_1_d[1] = aon_com_out_ctl_1_interrupt_1_qs_int;
+    aon_com_out_ctl_1_d[2] = aon_com_out_ctl_1_ec_rst_1_qs_int;
+    aon_com_out_ctl_1_d[3] = aon_com_out_ctl_1_rst_req_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(4),
+    .ResetVal(4'h0),
+    .BitMask(4'hf)
+  ) u_com_out_ctl_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_out_ctl_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[3:0]),
+    .src_busy_o   (com_out_ctl_1_busy),
+    .src_qs_o     (com_out_ctl_1_qs), // for software read back
+    .dst_d_i      (aon_com_out_ctl_1_d),
+    .dst_we_o     (aon_com_out_ctl_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_out_ctl_1_regwen),
+    .dst_wd_o     (aon_com_out_ctl_1_wdata)
+  );
+  assign unused_aon_com_out_ctl_1_wdata = ^aon_com_out_ctl_1_wdata;
+
+  logic  aon_com_out_ctl_2_bat_disable_2_qs_int;
+  logic  aon_com_out_ctl_2_interrupt_2_qs_int;
+  logic  aon_com_out_ctl_2_ec_rst_2_qs_int;
+  logic  aon_com_out_ctl_2_rst_req_2_qs_int;
+  logic [3:0] aon_com_out_ctl_2_d;
+  logic [3:0] aon_com_out_ctl_2_wdata;
+  logic aon_com_out_ctl_2_we;
+  logic unused_aon_com_out_ctl_2_wdata;
+  logic aon_com_out_ctl_2_regwen;
+
+  always_comb begin
+    aon_com_out_ctl_2_d = '0;
+    aon_com_out_ctl_2_d[0] = aon_com_out_ctl_2_bat_disable_2_qs_int;
+    aon_com_out_ctl_2_d[1] = aon_com_out_ctl_2_interrupt_2_qs_int;
+    aon_com_out_ctl_2_d[2] = aon_com_out_ctl_2_ec_rst_2_qs_int;
+    aon_com_out_ctl_2_d[3] = aon_com_out_ctl_2_rst_req_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(4),
+    .ResetVal(4'h0),
+    .BitMask(4'hf)
+  ) u_com_out_ctl_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_out_ctl_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[3:0]),
+    .src_busy_o   (com_out_ctl_2_busy),
+    .src_qs_o     (com_out_ctl_2_qs), // for software read back
+    .dst_d_i      (aon_com_out_ctl_2_d),
+    .dst_we_o     (aon_com_out_ctl_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_out_ctl_2_regwen),
+    .dst_wd_o     (aon_com_out_ctl_2_wdata)
+  );
+  assign unused_aon_com_out_ctl_2_wdata = ^aon_com_out_ctl_2_wdata;
+
+  logic  aon_com_out_ctl_3_bat_disable_3_qs_int;
+  logic  aon_com_out_ctl_3_interrupt_3_qs_int;
+  logic  aon_com_out_ctl_3_ec_rst_3_qs_int;
+  logic  aon_com_out_ctl_3_rst_req_3_qs_int;
+  logic [3:0] aon_com_out_ctl_3_d;
+  logic [3:0] aon_com_out_ctl_3_wdata;
+  logic aon_com_out_ctl_3_we;
+  logic unused_aon_com_out_ctl_3_wdata;
+  logic aon_com_out_ctl_3_regwen;
+
+  always_comb begin
+    aon_com_out_ctl_3_d = '0;
+    aon_com_out_ctl_3_d[0] = aon_com_out_ctl_3_bat_disable_3_qs_int;
+    aon_com_out_ctl_3_d[1] = aon_com_out_ctl_3_interrupt_3_qs_int;
+    aon_com_out_ctl_3_d[2] = aon_com_out_ctl_3_ec_rst_3_qs_int;
+    aon_com_out_ctl_3_d[3] = aon_com_out_ctl_3_rst_req_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(4),
+    .ResetVal(4'h0),
+    .BitMask(4'hf)
+  ) u_com_out_ctl_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (regwen_qs),
+    .src_we_i     (com_out_ctl_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[3:0]),
+    .src_busy_o   (com_out_ctl_3_busy),
+    .src_qs_o     (com_out_ctl_3_qs), // for software read back
+    .dst_d_i      (aon_com_out_ctl_3_d),
+    .dst_we_o     (aon_com_out_ctl_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_com_out_ctl_3_regwen),
+    .dst_wd_o     (aon_com_out_ctl_3_wdata)
+  );
+  assign unused_aon_com_out_ctl_3_wdata = ^aon_com_out_ctl_3_wdata;
+
+  logic  aon_combo_intr_status_combo0_h2l_qs_int;
+  logic  aon_combo_intr_status_combo1_h2l_qs_int;
+  logic  aon_combo_intr_status_combo2_h2l_qs_int;
+  logic  aon_combo_intr_status_combo3_h2l_qs_int;
+  logic [3:0] aon_combo_intr_status_d;
+  logic [3:0] aon_combo_intr_status_wdata;
+  logic aon_combo_intr_status_we;
+  logic unused_aon_combo_intr_status_wdata;
+
+  always_comb begin
+    aon_combo_intr_status_d = '0;
+    aon_combo_intr_status_d[0] = aon_combo_intr_status_combo0_h2l_qs_int;
+    aon_combo_intr_status_d[1] = aon_combo_intr_status_combo1_h2l_qs_int;
+    aon_combo_intr_status_d[2] = aon_combo_intr_status_combo2_h2l_qs_int;
+    aon_combo_intr_status_d[3] = aon_combo_intr_status_combo3_h2l_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(4),
+    .ResetVal(4'h0),
+    .BitMask(4'hf)
+  ) u_combo_intr_status_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (combo_intr_status_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[3:0]),
+    .src_busy_o   (combo_intr_status_busy),
+    .src_qs_o     (combo_intr_status_qs), // for software read back
+    .dst_d_i      (aon_combo_intr_status_d),
+    .dst_we_o     (aon_combo_intr_status_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_combo_intr_status_wdata)
+  );
+  assign unused_aon_combo_intr_status_wdata = ^aon_combo_intr_status_wdata;
+
+  logic  aon_key_intr_status_pwrb_h2l_qs_int;
+  logic  aon_key_intr_status_key0_in_h2l_qs_int;
+  logic  aon_key_intr_status_key1_in_h2l_qs_int;
+  logic  aon_key_intr_status_key2_in_h2l_qs_int;
+  logic  aon_key_intr_status_ac_present_h2l_qs_int;
+  logic  aon_key_intr_status_ec_rst_l_h2l_qs_int;
+  logic  aon_key_intr_status_pwrb_l2h_qs_int;
+  logic  aon_key_intr_status_key0_in_l2h_qs_int;
+  logic  aon_key_intr_status_key1_in_l2h_qs_int;
+  logic  aon_key_intr_status_key2_in_l2h_qs_int;
+  logic  aon_key_intr_status_ac_present_l2h_qs_int;
+  logic  aon_key_intr_status_ec_rst_l_l2h_qs_int;
+  logic [11:0] aon_key_intr_status_d;
+  logic [11:0] aon_key_intr_status_wdata;
+  logic aon_key_intr_status_we;
+  logic unused_aon_key_intr_status_wdata;
+
+  always_comb begin
+    aon_key_intr_status_d = '0;
+    aon_key_intr_status_d[0] = aon_key_intr_status_pwrb_h2l_qs_int;
+    aon_key_intr_status_d[1] = aon_key_intr_status_key0_in_h2l_qs_int;
+    aon_key_intr_status_d[2] = aon_key_intr_status_key1_in_h2l_qs_int;
+    aon_key_intr_status_d[3] = aon_key_intr_status_key2_in_h2l_qs_int;
+    aon_key_intr_status_d[4] = aon_key_intr_status_ac_present_h2l_qs_int;
+    aon_key_intr_status_d[5] = aon_key_intr_status_ec_rst_l_h2l_qs_int;
+    aon_key_intr_status_d[6] = aon_key_intr_status_pwrb_l2h_qs_int;
+    aon_key_intr_status_d[7] = aon_key_intr_status_key0_in_l2h_qs_int;
+    aon_key_intr_status_d[8] = aon_key_intr_status_key1_in_l2h_qs_int;
+    aon_key_intr_status_d[9] = aon_key_intr_status_key2_in_l2h_qs_int;
+    aon_key_intr_status_d[10] = aon_key_intr_status_ac_present_l2h_qs_int;
+    aon_key_intr_status_d[11] = aon_key_intr_status_ec_rst_l_l2h_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(12),
+    .ResetVal(12'h0),
+    .BitMask(12'hfff)
+  ) u_key_intr_status_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (key_intr_status_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[11:0]),
+    .src_busy_o   (key_intr_status_busy),
+    .src_qs_o     (key_intr_status_qs), // for software read back
+    .dst_d_i      (aon_key_intr_status_d),
+    .dst_we_o     (aon_key_intr_status_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_key_intr_status_wdata)
+  );
+  assign unused_aon_key_intr_status_wdata = ^aon_key_intr_status_wdata;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -669,1138 +1580,1342 @@ module sysrst_ctrl_reg_top (
 
   // R[ec_rst_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h7d0)
   ) u_ec_rst_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (ec_rst_ctl_we & regwen_qs),
-    .src_wd_i     (ec_rst_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (ec_rst_ctl_busy),
-    .src_qs_o     (ec_rst_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.ec_rst_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_ec_rst_ctl_we & aon_ec_rst_ctl_regwen),
+    .wd     (aon_ec_rst_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ec_rst_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_ec_rst_ctl_qs_int)
   );
 
 
   // R[ulp_ac_debounce_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40)
   ) u_ulp_ac_debounce_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (ulp_ac_debounce_ctl_we & regwen_qs),
-    .src_wd_i     (ulp_ac_debounce_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (ulp_ac_debounce_ctl_busy),
-    .src_qs_o     (ulp_ac_debounce_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.ulp_ac_debounce_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_ulp_ac_debounce_ctl_we & aon_ulp_ac_debounce_ctl_regwen),
+    .wd     (aon_ulp_ac_debounce_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ulp_ac_debounce_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_ulp_ac_debounce_ctl_qs_int)
   );
 
 
   // R[ulp_lid_debounce_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40)
   ) u_ulp_lid_debounce_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (ulp_lid_debounce_ctl_we & regwen_qs),
-    .src_wd_i     (ulp_lid_debounce_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (ulp_lid_debounce_ctl_busy),
-    .src_qs_o     (ulp_lid_debounce_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.ulp_lid_debounce_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_ulp_lid_debounce_ctl_we & aon_ulp_lid_debounce_ctl_regwen),
+    .wd     (aon_ulp_lid_debounce_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ulp_lid_debounce_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_ulp_lid_debounce_ctl_qs_int)
   );
 
 
   // R[ulp_pwrb_debounce_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h1f40)
   ) u_ulp_pwrb_debounce_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (ulp_pwrb_debounce_ctl_we & regwen_qs),
-    .src_wd_i     (ulp_pwrb_debounce_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (ulp_pwrb_debounce_ctl_busy),
-    .src_qs_o     (ulp_pwrb_debounce_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.ulp_pwrb_debounce_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_ulp_pwrb_debounce_ctl_we & aon_ulp_pwrb_debounce_ctl_regwen),
+    .wd     (aon_ulp_pwrb_debounce_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ulp_pwrb_debounce_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_ulp_pwrb_debounce_ctl_qs_int)
   );
 
 
   // R[ulp_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_ulp_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (ulp_ctl_we),
-    .src_wd_i     (ulp_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (ulp_ctl_busy),
-    .src_qs_o     (ulp_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.ulp_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_ulp_ctl_we),
+    .wd     (aon_ulp_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ulp_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_ulp_ctl_qs_int)
   );
 
 
   // R[ulp_status]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_ulp_status (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (ulp_status_we),
-    .src_wd_i     (ulp_status_wd),
-    .dst_de_i     (hw2reg.ulp_status.de),
-    .dst_d_i      (hw2reg.ulp_status.d),
-    .src_busy_o   (ulp_status_busy),
-    .src_qs_o     (ulp_status_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_ulp_status_we),
+    .wd     (aon_ulp_status_wdata[0]),
+
+    // from internal hardware
+    .de     (hw2reg.ulp_status.de),
+    .d      (hw2reg.ulp_status.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_ulp_status_qs_int)
   );
 
 
   // R[wkup_status]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_wkup_status (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_status_we),
-    .src_wd_i     (wkup_status_wd),
-    .dst_de_i     (hw2reg.wkup_status.de),
-    .dst_d_i      (hw2reg.wkup_status.d),
-    .src_busy_o   (wkup_status_busy),
-    .src_qs_o     (wkup_status_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_status.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_status_we),
+    .wd     (aon_wkup_status_wdata[0]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_status.de),
+    .d      (hw2reg.wkup_status.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_status.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_status_qs_int)
   );
 
 
   // R[key_invert_ctl]: V(False)
 
   //   F[key0_in]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_key0_in (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_key0_in_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_key0_in_busy),
-    .src_qs_o     (key_invert_ctl_key0_in_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.key0_in.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.key0_in.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_key0_in_qs_int)
   );
 
 
   //   F[key0_out]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_key0_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_key0_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_key0_out_busy),
-    .src_qs_o     (key_invert_ctl_key0_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.key0_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.key0_out.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_key0_out_qs_int)
   );
 
 
   //   F[key1_in]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_key1_in (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_key1_in_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_key1_in_busy),
-    .src_qs_o     (key_invert_ctl_key1_in_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.key1_in.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.key1_in.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_key1_in_qs_int)
   );
 
 
   //   F[key1_out]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_key1_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_key1_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_key1_out_busy),
-    .src_qs_o     (key_invert_ctl_key1_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.key1_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.key1_out.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_key1_out_qs_int)
   );
 
 
   //   F[key2_in]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_key2_in (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_key2_in_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_key2_in_busy),
-    .src_qs_o     (key_invert_ctl_key2_in_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.key2_in.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.key2_in.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_key2_in_qs_int)
   );
 
 
   //   F[key2_out]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_key2_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_key2_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_key2_out_busy),
-    .src_qs_o     (key_invert_ctl_key2_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.key2_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[5]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.key2_out.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_key2_out_qs_int)
   );
 
 
   //   F[pwrb_in]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_pwrb_in (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_pwrb_in_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_pwrb_in_busy),
-    .src_qs_o     (key_invert_ctl_pwrb_in_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.pwrb_in.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[6]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.pwrb_in.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_pwrb_in_qs_int)
   );
 
 
   //   F[pwrb_out]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_pwrb_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_pwrb_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_pwrb_out_busy),
-    .src_qs_o     (key_invert_ctl_pwrb_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.pwrb_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[7]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.pwrb_out.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_pwrb_out_qs_int)
   );
 
 
   //   F[ac_present]: 8:8
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_ac_present (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_ac_present_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_ac_present_busy),
-    .src_qs_o     (key_invert_ctl_ac_present_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.ac_present.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[8]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.ac_present.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_ac_present_qs_int)
   );
 
 
   //   F[bat_disable]: 9:9
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_bat_disable (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_bat_disable_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_bat_disable_busy),
-    .src_qs_o     (key_invert_ctl_bat_disable_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[9]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_bat_disable_qs_int)
   );
 
 
   //   F[lid_open]: 10:10
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_lid_open (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_lid_open_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_lid_open_busy),
-    .src_qs_o     (key_invert_ctl_lid_open_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.lid_open.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[10]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.lid_open.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_lid_open_qs_int)
   );
 
 
   //   F[z3_wakeup]: 11:11
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_invert_ctl_z3_wakeup (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_invert_ctl_we & regwen_qs),
-    .src_wd_i     (key_invert_ctl_z3_wakeup_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_invert_ctl_z3_wakeup_busy),
-    .src_qs_o     (key_invert_ctl_z3_wakeup_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_invert_ctl.z3_wakeup.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_invert_ctl_we & aon_key_invert_ctl_regwen),
+    .wd     (aon_key_invert_ctl_wdata[11]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_invert_ctl.z3_wakeup.q),
+
+    // to register interface (read)
+    .qs     (aon_key_invert_ctl_z3_wakeup_qs_int)
   );
 
 
   // R[pin_allowed_ctl]: V(False)
 
   //   F[bat_disable_0]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_bat_disable_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_bat_disable_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_bat_disable_0_busy),
-    .src_qs_o     (pin_allowed_ctl_bat_disable_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.bat_disable_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.bat_disable_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_bat_disable_0_qs_int)
   );
 
 
   //   F[ec_rst_l_0]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1)
   ) u_pin_allowed_ctl_ec_rst_l_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_ec_rst_l_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_ec_rst_l_0_busy),
-    .src_qs_o     (pin_allowed_ctl_ec_rst_l_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.ec_rst_l_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.ec_rst_l_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_ec_rst_l_0_qs_int)
   );
 
 
   //   F[pwrb_out_0]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_pwrb_out_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_pwrb_out_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_pwrb_out_0_busy),
-    .src_qs_o     (pin_allowed_ctl_pwrb_out_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.pwrb_out_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.pwrb_out_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_pwrb_out_0_qs_int)
   );
 
 
   //   F[key0_out_0]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_key0_out_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_key0_out_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_key0_out_0_busy),
-    .src_qs_o     (pin_allowed_ctl_key0_out_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.key0_out_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.key0_out_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_key0_out_0_qs_int)
   );
 
 
   //   F[key1_out_0]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_key1_out_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_key1_out_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_key1_out_0_busy),
-    .src_qs_o     (pin_allowed_ctl_key1_out_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.key1_out_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.key1_out_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_key1_out_0_qs_int)
   );
 
 
   //   F[key2_out_0]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_key2_out_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_key2_out_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_key2_out_0_busy),
-    .src_qs_o     (pin_allowed_ctl_key2_out_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.key2_out_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[5]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.key2_out_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_key2_out_0_qs_int)
   );
 
 
   //   F[z3_wakeup_0]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_z3_wakeup_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_z3_wakeup_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_z3_wakeup_0_busy),
-    .src_qs_o     (pin_allowed_ctl_z3_wakeup_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.z3_wakeup_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[6]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.z3_wakeup_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_z3_wakeup_0_qs_int)
   );
 
 
   //   F[flash_wp_l_0]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_flash_wp_l_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_flash_wp_l_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_flash_wp_l_0_busy),
-    .src_qs_o     (pin_allowed_ctl_flash_wp_l_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.flash_wp_l_0.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[7]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.flash_wp_l_0.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_flash_wp_l_0_qs_int)
   );
 
 
   //   F[bat_disable_1]: 8:8
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_bat_disable_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_bat_disable_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_bat_disable_1_busy),
-    .src_qs_o     (pin_allowed_ctl_bat_disable_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.bat_disable_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[8]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.bat_disable_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_bat_disable_1_qs_int)
   );
 
 
   //   F[ec_rst_l_1]: 9:9
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_ec_rst_l_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_ec_rst_l_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_ec_rst_l_1_busy),
-    .src_qs_o     (pin_allowed_ctl_ec_rst_l_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.ec_rst_l_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[9]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.ec_rst_l_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_ec_rst_l_1_qs_int)
   );
 
 
   //   F[pwrb_out_1]: 10:10
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_pwrb_out_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_pwrb_out_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_pwrb_out_1_busy),
-    .src_qs_o     (pin_allowed_ctl_pwrb_out_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.pwrb_out_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[10]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.pwrb_out_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_pwrb_out_1_qs_int)
   );
 
 
   //   F[key0_out_1]: 11:11
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_key0_out_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_key0_out_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_key0_out_1_busy),
-    .src_qs_o     (pin_allowed_ctl_key0_out_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.key0_out_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[11]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.key0_out_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_key0_out_1_qs_int)
   );
 
 
   //   F[key1_out_1]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_key1_out_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_key1_out_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_key1_out_1_busy),
-    .src_qs_o     (pin_allowed_ctl_key1_out_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.key1_out_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.key1_out_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_key1_out_1_qs_int)
   );
 
 
   //   F[key2_out_1]: 13:13
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_key2_out_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_key2_out_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_key2_out_1_busy),
-    .src_qs_o     (pin_allowed_ctl_key2_out_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.key2_out_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[13]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.key2_out_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_key2_out_1_qs_int)
   );
 
 
   //   F[z3_wakeup_1]: 14:14
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_z3_wakeup_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_z3_wakeup_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_z3_wakeup_1_busy),
-    .src_qs_o     (pin_allowed_ctl_z3_wakeup_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.z3_wakeup_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[14]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.z3_wakeup_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_z3_wakeup_1_qs_int)
   );
 
 
   //   F[flash_wp_l_1]: 15:15
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_allowed_ctl_flash_wp_l_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_allowed_ctl_we & regwen_qs),
-    .src_wd_i     (pin_allowed_ctl_flash_wp_l_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_allowed_ctl_flash_wp_l_1_busy),
-    .src_qs_o     (pin_allowed_ctl_flash_wp_l_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_allowed_ctl.flash_wp_l_1.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_allowed_ctl_we & aon_pin_allowed_ctl_regwen),
+    .wd     (aon_pin_allowed_ctl_wdata[15]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_allowed_ctl.flash_wp_l_1.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_allowed_ctl_flash_wp_l_1_qs_int)
   );
 
 
   // R[pin_out_ctl]: V(False)
 
   //   F[bat_disable]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_bat_disable (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_bat_disable_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_bat_disable_busy),
-    .src_qs_o     (pin_out_ctl_bat_disable_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_bat_disable_qs_int)
   );
 
 
   //   F[ec_rst_l]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h1)
   ) u_pin_out_ctl_ec_rst_l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_ec_rst_l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_ec_rst_l_busy),
-    .src_qs_o     (pin_out_ctl_ec_rst_l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.ec_rst_l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.ec_rst_l.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_ec_rst_l_qs_int)
   );
 
 
   //   F[pwrb_out]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_pwrb_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_pwrb_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_pwrb_out_busy),
-    .src_qs_o     (pin_out_ctl_pwrb_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.pwrb_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.pwrb_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_pwrb_out_qs_int)
   );
 
 
   //   F[key0_out]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_key0_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_key0_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_key0_out_busy),
-    .src_qs_o     (pin_out_ctl_key0_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.key0_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.key0_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_key0_out_qs_int)
   );
 
 
   //   F[key1_out]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_key1_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_key1_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_key1_out_busy),
-    .src_qs_o     (pin_out_ctl_key1_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.key1_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.key1_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_key1_out_qs_int)
   );
 
 
   //   F[key2_out]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_key2_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_key2_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_key2_out_busy),
-    .src_qs_o     (pin_out_ctl_key2_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.key2_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[5]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.key2_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_key2_out_qs_int)
   );
 
 
   //   F[z3_wakeup]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_z3_wakeup (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_z3_wakeup_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_z3_wakeup_busy),
-    .src_qs_o     (pin_out_ctl_z3_wakeup_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.z3_wakeup.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[6]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.z3_wakeup.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_z3_wakeup_qs_int)
   );
 
 
   //   F[flash_wp_l]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_ctl_flash_wp_l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_ctl_we),
-    .src_wd_i     (pin_out_ctl_flash_wp_l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_ctl_flash_wp_l_busy),
-    .src_qs_o     (pin_out_ctl_flash_wp_l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_ctl.flash_wp_l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_ctl_we),
+    .wd     (aon_pin_out_ctl_wdata[7]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_ctl.flash_wp_l.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_ctl_flash_wp_l_qs_int)
   );
 
 
   // R[pin_out_value]: V(False)
 
   //   F[bat_disable]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_bat_disable (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_bat_disable_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_bat_disable_busy),
-    .src_qs_o     (pin_out_value_bat_disable_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_bat_disable_qs_int)
   );
 
 
   //   F[ec_rst_l]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_ec_rst_l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_ec_rst_l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_ec_rst_l_busy),
-    .src_qs_o     (pin_out_value_ec_rst_l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.ec_rst_l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.ec_rst_l.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_ec_rst_l_qs_int)
   );
 
 
   //   F[pwrb_out]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_pwrb_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_pwrb_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_pwrb_out_busy),
-    .src_qs_o     (pin_out_value_pwrb_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.pwrb_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.pwrb_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_pwrb_out_qs_int)
   );
 
 
   //   F[key0_out]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_key0_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_key0_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_key0_out_busy),
-    .src_qs_o     (pin_out_value_key0_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.key0_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.key0_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_key0_out_qs_int)
   );
 
 
   //   F[key1_out]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_key1_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_key1_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_key1_out_busy),
-    .src_qs_o     (pin_out_value_key1_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.key1_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.key1_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_key1_out_qs_int)
   );
 
 
   //   F[key2_out]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_key2_out (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_key2_out_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_key2_out_busy),
-    .src_qs_o     (pin_out_value_key2_out_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.key2_out.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[5]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.key2_out.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_key2_out_qs_int)
   );
 
 
   //   F[z3_wakeup]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_z3_wakeup (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_z3_wakeup_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_z3_wakeup_busy),
-    .src_qs_o     (pin_out_value_z3_wakeup_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.z3_wakeup.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[6]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.z3_wakeup.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_z3_wakeup_qs_int)
   );
 
 
   //   F[flash_wp_l]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_pin_out_value_flash_wp_l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (pin_out_value_we),
-    .src_wd_i     (pin_out_value_flash_wp_l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (pin_out_value_flash_wp_l_busy),
-    .src_qs_o     (pin_out_value_flash_wp_l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.pin_out_value.flash_wp_l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_pin_out_value_we),
+    .wd     (aon_pin_out_value_wdata[7]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.pin_out_value.flash_wp_l.q),
+
+    // to register interface (read)
+    .qs     (aon_pin_out_value_flash_wp_l_qs_int)
   );
 
 
@@ -1991,469 +3106,553 @@ module sysrst_ctrl_reg_top (
   // R[key_intr_ctl]: V(False)
 
   //   F[pwrb_in_h2l]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_pwrb_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_pwrb_in_h2l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_pwrb_in_h2l_busy),
-    .src_qs_o     (key_intr_ctl_pwrb_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.pwrb_in_h2l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.pwrb_in_h2l.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_pwrb_in_h2l_qs_int)
   );
 
 
   //   F[key0_in_h2l]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_key0_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_key0_in_h2l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_key0_in_h2l_busy),
-    .src_qs_o     (key_intr_ctl_key0_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.key0_in_h2l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.key0_in_h2l.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_key0_in_h2l_qs_int)
   );
 
 
   //   F[key1_in_h2l]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_key1_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_key1_in_h2l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_key1_in_h2l_busy),
-    .src_qs_o     (key_intr_ctl_key1_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.key1_in_h2l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.key1_in_h2l.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_key1_in_h2l_qs_int)
   );
 
 
   //   F[key2_in_h2l]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_key2_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_key2_in_h2l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_key2_in_h2l_busy),
-    .src_qs_o     (key_intr_ctl_key2_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.key2_in_h2l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.key2_in_h2l.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_key2_in_h2l_qs_int)
   );
 
 
   //   F[ac_present_h2l]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_ac_present_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_ac_present_h2l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_ac_present_h2l_busy),
-    .src_qs_o     (key_intr_ctl_ac_present_h2l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.ac_present_h2l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.ac_present_h2l.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_ac_present_h2l_qs_int)
   );
 
 
   //   F[ec_rst_l_h2l]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_ec_rst_l_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_ec_rst_l_h2l_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_ec_rst_l_h2l_busy),
-    .src_qs_o     (key_intr_ctl_ec_rst_l_h2l_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.ec_rst_l_h2l.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[5]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.ec_rst_l_h2l.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_ec_rst_l_h2l_qs_int)
   );
 
 
   //   F[pwrb_in_l2h]: 8:8
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_pwrb_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_pwrb_in_l2h_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_pwrb_in_l2h_busy),
-    .src_qs_o     (key_intr_ctl_pwrb_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.pwrb_in_l2h.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[8]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.pwrb_in_l2h.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_pwrb_in_l2h_qs_int)
   );
 
 
   //   F[key0_in_l2h]: 9:9
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_key0_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_key0_in_l2h_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_key0_in_l2h_busy),
-    .src_qs_o     (key_intr_ctl_key0_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.key0_in_l2h.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[9]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.key0_in_l2h.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_key0_in_l2h_qs_int)
   );
 
 
   //   F[key1_in_l2h]: 10:10
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_key1_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_key1_in_l2h_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_key1_in_l2h_busy),
-    .src_qs_o     (key_intr_ctl_key1_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.key1_in_l2h.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[10]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.key1_in_l2h.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_key1_in_l2h_qs_int)
   );
 
 
   //   F[key2_in_l2h]: 11:11
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_key2_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_key2_in_l2h_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_key2_in_l2h_busy),
-    .src_qs_o     (key_intr_ctl_key2_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.key2_in_l2h.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[11]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.key2_in_l2h.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_key2_in_l2h_qs_int)
   );
 
 
   //   F[ac_present_l2h]: 12:12
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_ac_present_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_ac_present_l2h_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_ac_present_l2h_busy),
-    .src_qs_o     (key_intr_ctl_ac_present_l2h_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.ac_present_l2h.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[12]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.ac_present_l2h.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_ac_present_l2h_qs_int)
   );
 
 
   //   F[ec_rst_l_l2h]: 13:13
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_key_intr_ctl_ec_rst_l_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_ctl_ec_rst_l_l2h_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_ctl_ec_rst_l_l2h_busy),
-    .src_qs_o     (key_intr_ctl_ec_rst_l_l2h_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_ctl.ec_rst_l_l2h.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_ctl_we & aon_key_intr_ctl_regwen),
+    .wd     (aon_key_intr_ctl_wdata[13]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_ctl.ec_rst_l_l2h.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_ctl_ec_rst_l_l2h_qs_int)
   );
 
 
   // R[key_intr_debounce_ctl]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0)
   ) u_key_intr_debounce_ctl (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_debounce_ctl_we & regwen_qs),
-    .src_wd_i     (key_intr_debounce_ctl_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (key_intr_debounce_ctl_busy),
-    .src_qs_o     (key_intr_debounce_ctl_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.key_intr_debounce_ctl.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_debounce_ctl_we & aon_key_intr_debounce_ctl_regwen),
+    .wd     (aon_key_intr_debounce_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.key_intr_debounce_ctl.q),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_debounce_ctl_qs_int)
   );
 
 
   // R[auto_block_debounce_ctl]: V(False)
 
   //   F[debounce_timer]: 15:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (16'h0)
   ) u_auto_block_debounce_ctl_debounce_timer (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_debounce_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_debounce_ctl_debounce_timer_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_debounce_ctl_debounce_timer_busy),
-    .src_qs_o     (auto_block_debounce_ctl_debounce_timer_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_debounce_ctl.debounce_timer.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_debounce_ctl_we & aon_auto_block_debounce_ctl_regwen),
+    .wd     (aon_auto_block_debounce_ctl_wdata[15:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_debounce_ctl.debounce_timer.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_debounce_ctl_debounce_timer_qs_int)
   );
 
 
   //   F[auto_block_enable]: 16:16
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_debounce_ctl_auto_block_enable (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_debounce_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_debounce_ctl_auto_block_enable_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_debounce_ctl_auto_block_enable_busy),
-    .src_qs_o     (auto_block_debounce_ctl_auto_block_enable_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_debounce_ctl.auto_block_enable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_debounce_ctl_we & aon_auto_block_debounce_ctl_regwen),
+    .wd     (aon_auto_block_debounce_ctl_wdata[16]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_debounce_ctl.auto_block_enable.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_debounce_ctl_auto_block_enable_qs_int)
   );
 
 
   // R[auto_block_out_ctl]: V(False)
 
   //   F[key0_out_sel]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_out_ctl_key0_out_sel (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_out_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_out_ctl_key0_out_sel_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_out_ctl_key0_out_sel_busy),
-    .src_qs_o     (auto_block_out_ctl_key0_out_sel_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_out_ctl.key0_out_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_out_ctl_we & aon_auto_block_out_ctl_regwen),
+    .wd     (aon_auto_block_out_ctl_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_out_ctl.key0_out_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_out_ctl_key0_out_sel_qs_int)
   );
 
 
   //   F[key1_out_sel]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_out_ctl_key1_out_sel (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_out_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_out_ctl_key1_out_sel_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_out_ctl_key1_out_sel_busy),
-    .src_qs_o     (auto_block_out_ctl_key1_out_sel_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_out_ctl.key1_out_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_out_ctl_we & aon_auto_block_out_ctl_regwen),
+    .wd     (aon_auto_block_out_ctl_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_out_ctl.key1_out_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_out_ctl_key1_out_sel_qs_int)
   );
 
 
   //   F[key2_out_sel]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_out_ctl_key2_out_sel (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_out_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_out_ctl_key2_out_sel_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_out_ctl_key2_out_sel_busy),
-    .src_qs_o     (auto_block_out_ctl_key2_out_sel_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_out_ctl.key2_out_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_out_ctl_we & aon_auto_block_out_ctl_regwen),
+    .wd     (aon_auto_block_out_ctl_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_out_ctl.key2_out_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_out_ctl_key2_out_sel_qs_int)
   );
 
 
   //   F[key0_out_value]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_out_ctl_key0_out_value (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_out_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_out_ctl_key0_out_value_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_out_ctl_key0_out_value_busy),
-    .src_qs_o     (auto_block_out_ctl_key0_out_value_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_out_ctl.key0_out_value.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_out_ctl_we & aon_auto_block_out_ctl_regwen),
+    .wd     (aon_auto_block_out_ctl_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_out_ctl.key0_out_value.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_out_ctl_key0_out_value_qs_int)
   );
 
 
   //   F[key1_out_value]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_out_ctl_key1_out_value (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_out_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_out_ctl_key1_out_value_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_out_ctl_key1_out_value_busy),
-    .src_qs_o     (auto_block_out_ctl_key1_out_value_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_out_ctl.key1_out_value.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_out_ctl_we & aon_auto_block_out_ctl_regwen),
+    .wd     (aon_auto_block_out_ctl_wdata[5]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_out_ctl.key1_out_value.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_out_ctl_key1_out_value_qs_int)
   );
 
 
   //   F[key2_out_value]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_auto_block_out_ctl_key2_out_value (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (auto_block_out_ctl_we & regwen_qs),
-    .src_wd_i     (auto_block_out_ctl_key2_out_value_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (auto_block_out_ctl_key2_out_value_busy),
-    .src_qs_o     (auto_block_out_ctl_key2_out_value_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.auto_block_out_ctl.key2_out_value.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_auto_block_out_ctl_we & aon_auto_block_out_ctl_regwen),
+    .wd     (aon_auto_block_out_ctl_wdata[6]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.auto_block_out_ctl.key2_out_value.q),
+
+    // to register interface (read)
+    .qs     (aon_auto_block_out_ctl_key2_out_value_qs_int)
   );
 
 
@@ -2462,112 +3661,132 @@ module sysrst_ctrl_reg_top (
   // R[com_sel_ctl_0]: V(False)
 
   // F[key0_in_sel_0]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_0_key0_in_sel_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_0_key0_in_sel_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_0_key0_in_sel_0_busy),
-    .src_qs_o     (com_sel_ctl_0_key0_in_sel_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[0].key0_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_0_we & aon_com_sel_ctl_0_regwen),
+    .wd     (aon_com_sel_ctl_0_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[0].key0_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_0_key0_in_sel_0_qs_int)
   );
 
 
   // F[key1_in_sel_0]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_0_key1_in_sel_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_0_key1_in_sel_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_0_key1_in_sel_0_busy),
-    .src_qs_o     (com_sel_ctl_0_key1_in_sel_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[0].key1_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_0_we & aon_com_sel_ctl_0_regwen),
+    .wd     (aon_com_sel_ctl_0_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[0].key1_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_0_key1_in_sel_0_qs_int)
   );
 
 
   // F[key2_in_sel_0]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_0_key2_in_sel_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_0_key2_in_sel_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_0_key2_in_sel_0_busy),
-    .src_qs_o     (com_sel_ctl_0_key2_in_sel_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[0].key2_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_0_we & aon_com_sel_ctl_0_regwen),
+    .wd     (aon_com_sel_ctl_0_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[0].key2_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_0_key2_in_sel_0_qs_int)
   );
 
 
   // F[pwrb_in_sel_0]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_0_pwrb_in_sel_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_0_pwrb_in_sel_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_0_pwrb_in_sel_0_busy),
-    .src_qs_o     (com_sel_ctl_0_pwrb_in_sel_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[0].pwrb_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_0_we & aon_com_sel_ctl_0_regwen),
+    .wd     (aon_com_sel_ctl_0_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[0].pwrb_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int)
   );
 
 
   // F[ac_present_sel_0]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_0_ac_present_sel_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_0_ac_present_sel_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_0_ac_present_sel_0_busy),
-    .src_qs_o     (com_sel_ctl_0_ac_present_sel_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[0].ac_present_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_0_we & aon_com_sel_ctl_0_regwen),
+    .wd     (aon_com_sel_ctl_0_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[0].ac_present_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_0_ac_present_sel_0_qs_int)
   );
 
 
@@ -2575,112 +3794,132 @@ module sysrst_ctrl_reg_top (
   // R[com_sel_ctl_1]: V(False)
 
   // F[key0_in_sel_1]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_1_key0_in_sel_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_1_key0_in_sel_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_1_key0_in_sel_1_busy),
-    .src_qs_o     (com_sel_ctl_1_key0_in_sel_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[1].key0_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_1_we & aon_com_sel_ctl_1_regwen),
+    .wd     (aon_com_sel_ctl_1_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[1].key0_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_1_key0_in_sel_1_qs_int)
   );
 
 
   // F[key1_in_sel_1]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_1_key1_in_sel_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_1_key1_in_sel_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_1_key1_in_sel_1_busy),
-    .src_qs_o     (com_sel_ctl_1_key1_in_sel_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[1].key1_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_1_we & aon_com_sel_ctl_1_regwen),
+    .wd     (aon_com_sel_ctl_1_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[1].key1_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_1_key1_in_sel_1_qs_int)
   );
 
 
   // F[key2_in_sel_1]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_1_key2_in_sel_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_1_key2_in_sel_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_1_key2_in_sel_1_busy),
-    .src_qs_o     (com_sel_ctl_1_key2_in_sel_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[1].key2_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_1_we & aon_com_sel_ctl_1_regwen),
+    .wd     (aon_com_sel_ctl_1_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[1].key2_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_1_key2_in_sel_1_qs_int)
   );
 
 
   // F[pwrb_in_sel_1]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_1_pwrb_in_sel_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_1_pwrb_in_sel_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_1_pwrb_in_sel_1_busy),
-    .src_qs_o     (com_sel_ctl_1_pwrb_in_sel_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[1].pwrb_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_1_we & aon_com_sel_ctl_1_regwen),
+    .wd     (aon_com_sel_ctl_1_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[1].pwrb_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int)
   );
 
 
   // F[ac_present_sel_1]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_1_ac_present_sel_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_1_ac_present_sel_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_1_ac_present_sel_1_busy),
-    .src_qs_o     (com_sel_ctl_1_ac_present_sel_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[1].ac_present_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_1_we & aon_com_sel_ctl_1_regwen),
+    .wd     (aon_com_sel_ctl_1_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[1].ac_present_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_1_ac_present_sel_1_qs_int)
   );
 
 
@@ -2688,112 +3927,132 @@ module sysrst_ctrl_reg_top (
   // R[com_sel_ctl_2]: V(False)
 
   // F[key0_in_sel_2]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_2_key0_in_sel_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_2_key0_in_sel_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_2_key0_in_sel_2_busy),
-    .src_qs_o     (com_sel_ctl_2_key0_in_sel_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[2].key0_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_2_we & aon_com_sel_ctl_2_regwen),
+    .wd     (aon_com_sel_ctl_2_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[2].key0_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_2_key0_in_sel_2_qs_int)
   );
 
 
   // F[key1_in_sel_2]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_2_key1_in_sel_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_2_key1_in_sel_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_2_key1_in_sel_2_busy),
-    .src_qs_o     (com_sel_ctl_2_key1_in_sel_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[2].key1_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_2_we & aon_com_sel_ctl_2_regwen),
+    .wd     (aon_com_sel_ctl_2_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[2].key1_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_2_key1_in_sel_2_qs_int)
   );
 
 
   // F[key2_in_sel_2]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_2_key2_in_sel_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_2_key2_in_sel_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_2_key2_in_sel_2_busy),
-    .src_qs_o     (com_sel_ctl_2_key2_in_sel_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[2].key2_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_2_we & aon_com_sel_ctl_2_regwen),
+    .wd     (aon_com_sel_ctl_2_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[2].key2_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_2_key2_in_sel_2_qs_int)
   );
 
 
   // F[pwrb_in_sel_2]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_2_pwrb_in_sel_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_2_pwrb_in_sel_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_2_pwrb_in_sel_2_busy),
-    .src_qs_o     (com_sel_ctl_2_pwrb_in_sel_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[2].pwrb_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_2_we & aon_com_sel_ctl_2_regwen),
+    .wd     (aon_com_sel_ctl_2_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[2].pwrb_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int)
   );
 
 
   // F[ac_present_sel_2]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_2_ac_present_sel_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_2_ac_present_sel_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_2_ac_present_sel_2_busy),
-    .src_qs_o     (com_sel_ctl_2_ac_present_sel_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[2].ac_present_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_2_we & aon_com_sel_ctl_2_regwen),
+    .wd     (aon_com_sel_ctl_2_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[2].ac_present_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_2_ac_present_sel_2_qs_int)
   );
 
 
@@ -2801,112 +4060,132 @@ module sysrst_ctrl_reg_top (
   // R[com_sel_ctl_3]: V(False)
 
   // F[key0_in_sel_3]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_3_key0_in_sel_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_3_key0_in_sel_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_3_key0_in_sel_3_busy),
-    .src_qs_o     (com_sel_ctl_3_key0_in_sel_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[3].key0_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_3_we & aon_com_sel_ctl_3_regwen),
+    .wd     (aon_com_sel_ctl_3_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[3].key0_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_3_key0_in_sel_3_qs_int)
   );
 
 
   // F[key1_in_sel_3]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_3_key1_in_sel_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_3_key1_in_sel_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_3_key1_in_sel_3_busy),
-    .src_qs_o     (com_sel_ctl_3_key1_in_sel_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[3].key1_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_3_we & aon_com_sel_ctl_3_regwen),
+    .wd     (aon_com_sel_ctl_3_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[3].key1_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_3_key1_in_sel_3_qs_int)
   );
 
 
   // F[key2_in_sel_3]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_3_key2_in_sel_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_3_key2_in_sel_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_3_key2_in_sel_3_busy),
-    .src_qs_o     (com_sel_ctl_3_key2_in_sel_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[3].key2_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_3_we & aon_com_sel_ctl_3_regwen),
+    .wd     (aon_com_sel_ctl_3_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[3].key2_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_3_key2_in_sel_3_qs_int)
   );
 
 
   // F[pwrb_in_sel_3]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_3_pwrb_in_sel_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_3_pwrb_in_sel_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_3_pwrb_in_sel_3_busy),
-    .src_qs_o     (com_sel_ctl_3_pwrb_in_sel_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[3].pwrb_in_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_3_we & aon_com_sel_ctl_3_regwen),
+    .wd     (aon_com_sel_ctl_3_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[3].pwrb_in_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int)
   );
 
 
   // F[ac_present_sel_3]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_sel_ctl_3_ac_present_sel_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_sel_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_sel_ctl_3_ac_present_sel_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_sel_ctl_3_ac_present_sel_3_busy),
-    .src_qs_o     (com_sel_ctl_3_ac_present_sel_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_sel_ctl[3].ac_present_sel.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_sel_ctl_3_we & aon_com_sel_ctl_3_regwen),
+    .wd     (aon_com_sel_ctl_3_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_sel_ctl[3].ac_present_sel.q),
+
+    // to register interface (read)
+    .qs     (aon_com_sel_ctl_3_ac_present_sel_3_qs_int)
   );
 
 
@@ -2915,93 +4194,109 @@ module sysrst_ctrl_reg_top (
   // Subregister 0 of Multireg com_det_ctl
   // R[com_det_ctl_0]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0)
   ) u_com_det_ctl_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_det_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_det_ctl_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_det_ctl_0_busy),
-    .src_qs_o     (com_det_ctl_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_det_ctl[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_det_ctl_0_we & aon_com_det_ctl_0_regwen),
+    .wd     (aon_com_det_ctl_0_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_det_ctl[0].q),
+
+    // to register interface (read)
+    .qs     (aon_com_det_ctl_0_qs_int)
   );
 
   // Subregister 1 of Multireg com_det_ctl
   // R[com_det_ctl_1]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0)
   ) u_com_det_ctl_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_det_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_det_ctl_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_det_ctl_1_busy),
-    .src_qs_o     (com_det_ctl_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_det_ctl[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_det_ctl_1_we & aon_com_det_ctl_1_regwen),
+    .wd     (aon_com_det_ctl_1_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_det_ctl[1].q),
+
+    // to register interface (read)
+    .qs     (aon_com_det_ctl_1_qs_int)
   );
 
   // Subregister 2 of Multireg com_det_ctl
   // R[com_det_ctl_2]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0)
   ) u_com_det_ctl_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_det_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_det_ctl_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_det_ctl_2_busy),
-    .src_qs_o     (com_det_ctl_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_det_ctl[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_det_ctl_2_we & aon_com_det_ctl_2_regwen),
+    .wd     (aon_com_det_ctl_2_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_det_ctl[2].q),
+
+    // to register interface (read)
+    .qs     (aon_com_det_ctl_2_qs_int)
   );
 
   // Subregister 3 of Multireg com_det_ctl
   // R[com_det_ctl_3]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (32'h0)
   ) u_com_det_ctl_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_det_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_det_ctl_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_det_ctl_3_busy),
-    .src_qs_o     (com_det_ctl_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_det_ctl[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_det_ctl_3_we & aon_com_det_ctl_3_regwen),
+    .wd     (aon_com_det_ctl_3_wdata[31:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_det_ctl[3].q),
+
+    // to register interface (read)
+    .qs     (aon_com_det_ctl_3_qs_int)
   );
 
 
@@ -3010,90 +4305,106 @@ module sysrst_ctrl_reg_top (
   // R[com_out_ctl_0]: V(False)
 
   // F[bat_disable_0]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_0_bat_disable_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_0_bat_disable_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_0_bat_disable_0_busy),
-    .src_qs_o     (com_out_ctl_0_bat_disable_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[0].bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_0_we & aon_com_out_ctl_0_regwen),
+    .wd     (aon_com_out_ctl_0_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[0].bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_0_bat_disable_0_qs_int)
   );
 
 
   // F[interrupt_0]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_0_interrupt_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_0_interrupt_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_0_interrupt_0_busy),
-    .src_qs_o     (com_out_ctl_0_interrupt_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[0].interrupt.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_0_we & aon_com_out_ctl_0_regwen),
+    .wd     (aon_com_out_ctl_0_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[0].interrupt.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_0_interrupt_0_qs_int)
   );
 
 
   // F[ec_rst_0]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_0_ec_rst_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_0_ec_rst_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_0_ec_rst_0_busy),
-    .src_qs_o     (com_out_ctl_0_ec_rst_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[0].ec_rst.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_0_we & aon_com_out_ctl_0_regwen),
+    .wd     (aon_com_out_ctl_0_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[0].ec_rst.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_0_ec_rst_0_qs_int)
   );
 
 
   // F[rst_req_0]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_0_rst_req_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_0_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_0_rst_req_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_0_rst_req_0_busy),
-    .src_qs_o     (com_out_ctl_0_rst_req_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[0].rst_req.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_0_we & aon_com_out_ctl_0_regwen),
+    .wd     (aon_com_out_ctl_0_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[0].rst_req.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_0_rst_req_0_qs_int)
   );
 
 
@@ -3101,90 +4412,106 @@ module sysrst_ctrl_reg_top (
   // R[com_out_ctl_1]: V(False)
 
   // F[bat_disable_1]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_1_bat_disable_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_1_bat_disable_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_1_bat_disable_1_busy),
-    .src_qs_o     (com_out_ctl_1_bat_disable_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[1].bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_1_we & aon_com_out_ctl_1_regwen),
+    .wd     (aon_com_out_ctl_1_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[1].bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_1_bat_disable_1_qs_int)
   );
 
 
   // F[interrupt_1]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_1_interrupt_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_1_interrupt_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_1_interrupt_1_busy),
-    .src_qs_o     (com_out_ctl_1_interrupt_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[1].interrupt.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_1_we & aon_com_out_ctl_1_regwen),
+    .wd     (aon_com_out_ctl_1_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[1].interrupt.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_1_interrupt_1_qs_int)
   );
 
 
   // F[ec_rst_1]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_1_ec_rst_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_1_ec_rst_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_1_ec_rst_1_busy),
-    .src_qs_o     (com_out_ctl_1_ec_rst_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[1].ec_rst.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_1_we & aon_com_out_ctl_1_regwen),
+    .wd     (aon_com_out_ctl_1_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[1].ec_rst.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_1_ec_rst_1_qs_int)
   );
 
 
   // F[rst_req_1]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_1_rst_req_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_1_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_1_rst_req_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_1_rst_req_1_busy),
-    .src_qs_o     (com_out_ctl_1_rst_req_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[1].rst_req.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_1_we & aon_com_out_ctl_1_regwen),
+    .wd     (aon_com_out_ctl_1_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[1].rst_req.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_1_rst_req_1_qs_int)
   );
 
 
@@ -3192,90 +4519,106 @@ module sysrst_ctrl_reg_top (
   // R[com_out_ctl_2]: V(False)
 
   // F[bat_disable_2]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_2_bat_disable_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_2_bat_disable_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_2_bat_disable_2_busy),
-    .src_qs_o     (com_out_ctl_2_bat_disable_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[2].bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_2_we & aon_com_out_ctl_2_regwen),
+    .wd     (aon_com_out_ctl_2_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[2].bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_2_bat_disable_2_qs_int)
   );
 
 
   // F[interrupt_2]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_2_interrupt_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_2_interrupt_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_2_interrupt_2_busy),
-    .src_qs_o     (com_out_ctl_2_interrupt_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[2].interrupt.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_2_we & aon_com_out_ctl_2_regwen),
+    .wd     (aon_com_out_ctl_2_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[2].interrupt.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_2_interrupt_2_qs_int)
   );
 
 
   // F[ec_rst_2]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_2_ec_rst_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_2_ec_rst_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_2_ec_rst_2_busy),
-    .src_qs_o     (com_out_ctl_2_ec_rst_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[2].ec_rst.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_2_we & aon_com_out_ctl_2_regwen),
+    .wd     (aon_com_out_ctl_2_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[2].ec_rst.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_2_ec_rst_2_qs_int)
   );
 
 
   // F[rst_req_2]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_2_rst_req_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_2_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_2_rst_req_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_2_rst_req_2_busy),
-    .src_qs_o     (com_out_ctl_2_rst_req_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[2].rst_req.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_2_we & aon_com_out_ctl_2_regwen),
+    .wd     (aon_com_out_ctl_2_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[2].rst_req.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_2_rst_req_2_qs_int)
   );
 
 
@@ -3283,90 +4626,106 @@ module sysrst_ctrl_reg_top (
   // R[com_out_ctl_3]: V(False)
 
   // F[bat_disable_3]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_3_bat_disable_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_3_bat_disable_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_3_bat_disable_3_busy),
-    .src_qs_o     (com_out_ctl_3_bat_disable_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[3].bat_disable.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_3_we & aon_com_out_ctl_3_regwen),
+    .wd     (aon_com_out_ctl_3_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[3].bat_disable.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_3_bat_disable_3_qs_int)
   );
 
 
   // F[interrupt_3]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_3_interrupt_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_3_interrupt_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_3_interrupt_3_busy),
-    .src_qs_o     (com_out_ctl_3_interrupt_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[3].interrupt.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_3_we & aon_com_out_ctl_3_regwen),
+    .wd     (aon_com_out_ctl_3_wdata[1]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[3].interrupt.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_3_interrupt_3_qs_int)
   );
 
 
   // F[ec_rst_3]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_3_ec_rst_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_3_ec_rst_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_3_ec_rst_3_busy),
-    .src_qs_o     (com_out_ctl_3_ec_rst_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[3].ec_rst.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_3_we & aon_com_out_ctl_3_regwen),
+    .wd     (aon_com_out_ctl_3_wdata[2]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[3].ec_rst.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_3_ec_rst_3_qs_int)
   );
 
 
   // F[rst_req_3]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_com_out_ctl_3_rst_req_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (com_out_ctl_3_we & regwen_qs),
-    .src_wd_i     (com_out_ctl_3_rst_req_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (com_out_ctl_3_rst_req_3_busy),
-    .src_qs_o     (com_out_ctl_3_rst_req_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.com_out_ctl[3].rst_req.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_com_out_ctl_3_we & aon_com_out_ctl_3_regwen),
+    .wd     (aon_com_out_ctl_3_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.com_out_ctl[3].rst_req.q),
+
+    // to register interface (read)
+    .qs     (aon_com_out_ctl_3_rst_req_3_qs_int)
   );
 
 
@@ -3374,356 +4733,420 @@ module sysrst_ctrl_reg_top (
   // R[combo_intr_status]: V(False)
 
   //   F[combo0_h2l]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_combo_intr_status_combo0_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (combo_intr_status_we),
-    .src_wd_i     (combo_intr_status_combo0_h2l_wd),
-    .dst_de_i     (hw2reg.combo_intr_status.combo0_h2l.de),
-    .dst_d_i      (hw2reg.combo_intr_status.combo0_h2l.d),
-    .src_busy_o   (combo_intr_status_combo0_h2l_busy),
-    .src_qs_o     (combo_intr_status_combo0_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_combo_intr_status_we),
+    .wd     (aon_combo_intr_status_wdata[0]),
+
+    // from internal hardware
+    .de     (hw2reg.combo_intr_status.combo0_h2l.de),
+    .d      (hw2reg.combo_intr_status.combo0_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_combo_intr_status_combo0_h2l_qs_int)
   );
 
 
   //   F[combo1_h2l]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_combo_intr_status_combo1_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (combo_intr_status_we),
-    .src_wd_i     (combo_intr_status_combo1_h2l_wd),
-    .dst_de_i     (hw2reg.combo_intr_status.combo1_h2l.de),
-    .dst_d_i      (hw2reg.combo_intr_status.combo1_h2l.d),
-    .src_busy_o   (combo_intr_status_combo1_h2l_busy),
-    .src_qs_o     (combo_intr_status_combo1_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_combo_intr_status_we),
+    .wd     (aon_combo_intr_status_wdata[1]),
+
+    // from internal hardware
+    .de     (hw2reg.combo_intr_status.combo1_h2l.de),
+    .d      (hw2reg.combo_intr_status.combo1_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_combo_intr_status_combo1_h2l_qs_int)
   );
 
 
   //   F[combo2_h2l]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_combo_intr_status_combo2_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (combo_intr_status_we),
-    .src_wd_i     (combo_intr_status_combo2_h2l_wd),
-    .dst_de_i     (hw2reg.combo_intr_status.combo2_h2l.de),
-    .dst_d_i      (hw2reg.combo_intr_status.combo2_h2l.d),
-    .src_busy_o   (combo_intr_status_combo2_h2l_busy),
-    .src_qs_o     (combo_intr_status_combo2_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_combo_intr_status_we),
+    .wd     (aon_combo_intr_status_wdata[2]),
+
+    // from internal hardware
+    .de     (hw2reg.combo_intr_status.combo2_h2l.de),
+    .d      (hw2reg.combo_intr_status.combo2_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_combo_intr_status_combo2_h2l_qs_int)
   );
 
 
   //   F[combo3_h2l]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_combo_intr_status_combo3_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (combo_intr_status_we),
-    .src_wd_i     (combo_intr_status_combo3_h2l_wd),
-    .dst_de_i     (hw2reg.combo_intr_status.combo3_h2l.de),
-    .dst_d_i      (hw2reg.combo_intr_status.combo3_h2l.d),
-    .src_busy_o   (combo_intr_status_combo3_h2l_busy),
-    .src_qs_o     (combo_intr_status_combo3_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_combo_intr_status_we),
+    .wd     (aon_combo_intr_status_wdata[3]),
+
+    // from internal hardware
+    .de     (hw2reg.combo_intr_status.combo3_h2l.de),
+    .d      (hw2reg.combo_intr_status.combo3_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_combo_intr_status_combo3_h2l_qs_int)
   );
 
 
   // R[key_intr_status]: V(False)
 
   //   F[pwrb_h2l]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_pwrb_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_pwrb_h2l_wd),
-    .dst_de_i     (hw2reg.key_intr_status.pwrb_h2l.de),
-    .dst_d_i      (hw2reg.key_intr_status.pwrb_h2l.d),
-    .src_busy_o   (key_intr_status_pwrb_h2l_busy),
-    .src_qs_o     (key_intr_status_pwrb_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[0]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.pwrb_h2l.de),
+    .d      (hw2reg.key_intr_status.pwrb_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_pwrb_h2l_qs_int)
   );
 
 
   //   F[key0_in_h2l]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_key0_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_key0_in_h2l_wd),
-    .dst_de_i     (hw2reg.key_intr_status.key0_in_h2l.de),
-    .dst_d_i      (hw2reg.key_intr_status.key0_in_h2l.d),
-    .src_busy_o   (key_intr_status_key0_in_h2l_busy),
-    .src_qs_o     (key_intr_status_key0_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[1]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.key0_in_h2l.de),
+    .d      (hw2reg.key_intr_status.key0_in_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_key0_in_h2l_qs_int)
   );
 
 
   //   F[key1_in_h2l]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_key1_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_key1_in_h2l_wd),
-    .dst_de_i     (hw2reg.key_intr_status.key1_in_h2l.de),
-    .dst_d_i      (hw2reg.key_intr_status.key1_in_h2l.d),
-    .src_busy_o   (key_intr_status_key1_in_h2l_busy),
-    .src_qs_o     (key_intr_status_key1_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[2]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.key1_in_h2l.de),
+    .d      (hw2reg.key_intr_status.key1_in_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_key1_in_h2l_qs_int)
   );
 
 
   //   F[key2_in_h2l]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_key2_in_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_key2_in_h2l_wd),
-    .dst_de_i     (hw2reg.key_intr_status.key2_in_h2l.de),
-    .dst_d_i      (hw2reg.key_intr_status.key2_in_h2l.d),
-    .src_busy_o   (key_intr_status_key2_in_h2l_busy),
-    .src_qs_o     (key_intr_status_key2_in_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[3]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.key2_in_h2l.de),
+    .d      (hw2reg.key_intr_status.key2_in_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_key2_in_h2l_qs_int)
   );
 
 
   //   F[ac_present_h2l]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_ac_present_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_ac_present_h2l_wd),
-    .dst_de_i     (hw2reg.key_intr_status.ac_present_h2l.de),
-    .dst_d_i      (hw2reg.key_intr_status.ac_present_h2l.d),
-    .src_busy_o   (key_intr_status_ac_present_h2l_busy),
-    .src_qs_o     (key_intr_status_ac_present_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[4]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.ac_present_h2l.de),
+    .d      (hw2reg.key_intr_status.ac_present_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_ac_present_h2l_qs_int)
   );
 
 
   //   F[ec_rst_l_h2l]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_ec_rst_l_h2l (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_ec_rst_l_h2l_wd),
-    .dst_de_i     (hw2reg.key_intr_status.ec_rst_l_h2l.de),
-    .dst_d_i      (hw2reg.key_intr_status.ec_rst_l_h2l.d),
-    .src_busy_o   (key_intr_status_ec_rst_l_h2l_busy),
-    .src_qs_o     (key_intr_status_ec_rst_l_h2l_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[5]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.ec_rst_l_h2l.de),
+    .d      (hw2reg.key_intr_status.ec_rst_l_h2l.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_ec_rst_l_h2l_qs_int)
   );
 
 
   //   F[pwrb_l2h]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_pwrb_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_pwrb_l2h_wd),
-    .dst_de_i     (hw2reg.key_intr_status.pwrb_l2h.de),
-    .dst_d_i      (hw2reg.key_intr_status.pwrb_l2h.d),
-    .src_busy_o   (key_intr_status_pwrb_l2h_busy),
-    .src_qs_o     (key_intr_status_pwrb_l2h_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[6]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.pwrb_l2h.de),
+    .d      (hw2reg.key_intr_status.pwrb_l2h.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_pwrb_l2h_qs_int)
   );
 
 
   //   F[key0_in_l2h]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_key0_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_key0_in_l2h_wd),
-    .dst_de_i     (hw2reg.key_intr_status.key0_in_l2h.de),
-    .dst_d_i      (hw2reg.key_intr_status.key0_in_l2h.d),
-    .src_busy_o   (key_intr_status_key0_in_l2h_busy),
-    .src_qs_o     (key_intr_status_key0_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[7]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.key0_in_l2h.de),
+    .d      (hw2reg.key_intr_status.key0_in_l2h.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_key0_in_l2h_qs_int)
   );
 
 
   //   F[key1_in_l2h]: 8:8
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_key1_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_key1_in_l2h_wd),
-    .dst_de_i     (hw2reg.key_intr_status.key1_in_l2h.de),
-    .dst_d_i      (hw2reg.key_intr_status.key1_in_l2h.d),
-    .src_busy_o   (key_intr_status_key1_in_l2h_busy),
-    .src_qs_o     (key_intr_status_key1_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[8]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.key1_in_l2h.de),
+    .d      (hw2reg.key_intr_status.key1_in_l2h.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_key1_in_l2h_qs_int)
   );
 
 
   //   F[key2_in_l2h]: 9:9
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_key2_in_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_key2_in_l2h_wd),
-    .dst_de_i     (hw2reg.key_intr_status.key2_in_l2h.de),
-    .dst_d_i      (hw2reg.key_intr_status.key2_in_l2h.d),
-    .src_busy_o   (key_intr_status_key2_in_l2h_busy),
-    .src_qs_o     (key_intr_status_key2_in_l2h_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[9]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.key2_in_l2h.de),
+    .d      (hw2reg.key_intr_status.key2_in_l2h.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_key2_in_l2h_qs_int)
   );
 
 
   //   F[ac_present_l2h]: 10:10
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_ac_present_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_ac_present_l2h_wd),
-    .dst_de_i     (hw2reg.key_intr_status.ac_present_l2h.de),
-    .dst_d_i      (hw2reg.key_intr_status.ac_present_l2h.d),
-    .src_busy_o   (key_intr_status_ac_present_l2h_busy),
-    .src_qs_o     (key_intr_status_ac_present_l2h_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[10]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.ac_present_l2h.de),
+    .d      (hw2reg.key_intr_status.ac_present_l2h.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_ac_present_l2h_qs_int)
   );
 
 
   //   F[ec_rst_l_l2h]: 11:11
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
   ) u_key_intr_status_ec_rst_l_l2h (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (key_intr_status_we),
-    .src_wd_i     (key_intr_status_ec_rst_l_l2h_wd),
-    .dst_de_i     (hw2reg.key_intr_status.ec_rst_l_l2h.de),
-    .dst_d_i      (hw2reg.key_intr_status.ec_rst_l_l2h.d),
-    .src_busy_o   (key_intr_status_ec_rst_l_l2h_busy),
-    .src_qs_o     (key_intr_status_ec_rst_l_l2h_qs),
-    .dst_qe_o     (),
-    .q            ()
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_key_intr_status_we),
+    .wd     (aon_key_intr_status_wdata[11]),
+
+    // from internal hardware
+    .de     (hw2reg.key_intr_status.ec_rst_l_l2h.de),
+    .d      (hw2reg.key_intr_status.ec_rst_l_l2h.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (aon_key_intr_status_ec_rst_l_l2h_qs_int)
   );
 
 
@@ -3827,289 +5250,161 @@ module sysrst_ctrl_reg_top (
   assign regwen_wd = reg_wdata[0];
   assign ec_rst_ctl_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign ec_rst_ctl_wd = reg_wdata[15:0];
   assign ulp_ac_debounce_ctl_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign ulp_ac_debounce_ctl_wd = reg_wdata[15:0];
   assign ulp_lid_debounce_ctl_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign ulp_lid_debounce_ctl_wd = reg_wdata[15:0];
   assign ulp_pwrb_debounce_ctl_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign ulp_pwrb_debounce_ctl_wd = reg_wdata[15:0];
   assign ulp_ctl_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign ulp_ctl_wd = reg_wdata[0];
   assign ulp_status_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign ulp_status_wd = reg_wdata[0];
   assign wkup_status_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign wkup_status_wd = reg_wdata[0];
   assign key_invert_ctl_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign key_invert_ctl_key0_in_wd = reg_wdata[0];
 
-  assign key_invert_ctl_key0_out_wd = reg_wdata[1];
 
-  assign key_invert_ctl_key1_in_wd = reg_wdata[2];
 
-  assign key_invert_ctl_key1_out_wd = reg_wdata[3];
 
-  assign key_invert_ctl_key2_in_wd = reg_wdata[4];
 
-  assign key_invert_ctl_key2_out_wd = reg_wdata[5];
 
-  assign key_invert_ctl_pwrb_in_wd = reg_wdata[6];
 
-  assign key_invert_ctl_pwrb_out_wd = reg_wdata[7];
 
-  assign key_invert_ctl_ac_present_wd = reg_wdata[8];
 
-  assign key_invert_ctl_bat_disable_wd = reg_wdata[9];
 
-  assign key_invert_ctl_lid_open_wd = reg_wdata[10];
 
-  assign key_invert_ctl_z3_wakeup_wd = reg_wdata[11];
   assign pin_allowed_ctl_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign pin_allowed_ctl_bat_disable_0_wd = reg_wdata[0];
 
-  assign pin_allowed_ctl_ec_rst_l_0_wd = reg_wdata[1];
 
-  assign pin_allowed_ctl_pwrb_out_0_wd = reg_wdata[2];
 
-  assign pin_allowed_ctl_key0_out_0_wd = reg_wdata[3];
 
-  assign pin_allowed_ctl_key1_out_0_wd = reg_wdata[4];
 
-  assign pin_allowed_ctl_key2_out_0_wd = reg_wdata[5];
 
-  assign pin_allowed_ctl_z3_wakeup_0_wd = reg_wdata[6];
 
-  assign pin_allowed_ctl_flash_wp_l_0_wd = reg_wdata[7];
 
-  assign pin_allowed_ctl_bat_disable_1_wd = reg_wdata[8];
 
-  assign pin_allowed_ctl_ec_rst_l_1_wd = reg_wdata[9];
 
-  assign pin_allowed_ctl_pwrb_out_1_wd = reg_wdata[10];
 
-  assign pin_allowed_ctl_key0_out_1_wd = reg_wdata[11];
 
-  assign pin_allowed_ctl_key1_out_1_wd = reg_wdata[12];
 
-  assign pin_allowed_ctl_key2_out_1_wd = reg_wdata[13];
 
-  assign pin_allowed_ctl_z3_wakeup_1_wd = reg_wdata[14];
 
-  assign pin_allowed_ctl_flash_wp_l_1_wd = reg_wdata[15];
   assign pin_out_ctl_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign pin_out_ctl_bat_disable_wd = reg_wdata[0];
 
-  assign pin_out_ctl_ec_rst_l_wd = reg_wdata[1];
 
-  assign pin_out_ctl_pwrb_out_wd = reg_wdata[2];
 
-  assign pin_out_ctl_key0_out_wd = reg_wdata[3];
 
-  assign pin_out_ctl_key1_out_wd = reg_wdata[4];
 
-  assign pin_out_ctl_key2_out_wd = reg_wdata[5];
 
-  assign pin_out_ctl_z3_wakeup_wd = reg_wdata[6];
 
-  assign pin_out_ctl_flash_wp_l_wd = reg_wdata[7];
   assign pin_out_value_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign pin_out_value_bat_disable_wd = reg_wdata[0];
 
-  assign pin_out_value_ec_rst_l_wd = reg_wdata[1];
 
-  assign pin_out_value_pwrb_out_wd = reg_wdata[2];
 
-  assign pin_out_value_key0_out_wd = reg_wdata[3];
 
-  assign pin_out_value_key1_out_wd = reg_wdata[4];
 
-  assign pin_out_value_key2_out_wd = reg_wdata[5];
 
-  assign pin_out_value_z3_wakeup_wd = reg_wdata[6];
 
-  assign pin_out_value_flash_wp_l_wd = reg_wdata[7];
   assign key_intr_ctl_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign key_intr_ctl_pwrb_in_h2l_wd = reg_wdata[0];
 
-  assign key_intr_ctl_key0_in_h2l_wd = reg_wdata[1];
 
-  assign key_intr_ctl_key1_in_h2l_wd = reg_wdata[2];
 
-  assign key_intr_ctl_key2_in_h2l_wd = reg_wdata[3];
 
-  assign key_intr_ctl_ac_present_h2l_wd = reg_wdata[4];
 
-  assign key_intr_ctl_ec_rst_l_h2l_wd = reg_wdata[5];
 
-  assign key_intr_ctl_pwrb_in_l2h_wd = reg_wdata[8];
 
-  assign key_intr_ctl_key0_in_l2h_wd = reg_wdata[9];
 
-  assign key_intr_ctl_key1_in_l2h_wd = reg_wdata[10];
 
-  assign key_intr_ctl_key2_in_l2h_wd = reg_wdata[11];
 
-  assign key_intr_ctl_ac_present_l2h_wd = reg_wdata[12];
 
-  assign key_intr_ctl_ec_rst_l_l2h_wd = reg_wdata[13];
   assign key_intr_debounce_ctl_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign key_intr_debounce_ctl_wd = reg_wdata[15:0];
   assign auto_block_debounce_ctl_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign auto_block_debounce_ctl_debounce_timer_wd = reg_wdata[15:0];
 
-  assign auto_block_debounce_ctl_auto_block_enable_wd = reg_wdata[16];
   assign auto_block_out_ctl_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign auto_block_out_ctl_key0_out_sel_wd = reg_wdata[0];
 
-  assign auto_block_out_ctl_key1_out_sel_wd = reg_wdata[1];
 
-  assign auto_block_out_ctl_key2_out_sel_wd = reg_wdata[2];
 
-  assign auto_block_out_ctl_key0_out_value_wd = reg_wdata[4];
 
-  assign auto_block_out_ctl_key1_out_value_wd = reg_wdata[5];
 
-  assign auto_block_out_ctl_key2_out_value_wd = reg_wdata[6];
   assign com_sel_ctl_0_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign com_sel_ctl_0_key0_in_sel_0_wd = reg_wdata[0];
 
-  assign com_sel_ctl_0_key1_in_sel_0_wd = reg_wdata[1];
 
-  assign com_sel_ctl_0_key2_in_sel_0_wd = reg_wdata[2];
 
-  assign com_sel_ctl_0_pwrb_in_sel_0_wd = reg_wdata[3];
 
-  assign com_sel_ctl_0_ac_present_sel_0_wd = reg_wdata[4];
   assign com_sel_ctl_1_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign com_sel_ctl_1_key0_in_sel_1_wd = reg_wdata[0];
 
-  assign com_sel_ctl_1_key1_in_sel_1_wd = reg_wdata[1];
 
-  assign com_sel_ctl_1_key2_in_sel_1_wd = reg_wdata[2];
 
-  assign com_sel_ctl_1_pwrb_in_sel_1_wd = reg_wdata[3];
 
-  assign com_sel_ctl_1_ac_present_sel_1_wd = reg_wdata[4];
   assign com_sel_ctl_2_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign com_sel_ctl_2_key0_in_sel_2_wd = reg_wdata[0];
 
-  assign com_sel_ctl_2_key1_in_sel_2_wd = reg_wdata[1];
 
-  assign com_sel_ctl_2_key2_in_sel_2_wd = reg_wdata[2];
 
-  assign com_sel_ctl_2_pwrb_in_sel_2_wd = reg_wdata[3];
 
-  assign com_sel_ctl_2_ac_present_sel_2_wd = reg_wdata[4];
   assign com_sel_ctl_3_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign com_sel_ctl_3_key0_in_sel_3_wd = reg_wdata[0];
 
-  assign com_sel_ctl_3_key1_in_sel_3_wd = reg_wdata[1];
 
-  assign com_sel_ctl_3_key2_in_sel_3_wd = reg_wdata[2];
 
-  assign com_sel_ctl_3_pwrb_in_sel_3_wd = reg_wdata[3];
 
-  assign com_sel_ctl_3_ac_present_sel_3_wd = reg_wdata[4];
   assign com_det_ctl_0_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign com_det_ctl_0_wd = reg_wdata[31:0];
   assign com_det_ctl_1_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign com_det_ctl_1_wd = reg_wdata[31:0];
   assign com_det_ctl_2_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign com_det_ctl_2_wd = reg_wdata[31:0];
   assign com_det_ctl_3_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign com_det_ctl_3_wd = reg_wdata[31:0];
   assign com_out_ctl_0_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign com_out_ctl_0_bat_disable_0_wd = reg_wdata[0];
 
-  assign com_out_ctl_0_interrupt_0_wd = reg_wdata[1];
 
-  assign com_out_ctl_0_ec_rst_0_wd = reg_wdata[2];
 
-  assign com_out_ctl_0_rst_req_0_wd = reg_wdata[3];
   assign com_out_ctl_1_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign com_out_ctl_1_bat_disable_1_wd = reg_wdata[0];
 
-  assign com_out_ctl_1_interrupt_1_wd = reg_wdata[1];
 
-  assign com_out_ctl_1_ec_rst_1_wd = reg_wdata[2];
 
-  assign com_out_ctl_1_rst_req_1_wd = reg_wdata[3];
   assign com_out_ctl_2_we = addr_hit[31] & reg_we & !reg_error;
 
-  assign com_out_ctl_2_bat_disable_2_wd = reg_wdata[0];
 
-  assign com_out_ctl_2_interrupt_2_wd = reg_wdata[1];
 
-  assign com_out_ctl_2_ec_rst_2_wd = reg_wdata[2];
 
-  assign com_out_ctl_2_rst_req_2_wd = reg_wdata[3];
   assign com_out_ctl_3_we = addr_hit[32] & reg_we & !reg_error;
 
-  assign com_out_ctl_3_bat_disable_3_wd = reg_wdata[0];
 
-  assign com_out_ctl_3_interrupt_3_wd = reg_wdata[1];
 
-  assign com_out_ctl_3_ec_rst_3_wd = reg_wdata[2];
 
-  assign com_out_ctl_3_rst_req_3_wd = reg_wdata[3];
   assign combo_intr_status_we = addr_hit[33] & reg_we & !reg_error;
 
-  assign combo_intr_status_combo0_h2l_wd = reg_wdata[0];
 
-  assign combo_intr_status_combo1_h2l_wd = reg_wdata[1];
 
-  assign combo_intr_status_combo2_h2l_wd = reg_wdata[2];
 
-  assign combo_intr_status_combo3_h2l_wd = reg_wdata[3];
   assign key_intr_status_we = addr_hit[34] & reg_we & !reg_error;
 
-  assign key_intr_status_pwrb_h2l_wd = reg_wdata[0];
 
-  assign key_intr_status_key0_in_h2l_wd = reg_wdata[1];
 
-  assign key_intr_status_key1_in_h2l_wd = reg_wdata[2];
 
-  assign key_intr_status_key2_in_h2l_wd = reg_wdata[3];
 
-  assign key_intr_status_ac_present_h2l_wd = reg_wdata[4];
 
-  assign key_intr_status_ec_rst_l_h2l_wd = reg_wdata[5];
 
-  assign key_intr_status_pwrb_l2h_wd = reg_wdata[6];
 
-  assign key_intr_status_key0_in_l2h_wd = reg_wdata[7];
 
-  assign key_intr_status_key1_in_l2h_wd = reg_wdata[8];
 
-  assign key_intr_status_key2_in_l2h_wd = reg_wdata[9];
 
-  assign key_intr_status_ac_present_l2h_wd = reg_wdata[10];
 
-  assign key_intr_status_ec_rst_l_l2h_wd = reg_wdata[11];
 
   // Read data return
   always_comb begin
@@ -4136,89 +5431,38 @@ module sysrst_ctrl_reg_top (
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[15:0] = ec_rst_ctl_qs;
+        reg_rdata_next = DW'(ec_rst_ctl_qs);
       end
-
       addr_hit[6]: begin
-        reg_rdata_next[15:0] = ulp_ac_debounce_ctl_qs;
+        reg_rdata_next = DW'(ulp_ac_debounce_ctl_qs);
       end
-
       addr_hit[7]: begin
-        reg_rdata_next[15:0] = ulp_lid_debounce_ctl_qs;
+        reg_rdata_next = DW'(ulp_lid_debounce_ctl_qs);
       end
-
       addr_hit[8]: begin
-        reg_rdata_next[15:0] = ulp_pwrb_debounce_ctl_qs;
+        reg_rdata_next = DW'(ulp_pwrb_debounce_ctl_qs);
       end
-
       addr_hit[9]: begin
-        reg_rdata_next[0] = ulp_ctl_qs;
+        reg_rdata_next = DW'(ulp_ctl_qs);
       end
-
       addr_hit[10]: begin
-        reg_rdata_next[0] = ulp_status_qs;
+        reg_rdata_next = DW'(ulp_status_qs);
       end
-
       addr_hit[11]: begin
-        reg_rdata_next[0] = wkup_status_qs;
+        reg_rdata_next = DW'(wkup_status_qs);
       end
-
       addr_hit[12]: begin
-        reg_rdata_next[0] = key_invert_ctl_key0_in_qs;
-        reg_rdata_next[1] = key_invert_ctl_key0_out_qs;
-        reg_rdata_next[2] = key_invert_ctl_key1_in_qs;
-        reg_rdata_next[3] = key_invert_ctl_key1_out_qs;
-        reg_rdata_next[4] = key_invert_ctl_key2_in_qs;
-        reg_rdata_next[5] = key_invert_ctl_key2_out_qs;
-        reg_rdata_next[6] = key_invert_ctl_pwrb_in_qs;
-        reg_rdata_next[7] = key_invert_ctl_pwrb_out_qs;
-        reg_rdata_next[8] = key_invert_ctl_ac_present_qs;
-        reg_rdata_next[9] = key_invert_ctl_bat_disable_qs;
-        reg_rdata_next[10] = key_invert_ctl_lid_open_qs;
-        reg_rdata_next[11] = key_invert_ctl_z3_wakeup_qs;
+        reg_rdata_next = DW'(key_invert_ctl_qs);
       end
-
       addr_hit[13]: begin
-        reg_rdata_next[0] = pin_allowed_ctl_bat_disable_0_qs;
-        reg_rdata_next[1] = pin_allowed_ctl_ec_rst_l_0_qs;
-        reg_rdata_next[2] = pin_allowed_ctl_pwrb_out_0_qs;
-        reg_rdata_next[3] = pin_allowed_ctl_key0_out_0_qs;
-        reg_rdata_next[4] = pin_allowed_ctl_key1_out_0_qs;
-        reg_rdata_next[5] = pin_allowed_ctl_key2_out_0_qs;
-        reg_rdata_next[6] = pin_allowed_ctl_z3_wakeup_0_qs;
-        reg_rdata_next[7] = pin_allowed_ctl_flash_wp_l_0_qs;
-        reg_rdata_next[8] = pin_allowed_ctl_bat_disable_1_qs;
-        reg_rdata_next[9] = pin_allowed_ctl_ec_rst_l_1_qs;
-        reg_rdata_next[10] = pin_allowed_ctl_pwrb_out_1_qs;
-        reg_rdata_next[11] = pin_allowed_ctl_key0_out_1_qs;
-        reg_rdata_next[12] = pin_allowed_ctl_key1_out_1_qs;
-        reg_rdata_next[13] = pin_allowed_ctl_key2_out_1_qs;
-        reg_rdata_next[14] = pin_allowed_ctl_z3_wakeup_1_qs;
-        reg_rdata_next[15] = pin_allowed_ctl_flash_wp_l_1_qs;
+        reg_rdata_next = DW'(pin_allowed_ctl_qs);
       end
-
       addr_hit[14]: begin
-        reg_rdata_next[0] = pin_out_ctl_bat_disable_qs;
-        reg_rdata_next[1] = pin_out_ctl_ec_rst_l_qs;
-        reg_rdata_next[2] = pin_out_ctl_pwrb_out_qs;
-        reg_rdata_next[3] = pin_out_ctl_key0_out_qs;
-        reg_rdata_next[4] = pin_out_ctl_key1_out_qs;
-        reg_rdata_next[5] = pin_out_ctl_key2_out_qs;
-        reg_rdata_next[6] = pin_out_ctl_z3_wakeup_qs;
-        reg_rdata_next[7] = pin_out_ctl_flash_wp_l_qs;
+        reg_rdata_next = DW'(pin_out_ctl_qs);
       end
-
       addr_hit[15]: begin
-        reg_rdata_next[0] = pin_out_value_bat_disable_qs;
-        reg_rdata_next[1] = pin_out_value_ec_rst_l_qs;
-        reg_rdata_next[2] = pin_out_value_pwrb_out_qs;
-        reg_rdata_next[3] = pin_out_value_key0_out_qs;
-        reg_rdata_next[4] = pin_out_value_key1_out_qs;
-        reg_rdata_next[5] = pin_out_value_key2_out_qs;
-        reg_rdata_next[6] = pin_out_value_z3_wakeup_qs;
-        reg_rdata_next[7] = pin_out_value_flash_wp_l_qs;
+        reg_rdata_next = DW'(pin_out_value_qs);
       end
-
       addr_hit[16]: begin
         reg_rdata_next[0] = pin_in_value_ac_present_qs;
         reg_rdata_next[1] = pin_in_value_ec_rst_l_qs;
@@ -4230,136 +5474,59 @@ module sysrst_ctrl_reg_top (
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[0] = key_intr_ctl_pwrb_in_h2l_qs;
-        reg_rdata_next[1] = key_intr_ctl_key0_in_h2l_qs;
-        reg_rdata_next[2] = key_intr_ctl_key1_in_h2l_qs;
-        reg_rdata_next[3] = key_intr_ctl_key2_in_h2l_qs;
-        reg_rdata_next[4] = key_intr_ctl_ac_present_h2l_qs;
-        reg_rdata_next[5] = key_intr_ctl_ec_rst_l_h2l_qs;
-        reg_rdata_next[8] = key_intr_ctl_pwrb_in_l2h_qs;
-        reg_rdata_next[9] = key_intr_ctl_key0_in_l2h_qs;
-        reg_rdata_next[10] = key_intr_ctl_key1_in_l2h_qs;
-        reg_rdata_next[11] = key_intr_ctl_key2_in_l2h_qs;
-        reg_rdata_next[12] = key_intr_ctl_ac_present_l2h_qs;
-        reg_rdata_next[13] = key_intr_ctl_ec_rst_l_l2h_qs;
+        reg_rdata_next = DW'(key_intr_ctl_qs);
       end
-
       addr_hit[18]: begin
-        reg_rdata_next[15:0] = key_intr_debounce_ctl_qs;
+        reg_rdata_next = DW'(key_intr_debounce_ctl_qs);
       end
-
       addr_hit[19]: begin
-        reg_rdata_next[15:0] = auto_block_debounce_ctl_debounce_timer_qs;
-        reg_rdata_next[16] = auto_block_debounce_ctl_auto_block_enable_qs;
+        reg_rdata_next = DW'(auto_block_debounce_ctl_qs);
       end
-
       addr_hit[20]: begin
-        reg_rdata_next[0] = auto_block_out_ctl_key0_out_sel_qs;
-        reg_rdata_next[1] = auto_block_out_ctl_key1_out_sel_qs;
-        reg_rdata_next[2] = auto_block_out_ctl_key2_out_sel_qs;
-        reg_rdata_next[4] = auto_block_out_ctl_key0_out_value_qs;
-        reg_rdata_next[5] = auto_block_out_ctl_key1_out_value_qs;
-        reg_rdata_next[6] = auto_block_out_ctl_key2_out_value_qs;
+        reg_rdata_next = DW'(auto_block_out_ctl_qs);
       end
-
       addr_hit[21]: begin
-        reg_rdata_next[0] = com_sel_ctl_0_key0_in_sel_0_qs;
-        reg_rdata_next[1] = com_sel_ctl_0_key1_in_sel_0_qs;
-        reg_rdata_next[2] = com_sel_ctl_0_key2_in_sel_0_qs;
-        reg_rdata_next[3] = com_sel_ctl_0_pwrb_in_sel_0_qs;
-        reg_rdata_next[4] = com_sel_ctl_0_ac_present_sel_0_qs;
+        reg_rdata_next = DW'(com_sel_ctl_0_qs);
       end
-
       addr_hit[22]: begin
-        reg_rdata_next[0] = com_sel_ctl_1_key0_in_sel_1_qs;
-        reg_rdata_next[1] = com_sel_ctl_1_key1_in_sel_1_qs;
-        reg_rdata_next[2] = com_sel_ctl_1_key2_in_sel_1_qs;
-        reg_rdata_next[3] = com_sel_ctl_1_pwrb_in_sel_1_qs;
-        reg_rdata_next[4] = com_sel_ctl_1_ac_present_sel_1_qs;
+        reg_rdata_next = DW'(com_sel_ctl_1_qs);
       end
-
       addr_hit[23]: begin
-        reg_rdata_next[0] = com_sel_ctl_2_key0_in_sel_2_qs;
-        reg_rdata_next[1] = com_sel_ctl_2_key1_in_sel_2_qs;
-        reg_rdata_next[2] = com_sel_ctl_2_key2_in_sel_2_qs;
-        reg_rdata_next[3] = com_sel_ctl_2_pwrb_in_sel_2_qs;
-        reg_rdata_next[4] = com_sel_ctl_2_ac_present_sel_2_qs;
+        reg_rdata_next = DW'(com_sel_ctl_2_qs);
       end
-
       addr_hit[24]: begin
-        reg_rdata_next[0] = com_sel_ctl_3_key0_in_sel_3_qs;
-        reg_rdata_next[1] = com_sel_ctl_3_key1_in_sel_3_qs;
-        reg_rdata_next[2] = com_sel_ctl_3_key2_in_sel_3_qs;
-        reg_rdata_next[3] = com_sel_ctl_3_pwrb_in_sel_3_qs;
-        reg_rdata_next[4] = com_sel_ctl_3_ac_present_sel_3_qs;
+        reg_rdata_next = DW'(com_sel_ctl_3_qs);
       end
-
       addr_hit[25]: begin
-        reg_rdata_next[31:0] = com_det_ctl_0_qs;
+        reg_rdata_next = DW'(com_det_ctl_0_qs);
       end
-
       addr_hit[26]: begin
-        reg_rdata_next[31:0] = com_det_ctl_1_qs;
+        reg_rdata_next = DW'(com_det_ctl_1_qs);
       end
-
       addr_hit[27]: begin
-        reg_rdata_next[31:0] = com_det_ctl_2_qs;
+        reg_rdata_next = DW'(com_det_ctl_2_qs);
       end
-
       addr_hit[28]: begin
-        reg_rdata_next[31:0] = com_det_ctl_3_qs;
+        reg_rdata_next = DW'(com_det_ctl_3_qs);
       end
-
       addr_hit[29]: begin
-        reg_rdata_next[0] = com_out_ctl_0_bat_disable_0_qs;
-        reg_rdata_next[1] = com_out_ctl_0_interrupt_0_qs;
-        reg_rdata_next[2] = com_out_ctl_0_ec_rst_0_qs;
-        reg_rdata_next[3] = com_out_ctl_0_rst_req_0_qs;
+        reg_rdata_next = DW'(com_out_ctl_0_qs);
       end
-
       addr_hit[30]: begin
-        reg_rdata_next[0] = com_out_ctl_1_bat_disable_1_qs;
-        reg_rdata_next[1] = com_out_ctl_1_interrupt_1_qs;
-        reg_rdata_next[2] = com_out_ctl_1_ec_rst_1_qs;
-        reg_rdata_next[3] = com_out_ctl_1_rst_req_1_qs;
+        reg_rdata_next = DW'(com_out_ctl_1_qs);
       end
-
       addr_hit[31]: begin
-        reg_rdata_next[0] = com_out_ctl_2_bat_disable_2_qs;
-        reg_rdata_next[1] = com_out_ctl_2_interrupt_2_qs;
-        reg_rdata_next[2] = com_out_ctl_2_ec_rst_2_qs;
-        reg_rdata_next[3] = com_out_ctl_2_rst_req_2_qs;
+        reg_rdata_next = DW'(com_out_ctl_2_qs);
       end
-
       addr_hit[32]: begin
-        reg_rdata_next[0] = com_out_ctl_3_bat_disable_3_qs;
-        reg_rdata_next[1] = com_out_ctl_3_interrupt_3_qs;
-        reg_rdata_next[2] = com_out_ctl_3_ec_rst_3_qs;
-        reg_rdata_next[3] = com_out_ctl_3_rst_req_3_qs;
+        reg_rdata_next = DW'(com_out_ctl_3_qs);
       end
-
       addr_hit[33]: begin
-        reg_rdata_next[0] = combo_intr_status_combo0_h2l_qs;
-        reg_rdata_next[1] = combo_intr_status_combo1_h2l_qs;
-        reg_rdata_next[2] = combo_intr_status_combo2_h2l_qs;
-        reg_rdata_next[3] = combo_intr_status_combo3_h2l_qs;
+        reg_rdata_next = DW'(combo_intr_status_qs);
       end
-
       addr_hit[34]: begin
-        reg_rdata_next[0] = key_intr_status_pwrb_h2l_qs;
-        reg_rdata_next[1] = key_intr_status_key0_in_h2l_qs;
-        reg_rdata_next[2] = key_intr_status_key1_in_h2l_qs;
-        reg_rdata_next[3] = key_intr_status_key2_in_h2l_qs;
-        reg_rdata_next[4] = key_intr_status_ac_present_h2l_qs;
-        reg_rdata_next[5] = key_intr_status_ec_rst_l_h2l_qs;
-        reg_rdata_next[6] = key_intr_status_pwrb_l2h_qs;
-        reg_rdata_next[7] = key_intr_status_key0_in_l2h_qs;
-        reg_rdata_next[8] = key_intr_status_key1_in_l2h_qs;
-        reg_rdata_next[9] = key_intr_status_key2_in_l2h_qs;
-        reg_rdata_next[10] = key_intr_status_ac_present_l2h_qs;
-        reg_rdata_next[11] = key_intr_status_ec_rst_l_l2h_qs;
+        reg_rdata_next = DW'(key_intr_status_qs);
       end
-
       default: begin
         reg_rdata_next = '1;
       end
@@ -4398,124 +5565,40 @@ module sysrst_ctrl_reg_top (
         reg_busy_sel = wkup_status_busy;
       end
       addr_hit[12]: begin
-        reg_busy_sel =
-          key_invert_ctl_key0_in_busy |
-          key_invert_ctl_key0_out_busy |
-          key_invert_ctl_key1_in_busy |
-          key_invert_ctl_key1_out_busy |
-          key_invert_ctl_key2_in_busy |
-          key_invert_ctl_key2_out_busy |
-          key_invert_ctl_pwrb_in_busy |
-          key_invert_ctl_pwrb_out_busy |
-          key_invert_ctl_ac_present_busy |
-          key_invert_ctl_bat_disable_busy |
-          key_invert_ctl_lid_open_busy |
-          key_invert_ctl_z3_wakeup_busy;
+        reg_busy_sel = key_invert_ctl_busy;
       end
       addr_hit[13]: begin
-        reg_busy_sel =
-          pin_allowed_ctl_bat_disable_0_busy |
-          pin_allowed_ctl_ec_rst_l_0_busy |
-          pin_allowed_ctl_pwrb_out_0_busy |
-          pin_allowed_ctl_key0_out_0_busy |
-          pin_allowed_ctl_key1_out_0_busy |
-          pin_allowed_ctl_key2_out_0_busy |
-          pin_allowed_ctl_z3_wakeup_0_busy |
-          pin_allowed_ctl_flash_wp_l_0_busy |
-          pin_allowed_ctl_bat_disable_1_busy |
-          pin_allowed_ctl_ec_rst_l_1_busy |
-          pin_allowed_ctl_pwrb_out_1_busy |
-          pin_allowed_ctl_key0_out_1_busy |
-          pin_allowed_ctl_key1_out_1_busy |
-          pin_allowed_ctl_key2_out_1_busy |
-          pin_allowed_ctl_z3_wakeup_1_busy |
-          pin_allowed_ctl_flash_wp_l_1_busy;
+        reg_busy_sel = pin_allowed_ctl_busy;
       end
       addr_hit[14]: begin
-        reg_busy_sel =
-          pin_out_ctl_bat_disable_busy |
-          pin_out_ctl_ec_rst_l_busy |
-          pin_out_ctl_pwrb_out_busy |
-          pin_out_ctl_key0_out_busy |
-          pin_out_ctl_key1_out_busy |
-          pin_out_ctl_key2_out_busy |
-          pin_out_ctl_z3_wakeup_busy |
-          pin_out_ctl_flash_wp_l_busy;
+        reg_busy_sel = pin_out_ctl_busy;
       end
       addr_hit[15]: begin
-        reg_busy_sel =
-          pin_out_value_bat_disable_busy |
-          pin_out_value_ec_rst_l_busy |
-          pin_out_value_pwrb_out_busy |
-          pin_out_value_key0_out_busy |
-          pin_out_value_key1_out_busy |
-          pin_out_value_key2_out_busy |
-          pin_out_value_z3_wakeup_busy |
-          pin_out_value_flash_wp_l_busy;
+        reg_busy_sel = pin_out_value_busy;
       end
       addr_hit[17]: begin
-        reg_busy_sel =
-          key_intr_ctl_pwrb_in_h2l_busy |
-          key_intr_ctl_key0_in_h2l_busy |
-          key_intr_ctl_key1_in_h2l_busy |
-          key_intr_ctl_key2_in_h2l_busy |
-          key_intr_ctl_ac_present_h2l_busy |
-          key_intr_ctl_ec_rst_l_h2l_busy |
-          key_intr_ctl_pwrb_in_l2h_busy |
-          key_intr_ctl_key0_in_l2h_busy |
-          key_intr_ctl_key1_in_l2h_busy |
-          key_intr_ctl_key2_in_l2h_busy |
-          key_intr_ctl_ac_present_l2h_busy |
-          key_intr_ctl_ec_rst_l_l2h_busy;
+        reg_busy_sel = key_intr_ctl_busy;
       end
       addr_hit[18]: begin
         reg_busy_sel = key_intr_debounce_ctl_busy;
       end
       addr_hit[19]: begin
-        reg_busy_sel =
-          auto_block_debounce_ctl_debounce_timer_busy |
-          auto_block_debounce_ctl_auto_block_enable_busy;
+        reg_busy_sel = auto_block_debounce_ctl_busy;
       end
       addr_hit[20]: begin
-        reg_busy_sel =
-          auto_block_out_ctl_key0_out_sel_busy |
-          auto_block_out_ctl_key1_out_sel_busy |
-          auto_block_out_ctl_key2_out_sel_busy |
-          auto_block_out_ctl_key0_out_value_busy |
-          auto_block_out_ctl_key1_out_value_busy |
-          auto_block_out_ctl_key2_out_value_busy;
+        reg_busy_sel = auto_block_out_ctl_busy;
       end
       addr_hit[21]: begin
-        reg_busy_sel =
-          com_sel_ctl_0_key0_in_sel_0_busy |
-          com_sel_ctl_0_key1_in_sel_0_busy |
-          com_sel_ctl_0_key2_in_sel_0_busy |
-          com_sel_ctl_0_pwrb_in_sel_0_busy |
-          com_sel_ctl_0_ac_present_sel_0_busy;
+        reg_busy_sel = com_sel_ctl_0_busy;
       end
       addr_hit[22]: begin
-        reg_busy_sel =
-          com_sel_ctl_1_key0_in_sel_1_busy |
-          com_sel_ctl_1_key1_in_sel_1_busy |
-          com_sel_ctl_1_key2_in_sel_1_busy |
-          com_sel_ctl_1_pwrb_in_sel_1_busy |
-          com_sel_ctl_1_ac_present_sel_1_busy;
+        reg_busy_sel = com_sel_ctl_1_busy;
       end
       addr_hit[23]: begin
-        reg_busy_sel =
-          com_sel_ctl_2_key0_in_sel_2_busy |
-          com_sel_ctl_2_key1_in_sel_2_busy |
-          com_sel_ctl_2_key2_in_sel_2_busy |
-          com_sel_ctl_2_pwrb_in_sel_2_busy |
-          com_sel_ctl_2_ac_present_sel_2_busy;
+        reg_busy_sel = com_sel_ctl_2_busy;
       end
       addr_hit[24]: begin
-        reg_busy_sel =
-          com_sel_ctl_3_key0_in_sel_3_busy |
-          com_sel_ctl_3_key1_in_sel_3_busy |
-          com_sel_ctl_3_key2_in_sel_3_busy |
-          com_sel_ctl_3_pwrb_in_sel_3_busy |
-          com_sel_ctl_3_ac_present_sel_3_busy;
+        reg_busy_sel = com_sel_ctl_3_busy;
       end
       addr_hit[25]: begin
         reg_busy_sel = com_det_ctl_0_busy;
@@ -4530,61 +5613,28 @@ module sysrst_ctrl_reg_top (
         reg_busy_sel = com_det_ctl_3_busy;
       end
       addr_hit[29]: begin
-        reg_busy_sel =
-          com_out_ctl_0_bat_disable_0_busy |
-          com_out_ctl_0_interrupt_0_busy |
-          com_out_ctl_0_ec_rst_0_busy |
-          com_out_ctl_0_rst_req_0_busy;
+        reg_busy_sel = com_out_ctl_0_busy;
       end
       addr_hit[30]: begin
-        reg_busy_sel =
-          com_out_ctl_1_bat_disable_1_busy |
-          com_out_ctl_1_interrupt_1_busy |
-          com_out_ctl_1_ec_rst_1_busy |
-          com_out_ctl_1_rst_req_1_busy;
+        reg_busy_sel = com_out_ctl_1_busy;
       end
       addr_hit[31]: begin
-        reg_busy_sel =
-          com_out_ctl_2_bat_disable_2_busy |
-          com_out_ctl_2_interrupt_2_busy |
-          com_out_ctl_2_ec_rst_2_busy |
-          com_out_ctl_2_rst_req_2_busy;
+        reg_busy_sel = com_out_ctl_2_busy;
       end
       addr_hit[32]: begin
-        reg_busy_sel =
-          com_out_ctl_3_bat_disable_3_busy |
-          com_out_ctl_3_interrupt_3_busy |
-          com_out_ctl_3_ec_rst_3_busy |
-          com_out_ctl_3_rst_req_3_busy;
+        reg_busy_sel = com_out_ctl_3_busy;
       end
       addr_hit[33]: begin
-        reg_busy_sel =
-          combo_intr_status_combo0_h2l_busy |
-          combo_intr_status_combo1_h2l_busy |
-          combo_intr_status_combo2_h2l_busy |
-          combo_intr_status_combo3_h2l_busy;
+        reg_busy_sel = combo_intr_status_busy;
       end
       addr_hit[34]: begin
-        reg_busy_sel =
-          key_intr_status_pwrb_h2l_busy |
-          key_intr_status_key0_in_h2l_busy |
-          key_intr_status_key1_in_h2l_busy |
-          key_intr_status_key2_in_h2l_busy |
-          key_intr_status_ac_present_h2l_busy |
-          key_intr_status_ec_rst_l_h2l_busy |
-          key_intr_status_pwrb_l2h_busy |
-          key_intr_status_key0_in_l2h_busy |
-          key_intr_status_key1_in_l2h_busy |
-          key_intr_status_key2_in_l2h_busy |
-          key_intr_status_ac_present_l2h_busy |
-          key_intr_status_ec_rst_l_l2h_busy;
+        reg_busy_sel = key_intr_status_busy;
       end
       default: begin
         reg_busy_sel  = '0;
       end
     endcase
   end
-
 
 
   // Unused signal tieoff

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -1293,7 +1293,6 @@ module trial1_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -1656,7 +1656,6 @@ module uart_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -6723,7 +6723,6 @@ module usbdev_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -1778,7 +1778,6 @@ module usbuart_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -17159,7 +17159,6 @@ module alert_handler_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -2529,7 +2529,6 @@ module ast_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -739,7 +739,6 @@ module clkmgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -12343,7 +12343,6 @@ module flash_ctrl_core_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -2039,148 +2039,76 @@ module pinmux_reg_top (
   logic wkup_detector_regwen_7_qs;
   logic wkup_detector_regwen_7_wd;
   logic wkup_detector_en_0_we;
-  logic wkup_detector_en_0_qs;
-  logic wkup_detector_en_0_wd;
+  logic [0:0] wkup_detector_en_0_qs;
   logic wkup_detector_en_0_busy;
   logic wkup_detector_en_1_we;
-  logic wkup_detector_en_1_qs;
-  logic wkup_detector_en_1_wd;
+  logic [0:0] wkup_detector_en_1_qs;
   logic wkup_detector_en_1_busy;
   logic wkup_detector_en_2_we;
-  logic wkup_detector_en_2_qs;
-  logic wkup_detector_en_2_wd;
+  logic [0:0] wkup_detector_en_2_qs;
   logic wkup_detector_en_2_busy;
   logic wkup_detector_en_3_we;
-  logic wkup_detector_en_3_qs;
-  logic wkup_detector_en_3_wd;
+  logic [0:0] wkup_detector_en_3_qs;
   logic wkup_detector_en_3_busy;
   logic wkup_detector_en_4_we;
-  logic wkup_detector_en_4_qs;
-  logic wkup_detector_en_4_wd;
+  logic [0:0] wkup_detector_en_4_qs;
   logic wkup_detector_en_4_busy;
   logic wkup_detector_en_5_we;
-  logic wkup_detector_en_5_qs;
-  logic wkup_detector_en_5_wd;
+  logic [0:0] wkup_detector_en_5_qs;
   logic wkup_detector_en_5_busy;
   logic wkup_detector_en_6_we;
-  logic wkup_detector_en_6_qs;
-  logic wkup_detector_en_6_wd;
+  logic [0:0] wkup_detector_en_6_qs;
   logic wkup_detector_en_6_busy;
   logic wkup_detector_en_7_we;
-  logic wkup_detector_en_7_qs;
-  logic wkup_detector_en_7_wd;
+  logic [0:0] wkup_detector_en_7_qs;
   logic wkup_detector_en_7_busy;
   logic wkup_detector_0_we;
-  logic [2:0] wkup_detector_0_mode_0_qs;
-  logic [2:0] wkup_detector_0_mode_0_wd;
-  logic wkup_detector_0_mode_0_busy;
-  logic wkup_detector_0_filter_0_qs;
-  logic wkup_detector_0_filter_0_wd;
-  logic wkup_detector_0_filter_0_busy;
-  logic wkup_detector_0_miodio_0_qs;
-  logic wkup_detector_0_miodio_0_wd;
-  logic wkup_detector_0_miodio_0_busy;
+  logic [4:0] wkup_detector_0_qs;
+  logic wkup_detector_0_busy;
   logic wkup_detector_1_we;
-  logic [2:0] wkup_detector_1_mode_1_qs;
-  logic [2:0] wkup_detector_1_mode_1_wd;
-  logic wkup_detector_1_mode_1_busy;
-  logic wkup_detector_1_filter_1_qs;
-  logic wkup_detector_1_filter_1_wd;
-  logic wkup_detector_1_filter_1_busy;
-  logic wkup_detector_1_miodio_1_qs;
-  logic wkup_detector_1_miodio_1_wd;
-  logic wkup_detector_1_miodio_1_busy;
+  logic [4:0] wkup_detector_1_qs;
+  logic wkup_detector_1_busy;
   logic wkup_detector_2_we;
-  logic [2:0] wkup_detector_2_mode_2_qs;
-  logic [2:0] wkup_detector_2_mode_2_wd;
-  logic wkup_detector_2_mode_2_busy;
-  logic wkup_detector_2_filter_2_qs;
-  logic wkup_detector_2_filter_2_wd;
-  logic wkup_detector_2_filter_2_busy;
-  logic wkup_detector_2_miodio_2_qs;
-  logic wkup_detector_2_miodio_2_wd;
-  logic wkup_detector_2_miodio_2_busy;
+  logic [4:0] wkup_detector_2_qs;
+  logic wkup_detector_2_busy;
   logic wkup_detector_3_we;
-  logic [2:0] wkup_detector_3_mode_3_qs;
-  logic [2:0] wkup_detector_3_mode_3_wd;
-  logic wkup_detector_3_mode_3_busy;
-  logic wkup_detector_3_filter_3_qs;
-  logic wkup_detector_3_filter_3_wd;
-  logic wkup_detector_3_filter_3_busy;
-  logic wkup_detector_3_miodio_3_qs;
-  logic wkup_detector_3_miodio_3_wd;
-  logic wkup_detector_3_miodio_3_busy;
+  logic [4:0] wkup_detector_3_qs;
+  logic wkup_detector_3_busy;
   logic wkup_detector_4_we;
-  logic [2:0] wkup_detector_4_mode_4_qs;
-  logic [2:0] wkup_detector_4_mode_4_wd;
-  logic wkup_detector_4_mode_4_busy;
-  logic wkup_detector_4_filter_4_qs;
-  logic wkup_detector_4_filter_4_wd;
-  logic wkup_detector_4_filter_4_busy;
-  logic wkup_detector_4_miodio_4_qs;
-  logic wkup_detector_4_miodio_4_wd;
-  logic wkup_detector_4_miodio_4_busy;
+  logic [4:0] wkup_detector_4_qs;
+  logic wkup_detector_4_busy;
   logic wkup_detector_5_we;
-  logic [2:0] wkup_detector_5_mode_5_qs;
-  logic [2:0] wkup_detector_5_mode_5_wd;
-  logic wkup_detector_5_mode_5_busy;
-  logic wkup_detector_5_filter_5_qs;
-  logic wkup_detector_5_filter_5_wd;
-  logic wkup_detector_5_filter_5_busy;
-  logic wkup_detector_5_miodio_5_qs;
-  logic wkup_detector_5_miodio_5_wd;
-  logic wkup_detector_5_miodio_5_busy;
+  logic [4:0] wkup_detector_5_qs;
+  logic wkup_detector_5_busy;
   logic wkup_detector_6_we;
-  logic [2:0] wkup_detector_6_mode_6_qs;
-  logic [2:0] wkup_detector_6_mode_6_wd;
-  logic wkup_detector_6_mode_6_busy;
-  logic wkup_detector_6_filter_6_qs;
-  logic wkup_detector_6_filter_6_wd;
-  logic wkup_detector_6_filter_6_busy;
-  logic wkup_detector_6_miodio_6_qs;
-  logic wkup_detector_6_miodio_6_wd;
-  logic wkup_detector_6_miodio_6_busy;
+  logic [4:0] wkup_detector_6_qs;
+  logic wkup_detector_6_busy;
   logic wkup_detector_7_we;
-  logic [2:0] wkup_detector_7_mode_7_qs;
-  logic [2:0] wkup_detector_7_mode_7_wd;
-  logic wkup_detector_7_mode_7_busy;
-  logic wkup_detector_7_filter_7_qs;
-  logic wkup_detector_7_filter_7_wd;
-  logic wkup_detector_7_filter_7_busy;
-  logic wkup_detector_7_miodio_7_qs;
-  logic wkup_detector_7_miodio_7_wd;
-  logic wkup_detector_7_miodio_7_busy;
+  logic [4:0] wkup_detector_7_qs;
+  logic wkup_detector_7_busy;
   logic wkup_detector_cnt_th_0_we;
   logic [7:0] wkup_detector_cnt_th_0_qs;
-  logic [7:0] wkup_detector_cnt_th_0_wd;
   logic wkup_detector_cnt_th_0_busy;
   logic wkup_detector_cnt_th_1_we;
   logic [7:0] wkup_detector_cnt_th_1_qs;
-  logic [7:0] wkup_detector_cnt_th_1_wd;
   logic wkup_detector_cnt_th_1_busy;
   logic wkup_detector_cnt_th_2_we;
   logic [7:0] wkup_detector_cnt_th_2_qs;
-  logic [7:0] wkup_detector_cnt_th_2_wd;
   logic wkup_detector_cnt_th_2_busy;
   logic wkup_detector_cnt_th_3_we;
   logic [7:0] wkup_detector_cnt_th_3_qs;
-  logic [7:0] wkup_detector_cnt_th_3_wd;
   logic wkup_detector_cnt_th_3_busy;
   logic wkup_detector_cnt_th_4_we;
   logic [7:0] wkup_detector_cnt_th_4_qs;
-  logic [7:0] wkup_detector_cnt_th_4_wd;
   logic wkup_detector_cnt_th_4_busy;
   logic wkup_detector_cnt_th_5_we;
   logic [7:0] wkup_detector_cnt_th_5_qs;
-  logic [7:0] wkup_detector_cnt_th_5_wd;
   logic wkup_detector_cnt_th_5_busy;
   logic wkup_detector_cnt_th_6_we;
   logic [7:0] wkup_detector_cnt_th_6_qs;
-  logic [7:0] wkup_detector_cnt_th_6_wd;
   logic wkup_detector_cnt_th_6_busy;
   logic wkup_detector_cnt_th_7_we;
   logic [7:0] wkup_detector_cnt_th_7_qs;
-  logic [7:0] wkup_detector_cnt_th_7_wd;
   logic wkup_detector_cnt_th_7_busy;
   logic wkup_detector_padsel_0_we;
   logic [5:0] wkup_detector_padsel_0_qs;
@@ -2207,30 +2135,955 @@ module pinmux_reg_top (
   logic [5:0] wkup_detector_padsel_7_qs;
   logic [5:0] wkup_detector_padsel_7_wd;
   logic wkup_cause_we;
-  logic wkup_cause_cause_0_qs;
-  logic wkup_cause_cause_0_wd;
-  logic wkup_cause_cause_0_busy;
-  logic wkup_cause_cause_1_qs;
-  logic wkup_cause_cause_1_wd;
-  logic wkup_cause_cause_1_busy;
-  logic wkup_cause_cause_2_qs;
-  logic wkup_cause_cause_2_wd;
-  logic wkup_cause_cause_2_busy;
-  logic wkup_cause_cause_3_qs;
-  logic wkup_cause_cause_3_wd;
-  logic wkup_cause_cause_3_busy;
-  logic wkup_cause_cause_4_qs;
-  logic wkup_cause_cause_4_wd;
-  logic wkup_cause_cause_4_busy;
-  logic wkup_cause_cause_5_qs;
-  logic wkup_cause_cause_5_wd;
-  logic wkup_cause_cause_5_busy;
-  logic wkup_cause_cause_6_qs;
-  logic wkup_cause_cause_6_wd;
-  logic wkup_cause_cause_6_busy;
-  logic wkup_cause_cause_7_qs;
-  logic wkup_cause_cause_7_wd;
-  logic wkup_cause_cause_7_busy;
+  logic [7:0] wkup_cause_qs;
+  logic wkup_cause_busy;
+  // Define register CDC handling.
+  // CDC handling is done on a per-reg instead of per-field boundary.
+
+  logic  aon_wkup_detector_en_0_qs_int;
+  logic [0:0] aon_wkup_detector_en_0_d;
+  logic [0:0] aon_wkup_detector_en_0_wdata;
+  logic aon_wkup_detector_en_0_we;
+  logic unused_aon_wkup_detector_en_0_wdata;
+  logic aon_wkup_detector_en_0_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_0_d = '0;
+    aon_wkup_detector_en_0_d = aon_wkup_detector_en_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_0_qs),
+    .src_we_i     (wkup_detector_en_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_0_busy),
+    .src_qs_o     (wkup_detector_en_0_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_0_d),
+    .dst_we_o     (aon_wkup_detector_en_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_0_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_0_wdata)
+  );
+  assign unused_aon_wkup_detector_en_0_wdata = ^aon_wkup_detector_en_0_wdata;
+
+  logic  aon_wkup_detector_en_1_qs_int;
+  logic [0:0] aon_wkup_detector_en_1_d;
+  logic [0:0] aon_wkup_detector_en_1_wdata;
+  logic aon_wkup_detector_en_1_we;
+  logic unused_aon_wkup_detector_en_1_wdata;
+  logic aon_wkup_detector_en_1_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_1_d = '0;
+    aon_wkup_detector_en_1_d = aon_wkup_detector_en_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_1_qs),
+    .src_we_i     (wkup_detector_en_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_1_busy),
+    .src_qs_o     (wkup_detector_en_1_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_1_d),
+    .dst_we_o     (aon_wkup_detector_en_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_1_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_1_wdata)
+  );
+  assign unused_aon_wkup_detector_en_1_wdata = ^aon_wkup_detector_en_1_wdata;
+
+  logic  aon_wkup_detector_en_2_qs_int;
+  logic [0:0] aon_wkup_detector_en_2_d;
+  logic [0:0] aon_wkup_detector_en_2_wdata;
+  logic aon_wkup_detector_en_2_we;
+  logic unused_aon_wkup_detector_en_2_wdata;
+  logic aon_wkup_detector_en_2_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_2_d = '0;
+    aon_wkup_detector_en_2_d = aon_wkup_detector_en_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_2_qs),
+    .src_we_i     (wkup_detector_en_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_2_busy),
+    .src_qs_o     (wkup_detector_en_2_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_2_d),
+    .dst_we_o     (aon_wkup_detector_en_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_2_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_2_wdata)
+  );
+  assign unused_aon_wkup_detector_en_2_wdata = ^aon_wkup_detector_en_2_wdata;
+
+  logic  aon_wkup_detector_en_3_qs_int;
+  logic [0:0] aon_wkup_detector_en_3_d;
+  logic [0:0] aon_wkup_detector_en_3_wdata;
+  logic aon_wkup_detector_en_3_we;
+  logic unused_aon_wkup_detector_en_3_wdata;
+  logic aon_wkup_detector_en_3_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_3_d = '0;
+    aon_wkup_detector_en_3_d = aon_wkup_detector_en_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_3_qs),
+    .src_we_i     (wkup_detector_en_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_3_busy),
+    .src_qs_o     (wkup_detector_en_3_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_3_d),
+    .dst_we_o     (aon_wkup_detector_en_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_3_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_3_wdata)
+  );
+  assign unused_aon_wkup_detector_en_3_wdata = ^aon_wkup_detector_en_3_wdata;
+
+  logic  aon_wkup_detector_en_4_qs_int;
+  logic [0:0] aon_wkup_detector_en_4_d;
+  logic [0:0] aon_wkup_detector_en_4_wdata;
+  logic aon_wkup_detector_en_4_we;
+  logic unused_aon_wkup_detector_en_4_wdata;
+  logic aon_wkup_detector_en_4_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_4_d = '0;
+    aon_wkup_detector_en_4_d = aon_wkup_detector_en_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_4_qs),
+    .src_we_i     (wkup_detector_en_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_4_busy),
+    .src_qs_o     (wkup_detector_en_4_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_4_d),
+    .dst_we_o     (aon_wkup_detector_en_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_4_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_4_wdata)
+  );
+  assign unused_aon_wkup_detector_en_4_wdata = ^aon_wkup_detector_en_4_wdata;
+
+  logic  aon_wkup_detector_en_5_qs_int;
+  logic [0:0] aon_wkup_detector_en_5_d;
+  logic [0:0] aon_wkup_detector_en_5_wdata;
+  logic aon_wkup_detector_en_5_we;
+  logic unused_aon_wkup_detector_en_5_wdata;
+  logic aon_wkup_detector_en_5_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_5_d = '0;
+    aon_wkup_detector_en_5_d = aon_wkup_detector_en_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_5_qs),
+    .src_we_i     (wkup_detector_en_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_5_busy),
+    .src_qs_o     (wkup_detector_en_5_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_5_d),
+    .dst_we_o     (aon_wkup_detector_en_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_5_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_5_wdata)
+  );
+  assign unused_aon_wkup_detector_en_5_wdata = ^aon_wkup_detector_en_5_wdata;
+
+  logic  aon_wkup_detector_en_6_qs_int;
+  logic [0:0] aon_wkup_detector_en_6_d;
+  logic [0:0] aon_wkup_detector_en_6_wdata;
+  logic aon_wkup_detector_en_6_we;
+  logic unused_aon_wkup_detector_en_6_wdata;
+  logic aon_wkup_detector_en_6_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_6_d = '0;
+    aon_wkup_detector_en_6_d = aon_wkup_detector_en_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_6_qs),
+    .src_we_i     (wkup_detector_en_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_6_busy),
+    .src_qs_o     (wkup_detector_en_6_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_6_d),
+    .dst_we_o     (aon_wkup_detector_en_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_6_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_6_wdata)
+  );
+  assign unused_aon_wkup_detector_en_6_wdata = ^aon_wkup_detector_en_6_wdata;
+
+  logic  aon_wkup_detector_en_7_qs_int;
+  logic [0:0] aon_wkup_detector_en_7_d;
+  logic [0:0] aon_wkup_detector_en_7_wdata;
+  logic aon_wkup_detector_en_7_we;
+  logic unused_aon_wkup_detector_en_7_wdata;
+  logic aon_wkup_detector_en_7_regwen;
+
+  always_comb begin
+    aon_wkup_detector_en_7_d = '0;
+    aon_wkup_detector_en_7_d = aon_wkup_detector_en_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(1),
+    .ResetVal(1'h0),
+    .BitMask(1'h1)
+  ) u_wkup_detector_en_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_7_qs),
+    .src_we_i     (wkup_detector_en_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[0:0]),
+    .src_busy_o   (wkup_detector_en_7_busy),
+    .src_qs_o     (wkup_detector_en_7_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_en_7_d),
+    .dst_we_o     (aon_wkup_detector_en_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_en_7_regwen),
+    .dst_wd_o     (aon_wkup_detector_en_7_wdata)
+  );
+  assign unused_aon_wkup_detector_en_7_wdata = ^aon_wkup_detector_en_7_wdata;
+
+  logic [2:0]  aon_wkup_detector_0_mode_0_qs_int;
+  logic  aon_wkup_detector_0_filter_0_qs_int;
+  logic  aon_wkup_detector_0_miodio_0_qs_int;
+  logic [4:0] aon_wkup_detector_0_d;
+  logic [4:0] aon_wkup_detector_0_wdata;
+  logic aon_wkup_detector_0_we;
+  logic unused_aon_wkup_detector_0_wdata;
+  logic aon_wkup_detector_0_regwen;
+
+  always_comb begin
+    aon_wkup_detector_0_d = '0;
+    aon_wkup_detector_0_d[2:0] = aon_wkup_detector_0_mode_0_qs_int;
+    aon_wkup_detector_0_d[3] = aon_wkup_detector_0_filter_0_qs_int;
+    aon_wkup_detector_0_d[4] = aon_wkup_detector_0_miodio_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_0_qs),
+    .src_we_i     (wkup_detector_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_0_busy),
+    .src_qs_o     (wkup_detector_0_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_0_d),
+    .dst_we_o     (aon_wkup_detector_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_0_regwen),
+    .dst_wd_o     (aon_wkup_detector_0_wdata)
+  );
+  assign unused_aon_wkup_detector_0_wdata = ^aon_wkup_detector_0_wdata;
+
+  logic [2:0]  aon_wkup_detector_1_mode_1_qs_int;
+  logic  aon_wkup_detector_1_filter_1_qs_int;
+  logic  aon_wkup_detector_1_miodio_1_qs_int;
+  logic [4:0] aon_wkup_detector_1_d;
+  logic [4:0] aon_wkup_detector_1_wdata;
+  logic aon_wkup_detector_1_we;
+  logic unused_aon_wkup_detector_1_wdata;
+  logic aon_wkup_detector_1_regwen;
+
+  always_comb begin
+    aon_wkup_detector_1_d = '0;
+    aon_wkup_detector_1_d[2:0] = aon_wkup_detector_1_mode_1_qs_int;
+    aon_wkup_detector_1_d[3] = aon_wkup_detector_1_filter_1_qs_int;
+    aon_wkup_detector_1_d[4] = aon_wkup_detector_1_miodio_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_1_qs),
+    .src_we_i     (wkup_detector_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_1_busy),
+    .src_qs_o     (wkup_detector_1_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_1_d),
+    .dst_we_o     (aon_wkup_detector_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_1_regwen),
+    .dst_wd_o     (aon_wkup_detector_1_wdata)
+  );
+  assign unused_aon_wkup_detector_1_wdata = ^aon_wkup_detector_1_wdata;
+
+  logic [2:0]  aon_wkup_detector_2_mode_2_qs_int;
+  logic  aon_wkup_detector_2_filter_2_qs_int;
+  logic  aon_wkup_detector_2_miodio_2_qs_int;
+  logic [4:0] aon_wkup_detector_2_d;
+  logic [4:0] aon_wkup_detector_2_wdata;
+  logic aon_wkup_detector_2_we;
+  logic unused_aon_wkup_detector_2_wdata;
+  logic aon_wkup_detector_2_regwen;
+
+  always_comb begin
+    aon_wkup_detector_2_d = '0;
+    aon_wkup_detector_2_d[2:0] = aon_wkup_detector_2_mode_2_qs_int;
+    aon_wkup_detector_2_d[3] = aon_wkup_detector_2_filter_2_qs_int;
+    aon_wkup_detector_2_d[4] = aon_wkup_detector_2_miodio_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_2_qs),
+    .src_we_i     (wkup_detector_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_2_busy),
+    .src_qs_o     (wkup_detector_2_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_2_d),
+    .dst_we_o     (aon_wkup_detector_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_2_regwen),
+    .dst_wd_o     (aon_wkup_detector_2_wdata)
+  );
+  assign unused_aon_wkup_detector_2_wdata = ^aon_wkup_detector_2_wdata;
+
+  logic [2:0]  aon_wkup_detector_3_mode_3_qs_int;
+  logic  aon_wkup_detector_3_filter_3_qs_int;
+  logic  aon_wkup_detector_3_miodio_3_qs_int;
+  logic [4:0] aon_wkup_detector_3_d;
+  logic [4:0] aon_wkup_detector_3_wdata;
+  logic aon_wkup_detector_3_we;
+  logic unused_aon_wkup_detector_3_wdata;
+  logic aon_wkup_detector_3_regwen;
+
+  always_comb begin
+    aon_wkup_detector_3_d = '0;
+    aon_wkup_detector_3_d[2:0] = aon_wkup_detector_3_mode_3_qs_int;
+    aon_wkup_detector_3_d[3] = aon_wkup_detector_3_filter_3_qs_int;
+    aon_wkup_detector_3_d[4] = aon_wkup_detector_3_miodio_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_3_qs),
+    .src_we_i     (wkup_detector_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_3_busy),
+    .src_qs_o     (wkup_detector_3_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_3_d),
+    .dst_we_o     (aon_wkup_detector_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_3_regwen),
+    .dst_wd_o     (aon_wkup_detector_3_wdata)
+  );
+  assign unused_aon_wkup_detector_3_wdata = ^aon_wkup_detector_3_wdata;
+
+  logic [2:0]  aon_wkup_detector_4_mode_4_qs_int;
+  logic  aon_wkup_detector_4_filter_4_qs_int;
+  logic  aon_wkup_detector_4_miodio_4_qs_int;
+  logic [4:0] aon_wkup_detector_4_d;
+  logic [4:0] aon_wkup_detector_4_wdata;
+  logic aon_wkup_detector_4_we;
+  logic unused_aon_wkup_detector_4_wdata;
+  logic aon_wkup_detector_4_regwen;
+
+  always_comb begin
+    aon_wkup_detector_4_d = '0;
+    aon_wkup_detector_4_d[2:0] = aon_wkup_detector_4_mode_4_qs_int;
+    aon_wkup_detector_4_d[3] = aon_wkup_detector_4_filter_4_qs_int;
+    aon_wkup_detector_4_d[4] = aon_wkup_detector_4_miodio_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_4_qs),
+    .src_we_i     (wkup_detector_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_4_busy),
+    .src_qs_o     (wkup_detector_4_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_4_d),
+    .dst_we_o     (aon_wkup_detector_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_4_regwen),
+    .dst_wd_o     (aon_wkup_detector_4_wdata)
+  );
+  assign unused_aon_wkup_detector_4_wdata = ^aon_wkup_detector_4_wdata;
+
+  logic [2:0]  aon_wkup_detector_5_mode_5_qs_int;
+  logic  aon_wkup_detector_5_filter_5_qs_int;
+  logic  aon_wkup_detector_5_miodio_5_qs_int;
+  logic [4:0] aon_wkup_detector_5_d;
+  logic [4:0] aon_wkup_detector_5_wdata;
+  logic aon_wkup_detector_5_we;
+  logic unused_aon_wkup_detector_5_wdata;
+  logic aon_wkup_detector_5_regwen;
+
+  always_comb begin
+    aon_wkup_detector_5_d = '0;
+    aon_wkup_detector_5_d[2:0] = aon_wkup_detector_5_mode_5_qs_int;
+    aon_wkup_detector_5_d[3] = aon_wkup_detector_5_filter_5_qs_int;
+    aon_wkup_detector_5_d[4] = aon_wkup_detector_5_miodio_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_5_qs),
+    .src_we_i     (wkup_detector_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_5_busy),
+    .src_qs_o     (wkup_detector_5_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_5_d),
+    .dst_we_o     (aon_wkup_detector_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_5_regwen),
+    .dst_wd_o     (aon_wkup_detector_5_wdata)
+  );
+  assign unused_aon_wkup_detector_5_wdata = ^aon_wkup_detector_5_wdata;
+
+  logic [2:0]  aon_wkup_detector_6_mode_6_qs_int;
+  logic  aon_wkup_detector_6_filter_6_qs_int;
+  logic  aon_wkup_detector_6_miodio_6_qs_int;
+  logic [4:0] aon_wkup_detector_6_d;
+  logic [4:0] aon_wkup_detector_6_wdata;
+  logic aon_wkup_detector_6_we;
+  logic unused_aon_wkup_detector_6_wdata;
+  logic aon_wkup_detector_6_regwen;
+
+  always_comb begin
+    aon_wkup_detector_6_d = '0;
+    aon_wkup_detector_6_d[2:0] = aon_wkup_detector_6_mode_6_qs_int;
+    aon_wkup_detector_6_d[3] = aon_wkup_detector_6_filter_6_qs_int;
+    aon_wkup_detector_6_d[4] = aon_wkup_detector_6_miodio_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_6_qs),
+    .src_we_i     (wkup_detector_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_6_busy),
+    .src_qs_o     (wkup_detector_6_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_6_d),
+    .dst_we_o     (aon_wkup_detector_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_6_regwen),
+    .dst_wd_o     (aon_wkup_detector_6_wdata)
+  );
+  assign unused_aon_wkup_detector_6_wdata = ^aon_wkup_detector_6_wdata;
+
+  logic [2:0]  aon_wkup_detector_7_mode_7_qs_int;
+  logic  aon_wkup_detector_7_filter_7_qs_int;
+  logic  aon_wkup_detector_7_miodio_7_qs_int;
+  logic [4:0] aon_wkup_detector_7_d;
+  logic [4:0] aon_wkup_detector_7_wdata;
+  logic aon_wkup_detector_7_we;
+  logic unused_aon_wkup_detector_7_wdata;
+  logic aon_wkup_detector_7_regwen;
+
+  always_comb begin
+    aon_wkup_detector_7_d = '0;
+    aon_wkup_detector_7_d[2:0] = aon_wkup_detector_7_mode_7_qs_int;
+    aon_wkup_detector_7_d[3] = aon_wkup_detector_7_filter_7_qs_int;
+    aon_wkup_detector_7_d[4] = aon_wkup_detector_7_miodio_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(5),
+    .ResetVal(5'h0),
+    .BitMask(5'h1f)
+  ) u_wkup_detector_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_7_qs),
+    .src_we_i     (wkup_detector_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[4:0]),
+    .src_busy_o   (wkup_detector_7_busy),
+    .src_qs_o     (wkup_detector_7_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_7_d),
+    .dst_we_o     (aon_wkup_detector_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_7_regwen),
+    .dst_wd_o     (aon_wkup_detector_7_wdata)
+  );
+  assign unused_aon_wkup_detector_7_wdata = ^aon_wkup_detector_7_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_0_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_0_d;
+  logic [7:0] aon_wkup_detector_cnt_th_0_wdata;
+  logic aon_wkup_detector_cnt_th_0_we;
+  logic unused_aon_wkup_detector_cnt_th_0_wdata;
+  logic aon_wkup_detector_cnt_th_0_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_0_d = '0;
+    aon_wkup_detector_cnt_th_0_d = aon_wkup_detector_cnt_th_0_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_0_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_0_qs),
+    .src_we_i     (wkup_detector_cnt_th_0_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_0_busy),
+    .src_qs_o     (wkup_detector_cnt_th_0_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_0_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_0_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_0_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_0_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_0_wdata = ^aon_wkup_detector_cnt_th_0_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_1_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_1_d;
+  logic [7:0] aon_wkup_detector_cnt_th_1_wdata;
+  logic aon_wkup_detector_cnt_th_1_we;
+  logic unused_aon_wkup_detector_cnt_th_1_wdata;
+  logic aon_wkup_detector_cnt_th_1_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_1_d = '0;
+    aon_wkup_detector_cnt_th_1_d = aon_wkup_detector_cnt_th_1_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_1_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_1_qs),
+    .src_we_i     (wkup_detector_cnt_th_1_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_1_busy),
+    .src_qs_o     (wkup_detector_cnt_th_1_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_1_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_1_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_1_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_1_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_1_wdata = ^aon_wkup_detector_cnt_th_1_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_2_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_2_d;
+  logic [7:0] aon_wkup_detector_cnt_th_2_wdata;
+  logic aon_wkup_detector_cnt_th_2_we;
+  logic unused_aon_wkup_detector_cnt_th_2_wdata;
+  logic aon_wkup_detector_cnt_th_2_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_2_d = '0;
+    aon_wkup_detector_cnt_th_2_d = aon_wkup_detector_cnt_th_2_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_2_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_2_qs),
+    .src_we_i     (wkup_detector_cnt_th_2_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_2_busy),
+    .src_qs_o     (wkup_detector_cnt_th_2_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_2_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_2_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_2_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_2_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_2_wdata = ^aon_wkup_detector_cnt_th_2_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_3_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_3_d;
+  logic [7:0] aon_wkup_detector_cnt_th_3_wdata;
+  logic aon_wkup_detector_cnt_th_3_we;
+  logic unused_aon_wkup_detector_cnt_th_3_wdata;
+  logic aon_wkup_detector_cnt_th_3_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_3_d = '0;
+    aon_wkup_detector_cnt_th_3_d = aon_wkup_detector_cnt_th_3_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_3_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_3_qs),
+    .src_we_i     (wkup_detector_cnt_th_3_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_3_busy),
+    .src_qs_o     (wkup_detector_cnt_th_3_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_3_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_3_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_3_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_3_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_3_wdata = ^aon_wkup_detector_cnt_th_3_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_4_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_4_d;
+  logic [7:0] aon_wkup_detector_cnt_th_4_wdata;
+  logic aon_wkup_detector_cnt_th_4_we;
+  logic unused_aon_wkup_detector_cnt_th_4_wdata;
+  logic aon_wkup_detector_cnt_th_4_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_4_d = '0;
+    aon_wkup_detector_cnt_th_4_d = aon_wkup_detector_cnt_th_4_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_4_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_4_qs),
+    .src_we_i     (wkup_detector_cnt_th_4_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_4_busy),
+    .src_qs_o     (wkup_detector_cnt_th_4_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_4_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_4_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_4_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_4_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_4_wdata = ^aon_wkup_detector_cnt_th_4_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_5_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_5_d;
+  logic [7:0] aon_wkup_detector_cnt_th_5_wdata;
+  logic aon_wkup_detector_cnt_th_5_we;
+  logic unused_aon_wkup_detector_cnt_th_5_wdata;
+  logic aon_wkup_detector_cnt_th_5_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_5_d = '0;
+    aon_wkup_detector_cnt_th_5_d = aon_wkup_detector_cnt_th_5_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_5_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_5_qs),
+    .src_we_i     (wkup_detector_cnt_th_5_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_5_busy),
+    .src_qs_o     (wkup_detector_cnt_th_5_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_5_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_5_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_5_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_5_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_5_wdata = ^aon_wkup_detector_cnt_th_5_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_6_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_6_d;
+  logic [7:0] aon_wkup_detector_cnt_th_6_wdata;
+  logic aon_wkup_detector_cnt_th_6_we;
+  logic unused_aon_wkup_detector_cnt_th_6_wdata;
+  logic aon_wkup_detector_cnt_th_6_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_6_d = '0;
+    aon_wkup_detector_cnt_th_6_d = aon_wkup_detector_cnt_th_6_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_6_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_6_qs),
+    .src_we_i     (wkup_detector_cnt_th_6_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_6_busy),
+    .src_qs_o     (wkup_detector_cnt_th_6_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_6_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_6_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_6_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_6_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_6_wdata = ^aon_wkup_detector_cnt_th_6_wdata;
+
+  logic [7:0]  aon_wkup_detector_cnt_th_7_qs_int;
+  logic [7:0] aon_wkup_detector_cnt_th_7_d;
+  logic [7:0] aon_wkup_detector_cnt_th_7_wdata;
+  logic aon_wkup_detector_cnt_th_7_we;
+  logic unused_aon_wkup_detector_cnt_th_7_wdata;
+  logic aon_wkup_detector_cnt_th_7_regwen;
+
+  always_comb begin
+    aon_wkup_detector_cnt_th_7_d = '0;
+    aon_wkup_detector_cnt_th_7_d = aon_wkup_detector_cnt_th_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_detector_cnt_th_7_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i (wkup_detector_regwen_7_qs),
+    .src_we_i     (wkup_detector_cnt_th_7_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_detector_cnt_th_7_busy),
+    .src_qs_o     (wkup_detector_cnt_th_7_qs), // for software read back
+    .dst_d_i      (aon_wkup_detector_cnt_th_7_d),
+    .dst_we_o     (aon_wkup_detector_cnt_th_7_we),
+    .dst_re_o     (),
+    .dst_regwen_o (aon_wkup_detector_cnt_th_7_regwen),
+    .dst_wd_o     (aon_wkup_detector_cnt_th_7_wdata)
+  );
+  assign unused_aon_wkup_detector_cnt_th_7_wdata = ^aon_wkup_detector_cnt_th_7_wdata;
+
+  logic  aon_wkup_cause_cause_0_qs_int;
+  logic  aon_wkup_cause_cause_1_qs_int;
+  logic  aon_wkup_cause_cause_2_qs_int;
+  logic  aon_wkup_cause_cause_3_qs_int;
+  logic  aon_wkup_cause_cause_4_qs_int;
+  logic  aon_wkup_cause_cause_5_qs_int;
+  logic  aon_wkup_cause_cause_6_qs_int;
+  logic  aon_wkup_cause_cause_7_qs_int;
+  logic [7:0] aon_wkup_cause_d;
+  logic [7:0] aon_wkup_cause_wdata;
+  logic aon_wkup_cause_we;
+  logic unused_aon_wkup_cause_wdata;
+
+  always_comb begin
+    aon_wkup_cause_d = '0;
+    aon_wkup_cause_d[0] = aon_wkup_cause_cause_0_qs_int;
+    aon_wkup_cause_d[1] = aon_wkup_cause_cause_1_qs_int;
+    aon_wkup_cause_d[2] = aon_wkup_cause_cause_2_qs_int;
+    aon_wkup_cause_d[3] = aon_wkup_cause_cause_3_qs_int;
+    aon_wkup_cause_d[4] = aon_wkup_cause_cause_4_qs_int;
+    aon_wkup_cause_d[5] = aon_wkup_cause_cause_5_qs_int;
+    aon_wkup_cause_d[6] = aon_wkup_cause_cause_6_qs_int;
+    aon_wkup_cause_d[7] = aon_wkup_cause_cause_7_qs_int;
+  end
+
+  prim_reg_cdc #(
+    .DataWidth(8),
+    .ResetVal(8'h0),
+    .BitMask(8'hff)
+  ) u_wkup_cause_cdc (
+    .clk_src_i    (clk_i),
+    .rst_src_ni   (rst_ni),
+    .clk_dst_i    (clk_aon_i),
+    .rst_dst_ni   (rst_aon_ni),
+    .src_update_i (sync_aon_update),
+    .src_regwen_i ('0),
+    .src_we_i     (wkup_cause_we),
+    .src_re_i     ('0),
+    .src_wd_i     (reg_wdata[7:0]),
+    .src_busy_o   (wkup_cause_busy),
+    .src_qs_o     (wkup_cause_qs), // for software read back
+    .dst_d_i      (aon_wkup_cause_d),
+    .dst_we_o     (aon_wkup_cause_we),
+    .dst_re_o     (),
+    .dst_regwen_o (),
+    .dst_wd_o     (aon_wkup_cause_wdata)
+  );
+  assign unused_aon_wkup_cause_wdata = ^aon_wkup_cause_wdata;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -18670,185 +19523,217 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_en
   // R[wkup_detector_en_0]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_en_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_0_busy),
-    .src_qs_o     (wkup_detector_en_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_0_we & aon_wkup_detector_en_0_regwen),
+    .wd     (aon_wkup_detector_en_0_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[0].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_0_qs_int)
   );
 
   // Subregister 1 of Multireg wkup_detector_en
   // R[wkup_detector_en_1]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_en_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_1_busy),
-    .src_qs_o     (wkup_detector_en_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_1_we & aon_wkup_detector_en_1_regwen),
+    .wd     (aon_wkup_detector_en_1_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[1].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_1_qs_int)
   );
 
   // Subregister 2 of Multireg wkup_detector_en
   // R[wkup_detector_en_2]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_en_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_2_busy),
-    .src_qs_o     (wkup_detector_en_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_2_we & aon_wkup_detector_en_2_regwen),
+    .wd     (aon_wkup_detector_en_2_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[2].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_2_qs_int)
   );
 
   // Subregister 3 of Multireg wkup_detector_en
   // R[wkup_detector_en_3]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_en_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_3_busy),
-    .src_qs_o     (wkup_detector_en_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_3_we & aon_wkup_detector_en_3_regwen),
+    .wd     (aon_wkup_detector_en_3_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[3].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_3_qs_int)
   );
 
   // Subregister 4 of Multireg wkup_detector_en
   // R[wkup_detector_en_4]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_en_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_4_busy),
-    .src_qs_o     (wkup_detector_en_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[4].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_4_we & aon_wkup_detector_en_4_regwen),
+    .wd     (aon_wkup_detector_en_4_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[4].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_4_qs_int)
   );
 
   // Subregister 5 of Multireg wkup_detector_en
   // R[wkup_detector_en_5]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_en_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_5_busy),
-    .src_qs_o     (wkup_detector_en_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[5].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_5_we & aon_wkup_detector_en_5_regwen),
+    .wd     (aon_wkup_detector_en_5_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[5].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_5_qs_int)
   );
 
   // Subregister 6 of Multireg wkup_detector_en
   // R[wkup_detector_en_6]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_en_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_6_busy),
-    .src_qs_o     (wkup_detector_en_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[6].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_6_we & aon_wkup_detector_en_6_regwen),
+    .wd     (aon_wkup_detector_en_6_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[6].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_6_qs_int)
   );
 
   // Subregister 7 of Multireg wkup_detector_en
   // R[wkup_detector_en_7]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_en_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_en_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_en_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_en_7_busy),
-    .src_qs_o     (wkup_detector_en_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_en[7].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_en_7_we & aon_wkup_detector_en_7_regwen),
+    .wd     (aon_wkup_detector_en_7_wdata[0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_en[7].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_en_7_qs_int)
   );
 
 
@@ -18857,68 +19742,80 @@ module pinmux_reg_top (
   // R[wkup_detector_0]: V(False)
 
   // F[mode_0]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_0_mode_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_0_mode_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_0_mode_0_busy),
-    .src_qs_o     (wkup_detector_0_mode_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[0].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_0_we & aon_wkup_detector_0_regwen),
+    .wd     (aon_wkup_detector_0_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[0].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_0_mode_0_qs_int)
   );
 
 
   // F[filter_0]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_filter_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_0_filter_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_0_filter_0_busy),
-    .src_qs_o     (wkup_detector_0_filter_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[0].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_0_we & aon_wkup_detector_0_regwen),
+    .wd     (aon_wkup_detector_0_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[0].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_0_filter_0_qs_int)
   );
 
 
   // F[miodio_0]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_0_miodio_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_0_miodio_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_0_miodio_0_busy),
-    .src_qs_o     (wkup_detector_0_miodio_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[0].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_0_we & aon_wkup_detector_0_regwen),
+    .wd     (aon_wkup_detector_0_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[0].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_0_miodio_0_qs_int)
   );
 
 
@@ -18926,68 +19823,80 @@ module pinmux_reg_top (
   // R[wkup_detector_1]: V(False)
 
   // F[mode_1]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_1_mode_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_1_mode_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_1_mode_1_busy),
-    .src_qs_o     (wkup_detector_1_mode_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[1].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_1_we & aon_wkup_detector_1_regwen),
+    .wd     (aon_wkup_detector_1_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[1].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_1_mode_1_qs_int)
   );
 
 
   // F[filter_1]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_filter_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_1_filter_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_1_filter_1_busy),
-    .src_qs_o     (wkup_detector_1_filter_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[1].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_1_we & aon_wkup_detector_1_regwen),
+    .wd     (aon_wkup_detector_1_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[1].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_1_filter_1_qs_int)
   );
 
 
   // F[miodio_1]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_1_miodio_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_1_miodio_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_1_miodio_1_busy),
-    .src_qs_o     (wkup_detector_1_miodio_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[1].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_1_we & aon_wkup_detector_1_regwen),
+    .wd     (aon_wkup_detector_1_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[1].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_1_miodio_1_qs_int)
   );
 
 
@@ -18995,68 +19904,80 @@ module pinmux_reg_top (
   // R[wkup_detector_2]: V(False)
 
   // F[mode_2]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_2_mode_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_2_mode_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_2_mode_2_busy),
-    .src_qs_o     (wkup_detector_2_mode_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[2].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_2_we & aon_wkup_detector_2_regwen),
+    .wd     (aon_wkup_detector_2_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[2].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_2_mode_2_qs_int)
   );
 
 
   // F[filter_2]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_filter_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_2_filter_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_2_filter_2_busy),
-    .src_qs_o     (wkup_detector_2_filter_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[2].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_2_we & aon_wkup_detector_2_regwen),
+    .wd     (aon_wkup_detector_2_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[2].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_2_filter_2_qs_int)
   );
 
 
   // F[miodio_2]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_2_miodio_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_2_miodio_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_2_miodio_2_busy),
-    .src_qs_o     (wkup_detector_2_miodio_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[2].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_2_we & aon_wkup_detector_2_regwen),
+    .wd     (aon_wkup_detector_2_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[2].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_2_miodio_2_qs_int)
   );
 
 
@@ -19064,68 +19985,80 @@ module pinmux_reg_top (
   // R[wkup_detector_3]: V(False)
 
   // F[mode_3]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_3_mode_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_3_mode_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_3_mode_3_busy),
-    .src_qs_o     (wkup_detector_3_mode_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[3].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_3_we & aon_wkup_detector_3_regwen),
+    .wd     (aon_wkup_detector_3_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[3].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_3_mode_3_qs_int)
   );
 
 
   // F[filter_3]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_filter_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_3_filter_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_3_filter_3_busy),
-    .src_qs_o     (wkup_detector_3_filter_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[3].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_3_we & aon_wkup_detector_3_regwen),
+    .wd     (aon_wkup_detector_3_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[3].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_3_filter_3_qs_int)
   );
 
 
   // F[miodio_3]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_3_miodio_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_3_miodio_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_3_miodio_3_busy),
-    .src_qs_o     (wkup_detector_3_miodio_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[3].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_3_we & aon_wkup_detector_3_regwen),
+    .wd     (aon_wkup_detector_3_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[3].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_3_miodio_3_qs_int)
   );
 
 
@@ -19133,68 +20066,80 @@ module pinmux_reg_top (
   // R[wkup_detector_4]: V(False)
 
   // F[mode_4]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_4_mode_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_4_mode_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_4_mode_4_busy),
-    .src_qs_o     (wkup_detector_4_mode_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[4].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_4_we & aon_wkup_detector_4_regwen),
+    .wd     (aon_wkup_detector_4_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[4].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_4_mode_4_qs_int)
   );
 
 
   // F[filter_4]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_filter_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_4_filter_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_4_filter_4_busy),
-    .src_qs_o     (wkup_detector_4_filter_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[4].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_4_we & aon_wkup_detector_4_regwen),
+    .wd     (aon_wkup_detector_4_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[4].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_4_filter_4_qs_int)
   );
 
 
   // F[miodio_4]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_4_miodio_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_4_miodio_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_4_miodio_4_busy),
-    .src_qs_o     (wkup_detector_4_miodio_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[4].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_4_we & aon_wkup_detector_4_regwen),
+    .wd     (aon_wkup_detector_4_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[4].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_4_miodio_4_qs_int)
   );
 
 
@@ -19202,68 +20147,80 @@ module pinmux_reg_top (
   // R[wkup_detector_5]: V(False)
 
   // F[mode_5]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_5_mode_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_5_mode_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_5_mode_5_busy),
-    .src_qs_o     (wkup_detector_5_mode_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[5].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_5_we & aon_wkup_detector_5_regwen),
+    .wd     (aon_wkup_detector_5_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[5].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_5_mode_5_qs_int)
   );
 
 
   // F[filter_5]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_filter_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_5_filter_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_5_filter_5_busy),
-    .src_qs_o     (wkup_detector_5_filter_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[5].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_5_we & aon_wkup_detector_5_regwen),
+    .wd     (aon_wkup_detector_5_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[5].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_5_filter_5_qs_int)
   );
 
 
   // F[miodio_5]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_5_miodio_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_5_miodio_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_5_miodio_5_busy),
-    .src_qs_o     (wkup_detector_5_miodio_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[5].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_5_we & aon_wkup_detector_5_regwen),
+    .wd     (aon_wkup_detector_5_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[5].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_5_miodio_5_qs_int)
   );
 
 
@@ -19271,68 +20228,80 @@ module pinmux_reg_top (
   // R[wkup_detector_6]: V(False)
 
   // F[mode_6]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_6_mode_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_6_mode_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_6_mode_6_busy),
-    .src_qs_o     (wkup_detector_6_mode_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[6].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_6_we & aon_wkup_detector_6_regwen),
+    .wd     (aon_wkup_detector_6_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[6].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_6_mode_6_qs_int)
   );
 
 
   // F[filter_6]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_filter_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_6_filter_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_6_filter_6_busy),
-    .src_qs_o     (wkup_detector_6_filter_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[6].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_6_we & aon_wkup_detector_6_regwen),
+    .wd     (aon_wkup_detector_6_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[6].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_6_filter_6_qs_int)
   );
 
 
   // F[miodio_6]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_6_miodio_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_6_miodio_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_6_miodio_6_busy),
-    .src_qs_o     (wkup_detector_6_miodio_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[6].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_6_we & aon_wkup_detector_6_regwen),
+    .wd     (aon_wkup_detector_6_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[6].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_6_miodio_6_qs_int)
   );
 
 
@@ -19340,68 +20309,80 @@ module pinmux_reg_top (
   // R[wkup_detector_7]: V(False)
 
   // F[mode_7]: 2:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (3'h0)
   ) u_wkup_detector_7_mode_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_7_mode_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_7_mode_7_busy),
-    .src_qs_o     (wkup_detector_7_mode_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[7].mode.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_7_we & aon_wkup_detector_7_regwen),
+    .wd     (aon_wkup_detector_7_wdata[2:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[7].mode.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_7_mode_7_qs_int)
   );
 
 
   // F[filter_7]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_filter_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_7_filter_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_7_filter_7_busy),
-    .src_qs_o     (wkup_detector_7_filter_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[7].filter.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_7_we & aon_wkup_detector_7_regwen),
+    .wd     (aon_wkup_detector_7_wdata[3]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[7].filter.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_7_filter_7_qs_int)
   );
 
 
   // F[miodio_7]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
   ) u_wkup_detector_7_miodio_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_7_miodio_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_7_miodio_7_busy),
-    .src_qs_o     (wkup_detector_7_miodio_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector[7].miodio.q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_7_we & aon_wkup_detector_7_regwen),
+    .wd     (aon_wkup_detector_7_wdata[4]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector[7].miodio.q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_7_miodio_7_qs_int)
   );
 
 
@@ -19410,185 +20391,217 @@ module pinmux_reg_top (
   // Subregister 0 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_0]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_0_we & wkup_detector_regwen_0_qs),
-    .src_wd_i     (wkup_detector_cnt_th_0_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_0_busy),
-    .src_qs_o     (wkup_detector_cnt_th_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_0_we & aon_wkup_detector_cnt_th_0_regwen),
+    .wd     (aon_wkup_detector_cnt_th_0_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[0].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_0_qs_int)
   );
 
   // Subregister 1 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_1]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_1_we & wkup_detector_regwen_1_qs),
-    .src_wd_i     (wkup_detector_cnt_th_1_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_1_busy),
-    .src_qs_o     (wkup_detector_cnt_th_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_1_we & aon_wkup_detector_cnt_th_1_regwen),
+    .wd     (aon_wkup_detector_cnt_th_1_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[1].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_1_qs_int)
   );
 
   // Subregister 2 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_2]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_2_we & wkup_detector_regwen_2_qs),
-    .src_wd_i     (wkup_detector_cnt_th_2_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_2_busy),
-    .src_qs_o     (wkup_detector_cnt_th_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_2_we & aon_wkup_detector_cnt_th_2_regwen),
+    .wd     (aon_wkup_detector_cnt_th_2_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[2].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_2_qs_int)
   );
 
   // Subregister 3 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_3]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_3_we & wkup_detector_regwen_3_qs),
-    .src_wd_i     (wkup_detector_cnt_th_3_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_3_busy),
-    .src_qs_o     (wkup_detector_cnt_th_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_3_we & aon_wkup_detector_cnt_th_3_regwen),
+    .wd     (aon_wkup_detector_cnt_th_3_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[3].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_3_qs_int)
   );
 
   // Subregister 4 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_4]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_4_we & wkup_detector_regwen_4_qs),
-    .src_wd_i     (wkup_detector_cnt_th_4_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_4_busy),
-    .src_qs_o     (wkup_detector_cnt_th_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[4].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_4_we & aon_wkup_detector_cnt_th_4_regwen),
+    .wd     (aon_wkup_detector_cnt_th_4_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[4].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_4_qs_int)
   );
 
   // Subregister 5 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_5]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_5_we & wkup_detector_regwen_5_qs),
-    .src_wd_i     (wkup_detector_cnt_th_5_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_5_busy),
-    .src_qs_o     (wkup_detector_cnt_th_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[5].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_5_we & aon_wkup_detector_cnt_th_5_regwen),
+    .wd     (aon_wkup_detector_cnt_th_5_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[5].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_5_qs_int)
   );
 
   // Subregister 6 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_6]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_6_we & wkup_detector_regwen_6_qs),
-    .src_wd_i     (wkup_detector_cnt_th_6_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_6_busy),
-    .src_qs_o     (wkup_detector_cnt_th_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[6].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_6_we & aon_wkup_detector_cnt_th_6_regwen),
+    .wd     (aon_wkup_detector_cnt_th_6_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[6].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_6_qs_int)
   );
 
   // Subregister 7 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_7]: V(False)
 
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (8'h0)
   ) u_wkup_detector_cnt_th_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_detector_cnt_th_7_we & wkup_detector_regwen_7_qs),
-    .src_wd_i     (wkup_detector_cnt_th_7_wd),
-    .dst_de_i     (1'b0),
-    .dst_d_i      ('0),
-    .src_busy_o   (wkup_detector_cnt_th_7_busy),
-    .src_qs_o     (wkup_detector_cnt_th_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_detector_cnt_th[7].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_detector_cnt_th_7_we & aon_wkup_detector_cnt_th_7_regwen),
+    .wd     (aon_wkup_detector_cnt_th_7_wdata[7:0]),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_detector_cnt_th[7].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_detector_cnt_th_7_qs_int)
   );
 
 
@@ -19815,178 +20828,210 @@ module pinmux_reg_top (
   // R[wkup_cause]: V(False)
 
   // F[cause_0]: 0:0
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_0 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_0_wd),
-    .dst_de_i     (hw2reg.wkup_cause[0].de),
-    .dst_d_i      (hw2reg.wkup_cause[0].d),
-    .src_busy_o   (wkup_cause_cause_0_busy),
-    .src_qs_o     (wkup_cause_cause_0_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[0].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[0]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[0].de),
+    .d      (hw2reg.wkup_cause[0].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[0].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_0_qs_int)
   );
 
 
   // F[cause_1]: 1:1
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_1 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_1_wd),
-    .dst_de_i     (hw2reg.wkup_cause[1].de),
-    .dst_d_i      (hw2reg.wkup_cause[1].d),
-    .src_busy_o   (wkup_cause_cause_1_busy),
-    .src_qs_o     (wkup_cause_cause_1_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[1].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[1]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[1].de),
+    .d      (hw2reg.wkup_cause[1].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[1].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_1_qs_int)
   );
 
 
   // F[cause_2]: 2:2
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_2 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_2_wd),
-    .dst_de_i     (hw2reg.wkup_cause[2].de),
-    .dst_d_i      (hw2reg.wkup_cause[2].d),
-    .src_busy_o   (wkup_cause_cause_2_busy),
-    .src_qs_o     (wkup_cause_cause_2_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[2].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[2]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[2].de),
+    .d      (hw2reg.wkup_cause[2].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[2].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_2_qs_int)
   );
 
 
   // F[cause_3]: 3:3
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_3 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_3_wd),
-    .dst_de_i     (hw2reg.wkup_cause[3].de),
-    .dst_d_i      (hw2reg.wkup_cause[3].d),
-    .src_busy_o   (wkup_cause_cause_3_busy),
-    .src_qs_o     (wkup_cause_cause_3_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[3].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[3]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[3].de),
+    .d      (hw2reg.wkup_cause[3].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[3].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_3_qs_int)
   );
 
 
   // F[cause_4]: 4:4
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_4 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_4_wd),
-    .dst_de_i     (hw2reg.wkup_cause[4].de),
-    .dst_d_i      (hw2reg.wkup_cause[4].d),
-    .src_busy_o   (wkup_cause_cause_4_busy),
-    .src_qs_o     (wkup_cause_cause_4_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[4].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[4]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[4].de),
+    .d      (hw2reg.wkup_cause[4].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[4].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_4_qs_int)
   );
 
 
   // F[cause_5]: 5:5
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_5 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_5_wd),
-    .dst_de_i     (hw2reg.wkup_cause[5].de),
-    .dst_d_i      (hw2reg.wkup_cause[5].d),
-    .src_busy_o   (wkup_cause_cause_5_busy),
-    .src_qs_o     (wkup_cause_cause_5_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[5].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[5]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[5].de),
+    .d      (hw2reg.wkup_cause[5].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[5].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_5_qs_int)
   );
 
 
   // F[cause_6]: 6:6
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_6 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_6_wd),
-    .dst_de_i     (hw2reg.wkup_cause[6].de),
-    .dst_d_i      (hw2reg.wkup_cause[6].d),
-    .src_busy_o   (wkup_cause_cause_6_busy),
-    .src_qs_o     (wkup_cause_cause_6_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[6].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[6]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[6].de),
+    .d      (hw2reg.wkup_cause[6].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[6].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_6_qs_int)
   );
 
 
   // F[cause_7]: 7:7
-  prim_subreg_async #(
+  prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
   ) u_wkup_cause_cause_7 (
-    .clk_src_i    (clk_i),
-    .rst_src_ni   (rst_ni),
-    .clk_dst_i    (clk_aon_i),
-    .rst_dst_ni   (rst_aon_ni),
-    .src_update_i (sync_aon_update),
-    .src_we_i     (wkup_cause_we),
-    .src_wd_i     (wkup_cause_cause_7_wd),
-    .dst_de_i     (hw2reg.wkup_cause[7].de),
-    .dst_d_i      (hw2reg.wkup_cause[7].d),
-    .src_busy_o   (wkup_cause_cause_7_busy),
-    .src_qs_o     (wkup_cause_cause_7_qs),
-    .dst_qe_o     (),
-    .q            (reg2hw.wkup_cause[7].q)
+    .clk_i   (clk_aon_i),
+    .rst_ni  (rst_aon_ni),
+
+    // from register interface
+    .we     (aon_wkup_cause_we),
+    .wd     (aon_wkup_cause_wdata[7]),
+
+    // from internal hardware
+    .de     (hw2reg.wkup_cause[7].de),
+    .d      (hw2reg.wkup_cause[7].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.wkup_cause[7].q),
+
+    // to register interface (read)
+    .qs     (aon_wkup_cause_cause_7_qs_int)
   );
 
 
@@ -23134,108 +24179,68 @@ module pinmux_reg_top (
   assign wkup_detector_regwen_7_wd = reg_wdata[0];
   assign wkup_detector_en_0_we = addr_hit[571] & reg_we & !reg_error;
 
-  assign wkup_detector_en_0_wd = reg_wdata[0];
   assign wkup_detector_en_1_we = addr_hit[572] & reg_we & !reg_error;
 
-  assign wkup_detector_en_1_wd = reg_wdata[0];
   assign wkup_detector_en_2_we = addr_hit[573] & reg_we & !reg_error;
 
-  assign wkup_detector_en_2_wd = reg_wdata[0];
   assign wkup_detector_en_3_we = addr_hit[574] & reg_we & !reg_error;
 
-  assign wkup_detector_en_3_wd = reg_wdata[0];
   assign wkup_detector_en_4_we = addr_hit[575] & reg_we & !reg_error;
 
-  assign wkup_detector_en_4_wd = reg_wdata[0];
   assign wkup_detector_en_5_we = addr_hit[576] & reg_we & !reg_error;
 
-  assign wkup_detector_en_5_wd = reg_wdata[0];
   assign wkup_detector_en_6_we = addr_hit[577] & reg_we & !reg_error;
 
-  assign wkup_detector_en_6_wd = reg_wdata[0];
   assign wkup_detector_en_7_we = addr_hit[578] & reg_we & !reg_error;
 
-  assign wkup_detector_en_7_wd = reg_wdata[0];
   assign wkup_detector_0_we = addr_hit[579] & reg_we & !reg_error;
 
-  assign wkup_detector_0_mode_0_wd = reg_wdata[2:0];
 
-  assign wkup_detector_0_filter_0_wd = reg_wdata[3];
 
-  assign wkup_detector_0_miodio_0_wd = reg_wdata[4];
   assign wkup_detector_1_we = addr_hit[580] & reg_we & !reg_error;
 
-  assign wkup_detector_1_mode_1_wd = reg_wdata[2:0];
 
-  assign wkup_detector_1_filter_1_wd = reg_wdata[3];
 
-  assign wkup_detector_1_miodio_1_wd = reg_wdata[4];
   assign wkup_detector_2_we = addr_hit[581] & reg_we & !reg_error;
 
-  assign wkup_detector_2_mode_2_wd = reg_wdata[2:0];
 
-  assign wkup_detector_2_filter_2_wd = reg_wdata[3];
 
-  assign wkup_detector_2_miodio_2_wd = reg_wdata[4];
   assign wkup_detector_3_we = addr_hit[582] & reg_we & !reg_error;
 
-  assign wkup_detector_3_mode_3_wd = reg_wdata[2:0];
 
-  assign wkup_detector_3_filter_3_wd = reg_wdata[3];
 
-  assign wkup_detector_3_miodio_3_wd = reg_wdata[4];
   assign wkup_detector_4_we = addr_hit[583] & reg_we & !reg_error;
 
-  assign wkup_detector_4_mode_4_wd = reg_wdata[2:0];
 
-  assign wkup_detector_4_filter_4_wd = reg_wdata[3];
 
-  assign wkup_detector_4_miodio_4_wd = reg_wdata[4];
   assign wkup_detector_5_we = addr_hit[584] & reg_we & !reg_error;
 
-  assign wkup_detector_5_mode_5_wd = reg_wdata[2:0];
 
-  assign wkup_detector_5_filter_5_wd = reg_wdata[3];
 
-  assign wkup_detector_5_miodio_5_wd = reg_wdata[4];
   assign wkup_detector_6_we = addr_hit[585] & reg_we & !reg_error;
 
-  assign wkup_detector_6_mode_6_wd = reg_wdata[2:0];
 
-  assign wkup_detector_6_filter_6_wd = reg_wdata[3];
 
-  assign wkup_detector_6_miodio_6_wd = reg_wdata[4];
   assign wkup_detector_7_we = addr_hit[586] & reg_we & !reg_error;
 
-  assign wkup_detector_7_mode_7_wd = reg_wdata[2:0];
 
-  assign wkup_detector_7_filter_7_wd = reg_wdata[3];
 
-  assign wkup_detector_7_miodio_7_wd = reg_wdata[4];
   assign wkup_detector_cnt_th_0_we = addr_hit[587] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_0_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_1_we = addr_hit[588] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_1_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_2_we = addr_hit[589] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_2_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_3_we = addr_hit[590] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_3_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_4_we = addr_hit[591] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_4_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_5_we = addr_hit[592] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_5_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_6_we = addr_hit[593] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_6_wd = reg_wdata[7:0];
   assign wkup_detector_cnt_th_7_we = addr_hit[594] & reg_we & !reg_error;
 
-  assign wkup_detector_cnt_th_7_wd = reg_wdata[7:0];
   assign wkup_detector_padsel_0_we = addr_hit[595] & reg_we & !reg_error;
 
   assign wkup_detector_padsel_0_wd = reg_wdata[5:0];
@@ -23262,21 +24267,13 @@ module pinmux_reg_top (
   assign wkup_detector_padsel_7_wd = reg_wdata[5:0];
   assign wkup_cause_we = addr_hit[603] & reg_we & !reg_error;
 
-  assign wkup_cause_cause_0_wd = reg_wdata[0];
 
-  assign wkup_cause_cause_1_wd = reg_wdata[1];
 
-  assign wkup_cause_cause_2_wd = reg_wdata[2];
 
-  assign wkup_cause_cause_3_wd = reg_wdata[3];
 
-  assign wkup_cause_cause_4_wd = reg_wdata[4];
 
-  assign wkup_cause_cause_5_wd = reg_wdata[5];
 
-  assign wkup_cause_cause_6_wd = reg_wdata[6];
 
-  assign wkup_cause_cause_7_wd = reg_wdata[7];
 
   // Read data return
   always_comb begin
@@ -25635,117 +26632,77 @@ module pinmux_reg_top (
       end
 
       addr_hit[571]: begin
-        reg_rdata_next[0] = wkup_detector_en_0_qs;
+        reg_rdata_next = DW'(wkup_detector_en_0_qs);
       end
-
       addr_hit[572]: begin
-        reg_rdata_next[0] = wkup_detector_en_1_qs;
+        reg_rdata_next = DW'(wkup_detector_en_1_qs);
       end
-
       addr_hit[573]: begin
-        reg_rdata_next[0] = wkup_detector_en_2_qs;
+        reg_rdata_next = DW'(wkup_detector_en_2_qs);
       end
-
       addr_hit[574]: begin
-        reg_rdata_next[0] = wkup_detector_en_3_qs;
+        reg_rdata_next = DW'(wkup_detector_en_3_qs);
       end
-
       addr_hit[575]: begin
-        reg_rdata_next[0] = wkup_detector_en_4_qs;
+        reg_rdata_next = DW'(wkup_detector_en_4_qs);
       end
-
       addr_hit[576]: begin
-        reg_rdata_next[0] = wkup_detector_en_5_qs;
+        reg_rdata_next = DW'(wkup_detector_en_5_qs);
       end
-
       addr_hit[577]: begin
-        reg_rdata_next[0] = wkup_detector_en_6_qs;
+        reg_rdata_next = DW'(wkup_detector_en_6_qs);
       end
-
       addr_hit[578]: begin
-        reg_rdata_next[0] = wkup_detector_en_7_qs;
+        reg_rdata_next = DW'(wkup_detector_en_7_qs);
       end
-
       addr_hit[579]: begin
-        reg_rdata_next[2:0] = wkup_detector_0_mode_0_qs;
-        reg_rdata_next[3] = wkup_detector_0_filter_0_qs;
-        reg_rdata_next[4] = wkup_detector_0_miodio_0_qs;
+        reg_rdata_next = DW'(wkup_detector_0_qs);
       end
-
       addr_hit[580]: begin
-        reg_rdata_next[2:0] = wkup_detector_1_mode_1_qs;
-        reg_rdata_next[3] = wkup_detector_1_filter_1_qs;
-        reg_rdata_next[4] = wkup_detector_1_miodio_1_qs;
+        reg_rdata_next = DW'(wkup_detector_1_qs);
       end
-
       addr_hit[581]: begin
-        reg_rdata_next[2:0] = wkup_detector_2_mode_2_qs;
-        reg_rdata_next[3] = wkup_detector_2_filter_2_qs;
-        reg_rdata_next[4] = wkup_detector_2_miodio_2_qs;
+        reg_rdata_next = DW'(wkup_detector_2_qs);
       end
-
       addr_hit[582]: begin
-        reg_rdata_next[2:0] = wkup_detector_3_mode_3_qs;
-        reg_rdata_next[3] = wkup_detector_3_filter_3_qs;
-        reg_rdata_next[4] = wkup_detector_3_miodio_3_qs;
+        reg_rdata_next = DW'(wkup_detector_3_qs);
       end
-
       addr_hit[583]: begin
-        reg_rdata_next[2:0] = wkup_detector_4_mode_4_qs;
-        reg_rdata_next[3] = wkup_detector_4_filter_4_qs;
-        reg_rdata_next[4] = wkup_detector_4_miodio_4_qs;
+        reg_rdata_next = DW'(wkup_detector_4_qs);
       end
-
       addr_hit[584]: begin
-        reg_rdata_next[2:0] = wkup_detector_5_mode_5_qs;
-        reg_rdata_next[3] = wkup_detector_5_filter_5_qs;
-        reg_rdata_next[4] = wkup_detector_5_miodio_5_qs;
+        reg_rdata_next = DW'(wkup_detector_5_qs);
       end
-
       addr_hit[585]: begin
-        reg_rdata_next[2:0] = wkup_detector_6_mode_6_qs;
-        reg_rdata_next[3] = wkup_detector_6_filter_6_qs;
-        reg_rdata_next[4] = wkup_detector_6_miodio_6_qs;
+        reg_rdata_next = DW'(wkup_detector_6_qs);
       end
-
       addr_hit[586]: begin
-        reg_rdata_next[2:0] = wkup_detector_7_mode_7_qs;
-        reg_rdata_next[3] = wkup_detector_7_filter_7_qs;
-        reg_rdata_next[4] = wkup_detector_7_miodio_7_qs;
+        reg_rdata_next = DW'(wkup_detector_7_qs);
       end
-
       addr_hit[587]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_0_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_0_qs);
       end
-
       addr_hit[588]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_1_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_1_qs);
       end
-
       addr_hit[589]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_2_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_2_qs);
       end
-
       addr_hit[590]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_3_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_3_qs);
       end
-
       addr_hit[591]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_4_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_4_qs);
       end
-
       addr_hit[592]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_5_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_5_qs);
       end
-
       addr_hit[593]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_6_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_6_qs);
       end
-
       addr_hit[594]: begin
-        reg_rdata_next[7:0] = wkup_detector_cnt_th_7_qs;
+        reg_rdata_next = DW'(wkup_detector_cnt_th_7_qs);
       end
-
       addr_hit[595]: begin
         reg_rdata_next[5:0] = wkup_detector_padsel_0_qs;
       end
@@ -25779,16 +26736,8 @@ module pinmux_reg_top (
       end
 
       addr_hit[603]: begin
-        reg_rdata_next[0] = wkup_cause_cause_0_qs;
-        reg_rdata_next[1] = wkup_cause_cause_1_qs;
-        reg_rdata_next[2] = wkup_cause_cause_2_qs;
-        reg_rdata_next[3] = wkup_cause_cause_3_qs;
-        reg_rdata_next[4] = wkup_cause_cause_4_qs;
-        reg_rdata_next[5] = wkup_cause_cause_5_qs;
-        reg_rdata_next[6] = wkup_cause_cause_6_qs;
-        reg_rdata_next[7] = wkup_cause_cause_7_qs;
+        reg_rdata_next = DW'(wkup_cause_qs);
       end
-
       default: begin
         reg_rdata_next = '1;
       end
@@ -25830,52 +26779,28 @@ module pinmux_reg_top (
         reg_busy_sel = wkup_detector_en_7_busy;
       end
       addr_hit[579]: begin
-        reg_busy_sel =
-          wkup_detector_0_mode_0_busy |
-          wkup_detector_0_filter_0_busy |
-          wkup_detector_0_miodio_0_busy;
+        reg_busy_sel = wkup_detector_0_busy;
       end
       addr_hit[580]: begin
-        reg_busy_sel =
-          wkup_detector_1_mode_1_busy |
-          wkup_detector_1_filter_1_busy |
-          wkup_detector_1_miodio_1_busy;
+        reg_busy_sel = wkup_detector_1_busy;
       end
       addr_hit[581]: begin
-        reg_busy_sel =
-          wkup_detector_2_mode_2_busy |
-          wkup_detector_2_filter_2_busy |
-          wkup_detector_2_miodio_2_busy;
+        reg_busy_sel = wkup_detector_2_busy;
       end
       addr_hit[582]: begin
-        reg_busy_sel =
-          wkup_detector_3_mode_3_busy |
-          wkup_detector_3_filter_3_busy |
-          wkup_detector_3_miodio_3_busy;
+        reg_busy_sel = wkup_detector_3_busy;
       end
       addr_hit[583]: begin
-        reg_busy_sel =
-          wkup_detector_4_mode_4_busy |
-          wkup_detector_4_filter_4_busy |
-          wkup_detector_4_miodio_4_busy;
+        reg_busy_sel = wkup_detector_4_busy;
       end
       addr_hit[584]: begin
-        reg_busy_sel =
-          wkup_detector_5_mode_5_busy |
-          wkup_detector_5_filter_5_busy |
-          wkup_detector_5_miodio_5_busy;
+        reg_busy_sel = wkup_detector_5_busy;
       end
       addr_hit[585]: begin
-        reg_busy_sel =
-          wkup_detector_6_mode_6_busy |
-          wkup_detector_6_filter_6_busy |
-          wkup_detector_6_miodio_6_busy;
+        reg_busy_sel = wkup_detector_6_busy;
       end
       addr_hit[586]: begin
-        reg_busy_sel =
-          wkup_detector_7_mode_7_busy |
-          wkup_detector_7_filter_7_busy |
-          wkup_detector_7_miodio_7_busy;
+        reg_busy_sel = wkup_detector_7_busy;
       end
       addr_hit[587]: begin
         reg_busy_sel = wkup_detector_cnt_th_0_busy;
@@ -25902,22 +26827,13 @@ module pinmux_reg_top (
         reg_busy_sel = wkup_detector_cnt_th_7_busy;
       end
       addr_hit[603]: begin
-        reg_busy_sel =
-          wkup_cause_cause_0_busy |
-          wkup_cause_cause_1_busy |
-          wkup_cause_cause_2_busy |
-          wkup_cause_cause_3_busy |
-          wkup_cause_cause_4_busy |
-          wkup_cause_cause_5_busy |
-          wkup_cause_cause_6_busy |
-          wkup_cause_cause_7_busy;
+        reg_busy_sel = wkup_cause_busy;
       end
       default: begin
         reg_busy_sel  = '0;
       end
     endcase
   end
-
 
 
   // Unused signal tieoff

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -1221,7 +1221,6 @@ module pwrmgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -1014,7 +1014,6 @@ module rstmgr_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -23680,7 +23680,6 @@ module rv_plic_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -1754,7 +1754,6 @@ module sensor_ctrl_reg_top (
   end
 
 
-
   // Unused signal tieoff
 
   // wdata / byte enable are not always fully used

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -464,6 +464,13 @@ class Register(RegBase):
                                  wen_fld.swaccess.key,
                                  wen_fld.hwaccess.key))
 
+    def bitmask(self) -> str:
+        reg_bitmask = 0
+        for f in self.fields:
+            reg_bitmask |= f.bits.bitmask()
+
+        return format(reg_bitmask, "x")
+
     def _asdict(self) -> Dict[str, object]:
         rd = {
             'name': self.name,

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -546,8 +546,8 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
     else:
       reg_field_name = reg_name + "_" + field.name.lower()
 
-    if reg.async_name and not reg.hwext:
-      reg_field_name += ".u_subreg"
+    ##if reg.async_name and not reg.hwext:
+    ##  reg_field_name += ".u_subreg"
 %>\
 %   if ((field.hwaccess.value[1] == HwAccess.NONE and\
        field.swaccess.swrd() == SwRdAccess.RD and\


### PR DESCRIPTION
The current regfile CDC treats all the fields of a register as individuals. 
This generally works fine; however, if a register has the format of `EN`, `CTRL0`, `CTRL1`, they may be updated at different times.

The difference in update does not impact software, as any field that is still updating renders the entire register busy.  However hardware may interpret the fields at different times.

This could become a problem if there is logic expecting certain fields to be a particular value when another field is a certain value.
To get ahead of these problems, move the CDC handling at a per field level to a per reg level. 

Given that we are only doing this to async registers, some of the python logic is duplicated. Ideally, the way we would do this is that each register is wrapped up into its own `prim_reg`. Then inside the reg we can decide to do whatever we want.  That particular enhancement is left until another day. 

This fixes #7810 and should make it easier to de-duplicate `qe`'s later. 

