### PR TITLE
[sw/silicon_creator] Add manifest_check()

### DIFF
--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -5,9 +5,8 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 // Extern declarations for the inline functions in the manifest header.
-extern rom_error_t manifest_signed_region_get(
-    const manifest_t *manifest, manifest_signed_region_t *signed_region);
-extern rom_error_t manifest_code_region_get(const manifest_t *manifest,
-                                            epmp_region_t *code_region);
-extern rom_error_t manifest_entry_point_get(const manifest_t *manifest,
-                                            uintptr_t *entry_point);
+extern rom_error_t manifest_check(const manifest_t *manifest);
+extern manifest_signed_region_t manifest_signed_region_get(
+    const manifest_t *manifest);
+extern epmp_region_t manifest_code_region_get(const manifest_t *manifest);
+extern uintptr_t manifest_entry_point_get(const manifest_t *manifest);

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -5,99 +5,101 @@
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 #include "gtest/gtest.h"
-#include "sw/device/silicon_creator/lib/epmp.h"
+#include "sw/device/lib/testing/mask_rom_test.h"
 
 namespace manifest_unittest {
 namespace {
 
-TEST(Manifest, SignedRegionGet) {
-  manifest_t manifest{};
-  manifest.length = 4096;
-  manifest_signed_region_t signed_region;
+class ManifestTest : public mask_rom_test::MaskRomTest {
+ protected:
+  ManifestTest() {
+    manifest_.length = 0x1000;
+    manifest_.code_start = 0x400;
+    manifest_.code_end = 0x800;
+    manifest_.entry_point = 0x500;
+  }
 
-  EXPECT_EQ(manifest_signed_region_get(&manifest, &signed_region), kErrorOk);
-  // Signed region starts at `modulus` and ends at the end of the image.
-  EXPECT_EQ(&manifest.modulus, signed_region.start);
-  EXPECT_EQ(manifest.length - offsetof(manifest_t, modulus),
-            signed_region.length);
+  manifest_t manifest_{};
+};
+
+TEST_F(ManifestTest, SignedRegionGet) {
+  manifest_signed_region_t signed_region =
+      manifest_signed_region_get(&manifest_);
+
+  // Signed region starts after `signature` and ends at the end of the image.
+  EXPECT_EQ(signed_region.start, reinterpret_cast<const char *>(&manifest_) +
+                                     sizeof(manifest_t::signature));
+  EXPECT_EQ(signed_region.length,
+            manifest_.length - sizeof(manifest_t::signature));
 }
 
-TEST(Manifest, SignedRegionGetBadLength) {
-  manifest_t manifest{};
-  manifest_signed_region_t signed_region;
+TEST_F(ManifestTest, CodeRegionGet) {
+  epmp_region_t code_region = manifest_code_region_get(&manifest_);
 
-  manifest.length = MANIFEST_LENGTH_FIELD_MAX + 1;
-  EXPECT_EQ(manifest_signed_region_get(&manifest, &signed_region),
-            kErrorManifestBadLength);
-
-  manifest.length = MANIFEST_LENGTH_FIELD_MIN - 1;
-  EXPECT_EQ(manifest_signed_region_get(&manifest, &signed_region),
-            kErrorManifestBadLength);
-}
-
-TEST(Manifest, CodeRegionGet) {
-  manifest_t manifest{};
-  manifest.length = 0x1000;
-  manifest.code_start = 0x400;
-  manifest.code_end = 0x800;
-  epmp_region_t code_region;
-
-  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region), kErrorOk);
   EXPECT_EQ(code_region.start,
-            reinterpret_cast<uintptr_t>(&manifest) + manifest.code_start);
+            reinterpret_cast<uintptr_t>(&manifest_) + manifest_.code_start);
   EXPECT_EQ(code_region.end,
-            reinterpret_cast<uintptr_t>(&manifest) + manifest.code_end);
-  // Code region cannot be empty.
-  manifest.code_start = manifest.code_end;
-  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
-            kErrorManifestBadCodeRegion);
-  // Code region must be after the manifest.
-  manifest.code_start = sizeof(manifest_t) - 1;
-  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
-            kErrorManifestBadCodeRegion);
-  // Code region must be inside the image.
-  manifest.code_start = 0x400;
-  manifest.code_end = manifest.length + 1;
-  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
-            kErrorManifestBadCodeRegion);
-  // Start and end offsets must be word aligned.
-  manifest.code_start = 0x401;
-  manifest.code_end = 0x800;
-  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
-            kErrorManifestBadCodeRegion);
-  manifest.code_start = 0x400;
-  manifest.code_end = 0x801;
-  EXPECT_EQ(manifest_code_region_get(&manifest, &code_region),
-            kErrorManifestBadCodeRegion);
+            reinterpret_cast<uintptr_t>(&manifest_) + manifest_.code_end);
 }
 
