### PR TITLE
[kmac, fpga] Add command delay + accept message while idle for SCA

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -55,6 +55,29 @@
       local:   "false"
       expose:  "true"
     }
+    { name:    "SecCmdDelay"
+      type:    "int"
+      default: "0"
+      desc: '''
+        Command delay, useful for SCA measurements only.
+        A value of e.g. 40 allows the processor to go into sleep before KMAC starts operation.
+        If a value greater than 0 is chosen, software can pass two commands in series.
+        The second command is buffered internally and will be presented to the hardware SecCmdDelay number of cycles after the first one.
+        '''
+      local:   "false"
+      expose:  "true"
+    }
+    { name:    "SecIdleAcceptSwMsg"
+      type:    "bit"
+      default: "0"
+      desc: '''
+        If enabled (1), software writes to the message FIFO before having received a START command are not ignored.
+        Disabled (0) by default.
+        Useful for SCA measurements only.
+        '''
+      local:   "false"
+      expose:  "true"
+    }
     { name:    "NumWordsKey"
       type:    "int"
       default: "16"

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -11,7 +11,8 @@ module kmac_app
 #(
   // App specific configs are defined in kmac_pkg
   parameter  bit EnMasking = 1'b0,
-  localparam int Share = (EnMasking) ? 2 : 1 // derived parameter
+  localparam int Share = (EnMasking) ? 2 : 1, // derived parameter
+  parameter  bit SecIdleAcceptSwMsg = 1'b0
 ) (
   input clk_i,
   input rst_ni,
@@ -356,7 +357,7 @@ module kmac_app
   always_comb begin
     st_d = StIdle;
 
-    mux_sel = SelNone;
+    mux_sel = SecIdleAcceptSwMsg ? SelSw : SelNone;
 
     // app_id control
     set_appid = 1'b 0;
@@ -497,6 +498,12 @@ module kmac_app
         st_d = StIdle;
       end
     endcase
+  end
+
+  if (SecIdleAcceptSwMsg != 1'b0) begin : gen_lint_err
+    // Create a lint error to reduce the risk of accidentally enabling this feature.
+    logic sec_idle_accept_sw_msg_dummy;
+    assign sec_idle_accept_sw_msg_dummy = (st == StIdle);
   end
 
   //////////////

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4932,6 +4932,33 @@
           name_top: KmacReuseShare
         }
         {
+          name: SecCmdDelay
+          desc:
+            '''
+            Command delay, useful for SCA measurements only.
+            A value of e.g. 40 allows the processor to go into sleep before KMAC starts operation.
+            If a value greater than 0 is chosen, software can pass two commands in series.
+            The second command is buffered internally and will be presented to the hardware SecCmdDelay number of cycles after the first one.
+            '''
+          type: int
+          default: "0"
+          expose: "true"
+          name_top: SecKmacCmdDelay
+        }
+        {
+          name: SecIdleAcceptSwMsg
+          desc:
+            '''
+            If enabled (1), software writes to the message FIFO before having received a START command are not ignored.
+            Disabled (0) by default.
+            Useful for SCA measurements only.
+            '''
+          type: bit
+          default: "0"
+          expose: "true"
+          name_top: SecKmacIdleAcceptSwMsg
+        }
+        {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: kmac_pkg::lfsr_perm_t

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -752,6 +752,8 @@ module chip_earlgrey_cw310 #(
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
     .KmacEnMasking(0),
+    .SecKmacCmdDelay(40),
+    .SecKmacIdleAcceptSwMsg(1'b1),
     .KeymgrKmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -57,6 +57,8 @@ module top_earlgrey #(
   // parameters for kmac
   parameter bit KmacEnMasking = 1,
   parameter int KmacReuseShare = 0,
+  parameter int SecKmacCmdDelay = 0,
+  parameter bit SecKmacIdleAcceptSwMsg = 0,
   // parameters for keymgr
   parameter bit KeymgrKmacEnMasking = 1,
   // parameters for csrng
@@ -2005,6 +2007,8 @@ module top_earlgrey #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[40:40]),
     .EnMasking(KmacEnMasking),
     .ReuseShare(KmacReuseShare),
+    .SecCmdDelay(SecKmacCmdDelay),
+    .SecIdleAcceptSwMsg(SecKmacIdleAcceptSwMsg),
     .RndCnstLfsrPerm(RndCnstKmacLfsrPerm)
   ) u_kmac (
 

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1053,6 +1053,8 @@ module chip_${top["name"]}_${target["name"]} (
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
     .KmacEnMasking(0),
+    .SecKmacCmdDelay(40),
+    .SecKmacIdleAcceptSwMsg(1'b1),
     .KeymgrKmacEnMasking(0),
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),


### PR DESCRIPTION
This PR is related to #7841.

It adds two optional changes to KMAC to simplify SCA measurements on FPGA:
1. Writes to the command register are presented to the hardware 40 clock cycles later to allow Ibex to go to sleep before the operation starts. This reduces the noise during SCA measurements. In addition, software can write two commands in sequence. The second command is buffered internally and will be presented to the hardware 40 cycles after the first one. This allows for more efficient SCA measurements as Ibex doesn't need to be woken up after the absorb stage to trigger the squeeze.
2. KMAC accepts writes to the message FIFO while idle. This allows Ibex to provide the message before writing the start command, which simplifies SCA measurements.

Both these options are configured via separate parameters with a `Sec` prefix. They are only enabled on the FPGA platform used for SCA measurements. On all other platforms, safe default values are used (both options disabled). Choosing any non-default values will generate lint errors to reduce the risk of accidentally using these options.