### PR TITLE
[dv/clkmgr] Fix clk_status testpoint

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -122,15 +122,14 @@ interface clkmgr_if (
     actual_clk_io_div4 = actual_div4_value;
   endfunction
 
-  task automatic init(logic [NUM_TRANS-1:0] idle, logic ip_clk_en, lc_ctrl_pkg::lc_tx_t scanmode,
+  task automatic init(logic [NUM_TRANS-1:0] idle, lc_ctrl_pkg::lc_tx_t scanmode,
                       lc_ctrl_pkg::lc_tx_t lc_dft_en = lc_ctrl_pkg::Off,
                       lc_ctrl_pkg::lc_tx_t lc_clk_byp_req = lc_ctrl_pkg::Off,
                       lc_ctrl_pkg::lc_tx_t ast_clk_byp_ack = lc_ctrl_pkg::Off);
     update_ast_clk_byp_ack(ast_clk_byp_ack);
+    update_idle(idle);
     update_lc_clk_byp_req(lc_clk_byp_req);
     update_lc_dft_en(lc_dft_en);
-    update_idle(idle);
-    update_ip_clk_en(ip_clk_en);
     update_scanmode(scanmode);
   endtask
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -117,22 +117,18 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     super.run_phase(phase);
     fork
       monitor_ast_clk_byp();
-      begin : post_reset
+      monitor_div4_peri_clock();
+      monitor_div2_peri_clock();
+      monitor_io_peri_clock();
+      monitor_usb_peri_clock();
+      for (int i = 0; i < NUM_TRANS; ++i) begin
         fork
-          monitor_div4_peri_clock();
-          monitor_div2_peri_clock();
-          monitor_io_peri_clock();
-          monitor_usb_peri_clock();
-          for (int i = 0; i < NUM_TRANS; ++i) begin
-            fork
-              automatic int trans_index = i;
-              monitor_trans_clock(trans_index);
-            join_none
-          end
-          monitor_clk_dividers();
-          monitor_jitter_en();
+          automatic int trans_index = i;
+          monitor_trans_clock(trans_index);
         join_none
       end
+      monitor_clk_dividers();
+      monitor_jitter_en();
     join_none
   endtask
 

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
@@ -6,47 +6,30 @@
 // - Transitions with ip_clk_en going active, assuming the usb clock is either active or inactive.
 // - Transitions with ip_clk_en going inactive, and assumming any subset of the clocks
 //   remain enabled (per controls in pwrmgr `control` CSR).
+//
+// The checks are done via SVA in clkmgr_pwrmgr_sva_if.
 class clkmgr_clk_status_vseq extends clkmgr_base_vseq;
   `uvm_object_utils(clkmgr_clk_status_vseq)
 
   `uvm_object_new
 
-  rand logic usb_clk_en_active;
-
-  // If usb_clk_en_active is off we stop the incoming usb clock.
-  task control_clocks();
-    if (usb_clk_en_active) cfg.usb_clk_rst_vif.start_clk();
-    else cfg.usb_clk_rst_vif.stop_clk();
-  endtask
-
-  function string create_failure_report();
-    return $sformatf(
-        "With ip_clk_en=%b, usb_clk_en_active=%b, clk_status is unexpectedly %b",
-        ip_clk_en,
-        usb_clk_en_active,
-        cfg.clkmgr_vif.pwr_o.clk_status
-    );
-  endfunction
+  // And disable scanmode since it is not interesting.
+  constraint scanmode_off_c {sel_scanmode == LcTxTSelOff;}
 
   task body();
     update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
       cfg.clk_rst_vif.wait_clks(4);
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
-      control_clocks();
-      cfg.clk_rst_vif.wait_clks(10);
+      cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode));
+      control_ip_clocks();
+
       // If some units were not idle, make them so.
       idle = '1;
       // Wait for idle to percolate.
       cfg.clk_rst_vif.wait_clks(10);
