### PR TITLE
[csrng/hjson] Change hw_exc_sts swaccess to rw0c

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -252,7 +252,7 @@
     {
       name: "HW_EXC_STS",
       desc: "Hardware instance exception status register",
-      swaccess: "rw",
+      swaccess: "rw0c",
       hwaccess: "hwo",
       fields: [
         { bits: "14:0",

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -741,7 +741,7 @@ module csrng_reg_top (
 
   prim_subreg #(
     .DW      (15),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (15'h0)
   ) u_hw_exc_sts (
     .clk_i   (clk_i),


### PR DESCRIPTION
To fix CSR test fails, changing swaccess keyword to proper setting.
Fixes #7905

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>