### PR TITLE
[otbn,dv] Use x1 more in RIG-generated programs

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch.py
@@ -99,10 +99,8 @@ class Branch(SnippetGen):
         off_min, off_max = off_rng
 
         # Pick the source GPRs that we're comparing.
-        assert isinstance(grs1_op.op_type, RegOperandType)
-        assert isinstance(grs2_op.op_type, RegOperandType)
-        grs1 = model.pick_reg_operand_value(grs1_op.op_type)
-        grs2 = model.pick_reg_operand_value(grs2_op.op_type)
+        grs1 = model.pick_operand_value(grs1_op.op_type)
+        grs2 = model.pick_operand_value(grs2_op.op_type)
         if grs1 is None or grs2 is None:
             return None
 

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -463,6 +463,13 @@ class Model:
             return None
 
         if weights is None:
+            if op_type.reg_type == 'gpr' and is_dst and not is_src:
+                # Destination registers without a specific set of weights get a
+                # default that makes x1 more likely. The idea is that we'll be
+                # more likely to fill the call stack this way.
+                weights = {1: 8}
+
+        if weights is None:
             return random.choice(list(reg_set))
 
         regs = []


### PR DESCRIPTION
These two commits add a "weighting" option when picking operands and then give a heavier weight by default to `x1` as a destination, making it more likely that we'll fill the call stack.