### PR TITLE
[otbn,dv] Incr in BN.XID/BN.MOVR: Decoder Error to Illegal Insn 

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/decode.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/decode.py
@@ -8,7 +8,7 @@ import struct
 from typing import List, Optional, Iterator
 
 from .err_bits import ILLEGAL_INSN
-from .isa import INSNS_FILE, DecodeError, OTBNInsn
+from .isa import INSNS_FILE, OTBNInsn
 from .insn import INSN_CLASSES
 from .state import OTBNState
 
@@ -58,14 +58,7 @@ def _decode_word(pc: int, word: int) -> OTBNInsn:
     # shifting, sign interpretation etc.)
     op_vals = cls.insn.enc_vals_to_op_vals(pc, enc_vals)
 
-    # Catch any decode errors raised by the instruction constructor. This lets
-    # us generate errors if an instruction encoding has extra constraints that
-    # can't be captured by the logic in the Encoding class.
-    try:
-        return cls(word, op_vals)
-    except DecodeError as err:
-        return IllegalInsn(pc, word, str(err))
-
+    return cls(word, op_vals)
 
 def decode_bytes(base_addr: int, data: bytes) -> List[OTBNInsn]:
     '''Decode instruction bytes as instructions'''

--- a/hw/ip/otbn/dv/otbnsim/sim/isa.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/isa.py
@@ -20,16 +20,6 @@ except RuntimeError as err:
     sys.stderr.write('{}\n'.format(err))
     sys.exit(1)
 
-
-class DecodeError(Exception):
-    '''An error raised when trying to decode malformed instruction bits'''
-    def __init__(self, msg: str):
-        self.msg = msg
-
-    def __str__(self) -> str:
-        return 'DecodeError: {}'.format(self.msg)
-
-
 def insn_for_mnemonic(mnemonic: str, num_operands: int) -> Insn:
     '''Look up the named instruction in the loaded YAML data.
 


### PR DESCRIPTION
Previously two incremets in single instruction caused a decoder
error. That makes coverage for that faulty case impossible. In
order to fix it, error check moved to execute stage and generates
an `Illegal Insn` error now.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>