### PR TITLE
Do not install pyyaml distribution package

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -41,9 +41,6 @@ python3
 python3-pip
 python3-setuptools
 python3-wheel
-# The pip-installed version does not come with LibYAML support by default,
-# which significantly speeds up the parsing/dumping of YAML files.
-python3-yaml
 srecord
 tree
 xsltproc

--- a/yum-requirements.txt
+++ b/yum-requirements.txt
@@ -39,9 +39,6 @@ python3
 python3-pip
 python3-setuptools
 python3-wheel
-# The pip-installed version does not come with LibYAML support by default,
-# which significantly speeds up the parsing/dumping of YAML files.
-python3-yaml
 srecord
 tree
 xsltproc


### PR DESCRIPTION
PyYAML has the option to use a YAML library written in C, which is
significantly faster than the pure Python implementation. Previously,
if pyyaml was installed through pip, the C bindings were never used;
installing a version from the distribution's package manager provided
the faster version. That's no longer the case, the pyyaml project now
provides wheels which contain the necessary binary components. These are
installed when installing pyyaml through pip. We can hence use this
version and avoid installing a probably outdated version from the
distribution's package manager.