-      `DV_CHECK_EQ(cfg.clkmgr_vif.pwr_o.clk_status, ip_clk_en, create_failure_report())
-      // And set it back to a more common value for stress tests.
-      ip_clk_en = 1'b1;
-      usb_clk_en_active = 1'b1;
-      cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
-      control_clocks();
-      cfg.clk_rst_vif.wait_clks(10);
     end
+    // And set it back to more common values for stress tests.
+    initialize_on_start();
   endtask : body
 endclass : clkmgr_clk_status_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
@@ -40,6 +40,9 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
     !(lc_clk_byp_req_other inside {On, Off});
   }
 
+  // The extclk cannot be manipulated in low power mode.
+  constraint ip_clk_en_on_c {ip_clk_en == 1'b1;}
+
   // This randomizes the time when the extclk_sel CSR write and the lc_clk_byp_req
   // input is asserted for good measure. Of course, there is a good chance only a single
   // one of these trigger a request, so they are also independently tested.
@@ -96,8 +99,8 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       // Init needs to be synchronous.
       @cfg.clk_rst_vif.cb begin
-        cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode),
-                            .lc_dft_en(lc_dft_en));
+        cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode), .lc_dft_en(lc_dft_en));
+        control_ip_clocks();
       end
       fork
         begin
@@ -117,7 +120,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
                 scanmode
                 ), UVM_MEDIUM)
       csr_rd_check(.ptr(ral.extclk_sel), .compare_value(extclk_sel));
-      cfg.io_clk_rst_vif.wait_clks(cycles_before_next_trans);
+      cfg.clk_rst_vif.wait_clks(cycles_before_next_trans);
     end
     disable fork;
   endtask

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// peri test vseq
+// Tests the control of the peripheral clocks using clk_enables CSR.
 //
 // This is more general than the corresponding smoke test since it randomizes the initial
 // value of clk_enables CSR and the ip_clk_en input.
@@ -13,13 +13,16 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
 
   rand logic [NUM_PERI-1:0] initial_enables;
 
+  // The clk_enables CSR cannot be manipulated in low power mode.
+  constraint ip_clk_en_on_c {ip_clk_en == 1'b1;}
+
   task body();
     update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
       logic [NUM_PERI-1:0] flipped_enables;
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
-
+      cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode));
+      control_ip_clocks();
       csr_wr(.ptr(ral.clk_enables), .value(initial_enables));
 
       // Flip all bits of clk_enables.

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -19,6 +19,9 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
 
   rand bit [NUM_TRANS-1:0] initial_hints;
 
+  // The clk_hints CSR cannot be manipulated in low power mode.
+  constraint ip_clk_en_on_c {ip_clk_en == 1'b1;}
+
   task body();
     update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
@@ -26,8 +29,8 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
       logic [NUM_TRANS-1:0] value;
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      cfg.clkmgr_vif.init(.idle(idle), .ip_clk_en(ip_clk_en), .scanmode(scanmode));
-
+      cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode));
+      control_ip_clocks();
       cfg.clk_rst_vif.wait_clks(10);
       `uvm_info(`gfn, $sformatf("Updating hints to 0x%0x", initial_hints), UVM_MEDIUM)
       csr_wr(.ptr(ral.clk_hints), .value(initial_hints));

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -9,4 +9,8 @@ module clkmgr_bind;
   ) tlul_assert_device (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
 
   bind clkmgr clkmgr_csr_assert_fpv clkmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
+
+  bind clkmgr clkmgr_pwrmgr_sva_if clkmgr_pwrmgr_sva_if (
+    .clk_i, .rst_ni, .ip_clk_en(pwr_i.ip_clk_en), .clk_status(pwr_o.clk_status), .idle(idle_i)
+  );
 endmodule

--- a/hw/ip/clkmgr/dv/sva/clkmgr_pwrmgr_sva_if.core
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_pwrmgr_sva_if.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:clkmgr_pwrmgr_sva_if:0.1"
+description: "CLKMGR to PWRMGR assertion interface."
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - clkmgr_pwrmgr_sva_if.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/ip/clkmgr/dv/sva/clkmgr_pwrmgr_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_pwrmgr_sva_if.sv
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This contains SVA assertions to check that rising or falling edges of ip_clk_en
+// are followed by corresponding edges of clk_status. Notice when it falls the response
+// could be slower due to devices not being idle. We create two different assertions to
+// avoid very large wait times for them to be idle.
+interface clkmgr_pwrmgr_sva_if (
+  input logic clk_i,
+  input logic rst_ni,
+  input logic ip_clk_en,
+  input logic clk_status,
+  input logic [4:0] idle
+);
+
+  // The max times are longer to cover the different clock domain synchronizers.
+  // Ideally they would use the io_div4 clock, but it gets turned off when ip_clk_en
+  // goes inactive.
+  localparam int FallCyclesMin = 0;
+  localparam int FallCyclesMax = 16;
+
+  localparam int RiseCyclesMin = 0;
+  localparam int RiseCyclesMax = 16;
+
+  bit disable_sva;
+
+  // clk_status should fall if all units are idle when enable falls.
+  `ASSERT(StatusFallForDisableIdle_A,
+          $fell(ip_clk_en) && (idle == '1) |-> ##[FallCyclesMin:FallCyclesMax] $fell(clk_status),
+          clk_i, !rst_ni || disable_sva)
+
+  // clk_status should fall if all units become idle while enable is inactive.
+  `ASSERT(StatusFallForIdleDisable_A,
+          $rose(idle == '1) && !ip_clk_en |-> ##[FallCyclesMin:FallCyclesMax] $fell(clk_status),
+          clk_i, !rst_ni || disable_sva)
+
+  // clk_status whould rise is ip_clk_en rises.
+  `ASSERT(StatusRiseForEnable_A,
+          $rose(ip_clk_en) |-> ##[RiseCyclesMin:RiseCyclesMax] $rose(clk_status), clk_i,
+          !rst_ni || disable_sva)
+
+  // clk_status should not fall unless units are idle.
+  `ASSERT(NoStatusFallUnlessIdle_A, $fell(clk_status) |-> (idle == '1), clk_i,
+          !rst_ni || disable_sva)
+endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_sva.core
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_sva.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
+      - lowrisc:dv:clkmgr_pwrmgr_sva_if
     files:
       - clkmgr_bind.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
Fix problems in clk_status sequence.
Add SVA to cross check the clk_status output against ip_clk_en and
usb_clk_en_active.
Control the clocks as pwrmgr would do in response to changes in ip_clk_en.
Disable randomization of usb_clk_en_active to avoid failures due to issue

Signed-off-by: Guillermo Maturana <maturana@google.com>