### PR TITLE
Lots of minor tidy-ups to hw/Makefile

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -67,11 +67,20 @@ local_ips := \
 # Per-IP targets (all phonies)
 ips_reg        = $(addsuffix _reg, $(local_ips))
 ips_reg_header = $(addsuffix _reg_header, $(local_ips))
-ips_reg_rust   = $(addsuffix _reg_constants, $(local_ips))
+ips_reg_rust   = $(foreach ip,$(local_ips),$(REG_OUTPUT_SW_DIR)/$(ip)_reg_constants.rs)
 
 # Per-top targets (all phonies)
 tops_gen = $(addsuffix _gen,$(TOPS))
 tops_reg = $(addsuffix _reg,$(TOPS))
+
+# Targets for installing files into TOCK_ROOT (empty if TOCK_ROOT is not defined)
+ifneq ($(TOCK_ROOT),)
+tock_rust_destdir    := $(TOCK_ROOT)/chips/lowrisc/src/reg_constants
+ips_reg_rust_install := $(addprefix $(tock_rust_destdir)/,$(notdir $(ips_reg_rust)))
+
+$(tock_rust_destdir):
+	mkdir -p $@
+endif
 
 .PHONY: $(ips_reg) $(ips_reg_header) $(ips_reg_rust) $(tops_gen) $(tops_reg)
 
@@ -89,9 +98,6 @@ pre_reg:
 	mkdir -p ${REG_OUTPUT_DIR}
 	mkdir -p ${REG_OUTPUT_DV_DIR}
 	mkdir -p ${REG_OUTPUT_SW_DIR}
-	if ! [ -z "$(TOCK_ROOT)" ]; then \
-		mkdir -p ${TOCK_ROOT}/chips/lowrisc/src/reg_constants; \
-	fi
 
 blk-gen-script = $(PRJ_DIR)/hw/ip/$*/util/$*_gen.py
 blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
@@ -115,13 +121,13 @@ regs-header: $(ips_reg_header) banner
 $(ips_reg_header): %_reg_header: pre_reg
 	${PRJ_DIR}/util/regtool.py -D -o ${REG_OUTPUT_SW_DIR}/$*_reg_headers.h $(blk-hjson)
 
-regs-rust: $(ips_reg_rust) banner
+regs-rust: $(ips_reg_rust_install) $(ips_reg_rust) banner
 
-$(ips_reg_rust): %_reg_constants: pre_reg
-	${PRJ_DIR}/util/regtool.py -R -o ${REG_OUTPUT_SW_DIR}/$@.rs $(blk-hjson); \
-	if ! [ -z "$(TOCK_ROOT)" ]; then \
-	  cp ${REG_OUTPUT_SW_DIR}/$@.rs ${TOCK_ROOT}/chips/lowrisc/src/reg_constants; \
-	fi
+$(ips_reg_rust): $(REG_OUTPUT_SW_DIR)/%_reg_constants.rs: pre_reg
+	${PRJ_DIR}/util/regtool.py -R -o $@ $(blk-hjson)
+
+$(ips_reg_rust_install): $(tock_rust_destdir)/%: $(REG_OUTPUT_SW_DIR)/% | $(tock_rust_destdir)
+	cp $< $@
 
 clean-regs-header:
 	rm -r -f ${REG_OUTPUT_SW_DIR}

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -94,10 +94,8 @@ banner:
 
 regs: $(ips_reg) $(tops_reg) banner
 
-pre_reg:
-	mkdir -p ${REG_OUTPUT_DIR}
-	mkdir -p ${REG_OUTPUT_DV_DIR}
-	mkdir -p ${REG_OUTPUT_SW_DIR}
+$(REG_OUTPUT_DV_DIR) $(REG_OUTPUT_SW_DIR): %:
+	mkdir -p $@
 
 blk-gen-script = $(PRJ_DIR)/hw/ip/$*/util/$*_gen.py
 blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
@@ -105,10 +103,10 @@ blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
 # If the ip has a local generation script, run it first. This will
 # require all blocks to use a consistent naming. This should be hooked
 # into ipgen (see #5636) for completeness.
