### PR TITLE
[otbn] Create an UNIMP instruction

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -521,3 +521,19 @@
   straight-line: false
   literal-pseudo-op:
     - JALR x0, x1, 0
+
+# Implement the de-facto UNIMP RISC-V instruction alias according to
+# https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md
+# OTBN does not support the cycle CSR (0xC00), hence the illegal instruction
+# exception stems from the missing CSR instead of writing to a read-only, but
+# the end result is the same.
+- mnemonic: unimp
+  synopsis: Illegal instruction
+  rv32i: true
+  operands: []
+  doc: |
+    Triggers an illegal instruction error and aborts the program execution.
+    Commonly used in code which is meant to be unreachable.
+  literal-pseudo-op:
+    # 0xC00 is the "cycle" RISC-V CSR.
+    - CSRRW x0, 0xC00, x0


### PR DESCRIPTION
Add a new instruction alias to OTBN's ISA which is guaranteed to
generate an invalid instruction error. The UNIMP instruction is meant
typically used in an unreachable code path, like an `assert(1)`
statement.

An invalid instruction is a recoverable error in OTBN, which terminates
the execution immediately, returns control to the host CPU, and
additionally raises a recoverable alert.

In line with other instructions in the base instruction set of OTBN,
UNIMP is also borrowed from RISC-V, where it is defined in the same way
as de-facto instruction alias. See also
https://groups.google.com/a/groups.riscv.org/g/sw-dev/c/Xu6UmcIAKIk/m/piJEHdBlAAAJ
and https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md
for more information on the choice of encoding.

Due to us piggy-backing on RISC-V, GNU Binutils already supports the
alias out of the box, which means we don't need to do anything in our
OTBN toolchain to gain support for it, and can use `unimp` in assembly
without further changes.

Fixes #6147