### PR TITLE
Update to Verilator 4.210

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
   # If updating VERILATOR_VERSION, OPENOCD_VERSION, TOOLCHAIN_VERSION or RUST_VERSION
   # update the definitions in util/container/Dockerfile as well.
   #
-  VERILATOR_VERSION: 4.104
+  VERILATOR_VERSION: 4.210
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-1213-g9e5c085

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -22,7 +22,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'verilator': {
-        'min_version': '4.104',
+        'min_version': '4.210',
         'as_needed': True
     },
     'hugo_extended': {

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -6,7 +6,7 @@
 # for OpenTitan.
 
 # Global configuration options.
-ARG VERILATOR_VERSION=4.104
+ARG VERILATOR_VERSION=4.210
 ARG OPENOCD_VERSION=0.11.0
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20210412-1


### PR DESCRIPTION
Pull request lowRISC#7964 exposed a problem in Verilator that led to a segfault
of the verilated simulation during startup. We weren't able to fully
debug it, but know that the problem does not surface with Verilator 4.210
any more.

PR lowRISC#7964 was updated to include a workaround that also works with
earlier Verilator versions. The update here is only a safety measure in
case we find another problem that we cannot work around easily.

Furthermore, newer Verilator versions have a fair amount of changes to
improve compile time and run time performance specificially for
OpenTitan. However, the changes don't yet make a significant impact on
Verilator runs in CI.