-TEST(Manifest, EntryPointGet) {
-  manifest_t manifest{};
-  manifest.length = 0x1000;
-  manifest.code_start = 0x400;
-  manifest.entry_point = 0x500;
-  manifest.code_end = 0x800;
-  uintptr_t entry_point;
+TEST_F(ManifestTest, EntryPointGet) {
+  uintptr_t entry_point = manifest_entry_point_get(&manifest_);
 
-  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point), kErrorOk);
   EXPECT_EQ(entry_point,
-            reinterpret_cast<uintptr_t>(&manifest) + manifest.entry_point);
-  // entry_point must be at or after code_start.
-  manifest.entry_point = manifest.code_start - 1;
-  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
-            kErrorManifestBadEntryPoint);
-  // entry_point must be before code_end.
-  manifest.entry_point = manifest.code_end;
-  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
-            kErrorManifestBadEntryPoint);
-  // entry_point must be before the end of the image.
-  manifest.entry_point = manifest.length;
-  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
-            kErrorManifestBadEntryPoint);
-  // entry_point must be word aligned.
-  manifest.entry_point = 0x501;
-  EXPECT_EQ(manifest_entry_point_get(&manifest, &entry_point),
-            kErrorManifestBadEntryPoint);
+            reinterpret_cast<uintptr_t>(&manifest_) + manifest_.entry_point);
+}
+
+TEST_F(ManifestTest, BadLength) {
+  manifest_.length = MANIFEST_LENGTH_FIELD_MAX + 1;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadLength);
+
+  manifest_.length = MANIFEST_LENGTH_FIELD_MIN - 1;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadLength);
+}
+
+TEST_F(ManifestTest, CodeRegionEmpty) {
+  manifest_.code_start = manifest_.code_end;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);
+}
+
+TEST_F(ManifestTest, CodeRegionInsideManifest) {
+  manifest_.code_start = sizeof(manifest_) - 1;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);
+}
+
+TEST_F(ManifestTest, CodeRegionOutsideImage) {
+  manifest_.code_end = manifest_.length + 1;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);
+}
+
+TEST_F(ManifestTest, CodeRegionUnalignedStart) {
+  ++manifest_.code_start;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);
+}
+
+TEST_F(ManifestTest, CodeRegionUnalignedEnd) {
+  ++manifest_.code_end;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);
+}
+
+TEST_F(ManifestTest, EntryPointBeforeCodeStart) {
+  manifest_.entry_point = manifest_.code_start - 1;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadEntryPoint);
+}
+
+TEST_F(ManifestTest, EntryPointAfterCodeEnd) {
+  manifest_.entry_point = manifest_.code_end;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadEntryPoint);
+}
+
+TEST_F(ManifestTest, EntryPointOutsideImage) {
+  manifest_.entry_point = manifest_.length;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadEntryPoint);
+}
+
+TEST_F(ManifestTest, EntryPointUnaligned) {
+  ++manifest_.entry_point;
+  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadEntryPoint);
 }
 
 }  // namespace


### PR DESCRIPTION
This change moves the checks in the getters in manifest.h to `manifest_check()`.

Signed-off-by: Alphan Ulusoy <alphan@google.com>