### PR TITLE
[doc/chip_level] Add a testpoint entry about strap sampling

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -335,6 +335,17 @@
       milestone: V2
       tests: []
     }
+    {
+      name: chip_tap_strap_sampling
+      desc: '''Verify tap accesses in different LC states.
+
+            Verify pinmux can select the life_cycle, RISC-V, and DFT taps after reset.
+            Verify that in TEST_UNLOCKED* and RMA states, pinmux can switch between the three TAPs
+            without issuing reset.
+            '''
+      milestone: V2
+      tests: []
+    }
 
     // PADCTRL tests:
     {


### PR DESCRIPTION
This PR adds a testentry in pinmux to capture the strap sampling
functionality.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>