### PR TITLE
[doc] Document recommendation to install latest pip and setuptools

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -133,15 +133,23 @@ Then run the following command to install the required package dependencies on R
 {{< pkgmgr_cmd "yum" >}}
 
 Some tools in this repository are written in Python 3 and require Python dependencies to be installed through `pip`.
+We recommend installing the latest version of `pip` and `setuptools` (especially if on older systems such as Ubuntu 18.04) using:
+
+```console
+python3 -m pip install --user -U pip setuptools
+```
+
+The `pip` installation instructions use the `--user` flag to install without root permissions.
+Binaries are installed to `~/.local/bin`; check that this directory is listed in your `PATH` by running `which pip3`, which should show `~/.local/bin/pip3`.
+If it doesn't, add `~/.local/bin` to your `PATH`, e.g. by modifying your `~/.bashrc` file.
+
+Now install additional Python dependencies:
 
 ```console
 $ cd $REPO_TOP
 $ pip3 install --user -r python-requirements.txt
 ```
 
-The `pip` installation instructions use the `--user` flag to install without root permissions.
-Binaries are installed to `~/.local/bin`; check that this directory is listed in your `PATH` by running `fusesoc --version`.
-If the `fusesoc` binary is not found, add `~/.local/bin` to your `PATH`, e.g. by modifying your `~/.bashrc` file.
 
 ## Software development
 


### PR DESCRIPTION
In CI (and recently the Docker image builds - see #7960) we install the
latest version of pip and setuptools as older distro-provided versions
may not parse our version specifiers correctly, or lack support for
features like skipping yanked packages.

This patch makes the same recommendation to end users, which hopefully
avoids one source of hard to diagnose issues.
