### PR TITLE
[fpv/batch] add more IPs to FPV regression

### DIFF
--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -17,11 +17,11 @@
              // Unit tests for UVCs.
              "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
              // IPs.
+             "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
-             "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_sim_cfg.hjson",
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson",
              "{proj_root}/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson",

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -190,6 +190,13 @@
              // FPV only verifies TLUL interface and build-in assertions,
              // so will not collect FPV coverage.
              {
+               name: adc_ctrl
+               fusesoc_core: lowrisc:dv:adc_ctrl_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/adc_ctrl/{sub_flow}/{tool}"
+               cov: false
+             }
+             {
                name: aes
                fusesoc_core: lowrisc:dv:aes_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
@@ -201,6 +208,20 @@
                fusesoc_core: lowrisc:dv:alert_handler_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/alert_handler/{sub_flow}/{tool}"
+               cov: false
+             }
+             {
+               name: aon_timer
+               fusesoc_core: lowrisc:dv:aon_timer_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/aon_timer/{sub_flow}/{tool}"
+               cov: false
+             }
+             {
+               name: clkmgr
+               fusesoc_core: lowrisc:dv:clkmgr_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/clkmgr/{sub_flow}/{tool}"
                cov: false
              }
              {
@@ -253,13 +274,6 @@
                cov: false
              }
              {
-               name: pattgen
-               fusesoc_core: lowrisc:dv:pattgen_sva
-               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
-               rel_path: "hw/ip/pattgen/{sub_flow}/{tool}"
-               cov: false
-             }
-             {
                name: keymgr
                fusesoc_core: lowrisc:dv:keymgr_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
@@ -285,6 +299,27 @@
                fusesoc_core: lowrisc:dv:otbn_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/otbn/{sub_flow}/{tool}"
+               cov: false
+             }
+             {
+               name: pattgen
+               fusesoc_core: lowrisc:dv:pattgen_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/pattgen/{sub_flow}/{tool}"
+               cov: false
+             }
+             {
+               name: pwrmgr
+               fusesoc_core: lowrisc:dv:pwrmgr_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/pwrmgr/{sub_flow}/{tool}"
+               cov: false
+             }
+             {
+               name: rom_ctrl
+               fusesoc_core: lowrisc:dv:rom_ctrl_sva
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/rom_ctrl/{sub_flow}/{tool}"
                cov: false
              }
              {


### PR DESCRIPTION
This PR adds more IPs to the FPV regression.
This PR also fixes a small alphabetical order issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>