### PR TITLE
[pwm, rtl] PWM RTL change for issue #7425 

### DIFF
--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -51,6 +51,7 @@
       desc: "Configuration register",
       swaccess: "rw",
       async: "clk_core_i",
+      hwqe: "true",
       fields: [
         { bits: "31",
           name: "CNTR_EN",
@@ -86,6 +87,7 @@
         cname: "pwm_en",
         compact: "1",
         async: "clk_core_i",
+        hwqe: "true",
         fields: [
           { bits: "0",
             name: "EN",
@@ -103,6 +105,7 @@
         cname: "pwm_invert",
         compact: "1",
         async: "clk_core_i",
+        hwqe: "true",
         fields: [
           { bits: "0",
             name: "INVERT",
@@ -119,6 +122,7 @@
         swaccess: "rw",
         cname: "pwm_params",
         async: "clk_core_i",
+        hwqe: "true",
         fields: [
           { bits: "31",
             name: "BLINK_EN",
@@ -156,6 +160,7 @@
         swaccess: "rw",
         cname: "duty_cycle",
         async: "clk_core_i",
+        hwqe: "true",
         fields: [
           { bits: "31:16",
             name: "B",
@@ -186,6 +191,7 @@
         swaccess: "rw",
         cname: "blink_param",
         async: "clk_core_i",
+        hwqe: "true",
         fields: [
           { bits: "15:0",
             name: "X",

--- a/hw/ip/pwm/rtl/pwm_core.sv
+++ b/hw/ip/pwm/rtl/pwm_core.sv
@@ -15,55 +15,26 @@ module pwm_core #(
   output logic [NOutputs-1:0]     pwm_o
 );
 
-  logic [31:0] common_param_d;
-  assign common_param_d = {reg2hw.cfg.clk_div.q,
-                           reg2hw.cfg.dc_resn.q,
-                           reg2hw.cfg.cntr_en.q};
-
-  logic [31:0] common_param_q;
-
-  always_ff @(posedge clk_core_i or negedge rst_core_ni) begin
-    if (!rst_core_ni) begin
-      common_param_q <= 32'h0;
-    end else begin
-      common_param_q <= common_param_d;
-    end
-  end
-
   // Reset internal counters whenever parameters change.
 
   logic                clr_phase_cntr;
   logic [NOutputs-1:0] clr_blink_cntr;
 
-  assign clr_phase_cntr = (common_param_q != common_param_d);
+  assign clr_phase_cntr = reg2hw.cfg.clk_div.qe | reg2hw.cfg.dc_resn.qe | reg2hw.cfg.cntr_en.qe;
 
   for (genvar ii = 0; ii < NOutputs; ii++) begin : gen_chan_clr
-
-    logic [83:0] chan_param_d;
-    assign chan_param_d  = {reg2hw.pwm_en[ii].q,
-                            reg2hw.invert[ii].q,
-                            reg2hw.pwm_param[ii].phase_delay.q,
-                            reg2hw.pwm_param[ii].htbt_en.q,
-                            reg2hw.pwm_param[ii].blink_en.q,
-                            reg2hw.duty_cycle[ii].a.q,
-                            reg2hw.duty_cycle[ii].b.q,
-                            reg2hw.blink_param[ii].x.q,
-                            reg2hw.blink_param[ii].y.q};
-
-    logic [83:0] chan_param_q;
-
-    always_ff @(posedge clk_core_i or negedge rst_core_ni) begin
-      if (!rst_core_ni) begin
-        chan_param_q <= 84'h0;
-      end else begin
-        chan_param_q <= chan_param_d;
-      end
-    end
 
     // Though it may be a bit overkill, we reset the internal blink counters whenever any channel
     // specific parameters change.
 
-    assign clr_blink_cntr[ii] = (chan_param_q != chan_param_d);
+    assign clr_blink_cntr[ii] = reg2hw.pwm_en[ii].qe | reg2hw.invert[ii].qe |
+                                reg2hw.pwm_param[ii].phase_delay.qe |
+                                reg2hw.pwm_param[ii].htbt_en.qe |
+                                reg2hw.pwm_param[ii].blink_en.qe |
+                                reg2hw.duty_cycle[ii].a.qe |
+                                reg2hw.duty_cycle[ii].b.qe |
+                                reg2hw.blink_param[ii].x.qe |
+                                reg2hw.blink_param[ii].y.qe;
 
   end : gen_chan_clr
 

--- a/hw/ip/pwm/rtl/pwm_reg_pkg.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_pkg.sv
@@ -29,63 +29,75 @@ package pwm_reg_pkg;
   typedef struct packed {
     struct packed {
       logic [26:0] q;
+      logic        qe;
     } clk_div;
     struct packed {
       logic [3:0]  q;
+      logic        qe;
     } dc_resn;
     struct packed {
       logic        q;
+      logic        qe;
     } cntr_en;
   } pwm_reg2hw_cfg_reg_t;
 
   typedef struct packed {
     logic        q;
+    logic        qe;
   } pwm_reg2hw_pwm_en_mreg_t;
 
   typedef struct packed {
     logic        q;
+    logic        qe;
   } pwm_reg2hw_invert_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
+      logic        qe;
     } phase_delay;
     struct packed {
       logic        q;
+      logic        qe;
     } htbt_en;
     struct packed {
       logic        q;
+      logic        qe;
     } blink_en;
   } pwm_reg2hw_pwm_param_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
+      logic        qe;
     } a;
     struct packed {
       logic [15:0] q;
+      logic        qe;
     } b;
   } pwm_reg2hw_duty_cycle_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic [15:0] q;
+      logic        qe;
     } x;
     struct packed {
       logic [15:0] q;
+      logic        qe;
     } y;
   } pwm_reg2hw_blink_param_mreg_t;
 
   // Register -> HW type
   typedef struct packed {
-    pwm_reg2hw_alert_test_reg_t alert_test; // [538:537]
-    pwm_reg2hw_regen_reg_t regen; // [536:536]
-    pwm_reg2hw_cfg_reg_t cfg; // [535:504]
-    pwm_reg2hw_pwm_en_mreg_t [5:0] pwm_en; // [503:498]
-    pwm_reg2hw_invert_mreg_t [5:0] invert; // [497:492]
-    pwm_reg2hw_pwm_param_mreg_t [5:0] pwm_param; // [491:384]
-    pwm_reg2hw_duty_cycle_mreg_t [5:0] duty_cycle; // [383:192]
-    pwm_reg2hw_blink_param_mreg_t [5:0] blink_param; // [191:0]
+    pwm_reg2hw_alert_test_reg_t alert_test; // [595:594]
+    pwm_reg2hw_regen_reg_t regen; // [593:593]
+    pwm_reg2hw_cfg_reg_t cfg; // [592:558]
+    pwm_reg2hw_pwm_en_mreg_t [5:0] pwm_en; // [557:546]
+    pwm_reg2hw_invert_mreg_t [5:0] invert; // [545:534]
+    pwm_reg2hw_pwm_param_mreg_t [5:0] pwm_param; // [533:408]
+    pwm_reg2hw_duty_cycle_mreg_t [5:0] duty_cycle; // [407:204]
+    pwm_reg2hw_blink_param_mreg_t [5:0] blink_param; // [203:0]
   } pwm_reg2hw_t;
 
   // Register offsets

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -1095,7 +1095,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.cfg.clk_div.qe),
     .q      (reg2hw.cfg.clk_div.q),
 
     // to register interface (read)
@@ -1121,7 +1121,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.cfg.dc_resn.qe),
     .q      (reg2hw.cfg.dc_resn.q),
 
     // to register interface (read)
@@ -1147,7 +1147,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.cfg.cntr_en.qe),
     .q      (reg2hw.cfg.cntr_en.q),
 
     // to register interface (read)
@@ -1177,7 +1177,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_en[0].qe),
     .q      (reg2hw.pwm_en[0].q),
 
     // to register interface (read)
@@ -1203,7 +1203,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_en[1].qe),
     .q      (reg2hw.pwm_en[1].q),
 
     // to register interface (read)
