### PR TITLE
[otbn,dv] Fix callstack flags in coverage

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_rf_base_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_rf_base_if.sv
@@ -11,17 +11,16 @@ interface otbn_rf_base_if (
   // Signal names from the otbn_rf_base module (where we are bound)
   input logic pop_stack_a, 
   input logic pop_stack_b,
-  input logic pop_stack,
-  input logic push_stack,
+  input logic push_stack_reqd,
   input logic stack_full,
   input logic stack_data_valid 
 );
 
   function automatic otbn_env_pkg::call_stack_flags_t get_call_stack_flags();
     return '{
-              pop_a: pop_stack && pop_stack_a,
-              pop_b: pop_stack && pop_stack_b,
-              push: push_stack
+              pop_a: pop_stack_a,
+              pop_b: pop_stack_b,
+              push: push_stack_reqd
             };
   endfunction
 


### PR DESCRIPTION
`pop_stack_a` (resp. `pop_stack_b`) is signalled if the instruction in
question tries to read from `x1` with operand `a` (resp `b`). `pop_stack` is
only true if, furthermore, `rd_commit_i` holds. This guarantees that the
instruction isn't stalled, but also implies that the instruction
didn't cause a fault.

We don't need to check for stalling instructions when calculating
these flags: they'll only be read in `otbn_trace_monitor.sv` if the
instruction isn't stalled. But we *do* need to make sure we get the
raw values for a faulting instruction. Without this fix, it would be
impossible to see e.g. how we caused an underflow with an instruction
like `add x0, x1, x1`.

Similarly, the `push_stack` signal requires that the instruction didn't
cause a fault: we actually want the raw signal in `push_stack_reqd`.
