### PR TITLE
[dv/otp_ctrl] Fix null object in otp_cov

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -279,7 +279,7 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
       end
       OtpHwCfgErrIdx, OtpSecret0ErrIdx, OtpSecret1ErrIdx, OtpSecret2ErrIdx,
       OtpLifeCycleErrIdx: begin
-        buf_err_code_cg_wrap[field_idx - 2].buf_err_code_cg.sample(val);
+        buf_err_code_cg_wrap[field_idx - NUM_UNBUFF_PARTS].buf_err_code_cg.sample(val);
       end
       OtpDaiErrIdx: begin
         dai_err_code_cg.sample(val, part_idx);


### PR DESCRIPTION
This PR changes a hard-coded number to use a parameter, and fix a null
object issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>