### PR TITLE
[prim] Edge Detector

### DIFF
--- a/hw/ip/prim/prim_edge_detector.core
+++ b/hw/ip/prim/prim_edge_detector.core
@@ -1,0 +1,44 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+name: "lowrisc:prim:edge_detector:0.1"
+description: "Positive/ Negative Edge detector"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:flop_2sync
+    files:
+      - rtl/prim_edge_detector.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_edge_detector.sv
+++ b/hw/ip/prim/rtl/prim_edge_detector.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Edge Detector
+
+module prim_edge_detector #(
+  parameter int unsigned Width = 1,
+
+  parameter logic [Width-1:0] ResetValue = '0,
+
+  // EnSync
+  //
+  // Enable Synchronizer to the input signal.
+  // It is assumed that the input signal is glitch free (registered input).
+  parameter bit EnSync  = 1'b 1
+) (
+  input clk_i,
+  input rst_ni,
+
+  input        [Width-1:0] d_i,
+  output logic [Width-1:0] q_sync_o,
+
+  output logic [Width-1:0] q_posedge_pulse_o,
+  output logic [Width-1:0] q_negedge_pulse_o
+);
+
+  logic [Width-1:0] q_sync_d, q_sync_q;
+
+  if (EnSync) begin : g_sync
+    prim_flop_2sync #(
+      .Width (Width),
+      .ResetValue (ResetValue)
+    ) u_sync (
+      .clk_i,
+      .rst_ni,
+      .d_i,
+      .q_o (q_sync_d)
+    );
+  end : g_sync
+  else begin : g_nosync
+    assign q_sync_d = d_i;
+  end : g_nosync
+
+  assign q_sync_o = q_sync_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) q_sync_q <= ResetValue;
+    else         q_sync_q <= q_sync_d;
+  end
+
+  assign q_posedge_pulse_o = ~q_sync_d & q_sync_q;
+  assign q_negedge_pulse_o = q_sync_d & ~q_sync_q;
+
+endmodule : prim_edge_detector


### PR DESCRIPTION
This commit introduces the edge detector in the prim lib.
The edge detector detects the signal changes by latching the signal into
the register and comparing the latched value and the current input
signal.

It also provides the synch option which is useful when the input signal
comes from outside of the chip (PAD) or from the other clock domains.

