### PR TITLE
[dv] Add sv_flist_gen_flags HJson var for FuseSoc

### DIFF
--- a/hw/dv/tools/dvsim/fusesoc.hjson
+++ b/hw/dv/tools/dvsim/fusesoc.hjson
@@ -6,11 +6,12 @@
   fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
   sv_flist_gen_opts:  ["{fusesoc_cores_root_dirs}",
                        "run",
-                       "--flag=fileset_{design_level}",
+                       "{sv_flist_gen_flags}",
                        "--target=sim",
                        "--build-root={build_dir}",
                        "--setup {fusesoc_core}"]
   fusesoc_cores_root_dirs: ["--cores-root {proj_root}"]
   sv_flist_gen_dir:   "{build_dir}/sim-vcs"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
+  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 }

--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -25,12 +25,13 @@
   fusesoc_target:    formal
   sv_flist_gen_opts: ["--cores-root {proj_root}",
                       "run",
-                      "--flag=fileset_{design_level}",
+                       "{sv_flist_gen_flags}",
                       "--tool=icarus",
                       "--target={fusesoc_target}",
                       "--build-root={build_dir}",
                       "--setup {fusesoc_core}"]
   sv_flist_gen_dir:  "{build_dir}/{fusesoc_target}-icarus"
+  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 
   report_cmd:  "python3 {formal_root}/tools/{tool}/parse-formal-report.py"
   report_opts: ["--logpath={build_log}",

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -33,7 +33,7 @@
   // TODO: switch the tool to dc once the corresponding edalize backend is available
   sv_flist_gen_opts:  ["--cores-root {proj_root}",
                        "run"
-                       "--flag=fileset_{design_level}",
+                       "{sv_flist_gen_flags}",
                        "--target={flow}",
                        "--tool icarus",
                        "--build-root={build_dir}",
@@ -41,6 +41,7 @@
                        "{fusesoc_core}"]
   sv_flist_gen_dir:   "{build_dir}/syn-icarus"
   sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
+  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
 
   // Common fail patterns.
   build_fail_patterns: [// FuseSoC build error

--- a/hw/top_earlgrey/dv/partner_chip_sim_cfg_sample.hjson
+++ b/hw/top_earlgrey/dv/partner_chip_sim_cfg_sample.hjson
@@ -10,9 +10,9 @@
   // Import the chip_sim_cfg.hjson to run the chip level simulations.
   import_cfgs: ["{proj_root}/hw/top_earlgrey/dv/chip_sim_cfg.hjson"]
 
-  // Pass the fileset_vendor flag to FuseSoC to swap the open source files with vendor
-  // implementations.
-  sv_flist_gen_opts: ["--flag=fileset_partner"]
+  // Pass the fileset_partner flag to FuseSoC to swap the open source files
+  // with partner implementations.
+  sv_flist_gen_flags: ["--flag=fileset_partner"]
 
   // Override the required keys to customize the simulation flow. For instance,
   // the FuseSoC core file or the search paths provided to FuseSoC to find the


### PR DESCRIPTION
This commit adds the `sv_flist_gen_flags` variable for FuseSoC which can
be used to add fileset flags. Previously, the recommendation was to use
`sv_flist_gen_opts` to add more flags. But that does not work given that
new flags added in imported HJSon files can result in FuseSoC command
args to appear out of order, which FuseSoC does not like, This makes the
fileset_flags appear at the right place.

This is added for DV, FPV as well as synthesis flows in DVSim.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>