@@ -1229,7 +1229,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_en[2].qe),
     .q      (reg2hw.pwm_en[2].q),
 
     // to register interface (read)
@@ -1255,7 +1255,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_en[3].qe),
     .q      (reg2hw.pwm_en[3].q),
 
     // to register interface (read)
@@ -1281,7 +1281,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_en[4].qe),
     .q      (reg2hw.pwm_en[4].q),
 
     // to register interface (read)
@@ -1307,7 +1307,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_en[5].qe),
     .q      (reg2hw.pwm_en[5].q),
 
     // to register interface (read)
@@ -1338,7 +1338,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.invert[0].qe),
     .q      (reg2hw.invert[0].q),
 
     // to register interface (read)
@@ -1364,7 +1364,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.invert[1].qe),
     .q      (reg2hw.invert[1].q),
 
     // to register interface (read)
@@ -1390,7 +1390,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.invert[2].qe),
     .q      (reg2hw.invert[2].q),
 
     // to register interface (read)
@@ -1416,7 +1416,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.invert[3].qe),
     .q      (reg2hw.invert[3].q),
 
     // to register interface (read)
@@ -1442,7 +1442,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.invert[4].qe),
     .q      (reg2hw.invert[4].q),
 
     // to register interface (read)
@@ -1468,7 +1468,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.invert[5].qe),
     .q      (reg2hw.invert[5].q),
 
     // to register interface (read)
