### PR TITLE
[clkmgr] Use local BUFHCE clock gates on FPGA

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -322,7 +322,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_${k}_cg (
     .clk_i(clk_${v.src.name}_root),
     .en_i(${k}_sw_en & clk_${v.src.name}_en),
@@ -367,7 +367,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_${clk}_cg (
     .clk_i(clk_${sig.src.name}_root),
     .en_i(${clk}_en & clk_${sig.src.name}_en),

--- a/hw/ip/prim_generic/lint/prim_generic_clock_gating.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_gating.vlt
@@ -6,3 +6,4 @@
 `verilator_config
 
 lint_off -rule UNUSED -file "*/rtl/prim_generic_clock_gating.sv" -match "Parameter is not used: 'NoFpgaGate'"
+lint_off -rule UNUSED -file "*/rtl/prim_generic_clock_gating.sv" -match "Parameter is not used: 'FpgaBufGlobal'"

--- a/hw/ip/prim_generic/lint/prim_generic_clock_gating.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_clock_gating.waiver
@@ -9,3 +9,5 @@ waive -rules COMBO_NBA            -location {prim_generic_clock_gating.sv} -rege
       -comment "clock gating cell creates a latch"
 waive -rules PARAM_NOT_USED -location {prim_generic_clock_gating.sv} -regexp {Parameter 'NoFpgaGate' not used} \
       -comment "parameter unused but required to maintain uniform interface"
+waive -rules PARAM_NOT_USED -location {prim_generic_clock_gating.sv} -regexp {Parameter 'FpgaBufGlobal' not used} \
+      -comment "parameter unused but required to maintain uniform interface"

--- a/hw/ip/prim_generic/rtl/prim_generic_clock_gating.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_gating.sv
@@ -8,7 +8,8 @@
 // synchronizer before en_i).
 
 module prim_generic_clock_gating #(
-  parameter bit NoFpgaGate = 1'b0 // this parameter has no function in generic
+  parameter bit NoFpgaGate = 1'b0, // this parameter has no function in generic
+  parameter bit FpgaBufGlobal = 1'b1 // this parameter has no function in generic
 ) (
   input        clk_i,
   input        en_i,

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_clock_gating.sv
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module prim_xilinx_clock_gating #(
-  parameter bit NoFpgaGate = 1'b0
+  parameter bit NoFpgaGate = 1'b0,
+  parameter bit FpgaBufGlobal = 1'b1
 ) (
   input        clk_i,
   input        en_i,
@@ -14,13 +15,28 @@ module prim_xilinx_clock_gating #(
   if (NoFpgaGate) begin : gen_no_gate
     assign clk_o = clk_i;
   end else begin : gen_gate
-    BUFGCE #(
-      .SIM_DEVICE("7SERIES")
-    ) u_bufgce (
-      .I (clk_i),
-      .CE(en_i | test_en_i),
-      .O (clk_o)
-    );
+    if (FpgaBufGlobal) begin : gen_bufgce
+      // By default, we use BUFG(CE)s, i.e., global clock buffers (with enable input).
+      // These resources are scarce (32 in monolithic 7 series devices) and under some
+      // circumstances cannot be cascaded. They should especially be used for (gating)
+      // clocks that span big parts of the design/multiple clock regions.
+      BUFGCE #(
+        .SIM_DEVICE("7SERIES")
+      ) u_bufgce (
+        .I (clk_i),
+        .CE(en_i | test_en_i),
+        .O (clk_o)
+      );
+    end else begin : gen_bufhce
+      // The BUFH(CE) is a horizontal or local clock buffer (with enable input). Every clock
+      // region has 12 of these buffers. They should be used for (gating) clocks that are
+      // being used locally.
+      BUFHCE u_bufhce (
+        .I (clk_i),
+        .CE(en_i | test_en_i),
+        .O (clk_o)
+      );
+    end
   end
 
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -458,7 +458,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_div4_peri_cg (
     .clk_i(clk_io_div4_root),
     .en_i(clk_io_div4_peri_sw_en & clk_io_div4_en),
@@ -487,7 +487,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_div2_peri_cg (
     .clk_i(clk_io_div2_root),
     .en_i(clk_io_div2_peri_sw_en & clk_io_div2_en),
@@ -516,7 +516,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_peri_cg (
     .clk_i(clk_io_root),
     .en_i(clk_io_peri_sw_en & clk_io_en),
@@ -545,7 +545,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_usb_peri_cg (
     .clk_i(clk_usb_root),
     .en_i(clk_usb_peri_sw_en & clk_usb_en),
@@ -594,7 +594,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_aes_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_aes_en & clk_main_en),
@@ -625,7 +625,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_hmac_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_hmac_en & clk_main_en),
@@ -656,7 +656,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_kmac_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_kmac_en & clk_main_en),
@@ -687,7 +687,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_main_otbn_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_otbn_en & clk_main_en),
@@ -718,7 +718,7 @@
   );
 
   prim_clock_gating #(
-    .NoFpgaGate(1'b1)
+    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
   ) u_clk_io_div4_otbn_cg (
     .clk_i(clk_io_div4_root),
     .en_i(clk_io_div4_otbn_en & clk_io_div4_en),


### PR DESCRIPTION
With this PR, clkmgr now uses local BUFHCE resources to clock gate the software hintable clocks (AES, HMAC, KMAC, OTBN) as well as some software controllable clocks (clk_io_div2_peri, clk_io_peri, clk_usb_peri).

Previously, we were only using global BUFGCE resources. But these are scarce and under some circumstances, cannot be cascaded. As a result, we weren't gating software controllable and hintable clocks at all on FPGA. But since these clocks don't span across many FPGA clock regions, they are well suited to be gated via local BUFHCE instead of global BUFGCE resources.

The only exception is currently clk_io_div4_peri which is used in many peripherals. Therefore, a global BUFGCE clock gate is now used for this clock.