### PR TITLE
[sva/keymgr] Fix csr assertion error

### DIFF
--- a/hw/ip/keymgr/dv/sva/keymgr_bind.sv
+++ b/hw/ip/keymgr/dv/sva/keymgr_bind.sv
@@ -13,12 +13,11 @@ module keymgr_bind;
     .d2h  (tl_o)
   );
 
- // TODO: fix shadow reg assertion errors and enable this check.
- // bind keymgr keymgr_csr_assert_fpv keymgr_csr_assert (
- //   .clk_i,
- //   .rst_ni,
- //   .h2d    (tl_i),
- //   .d2h    (tl_o)
- // );
+  bind keymgr keymgr_csr_assert_fpv keymgr_csr_assert (
+    .clk_i,
+    .rst_ni,
+    .h2d    (tl_i),
+    .d2h    (tl_o)
+ );
 
 endmodule

--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -38,7 +38,7 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
 <%
   addr_width = rb.get_addr_width()
   addr_msb  = addr_width - 1
-  hro_regs_list = [r for r in rb.flat_regs if not r.is_hw_writable()]
+  hro_regs_list = [r for r in rb.flat_regs if (not r.is_hw_writable() and not r.shadowed)]
   num_hro_regs = len(hro_regs_list)
   hro_map = {r.offset: (idx, r) for idx, r in enumerate(hro_regs_list)}
 %>\


### PR DESCRIPTION
This PR fixes the auto-generated assertion error (PR #7782):
The issue is that some shadow registers are hro and sw rw. When
generating CSR assertion checks, we did not exclude this scenario.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>