@@ -1499,7 +1499,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[0].phase_delay.qe),
     .q      (reg2hw.pwm_param[0].phase_delay.q),
 
     // to register interface (read)
@@ -1525,7 +1525,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[0].htbt_en.qe),
     .q      (reg2hw.pwm_param[0].htbt_en.q),
 
     // to register interface (read)
@@ -1551,7 +1551,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[0].blink_en.qe),
     .q      (reg2hw.pwm_param[0].blink_en.q),
 
     // to register interface (read)
@@ -1580,7 +1580,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[1].phase_delay.qe),
     .q      (reg2hw.pwm_param[1].phase_delay.q),
 
     // to register interface (read)
@@ -1606,7 +1606,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[1].htbt_en.qe),
     .q      (reg2hw.pwm_param[1].htbt_en.q),
 
     // to register interface (read)
@@ -1632,7 +1632,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[1].blink_en.qe),
     .q      (reg2hw.pwm_param[1].blink_en.q),
 
     // to register interface (read)
@@ -1661,7 +1661,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[2].phase_delay.qe),
     .q      (reg2hw.pwm_param[2].phase_delay.q),
 
     // to register interface (read)
@@ -1687,7 +1687,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[2].htbt_en.qe),
     .q      (reg2hw.pwm_param[2].htbt_en.q),
 
     // to register interface (read)
@@ -1713,7 +1713,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[2].blink_en.qe),
     .q      (reg2hw.pwm_param[2].blink_en.q),
 
     // to register interface (read)
@@ -1742,7 +1742,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[3].phase_delay.qe),
     .q      (reg2hw.pwm_param[3].phase_delay.q),
 
     // to register interface (read)
@@ -1768,7 +1768,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[3].htbt_en.qe),
     .q      (reg2hw.pwm_param[3].htbt_en.q),
 
     // to register interface (read)
@@ -1794,7 +1794,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[3].blink_en.qe),
     .q      (reg2hw.pwm_param[3].blink_en.q),
 
     // to register interface (read)
@@ -1823,7 +1823,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[4].phase_delay.qe),
     .q      (reg2hw.pwm_param[4].phase_delay.q),
 
     // to register interface (read)
@@ -1849,7 +1849,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[4].htbt_en.qe),
     .q      (reg2hw.pwm_param[4].htbt_en.q),
 
     // to register interface (read)
@@ -1875,7 +1875,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[4].blink_en.qe),
     .q      (reg2hw.pwm_param[4].blink_en.q),
 
     // to register interface (read)
@@ -1904,7 +1904,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[5].phase_delay.qe),
     .q      (reg2hw.pwm_param[5].phase_delay.q),
 
     // to register interface (read)
@@ -1930,7 +1930,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[5].htbt_en.qe),
     .q      (reg2hw.pwm_param[5].htbt_en.q),
 
     // to register interface (read)
