### PR TITLE
[dv/prim_esc] Add a testplan and increase coverage

### DIFF
--- a/hw/ip/prim/dv/prim_esc/data/prim_esc_testplan.hjson
+++ b/hw/ip/prim/dv/prim_esc/data/prim_esc_testplan.hjson
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: "prim_esc"
+  testpoints: [
+    {
+      name: prim_esc_request_test
+      desc: '''Verify escalation request from prim_esc_sender.
+
+            - Send an escalation request by driving `esc_req` pin to 1.
+            - Wait random length of cycles and verify `esc_en` output is set and `integ_fail`
+              output remains 0.
+            '''
+      milestone: V1
+      tests: ["prim_esc_test"]
+    }
+
+    {
+      name: prim_esc_tx_integrity_errors_test
+      desc: '''Verify `esc_tx` signal integrity error.
+
+            - Send an escalation request by driving `esc_req` pin to 1.
+            - Force `esc_n` signal to stay high to trigger an integrity error.
+            - Verify that prim_esc_sender identifies the error by setting `integ_fail` signal.
+            - Release the `esc_n` signal.
+            '''
+      milestone: V1
+      tests: ["prim_esc_test"]
+    }
+
+    {
+      name: prim_esc_reverse_ping_timeout_test
+      desc: '''Verify prim_esc_receiver detects ping timeout.
+
+            - Send a ping request by driving `ping_req` pin to 1.
+            - Wait for ping handshake to finish and `ping_ok` signal is set.
+            - Verify that `esc_en` output remains 0 and `integ_fail` output remains 0.
+            - Drive `ping_req` signal back to 0 and wait until ping counter timeout.
+            - Verify that `prim_esc_receiver` detects the ping timeout by setting `esc_en` output
+              to 1.
+            - Reset the DUT to clear `esc_en` output.
+            '''
+      milestone: V1
+      tests: ["prim_esc_test"]
+    }
+
+    {
+      name: prim_esc_receiver_counter_fail_test
+      desc: '''Verify prim_esc_receiver detects counter mismatch.
+
+            - Send a ping request by driving `ping_req` pin to 1.
+            - Wait until `ping_ok` output sets to 1, which means the two counters start.
+            - Force one of the two identical counters to 0.
+            - Verify that prim_esc_receiver detects the counter mismatch and set `esc_en` signal to
+              1.
+            '''
+      milestone: V1
+      tests: ["prim_esc_test"]
+    }
+
+    {
+      name: prim_esc_handshake_with_rand_reset_test
+      desc: '''Verify alert request from prim_alert_sender.
+
+            - Send a ping request by driving `ping_req` pin to 1.
+            - Randomly issue reset during the escalation handshake.
+            - Verify that after reset, the prim_esc_sender and prim_esc_receiver pair functions
+              correctly by issuing the tests above.
+            '''
+      milestone: V1
+      tests: ["prim_esc_test"]
+    }
+
+  ]
+}

--- a/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_esc/prim_esc_sim_cfg.hjson
@@ -17,11 +17,14 @@
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:prim_esc_sim:0.1
 
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/prim/dv/prim_esc/data/prim_esc_testplan.hjson"
+
   // Import additional common sim cfg files.
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 5
+  reseed: 20
 
   // List of test specifications.
   tests: [


### PR DESCRIPTION
This PR:
1). Adds a testplan for prim_esc.
2). Add a random reset sequnece to cover more FSM coverage.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>