### PR TITLE
[dv/shadow_reg] add shadow reg status check

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -13,11 +13,18 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
 
   // Override this alert name at `initialize` if it's not as below
   string              tl_intg_alert_name = "fatal_fault";
+
   // If there is a bit in an "alert cause" register that will be set by a corrupt bus access, this
   // should be the name of that field (with syntax "reg.field"). Used by cip_base_scoreboard to
   // update the relevant field in the RAL model if it sees an error.
   // Format: tl_intg_alert_fields[ral.a_reg.a_field] = value
   uvm_reg_data_t      tl_intg_alert_fields[dv_base_reg_field];
+
+  // Similar as the associative array above, if DUT has shadow registers, these two associative
+  // arrays contains register fields related to shadow register's update and storage error status.
+  uvm_reg_data_t      shadow_update_err_status_fields[dv_base_reg_field];
+  uvm_reg_data_t      shadow_storage_err_status_fields[dv_base_reg_field];
+
   // Enables TL integrity generation & checking with *_user bits.
   // Assume ALL TL agents have integrity check enabled or disabled altogether.
   bit                 en_tl_intg_gen = 1;

--- a/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
@@ -5,20 +5,45 @@
   testpoints: [
     {
       // this testplan should be imported by all IPs containing shadowed CSRs
-      name: shadow_reg_errors
-      desc: '''Verify shadowed registers' update and storage errors.
+      name: shadow_reg_update_error
+      desc: '''Verify shadowed registers' update error.
 
-            For all shadow registers in the DUT:
-            - Randomly pick a shadowed register.
-            - Write it twice with different values, verify that the update error alert is triggered
-              and the register value remains unchanged.
+            - Randomly pick a shadowed register in the DUT.
+            - Write it twice with different values.
+            - Verify that the update error alert is triggered and the register value remains
+              unchanged.
+            - Verify the update_error status register field is set to 1.
+            - Repeat the above steps a bunch of times.
+            '''
+      milestone: V1
+      tests: ["{name}_shadow_reg_errors"]
+    }
+
+    {
+      name: shadow_reg_read_clear_staged_value
+      desc: '''Verify reading a shadowed register will clear its staged value.
+
+            - Randomly pick a shadowed register in the DUT.
             - Write it once and read it back to clear the staged value.
             - Then write it twice with the same new value (but different from the previous step).
             - Read it back to verify the new value and ensure that the update error alert did not
               trigger.
+            - Verify the update_error status register field remains the same value.
+            - Repeat the above steps a bunch of times.
+            '''
+      milestone: V1
+      tests: ["{name}_shadow_reg_errors"]
+    }
+
+    {
+      name: shadow_reg_storage_error
+      desc: '''Verify shadowed registers' storage error.
+
+            - Randomly pick a shadowed register in the DUT.
             - Backdoor write to shadowed or committed flops to create a storage fatal alert.
             - Check if fatal alert continuously fires until reset.
             - Verify that all other frontdoor write attempts are blocked during the storage error.
+            - Verify that storage_error status register field is set to 1.
             - Reset the DUT.
             - Read all CSRs to ensure the DUT is properly reset.
             - Repeat the above steps a bunch of times.

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -182,6 +182,8 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
     has_edn = 1;
     super.initialize(csr_base_addr);
     tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;
+    shadow_update_err_status_fields[ral.status.alert_recov_ctrl_update_err] = 1;
+    shadow_storage_err_status_fields[ral.status.alert_fatal_fault] = 1;
   endfunction
 
 endclass

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -21,6 +21,9 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
     super.initialize(csr_base_addr);
     tl_intg_alert_fields[ral.err_code.invalid_states] = 1;
     tl_intg_alert_fields[ral.fault_status.regfile_intg] = 1;
+    shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
+    shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;
+    shadow_storage_err_status_fields[ral.err_code.invalid_states] = 1;
 
     m_keymgr_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_keymgr_kmac_agent_cfg");
     m_keymgr_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;


### PR DESCRIPTION
The first PR is separate to PR #7753.

Feel free to only focus on the second commit.
The second commit addresses one of the task in issue #7845 :
1). Added a status check after shadow reg errors sequence.
2). Instead of execute shadow reg sequences in order, we randomly pick sequences to execute - i believe this can better check status registers, as some of the status bit might be sticky.
3). Update the testplan accordingly.