### PR TITLE
[prim] xoshiro primitive

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -25,21 +25,13 @@
       local:   "false",
       expose:  "true"
     },
-    { name:    "RndCnstUrndLfsrSeed",
-      type:    "otbn_pkg::urnd_lfsr_seed_t",
+    { name:    "RndCnstUrndPrngSeed",
+      type:    "otbn_pkg::urnd_prng_seed_t",
       desc:    '''
         Default seed of the PRNG used for URND.
       '''
       randcount: "256",
       randtype:  "data"
-    },
-    { name:    "RndCnstUrndChunkLfsrPerm",
-      type:    "otbn_pkg::urnd_chunk_lfsr_perm_t",
-      desc:    '''
-        Permutation applied to the LFSR chunks of the PRNG used for URND.
-      '''
-      randcount: "64",
-      randtype:  "perm"
     },
     { name: "RndCnstOtbnKey",
       type: "otp_ctrl_pkg::otbn_key_t",

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:util
       - lowrisc:prim:lfsr
+      - lowrisc:prim:xoshiro256pp
       - lowrisc:prim:cipher_pkg
       - lowrisc:prim:mubi
       - lowrisc:ip:edn_pkg

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -16,9 +16,8 @@ module otbn
   parameter regfile_e             RegFile      = RegFileFF,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
 
-  // Default seed and permutation for URND LFSR
-  parameter urnd_lfsr_seed_t       RndCnstUrndLfsrSeed      = RndCnstUrndLfsrSeedDefault,
-  parameter urnd_chunk_lfsr_perm_t RndCnstUrndChunkLfsrPerm = RndCnstUrndChunkLfsrPermDefault,
+  // Default seed for URND PRNG
+  parameter urnd_prng_seed_t       RndCnstUrndPrngSeed      = RndCnstUrndPrngSeedDefault,
 
   // Default seed and nonce for scrambling
   parameter otp_ctrl_pkg::otbn_key_t   RndCnstOtbnKey   = RndCnstOtbnKeyDefault,
@@ -835,8 +834,7 @@ module otbn
       .RegFile(RegFile),
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte),
-      .RndCnstUrndLfsrSeed(RndCnstUrndLfsrSeed),
-      .RndCnstUrndChunkLfsrPerm(RndCnstUrndChunkLfsrPerm)
+      .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)
     ) u_otbn_core (
       .clk_i,
       .rst_ni                 (rst_n),
@@ -885,8 +883,7 @@ module otbn
       .RegFile(RegFile),
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte),
-      .RndCnstUrndLfsrSeed(RndCnstUrndLfsrSeed),
-      .RndCnstUrndChunkLfsrPerm(RndCnstUrndChunkLfsrPerm)
+      .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)
     ) u_otbn_core (
       .clk_i,
       .rst_ni                 (rst_n),

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -22,9 +22,8 @@ module otbn_core
   // Enable internal secure wipe
   parameter bit SecWipeEn  = 1'b0,
 
-  // Default seed and permutation for URND LFSR
-  parameter urnd_lfsr_seed_t       RndCnstUrndLfsrSeed      = RndCnstUrndLfsrSeedDefault,
-  parameter urnd_chunk_lfsr_perm_t RndCnstUrndChunkLfsrPerm = RndCnstUrndChunkLfsrPermDefault,
+  // Default seed for URND PRNG
+  parameter urnd_prng_seed_t       RndCnstUrndPrngSeed      = RndCnstUrndPrngSeedDefault,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
@@ -582,8 +581,7 @@ module otbn_core
   );
 
   otbn_rnd #(
-    .RndCnstUrndLfsrSeed      (RndCnstUrndLfsrSeed),
-    .RndCnstUrndChunkLfsrPerm (RndCnstUrndChunkLfsrPerm)
+    .RndCnstUrndPrngSeed      (RndCnstUrndPrngSeed)
   ) u_otbn_rnd (
     .clk_i,
     .rst_ni,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -398,24 +398,13 @@ package otbn_pkg;
     OtbnStartStopSecureWipeComplete
   } otbn_start_stop_state_e;
 
