### PR TITLE
[mask_rom] Clear the retention SRAM if the reset reason is POR

### DIFF
--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -173,6 +173,8 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_driver_keymgr,
       sw_silicon_creator_lib_driver_lifecycle,
       sw_silicon_creator_lib_driver_pinmux,
+      sw_silicon_creator_lib_driver_retention_sram,
+      sw_silicon_creator_lib_driver_rstmgr,
       sw_silicon_creator_lib_driver_uart,
       sw_silicon_creator_lib_fake_deps,
       sw_silicon_creator_lib_irq_asm,


### PR DESCRIPTION
This will need to be tested as part of the mask ROM end-to-end tests. The individual functions used already have tests.