### PR TITLE
[otbn,dv] Remove debug prints from BadCallStackRW; give it a weight

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -17,6 +17,7 @@ gen-weights:
   ECall: 1
   BadAtEnd: 1
   BadBNMovr: 1
+  BadCallStackRW: 1
   BadDeepLoop: 1
   BadInsn: 1
   BadGiantLoop: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/call_stack_rw.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/call_stack_rw.py
@@ -196,7 +196,6 @@ class BadCallStackRW(CallStackRW):
 
         mode_ret = self._pick_mode(model)
         if mode_ret is None:
-            print('boo (unknown)')
             return None
 
         is_overflow, steps = mode_ret
@@ -204,7 +203,6 @@ class BadCallStackRW(CallStackRW):
         # We will generate steps instructions in a straight line: make sure
         # we've got space.
         if program.get_insn_space_at(model.pc) < steps:
-            print('boo (squashed)')
             return None
 
         assert steps > 0
@@ -233,7 +231,5 @@ class BadCallStackRW(CallStackRW):
         # exception, the result doesn't matter). But move PC to the final
         # instruction.
         model.pc += 4 * (len(prog_insns) - 1)
-
-        print('success!')
 
         return (snippet, True, model)


### PR DESCRIPTION
Oops, sorry guys! I didn't clean up 8b76725df0269f171b827dcbe0b775dfa49c1692 as much as I thought I had :-/