-  // URNG PRNG default LFSR seed and permutation
-  // A single default seed is split into 64 bit chunks, a separate LFSR is used for each chunk. All
-  // LFSR chunks use the same permutation.
-  // These LFSR parameters have been generated with
+  // URNG PRNG default seed.
+  // These parameters have been generated with
   // $ ./util/design/gen-lfsr-seed.py --width 256 --seed 2840984437 --prefix "Urnd"
-  parameter int UrndLfsrWidth = 256;
-  typedef logic [UrndLfsrWidth-1:0] urnd_lfsr_seed_t;
-  parameter urnd_lfsr_seed_t RndCnstUrndLfsrSeedDefault =
+  parameter int UrndPrngWidth = 256;
+  typedef logic [UrndPrngWidth-1:0] urnd_prng_seed_t;
+  parameter urnd_prng_seed_t RndCnstUrndPrngSeedDefault =
       256'h84ddfadaf7e1134d70aa1c59de6197ff25a4fe335d095f1e2cba89acbe4a07e9;
-
-  // These LFSR parameters have been generated with
-  // $ ./util/design/gen-lfsr-seed.py --width 64 --seed 2840984437 --prefix "UrndChunk"
-  parameter int UrndChunkLfsrWidth = 64;
-  typedef logic [UrndChunkLfsrWidth-1:0][$clog2(UrndChunkLfsrWidth)-1:0] urnd_chunk_lfsr_perm_t;
-  parameter urnd_chunk_lfsr_perm_t RndCnstUrndChunkLfsrPermDefault = {
-    128'h911992e063cafd4f3b13ee5682b969be,
-    256'h86c701ecc39d9d483bdcacb5a15340b0988e2336e955ddd0dc01ab17e173726e
-  };
 
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnKeyDefault =
       128'h14e8cecae3040d5e12286bb3cc113298;

