### PR TITLE
[dv/rstmgr] Fix rstmgr_smoke

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_if.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_if.sv
@@ -12,25 +12,27 @@ interface rstmgr_if (
   import rstmgr_env_pkg::*;
   import rstmgr_pkg::*;
 
-  pwrmgr_pkg::pwr_rst_req_t pwr_i;
-  pwrmgr_pkg::pwr_rst_rsp_t pwr_o;
+  logic                        por_n;
+
+  pwrmgr_pkg::pwr_rst_req_t    pwr_i;
+  pwrmgr_pkg::pwr_rst_rsp_t    pwr_o;
 
   // cpu related inputs
-  rstmgr_pkg::rstmgr_cpu_t cpu_i;
+  rstmgr_pkg::rstmgr_cpu_t     cpu_i;
 
   // Interface to alert handler
   alert_pkg::alert_crashdump_t alert_dump_i;
 
   // Interface to cpu crash dump
-  ibex_pkg::crash_dump_t cpu_dump_i;
+  ibex_pkg::crash_dump_t       cpu_dump_i;
 
   // dft bypass
-  logic scan_rst_ni;
+  logic                        scan_rst_ni;
 
-  lc_ctrl_pkg::lc_tx_t scanmode_i;
+  lc_ctrl_pkg::lc_tx_t         scanmode_i;
 
   // reset outputs
   rstmgr_pkg::rstmgr_ast_out_t resets_ast_o;
-  rstmgr_pkg::rstmgr_out_t resets_o;
+  rstmgr_pkg::rstmgr_out_t     resets_o;
 
 endinterface

--- a/hw/ip/rstmgr/dv/tb.sv
+++ b/hw/ip/rstmgr/dv/tb.sv
@@ -74,6 +74,8 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
+    .por_n_i(rstmgr_if.por_n),
+
     .pwr_i(rstmgr_if.pwr_i),
     .pwr_o(rstmgr_if.pwr_o),
 


### PR DESCRIPTION
Add new por_n_i input.
Fix setting of rst_lc_req and rst_sys_req to flip all bits.

Signed-off-by: Guillermo Maturana <maturana@google.com>