### PR TITLE
[ibex] Connect up random constants

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -138,6 +138,23 @@
 
   ],
   param_list: [
+    # Random netlist constants
+    { name:    "RndCnstLfsrSeed",
+      type:    "ibex_pkg::lfsr_seed_t",
+      desc:    '''
+        Default seed of the PRNG used for random instructions.
+      '''
+      randcount: "32",
+      randtype:  "data"
+    },
+    { name:    "RndCnstLfsrPerm",
+      type:    "ibex_pkg::lfsr_perm_t",
+      desc:    '''
+        Permutation applied to the LFSR of the PRNG used for random instructions.
+      '''
+      randcount: "32",
+      randtype:  "perm"
+    },
     { name:    "PMPEnable"
       type:    "bit"
       default: "1'b0"

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -12,26 +12,28 @@ module rv_core_ibex
   import rv_core_ibex_pkg::*;
   import rv_core_ibex_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
-  parameter bit                 PMPEnable         = 1'b0,
-  parameter int unsigned        PMPGranularity    = 0,
-  parameter int unsigned        PMPNumRegions     = 4,
-  parameter int unsigned        MHPMCounterNum    = 10,
-  parameter int unsigned        MHPMCounterWidth  = 32,
-  parameter bit                 RV32E             = 0,
-  parameter ibex_pkg::rv32m_e   RV32M             = ibex_pkg::RV32MSingleCycle,
-  parameter ibex_pkg::rv32b_e   RV32B             = ibex_pkg::RV32BNone,
-  parameter ibex_pkg::regfile_e RegFile           = ibex_pkg::RegFileFF,
-  parameter bit                 BranchTargetALU   = 1'b1,
-  parameter bit                 WritebackStage    = 1'b1,
-  parameter bit                 ICache            = 1'b0,
-  parameter bit                 ICacheECC         = 1'b0,
-  parameter bit                 BranchPredictor   = 1'b0,
-  parameter bit                 DbgTriggerEn      = 1'b1,
-  parameter bit                 SecureIbex        = 1'b0,
-  parameter int unsigned        DmHaltAddr        = 32'h1A110800,
-  parameter int unsigned        DmExceptionAddr   = 32'h1A110808,
-  parameter bit                 PipeLine          = 1'b0
+  parameter logic [NumAlerts-1:0] AlertAsyncOn     = {NumAlerts{1'b1}},
+  parameter bit                   PMPEnable        = 1'b0,
+  parameter int unsigned          PMPGranularity   = 0,
+  parameter int unsigned          PMPNumRegions    = 4,
+  parameter int unsigned          MHPMCounterNum   = 10,
+  parameter int unsigned          MHPMCounterWidth = 32,
+  parameter bit                   RV32E            = 0,
+  parameter ibex_pkg::rv32m_e     RV32M            = ibex_pkg::RV32MSingleCycle,
+  parameter ibex_pkg::rv32b_e     RV32B            = ibex_pkg::RV32BNone,
+  parameter ibex_pkg::regfile_e   RegFile          = ibex_pkg::RegFileFF,
+  parameter bit                   BranchTargetALU  = 1'b1,
+  parameter bit                   WritebackStage   = 1'b1,
+  parameter bit                   ICache           = 1'b0,
+  parameter bit                   ICacheECC        = 1'b0,
+  parameter bit                   BranchPredictor  = 1'b0,
+  parameter bit                   DbgTriggerEn     = 1'b1,
+  parameter bit                   SecureIbex       = 1'b0,
+  parameter ibex_pkg::lfsr_seed_t RndCnstLfsrSeed  = ibex_pkg::RndCnstLfsrSeedDefault,
+  parameter ibex_pkg::lfsr_perm_t RndCnstLfsrPerm  = ibex_pkg::RndCnstLfsrPermDefault,
+  parameter int unsigned          DmHaltAddr       = 32'h1A110800,
+  parameter int unsigned          DmExceptionAddr  = 32'h1A110808,
+  parameter bit                   PipeLine         = 1'b0
 ) (
   // Clock and Reset
   input  logic        clk_i,
@@ -260,6 +262,8 @@ module rv_core_ibex
     .BranchPredictor          ( BranchPredictor          ),
     .DbgTriggerEn             ( DbgTriggerEn             ),
     .SecureIbex               ( SecureIbex               ),
+    .RndCnstLfsrSeed          ( RndCnstLfsrSeed          ),
+    .RndCnstLfsrPerm          ( RndCnstLfsrPerm          ),
     .DmHaltAddr               ( DmHaltAddr               ),
     .DmExceptionAddr          ( DmExceptionAddr          )
   ) u_core (

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6404,6 +6404,26 @@
       param_list:
       [
         {
+          name: RndCnstLfsrSeed
+          desc: Default seed of the PRNG used for random instructions.
+          type: ibex_pkg::lfsr_seed_t
+          randcount: 32
+          randtype: data
+          name_top: RndCnstRvCoreIbexLfsrSeed
+          default: 0x7d8490dc
+          randwidth: 32
+        }
+        {
+          name: RndCnstLfsrPerm
+          desc: Permutation applied to the LFSR of the PRNG used for random instructions.
+          type: ibex_pkg::lfsr_perm_t
+          randcount: 32
+          randtype: perm
+          name_top: RndCnstRvCoreIbexLfsrPerm
+          default: 0xe3c46469cdee68cbacff8ccb555b019101b1c13e
+          randwidth: 160
+        }
+        {
           name: PMPEnable
           desc: Enable PMP
           type: bit

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2344,6 +2344,8 @@ module top_earlgrey #(
 
   rv_core_ibex #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[69:66]),
+    .RndCnstLfsrSeed(RndCnstRvCoreIbexLfsrSeed),
+    .RndCnstLfsrPerm(RndCnstRvCoreIbexLfsrPerm),
     .PMPEnable(RvCoreIbexPMPEnable),
     .PMPGranularity(RvCoreIbexPMPGranularity),
     .PMPNumRegions(RvCoreIbexPMPNumRegions),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -285,4 +285,17 @@ package top_earlgrey_rnd_cnst_pkg;
     128'h838E24FAFE4257BCD0D4AF885661E47D
   };
 
+  ////////////////////////////////////////////
+  // rv_core_ibex
+  ////////////////////////////////////////////
+  // Default seed of the PRNG used for random instructions.
+  parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
+    32'h7D8490DC
+  };
+
+  // Permutation applied to the LFSR of the PRNG used for random instructions.
+  parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
+    160'hE3C46469CDEE68CBACFF8CCB555B019101B1C13E
+  };
+
 endpackage : top_earlgrey_rnd_cnst_pkg


### PR DESCRIPTION
Used for the Ibex internal LFSR. Relates to #1920

Signed-off-by: Tom Roberts <tomroberts@lowrisc.org>