### PR TITLE
[keymgr/dv] Scb update for LC disable

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -289,6 +289,8 @@ interface keymgr_if(input clk, input rst_n);
   endfunction
 
   function automatic void wipe_sideload_keys();
+    is_kmac_key_good <= 0;
+
     aes_key_exp.valid  <= 0;
     kmac_key_exp.valid <= 0;
     otbn_key_exp.valid <= 0;


### PR DESCRIPTION
Clean all regression failures in keymgr_lc_disable, except
that LC disable occurs at StReset, as design will fix it

Signed-off-by: Weicai Yang <weicai@google.com>