--- a/hw/ip/prim/doc/prim_xoshiro256pp.md
+++ b/hw/ip/prim/doc/prim_xoshiro256pp.md
@@ -1,0 +1,76 @@
+---
+title: "Primitive Component: XoShiRo256++"
+---
+
+# Overviewtitle
+
+`prim_xoshiro256pp` is a PRNG with 256 bit state.
+For more information refer to [this page](https://arxiv.org/pdf/1805.01407.pdf).
+
+## Parameters
+
+Name         | type   | Description
+-------------|--------|----------------------------------------------------------
+OutputDw     | int    | Width of the PRNG output. Must be a multiple of 64.
+DefaultSeed  | logic  | Initial 256-bit state of the PRNG, must be nonzero.
+
+## Signal Interfaces
+
+Name                 | In/Out | Description
+---------------------|--------|---------------------------------
+seed_en_i            | input  | External seed input enable
+seed_i[256]          | input  | External seed input
+xoshiro_en_i         | input  | PRNG enable
+entropy_i[256]       | input  | Entropy input
+data_o[OutputDw]     | output | PRNG output
+all_zero_o           | output | Impossible all-zero state
+
+# Theory of Operations
+
+```
+             /----------------\
+seed_en_i    |                |
+------------>|  xoshiro256++  |
+seed_i       |                |  data_o
+=====/======>|                |=====/=======>
+ [256]       |                |  [OutputDw]
+xoshiro_en_i |                |
+------------>|    OutputDw    |
+entropy_i    |   DefaultSeed  |  all_zero_o
+=====/======>|                |------------->
+ [256]       |                |
+             |                |
+             \----------------/
+```
+
+Xoshiro256++ PRNG consists of:
+ * 256b state
+ * A single-cycle state-update function.
+ * A state output function.
+
+The basic xoshiro256++ PRNG has a 64 bit output.
+This implementation enables the output size to be any multiple of 64 bits.
+The output size controlled using the `OutputDW` parameter.
+
+The xoshiro256++ module has an enable input and an additional entropy input that is
+XOR'ed into the PRNG state (connect to zero if this feature is unused).
+As the PRNG may jump into the all-zero state (e.g. due to an active attack), the PRNG
+state-update function contains a lockup protection which re-seeds the state with
+`DefaultSeed` and raises the alert signal `all_zero_o`, once this condition is detected.
+
+When the seed enable signal `seed_en_i` is raised, the internal state of xoshiro256++ is updated
+with the value provided at the 256b input 'seed_i'.
+The state is internaly updated in every clock cycle whenever the enable signal `xoshiro_en_i` is raised.
+The timing diagram below visualizes this process.
+
+{{< wavejson >}}
+{
+  signal: [
+    {name: 'clk', wave: 'p......|....'},
+    {name: 'xoshiro_en_i', wave: '0...1..|..0.'},
+    {name: 'seed_en_i', wave: '010....|....'},
+    {name:'seed_i',     wave: '3..x...|....', data: 'Seed' },
+    {name: 'state', wave: 'x.3..45|678.', data: 'Seed'}
+  ]
+}
+{{< /wavejson >}}

--- a/hw/ip/prim/lint/prim_xoshiro256pp.vlt
+++ b/hw/ip/prim/lint/prim_xoshiro256pp.vlt
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// waiver file for prim_xoshiro256pp
+
+`verilator_config
+
+// In the following array some members may depend on others.
+split_var -module "prim_xoshiro256pp" -var "unrolled_state"

--- a/hw/ip/prim/prim_xoshiro256pp.core
+++ b/hw/ip/prim/prim_xoshiro256pp.core
@@ -1,0 +1,53 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:xoshiro256pp"
+description: "A xoshiro256pp PRNG primitive"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_xoshiro256pp.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_xoshiro256pp.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/prim/rtl/prim_xoshiro256pp.sv
+++ b/hw/ip/prim/rtl/prim_xoshiro256pp.sv
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module implements XoShiRo256++ PRNG
+//
+// Additional Entropy input to XOR fresh entropy into the state.
+// Lockup protection that reseeds the generator if it falls into the all-zero state.
+//
+// Refs: [1] D. Blackman and S. Vigna, Scrambled Linear Pseudorndom Number Generators
+//           https://arxiv.org/pdf/1805.01407.pdf
+//       [2] https://prng.di.unimi.it/
+//       [3] https://en.wikipedia.org/wiki/Xorshift#xoshiro_and_xoroshiro
+
+`include "prim_assert.sv"
+
+module prim_xoshiro256pp #(
+  // Output width, must be a multiple of 64
+  parameter int unsigned       OutputDw       = 64,
+  // PRNG reset state, must be nonzero!
+  parameter logic [255:0]      DefaultSeed    = 256'(1'b1),
+
+  parameter int unsigned NumStages = OutputDw / 64 // derived parameter
+) (
+  input  logic                  clk_i,
+  input  logic                  rst_ni,
+  input  logic                  seed_en_i,    // load external seed into the state
+  input  logic [255:0]          seed_i,       // external seed input
+  input  logic                  xoshiro_en_i, // enables the PRNG
+  input  logic [255:0]          entropy_i,    // additional entropy to be XOR'ed into the state
+  output logic [OutputDw-1:0]   data_o,       // PRNG output
+  output logic                  all_zero_o   // alert signal indicates the all-zero state
+);
+
+  logic [255:0] unrolled_state [NumStages+1];
+  logic [63:0] mid [NumStages];
+
+  logic lockup;
+  logic [255:0] xoshiro_d, xoshiro_q, next_xoshiro_state;
+
+  function automatic logic [255:0] state_update (input logic [255:0] data_in);
+    logic [63:0] a_in, b_in, c_in, d_in;
+    logic [63:0] a_out, b_out, c_out, d_out;
+    a_in = data_in[255:192];
+    b_in = data_in[191:128];
+    c_in = data_in[127:64];
+    d_in = data_in[63:0];
+    a_out = a_in ^ b_in ^ d_in;
+    b_out = a_in ^ b_in ^ c_in;
+    c_out = a_in ^ (b_in << 17) ^ c_in;
+    d_out = {d_in[18:0], d_in[63:19]} ^ {b_in[18:0], b_in[63:19]};
+    return {a_out, b_out, c_out, d_out};
+  endfunction: state_update
+
+  assign unrolled_state[0] = xoshiro_q;
+
+  for (genvar k = 0; k < NumStages; k++) begin : gen_state_functions
+    // State update function
+    assign unrolled_state[k+1] = state_update(unrolled_state[k]);
+    // State output function
+    assign mid[k] = unrolled_state[k][255:192] + unrolled_state[k][63:0];
+    assign data_o[(k+1)*64-1:k*64] = {mid[k][40:0], mid[k][63:41]} + unrolled_state[k][255:192];
+  end
+
+  assign next_xoshiro_state = entropy_i ^ unrolled_state[NumStages];
+  assign xoshiro_d = (seed_en_i)              ? seed_i             :
+                     (xoshiro_en_i && lockup) ? DefaultSeed        :
+                     (xoshiro_en_i)           ? next_xoshiro_state : xoshiro_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : reg_state
+    if (!rst_ni) begin
+      xoshiro_q <= DefaultSeed;
+    end else begin
+      xoshiro_q <= xoshiro_d;
+    end
+  end
+
+  // lockup condition is all-zero
+  assign lockup = ~(|xoshiro_q);
+
+  // Indicate that the state is all zeros.
+  assign all_zero_o = lockup;
+
+  // check that seed is not all-zero
+  `ASSERT_INIT(DefaultSeedNzCheck_A, |DefaultSeed)
+
+endmodule

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5161,24 +5161,14 @@
           name_top: OtbnRegFile
         }
         {
-          name: RndCnstUrndLfsrSeed
+          name: RndCnstUrndPrngSeed
           desc: Default seed of the PRNG used for URND.
-          type: otbn_pkg::urnd_lfsr_seed_t
+          type: otbn_pkg::urnd_prng_seed_t
           randcount: 256
           randtype: data
-          name_top: RndCnstOtbnUrndLfsrSeed
+          name_top: RndCnstOtbnUrndPrngSeed
           default: 0x8745ae400e4aee8385f157b88ab8ed1fce7408f7be58b7d21102be301eb1a8d0
           randwidth: 256
-        }
-        {
-          name: RndCnstUrndChunkLfsrPerm
-          desc: Permutation applied to the LFSR chunks of the PRNG used for URND.
-          type: otbn_pkg::urnd_chunk_lfsr_perm_t
-          randcount: 64
-          randtype: perm
-          name_top: RndCnstOtbnUrndChunkLfsrPerm
-          default: 0xb5abde2c9cd73a2eea3e9c2edb9d040dbf9c47fe80959f0a4025138521d5b18ae6805c417ddf56d4d3271a3e37a08ca4
-          randwidth: 384
         }
         {
           name: RndCnstOtbnKey
@@ -5187,7 +5177,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0x54125d61930d203f199a87c123c074e0
+          default: 0xa008d66622dd38e0cab1ca634857ffe3
           randwidth: 128
         }
         {
@@ -5197,7 +5187,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0x1b143b74476e5767
+          default: 0xe28503e9dd872066
           randwidth: 64
         }
       ]
@@ -5356,7 +5346,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0x85eaa2e073e5bc25
+          default: 0x189f1d198d56ac2f
           randwidth: 64
         }
         {
@@ -5366,7 +5356,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0x223af531dc56bb4e2fc9e97b914855a1f03915c9bea5264d1e088613dc0a436b0f07c0fafe7ddb4da2426335ce44baad
+          default: 0xe7b469657e062ecb7c3e771e3a327631a6eba2ad440f78a5cfd02e2900a45138521d5cbfd26805c7ac2f05f7485be358
           randwidth: 384
         }
         {
@@ -5376,7 +5366,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0xc4aa63b1c5de840ca2f1a42cae0e7ef852b793ad
+          default: 0xdc8da53f3370ae307bf1c5a896902ce9d05aae1c
           randwidth: 160
         }
         {
@@ -5386,7 +5376,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0xbfafcbebd7c3361357bee83e46164c82a0c86b9c1ef6117215c2e6fcb683d3a9
+          default: 0xc9e673e4db3fee8922d1f0bcdd0915337f67765a0d2eb0cb514e4199cf3de67
           randwidth: 256
         }
         {
@@ -5396,7 +5386,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0xdf2a87abf7c57a6d06f2e1721e3a5f3b217d62acf1c966c712691421cef76350
+          default: 0xe3ed3cd5ea91a34a06bd6b4a084443ce2fde3bbe4ee6f63a8c0be6a2f45740eb
           randwidth: 256
         }
         {
@@ -5406,7 +5396,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0x5910642e0f9946cb60f5f7d233a13b89bfc3162d205b4d60c9b16a8eb0aa75fa
+          default: 0xf0c5e668a34ce09780a8d540ce8fd0cd3d3bc1416c0834af84dc448f6a9887a8
           randwidth: 256
         }
         {
@@ -5416,7 +5406,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0x30ac79eec48e320bdcfa32f724f82840fdaced02da0253d803d1cdf325afff8b
+          default: 0x2ee4c310defc471b95ec8aa1ba59ceee7530a14494e10193220b62d997f24a95
           randwidth: 256
         }
         {
@@ -5426,7 +5416,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0x8db302ed56b78538c92ba96fe7ba5d882e53c3844212490ced20e7e16f71067e
+          default: 0xb1987a780af5815cf779ee523615334390cf654ec6352adf5010157d1342bd7b
           randwidth: 256
         }
         {
@@ -5436,7 +5426,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0xb00fe9a3a2be362bc57ce4588424f90946b441fa5e08b2317fb3e9032db9eddf
+          default: 0x1952cd5387f9fb727236a121e1e0ff0a4fd70234bb32ea7240d7d8470e011cf1
           randwidth: 256
         }
         {
@@ -5446,7 +5436,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0xd05781d31c4b4dab379c12b6681950e6d52654489a981b7bdc91865141701fd5
+          default: 0x6d17f3660ebad9424ae5e2cf5e723b547cb4949b21b3decfe8f6679035da3506
           randwidth: 256
         }
         {
@@ -5456,7 +5446,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0x1aeca9607328c3621ee7fd88c63032eb50ee437eeda142fce033c343e179c299
+          default: 0xfe4257bcd0d4af885661e47d54c36f827b99dcc91893c0ce9e8e560026005817
           randwidth: 256
         }
         {
@@ -5466,7 +5456,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOtbnSeed
-          default: 0x45a488652c63c1f68cecf9596cda21a8d5398ced8676e230226a9635bea51c6e
+          default: 0x1e1cbebb834986e64be66e95792c3d8eafd0bc4de80468fd7d8490dc838e24fa
           randwidth: 256
         }
         {
@@ -5476,7 +5466,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0x4dfb68eaea920c1e6c7b2dc4b639ba1ae564b19dd8235c2f90c064c4849172a2
+          default: 0x92bbc26408e95bdbe8bc8757cc921f3c920c664026717440062ca8d4d838b350
           randwidth: 256
         }
       ]
@@ -5682,7 +5672,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0xb8e9f2147556a5bca2e5f635e555c46c406d9d57c967eaa9fc47e9e7507d72b87001fa7b0eb63a613068d71d5186d12d
+          default: 0x15c2e6fcb683d3a9740aabd84d6481d22fe896642a15985eb9ecde94c6064c512f50996293612ad056cbeefc913b5ff5
           randwidth: 384
         }
         {
@@ -5692,7 +5682,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0x19a51f55617306d35c573898670c91f2491024562d76da13a1276809927dc4d31864d4febc9def4f7c50b1e1906ebcb1
+          default: 0x6f2e1721e3a5f3b217d62acf1c966c712691421cef76350bfafcbebd7c3361357bee83e46164c82a0c86b9c1ef61172
           randwidth: 384
         }
         {
@@ -6155,7 +6145,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0xacebe93343ed6321c82c19be70b04c05
+          default: 0xc9b16a8eb0aa75fadf2a87abf7c57a6d
           randwidth: 128
         }
         {
@@ -6165,7 +6155,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x8bac50ef39daf7229cf1edb4fedb1e5
+          default: 0x60f5f7d233a13b89bfc3162d205b4d60
           randwidth: 128
         }
         {
@@ -6175,7 +6165,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0xed700c07
+          default: 0xf9946cb
           randwidth: 32
         }
         {
@@ -6185,7 +6175,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x327418551e20e7d92cb4b89b6fe540c478c71f6f
+          default: 0xe305493ba7acc23ca750badff8a8a869b1ed8096
           randwidth: 160
         }
         {
@@ -6355,7 +6345,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0xfbd120f152a9ef95
+          default: 0x849172a245a48865
           randwidth: 64
         }
         {
@@ -6365,7 +6355,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0x18d5a1fe3b04ff09932a2605b23cb7a
+          default: 0xb639ba1ae564b19dd8235c2f90c064c4
           randwidth: 128
         }
         {
@@ -6532,7 +6522,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x2599381c
+          default: 0x6c7b2dc4
           randwidth: 32
         }
         {
@@ -6542,7 +6532,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0x67321029fe8dceea175830be45dab386e4d1a51d
+          default: 0xc2ed0fb6e016887e762c496a37cb74467ce09953
           randwidth: 160
         }
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2197,8 +2197,7 @@ module top_earlgrey #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[41:40]),
     .Stub(OtbnStub),
     .RegFile(OtbnRegFile),
-    .RndCnstUrndLfsrSeed(RndCnstOtbnUrndLfsrSeed),
-    .RndCnstUrndChunkLfsrPerm(RndCnstOtbnUrndChunkLfsrPerm),
+    .RndCnstUrndPrngSeed(RndCnstOtbnUrndPrngSeed),
     .RndCnstOtbnKey(RndCnstOtbnOtbnKey),
     .RndCnstOtbnNonce(RndCnstOtbnOtbnNonce)
   ) u_otbn (

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -149,24 +149,18 @@ package top_earlgrey_rnd_cnst_pkg;
   // otbn
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
-  parameter otbn_pkg::urnd_lfsr_seed_t RndCnstOtbnUrndLfsrSeed = {
+  parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
     256'h8745AE400E4AEE8385F157B88AB8ED1FCE7408F7BE58B7D21102BE301EB1A8D0
-  };
-
-  // Permutation applied to the LFSR chunks of the PRNG used for URND.
-  parameter otbn_pkg::urnd_chunk_lfsr_perm_t RndCnstOtbnUrndChunkLfsrPerm = {
-    128'hB5ABDE2C9CD73A2EEA3E9C2EDB9D040D,
-    256'hBF9C47FE80959F0A4025138521D5B18AE6805C417DDF56D4D3271A3E37A08CA4
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'h54125D61930D203F199A87C123C074E0
+    128'hA008D66622DD38E0CAB1CA634857FFE3
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'h1B143B74476E5767
+    64'hE28503E9DD872066
   };
 
   ////////////////////////////////////////////
@@ -174,68 +168,68 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'h85EAA2E073E5BC25
+    64'h189F1D198D56AC2F
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'h223AF531DC56BB4E2FC9E97B914855A1,
-    256'hF03915C9BEA5264D1E088613DC0A436B0F07C0FAFE7DDB4DA2426335CE44BAAD
+    128'hE7B469657E062ECB7C3E771E3A327631,
+    256'hA6EBA2AD440F78A5CFD02E2900A45138521D5CBFD26805C7AC2F05F7485BE358
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'hC4AA63B1C5DE840CA2F1A42CAE0E7EF852B793AD
+    160'hDC8DA53F3370AE307BF1C5A896902CE9D05AAE1C
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'hBFAFCBEBD7C3361357BEE83E46164C82A0C86B9C1EF6117215C2E6FCB683D3A9
+    256'h0C9E673E4DB3FEE8922D1F0BCDD0915337F67765A0D2EB0CB514E4199CF3DE67
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'hDF2A87ABF7C57A6D06F2E1721E3A5F3B217D62ACF1C966C712691421CEF76350
+    256'hE3ED3CD5EA91A34A06BD6B4A084443CE2FDE3BBE4EE6F63A8C0BE6A2F45740EB
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'h5910642E0F9946CB60F5F7D233A13B89BFC3162D205B4D60C9B16A8EB0AA75FA
+    256'hF0C5E668A34CE09780A8D540CE8FD0CD3D3BC1416C0834AF84DC448F6A9887A8
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'h30AC79EEC48E320BDCFA32F724F82840FDACED02DA0253D803D1CDF325AFFF8B
+    256'h2EE4C310DEFC471B95EC8AA1BA59CEEE7530A14494E10193220B62D997F24A95
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'h8DB302ED56B78538C92BA96FE7BA5D882E53C3844212490CED20E7E16F71067E
+    256'hB1987A780AF5815CF779EE523615334390CF654EC6352ADF5010157D1342BD7B
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'hB00FE9A3A2BE362BC57CE4588424F90946B441FA5E08B2317FB3E9032DB9EDDF
+    256'h1952CD5387F9FB727236A121E1E0FF0A4FD70234BB32EA7240D7D8470E011CF1
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'hD05781D31C4B4DAB379C12B6681950E6D52654489A981B7BDC91865141701FD5
+    256'h6D17F3660EBAD9424AE5E2CF5E723B547CB4949B21B3DECFE8F6679035DA3506
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'h1AECA9607328C3621EE7FD88C63032EB50EE437EEDA142FCE033C343E179C299
+    256'hFE4257BCD0D4AF885661E47D54C36F827B99DCC91893C0CE9E8E560026005817
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrOtbnSeed = {
-    256'h45A488652C63C1F68CECF9596CDA21A8D5398CED8676E230226A9635BEA51C6E
+    256'h1E1CBEBB834986E64BE66E95792C3D8EAFD0BC4DE80468FD7D8490DC838E24FA
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'h4DFB68EAEA920C1E6C7B2DC4B639BA1AE564B19DD8235C2F90C064C4849172A2
+    256'h92BBC26408E95BDBE8BC8757CC921F3C920C664026717440062CA8D4D838B350
   };
 
   ////////////////////////////////////////////
@@ -243,14 +237,14 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'hB8E9F2147556A5BCA2E5F635E555C46C,
-    256'h406D9D57C967EAA9FC47E9E7507D72B87001FA7B0EB63A613068D71D5186D12D
+    128'h15C2E6FCB683D3A9740AABD84D6481D2,
+    256'h2FE896642A15985EB9ECDE94C6064C512F50996293612AD056CBEEFC913B5FF5
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'h19A51F55617306D35C573898670C91F2,
-    256'h491024562D76DA13A1276809927DC4D31864D4FEBC9DEF4F7C50B1E1906EBCB1
+    128'h06F2E1721E3A5F3B217D62ACF1C966C7,
+    256'h12691421CEF76350BFAFCBEBD7C3361357BEE83E46164C82A0C86B9C1EF61172
   };
 
   ////////////////////////////////////////////
@@ -258,22 +252,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'hACEBE93343ED6321C82C19BE70B04C05
+    128'hC9B16A8EB0AA75FADF2A87ABF7C57A6D
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h08BAC50EF39DAF7229CF1EDB4FEDB1E5
+    128'h60F5F7D233A13B89BFC3162D205B4D60
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'hED700C07
+    32'h0F9946CB
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'h327418551E20E7D92CB4B89B6FE540C478C71F6F
+    160'hE305493BA7ACC23CA750BADFF8A8A869B1ED8096
   };
 
   ////////////////////////////////////////////
@@ -281,12 +275,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'hFBD120F152A9EF95
+    64'h849172A245A48865
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'h018D5A1FE3B04FF09932A2605B23CB7A
+    128'hB639BA1AE564B19DD8235C2F90C064C4
   };
 
   ////////////////////////////////////////////
@@ -294,12 +288,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h2599381C
+    32'h6C7B2DC4
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'h67321029FE8DCEEA175830BE45DAB386E4D1A51D
+    160'hC2ED0FB6E016887E762C496A37CB74467CE09953
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg


### PR DESCRIPTION
This PR has two commits.
The first commit adds xoshiro256++ primitive PRNG.
The second commit replaces LFSR in OTBN's URNG with xoshiro256++.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>