### PR TITLE
Otbn illegal bus

### DIFF
--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -61,42 +61,43 @@ module otbn_top_sim (
     .ImemSizeByte ( ImemSizeByte ),
     .DmemSizeByte ( DmemSizeByte )
   ) u_otbn_core (
-    .clk_i           ( IO_CLK           ),
-    .rst_ni          ( IO_RST_N         ),
+    .clk_i                ( IO_CLK           ),
+    .rst_ni               ( IO_RST_N         ),
 
-    .start_i         ( otbn_start       ),
-    .done_o          ( otbn_done_d      ),
+    .start_i              ( otbn_start       ),
+    .done_o               ( otbn_done_d      ),
 
-    .err_bits_o      ( otbn_err_bits_d  ),
+    .err_bits_o           ( otbn_err_bits_d  ),
 
-    .start_addr_i    ( ImemStartAddr    ),
+    .start_addr_i         ( ImemStartAddr    ),
 
-    .imem_req_o      ( imem_req         ),
-    .imem_addr_o     ( imem_addr        ),
-    .imem_wdata_o    (                  ),
-    .imem_rdata_i    ( imem_rdata[31:0] ),
-    .imem_rvalid_i   ( imem_rvalid      ),
-    .imem_rerror_i   ( imem_rerror      ),
+    .imem_req_o           ( imem_req         ),
+    .imem_addr_o          ( imem_addr        ),
+    .imem_wdata_o         (                  ),
+    .imem_rdata_i         ( imem_rdata[31:0] ),
+    .imem_rvalid_i        ( imem_rvalid      ),
+    .imem_rerror_i        ( imem_rerror      ),
 
-    .dmem_req_o      ( dmem_req         ),
-    .dmem_write_o    ( dmem_write       ),
-    .dmem_addr_o     ( dmem_addr        ),
-    .dmem_wdata_o    ( dmem_wdata       ),
-    .dmem_wmask_o    ( dmem_wmask       ),
-    .dmem_rmask_o    ( ),
-    .dmem_rdata_i    ( dmem_rdata       ),
-    .dmem_rvalid_i   ( dmem_rvalid      ),
-    .dmem_rerror_i   ( dmem_rerror      ),
+    .dmem_req_o           ( dmem_req         ),
+    .dmem_write_o         ( dmem_write       ),
+    .dmem_addr_o          ( dmem_addr        ),
+    .dmem_wdata_o         ( dmem_wdata       ),
+    .dmem_wmask_o         ( dmem_wmask       ),
+    .dmem_rmask_o         ( ),
+    .dmem_rdata_i         ( dmem_rdata       ),
+    .dmem_rvalid_i        ( dmem_rvalid      ),
+    .dmem_rerror_i        ( dmem_rerror      ),
 
-    .edn_rnd_req_o   ( edn_rnd_req      ),
-    .edn_rnd_ack_i   ( edn_rnd_ack      ),
-    .edn_rnd_data_i  ( edn_rnd_data     ),
+    .edn_rnd_req_o        ( edn_rnd_req      ),
+    .edn_rnd_ack_i        ( edn_rnd_ack      ),
+    .edn_rnd_data_i       ( edn_rnd_data     ),
 
-    .edn_urnd_req_o  ( edn_urnd_req     ),
-    .edn_urnd_ack_i  ( edn_urnd_ack     ),
-    .edn_urnd_data_i ( edn_urnd_data    ),
+    .edn_urnd_req_o       ( edn_urnd_req     ),
+    .edn_urnd_ack_i       ( edn_urnd_ack     ),
+    .edn_urnd_data_i      ( edn_urnd_data    ),
 
-    .insn_cnt_o      ( insn_cnt )
+    .insn_cnt_o           ( insn_cnt         ),
+    .illegal_bus_access_i ( 1'b0             )
   );
 
   // The top bits of IMEM rdata aren't currently used (they will eventually be used for integrity

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -124,7 +124,8 @@ module otbn_controller
   input  logic rnd_valid_i,
 
   input  logic        state_reset_i,
-  output logic [31:0] insn_cnt_o
+  output logic [31:0] insn_cnt_o,
+  input  logic        illegal_bus_access_i
 );
   otbn_state_e state_q, state_d, state_raw;
 
@@ -326,7 +327,7 @@ module otbn_controller
     end
   end
 
-  assign err_bits_o.fatal_illegal_bus_access = 1'b0; // TODO: implement
+  assign err_bits_o.fatal_illegal_bus_access = illegal_bus_access_i;
   assign err_bits_o.fatal_reg                = rf_base_rd_data_err_i | rf_bignum_rd_data_err_i;
   assign err_bits_o.fatal_imem               = insn_fetch_err_i;
   assign err_bits_o.fatal_dmem               = lsu_rdata_err_i;

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -66,7 +66,11 @@ module otbn_core
   input  logic                    edn_urnd_ack_i,
   input  logic [EdnDataWidth-1:0] edn_urnd_data_i,
 
-  output logic [31:0]             insn_cnt_o
+  output logic [31:0]             insn_cnt_o,
+
+  // Asserted by system when bus tries to access OTBN memories whilst OTBN is active. Results in an
+  // fatal error.
+  input  logic                    illegal_bus_access_i
 );
   // Fetch request (the next instruction)
   logic [ImemAddrWidth-1:0] insn_fetch_req_addr;
@@ -348,7 +352,8 @@ module otbn_core
     .rnd_valid_i        (rnd_valid),
 
     .state_reset_i      (state_reset),
-    .insn_cnt_o         (insn_cnt)
+    .insn_cnt_o         (insn_cnt),
+    .illegal_bus_access_i
   );
 
   assign insn_cnt_o = insn_cnt;


### PR DESCRIPTION
This shouldn't be merged until #7626 is merged. I could have pushed it to that PR but didn't want to interfere with any work @imphil may have been doing to fix the CI.

The one extra I've added into this is totally blanking off the dmem/imem read path from OTBN -> Ibex once an illegal bus access is seen. This makes OTBN pretty useless until reset, but a fatal error should do that anyway and it felt worthwhile.