-$(ips_reg): %_reg: pre_reg otp-mmap lc-state-enc
+$(ips_reg): %_reg: otp-mmap lc-state-enc | $(REG_OUTPUT_DV_DIR)
 	$(if $(wildcard $(blk-gen-script)),$(blk-gen-script))
 	${PRJ_DIR}/util/regtool.py ${toolflags} -r $(blk-hjson)
-	${PRJ_DIR}/util/regtool.py -s -t ${REG_OUTPUT_DV_DIR} $(blk-hjson)
+	${PRJ_DIR}/util/regtool.py -s -t $(REG_OUTPUT_DV_DIR) $(blk-hjson)
 
 otp-mmap:
 	cd ${PRJ_DIR} && ./util/design/gen-otp-mmap.py
@@ -118,12 +116,12 @@ lc-state-enc:
 
 regs-header: $(ips_reg_header) banner
 
-$(ips_reg_header): %_reg_header: pre_reg
-	${PRJ_DIR}/util/regtool.py -D -o ${REG_OUTPUT_SW_DIR}/$*_reg_headers.h $(blk-hjson)
+$(ips_reg_header): %_reg_header: | $(REG_OUTPUT_SW_DIR)
+	${PRJ_DIR}/util/regtool.py -D -o $(REG_OUTPUT_SW_DIR)/$*_reg_headers.h $(blk-hjson)
 
 regs-rust: $(ips_reg_rust_install) $(ips_reg_rust) banner
 
-$(ips_reg_rust): $(REG_OUTPUT_SW_DIR)/%_reg_constants.rs: pre_reg
+$(ips_reg_rust): $(REG_OUTPUT_SW_DIR)/%_reg_constants.rs: | $(REG_OUTPUT_SW_DIR)
 	${PRJ_DIR}/util/regtool.py -R -o $@ $(blk-hjson)
 
 $(ips_reg_rust_install): $(tock_rust_destdir)/%: $(REG_OUTPUT_SW_DIR)/% | $(tock_rust_destdir)
@@ -138,7 +136,7 @@ $(tops_gen):
 	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/data/$($@_TOP).hjson \
 		-o ${PRJ_DIR}/hw/$($@_TOP)/ ${toolflags}
 
-$(tops_reg): pre_reg
+$(tops_reg):
 	$(eval $@_TOP := $(strip $(foreach top,$(TOPS),$(findstring $(top),$@))))
 	mkdir -p ${REG_OUTPUT_DV_DIR}/$($@_TOP)
 	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/data/$($@_TOP).hjson \

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -58,19 +58,24 @@ endif
 
 dir_hjson = data
 
-dynips_reg = $(addsuffix _reg, $(IPS))
+hjson_for_ip = ${PRJ_DIR}/hw/ip/$(1)/$(dir_hjson)/$(1).hjson
 
-ips_reg = $(addsuffix _reg, $(IPS))
+# IPs that have a directory in hw/ip
+local_ips := \
+  $(foreach i,$(IPS),$(if $(wildcard $(call hjson_for_ip,$(i))),$(i)))
 
-ips_reg_header = $(addsuffix _reg_header, $(IPS))
+# Per-IP targets (all phonies)
+ips_reg        = $(addsuffix _reg, $(local_ips))
+ips_reg_header = $(addsuffix _reg_header, $(local_ips))
+ips_reg_rust   = $(addsuffix _reg_constants, $(local_ips))
 
-ips_reg_rust = $(addsuffix _reg_constants, $(IPS))
-
+# Per-top targets (all phonies)
 tops_gen = $(addsuffix _gen,$(TOPS))
-
 tops_reg = $(addsuffix _reg,$(TOPS))
 
-all: $(dynips_reg) $(tops_gen) $(tops_reg) banner
+.PHONY: $(ips_reg) $(ips_reg_header) $(ips_reg_rust) $(tops_gen) $(tops_reg)
+
+all: $(ips_reg) $(tops_gen) $(tops_reg) banner
 
 banner:
 	@echo "############################################"
@@ -78,7 +83,7 @@ banner:
 	@echo "${REG_OUTPUT_DIR}"
 	@echo "############################################"
 
-regs: $(dynips_reg) $(tops_reg) banner
+regs: $(ips_reg) $(tops_reg) banner
 
 pre_reg:
 	mkdir -p ${REG_OUTPUT_DIR}
