### PR TITLE
[dv, chip] Fix for CSR RW test

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson
+++ b/hw/ip/pinmux/data/pinmux.hjson
@@ -836,6 +836,11 @@
                       resval: 0,
                       desc: '''Set to 1 if the corresponding detector has detected a wakeup pattern. Write 0 to clear.
                       '''
+                      // Random writes to the wkup detect CSRs may result in the case where the
+                      // wakeup gets enabled and signaled due to a pin being low for a programmed
+                      // time. In CSR tests, the IOs are not touched (i.e. they are internally
+                      // pulled low).
+                      tags: ["excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -848,6 +848,11 @@
                       resval: 0,
                       desc: '''Set to 1 if the corresponding detector has detected a wakeup pattern. Write 0 to clear.
                       '''
+                      // Random writes to the wkup detect CSRs may result in the case where the
+                      // wakeup gets enabled and signaled due to a pin being low for a programmed
+                      // time. In CSR tests, the IOs are not touched (i.e. they are internally
+                      // pulled low).
+                      tags: ["excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -844,6 +844,11 @@
                       resval: 0,
                       desc: '''Set to 1 if the corresponding detector has detected a wakeup pattern. Write 0 to clear.
                       '''
+                      // Random writes to the wkup detect CSRs may result in the case where the
+                      // wakeup gets enabled and signaled due to a pin being low for a programmed
+                      // time. In CSR tests, the IOs are not touched (i.e. they are internally
+                      // pulled low).
+                      tags: ["excl:CsrNonInitTests:CsrExclWriteCheck"]
                     }
                   ]
                 }


### PR DESCRIPTION
This commit excludes the pinmux register `wkup_cause` from write-checks.
The justfication for this exclusion is as follows:
- In CSR tests, we do not touch the IOs, so they appear as internally
pull-downs (0).
- Random writes to pinmux wakeup detection registers may result in the
detection of a randomly chosen pin with value 0 for a programmed amount
of time.
- This CSR will thus, read back a non-zero value which the CSR tests
cannot predict.
- It is better to exclude this one register from write-checks than
excluding N `wkup_detect_en` registers from writes.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>