### PR TITLE
[sram_ctrl] Rename TL adapter submodule

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -343,7 +343,7 @@ module sram_ctrl
     .EnableRspIntgGen(1),
     .EnableDataIntgGen(0),
     .EnableDataIntgPt(1)
-  ) u_tl_adapter_ram_main (
+  ) u_tlul_adapter_sram (
     .clk_i,
     .rst_ni,
     .tl_i        (ram_tl_i),


### PR DESCRIPTION
The label was copy pasted from the top-level instance. 
Let's rename it to something that is less misleading.

Signed-off-by: Michael Schaffner <msf@google.com>