### PR TITLE
[pwrmgr] Harden pwrmgr FSM handling

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -10,6 +10,7 @@
 { name: "PWRMGR",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
+    {reset: "rst_main_ni"},
     {clock: "clk_slow_i", reset: "rst_slow_ni"}
   ]
   bus_interfaces: [

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -4,6 +4,7 @@
 { name: "PWRMGR",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
+    {reset: "rst_main_ni"},
     {clock: "clk_slow_i", reset: "rst_slow_ni"}
   ]
   bus_interfaces: [

--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -117,10 +117,10 @@ Once the request is acknowledged, the fast FSM transitions to low power and wait
 
 ## Reset Request Handling
 
-There are 3 reset requests in the system - peripheral requested reset such as watchdog, alert escalation reset and non-debug module reset.
+There are 3 reset requests in the system - peripheral requested reset such as watchdog, power manager's internal reset request and non-debug module reset.
 Flash brownout is handled separately and described in [flash handling section](#flash-handling) below.
 
-Watchdog and alert escalation resets are handled directly by the power manager, while the non-debug module reset is handled by the reset controller.
+Peripheral requested resets such as watchdog are handled directly by the power manager, while the non-debug module reset is handled by the reset controller.
 This separation is because the non-debug reset does not affect the life cycle controller, non-volatile storage controllers and alert states.
 There is thus no need to sequence its operation like the others.
 
@@ -130,6 +130,27 @@ When a reset request is received during slow FSM `Low Power` state, the system b
 When a reset request is received during fast FSM `Active` state, the fast FSM asserts resets and transitions back to its `Low Power` state.
 The normal power-up process described [above](#fast-clock-domain-fsm) is then followed to release the resets.
 Note in this case, the slow FSM is "not activated" and remains in its `Idle` state.
+
+### Power Manager Internal Reset Requests
+
+In additional to external requests, the power manager maintains 2 internal reset requests:
+* Escalation reset request
+* Main power domain unstable reset request
+
+#### Escalation Reset Request
+Alert escalation resets in general behave similarly to peripehral requested resets.
+However, peripheral resets are always handled gracefully and follow the normal FSM transition.
+
+Alert escalations can happen at any time and do not always obey normal rules.
+As a result, upon alert escalation, the power manager makes a best case effort to transition directly into reset handling.
+
+This may not always be possible if the escalation happens while in low power (for example the FSM is in an invalid state).
+In this scenario, the pwrmgr keeps everything powered off and silenced and requests escalation handling if the system ever wakes up.
+
+#### Main Power Unstable Reset Requests
+If the main power ever becomes unstable (the power okay indication is low even though it is powered on), the power manager requests an internal reset.
+
+This reset behaves similarly to the escalation reset and transitions directly into reset handling.
 
 
 ### Reset Requests Received During Other States

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -59,7 +59,7 @@ interface pwrmgr_if (
 
   // Slow fsm state.
   pwrmgr_pkg::slow_pwr_state_e                                   slow_state;
-  always_comb slow_state = tb.dut.i_slow_fsm.state_q;
+  always_comb slow_state = tb.dut.u_slow_fsm.state_q;
 
   // Fast fsm state.
   pwrmgr_pkg::fast_pwr_state_e fast_state;

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -14,7 +14,7 @@ module pwrmgr_bind;
   bind pwrmgr pwrmgr_clock_enables_sva_if pwrmgr_clock_enables_sva_if (
     .clk_i(clk_slow_i),
     .rst_ni(rst_slow_ni),
-    .state(i_slow_fsm.state_q),
+    .state(u_slow_fsm.state_q),
     // The synchronized control CSR bits.
     .main_pd_ni(slow_main_pd_n),
     .core_clk_en_i(slow_core_clk_en),

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -51,6 +51,7 @@ module tb;
     .rst_ni     (rst_n),
     .clk_slow_i (clk_slow),
     .rst_slow_ni(rst_slow_n),
+    .rst_main_ni(rst_slow_n),
 
     .tl_i(tl_if.h2d),
     .tl_o(tl_if.d2h),

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -4,6 +4,7 @@
 
 <%
   crash_dump_srcs = ['alert', 'cpu']
+  total_hw_resets = num_rstreqs+2
 %>
 
 # RSTMGR register template
@@ -45,9 +46,9 @@
     },
 
     { name: "NumHwResets",
-      desc: "Number of hardware reset requests, inclusive of escalation",
+      desc: "Number of hardware reset requests, inclusive of pwrmgr's 2 internal resets",
       type: "int",
-      default: "${num_rstreqs+1}",
+      default: "${total_hw_resets}",
       local: "true"
     },
 
@@ -67,6 +68,7 @@
       type:    "uni",
       name:    "por_n",
       act:     "rcv",
+      width:   "${len(power_domains)}"
     },
 
     { struct:  "pwr_rst",    // pwr_rst_req_t, pwr_rst_rsp_t
@@ -153,7 +155,7 @@
         },
 
         // reset requests include escalation reset + peripheral requests
-        { bits: "${3 + num_rstreqs}:3",
+        { bits: "${3 + total_hw_resets - 1}:3",
           hwaccess: "hrw",
           name: "HW_REQ",
           desc: '''

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -15,7 +15,7 @@ interface rstmgr_cascading_sva_if (
   input logic clk_io_i,
   input logic clk_main_i,
   input logic clk_usb_i,
-  input logic por_n_i,
+  input [rstmgr_pkg::PowerDomains-1:0] por_n_i,
   input rstmgr_pkg::rstmgr_out_t resets_o,
   input [rstmgr_pkg::PowerDomains-1:0] rst_lc_src_n,
   input [rstmgr_pkg::PowerDomains-1:0] rst_sys_src_n,
@@ -76,14 +76,14 @@ interface rstmgr_cascading_sva_if (
       `RISE_ASSERT(name, from, to, cycles, clk)
 
   // A fall in por_n_i leads to a fall in rst_por_aon_n[0].
-  `FALL_ASSERT(CascadePorToAon, por_n_i, resets_o.rst_por_aon_n[0], PorCycles, clk_aon_i)
+  `FALL_ASSERT(CascadePorToAon, por_n_i[rstmgr_pkg::DomainAonSel], resets_o.rst_por_aon_n[0], PorCycles, clk_aon_i)
 
   // A number of consecutive cycles with por_n_i inactive (high) should cause the aon resets to
   // become inactive. This checks POR stretching.
 
   // The antecedent: por_n_i rising and being stably high for a minimum number of cycles.
   sequence PorStable_S;
-    $rose(por_n_i) ##1 por_n_i [* PorCycles.rise.min];
+    $rose(por_n_i[rstmgr_pkg::DomainAonSel]) ##1 por_n_i[rstmgr_pkg::DomainAonSel] [* PorCycles.rise.min];
   endsequence
 
   // The consequence: reset will rise after some cycles.

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -179,6 +179,7 @@
         domains:
         [
           Aon
+          "0"
         ]
         shadowed: false
         sw: false
@@ -254,6 +255,7 @@
         domains:
         [
           Aon
+          "0"
         ]
         shadowed: false
         sw: false
@@ -2335,6 +2337,11 @@
           name: por_io_div4
           domain: Aon
         }
+        rst_main_ni:
+        {
+          name: por_aon
+          domain: "0"
+        }
         rst_slow_ni:
         {
           name: por_aon
@@ -2344,6 +2351,7 @@
       domain:
       [
         Aon
+        "0"
       ]
       attr: templated
       clock_connections:
@@ -2617,7 +2625,7 @@
           struct: logic
           type: uni
           act: rcv
-          width: 1
+          width: 2
           inst_name: rstmgr_aon
           default: ""
           package: ""
@@ -14810,7 +14818,7 @@
         struct: logic
         type: uni
         act: rcv
-        width: 1
+        width: 2
         inst_name: rstmgr_aon
         default: ""
         package: ""
@@ -18283,7 +18291,7 @@
         package: ""
         struct: logic
         signame: por_n_i
-        width: 1
+        width: 2
         type: uni
         default: ""
         direction: in

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -337,8 +337,21 @@
       type: "pwrmgr",
       clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "por_io_div4", rst_slow_ni: "por_aon"},
-      domain: ["Aon"],
+      reset_connections: {
+        rst_ni: {
+          name: "por_io_div4",
+          domain: "Aon"
+        },
+        rst_main_ni: {
+          name: "por_aon",
+          domain: "0"
+        }
+        rst_slow_ni: {
+          name: "por_aon",
+          domain: "Aon",
+        },
+      }
+      domain: ["Aon", "0"],
       base_addr: "0x40400000",
       attr: "templated",
 

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -10,6 +10,7 @@
 { name: "PWRMGR",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
+    {reset: "rst_main_ni"},
     {clock: "clk_slow_i", reset: "rst_slow_ni"}
   ]
   bus_interfaces: [

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -52,9 +52,9 @@
     },
 
     { name: "NumHwResets",
-      desc: "Number of hardware reset requests, inclusive of escalation",
+      desc: "Number of hardware reset requests, inclusive of pwrmgr's 2 internal resets",
       type: "int",
-      default: "3",
+      default: "4",
       local: "true"
     },
 
@@ -74,6 +74,7 @@
       type:    "uni",
       name:    "por_n",
       act:     "rcv",
+      width:   "2"
     },
 
     { struct:  "pwr_rst",    // pwr_rst_req_t, pwr_rst_rsp_t
@@ -152,7 +153,7 @@
         },
 
         // reset requests include escalation reset + peripheral requests
-        { bits: "5:3",
+        { bits: "6:3",
           hwaccess: "hrw",
           name: "HW_REQ",
           desc: '''

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -30,7 +30,7 @@ module rstmgr
   input clk_usb_i,
 
   // POR input
-  input por_n_i,
+  input [PowerDomains-1:0] por_n_i,
 
   // Bus Interface
   input tlul_pkg::tl_h2d_t tl_i,
@@ -71,9 +71,8 @@ module rstmgr
   logic [PowerDomains-1:0] rst_por_aon_n;
 
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
-    if (i == DomainAonSel) begin : gen_rst_por_aon_normal
 
-      lc_ctrl_pkg::lc_tx_t por_aon_scanmode;
+      lc_ctrl_pkg::lc_tx_t por_scanmode;
       prim_lc_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -81,23 +80,41 @@ module rstmgr
         .clk_i(1'b0),  // unused clock
         .rst_ni(1'b1), // unused reset
         .lc_en_i(scanmode_i),
-        .lc_en_o(por_aon_scanmode)
+        .lc_en_o(por_scanmode)
       );
 
+    if (i == DomainAonSel) begin : gen_rst_por_aon_normal
       rstmgr_por u_rst_por_aon (
         .clk_i(clk_aon_i),
-        .rst_ni(por_n_i),
+        .rst_ni(por_n_i[i]),
         .scan_rst_ni,
-        .scanmode_i(por_aon_scanmode == lc_ctrl_pkg::On),
+        .scanmode_i(por_scanmode == lc_ctrl_pkg::On),
         .rst_no(rst_por_aon_n[i])
       );
-    end else begin : gen_rst_por_aon_tieoff
-      assign rst_por_aon_n[i] = 1'b0;
+    end else begin : gen_rst_por_domain
+      logic rst_por_aon_premux;
+      prim_flop_2sync #(
+        .Width(1),
+        .ResetValue('0)
+      ) u_por_domain_sync (
+        .clk_i(clk_aon_i),
+        // do not release from reset if aon has not
+        .rst_ni(rst_por_aon_n[DomainAonSel] & por_n_i[i]),
+        .d_i(1'b1),
+        .q_o(rst_por_aon_premux)
+      );
+
+      prim_clock_mux2 #(
+        .NoFpgaBufG(1'b1)
+      ) u_por_domain_mux (
+        .clk0_i(rst_por_aon_premux),
+        .clk1_i(scan_rst_ni),
+        .sel_i(por_scanmode == lc_ctrl_pkg::On),
+        .clk_o(rst_por_aon_n[i])
+      );
     end
-
-    assign resets_o.rst_por_aon_n[i] = rst_por_aon_n[i];
   end
-
+  assign resets_o.rst_por_aon_n = rst_por_aon_n;
 
   ////////////////////////////////////////////////////
   // Register Interface                             //
@@ -153,7 +170,7 @@ module rstmgr
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
-  ) u_sync (
+  ) u_ndm_sync (
     .clk_i,
     .rst_ni,
     .d_i(ndmreset_req_i),
@@ -332,7 +349,7 @@ module rstmgr
   assign resets_o.rst_por_io_div2_n[Domain0Sel] = rst_por_io_div2_n[Domain0Sel];
 
   // Generating resets for por_io_div4
-  // Power Domains: ['Aon']
+  // Power Domains: ['Aon', '0']
   // Shadowed: False
   logic [PowerDomains-1:0] rst_por_io_div4_n;
   prim_flop_2sync #(
@@ -354,8 +371,24 @@ module rstmgr
     .clk_o(resets_o.rst_por_io_div4_n[DomainAonSel])
   );
 
-  assign rst_por_io_div4_n[Domain0Sel] = 1'b0;
-  assign resets_o.rst_por_io_div4_n[Domain0Sel] = rst_por_io_div4_n[Domain0Sel];
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_0_por_io_div4 (
+    .clk_i(clk_io_div4_i),
+    .rst_ni(rst_por_aon_n[Domain0Sel]),
+    .d_i(1'b1),
+    .q_o(rst_por_io_div4_n[Domain0Sel])
+  );
+
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_0_por_io_div4_mux (
+    .clk0_i(rst_por_io_div4_n[Domain0Sel]),
+    .clk1_i(scan_rst_ni),
+    .sel_i(leaf_rst_scanmode[3] == lc_ctrl_pkg::On),
+    .clk_o(resets_o.rst_por_io_div4_n[Domain0Sel])
+  );
 
   // Generating resets for por_usb
   // Power Domains: ['Aon']
@@ -1012,6 +1045,8 @@ module rstmgr
   ////////////////////////////////////////////////////
   // Assertions                                     //
   ////////////////////////////////////////////////////
+
+  `ASSERT_INIT(ParameterMatch_A, NumHwResets == pwrmgr_pkg::TotalResetWidth)
 
   // when upstream resets, downstream must also reset
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -9,7 +9,7 @@ package rstmgr_reg_pkg;
   // Param list
   parameter int RdWidth = 32;
   parameter int IdxWidth = 4;
-  parameter int NumHwResets = 3;
+  parameter int NumHwResets = 4;
   parameter int NumSwResets = 10;
   parameter int NumAlerts = 1;
 
@@ -27,7 +27,7 @@ package rstmgr_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic [2:0]  q;
+      logic [3:0]  q;
     } hw_req;
   } rstmgr_reg2hw_reset_info_reg_t;
 
@@ -68,7 +68,7 @@ package rstmgr_reg_pkg;
       logic        de;
     } ndm_reset;
     struct packed {
-      logic [2:0]  d;
+      logic [3:0]  d;
       logic        de;
     } hw_req;
   } rstmgr_hw2reg_reset_info_reg_t;
@@ -109,8 +109,8 @@ package rstmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    rstmgr_reg2hw_alert_test_reg_t alert_test; // [44:43]
-    rstmgr_reg2hw_reset_info_reg_t reset_info; // [42:40]
+    rstmgr_reg2hw_alert_test_reg_t alert_test; // [45:44]
+    rstmgr_reg2hw_reset_info_reg_t reset_info; // [43:40]
     rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [39:35]
     rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [34:30]
     rstmgr_reg2hw_sw_rst_regen_mreg_t [9:0] sw_rst_regen; // [29:20]
@@ -119,7 +119,7 @@ package rstmgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [93:86]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [94:86]
     rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [85:84]
     rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [83:80]
     rstmgr_hw2reg_alert_info_reg_t alert_info; // [79:48]

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -117,8 +117,8 @@ module rstmgr_reg_top (
   logic reset_info_low_power_exit_wd;
   logic reset_info_ndm_reset_qs;
   logic reset_info_ndm_reset_wd;
-  logic [2:0] reset_info_hw_req_qs;
-  logic [2:0] reset_info_hw_req_wd;
+  logic [3:0] reset_info_hw_req_qs;
+  logic [3:0] reset_info_hw_req_wd;
   logic alert_regwen_we;
   logic alert_regwen_qs;
   logic alert_regwen_wd;
@@ -279,11 +279,11 @@ module rstmgr_reg_top (
     .qs     (reset_info_ndm_reset_qs)
   );
 
-  //   F[hw_req]: 5:3
+  //   F[hw_req]: 6:3
   prim_subreg #(
-    .DW      (3),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (3'h0)
+    .RESVAL  (4'h0)
   ) u_reset_info_hw_req (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -964,7 +964,7 @@ module rstmgr_reg_top (
 
   assign reset_info_ndm_reset_wd = reg_wdata[2];
 
-  assign reset_info_hw_req_wd = reg_wdata[5:3];
+  assign reset_info_hw_req_wd = reg_wdata[6:3];
   assign alert_regwen_we = addr_hit[2] & reg_we & !reg_error;
 
   assign alert_regwen_wd = reg_wdata[0];
@@ -1041,7 +1041,7 @@ module rstmgr_reg_top (
         reg_rdata_next[0] = reset_info_por_qs;
         reg_rdata_next[1] = reset_info_low_power_exit_qs;
         reg_rdata_next[2] = reset_info_ndm_reset_qs;
-        reg_rdata_next[5:3] = reset_info_hw_req_qs;
+        reg_rdata_next[6:3] = reset_info_hw_req_qs;
       end
 
       addr_hit[2]: begin

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -1061,11 +1061,13 @@ module chip_earlgrey_asic (
   // Top-level design //
   //////////////////////
 
+  logic [rstmgr_pkg::PowerDomains-1:0] por_n;
+  assign por_n = {ast_pwst.main_pok, ast_pwst.aon_pok};
   top_earlgrey #(
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
     // ast connections
-    .por_n_i                      ( ast_pwst.aon_pok           ),
+    .por_n_i                      ( por_n                      ),
     .clk_main_i                   ( ast_base_clks.clk_sys      ),
     .clk_io_i                     ( ast_base_clks.clk_io       ),
     .clk_usb_i                    ( ast_base_clks.clk_usb      ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -764,7 +764,7 @@ module chip_earlgrey_cw310 #(
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .por_n_i                      ( rst_n            ),
+    .por_n_i                      ( {rst_n, rst_n}   ),
     .clk_main_i                   ( clk_main         ),
     .clk_io_i                     ( clk_main         ),
     .clk_usb_i                    ( clk_usb_48mhz    ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -748,7 +748,7 @@ module chip_earlgrey_nexysvideo #(
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .por_n_i                      ( rst_n            ),
+    .por_n_i                      ( {rst_n, rst_n}   ),
     .clk_main_i                   ( clk_main         ),
     .clk_io_i                     ( clk_main         ),
     .clk_usb_i                    ( clk_usb_48mhz    ),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -145,7 +145,7 @@ module top_earlgrey #(
   input  otp_ctrl_pkg::otp_ast_rsp_t       otp_ctrl_otp_ast_pwr_seq_h_i,
   inout         otp_ext_voltage_h_io,
   output ast_pkg::ast_dif_t       otp_alert_o,
-  input  logic       por_n_i,
+  input  logic [1:0] por_n_i,
   input  ast_pkg::ast_alert_req_t       sensor_ctrl_ast_alert_req_i,
   output ast_pkg::ast_alert_rsp_t       sensor_ctrl_ast_alert_rsp_o,
   input  ast_pkg::ast_status_t       sensor_ctrl_ast_status_i,
@@ -1510,6 +1510,7 @@ module top_earlgrey #(
       .clk_i (clkmgr_aon_clocks.clk_io_div4_powerup),
       .clk_slow_i (clkmgr_aon_clocks.clk_aon_powerup),
       .rst_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
+      .rst_main_ni (rstmgr_aon_resets.rst_por_aon_n[rstmgr_pkg::Domain0Sel]),
       .rst_slow_ni (rstmgr_aon_resets.rst_por_aon_n[rstmgr_pkg::DomainAonSel])
   );
 

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -176,7 +176,7 @@ module chip_earlgrey_verilator (
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .por_n_i                      (rst_ni            ),
+    .por_n_i                      ( {rst_ni, rst_ni} ),
     .clk_main_i                   (clk_i             ),
     .clk_io_i                     (clk_i             ),
     .clk_usb_i                    (clk_i             ),

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.cc
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.cc
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
   simctrl.RegisterExtension(&memutil);
 
   // see chip_earlgrey_verilator.cc for justification and explanation
-  simctrl.SetInitialResetDelay(500);
+  simctrl.SetInitialResetDelay(1000);
   simctrl.SetResetDuration(10);
 
   std::cout << "Simulation of OpenTitan English Breakfast" << std::endl

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -234,7 +234,7 @@
       type: "pwrmgr",
       clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "por", rst_slow_ni: "por_aon"},
+      reset_connections: {rst_ni: "por_io_div4", rst_main_ni: "por_aon", rst_slow_ni: "por_aon"},
       domain: ["Aon"],
       base_addr: "0x40400000",
       attr: "templated",

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -162,7 +162,7 @@ module chip_englishbreakfast_verilator (
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_englishbreakfast (
-    .por_n_i                      (rst_ni            ),
+    .por_n_i                      ({rst_ni, rst_ni}  ),
     .clk_main_i                   (clk_i             ),
     .clk_io_i                     (clk_i             ),
     .clk_usb_i                    (clk_i             ),

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -86,7 +86,7 @@ typedef enum dif_rstmgr_reset_info {
    * Device has reset due to a peripheral request. This can be an alert
    * escalation, watchdog or anything else.
    */
-  kDifRstmgrResetInfoHwReq = (0x7 << 3),
+  kDifRstmgrResetInfoHwReq = (0xf << 3),
 } dif_rstmgr_reset_info_t;
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -53,7 +53,7 @@ uint32_t rstmgr_reason_get(void) {
   // peripheral.
   REASON_ASSERT(kRstmgrReasonEscalation,
                 RSTMGR_RESET_INFO_HW_REQ_OFFSET +
-                    kTopEarlgreyPowerManagerResetRequestsLast + 1)
+                    kTopEarlgreyPowerManagerResetRequestsLast + 2)
 
   // Check that the last index corresponds to the last bit in HW_REQ.
   static_assert(

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -54,12 +54,13 @@ typedef enum rstmgr_reason {
    */
   kRstmgrReasonSysrstCtrl = 3,
   kRstmgrReasonWatchdog = 4,
-  kRstmgrReasonEscalation = 5,
+  kRstmgrReasonPowerUnstable = 5,
+  kRstmgrReasonEscalation = 6,
 
   /**
    * Last used bit index (inclusive).
    */
-  kRstmgrReasonLast = 5,
+  kRstmgrReasonLast = 6,
 } rstmgr_reason_t;
 
 /**

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -908,11 +908,13 @@ module chip_${top["name"]}_${target["name"]} (
   // Top-level design //
   //////////////////////
 
+  logic [rstmgr_pkg::PowerDomains-1:0] por_n;
+  assign por_n = {ast_pwst.main_pok, ast_pwst.aon_pok};
   top_${top["name"]} #(
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_${top["name"]} (
     // ast connections
-    .por_n_i                      ( ast_pwst.aon_pok           ),
+    .por_n_i                      ( por_n                      ),
     .clk_main_i                   ( ast_base_clks.clk_sys      ),
     .clk_io_i                     ( ast_base_clks.clk_io       ),
     .clk_usb_i                    ( ast_base_clks.clk_usb      ),
@@ -1087,7 +1089,7 @@ module chip_${top["name"]}_${target["name"]} (
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_${top["name"]} (
-    .por_n_i                      ( rst_n            ),
+    .por_n_i                      ( {rst_n, rst_n}   ),
     .clk_main_i                   ( clk_main         ),
     .clk_io_i                     ( clk_main         ),
     .clk_usb_i                    ( clk_usb_48mhz    ),


### PR DESCRIPTION
- Fixes #7928
- Fixes #7986
- Bypass low power entry handshaking when internal reset is observed
- Sparsely encode both fast / slow FSMs
- Check for unstable power and treat it as an internal reset source
- If the FSM gets out of sync, make a best case effort to kill the system