### PR TITLE
[sw/silicon_creator] Move digest computation out of sigverify_rsa_verify()

### DIFF
--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -56,7 +56,6 @@ sw_silicon_creator_lib_sigverify = declare_dependency(
       hw_ip_otp_ctrl_reg_h,
     ],
     dependencies: [
-      sw_silicon_creator_lib_driver_hmac,
       sw_silicon_creator_lib_driver_otp,
     ],
   ),
@@ -218,6 +217,7 @@ sw_silicon_creator_lib_sigverify_functest = declare_dependency(
     ],
     dependencies: [
       sw_silicon_creator_lib_sigverify,
+      sw_silicon_creator_lib_driver_hmac,
     ],
   ),
 )

--- a/sw/device/silicon_creator/lib/sigverify.h
+++ b/sw/device/silicon_creator/lib/sigverify.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/sigverify_rsa_key.h"
@@ -36,17 +37,15 @@ inline uint32_t sigverify_rsa_key_id_get(
  * The actual implementation that is used (software or OTBN) is determined by
  * the life cycle state of the device and the OTP value.
  *
- * @param signed_message Message whose signature is to be verified.
- * @param signed_message_len Length of the signed message in bytes.
  * @param signature Signature to be verified.
  * @param key Signer's RSA public key.
+ * @param act_digest Actual digest of the message being verified.
  * @param lc_state Life cycle state of the device.
  * @return Result of the operation.
  */
-rom_error_t sigverify_rsa_verify(const void *signed_message,
-                                 size_t signed_message_len,
-                                 const sigverify_rsa_buffer_t *signature,
+rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  const sigverify_rsa_key_t *key,
+                                 const hmac_digest_t *act_digest,
                                  lifecycle_state_t lc_state);
 
 #ifdef __cplusplus

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -94,9 +94,13 @@ static rom_error_t mask_rom_verify(const manifest_t *manifest) {
 
   // TODO(#5956): Manifest usage constraints.
   manifest_signed_region_t signed_region = manifest_signed_region_get(manifest);
-  RETURN_IF_ERROR(sigverify_rsa_verify(signed_region.start,
-                                       signed_region.length,
-                                       &manifest->signature, key, lc_state));
+  hmac_sha256_init();
+  RETURN_IF_ERROR(
+      hmac_sha256_update(signed_region.start, signed_region.length));
+  hmac_digest_t act_digest;
+  RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
+  RETURN_IF_ERROR(
+      sigverify_rsa_verify(&manifest->signature, key, &act_digest, lc_state));
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -24,10 +24,7 @@
 
 namespace sigverify_keys_unittest {
 namespace {
-using ::testing::DoAll;
-using ::testing::NotNull;
 using ::testing::Return;
-using ::testing::SetArgPointee;
 
 /**
  * Mock keys used in tests.
@@ -367,7 +364,6 @@ TEST(Keys, UniqueIds) {
  *    xxd -p -c 4 | tac | sed 's|.*|0x&,|'
  * ```
  */
-constexpr std::array<uint8_t, 4> kMessage{'t', 'e', 's', 't'};
 constexpr hmac_digest_t kDigest = {
     .digest =
         {
@@ -474,17 +470,12 @@ class SigverifyRsaVerify
 };
 
 TEST_P(SigverifyRsaVerify, Ibex) {
-  EXPECT_CALL(hmac_, sha256_init());
-  EXPECT_CALL(hmac_, sha256_update(kMessage.data(), kMessage.size()))
-      .WillOnce(Return(kErrorOk));
-  EXPECT_CALL(hmac_, sha256_final(NotNull()))
-      .WillOnce(DoAll(SetArgPointee<0>(kDigest), Return(kErrorOk)));
   EXPECT_CALL(otp_,
               read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_USE_SW_RSA_VERIFY_OFFSET))
       .WillOnce(Return(kHardenedBoolTrue));
 
-  EXPECT_EQ(sigverify_rsa_verify(kMessage.data(), kMessage.size(),
-                                 &GetParam().sig, GetParam().key, kLcStateProd),
+  EXPECT_EQ(sigverify_rsa_verify(&GetParam().sig, GetParam().key, &kDigest,
+                                 kLcStateProd),
             kErrorOk);
 }
 


### PR DESCRIPTION
This change moves the digest computation out of sigverify_rsa_verify() so that we can customize how it is computed, e.g. to implement usage constraints described in #5956.

Signed-off-by: Alphan Ulusoy <alphan@google.com>