### PR TITLE
[top] Add intermodule io support

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -652,6 +652,14 @@
   /////////////////////////////
 
   inter_signal_list: [
+    // OTP dedicated power connection from AST
+    { struct:  ""
+      type:    "io"
+      name:    "otp_ext_voltage_h"
+      act:     "none"
+      default: "'0"
+      package: "",
+    }
     // Power sequencing signals to AST
     { struct:  "otp_ast_req"
       type:    "uni"

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -177,6 +177,14 @@
   /////////////////////////////
 
   inter_signal_list: [
+    // OTP dedicated power connection from AST
+    { struct:  ""
+      type:    "io"
+      name:    "otp_ext_voltage_h"
+      act:     "none"
+      default: "'0"
+      package: "",
+    }
     // Power sequencing signals to AST
     { struct:  "otp_ast_req"
       type:    "uni"

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1251,6 +1251,19 @@
       inter_signal_list:
       [
         {
+          name: otp_ext_voltage_h
+          struct: ""
+          type: io
+          act: none
+          width: 1
+          default: "'0"
+          inst_name: otp_ctrl
+          package: ""
+          external: true
+          top_signame: otp_ext_voltage_h
+          index: -1
+        }
+        {
           name: otp_ast_pwr_seq
           struct: otp_ast_req
           package: otp_ctrl_pkg
@@ -6969,6 +6982,7 @@
       pwrmgr_aon.pwr_ast: pwrmgr_ast
       otp_ctrl.otp_ast_pwr_seq: ""
       otp_ctrl.otp_ast_pwr_seq_h: ""
+      otp_ctrl.otp_ext_voltage_h: otp_ext_voltage_h
       otp_ctrl.otp_alert: otp_alert
       rstmgr_aon.por_n: por_n
       sensor_ctrl_aon.ast_alert: sensor_ctrl_ast_alert
@@ -13379,6 +13393,19 @@
         index: -1
       }
       {
+        name: otp_ext_voltage_h
+        struct: ""
+        type: io
+        act: none
+        width: 1
+        default: "'0"
+        inst_name: otp_ctrl
+        package: ""
+        external: true
+        top_signame: otp_ext_voltage_h
+        index: -1
+      }
+      {
         name: otp_ast_pwr_seq
         struct: otp_ast_req
         package: otp_ctrl_pkg
@@ -17740,6 +17767,18 @@
         conn_type: false
         index: -1
         netname: otp_ctrl_otp_ast_pwr_seq_h
+      }
+      {
+        package: ""
+        struct: ""
+        signame: otp_ext_voltage_h_io
+        width: 1
+        type: io
+        default: "'0"
+        direction: inout
+        conn_type: false
+        index: -1
+        netname: otp_ext_voltage_h
       }
       {
         package: ast_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -943,6 +943,7 @@
         'pwrmgr_aon.pwr_ast'           : 'pwrmgr_ast',
         'otp_ctrl.otp_ast_pwr_seq'     : '',
         'otp_ctrl.otp_ast_pwr_seq_h'   : '',
+        'otp_ctrl.otp_ext_voltage_h'   : 'otp_ext_voltage_h',
         'otp_ctrl.otp_alert'           : 'otp_alert',
         'rstmgr_aon.por_n'             : 'por_n'
         'sensor_ctrl_aon.ast_alert'    : 'sensor_ctrl_ast_alert',

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -141,6 +141,7 @@ module top_earlgrey #(
   input  pwrmgr_pkg::pwr_ast_rsp_t       pwrmgr_ast_rsp_i,
   output otp_ctrl_pkg::otp_ast_req_t       otp_ctrl_otp_ast_pwr_seq_o,
   input  otp_ctrl_pkg::otp_ast_rsp_t       otp_ctrl_otp_ast_pwr_seq_h_i,
+  inout         otp_ext_voltage_h_io,
   output ast_pkg::ast_dif_t       otp_alert_o,
   input  logic       por_n_i,
   input  ast_pkg::ast_alert_req_t       sensor_ctrl_ast_alert_req_i,
@@ -156,9 +157,6 @@ module top_earlgrey #(
   // Flash specific voltages
   inout [1:0] flash_test_mode_a_io,
   inout flash_test_voltage_h_io,
-
-  // OTP specific voltages
-  inout otp_ext_voltage_h_io,
 
   input                      scan_rst_ni, // reset used for test mode
   input                      scan_en_i,
@@ -1431,6 +1429,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[16:14] ),
 
       // Inter-module signals
+      .otp_ext_voltage_h_io(otp_ext_voltage_h_io),
       .otp_ast_pwr_seq_o(otp_ctrl_otp_ast_pwr_seq_o),
       .otp_ast_pwr_seq_h_i(otp_ctrl_otp_ast_pwr_seq_h_i),
       .otp_alert_o(otp_alert_o),
@@ -1458,7 +1457,6 @@ module top_earlgrey #(
       .core_tl_o(otp_ctrl_core_tl_rsp),
       .prim_tl_i(otp_ctrl_prim_tl_req),
       .prim_tl_o(otp_ctrl_prim_tl_rsp),
-      .otp_ext_voltage_h_io,
       .scanmode_i,
       .scan_rst_ni,
       .scan_en_i,

--- a/util/topgen/intermodule.py
+++ b/util/topgen/intermodule.py
@@ -13,9 +13,9 @@ from reggen.inter_signal import InterSignal
 from reggen.validate import check_int
 from topgen import lib
 
-IM_TYPES = ['uni', 'req_rsp']
-IM_ACTS = ['req', 'rsp', 'rcv']
-IM_VALID_TYPEACT = {'uni': ['req', 'rcv'], 'req_rsp': ['req', 'rsp']}
+IM_TYPES = ['uni', 'req_rsp', 'io']
+IM_ACTS = ['req', 'rsp', 'rcv', 'none']
+IM_VALID_TYPEACT = {'uni': ['req', 'rcv'], 'req_rsp': ['req', 'rsp'], 'io': ['none']}
 IM_CONN_TYPE = ['1-to-1', '1-to-N', 'broadcast']
 
 
@@ -531,6 +531,18 @@ def elab_intermodule(topcfg: OrderedDict):
                              ('conn_type', conn_type),
                              ('index', index),
                              ('netname', netname + rsp_suffix)]))
+        elif sig["type"] == "io":
+            sigsuffix = "_io"
+            topcfg["inter_signal"]["external"].append(
+                OrderedDict([('package', sig.get("package", "")),
+                             ('struct', sig["struct"]),
+                             ('signame', sig_name + sigsuffix),
+                             ('width', sig["width"]), ('type', sig["type"]),
+                             ('default', sig["default"]),
+                             ('direction', "inout"),
+                             ('conn_type', conn_type),
+                             ('index', index),
+                             ('netname', netname)]))
         else:  # uni
             if sig["act"] == "req":
                 sigsuffix = "_o"
@@ -861,12 +873,25 @@ def check_intermodule(topcfg: Dict, prefix: str) -> int:
     return total_error
 
 
+def get_direction(sig):
+    if sig["direction"] == "in":
+        return "input "
+    elif sig["direction"] == "out":
+        return "output"
+    elif sig["direction"] == "inout":
+        return "inout "
+
+
 # Template functions
 def im_defname(obj: OrderedDict) -> str:
     """return definition struct name
 
     e.g. flash_ctrl::flash_req_t
     """
+    if obj["type"] == "io":
+        # io type, don't declare anything
+        return ""
+
     if obj["package"] == "":
         # should be logic
         return "logic"
@@ -888,6 +913,7 @@ def im_netname(sig: OrderedDict,
     # Basic check and add missing fields
     err, obj = check_intermodule_field(sig)
     assert not err
+
 
     # Floating signals
     # TODO: Find smarter way to assign default?
@@ -931,9 +957,13 @@ def im_netname(sig: OrderedDict,
         return ""
 
     # Connected signals
-    assert suffix in ["", "req", "rsp"]
+    assert suffix in ["", "req", "rsp", "io"]
 
-    suffix_s = "_{suffix}".format(suffix=suffix) if suffix != "" else suffix
+    # io types have no role
+    if suffix == "io":
+        suffix_s = ""
+    else:
+        suffix_s = "_{suffix}".format(suffix=suffix) if suffix != "" else suffix
 
     # External signal handling
     if "external" in obj and obj["external"]:
@@ -944,7 +974,8 @@ def im_netname(sig: OrderedDict,
             ("rsp", "req"): "_i",
             ("rsp", "rsp"): "_o",
             ("req", ""): "_o",
-            ("rcv", ""): "_i"
+            ("rcv", ""): "_i",
+            ("none", "io"): "_io"
         }
         suffix_s += pairs[(obj['act'], suffix)]
 
@@ -959,6 +990,7 @@ def im_portname(obj: OrderedDict, suffix: str = "") -> str:
 
     e.g signame_o for requester req signal
     """
+
     act = obj['act']
     name = obj['name']
 
@@ -966,6 +998,8 @@ def im_portname(obj: OrderedDict, suffix: str = "") -> str:
         suffix_s = "_o" if act == "req" else "_i"
     elif suffix == "req":
         suffix_s = "_o" if act == "req" else "_i"
+    elif suffix == "io":
+        suffix_s = "_io"
     else:
         suffix_s = "_o" if act == "rsp" else "_i"
 

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -16,7 +16,8 @@ from reggen.ip_block import IpBlock
 # Ignore flake8 warning as the function is used in the template
 # disable isort formating, as conflicting with flake8
 from .intermodule import find_otherside_modules  # noqa : F401 # isort:skip
-from .intermodule import im_portname, im_defname, im_netname  # noqa : F401 # isort:skip
+from .intermodule import im_portname, im_defname, im_netname # noqa : F401 # isort:skip
+from .intermodule import get_direction # noqa : F401 # isort:skip
 from .intermodule import get_dangling_im_def # noqa : F401 # isort:skip
 
 

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -88,17 +88,14 @@ module top_${top["name"]} #(
 
   // Inter-module Signal External type
   % for sig in top["inter_signal"]["external"]:
-  ${"input " if sig["direction"] == "in" else "output"} ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]},
+  ${lib.get_direction(sig)} ${lib.im_defname(sig)} ${lib.bitarray(sig["width"],1)} ${sig["signame"]},
   % endfor
 
+% endif
   // Flash specific voltages
   inout [1:0] flash_test_mode_a_io,
   inout flash_test_voltage_h_io,
 
-  // OTP specific voltages
-  inout otp_ext_voltage_h_io,
-
-% endif
   input                      scan_rst_ni, // reset used for test mode
   input                      scan_en_i,
   input lc_ctrl_pkg::lc_tx_t scanmode_i   // lc_ctrl_pkg::On for Scan
@@ -443,6 +440,8 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
         % if sig['type'] == "req_rsp":
       .${lib.im_portname(sig,"req")}(${lib.im_netname(sig, "req")}),
       .${lib.im_portname(sig,"rsp")}(${lib.im_netname(sig, "rsp")}),
+        % elif sig['type'] == "io":
+      .${lib.im_portname(sig,"io")}(${lib.im_netname(sig, "io")}),
         % elif sig['type'] == "uni":
           ## TODO: Broadcast type
           ## TODO: default for logic type
@@ -478,9 +477,6 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
       // alert signals
       .alert_rx_o  ( alert_rx ),
       .alert_tx_i  ( alert_tx ),
-    % endif
-    % if m["type"] == "otp_ctrl":
-      .otp_ext_voltage_h_io,
     % endif
     % if block.scan:
       .scanmode_i,


### PR DESCRIPTION
- update otp to use 'io' instead of hardwiring
- will be used for other modules as well