@@ -88,18 +93,16 @@ pre_reg:
 		mkdir -p ${TOCK_ROOT}/chips/lowrisc/src/reg_constants; \
 	fi
 
-# If the ip has a local generation script, run it
-# This will require all blocks to use a consistent naming
-# This should be hooked into ipgen (see #5636) for completeness.
-$(ips_reg): pre_reg otp-mmap lc-state-enc
-	if [ -f ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/util/$(subst _reg,,$@)_gen.py ]; then \
-		${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/util/$(subst _reg,,$@)_gen.py; \
-	fi
-	if [ -f ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson ]; then \
-		${PRJ_DIR}/util/regtool.py ${toolflags} -r ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson && \
-		${PRJ_DIR}/util/regtool.py -s -t ${REG_OUTPUT_DV_DIR} \
-		  ${PRJ_DIR}/hw/ip/$(subst _reg,,$@)/$(dir_hjson)/$(subst _reg,,$@).hjson; \
-	fi
+blk-gen-script = $(PRJ_DIR)/hw/ip/$*/util/$*_gen.py
+blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
+
+# If the ip has a local generation script, run it first. This will
+# require all blocks to use a consistent naming. This should be hooked
+# into ipgen (see #5636) for completeness.
+$(ips_reg): %_reg: pre_reg otp-mmap lc-state-enc
+	$(if $(wildcard $(blk-gen-script)),$(blk-gen-script))
+	${PRJ_DIR}/util/regtool.py ${toolflags} -r $(blk-hjson)
+	${PRJ_DIR}/util/regtool.py -s -t ${REG_OUTPUT_DV_DIR} $(blk-hjson)
 
 otp-mmap:
 	cd ${PRJ_DIR} && ./util/design/gen-otp-mmap.py
@@ -109,21 +112,15 @@ lc-state-enc:
 
 regs-header: $(ips_reg_header) banner
 
-$(ips_reg_header): pre_reg
-	if [ -f ${PRJ_DIR}/hw/ip/$(subst _reg_header,,$@)/$(dir_hjson)/$(subst _reg_header,,$@).hjson ]; then \
-		${PRJ_DIR}/util/regtool.py -D -o ${REG_OUTPUT_SW_DIR}/$(subst _reg_header,_reg_headers,$@).h\
-		${PRJ_DIR}/hw/ip/$(subst _reg_header,,$@)/$(dir_hjson)/$(subst _reg_header,,$@).hjson; \
-	fi
+$(ips_reg_header): %_reg_header: pre_reg
+	${PRJ_DIR}/util/regtool.py -D -o ${REG_OUTPUT_SW_DIR}/$*_reg_headers.h $(blk-hjson)
 
 regs-rust: $(ips_reg_rust) banner
 
-$(ips_reg_rust): pre_reg
-	if [ -f ${PRJ_DIR}/hw/ip/$(subst _reg_constants,,$@)/$(dir_hjson)/$(subst _reg_constants,,$@).hjson ]; then \
-		${PRJ_DIR}/util/regtool.py -R -o ${REG_OUTPUT_SW_DIR}/$@.rs\
-		${PRJ_DIR}/hw/ip/$(subst _reg_constants,,$@)/$(dir_hjson)/$(subst _reg_constants,,$@).hjson; \
-		if ! [ -z "$(TOCK_ROOT)" ]; then \
-			cp ${REG_OUTPUT_SW_DIR}/$@.rs ${TOCK_ROOT}/chips/lowrisc/src/reg_constants; \
-		fi \
+$(ips_reg_rust): %_reg_constants: pre_reg
+	${PRJ_DIR}/util/regtool.py -R -o ${REG_OUTPUT_SW_DIR}/$@.rs $(blk-hjson); \
+	if ! [ -z "$(TOCK_ROOT)" ]; then \
+	  cp ${REG_OUTPUT_SW_DIR}/$@.rs ${TOCK_ROOT}/chips/lowrisc/src/reg_constants; \
 	fi
 
 clean-regs-header:
@@ -142,4 +139,4 @@ $(tops_reg): pre_reg
 		-r -o ${REG_OUTPUT_DV_DIR}/$($@_TOP) ${toolflags}
 
 
-.PHONY: all banner otp-mmap lc-state-enc $(ips_reg) $(tops_gen) $(ips_reg_header)
+.PHONY: all banner otp-mmap lc-state-enc

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -84,15 +84,9 @@ endif
 
 .PHONY: $(ips_reg) $(ips_reg_header) $(ips_reg_rust) $(tops_gen) $(tops_reg)
 
-all: $(ips_reg) $(tops_gen) $(tops_reg) banner
+all: $(ips_reg) $(tops_gen) $(tops_reg)
 
-banner:
-	@echo "############################################"
-	@echo "Note: Regs for DV & SW are now generated at:"
-	@echo "${REG_OUTPUT_DIR}"
-	@echo "############################################"
-
-regs: $(ips_reg) $(tops_reg) banner
+regs: $(ips_reg) $(tops_reg)
 
 $(REG_OUTPUT_DV_DIR) $(REG_OUTPUT_SW_DIR): %:
 	mkdir -p $@
@@ -114,12 +108,12 @@ otp-mmap:
 lc-state-enc:
 	cd ${PRJ_DIR} && ./util/design/gen-lc-state-enc.py
 
-regs-header: $(ips_reg_header) banner
+regs-header: $(ips_reg_header)
 
 $(ips_reg_header): %_reg_header: | $(REG_OUTPUT_SW_DIR)
 	${PRJ_DIR}/util/regtool.py -D -o $(REG_OUTPUT_SW_DIR)/$*_reg_headers.h $(blk-hjson)
 
-regs-rust: $(ips_reg_rust_install) $(ips_reg_rust) banner
+regs-rust: $(ips_reg_rust_install) $(ips_reg_rust)
 
 $(ips_reg_rust): $(REG_OUTPUT_SW_DIR)/%_reg_constants.rs: | $(REG_OUTPUT_SW_DIR)
 	${PRJ_DIR}/util/regtool.py -R -o $@ $(blk-hjson)
@@ -143,4 +137,4 @@ $(tops_reg):
 		-r -o ${REG_OUTPUT_DV_DIR}/$($@_TOP) ${toolflags}
 
 
-.PHONY: all banner otp-mmap lc-state-enc
+.PHONY: all otp-mmap lc-state-enc

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -4,7 +4,6 @@
 
 CUR_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PRJ_DIR := $(realpath ${CUR_DIR}/../)
-export PRJ_DIR
 
 REG_OUTPUT_DIR    ?= ${PRJ_DIR}/build/regs-generated
 REG_OUTPUT_DV_DIR ?= ${REG_OUTPUT_DIR}/dv

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -130,17 +130,15 @@ $(ips_reg_rust_install): $(tock_rust_destdir)/%: $(REG_OUTPUT_SW_DIR)/% | $(tock
 clean-regs-header:
 	rm -r -f ${REG_OUTPUT_SW_DIR}
 
-top: $(tops_gen) $(tops_reg)
-$(tops_gen):
-	$(eval $@_TOP := $(strip $(foreach top,$(TOPS),$(findstring $(top),$@))))
-	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/data/$($@_TOP).hjson \
-		-o ${PRJ_DIR}/hw/$($@_TOP)/ ${toolflags}
+top-hjson = $(PRJ_DIR)/hw/$*/data/$*.hjson
 
-$(tops_reg):
-	$(eval $@_TOP := $(strip $(foreach top,$(TOPS),$(findstring $(top),$@))))
-	mkdir -p ${REG_OUTPUT_DV_DIR}/$($@_TOP)
-	${PRJ_DIR}/util/topgen.py -t ${PRJ_DIR}/hw/$($@_TOP)/data/$($@_TOP).hjson \
-		-r -o ${REG_OUTPUT_DV_DIR}/$($@_TOP) ${toolflags}
+top: $(tops_gen) $(tops_reg)
+$(tops_gen): %_gen:
+	${PRJ_DIR}/util/topgen.py -t $(top-hjson) -o ${PRJ_DIR}/hw/$*/ ${toolflags}
+
+$(tops_reg): %_reg:
+	mkdir -p ${REG_OUTPUT_DV_DIR}/$*
+	${PRJ_DIR}/util/topgen.py -t $(top-hjson) -r -o ${REG_OUTPUT_DV_DIR}/$* ${toolflags}
 
 
 .PHONY: all

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -97,7 +97,7 @@ blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
 # If the ip has a local generation script, run it first. This will
 # require all blocks to use a consistent naming. This should be hooked
 # into ipgen (see #5636) for completeness.
-$(ips_reg): %_reg: lc-state-enc | $(REG_OUTPUT_DV_DIR)
+$(ips_reg): %_reg: | $(REG_OUTPUT_DV_DIR)
 	$(if $(wildcard $(blk-gen-script)),$(blk-gen-script))
 	${PRJ_DIR}/util/regtool.py ${toolflags} -r $(blk-hjson)
 	${PRJ_DIR}/util/regtool.py -s -t $(REG_OUTPUT_DV_DIR) $(blk-hjson)
@@ -108,6 +108,9 @@ $(filter otp_ctrl_reg,$(ips_reg)): otp-mmap
 otp-mmap:
 	cd ${PRJ_DIR} && ./util/design/gen-otp-mmap.py
 
+# Register generation for lc_ctrl also depends on running gen-lc-state-enc.py
+.PHONY: lc-state-enc
+$(filter lc_ctrl_reg,$(ips_reg)): lc-state-enc
 lc-state-enc:
 	cd ${PRJ_DIR} && ./util/design/gen-lc-state-enc.py
 
@@ -140,4 +143,4 @@ $(tops_reg):
 		-r -o ${REG_OUTPUT_DV_DIR}/$($@_TOP) ${toolflags}
 
 
-.PHONY: all lc-state-enc
+.PHONY: all

--- a/hw/Makefile
+++ b/hw/Makefile
@@ -97,11 +97,14 @@ blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
 # If the ip has a local generation script, run it first. This will
 # require all blocks to use a consistent naming. This should be hooked
 # into ipgen (see #5636) for completeness.
-$(ips_reg): %_reg: otp-mmap lc-state-enc | $(REG_OUTPUT_DV_DIR)
+$(ips_reg): %_reg: lc-state-enc | $(REG_OUTPUT_DV_DIR)
 	$(if $(wildcard $(blk-gen-script)),$(blk-gen-script))
 	${PRJ_DIR}/util/regtool.py ${toolflags} -r $(blk-hjson)
 	${PRJ_DIR}/util/regtool.py -s -t $(REG_OUTPUT_DV_DIR) $(blk-hjson)
 
+# Register generation for otp_ctrl also depends on running gen-otp-mmap.py
+.PHONY: otp-mmap
+$(filter otp_ctrl_reg,$(ips_reg)): otp-mmap
 otp-mmap:
 	cd ${PRJ_DIR} && ./util/design/gen-otp-mmap.py
 
@@ -137,4 +140,4 @@ $(tops_reg):
 		-r -o ${REG_OUTPUT_DV_DIR}/$($@_TOP) ${toolflags}
 
 
-.PHONY: all otp-mmap lc-state-enc
+.PHONY: all lc-state-enc

--- a/util/design/gen-lc-state-enc.py
+++ b/util/design/gen-lc-state-enc.py
@@ -23,7 +23,7 @@ TEMPLATES = ["hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl"]
 
 
 def main():
-    log.basicConfig(level=log.INFO,
+    log.basicConfig(level=log.WARNING,
                     format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(

--- a/util/design/gen-otp-mmap.py
+++ b/util/design/gen-otp-mmap.py
@@ -36,7 +36,7 @@ TEMPLATES = [
 
 
 def main():
-    log.basicConfig(level=log.INFO,
+    log.basicConfig(level=log.WARNING,
                     format="%(levelname)s: %(message)s")
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
This isn't a big deal per se, but I've been regenerating registers a lot recently and poring through the console output to find the stuff I cared about was getting a bit painful. I've split the changes into a series of self-contained commits: this might be a bit easier to review but, more importantly, is easier to bisect if I've messed something up.

The point of all of this is to tidy up the output. Before, `make -C hw -j4 all` generated 475 lines. Now it generates 80.