### PR TITLE
[docker] Install Python deps in the same way as CI

### DIFF
--- a/site/docs/builder.Dockerfile
+++ b/site/docs/builder.Dockerfile
@@ -13,4 +13,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 COPY python-requirements.txt ./
-RUN pip3 install -r python-requirements.txt
+ENV PATH "/root/.local/bin:${PATH}"
+# Explicitly updating pip and setuptools is required to have these tools
+# properly parse Python-version metadata, which some packages uses to
+# specify that an older version of a package must be used for a certain
+# Python version. If that information is not read, pip installs the latest
+# version, which then fails to run.
+RUN python3 -m pip install --user -U pip setuptools
+RUN pip3 install --user -r python-requirements.txt

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -70,9 +70,16 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
-# Copy repository into tmp directory to execute additional install steps.
+ENV PATH "/root/.local/bin:${PATH}"
+# Explicitly updating pip and setuptools is required to have these tools
+# properly parse Python-version metadata, which some packages uses to
+# specify that an older version of a package must be used for a certain
+# Python version. If that information is not read, pip installs the latest
+# version, which then fails to run.
+RUN python3 -m pip install --user -U pip setuptools
+
 COPY python-requirements.txt /tmp/python-requirements.txt
-RUN pip3 install -r /tmp/python-requirements.txt
+RUN pip3 install --user -r /tmp/python-requirements.txt
 
 COPY util/get-toolchain.py /tmp/get-toolchain.py
 RUN /tmp/get-toolchain.py -r ${RISCV_TOOLCHAIN_TAR_VERSION}


### PR DESCRIPTION
This is now ready for review:
Fixes #7952

Currently, the dockerfiles install Python dependencies system-wide and
doesn't explicitly update pip and setuptools. CI and instructions for
users will install Python packages with --user and force an update of
setuptools and pip. While installing with --user may seem unnecessary in
the context of a Docker container, it avoids interactions with the
system package manager (`python3 -m pip install -U pip setuptools` will
fail due to the system install PyYAML).

As background, CI is currently failing for Docker builds:
* <#7952>

While a follow-up fix to pin more dependencies is likely desirable,
minimising the differences between the dependency installation in our
Dockerfiles vs dependency installation elsewhere should reduce our
exposure to future such issues.