### PR TITLE
[util] Fix topgen verbosity

### DIFF
--- a/util/topgen.py
+++ b/util/topgen.py
@@ -978,7 +978,8 @@ def main():
 
     # Don't print warnings when querying the list of blocks.
     log_level = (log.ERROR if args.get_blocks else
-                 log.DEBUG if args.verbose else log.NOTSET)
+                 log.DEBUG if args.verbose else None)
+
     log.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
 
     if not args.outdir:


### PR DESCRIPTION
The `log_level` logic added in e42c8f6 wasn't quite right: the value
that the Python logging library gets with no argument is `None`, not
`log.NOTSET`. Before the fix, we had debug-level output on every
run.