@@ -1956,7 +1956,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.pwm_param[5].blink_en.qe),
     .q      (reg2hw.pwm_param[5].blink_en.q),
 
     // to register interface (read)
@@ -1987,7 +1987,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[0].a.qe),
     .q      (reg2hw.duty_cycle[0].a.q),
 
     // to register interface (read)
@@ -2013,7 +2013,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[0].b.qe),
     .q      (reg2hw.duty_cycle[0].b.q),
 
     // to register interface (read)
@@ -2042,7 +2042,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[1].a.qe),
     .q      (reg2hw.duty_cycle[1].a.q),
 
     // to register interface (read)
@@ -2068,7 +2068,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[1].b.qe),
     .q      (reg2hw.duty_cycle[1].b.q),
 
     // to register interface (read)
@@ -2097,7 +2097,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[2].a.qe),
     .q      (reg2hw.duty_cycle[2].a.q),
 
     // to register interface (read)
@@ -2123,7 +2123,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[2].b.qe),
     .q      (reg2hw.duty_cycle[2].b.q),
 
     // to register interface (read)
@@ -2152,7 +2152,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[3].a.qe),
     .q      (reg2hw.duty_cycle[3].a.q),
 
     // to register interface (read)
@@ -2178,7 +2178,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[3].b.qe),
     .q      (reg2hw.duty_cycle[3].b.q),
 
     // to register interface (read)
@@ -2207,7 +2207,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[4].a.qe),
     .q      (reg2hw.duty_cycle[4].a.q),
 
     // to register interface (read)
@@ -2233,7 +2233,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[4].b.qe),
     .q      (reg2hw.duty_cycle[4].b.q),
 
     // to register interface (read)
@@ -2262,7 +2262,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[5].a.qe),
     .q      (reg2hw.duty_cycle[5].a.q),
 
     // to register interface (read)
@@ -2288,7 +2288,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.duty_cycle[5].b.qe),
     .q      (reg2hw.duty_cycle[5].b.q),
 
     // to register interface (read)
@@ -2319,7 +2319,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[0].x.qe),
     .q      (reg2hw.blink_param[0].x.q),
 
     // to register interface (read)
@@ -2345,7 +2345,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[0].y.qe),
     .q      (reg2hw.blink_param[0].y.q),
 
     // to register interface (read)
@@ -2374,7 +2374,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[1].x.qe),
     .q      (reg2hw.blink_param[1].x.q),
 
     // to register interface (read)
@@ -2400,7 +2400,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[1].y.qe),
     .q      (reg2hw.blink_param[1].y.q),
 
     // to register interface (read)
@@ -2429,7 +2429,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[2].x.qe),
     .q      (reg2hw.blink_param[2].x.q),
 
     // to register interface (read)
@@ -2455,7 +2455,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[2].y.qe),
     .q      (reg2hw.blink_param[2].y.q),
 
     // to register interface (read)
@@ -2484,7 +2484,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[3].x.qe),
     .q      (reg2hw.blink_param[3].x.q),
 
     // to register interface (read)
@@ -2510,7 +2510,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[3].y.qe),
     .q      (reg2hw.blink_param[3].y.q),
 
     // to register interface (read)
@@ -2539,7 +2539,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[4].x.qe),
     .q      (reg2hw.blink_param[4].x.q),
 
     // to register interface (read)
@@ -2565,7 +2565,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[4].y.qe),
     .q      (reg2hw.blink_param[4].y.q),
 
     // to register interface (read)
@@ -2594,7 +2594,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[5].x.qe),
     .q      (reg2hw.blink_param[5].x.q),
 
     // to register interface (read)
@@ -2620,7 +2620,7 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (reg2hw.blink_param[5].y.qe),
     .q      (reg2hw.blink_param[5].y.q),
 
     // to register interface (read)


### PR DESCRIPTION
Lightweight check for parameter updates

  - Update pwm.hjson file to add write enable signal for registers through hwqe parameter
  - Remove the redundant registers created for checking parameter updates
  - Fixes #7425

Signed-off-by: Muqing Liu <muqing.liu@wdc.com>