### PR TITLE
[chip dv] Fix failing SVA in pwrmgr_ast_sva_if

### DIFF
--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_ast_sva_if.sv
@@ -21,7 +21,7 @@ interface pwrmgr_ast_sva_if (
   // the slow clock; deassertion of main_pok takes one cycle, and assertion
   // not more than 2 cycles.
   localparam int MIN_CLK_WAIT_CYCLES = 0;
-  localparam int MIN_PDN_WAIT_CYCLES = 1;
+  localparam int MIN_PDN_WAIT_CYCLES = 0;
   localparam int MAX_WAIT_CYCLES = 10;
 
   bit disable_sva;


### PR DESCRIPTION
This is a possible fix for #7942. Instead of tracking levels, this
change tracks edges instead, and reduces the lower clock cycle bound to
0.

EDIT: changed back to tracking levels instead of edges, but reduced the lower bound clock cycle to 0. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>