### PR TITLE
[util] Tidy up how we call finst_gen in reg_top.sv.tpl

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -1210,7 +1210,6 @@ module adc_ctrl_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1237,7 +1236,6 @@ module adc_ctrl_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1264,7 +1262,6 @@ module adc_ctrl_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -1280,7 +1277,6 @@ module adc_ctrl_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1296,7 +1292,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_en_ctl]: V(False)
-
   //   F[adc_enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1321,7 +1316,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_adc_en_ctl_adc_enable_qs_int)
   );
-
 
   //   F[oneshot_mode]: 1:1
   prim_subreg #(
@@ -1350,7 +1344,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_pd_ctl]: V(False)
-
   //   F[lp_mode]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1376,7 +1369,6 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_pd_ctl_lp_mode_qs_int)
   );
 
-
   //   F[pwrup_time]: 7:4
   prim_subreg #(
     .DW      (4),
@@ -1401,7 +1393,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_adc_pd_ctl_pwrup_time_qs_int)
   );
-
 
   //   F[wakeup_time]: 31:8
   prim_subreg #(
@@ -1430,7 +1421,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_lp_sample_ctl]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1457,7 +1447,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_sample_ctl]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1484,7 +1473,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_fsm_rst]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1510,11 +1498,9 @@ module adc_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_0]: V(False)
-
-  // F[min_v_0]: 11:2
+  //   F[min_v_0]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1539,8 +1525,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_0_min_v_0_qs_int)
   );
 
-
-  // F[cond_0]: 12:12
+  //   F[cond_0]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1565,8 +1550,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_0_cond_0_qs_int)
   );
 
-
-  // F[max_v_0]: 27:18
+  //   F[max_v_0]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1591,8 +1575,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_0_max_v_0_qs_int)
   );
 
-
-  // F[en_0]: 31:31
+  //   F[en_0]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1620,8 +1603,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 1 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_1]: V(False)
-
-  // F[min_v_1]: 11:2
+  //   F[min_v_1]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1646,8 +1628,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_1_min_v_1_qs_int)
   );
 
-
-  // F[cond_1]: 12:12
+  //   F[cond_1]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1672,8 +1653,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_1_cond_1_qs_int)
   );
 
-
-  // F[max_v_1]: 27:18
+  //   F[max_v_1]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1698,8 +1678,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_1_max_v_1_qs_int)
   );
 
-
-  // F[en_1]: 31:31
+  //   F[en_1]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1727,8 +1706,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 2 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_2]: V(False)
-
-  // F[min_v_2]: 11:2
+  //   F[min_v_2]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1753,8 +1731,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_2_min_v_2_qs_int)
   );
 
-
-  // F[cond_2]: 12:12
+  //   F[cond_2]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1779,8 +1756,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_2_cond_2_qs_int)
   );
 
-
-  // F[max_v_2]: 27:18
+  //   F[max_v_2]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1805,8 +1781,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_2_max_v_2_qs_int)
   );
 
-
-  // F[en_2]: 31:31
+  //   F[en_2]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1834,8 +1809,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 3 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_3]: V(False)
-
-  // F[min_v_3]: 11:2
+  //   F[min_v_3]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1860,8 +1834,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_3_min_v_3_qs_int)
   );
 
-
-  // F[cond_3]: 12:12
+  //   F[cond_3]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1886,8 +1859,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_3_cond_3_qs_int)
   );
 
-
-  // F[max_v_3]: 27:18
+  //   F[max_v_3]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1912,8 +1884,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_3_max_v_3_qs_int)
   );
 
-
-  // F[en_3]: 31:31
+  //   F[en_3]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1941,8 +1912,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 4 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_4]: V(False)
-
-  // F[min_v_4]: 11:2
+  //   F[min_v_4]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1967,8 +1937,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_4_min_v_4_qs_int)
   );
 
-
-  // F[cond_4]: 12:12
+  //   F[cond_4]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1993,8 +1962,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_4_cond_4_qs_int)
   );
 
-
-  // F[max_v_4]: 27:18
+  //   F[max_v_4]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2019,8 +1987,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_4_max_v_4_qs_int)
   );
 
-
-  // F[en_4]: 31:31
+  //   F[en_4]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2048,8 +2015,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 5 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_5]: V(False)
-
-  // F[min_v_5]: 11:2
+  //   F[min_v_5]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2074,8 +2040,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_5_min_v_5_qs_int)
   );
 
-
-  // F[cond_5]: 12:12
+  //   F[cond_5]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2100,8 +2065,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_5_cond_5_qs_int)
   );
 
-
-  // F[max_v_5]: 27:18
+  //   F[max_v_5]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2126,8 +2090,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_5_max_v_5_qs_int)
   );
 
-
-  // F[en_5]: 31:31
+  //   F[en_5]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2155,8 +2118,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 6 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_6]: V(False)
-
-  // F[min_v_6]: 11:2
+  //   F[min_v_6]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2181,8 +2143,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_6_min_v_6_qs_int)
   );
 
-
-  // F[cond_6]: 12:12
+  //   F[cond_6]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2207,8 +2168,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_6_cond_6_qs_int)
   );
 
-
-  // F[max_v_6]: 27:18
+  //   F[max_v_6]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2233,8 +2193,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_6_max_v_6_qs_int)
   );
 
-
-  // F[en_6]: 31:31
+  //   F[en_6]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2262,8 +2221,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 7 of Multireg adc_chn0_filter_ctl
   // R[adc_chn0_filter_ctl_7]: V(False)
-
-  // F[min_v_7]: 11:2
+  //   F[min_v_7]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2288,8 +2246,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_7_min_v_7_qs_int)
   );
 
-
-  // F[cond_7]: 12:12
+  //   F[cond_7]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2314,8 +2271,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_7_cond_7_qs_int)
   );
 
-
-  // F[max_v_7]: 27:18
+  //   F[max_v_7]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2340,8 +2296,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn0_filter_ctl_7_max_v_7_qs_int)
   );
 
-
-  // F[en_7]: 31:31
+  //   F[en_7]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2367,12 +2322,9 @@ module adc_ctrl_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_0]: V(False)
-
-  // F[min_v_0]: 11:2
+  //   F[min_v_0]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2397,8 +2349,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_0_min_v_0_qs_int)
   );
 
-
-  // F[cond_0]: 12:12
+  //   F[cond_0]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2423,8 +2374,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_0_cond_0_qs_int)
   );
 
-
-  // F[max_v_0]: 27:18
+  //   F[max_v_0]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2449,8 +2399,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_0_max_v_0_qs_int)
   );
 
-
-  // F[en_0]: 31:31
+  //   F[en_0]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2478,8 +2427,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 1 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_1]: V(False)
-
-  // F[min_v_1]: 11:2
+  //   F[min_v_1]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2504,8 +2452,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_1_min_v_1_qs_int)
   );
 
-
-  // F[cond_1]: 12:12
+  //   F[cond_1]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2530,8 +2477,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_1_cond_1_qs_int)
   );
 
-
-  // F[max_v_1]: 27:18
+  //   F[max_v_1]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2556,8 +2502,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_1_max_v_1_qs_int)
   );
 
-
-  // F[en_1]: 31:31
+  //   F[en_1]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2585,8 +2530,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 2 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_2]: V(False)
-
-  // F[min_v_2]: 11:2
+  //   F[min_v_2]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2611,8 +2555,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_2_min_v_2_qs_int)
   );
 
-
-  // F[cond_2]: 12:12
+  //   F[cond_2]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2637,8 +2580,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_2_cond_2_qs_int)
   );
 
-
-  // F[max_v_2]: 27:18
+  //   F[max_v_2]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2663,8 +2605,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_2_max_v_2_qs_int)
   );
 
-
-  // F[en_2]: 31:31
+  //   F[en_2]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2692,8 +2633,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 3 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_3]: V(False)
-
-  // F[min_v_3]: 11:2
+  //   F[min_v_3]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2718,8 +2658,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_3_min_v_3_qs_int)
   );
 
-
-  // F[cond_3]: 12:12
+  //   F[cond_3]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2744,8 +2683,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_3_cond_3_qs_int)
   );
 
-
-  // F[max_v_3]: 27:18
+  //   F[max_v_3]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2770,8 +2708,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_3_max_v_3_qs_int)
   );
 
-
-  // F[en_3]: 31:31
+  //   F[en_3]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2799,8 +2736,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 4 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_4]: V(False)
-
-  // F[min_v_4]: 11:2
+  //   F[min_v_4]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2825,8 +2761,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_4_min_v_4_qs_int)
   );
 
-
-  // F[cond_4]: 12:12
+  //   F[cond_4]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2851,8 +2786,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_4_cond_4_qs_int)
   );
 
-
-  // F[max_v_4]: 27:18
+  //   F[max_v_4]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2877,8 +2811,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_4_max_v_4_qs_int)
   );
 
-
-  // F[en_4]: 31:31
+  //   F[en_4]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2906,8 +2839,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 5 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_5]: V(False)
-
-  // F[min_v_5]: 11:2
+  //   F[min_v_5]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2932,8 +2864,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_5_min_v_5_qs_int)
   );
 
-
-  // F[cond_5]: 12:12
+  //   F[cond_5]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2958,8 +2889,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_5_cond_5_qs_int)
   );
 
-
-  // F[max_v_5]: 27:18
+  //   F[max_v_5]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2984,8 +2914,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_5_max_v_5_qs_int)
   );
 
-
-  // F[en_5]: 31:31
+  //   F[en_5]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3013,8 +2942,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 6 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_6]: V(False)
-
-  // F[min_v_6]: 11:2
+  //   F[min_v_6]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3039,8 +2967,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_6_min_v_6_qs_int)
   );
 
-
-  // F[cond_6]: 12:12
+  //   F[cond_6]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3065,8 +2992,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_6_cond_6_qs_int)
   );
 
-
-  // F[max_v_6]: 27:18
+  //   F[max_v_6]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3091,8 +3017,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_6_max_v_6_qs_int)
   );
 
-
-  // F[en_6]: 31:31
+  //   F[en_6]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3120,8 +3045,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 7 of Multireg adc_chn1_filter_ctl
   // R[adc_chn1_filter_ctl_7]: V(False)
-
-  // F[min_v_7]: 11:2
+  //   F[min_v_7]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3146,8 +3070,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_7_min_v_7_qs_int)
   );
 
-
-  // F[cond_7]: 12:12
+  //   F[cond_7]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3172,8 +3095,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_7_cond_7_qs_int)
   );
 
-
-  // F[max_v_7]: 27:18
+  //   F[max_v_7]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3198,8 +3120,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn1_filter_ctl_7_max_v_7_qs_int)
   );
 
-
-  // F[en_7]: 31:31
+  //   F[en_7]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3225,12 +3146,9 @@ module adc_ctrl_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg adc_chn_val
   // R[adc_chn_val_0]: V(False)
-
-  // F[adc_chn_value_ext_0]: 1:0
+  //   F[adc_chn_value_ext_0]: 1:0
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3255,8 +3173,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn_val_0_adc_chn_value_ext_0_qs_int)
   );
 
-
-  // F[adc_chn_value_0]: 11:2
+  //   F[adc_chn_value_0]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3281,8 +3198,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn_val_0_adc_chn_value_0_qs_int)
   );
 
-
-  // F[adc_chn_value_intr_ext_0]: 17:16
+  //   F[adc_chn_value_intr_ext_0]: 17:16
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3307,8 +3223,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn_val_0_adc_chn_value_intr_ext_0_qs_int)
   );
 
-
-  // F[adc_chn_value_intr_0]: 27:18
+  //   F[adc_chn_value_intr_0]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3336,8 +3251,7 @@ module adc_ctrl_reg_top (
 
   // Subregister 1 of Multireg adc_chn_val
   // R[adc_chn_val_1]: V(False)
-
-  // F[adc_chn_value_ext_1]: 1:0
+  //   F[adc_chn_value_ext_1]: 1:0
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3362,8 +3276,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn_val_1_adc_chn_value_ext_1_qs_int)
   );
 
-
-  // F[adc_chn_value_1]: 11:2
+  //   F[adc_chn_value_1]: 11:2
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3388,8 +3301,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn_val_1_adc_chn_value_1_qs_int)
   );
 
-
-  // F[adc_chn_value_intr_ext_1]: 17:16
+  //   F[adc_chn_value_intr_ext_1]: 17:16
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3414,8 +3326,7 @@ module adc_ctrl_reg_top (
     .qs     (aon_adc_chn_val_1_adc_chn_value_intr_ext_1_qs_int)
   );
 
-
-  // F[adc_chn_value_intr_1]: 27:18
+  //   F[adc_chn_value_intr_1]: 27:18
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3441,9 +3352,7 @@ module adc_ctrl_reg_top (
   );
 
 
-
   // R[adc_wakeup_ctl]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3470,7 +3379,6 @@ module adc_ctrl_reg_top (
 
 
   // R[filter_status]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3497,7 +3405,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_intr_ctl]: V(False)
-
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3524,7 +3431,6 @@ module adc_ctrl_reg_top (
 
 
   // R[adc_intr_status]: V(False)
-
   //   F[cc_sink_det]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -3549,7 +3455,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (adc_intr_status_cc_sink_det_qs)
   );
-
 
   //   F[cc_1a5_sink_det]: 1:1
   prim_subreg #(
@@ -3576,7 +3481,6 @@ module adc_ctrl_reg_top (
     .qs     (adc_intr_status_cc_1a5_sink_det_qs)
   );
 
-
   //   F[cc_3a0_sink_det]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -3601,7 +3505,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (adc_intr_status_cc_3a0_sink_det_qs)
   );
-
 
   //   F[cc_src_det]: 3:3
   prim_subreg #(
@@ -3628,7 +3531,6 @@ module adc_ctrl_reg_top (
     .qs     (adc_intr_status_cc_src_det_qs)
   );
 
-
   //   F[cc_1a5_src_det]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -3653,7 +3555,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (adc_intr_status_cc_1a5_src_det_qs)
   );
-
 
   //   F[cc_src_det_flip]: 5:5
   prim_subreg #(
@@ -3680,7 +3581,6 @@ module adc_ctrl_reg_top (
     .qs     (adc_intr_status_cc_src_det_flip_qs)
   );
 
-
   //   F[cc_1a5_src_det_flip]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -3705,7 +3605,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (adc_intr_status_cc_1a5_src_det_flip_qs)
   );
-
 
   //   F[cc_discon]: 7:7
   prim_subreg #(
@@ -3732,7 +3631,6 @@ module adc_ctrl_reg_top (
     .qs     (adc_intr_status_cc_discon_qs)
   );
 
-
   //   F[oneshot]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -3757,7 +3655,6 @@ module adc_ctrl_reg_top (
     // to register interface (read)
     .qs     (adc_intr_status_oneshot_qs)
   );
-
 
 
 

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -194,7 +194,6 @@ module aes_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   //   F[recov_ctrl_update_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -208,7 +207,6 @@ module aes_reg_top (
     .q      (reg2hw.alert_test.recov_ctrl_update_err.q),
     .qs     ()
   );
-
 
   //   F[fatal_fault]: 1:1
   prim_subreg_ext #(
@@ -225,10 +223,8 @@ module aes_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg key_share0
   // R[key_share0_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_0 (
@@ -242,9 +238,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg key_share0
   // R[key_share0_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_1 (
@@ -258,9 +254,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg key_share0
   // R[key_share0_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_2 (
@@ -274,9 +270,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg key_share0
   // R[key_share0_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_3 (
@@ -290,9 +286,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 4 of Multireg key_share0
   // R[key_share0_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_4 (
@@ -306,9 +302,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 5 of Multireg key_share0
   // R[key_share0_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_5 (
@@ -322,9 +318,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 6 of Multireg key_share0
   // R[key_share0_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_6 (
@@ -338,9 +334,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 7 of Multireg key_share0
   // R[key_share0_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_7 (
@@ -355,10 +351,8 @@ module aes_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg key_share1
   // R[key_share1_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_0 (
@@ -372,9 +366,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg key_share1
   // R[key_share1_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_1 (
@@ -388,9 +382,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg key_share1
   // R[key_share1_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_2 (
@@ -404,9 +398,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg key_share1
   // R[key_share1_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_3 (
@@ -420,9 +414,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 4 of Multireg key_share1
   // R[key_share1_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_4 (
@@ -436,9 +430,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 5 of Multireg key_share1
   // R[key_share1_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_5 (
@@ -452,9 +446,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 6 of Multireg key_share1
   // R[key_share1_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_6 (
@@ -468,9 +462,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 7 of Multireg key_share1
   // R[key_share1_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_7 (
@@ -485,10 +479,8 @@ module aes_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg iv
   // R[iv_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_0 (
@@ -502,9 +494,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg iv
   // R[iv_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_1 (
@@ -518,9 +510,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg iv
   // R[iv_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_2 (
@@ -534,9 +526,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg iv
   // R[iv_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_3 (
@@ -551,10 +543,8 @@ module aes_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg data_in
   // R[data_in_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -579,9 +569,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg data_in
   // R[data_in_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -606,9 +596,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg data_in
   // R[data_in_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -633,9 +623,9 @@ module aes_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg data_in
   // R[data_in_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -661,10 +651,8 @@ module aes_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg data_out
   // R[data_out_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_data_out_0 (
@@ -678,9 +666,9 @@ module aes_reg_top (
     .qs     (data_out_0_qs)
   );
 
+
   // Subregister 1 of Multireg data_out
   // R[data_out_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_data_out_1 (
@@ -694,9 +682,9 @@ module aes_reg_top (
     .qs     (data_out_1_qs)
   );
 
+
   // Subregister 2 of Multireg data_out
   // R[data_out_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_data_out_2 (
@@ -710,9 +698,9 @@ module aes_reg_top (
     .qs     (data_out_2_qs)
   );
 
+
   // Subregister 3 of Multireg data_out
   // R[data_out_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_data_out_3 (
@@ -728,7 +716,6 @@ module aes_reg_top (
 
 
   // R[ctrl_shadowed]: V(True)
-
   //   F[operation]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -742,7 +729,6 @@ module aes_reg_top (
     .q      (reg2hw.ctrl_shadowed.operation.q),
     .qs     (ctrl_shadowed_operation_qs)
   );
-
 
   //   F[mode]: 6:1
   prim_subreg_ext #(
@@ -758,7 +744,6 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_mode_qs)
   );
 
-
   //   F[key_len]: 9:7
   prim_subreg_ext #(
     .DW    (3)
@@ -773,7 +758,6 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_key_len_qs)
   );
 
-
   //   F[manual_operation]: 10:10
   prim_subreg_ext #(
     .DW    (1)
@@ -787,7 +771,6 @@ module aes_reg_top (
     .q      (reg2hw.ctrl_shadowed.manual_operation.q),
     .qs     (ctrl_shadowed_manual_operation_qs)
   );
-
 
   //   F[force_zero_masks]: 11:11
   prim_subreg_ext #(
@@ -805,7 +788,6 @@ module aes_reg_top (
 
 
   // R[trigger]: V(False)
-
   //   F[start]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -830,7 +812,6 @@ module aes_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[key_iv_data_in_clear]: 1:1
   prim_subreg #(
@@ -857,7 +838,6 @@ module aes_reg_top (
     .qs     ()
   );
 
-
   //   F[data_out_clear]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -882,7 +862,6 @@ module aes_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[prng_reseed]: 3:3
   prim_subreg #(
@@ -911,7 +890,6 @@ module aes_reg_top (
 
 
   // R[status]: V(False)
-
   //   F[idle]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -936,7 +914,6 @@ module aes_reg_top (
     // to register interface (read)
     .qs     (status_idle_qs)
   );
-
 
   //   F[stall]: 1:1
   prim_subreg #(
@@ -963,7 +940,6 @@ module aes_reg_top (
     .qs     (status_stall_qs)
   );
 
-
   //   F[output_lost]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -988,7 +964,6 @@ module aes_reg_top (
     // to register interface (read)
     .qs     (status_output_lost_qs)
   );
-
 
   //   F[output_valid]: 3:3
   prim_subreg #(
@@ -1015,7 +990,6 @@ module aes_reg_top (
     .qs     (status_output_valid_qs)
   );
 
-
   //   F[input_ready]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1040,7 +1014,6 @@ module aes_reg_top (
     // to register interface (read)
     .qs     (status_input_ready_qs)
   );
-
 
   //   F[alert_recov_ctrl_update_err]: 5:5
   prim_subreg #(
@@ -1067,7 +1040,6 @@ module aes_reg_top (
     .qs     (status_alert_recov_ctrl_update_err_qs)
   );
 
-
   //   F[alert_fatal_fault]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -1092,7 +1064,6 @@ module aes_reg_top (
     // to register interface (read)
     .qs     (status_alert_fatal_fault_qs)
   );
-
 
 
 

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_top.sv
@@ -564,7 +564,6 @@ module alert_handler_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[classa]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -589,7 +588,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_state_classa_qs)
   );
-
 
   //   F[classb]: 1:1
   prim_subreg #(
@@ -616,7 +614,6 @@ module alert_handler_reg_top (
     .qs     (intr_state_classb_qs)
   );
 
-
   //   F[classc]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -641,7 +638,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_state_classc_qs)
   );
-
 
   //   F[classd]: 3:3
   prim_subreg #(
@@ -670,7 +666,6 @@ module alert_handler_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[classa]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -695,7 +690,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_enable_classa_qs)
   );
-
 
   //   F[classb]: 1:1
   prim_subreg #(
@@ -722,7 +716,6 @@ module alert_handler_reg_top (
     .qs     (intr_enable_classb_qs)
   );
 
-
   //   F[classc]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -747,7 +740,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_enable_classc_qs)
   );
-
 
   //   F[classd]: 3:3
   prim_subreg #(
@@ -776,7 +768,6 @@ module alert_handler_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[classa]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -790,7 +781,6 @@ module alert_handler_reg_top (
     .q      (reg2hw.intr_test.classa.q),
     .qs     ()
   );
-
 
   //   F[classb]: 1:1
   prim_subreg_ext #(
@@ -806,7 +796,6 @@ module alert_handler_reg_top (
     .qs     ()
   );
 
-
   //   F[classc]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -820,7 +809,6 @@ module alert_handler_reg_top (
     .q      (reg2hw.intr_test.classc.q),
     .qs     ()
   );
-
 
   //   F[classd]: 3:3
   prim_subreg_ext #(
@@ -838,7 +826,6 @@ module alert_handler_reg_top (
 
 
   // R[ping_timer_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -865,7 +852,6 @@ module alert_handler_reg_top (
 
 
   // R[ping_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -898,7 +884,6 @@ module alert_handler_reg_top (
 
 
   // R[ping_timer_en_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -930,10 +915,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_regwen
   // R[alert_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -958,9 +941,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg alert_regwen
   // R[alert_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -985,9 +968,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg alert_regwen
   // R[alert_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1012,9 +995,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg alert_regwen
   // R[alert_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1040,10 +1023,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1074,9 +1055,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1107,9 +1088,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1140,9 +1121,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1174,10 +1155,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1208,9 +1187,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1241,9 +1220,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1274,9 +1253,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1308,10 +1287,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_cause
   // R[alert_cause_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1336,9 +1313,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_0_qs)
   );
 
+
   // Subregister 1 of Multireg alert_cause
   // R[alert_cause_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1363,9 +1340,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_1_qs)
   );
 
+
   // Subregister 2 of Multireg alert_cause
   // R[alert_cause_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1390,9 +1367,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_2_qs)
   );
 
+
   // Subregister 3 of Multireg alert_cause
   // R[alert_cause_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1418,10 +1395,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1446,9 +1421,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1473,9 +1448,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1500,9 +1475,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1527,9 +1502,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1554,9 +1529,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1581,9 +1556,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1609,10 +1584,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1643,9 +1616,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1676,9 +1649,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1709,9 +1682,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1742,9 +1715,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[3].err_storage)
   );
 
+
   // Subregister 4 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_4]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1775,9 +1748,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[4].err_storage)
   );
 
+
   // Subregister 5 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_5]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1808,9 +1781,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[5].err_storage)
   );
 
+
   // Subregister 6 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_6]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1842,10 +1815,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1876,9 +1847,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1909,9 +1880,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1942,9 +1913,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1975,9 +1946,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[3].err_storage)
   );
 
+
   // Subregister 4 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_4]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2008,9 +1979,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[4].err_storage)
   );
 
+
   // Subregister 5 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_5]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2041,9 +2012,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[5].err_storage)
   );
 
+
   // Subregister 6 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_6]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2075,10 +2046,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_cause
   // R[loc_alert_cause_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2103,9 +2072,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_0_qs)
   );
 
+
   // Subregister 1 of Multireg loc_alert_cause
   // R[loc_alert_cause_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2130,9 +2099,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_1_qs)
   );
 
+
   // Subregister 2 of Multireg loc_alert_cause
   // R[loc_alert_cause_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2157,9 +2126,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_2_qs)
   );
 
+
   // Subregister 3 of Multireg loc_alert_cause
   // R[loc_alert_cause_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2184,9 +2153,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_3_qs)
   );
 
+
   // Subregister 4 of Multireg loc_alert_cause
   // R[loc_alert_cause_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2211,9 +2180,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_4_qs)
   );
 
+
   // Subregister 5 of Multireg loc_alert_cause
   // R[loc_alert_cause_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2238,9 +2207,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_5_qs)
   );
 
+
   // Subregister 6 of Multireg loc_alert_cause
   // R[loc_alert_cause_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2267,7 +2236,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2294,7 +2262,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -2325,7 +2292,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -2358,7 +2324,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -2389,7 +2354,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -2422,7 +2386,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -2453,7 +2416,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -2486,7 +2448,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -2517,7 +2478,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -2550,7 +2510,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -2581,7 +2540,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -2616,7 +2574,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2643,7 +2600,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2676,7 +2632,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classa_accum_cnt (
@@ -2692,7 +2647,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2725,7 +2679,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2758,7 +2711,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2791,7 +2743,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2824,7 +2775,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2857,7 +2807,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2890,7 +2839,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2923,7 +2871,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classa_esc_cnt (
@@ -2939,7 +2886,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classa_state (
@@ -2955,7 +2901,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2982,7 +2927,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -3013,7 +2957,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -3046,7 +2989,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -3077,7 +3019,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -3110,7 +3051,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -3141,7 +3081,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -3174,7 +3113,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -3205,7 +3143,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -3238,7 +3175,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -3269,7 +3205,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -3304,7 +3239,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3331,7 +3265,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3364,7 +3297,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classb_accum_cnt (
@@ -3380,7 +3312,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3413,7 +3344,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3446,7 +3376,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3479,7 +3408,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3512,7 +3440,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3545,7 +3472,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3578,7 +3504,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3611,7 +3536,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classb_esc_cnt (
@@ -3627,7 +3551,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classb_state (
@@ -3643,7 +3566,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3670,7 +3592,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -3701,7 +3622,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -3734,7 +3654,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -3765,7 +3684,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -3798,7 +3716,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -3829,7 +3746,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -3862,7 +3778,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -3893,7 +3808,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -3926,7 +3840,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -3957,7 +3870,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -3992,7 +3904,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4019,7 +3930,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4052,7 +3962,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classc_accum_cnt (
@@ -4068,7 +3977,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4101,7 +4009,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4134,7 +4041,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4167,7 +4073,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4200,7 +4105,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4233,7 +4137,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4266,7 +4169,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4299,7 +4201,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classc_esc_cnt (
@@ -4315,7 +4216,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classc_state (
@@ -4331,7 +4231,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4358,7 +4257,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -4389,7 +4287,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -4422,7 +4319,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -4453,7 +4349,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -4486,7 +4381,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -4517,7 +4411,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -4550,7 +4443,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -4581,7 +4473,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -4614,7 +4505,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -4645,7 +4535,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -4680,7 +4569,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4707,7 +4595,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4740,7 +4627,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classd_accum_cnt (
@@ -4756,7 +4642,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4789,7 +4674,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4822,7 +4706,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4855,7 +4738,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4888,7 +4770,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4921,7 +4802,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4954,7 +4834,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4987,7 +4866,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classd_esc_cnt (
@@ -5003,7 +4881,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classd_state (
@@ -5016,7 +4893,6 @@ module alert_handler_reg_top (
     .q      (),
     .qs     (classd_state_qs)
   );
-
 
 
 

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -448,7 +448,6 @@ module aon_timer_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -464,7 +463,6 @@ module aon_timer_reg_top (
 
 
   // R[wkup_ctrl]: V(False)
-
   //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -489,7 +487,6 @@ module aon_timer_reg_top (
     // to register interface (read)
     .qs     (aon_wkup_ctrl_enable_qs_int)
   );
-
 
   //   F[prescaler]: 12:1
   prim_subreg #(
@@ -518,7 +515,6 @@ module aon_timer_reg_top (
 
 
   // R[wkup_thold]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -545,7 +541,6 @@ module aon_timer_reg_top (
 
 
   // R[wkup_count]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -572,7 +567,6 @@ module aon_timer_reg_top (
 
 
   // R[wdog_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -599,7 +593,6 @@ module aon_timer_reg_top (
 
 
   // R[wdog_ctrl]: V(False)
-
   //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -624,7 +617,6 @@ module aon_timer_reg_top (
     // to register interface (read)
     .qs     (aon_wdog_ctrl_enable_qs_int)
   );
-
 
   //   F[pause_in_sleep]: 1:1
   prim_subreg #(
@@ -653,7 +645,6 @@ module aon_timer_reg_top (
 
 
   // R[wdog_bark_thold]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -680,7 +671,6 @@ module aon_timer_reg_top (
 
 
   // R[wdog_bite_thold]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -707,7 +697,6 @@ module aon_timer_reg_top (
 
 
   // R[wdog_count]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -734,7 +723,6 @@ module aon_timer_reg_top (
 
 
   // R[intr_state]: V(False)
-
   //   F[wkup_timer_expired]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -759,7 +747,6 @@ module aon_timer_reg_top (
     // to register interface (read)
     .qs     (intr_state_wkup_timer_expired_qs)
   );
-
 
   //   F[wdog_timer_expired]: 1:1
   prim_subreg #(
@@ -788,7 +775,6 @@ module aon_timer_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[wkup_timer_expired]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -802,7 +788,6 @@ module aon_timer_reg_top (
     .q      (reg2hw.intr_test.wkup_timer_expired.q),
     .qs     ()
   );
-
 
   //   F[wdog_timer_expired]: 1:1
   prim_subreg_ext #(
@@ -820,7 +805,6 @@ module aon_timer_reg_top (
 
 
   // R[wkup_cause]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -844,7 +828,6 @@ module aon_timer_reg_top (
     // to register interface (read)
     .qs     (aon_wkup_cause_qs_int)
   );
-
 
 
 

--- a/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_reg_top.sv
@@ -123,7 +123,6 @@ module clkmgr_reg_top (
 
   // Register instances
   // R[clk_enables]: V(False)
-
   //   F[clk_fixed_peri_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -148,7 +147,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_enables_clk_fixed_peri_en_qs)
   );
-
 
   //   F[clk_usb_48mhz_peri_en]: 1:1
   prim_subreg #(
@@ -177,7 +175,6 @@ module clkmgr_reg_top (
 
 
   // R[clk_hints]: V(False)
-
   //   F[clk_main_aes_hint]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -202,7 +199,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_clk_main_aes_hint_qs)
   );
-
 
   //   F[clk_main_hmac_hint]: 1:1
   prim_subreg #(
@@ -231,7 +227,6 @@ module clkmgr_reg_top (
 
 
   // R[clk_hints_status]: V(False)
-
   //   F[clk_main_aes_val]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -257,7 +252,6 @@ module clkmgr_reg_top (
     .qs     (clk_hints_status_clk_main_aes_val_qs)
   );
 
-
   //   F[clk_main_hmac_val]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -282,7 +276,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_status_clk_main_hmac_val_qs)
   );
-
 
 
 

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -205,7 +205,6 @@ module csrng_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[cs_cmd_req_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -230,7 +229,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (intr_state_cs_cmd_req_done_qs)
   );
-
 
   //   F[cs_entropy_req]: 1:1
   prim_subreg #(
@@ -257,7 +255,6 @@ module csrng_reg_top (
     .qs     (intr_state_cs_entropy_req_qs)
   );
 
-
   //   F[cs_hw_inst_exc]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -282,7 +279,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (intr_state_cs_hw_inst_exc_qs)
   );
-
 
   //   F[cs_fatal_err]: 3:3
   prim_subreg #(
@@ -311,7 +307,6 @@ module csrng_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[cs_cmd_req_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -336,7 +331,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (intr_enable_cs_cmd_req_done_qs)
   );
-
 
   //   F[cs_entropy_req]: 1:1
   prim_subreg #(
@@ -363,7 +357,6 @@ module csrng_reg_top (
     .qs     (intr_enable_cs_entropy_req_qs)
   );
 
-
   //   F[cs_hw_inst_exc]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -388,7 +381,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (intr_enable_cs_hw_inst_exc_qs)
   );
-
 
   //   F[cs_fatal_err]: 3:3
   prim_subreg #(
@@ -417,7 +409,6 @@ module csrng_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[cs_cmd_req_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -431,7 +422,6 @@ module csrng_reg_top (
     .q      (reg2hw.intr_test.cs_cmd_req_done.q),
     .qs     ()
   );
-
 
   //   F[cs_entropy_req]: 1:1
   prim_subreg_ext #(
@@ -447,7 +437,6 @@ module csrng_reg_top (
     .qs     ()
   );
 
-
   //   F[cs_hw_inst_exc]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -461,7 +450,6 @@ module csrng_reg_top (
     .q      (reg2hw.intr_test.cs_hw_inst_exc.q),
     .qs     ()
   );
-
 
   //   F[cs_fatal_err]: 3:3
   prim_subreg_ext #(
@@ -479,7 +467,6 @@ module csrng_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -493,7 +480,6 @@ module csrng_reg_top (
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
-
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -511,7 +497,6 @@ module csrng_reg_top (
 
 
   // R[regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -538,7 +523,6 @@ module csrng_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[enable]: 3:0
   prim_subreg #(
     .DW      (4),
@@ -564,7 +548,6 @@ module csrng_reg_top (
     .qs     (ctrl_enable_qs)
   );
 
-
   //   F[sw_app_enable]: 7:4
   prim_subreg #(
     .DW      (4),
@@ -589,7 +572,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (ctrl_sw_app_enable_qs)
   );
-
 
   //   F[read_int_state]: 11:8
   prim_subreg #(
@@ -618,7 +600,6 @@ module csrng_reg_top (
 
 
   // R[cmd_req]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -645,7 +626,6 @@ module csrng_reg_top (
 
 
   // R[sw_cmd_sts]: V(False)
-
   //   F[cmd_rdy]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -670,7 +650,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_rdy_qs)
   );
-
 
   //   F[cmd_sts]: 1:1
   prim_subreg #(
@@ -699,7 +678,6 @@ module csrng_reg_top (
 
 
   // R[genbits_vld]: V(True)
-
   //   F[genbits_vld]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -713,7 +691,6 @@ module csrng_reg_top (
     .q      (),
     .qs     (genbits_vld_genbits_vld_qs)
   );
-
 
   //   F[genbits_fips]: 1:1
   prim_subreg_ext #(
@@ -731,7 +708,6 @@ module csrng_reg_top (
 
 
   // R[genbits]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_genbits (
@@ -747,7 +723,6 @@ module csrng_reg_top (
 
 
   // R[int_state_num]: V(False)
-
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -774,7 +749,6 @@ module csrng_reg_top (
 
 
   // R[int_state_val]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_int_state_val (
@@ -790,7 +764,6 @@ module csrng_reg_top (
 
 
   // R[hw_exc_sts]: V(False)
-
   prim_subreg #(
     .DW      (15),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -817,7 +790,6 @@ module csrng_reg_top (
 
 
   // R[recov_alert_sts]: V(False)
-
   //   F[enable_field_alert]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -843,7 +815,6 @@ module csrng_reg_top (
     .qs     (recov_alert_sts_enable_field_alert_qs)
   );
 
-
   //   F[sw_app_enable_field_alert]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -868,7 +839,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (recov_alert_sts_sw_app_enable_field_alert_qs)
   );
-
 
   //   F[read_int_state_field_alert]: 2:2
   prim_subreg #(
@@ -897,7 +867,6 @@ module csrng_reg_top (
 
 
   // R[err_code]: V(False)
-
   //   F[sfifo_cmd_err]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -922,7 +891,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_cmd_err_qs)
   );
-
 
   //   F[sfifo_genbits_err]: 1:1
   prim_subreg #(
@@ -949,7 +917,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_genbits_err_qs)
   );
 
-
   //   F[sfifo_cmdreq_err]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -974,7 +941,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_cmdreq_err_qs)
   );
-
 
   //   F[sfifo_rcstage_err]: 3:3
   prim_subreg #(
@@ -1001,7 +967,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_rcstage_err_qs)
   );
 
-
   //   F[sfifo_keyvrc_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1026,7 +991,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_keyvrc_err_qs)
   );
-
 
   //   F[sfifo_updreq_err]: 5:5
   prim_subreg #(
@@ -1053,7 +1017,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_updreq_err_qs)
   );
 
-
   //   F[sfifo_bencreq_err]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -1078,7 +1041,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_bencreq_err_qs)
   );
-
 
   //   F[sfifo_bencack_err]: 7:7
   prim_subreg #(
@@ -1105,7 +1067,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_bencack_err_qs)
   );
 
-
   //   F[sfifo_pdata_err]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -1130,7 +1091,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_pdata_err_qs)
   );
-
 
   //   F[sfifo_final_err]: 9:9
   prim_subreg #(
@@ -1157,7 +1117,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_final_err_qs)
   );
 
-
   //   F[sfifo_gbencack_err]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -1182,7 +1141,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_gbencack_err_qs)
   );
-
 
   //   F[sfifo_grcstage_err]: 11:11
   prim_subreg #(
@@ -1209,7 +1167,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_grcstage_err_qs)
   );
 
-
   //   F[sfifo_ggenreq_err]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -1234,7 +1191,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_ggenreq_err_qs)
   );
-
 
   //   F[sfifo_gadstage_err]: 13:13
   prim_subreg #(
@@ -1261,7 +1217,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_gadstage_err_qs)
   );
 
-
   //   F[sfifo_ggenbits_err]: 14:14
   prim_subreg #(
     .DW      (1),
@@ -1286,7 +1241,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_ggenbits_err_qs)
   );
-
 
   //   F[sfifo_blkenc_err]: 15:15
   prim_subreg #(
@@ -1313,7 +1267,6 @@ module csrng_reg_top (
     .qs     (err_code_sfifo_blkenc_err_qs)
   );
 
-
   //   F[cmd_stage_sm_err]: 20:20
   prim_subreg #(
     .DW      (1),
@@ -1338,7 +1291,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_cmd_stage_sm_err_qs)
   );
-
 
   //   F[main_sm_err]: 21:21
   prim_subreg #(
@@ -1365,7 +1317,6 @@ module csrng_reg_top (
     .qs     (err_code_main_sm_err_qs)
   );
 
-
   //   F[drbg_gen_sm_err]: 22:22
   prim_subreg #(
     .DW      (1),
@@ -1390,7 +1341,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_drbg_gen_sm_err_qs)
   );
-
 
   //   F[drbg_updbe_sm_err]: 23:23
   prim_subreg #(
@@ -1417,7 +1367,6 @@ module csrng_reg_top (
     .qs     (err_code_drbg_updbe_sm_err_qs)
   );
 
-
   //   F[drbg_updob_sm_err]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -1442,7 +1391,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_drbg_updob_sm_err_qs)
   );
-
 
   //   F[aes_cipher_sm_err]: 25:25
   prim_subreg #(
@@ -1469,7 +1417,6 @@ module csrng_reg_top (
     .qs     (err_code_aes_cipher_sm_err_qs)
   );
 
-
   //   F[fifo_write_err]: 28:28
   prim_subreg #(
     .DW      (1),
@@ -1495,7 +1442,6 @@ module csrng_reg_top (
     .qs     (err_code_fifo_write_err_qs)
   );
 
-
   //   F[fifo_read_err]: 29:29
   prim_subreg #(
     .DW      (1),
@@ -1520,7 +1466,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (err_code_fifo_read_err_qs)
   );
-
 
   //   F[fifo_state_err]: 30:30
   prim_subreg #(
@@ -1549,7 +1494,6 @@ module csrng_reg_top (
 
 
   // R[err_code_test]: V(False)
-
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1576,7 +1520,6 @@ module csrng_reg_top (
 
 
   // R[sel_tracking_sm]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1603,7 +1546,6 @@ module csrng_reg_top (
 
 
   // R[tracking_sm_obs]: V(False)
-
   //   F[tracking_sm_obs0]: 7:0
   prim_subreg #(
     .DW      (8),
@@ -1628,7 +1570,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (tracking_sm_obs_tracking_sm_obs0_qs)
   );
-
 
   //   F[tracking_sm_obs1]: 15:8
   prim_subreg #(
@@ -1655,7 +1596,6 @@ module csrng_reg_top (
     .qs     (tracking_sm_obs_tracking_sm_obs1_qs)
   );
 
-
   //   F[tracking_sm_obs2]: 23:16
   prim_subreg #(
     .DW      (8),
@@ -1681,7 +1621,6 @@ module csrng_reg_top (
     .qs     (tracking_sm_obs_tracking_sm_obs2_qs)
   );
 
-
   //   F[tracking_sm_obs3]: 31:24
   prim_subreg #(
     .DW      (8),
@@ -1706,7 +1645,6 @@ module csrng_reg_top (
     // to register interface (read)
     .qs     (tracking_sm_obs_tracking_sm_obs3_qs)
   );
-
 
 
 

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -168,7 +168,6 @@ module edn_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[edn_cmd_req_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -193,7 +192,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (intr_state_edn_cmd_req_done_qs)
   );
-
 
   //   F[edn_fatal_err]: 1:1
   prim_subreg #(
@@ -222,7 +220,6 @@ module edn_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[edn_cmd_req_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -247,7 +244,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (intr_enable_edn_cmd_req_done_qs)
   );
-
 
   //   F[edn_fatal_err]: 1:1
   prim_subreg #(
@@ -276,7 +272,6 @@ module edn_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[edn_cmd_req_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -290,7 +285,6 @@ module edn_reg_top (
     .q      (reg2hw.intr_test.edn_cmd_req_done.q),
     .qs     ()
   );
-
 
   //   F[edn_fatal_err]: 1:1
   prim_subreg_ext #(
@@ -308,7 +302,6 @@ module edn_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -322,7 +315,6 @@ module edn_reg_top (
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
-
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -340,7 +332,6 @@ module edn_reg_top (
 
 
   // R[regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -367,7 +358,6 @@ module edn_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[edn_enable]: 3:0
   prim_subreg #(
     .DW      (4),
@@ -392,7 +382,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (ctrl_edn_enable_qs)
   );
-
 
   //   F[boot_req_mode]: 7:4
   prim_subreg #(
@@ -419,7 +408,6 @@ module edn_reg_top (
     .qs     (ctrl_boot_req_mode_qs)
   );
 
-
   //   F[auto_req_mode]: 11:8
   prim_subreg #(
     .DW      (4),
@@ -444,7 +432,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (ctrl_auto_req_mode_qs)
   );
-
 
   //   F[cmd_fifo_rst]: 15:12
   prim_subreg #(
@@ -473,7 +460,6 @@ module edn_reg_top (
 
 
   // R[sum_sts]: V(False)
-
   //   F[req_mode_sm_sts]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -498,7 +484,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (sum_sts_req_mode_sm_sts_qs)
   );
-
 
   //   F[boot_inst_ack]: 1:1
   prim_subreg #(
@@ -527,7 +512,6 @@ module edn_reg_top (
 
 
   // R[sw_cmd_req]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_sw_cmd_req (
@@ -543,7 +527,6 @@ module edn_reg_top (
 
 
   // R[sw_cmd_sts]: V(False)
-
   //   F[cmd_rdy]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -568,7 +551,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (sw_cmd_sts_cmd_rdy_qs)
   );
-
 
   //   F[cmd_sts]: 1:1
   prim_subreg #(
@@ -597,7 +579,6 @@ module edn_reg_top (
 
 
   // R[reseed_cmd]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_reseed_cmd (
@@ -613,7 +594,6 @@ module edn_reg_top (
 
 
   // R[generate_cmd]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_generate_cmd (
@@ -629,7 +609,6 @@ module edn_reg_top (
 
 
   // R[max_num_reqs_between_reseeds]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -656,7 +635,6 @@ module edn_reg_top (
 
 
   // R[recov_alert_sts]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -683,7 +661,6 @@ module edn_reg_top (
 
 
   // R[err_code]: V(False)
-
   //   F[sfifo_rescmd_err]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -708,7 +685,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_rescmd_err_qs)
   );
-
 
   //   F[sfifo_gencmd_err]: 1:1
   prim_subreg #(
@@ -735,7 +711,6 @@ module edn_reg_top (
     .qs     (err_code_sfifo_gencmd_err_qs)
   );
 
-
   //   F[edn_ack_sm_err]: 20:20
   prim_subreg #(
     .DW      (1),
@@ -760,7 +735,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (err_code_edn_ack_sm_err_qs)
   );
-
 
   //   F[edn_main_sm_err]: 21:21
   prim_subreg #(
@@ -787,7 +761,6 @@ module edn_reg_top (
     .qs     (err_code_edn_main_sm_err_qs)
   );
 
-
   //   F[fifo_write_err]: 28:28
   prim_subreg #(
     .DW      (1),
@@ -813,7 +786,6 @@ module edn_reg_top (
     .qs     (err_code_fifo_write_err_qs)
   );
 
-
   //   F[fifo_read_err]: 29:29
   prim_subreg #(
     .DW      (1),
@@ -838,7 +810,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (err_code_fifo_read_err_qs)
   );
-
 
   //   F[fifo_state_err]: 30:30
   prim_subreg #(
@@ -867,7 +838,6 @@ module edn_reg_top (
 
 
   // R[err_code_test]: V(False)
-
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -891,7 +861,6 @@ module edn_reg_top (
     // to register interface (read)
     .qs     (err_code_test_qs)
   );
-
 
 
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -337,7 +337,6 @@ module entropy_src_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[es_entropy_valid]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -362,7 +361,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (intr_state_es_entropy_valid_qs)
   );
-
 
   //   F[es_health_test_failed]: 1:1
   prim_subreg #(
@@ -389,7 +387,6 @@ module entropy_src_reg_top (
     .qs     (intr_state_es_health_test_failed_qs)
   );
 
-
   //   F[es_observe_fifo_ready]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -414,7 +411,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (intr_state_es_observe_fifo_ready_qs)
   );
-
 
   //   F[es_fatal_err]: 3:3
   prim_subreg #(
@@ -443,7 +439,6 @@ module entropy_src_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[es_entropy_valid]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -468,7 +463,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (intr_enable_es_entropy_valid_qs)
   );
-
 
   //   F[es_health_test_failed]: 1:1
   prim_subreg #(
@@ -495,7 +489,6 @@ module entropy_src_reg_top (
     .qs     (intr_enable_es_health_test_failed_qs)
   );
 
-
   //   F[es_observe_fifo_ready]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -520,7 +513,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (intr_enable_es_observe_fifo_ready_qs)
   );
-
 
   //   F[es_fatal_err]: 3:3
   prim_subreg #(
@@ -549,7 +541,6 @@ module entropy_src_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[es_entropy_valid]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -563,7 +554,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.intr_test.es_entropy_valid.q),
     .qs     ()
   );
-
 
   //   F[es_health_test_failed]: 1:1
   prim_subreg_ext #(
@@ -579,7 +569,6 @@ module entropy_src_reg_top (
     .qs     ()
   );
 
-
   //   F[es_observe_fifo_ready]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -593,7 +582,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.intr_test.es_observe_fifo_ready.q),
     .qs     ()
   );
-
 
   //   F[es_fatal_err]: 3:3
   prim_subreg_ext #(
@@ -611,7 +599,6 @@ module entropy_src_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -625,7 +612,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
-
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -643,7 +629,6 @@ module entropy_src_reg_top (
 
 
   // R[regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_regwen (
@@ -659,16 +644,13 @@ module entropy_src_reg_top (
 
 
   // R[rev]: V(False)
-
   //   F[abi_revision]: 7:0
   // constant-only read
   assign rev_abi_revision_qs = 8'h3;
 
-
   //   F[hw_revision]: 15:8
   // constant-only read
   assign rev_hw_revision_qs = 8'h3;
-
 
   //   F[chip_type]: 23:16
   // constant-only read
@@ -676,7 +658,6 @@ module entropy_src_reg_top (
 
 
   // R[conf]: V(False)
-
   //   F[enable]: 1:0
   prim_subreg #(
     .DW      (2),
@@ -701,7 +682,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (conf_enable_qs)
   );
-
 
   //   F[boot_bypass_disable]: 3:3
   prim_subreg #(
@@ -728,7 +708,6 @@ module entropy_src_reg_top (
     .qs     (conf_boot_bypass_disable_qs)
   );
 
-
   //   F[repcnt_disable]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -753,7 +732,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (conf_repcnt_disable_qs)
   );
-
 
   //   F[adaptp_disable]: 5:5
   prim_subreg #(
@@ -780,7 +758,6 @@ module entropy_src_reg_top (
     .qs     (conf_adaptp_disable_qs)
   );
 
-
   //   F[bucket_disable]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -805,7 +782,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (conf_bucket_disable_qs)
   );
-
 
   //   F[markov_disable]: 7:7
   prim_subreg #(
@@ -832,7 +808,6 @@ module entropy_src_reg_top (
     .qs     (conf_markov_disable_qs)
   );
 
-
   //   F[health_test_clr]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -857,7 +832,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (conf_health_test_clr_qs)
   );
-
 
   //   F[rng_bit_en]: 9:9
   prim_subreg #(
@@ -884,7 +858,6 @@ module entropy_src_reg_top (
     .qs     (conf_rng_bit_en_qs)
   );
 
-
   //   F[rng_bit_sel]: 11:10
   prim_subreg #(
     .DW      (2),
@@ -910,7 +883,6 @@ module entropy_src_reg_top (
     .qs     (conf_rng_bit_sel_qs)
   );
 
-
   //   F[extht_enable]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -935,7 +907,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (conf_extht_enable_qs)
   );
-
 
   //   F[repcnts_disable]: 13:13
   prim_subreg #(
@@ -964,7 +935,6 @@ module entropy_src_reg_top (
 
 
   // R[rate]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -991,7 +961,6 @@ module entropy_src_reg_top (
 
 
   // R[entropy_control]: V(False)
-
   //   F[es_route]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1016,7 +985,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (entropy_control_es_route_qs)
   );
-
 
   //   F[es_type]: 1:1
   prim_subreg #(
@@ -1045,7 +1013,6 @@ module entropy_src_reg_top (
 
 
   // R[entropy_data]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_entropy_data (
@@ -1061,7 +1028,6 @@ module entropy_src_reg_top (
 
 
   // R[health_test_windows]: V(False)
-
   //   F[fips_window]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1086,7 +1052,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (health_test_windows_fips_window_qs)
   );
-
 
   //   F[bypass_window]: 31:16
   prim_subreg #(
@@ -1115,7 +1080,6 @@ module entropy_src_reg_top (
 
 
   // R[repcnt_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1129,7 +1093,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.repcnt_thresholds.fips_thresh.q),
     .qs     (repcnt_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1147,7 +1110,6 @@ module entropy_src_reg_top (
 
 
   // R[repcnts_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1161,7 +1123,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.repcnts_thresholds.fips_thresh.q),
     .qs     (repcnts_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1179,7 +1140,6 @@ module entropy_src_reg_top (
 
 
   // R[adaptp_hi_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1193,7 +1153,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.adaptp_hi_thresholds.fips_thresh.q),
     .qs     (adaptp_hi_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1211,7 +1170,6 @@ module entropy_src_reg_top (
 
 
   // R[adaptp_lo_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1225,7 +1183,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.adaptp_lo_thresholds.fips_thresh.q),
     .qs     (adaptp_lo_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1243,7 +1200,6 @@ module entropy_src_reg_top (
 
 
   // R[bucket_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1257,7 +1213,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.bucket_thresholds.fips_thresh.q),
     .qs     (bucket_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1275,7 +1230,6 @@ module entropy_src_reg_top (
 
 
   // R[markov_hi_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1289,7 +1243,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.markov_hi_thresholds.fips_thresh.q),
     .qs     (markov_hi_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1307,7 +1260,6 @@ module entropy_src_reg_top (
 
 
   // R[markov_lo_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1321,7 +1273,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.markov_lo_thresholds.fips_thresh.q),
     .qs     (markov_lo_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1339,7 +1290,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_hi_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1353,7 +1303,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.extht_hi_thresholds.fips_thresh.q),
     .qs     (extht_hi_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1371,7 +1320,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_lo_thresholds]: V(True)
-
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1385,7 +1333,6 @@ module entropy_src_reg_top (
     .q      (reg2hw.extht_lo_thresholds.fips_thresh.q),
     .qs     (extht_lo_thresholds_fips_thresh_qs)
   );
-
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1403,7 +1350,6 @@ module entropy_src_reg_top (
 
 
   // R[repcnt_hi_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1417,7 +1363,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (repcnt_hi_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1435,7 +1380,6 @@ module entropy_src_reg_top (
 
 
   // R[repcnts_hi_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1449,7 +1393,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (repcnts_hi_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1467,7 +1410,6 @@ module entropy_src_reg_top (
 
 
   // R[adaptp_hi_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1481,7 +1423,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (adaptp_hi_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1499,7 +1440,6 @@ module entropy_src_reg_top (
 
 
   // R[adaptp_lo_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1513,7 +1453,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (adaptp_lo_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1531,7 +1470,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_hi_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1545,7 +1483,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (extht_hi_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1563,7 +1500,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_lo_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1577,7 +1513,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (extht_lo_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1595,7 +1530,6 @@ module entropy_src_reg_top (
 
 
   // R[bucket_hi_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1609,7 +1543,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (bucket_hi_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1627,7 +1560,6 @@ module entropy_src_reg_top (
 
 
   // R[markov_hi_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1641,7 +1573,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (markov_hi_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1659,7 +1590,6 @@ module entropy_src_reg_top (
 
 
   // R[markov_lo_watermarks]: V(True)
-
   //   F[fips_watermark]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1673,7 +1603,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (markov_lo_watermarks_fips_watermark_qs)
   );
-
 
   //   F[bypass_watermark]: 31:16
   prim_subreg_ext #(
@@ -1691,7 +1620,6 @@ module entropy_src_reg_top (
 
 
   // R[repcnt_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_repcnt_total_fails (
@@ -1707,7 +1635,6 @@ module entropy_src_reg_top (
 
 
   // R[repcnts_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_repcnts_total_fails (
@@ -1723,7 +1650,6 @@ module entropy_src_reg_top (
 
 
   // R[adaptp_hi_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_adaptp_hi_total_fails (
@@ -1739,7 +1665,6 @@ module entropy_src_reg_top (
 
 
   // R[adaptp_lo_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_adaptp_lo_total_fails (
@@ -1755,7 +1680,6 @@ module entropy_src_reg_top (
 
 
   // R[bucket_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_bucket_total_fails (
@@ -1771,7 +1695,6 @@ module entropy_src_reg_top (
 
 
   // R[markov_hi_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_markov_hi_total_fails (
@@ -1787,7 +1710,6 @@ module entropy_src_reg_top (
 
 
   // R[markov_lo_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_markov_lo_total_fails (
@@ -1803,7 +1725,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_hi_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_extht_hi_total_fails (
@@ -1819,7 +1740,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_lo_total_fails]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_extht_lo_total_fails (
@@ -1835,7 +1755,6 @@ module entropy_src_reg_top (
 
 
   // R[alert_threshold]: V(False)
-
   //   F[alert_threshold]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1860,7 +1779,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (alert_threshold_alert_threshold_qs)
   );
-
 
   //   F[alert_threshold_inv]: 31:16
   prim_subreg #(
@@ -1889,7 +1807,6 @@ module entropy_src_reg_top (
 
 
   // R[alert_summary_fail_counts]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_alert_summary_fail_counts (
@@ -1905,7 +1822,6 @@ module entropy_src_reg_top (
 
 
   // R[alert_fail_counts]: V(True)
-
   //   F[repcnt_fail_count]: 7:4
   prim_subreg_ext #(
     .DW    (4)
@@ -1919,7 +1835,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (alert_fail_counts_repcnt_fail_count_qs)
   );
-
 
   //   F[adaptp_hi_fail_count]: 11:8
   prim_subreg_ext #(
@@ -1935,7 +1850,6 @@ module entropy_src_reg_top (
     .qs     (alert_fail_counts_adaptp_hi_fail_count_qs)
   );
 
-
   //   F[adaptp_lo_fail_count]: 15:12
   prim_subreg_ext #(
     .DW    (4)
@@ -1949,7 +1863,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (alert_fail_counts_adaptp_lo_fail_count_qs)
   );
-
 
   //   F[bucket_fail_count]: 19:16
   prim_subreg_ext #(
@@ -1965,7 +1878,6 @@ module entropy_src_reg_top (
     .qs     (alert_fail_counts_bucket_fail_count_qs)
   );
 
-
   //   F[markov_hi_fail_count]: 23:20
   prim_subreg_ext #(
     .DW    (4)
@@ -1980,7 +1892,6 @@ module entropy_src_reg_top (
     .qs     (alert_fail_counts_markov_hi_fail_count_qs)
   );
 
-
   //   F[markov_lo_fail_count]: 27:24
   prim_subreg_ext #(
     .DW    (4)
@@ -1994,7 +1905,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (alert_fail_counts_markov_lo_fail_count_qs)
   );
-
 
   //   F[repcnts_fail_count]: 31:28
   prim_subreg_ext #(
@@ -2012,7 +1922,6 @@ module entropy_src_reg_top (
 
 
   // R[extht_fail_counts]: V(True)
-
   //   F[extht_hi_fail_count]: 3:0
   prim_subreg_ext #(
     .DW    (4)
@@ -2026,7 +1935,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (extht_fail_counts_extht_hi_fail_count_qs)
   );
-
 
   //   F[extht_lo_fail_count]: 7:4
   prim_subreg_ext #(
@@ -2044,7 +1952,6 @@ module entropy_src_reg_top (
 
 
   // R[fw_ov_control]: V(False)
-
   //   F[fw_ov_mode]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2069,7 +1976,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (fw_ov_control_fw_ov_mode_qs)
   );
-
 
   //   F[fw_ov_entropy_insert]: 1:1
   prim_subreg #(
@@ -2098,7 +2004,6 @@ module entropy_src_reg_top (
 
 
   // R[fw_ov_rd_data]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_fw_ov_rd_data (
@@ -2114,7 +2019,6 @@ module entropy_src_reg_top (
 
 
   // R[fw_ov_wr_data]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_fw_ov_wr_data (
@@ -2130,7 +2034,6 @@ module entropy_src_reg_top (
 
 
   // R[observe_fifo_thresh]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2157,7 +2060,6 @@ module entropy_src_reg_top (
 
 
   // R[debug_status]: V(True)
-
   //   F[entropy_fifo_depth]: 2:0
   prim_subreg_ext #(
     .DW    (3)
@@ -2171,7 +2073,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (debug_status_entropy_fifo_depth_qs)
   );
-
 
   //   F[sha3_fsm]: 5:3
   prim_subreg_ext #(
@@ -2187,7 +2088,6 @@ module entropy_src_reg_top (
     .qs     (debug_status_sha3_fsm_qs)
   );
 
-
   //   F[sha3_block_pr]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -2201,7 +2101,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (debug_status_sha3_block_pr_qs)
   );
-
 
   //   F[sha3_squeezing]: 7:7
   prim_subreg_ext #(
@@ -2217,7 +2116,6 @@ module entropy_src_reg_top (
     .qs     (debug_status_sha3_squeezing_qs)
   );
 
-
   //   F[sha3_absorbed]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -2231,7 +2129,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (debug_status_sha3_absorbed_qs)
   );
-
 
   //   F[sha3_err]: 9:9
   prim_subreg_ext #(
@@ -2247,7 +2144,6 @@ module entropy_src_reg_top (
     .qs     (debug_status_sha3_err_qs)
   );
 
-
   //   F[main_sm_idle]: 16:16
   prim_subreg_ext #(
     .DW    (1)
@@ -2261,7 +2157,6 @@ module entropy_src_reg_top (
     .q      (),
     .qs     (debug_status_main_sm_idle_qs)
   );
-
 
   //   F[main_sm_state]: 31:24
   prim_subreg_ext #(
@@ -2279,7 +2174,6 @@ module entropy_src_reg_top (
 
 
   // R[seed]: V(False)
-
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2306,7 +2200,6 @@ module entropy_src_reg_top (
 
 
   // R[recov_alert_sts]: V(False)
-
   //   F[es_main_sm_alert]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -2331,7 +2224,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (recov_alert_sts_es_main_sm_alert_qs)
   );
-
 
   //   F[es_bus_cmp_alert]: 13:13
   prim_subreg #(
@@ -2360,7 +2252,6 @@ module entropy_src_reg_top (
 
 
   // R[err_code]: V(False)
-
   //   F[sfifo_esrng_err]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2385,7 +2276,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_esrng_err_qs)
   );
-
 
   //   F[sfifo_observe_err]: 1:1
   prim_subreg #(
@@ -2412,7 +2302,6 @@ module entropy_src_reg_top (
     .qs     (err_code_sfifo_observe_err_qs)
   );
 
-
   //   F[sfifo_esfinal_err]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2437,7 +2326,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (err_code_sfifo_esfinal_err_qs)
   );
-
 
   //   F[es_ack_sm_err]: 20:20
   prim_subreg #(
@@ -2464,7 +2352,6 @@ module entropy_src_reg_top (
     .qs     (err_code_es_ack_sm_err_qs)
   );
 
-
   //   F[es_main_sm_err]: 21:21
   prim_subreg #(
     .DW      (1),
@@ -2489,7 +2376,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (err_code_es_main_sm_err_qs)
   );
-
 
   //   F[fifo_write_err]: 28:28
   prim_subreg #(
@@ -2516,7 +2402,6 @@ module entropy_src_reg_top (
     .qs     (err_code_fifo_write_err_qs)
   );
 
-
   //   F[fifo_read_err]: 29:29
   prim_subreg #(
     .DW      (1),
@@ -2541,7 +2426,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (err_code_fifo_read_err_qs)
   );
-
 
   //   F[fifo_state_err]: 30:30
   prim_subreg #(
@@ -2570,7 +2454,6 @@ module entropy_src_reg_top (
 
 
   // R[err_code_test]: V(False)
-
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2594,7 +2477,6 @@ module entropy_src_reg_top (
     // to register interface (read)
     .qs     (err_code_test_qs)
   );
-
 
 
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -973,7 +973,6 @@ module flash_ctrl_core_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -998,7 +997,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_prog_empty_qs)
   );
-
 
   //   F[prog_lvl]: 1:1
   prim_subreg #(
@@ -1025,7 +1023,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_state_prog_lvl_qs)
   );
 
-
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1050,7 +1047,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_rd_full_qs)
   );
-
 
   //   F[rd_lvl]: 3:3
   prim_subreg #(
@@ -1077,7 +1073,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_state_rd_lvl_qs)
   );
 
-
   //   F[op_done]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1102,7 +1097,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_op_done_qs)
   );
-
 
   //   F[err]: 5:5
   prim_subreg #(
@@ -1131,7 +1125,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1156,7 +1149,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_prog_empty_qs)
   );
-
 
   //   F[prog_lvl]: 1:1
   prim_subreg #(
@@ -1183,7 +1175,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_enable_prog_lvl_qs)
   );
 
-
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1208,7 +1199,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rd_full_qs)
   );
-
 
   //   F[rd_lvl]: 3:3
   prim_subreg #(
@@ -1235,7 +1225,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_enable_rd_lvl_qs)
   );
 
-
   //   F[op_done]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1260,7 +1249,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_op_done_qs)
   );
-
 
   //   F[err]: 5:5
   prim_subreg #(
@@ -1289,7 +1277,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[prog_empty]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1303,7 +1290,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.prog_empty.q),
     .qs     ()
   );
-
 
   //   F[prog_lvl]: 1:1
   prim_subreg_ext #(
@@ -1319,7 +1305,6 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[rd_full]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1333,7 +1318,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.rd_full.q),
     .qs     ()
   );
-
 
   //   F[rd_lvl]: 3:3
   prim_subreg_ext #(
@@ -1349,7 +1333,6 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[op_done]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1363,7 +1346,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.op_done.q),
     .qs     ()
   );
-
 
   //   F[err]: 5:5
   prim_subreg_ext #(
@@ -1381,7 +1363,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1395,7 +1376,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.alert_test.recov_err.q),
     .qs     ()
   );
-
 
   //   F[recov_mp_err]: 1:1
   prim_subreg_ext #(
@@ -1411,7 +1391,6 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_ecc_err]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1425,7 +1404,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.alert_test.recov_ecc_err.q),
     .qs     ()
   );
-
 
   //   F[fatal_intg_err]: 3:3
   prim_subreg_ext #(
@@ -1443,7 +1421,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[flash_disable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -1470,7 +1447,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[init]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -1497,7 +1473,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[ctrl_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_regwen (
@@ -1513,7 +1488,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[start]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1538,7 +1512,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (control_start_qs)
   );
-
 
   //   F[op]: 5:4
   prim_subreg #(
@@ -1565,7 +1538,6 @@ module flash_ctrl_core_reg_top (
     .qs     (control_op_qs)
   );
 
-
   //   F[prog_sel]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -1590,7 +1562,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (control_prog_sel_qs)
   );
-
 
   //   F[erase_sel]: 7:7
   prim_subreg #(
@@ -1617,7 +1588,6 @@ module flash_ctrl_core_reg_top (
     .qs     (control_erase_sel_qs)
   );
 
-
   //   F[partition_sel]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -1643,7 +1613,6 @@ module flash_ctrl_core_reg_top (
     .qs     (control_partition_sel_qs)
   );
 
-
   //   F[info_sel]: 10:9
   prim_subreg #(
     .DW      (2),
@@ -1668,7 +1637,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (control_info_sel_qs)
   );
-
 
   //   F[num]: 27:16
   prim_subreg #(
@@ -1697,7 +1665,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[addr]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1724,7 +1691,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[prog_type_en]: V(False)
-
   //   F[normal]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1749,7 +1715,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (prog_type_en_normal_qs)
   );
-
 
   //   F[repair]: 1:1
   prim_subreg #(
@@ -1778,7 +1743,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[erase_suspend]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1804,10 +1768,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1832,9 +1794,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1859,9 +1821,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1886,9 +1848,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1913,9 +1875,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1940,9 +1902,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1967,9 +1929,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1994,9 +1956,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2022,11 +1984,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mp_region_cfg
   // R[mp_region_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2051,8 +2011,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2077,8 +2036,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2103,8 +2061,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2129,8 +2086,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2155,8 +2111,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2181,8 +2136,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2207,8 +2161,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_he_en_0_qs)
   );
 
-
-  // F[base_0]: 16:8
+  //   F[base_0]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2233,8 +2186,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_base_0_qs)
   );
 
-
-  // F[size_0]: 26:17
+  //   F[size_0]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2262,8 +2214,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg mp_region_cfg
   // R[mp_region_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2288,8 +2239,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2314,8 +2264,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2340,8 +2289,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2366,8 +2314,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2392,8 +2339,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2418,8 +2364,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2444,8 +2389,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_he_en_1_qs)
   );
 
-
-  // F[base_1]: 16:8
+  //   F[base_1]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2470,8 +2414,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_base_1_qs)
   );
 
-
-  // F[size_1]: 26:17
+  //   F[size_1]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2499,8 +2442,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 2 of Multireg mp_region_cfg
   // R[mp_region_cfg_2]: V(False)
-
-  // F[en_2]: 0:0
+  //   F[en_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2525,8 +2467,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_en_2_qs)
   );
 
-
-  // F[rd_en_2]: 1:1
+  //   F[rd_en_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2551,8 +2492,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_rd_en_2_qs)
   );
 
-
-  // F[prog_en_2]: 2:2
+  //   F[prog_en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2577,8 +2517,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_prog_en_2_qs)
   );
 
-
-  // F[erase_en_2]: 3:3
+  //   F[erase_en_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2603,8 +2542,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_erase_en_2_qs)
   );
 
-
-  // F[scramble_en_2]: 4:4
+  //   F[scramble_en_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2629,8 +2567,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_scramble_en_2_qs)
   );
 
-
-  // F[ecc_en_2]: 5:5
+  //   F[ecc_en_2]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2655,8 +2592,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_ecc_en_2_qs)
   );
 
-
-  // F[he_en_2]: 6:6
+  //   F[he_en_2]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2681,8 +2617,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_he_en_2_qs)
   );
 
-
-  // F[base_2]: 16:8
+  //   F[base_2]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2707,8 +2642,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_base_2_qs)
   );
 
-
-  // F[size_2]: 26:17
+  //   F[size_2]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2736,8 +2670,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 3 of Multireg mp_region_cfg
   // R[mp_region_cfg_3]: V(False)
-
-  // F[en_3]: 0:0
+  //   F[en_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2762,8 +2695,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_en_3_qs)
   );
 
-
-  // F[rd_en_3]: 1:1
+  //   F[rd_en_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2788,8 +2720,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_rd_en_3_qs)
   );
 
-
-  // F[prog_en_3]: 2:2
+  //   F[prog_en_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2814,8 +2745,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_prog_en_3_qs)
   );
 
-
-  // F[erase_en_3]: 3:3
+  //   F[erase_en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2840,8 +2770,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_erase_en_3_qs)
   );
 
-
-  // F[scramble_en_3]: 4:4
+  //   F[scramble_en_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2866,8 +2795,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_scramble_en_3_qs)
   );
 
-
-  // F[ecc_en_3]: 5:5
+  //   F[ecc_en_3]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2892,8 +2820,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_ecc_en_3_qs)
   );
 
-
-  // F[he_en_3]: 6:6
+  //   F[he_en_3]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2918,8 +2845,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_he_en_3_qs)
   );
 
-
-  // F[base_3]: 16:8
+  //   F[base_3]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2944,8 +2870,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_base_3_qs)
   );
 
-
-  // F[size_3]: 26:17
+  //   F[size_3]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2973,8 +2898,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 4 of Multireg mp_region_cfg
   // R[mp_region_cfg_4]: V(False)
-
-  // F[en_4]: 0:0
+  //   F[en_4]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2999,8 +2923,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_en_4_qs)
   );
 
-
-  // F[rd_en_4]: 1:1
+  //   F[rd_en_4]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3025,8 +2948,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_rd_en_4_qs)
   );
 
-
-  // F[prog_en_4]: 2:2
+  //   F[prog_en_4]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3051,8 +2973,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_prog_en_4_qs)
   );
 
-
-  // F[erase_en_4]: 3:3
+  //   F[erase_en_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3077,8 +2998,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_erase_en_4_qs)
   );
 
-
-  // F[scramble_en_4]: 4:4
+  //   F[scramble_en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3103,8 +3023,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_scramble_en_4_qs)
   );
 
-
-  // F[ecc_en_4]: 5:5
+  //   F[ecc_en_4]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3129,8 +3048,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_ecc_en_4_qs)
   );
 
-
-  // F[he_en_4]: 6:6
+  //   F[he_en_4]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3155,8 +3073,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_he_en_4_qs)
   );
 
-
-  // F[base_4]: 16:8
+  //   F[base_4]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3181,8 +3098,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_base_4_qs)
   );
 
-
-  // F[size_4]: 26:17
+  //   F[size_4]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3210,8 +3126,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 5 of Multireg mp_region_cfg
   // R[mp_region_cfg_5]: V(False)
-
-  // F[en_5]: 0:0
+  //   F[en_5]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3236,8 +3151,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_en_5_qs)
   );
 
-
-  // F[rd_en_5]: 1:1
+  //   F[rd_en_5]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3262,8 +3176,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_rd_en_5_qs)
   );
 
-
-  // F[prog_en_5]: 2:2
+  //   F[prog_en_5]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3288,8 +3201,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_prog_en_5_qs)
   );
 
-
-  // F[erase_en_5]: 3:3
+  //   F[erase_en_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3314,8 +3226,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_erase_en_5_qs)
   );
 
-
-  // F[scramble_en_5]: 4:4
+  //   F[scramble_en_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3340,8 +3251,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_scramble_en_5_qs)
   );
 
-
-  // F[ecc_en_5]: 5:5
+  //   F[ecc_en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3366,8 +3276,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_ecc_en_5_qs)
   );
 
-
-  // F[he_en_5]: 6:6
+  //   F[he_en_5]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3392,8 +3301,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_he_en_5_qs)
   );
 
-
-  // F[base_5]: 16:8
+  //   F[base_5]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3418,8 +3326,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_base_5_qs)
   );
 
-
-  // F[size_5]: 26:17
+  //   F[size_5]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3447,8 +3354,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 6 of Multireg mp_region_cfg
   // R[mp_region_cfg_6]: V(False)
-
-  // F[en_6]: 0:0
+  //   F[en_6]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3473,8 +3379,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_en_6_qs)
   );
 
-
-  // F[rd_en_6]: 1:1
+  //   F[rd_en_6]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3499,8 +3404,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_rd_en_6_qs)
   );
 
-
-  // F[prog_en_6]: 2:2
+  //   F[prog_en_6]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3525,8 +3429,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_prog_en_6_qs)
   );
 
-
-  // F[erase_en_6]: 3:3
+  //   F[erase_en_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3551,8 +3454,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_erase_en_6_qs)
   );
 
-
-  // F[scramble_en_6]: 4:4
+  //   F[scramble_en_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3577,8 +3479,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_scramble_en_6_qs)
   );
 
-
-  // F[ecc_en_6]: 5:5
+  //   F[ecc_en_6]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3603,8 +3504,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_ecc_en_6_qs)
   );
 
-
-  // F[he_en_6]: 6:6
+  //   F[he_en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3629,8 +3529,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_he_en_6_qs)
   );
 
-
-  // F[base_6]: 16:8
+  //   F[base_6]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3655,8 +3554,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_base_6_qs)
   );
 
-
-  // F[size_6]: 26:17
+  //   F[size_6]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3684,8 +3582,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 7 of Multireg mp_region_cfg
   // R[mp_region_cfg_7]: V(False)
-
-  // F[en_7]: 0:0
+  //   F[en_7]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3710,8 +3607,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_en_7_qs)
   );
 
-
-  // F[rd_en_7]: 1:1
+  //   F[rd_en_7]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3736,8 +3632,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_rd_en_7_qs)
   );
 
-
-  // F[prog_en_7]: 2:2
+  //   F[prog_en_7]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3762,8 +3657,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_prog_en_7_qs)
   );
 
-
-  // F[erase_en_7]: 3:3
+  //   F[erase_en_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3788,8 +3682,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_erase_en_7_qs)
   );
 
-
-  // F[scramble_en_7]: 4:4
+  //   F[scramble_en_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3814,8 +3707,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_scramble_en_7_qs)
   );
 
-
-  // F[ecc_en_7]: 5:5
+  //   F[ecc_en_7]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3840,8 +3732,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_ecc_en_7_qs)
   );
 
-
-  // F[he_en_7]: 6:6
+  //   F[he_en_7]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3866,8 +3757,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_he_en_7_qs)
   );
 
-
-  // F[base_7]: 16:8
+  //   F[base_7]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3892,8 +3782,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_base_7_qs)
   );
 
-
-  // F[size_7]: 26:17
+  //   F[size_7]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3919,9 +3808,7 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // R[default_region]: V(False)
-
   //   F[rd_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -3946,7 +3833,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_rd_en_qs)
   );
-
 
   //   F[prog_en]: 1:1
   prim_subreg #(
@@ -3973,7 +3859,6 @@ module flash_ctrl_core_reg_top (
     .qs     (default_region_prog_en_qs)
   );
 
-
   //   F[erase_en]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -3998,7 +3883,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_erase_en_qs)
   );
-
 
   //   F[scramble_en]: 3:3
   prim_subreg #(
@@ -4025,7 +3909,6 @@ module flash_ctrl_core_reg_top (
     .qs     (default_region_scramble_en_qs)
   );
 
-
   //   F[ecc_en]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -4050,7 +3933,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_ecc_en_qs)
   );
-
 
   //   F[he_en]: 5:5
   prim_subreg #(
@@ -4078,10 +3960,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4106,9 +3986,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4133,9 +4013,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4160,9 +4040,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4187,9 +4067,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4214,9 +4094,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4241,9 +4121,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4268,9 +4148,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4295,9 +4175,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4322,9 +4202,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4350,11 +4230,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4379,8 +4257,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4405,8 +4282,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4431,8 +4307,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4457,8 +4332,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4483,8 +4357,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4509,8 +4382,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4538,8 +4410,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4564,8 +4435,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4590,8 +4460,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4616,8 +4485,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4642,8 +4510,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4668,8 +4535,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4694,8 +4560,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4723,8 +4588,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 2 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_2]: V(False)
-
-  // F[en_2]: 0:0
+  //   F[en_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4749,8 +4613,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_en_2_qs)
   );
 
-
-  // F[rd_en_2]: 1:1
+  //   F[rd_en_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4775,8 +4638,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_rd_en_2_qs)
   );
 
-
-  // F[prog_en_2]: 2:2
+  //   F[prog_en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4801,8 +4663,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_prog_en_2_qs)
   );
 
-
-  // F[erase_en_2]: 3:3
+  //   F[erase_en_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4827,8 +4688,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_erase_en_2_qs)
   );
 
-
-  // F[scramble_en_2]: 4:4
+  //   F[scramble_en_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4853,8 +4713,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
   );
 
-
-  // F[ecc_en_2]: 5:5
+  //   F[ecc_en_2]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4879,8 +4738,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
   );
 
-
-  // F[he_en_2]: 6:6
+  //   F[he_en_2]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4908,8 +4766,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 3 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_3]: V(False)
-
-  // F[en_3]: 0:0
+  //   F[en_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4934,8 +4791,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_en_3_qs)
   );
 
-
-  // F[rd_en_3]: 1:1
+  //   F[rd_en_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4960,8 +4816,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_rd_en_3_qs)
   );
 
-
-  // F[prog_en_3]: 2:2
+  //   F[prog_en_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4986,8 +4841,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_prog_en_3_qs)
   );
 
-
-  // F[erase_en_3]: 3:3
+  //   F[erase_en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5012,8 +4866,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
   );
 
-
-  // F[scramble_en_3]: 4:4
+  //   F[scramble_en_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5038,8 +4891,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
   );
 
-
-  // F[ecc_en_3]: 5:5
+  //   F[ecc_en_3]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5064,8 +4916,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
   );
 
-
-  // F[he_en_3]: 6:6
+  //   F[he_en_3]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5093,8 +4944,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 4 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_4]: V(False)
-
-  // F[en_4]: 0:0
+  //   F[en_4]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5119,8 +4969,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_en_4_qs)
   );
 
-
-  // F[rd_en_4]: 1:1
+  //   F[rd_en_4]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5145,8 +4994,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_rd_en_4_qs)
   );
 
-
-  // F[prog_en_4]: 2:2
+  //   F[prog_en_4]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5171,8 +5019,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_prog_en_4_qs)
   );
 
-
-  // F[erase_en_4]: 3:3
+  //   F[erase_en_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5197,8 +5044,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_erase_en_4_qs)
   );
 
-
-  // F[scramble_en_4]: 4:4
+  //   F[scramble_en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5223,8 +5069,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_scramble_en_4_qs)
   );
 
-
-  // F[ecc_en_4]: 5:5
+  //   F[ecc_en_4]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5249,8 +5094,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_ecc_en_4_qs)
   );
 
-
-  // F[he_en_4]: 6:6
+  //   F[he_en_4]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5278,8 +5122,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 5 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_5]: V(False)
-
-  // F[en_5]: 0:0
+  //   F[en_5]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5304,8 +5147,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_en_5_qs)
   );
 
-
-  // F[rd_en_5]: 1:1
+  //   F[rd_en_5]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5330,8 +5172,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_rd_en_5_qs)
   );
 
-
-  // F[prog_en_5]: 2:2
+  //   F[prog_en_5]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5356,8 +5197,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_prog_en_5_qs)
   );
 
-
-  // F[erase_en_5]: 3:3
+  //   F[erase_en_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5382,8 +5222,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_erase_en_5_qs)
   );
 
-
-  // F[scramble_en_5]: 4:4
+  //   F[scramble_en_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5408,8 +5247,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_scramble_en_5_qs)
   );
 
-
-  // F[ecc_en_5]: 5:5
+  //   F[ecc_en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5434,8 +5272,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_ecc_en_5_qs)
   );
 
-
-  // F[he_en_5]: 6:6
+  //   F[he_en_5]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5463,8 +5300,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 6 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_6]: V(False)
-
-  // F[en_6]: 0:0
+  //   F[en_6]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5489,8 +5325,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_en_6_qs)
   );
 
-
-  // F[rd_en_6]: 1:1
+  //   F[rd_en_6]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5515,8 +5350,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_rd_en_6_qs)
   );
 
-
-  // F[prog_en_6]: 2:2
+  //   F[prog_en_6]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5541,8 +5375,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_prog_en_6_qs)
   );
 
-
-  // F[erase_en_6]: 3:3
+  //   F[erase_en_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5567,8 +5400,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_erase_en_6_qs)
   );
 
-
-  // F[scramble_en_6]: 4:4
+  //   F[scramble_en_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5593,8 +5425,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_scramble_en_6_qs)
   );
 
-
-  // F[ecc_en_6]: 5:5
+  //   F[ecc_en_6]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5619,8 +5450,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_ecc_en_6_qs)
   );
 
-
-  // F[he_en_6]: 6:6
+  //   F[he_en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5648,8 +5478,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 7 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_7]: V(False)
-
-  // F[en_7]: 0:0
+  //   F[en_7]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5674,8 +5503,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_en_7_qs)
   );
 
-
-  // F[rd_en_7]: 1:1
+  //   F[rd_en_7]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5700,8 +5528,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_rd_en_7_qs)
   );
 
-
-  // F[prog_en_7]: 2:2
+  //   F[prog_en_7]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5726,8 +5553,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_prog_en_7_qs)
   );
 
-
-  // F[erase_en_7]: 3:3
+  //   F[erase_en_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5752,8 +5578,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_erase_en_7_qs)
   );
 
-
-  // F[scramble_en_7]: 4:4
+  //   F[scramble_en_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5778,8 +5603,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_scramble_en_7_qs)
   );
 
-
-  // F[ecc_en_7]: 5:5
+  //   F[ecc_en_7]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5804,8 +5628,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_ecc_en_7_qs)
   );
 
-
-  // F[he_en_7]: 6:6
+  //   F[he_en_7]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5833,8 +5656,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 8 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_8]: V(False)
-
-  // F[en_8]: 0:0
+  //   F[en_8]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5859,8 +5681,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_en_8_qs)
   );
 
-
-  // F[rd_en_8]: 1:1
+  //   F[rd_en_8]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5885,8 +5706,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_rd_en_8_qs)
   );
 
-
-  // F[prog_en_8]: 2:2
+  //   F[prog_en_8]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5911,8 +5731,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_prog_en_8_qs)
   );
 
-
-  // F[erase_en_8]: 3:3
+  //   F[erase_en_8]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5937,8 +5756,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_erase_en_8_qs)
   );
 
-
-  // F[scramble_en_8]: 4:4
+  //   F[scramble_en_8]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5963,8 +5781,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_scramble_en_8_qs)
   );
 
-
-  // F[ecc_en_8]: 5:5
+  //   F[ecc_en_8]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5989,8 +5806,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_ecc_en_8_qs)
   );
 
-
-  // F[he_en_8]: 6:6
+  //   F[he_en_8]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6018,8 +5834,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 9 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_9]: V(False)
-
-  // F[en_9]: 0:0
+  //   F[en_9]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6044,8 +5859,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_en_9_qs)
   );
 
-
-  // F[rd_en_9]: 1:1
+  //   F[rd_en_9]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6070,8 +5884,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_rd_en_9_qs)
   );
 
-
-  // F[prog_en_9]: 2:2
+  //   F[prog_en_9]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6096,8 +5909,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_prog_en_9_qs)
   );
 
-
-  // F[erase_en_9]: 3:3
+  //   F[erase_en_9]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6122,8 +5934,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_erase_en_9_qs)
   );
 
-
-  // F[scramble_en_9]: 4:4
+  //   F[scramble_en_9]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6148,8 +5959,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_scramble_en_9_qs)
   );
 
-
-  // F[ecc_en_9]: 5:5
+  //   F[ecc_en_9]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6174,8 +5984,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_ecc_en_9_qs)
   );
 
-
-  // F[he_en_9]: 6:6
+  //   F[he_en_9]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6201,11 +6010,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank0_info1_regwen
   // R[bank0_info1_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6231,11 +6037,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6260,8 +6064,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6286,8 +6089,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6312,8 +6114,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6338,8 +6139,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6364,8 +6164,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6390,8 +6189,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6417,11 +6215,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank0_info2_regwen
   // R[bank0_info2_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6446,9 +6241,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank0_info2_regwen
   // R[bank0_info2_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6474,11 +6269,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info2_page_cfg
   // R[bank0_info2_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6503,8 +6296,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6529,8 +6321,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6555,8 +6346,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6581,8 +6371,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6607,8 +6396,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6633,8 +6421,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6662,8 +6449,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank0_info2_page_cfg
   // R[bank0_info2_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6688,8 +6474,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6714,8 +6499,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6740,8 +6524,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6766,8 +6549,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6792,8 +6574,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6818,8 +6599,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6845,11 +6625,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6874,9 +6651,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6901,9 +6678,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6928,9 +6705,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6955,9 +6732,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6982,9 +6759,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7009,9 +6786,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7036,9 +6813,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7063,9 +6840,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7090,9 +6867,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7118,11 +6895,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7147,8 +6922,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7173,8 +6947,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7199,8 +6972,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7225,8 +6997,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7251,8 +7022,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7277,8 +7047,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7306,8 +7075,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7332,8 +7100,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7358,8 +7125,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7384,8 +7150,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7410,8 +7175,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7436,8 +7200,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7462,8 +7225,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7491,8 +7253,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 2 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_2]: V(False)
-
-  // F[en_2]: 0:0
+  //   F[en_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7517,8 +7278,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_en_2_qs)
   );
 
-
-  // F[rd_en_2]: 1:1
+  //   F[rd_en_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7543,8 +7303,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_rd_en_2_qs)
   );
 
-
-  // F[prog_en_2]: 2:2
+  //   F[prog_en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7569,8 +7328,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_prog_en_2_qs)
   );
 
-
-  // F[erase_en_2]: 3:3
+  //   F[erase_en_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7595,8 +7353,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_erase_en_2_qs)
   );
 
-
-  // F[scramble_en_2]: 4:4
+  //   F[scramble_en_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7621,8 +7378,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
   );
 
-
-  // F[ecc_en_2]: 5:5
+  //   F[ecc_en_2]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7647,8 +7403,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
   );
 
-
-  // F[he_en_2]: 6:6
+  //   F[he_en_2]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7676,8 +7431,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 3 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_3]: V(False)
-
-  // F[en_3]: 0:0
+  //   F[en_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7702,8 +7456,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_en_3_qs)
   );
 
-
-  // F[rd_en_3]: 1:1
+  //   F[rd_en_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7728,8 +7481,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_rd_en_3_qs)
   );
 
-
-  // F[prog_en_3]: 2:2
+  //   F[prog_en_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7754,8 +7506,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_prog_en_3_qs)
   );
 
-
-  // F[erase_en_3]: 3:3
+  //   F[erase_en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7780,8 +7531,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
   );
 
-
-  // F[scramble_en_3]: 4:4
+  //   F[scramble_en_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7806,8 +7556,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
   );
 
-
-  // F[ecc_en_3]: 5:5
+  //   F[ecc_en_3]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7832,8 +7581,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
   );
 
-
-  // F[he_en_3]: 6:6
+  //   F[he_en_3]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7861,8 +7609,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 4 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_4]: V(False)
-
-  // F[en_4]: 0:0
+  //   F[en_4]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7887,8 +7634,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_en_4_qs)
   );
 
-
-  // F[rd_en_4]: 1:1
+  //   F[rd_en_4]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7913,8 +7659,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_rd_en_4_qs)
   );
 
-
-  // F[prog_en_4]: 2:2
+  //   F[prog_en_4]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7939,8 +7684,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_prog_en_4_qs)
   );
 
-
-  // F[erase_en_4]: 3:3
+  //   F[erase_en_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7965,8 +7709,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_erase_en_4_qs)
   );
 
-
-  // F[scramble_en_4]: 4:4
+  //   F[scramble_en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7991,8 +7734,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_scramble_en_4_qs)
   );
 
-
-  // F[ecc_en_4]: 5:5
+  //   F[ecc_en_4]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8017,8 +7759,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_ecc_en_4_qs)
   );
 
-
-  // F[he_en_4]: 6:6
+  //   F[he_en_4]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8046,8 +7787,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 5 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_5]: V(False)
-
-  // F[en_5]: 0:0
+  //   F[en_5]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8072,8 +7812,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_en_5_qs)
   );
 
-
-  // F[rd_en_5]: 1:1
+  //   F[rd_en_5]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8098,8 +7837,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_rd_en_5_qs)
   );
 
-
-  // F[prog_en_5]: 2:2
+  //   F[prog_en_5]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8124,8 +7862,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_prog_en_5_qs)
   );
 
-
-  // F[erase_en_5]: 3:3
+  //   F[erase_en_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8150,8 +7887,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_erase_en_5_qs)
   );
 
-
-  // F[scramble_en_5]: 4:4
+  //   F[scramble_en_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8176,8 +7912,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_scramble_en_5_qs)
   );
 
-
-  // F[ecc_en_5]: 5:5
+  //   F[ecc_en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8202,8 +7937,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_ecc_en_5_qs)
   );
 
-
-  // F[he_en_5]: 6:6
+  //   F[he_en_5]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8231,8 +7965,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 6 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_6]: V(False)
-
-  // F[en_6]: 0:0
+  //   F[en_6]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8257,8 +7990,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_en_6_qs)
   );
 
-
-  // F[rd_en_6]: 1:1
+  //   F[rd_en_6]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8283,8 +8015,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_rd_en_6_qs)
   );
 
-
-  // F[prog_en_6]: 2:2
+  //   F[prog_en_6]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8309,8 +8040,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_prog_en_6_qs)
   );
 
-
-  // F[erase_en_6]: 3:3
+  //   F[erase_en_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8335,8 +8065,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_erase_en_6_qs)
   );
 
-
-  // F[scramble_en_6]: 4:4
+  //   F[scramble_en_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8361,8 +8090,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_scramble_en_6_qs)
   );
 
-
-  // F[ecc_en_6]: 5:5
+  //   F[ecc_en_6]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8387,8 +8115,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_ecc_en_6_qs)
   );
 
-
-  // F[he_en_6]: 6:6
+  //   F[he_en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8416,8 +8143,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 7 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_7]: V(False)
-
-  // F[en_7]: 0:0
+  //   F[en_7]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8442,8 +8168,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_en_7_qs)
   );
 
-
-  // F[rd_en_7]: 1:1
+  //   F[rd_en_7]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8468,8 +8193,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_rd_en_7_qs)
   );
 
-
-  // F[prog_en_7]: 2:2
+  //   F[prog_en_7]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8494,8 +8218,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_prog_en_7_qs)
   );
 
-
-  // F[erase_en_7]: 3:3
+  //   F[erase_en_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8520,8 +8243,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_erase_en_7_qs)
   );
 
-
-  // F[scramble_en_7]: 4:4
+  //   F[scramble_en_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8546,8 +8268,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_scramble_en_7_qs)
   );
 
-
-  // F[ecc_en_7]: 5:5
+  //   F[ecc_en_7]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8572,8 +8293,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_ecc_en_7_qs)
   );
 
-
-  // F[he_en_7]: 6:6
+  //   F[he_en_7]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8601,8 +8321,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 8 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_8]: V(False)
-
-  // F[en_8]: 0:0
+  //   F[en_8]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8627,8 +8346,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_en_8_qs)
   );
 
-
-  // F[rd_en_8]: 1:1
+  //   F[rd_en_8]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8653,8 +8371,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_rd_en_8_qs)
   );
 
-
-  // F[prog_en_8]: 2:2
+  //   F[prog_en_8]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8679,8 +8396,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_prog_en_8_qs)
   );
 
-
-  // F[erase_en_8]: 3:3
+  //   F[erase_en_8]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8705,8 +8421,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_erase_en_8_qs)
   );
 
-
-  // F[scramble_en_8]: 4:4
+  //   F[scramble_en_8]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8731,8 +8446,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_scramble_en_8_qs)
   );
 
-
-  // F[ecc_en_8]: 5:5
+  //   F[ecc_en_8]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8757,8 +8471,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_ecc_en_8_qs)
   );
 
-
-  // F[he_en_8]: 6:6
+  //   F[he_en_8]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8786,8 +8499,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 9 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_9]: V(False)
-
-  // F[en_9]: 0:0
+  //   F[en_9]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8812,8 +8524,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_en_9_qs)
   );
 
-
-  // F[rd_en_9]: 1:1
+  //   F[rd_en_9]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8838,8 +8549,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_rd_en_9_qs)
   );
 
-
-  // F[prog_en_9]: 2:2
+  //   F[prog_en_9]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8864,8 +8574,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_prog_en_9_qs)
   );
 
-
-  // F[erase_en_9]: 3:3
+  //   F[erase_en_9]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8890,8 +8599,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_erase_en_9_qs)
   );
 
-
-  // F[scramble_en_9]: 4:4
+  //   F[scramble_en_9]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8916,8 +8624,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_scramble_en_9_qs)
   );
 
-
-  // F[ecc_en_9]: 5:5
+  //   F[ecc_en_9]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8942,8 +8649,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_ecc_en_9_qs)
   );
 
-
-  // F[he_en_9]: 6:6
+  //   F[he_en_9]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8969,11 +8675,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank1_info1_regwen
   // R[bank1_info1_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8999,11 +8702,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9028,8 +8729,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9054,8 +8754,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9080,8 +8779,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9106,8 +8804,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9132,8 +8829,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9158,8 +8854,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9185,11 +8880,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank1_info2_regwen
   // R[bank1_info2_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9214,9 +8906,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank1_info2_regwen
   // R[bank1_info2_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9242,11 +8934,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank1_info2_page_cfg
   // R[bank1_info2_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9271,8 +8961,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9297,8 +8986,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9323,8 +9011,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9349,8 +9036,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9375,8 +9061,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9401,8 +9086,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9430,8 +9114,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank1_info2_page_cfg
   // R[bank1_info2_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9456,8 +9139,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9482,8 +9164,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9508,8 +9189,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9534,8 +9214,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9560,8 +9239,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9586,8 +9264,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9613,9 +9290,7 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // R[bank_cfg_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9641,11 +9316,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mp_bank_cfg
   // R[mp_bank_cfg]: V(False)
-
-  // F[erase_en_0]: 0:0
+  //   F[erase_en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9670,8 +9343,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_bank_cfg_erase_en_0_qs)
   );
 
-
-  // F[erase_en_1]: 1:1
+  //   F[erase_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9697,9 +9369,7 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // R[op_status]: V(False)
-
   //   F[done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -9724,7 +9394,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (op_status_done_qs)
   );
-
 
   //   F[err]: 1:1
   prim_subreg #(
@@ -9753,7 +9422,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[status]: V(False)
-
   //   F[rd_full]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -9778,7 +9446,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (status_rd_full_qs)
   );
-
 
   //   F[rd_empty]: 1:1
   prim_subreg #(
@@ -9805,7 +9472,6 @@ module flash_ctrl_core_reg_top (
     .qs     (status_rd_empty_qs)
   );
 
-
   //   F[prog_full]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -9831,7 +9497,6 @@ module flash_ctrl_core_reg_top (
     .qs     (status_prog_full_qs)
   );
 
-
   //   F[prog_empty]: 3:3
   prim_subreg #(
     .DW      (1),
@@ -9856,7 +9521,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (status_prog_empty_qs)
   );
-
 
   //   F[init_wip]: 4:4
   prim_subreg #(
@@ -9885,7 +9549,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_code_intr_en]: V(False)
-
   //   F[flash_err_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -9910,7 +9573,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_intr_en_flash_err_en_qs)
   );
-
 
   //   F[flash_alert_en]: 1:1
   prim_subreg #(
@@ -9937,7 +9599,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_intr_en_flash_alert_en_qs)
   );
 
-
   //   F[oob_err]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -9962,7 +9623,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_intr_en_oob_err_qs)
   );
-
 
   //   F[mp_err]: 3:3
   prim_subreg #(
@@ -9989,7 +9649,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_intr_en_mp_err_qs)
   );
 
-
   //   F[ecc_single_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -10014,7 +9673,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_intr_en_ecc_single_err_qs)
   );
-
 
   //   F[ecc_multi_err]: 5:5
   prim_subreg #(
@@ -10043,7 +9701,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_code]: V(False)
-
   //   F[flash_err]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -10068,7 +9725,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_flash_err_qs)
   );
-
 
   //   F[flash_alert]: 1:1
   prim_subreg #(
@@ -10095,7 +9751,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_flash_alert_qs)
   );
 
-
   //   F[oob_err]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -10120,7 +9775,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_oob_err_qs)
   );
-
 
   //   F[mp_err]: 3:3
   prim_subreg #(
@@ -10147,7 +9801,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_mp_err_qs)
   );
 
-
   //   F[ecc_single_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -10172,7 +9825,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_ecc_single_err_qs)
   );
-
 
   //   F[ecc_multi_err]: 5:5
   prim_subreg #(
@@ -10201,7 +9853,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_addr]: V(False)
-
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10228,7 +9879,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[ecc_single_err_cnt]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10254,10 +9904,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ecc_single_err_addr
   // R[ecc_single_err_addr_0]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10282,9 +9930,9 @@ module flash_ctrl_core_reg_top (
     .qs     (ecc_single_err_addr_0_qs)
   );
 
+
   // Subregister 1 of Multireg ecc_single_err_addr
   // R[ecc_single_err_addr_1]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10311,7 +9959,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[ecc_multi_err_cnt]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10337,10 +9984,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ecc_multi_err_addr
   // R[ecc_multi_err_addr_0]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10365,9 +10010,9 @@ module flash_ctrl_core_reg_top (
     .qs     (ecc_multi_err_addr_0_qs)
   );
 
+
   // Subregister 1 of Multireg ecc_multi_err_addr
   // R[ecc_multi_err_addr_1]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10394,7 +10039,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_err_cfg_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10421,7 +10065,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_err_cfg]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10448,7 +10091,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_alert_cfg]: V(False)
-
   //   F[alert_ack]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -10473,7 +10115,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (phy_alert_cfg_alert_ack_qs)
   );
-
 
   //   F[alert_trig]: 1:1
   prim_subreg #(
@@ -10502,7 +10143,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_status]: V(False)
-
   //   F[init_wip]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -10528,7 +10168,6 @@ module flash_ctrl_core_reg_top (
     .qs     (phy_status_init_wip_qs)
   );
 
-
   //   F[prog_normal_avail]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -10553,7 +10192,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (phy_status_prog_normal_avail_qs)
   );
-
 
   //   F[prog_repair_avail]: 2:2
   prim_subreg #(
@@ -10582,7 +10220,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[scratch]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10609,7 +10246,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[fifo_lvl]: V(False)
-
   //   F[prog]: 4:0
   prim_subreg #(
     .DW      (5),
@@ -10634,7 +10270,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (fifo_lvl_prog_qs)
   );
-
 
   //   F[rd]: 12:8
   prim_subreg #(
@@ -10663,7 +10298,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[fifo_rst]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10687,7 +10321,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (fifo_rst_qs)
   );
-
 
 
 

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -167,7 +167,6 @@ module gpio_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -194,7 +193,6 @@ module gpio_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -221,7 +219,6 @@ module gpio_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_intr_test (
@@ -237,7 +234,6 @@ module gpio_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -253,7 +249,6 @@ module gpio_reg_top (
 
 
   // R[data_in]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -280,7 +275,6 @@ module gpio_reg_top (
 
 
   // R[direct_out]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_direct_out (
@@ -296,7 +290,6 @@ module gpio_reg_top (
 
 
   // R[masked_out_lower]: V(True)
-
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -310,7 +303,6 @@ module gpio_reg_top (
     .q      (reg2hw.masked_out_lower.data.q),
     .qs     (masked_out_lower_data_qs)
   );
-
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -328,7 +320,6 @@ module gpio_reg_top (
 
 
   // R[masked_out_upper]: V(True)
-
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -342,7 +333,6 @@ module gpio_reg_top (
     .q      (reg2hw.masked_out_upper.data.q),
     .qs     (masked_out_upper_data_qs)
   );
-
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -360,7 +350,6 @@ module gpio_reg_top (
 
 
   // R[direct_oe]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_direct_oe (
@@ -376,7 +365,6 @@ module gpio_reg_top (
 
 
   // R[masked_oe_lower]: V(True)
-
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -390,7 +378,6 @@ module gpio_reg_top (
     .q      (reg2hw.masked_oe_lower.data.q),
     .qs     (masked_oe_lower_data_qs)
   );
-
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -408,7 +395,6 @@ module gpio_reg_top (
 
 
   // R[masked_oe_upper]: V(True)
-
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -422,7 +408,6 @@ module gpio_reg_top (
     .q      (reg2hw.masked_oe_upper.data.q),
     .qs     (masked_oe_upper_data_qs)
   );
-
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -440,7 +425,6 @@ module gpio_reg_top (
 
 
   // R[intr_ctrl_en_rising]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -467,7 +451,6 @@ module gpio_reg_top (
 
 
   // R[intr_ctrl_en_falling]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -494,7 +477,6 @@ module gpio_reg_top (
 
 
   // R[intr_ctrl_en_lvlhigh]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -521,7 +503,6 @@ module gpio_reg_top (
 
 
   // R[intr_ctrl_en_lvllow]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -548,7 +529,6 @@ module gpio_reg_top (
 
 
   // R[ctrl_en_input_filter]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -572,7 +552,6 @@ module gpio_reg_top (
     // to register interface (read)
     .qs     (ctrl_en_input_filter_qs)
   );
-
 
 
 

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -233,7 +233,6 @@ module hmac_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[hmac_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -259,7 +258,6 @@ module hmac_reg_top (
     .qs     (intr_state_hmac_done_qs)
   );
 
-
   //   F[fifo_empty]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -284,7 +282,6 @@ module hmac_reg_top (
     // to register interface (read)
     .qs     (intr_state_fifo_empty_qs)
   );
-
 
   //   F[hmac_err]: 2:2
   prim_subreg #(
@@ -313,7 +310,6 @@ module hmac_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[hmac_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -339,7 +335,6 @@ module hmac_reg_top (
     .qs     (intr_enable_hmac_done_qs)
   );
 
-
   //   F[fifo_empty]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -364,7 +359,6 @@ module hmac_reg_top (
     // to register interface (read)
     .qs     (intr_enable_fifo_empty_qs)
   );
-
 
   //   F[hmac_err]: 2:2
   prim_subreg #(
@@ -393,7 +387,6 @@ module hmac_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[hmac_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -408,7 +401,6 @@ module hmac_reg_top (
     .qs     ()
   );
 
-
   //   F[fifo_empty]: 1:1
   prim_subreg_ext #(
     .DW    (1)
@@ -422,7 +414,6 @@ module hmac_reg_top (
     .q      (reg2hw.intr_test.fifo_empty.q),
     .qs     ()
   );
-
 
   //   F[hmac_err]: 2:2
   prim_subreg_ext #(
@@ -440,7 +431,6 @@ module hmac_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -456,7 +446,6 @@ module hmac_reg_top (
 
 
   // R[cfg]: V(True)
-
   //   F[hmac_en]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -470,7 +459,6 @@ module hmac_reg_top (
     .q      (reg2hw.cfg.hmac_en.q),
     .qs     (cfg_hmac_en_qs)
   );
-
 
   //   F[sha_en]: 1:1
   prim_subreg_ext #(
@@ -486,7 +474,6 @@ module hmac_reg_top (
     .qs     (cfg_sha_en_qs)
   );
 
-
   //   F[endian_swap]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -500,7 +487,6 @@ module hmac_reg_top (
     .q      (reg2hw.cfg.endian_swap.q),
     .qs     (cfg_endian_swap_qs)
   );
-
 
   //   F[digest_swap]: 3:3
   prim_subreg_ext #(
@@ -518,7 +504,6 @@ module hmac_reg_top (
 
 
   // R[cmd]: V(True)
-
   //   F[hash_start]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -532,7 +517,6 @@ module hmac_reg_top (
     .q      (reg2hw.cmd.hash_start.q),
     .qs     ()
   );
-
 
   //   F[hash_process]: 1:1
   prim_subreg_ext #(
@@ -550,7 +534,6 @@ module hmac_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[fifo_empty]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -565,7 +548,6 @@ module hmac_reg_top (
     .qs     (status_fifo_empty_qs)
   );
 
-
   //   F[fifo_full]: 1:1
   prim_subreg_ext #(
     .DW    (1)
@@ -579,7 +561,6 @@ module hmac_reg_top (
     .q      (),
     .qs     (status_fifo_full_qs)
   );
-
 
   //   F[fifo_depth]: 8:4
   prim_subreg_ext #(
@@ -597,7 +578,6 @@ module hmac_reg_top (
 
 
   // R[err_code]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -624,7 +604,6 @@ module hmac_reg_top (
 
 
   // R[wipe_secret]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_wipe_secret (
@@ -639,10 +618,8 @@ module hmac_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg key
   // R[key_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_0 (
@@ -656,9 +633,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg key
   // R[key_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_1 (
@@ -672,9 +649,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg key
   // R[key_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_2 (
@@ -688,9 +665,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg key
   // R[key_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_3 (
@@ -704,9 +681,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 4 of Multireg key
   // R[key_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_4 (
@@ -720,9 +697,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 5 of Multireg key
   // R[key_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_5 (
@@ -736,9 +713,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 6 of Multireg key
   // R[key_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_6 (
@@ -752,9 +729,9 @@ module hmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 7 of Multireg key
   // R[key_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_7 (
@@ -769,10 +746,8 @@ module hmac_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg digest
   // R[digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_0 (
@@ -786,9 +761,9 @@ module hmac_reg_top (
     .qs     (digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg digest
   // R[digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_1 (
@@ -802,9 +777,9 @@ module hmac_reg_top (
     .qs     (digest_1_qs)
   );
 
+
   // Subregister 2 of Multireg digest
   // R[digest_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_2 (
@@ -818,9 +793,9 @@ module hmac_reg_top (
     .qs     (digest_2_qs)
   );
 
+
   // Subregister 3 of Multireg digest
   // R[digest_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_3 (
@@ -834,9 +809,9 @@ module hmac_reg_top (
     .qs     (digest_3_qs)
   );
 
+
   // Subregister 4 of Multireg digest
   // R[digest_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_4 (
@@ -850,9 +825,9 @@ module hmac_reg_top (
     .qs     (digest_4_qs)
   );
 
+
   // Subregister 5 of Multireg digest
   // R[digest_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_5 (
@@ -866,9 +841,9 @@ module hmac_reg_top (
     .qs     (digest_5_qs)
   );
 
+
   // Subregister 6 of Multireg digest
   // R[digest_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_6 (
@@ -882,9 +857,9 @@ module hmac_reg_top (
     .qs     (digest_6_qs)
   );
 
+
   // Subregister 7 of Multireg digest
   // R[digest_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_digest_7 (
@@ -900,7 +875,6 @@ module hmac_reg_top (
 
 
   // R[msg_length_lower]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -927,7 +901,6 @@ module hmac_reg_top (
 
 
   // R[msg_length_upper]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -951,7 +924,6 @@ module hmac_reg_top (
     // to register interface (read)
     .qs     (msg_length_upper_qs)
   );
-
 
 
 

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -303,7 +303,6 @@ module i2c_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[fmt_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -328,7 +327,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_fmt_watermark_qs)
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg #(
@@ -355,7 +353,6 @@ module i2c_reg_top (
     .qs     (intr_state_rx_watermark_qs)
   );
 
-
   //   F[fmt_overflow]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -380,7 +377,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_fmt_overflow_qs)
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg #(
@@ -407,7 +403,6 @@ module i2c_reg_top (
     .qs     (intr_state_rx_overflow_qs)
   );
 
-
   //   F[nak]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -432,7 +427,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_nak_qs)
   );
-
 
   //   F[scl_interference]: 5:5
   prim_subreg #(
@@ -459,7 +453,6 @@ module i2c_reg_top (
     .qs     (intr_state_scl_interference_qs)
   );
 
-
   //   F[sda_interference]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -484,7 +477,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_sda_interference_qs)
   );
-
 
   //   F[stretch_timeout]: 7:7
   prim_subreg #(
@@ -511,7 +503,6 @@ module i2c_reg_top (
     .qs     (intr_state_stretch_timeout_qs)
   );
 
-
   //   F[sda_unstable]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -536,7 +527,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_sda_unstable_qs)
   );
-
 
   //   F[trans_complete]: 9:9
   prim_subreg #(
@@ -563,7 +553,6 @@ module i2c_reg_top (
     .qs     (intr_state_trans_complete_qs)
   );
 
-
   //   F[tx_empty]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -588,7 +577,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_tx_empty_qs)
   );
-
 
   //   F[tx_nonempty]: 11:11
   prim_subreg #(
@@ -615,7 +603,6 @@ module i2c_reg_top (
     .qs     (intr_state_tx_nonempty_qs)
   );
 
-
   //   F[tx_overflow]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -640,7 +627,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_tx_overflow_qs)
   );
-
 
   //   F[acq_overflow]: 13:13
   prim_subreg #(
@@ -667,7 +653,6 @@ module i2c_reg_top (
     .qs     (intr_state_acq_overflow_qs)
   );
 
-
   //   F[ack_stop]: 14:14
   prim_subreg #(
     .DW      (1),
@@ -692,7 +677,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_state_ack_stop_qs)
   );
-
 
   //   F[host_timeout]: 15:15
   prim_subreg #(
@@ -721,7 +705,6 @@ module i2c_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[fmt_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -746,7 +729,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_fmt_watermark_qs)
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg #(
@@ -773,7 +755,6 @@ module i2c_reg_top (
     .qs     (intr_enable_rx_watermark_qs)
   );
 
-
   //   F[fmt_overflow]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -798,7 +779,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_fmt_overflow_qs)
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg #(
@@ -825,7 +805,6 @@ module i2c_reg_top (
     .qs     (intr_enable_rx_overflow_qs)
   );
 
-
   //   F[nak]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -850,7 +829,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_nak_qs)
   );
-
 
   //   F[scl_interference]: 5:5
   prim_subreg #(
@@ -877,7 +855,6 @@ module i2c_reg_top (
     .qs     (intr_enable_scl_interference_qs)
   );
 
-
   //   F[sda_interference]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -902,7 +879,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_sda_interference_qs)
   );
-
 
   //   F[stretch_timeout]: 7:7
   prim_subreg #(
@@ -929,7 +905,6 @@ module i2c_reg_top (
     .qs     (intr_enable_stretch_timeout_qs)
   );
 
-
   //   F[sda_unstable]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -954,7 +929,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_sda_unstable_qs)
   );
-
 
   //   F[trans_complete]: 9:9
   prim_subreg #(
@@ -981,7 +955,6 @@ module i2c_reg_top (
     .qs     (intr_enable_trans_complete_qs)
   );
 
-
   //   F[tx_empty]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -1006,7 +979,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_tx_empty_qs)
   );
-
 
   //   F[tx_nonempty]: 11:11
   prim_subreg #(
@@ -1033,7 +1005,6 @@ module i2c_reg_top (
     .qs     (intr_enable_tx_nonempty_qs)
   );
 
-
   //   F[tx_overflow]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -1058,7 +1029,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_tx_overflow_qs)
   );
-
 
   //   F[acq_overflow]: 13:13
   prim_subreg #(
@@ -1085,7 +1055,6 @@ module i2c_reg_top (
     .qs     (intr_enable_acq_overflow_qs)
   );
 
-
   //   F[ack_stop]: 14:14
   prim_subreg #(
     .DW      (1),
@@ -1110,7 +1079,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (intr_enable_ack_stop_qs)
   );
-
 
   //   F[host_timeout]: 15:15
   prim_subreg #(
@@ -1139,7 +1107,6 @@ module i2c_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[fmt_watermark]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1153,7 +1120,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.fmt_watermark.q),
     .qs     ()
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -1169,7 +1135,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[fmt_overflow]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1183,7 +1148,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.fmt_overflow.q),
     .qs     ()
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg_ext #(
@@ -1199,7 +1163,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[nak]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1213,7 +1176,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.nak.q),
     .qs     ()
   );
-
 
   //   F[scl_interference]: 5:5
   prim_subreg_ext #(
@@ -1229,7 +1191,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[sda_interference]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -1243,7 +1204,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.sda_interference.q),
     .qs     ()
   );
-
 
   //   F[stretch_timeout]: 7:7
   prim_subreg_ext #(
@@ -1259,7 +1219,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[sda_unstable]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -1273,7 +1232,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.sda_unstable.q),
     .qs     ()
   );
-
 
   //   F[trans_complete]: 9:9
   prim_subreg_ext #(
@@ -1289,7 +1247,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[tx_empty]: 10:10
   prim_subreg_ext #(
     .DW    (1)
@@ -1303,7 +1260,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.tx_empty.q),
     .qs     ()
   );
-
 
   //   F[tx_nonempty]: 11:11
   prim_subreg_ext #(
@@ -1319,7 +1275,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[tx_overflow]: 12:12
   prim_subreg_ext #(
     .DW    (1)
@@ -1333,7 +1288,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.tx_overflow.q),
     .qs     ()
   );
-
 
   //   F[acq_overflow]: 13:13
   prim_subreg_ext #(
@@ -1349,7 +1303,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[ack_stop]: 14:14
   prim_subreg_ext #(
     .DW    (1)
@@ -1363,7 +1316,6 @@ module i2c_reg_top (
     .q      (reg2hw.intr_test.ack_stop.q),
     .qs     ()
   );
-
 
   //   F[host_timeout]: 15:15
   prim_subreg_ext #(
@@ -1381,7 +1333,6 @@ module i2c_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1397,7 +1348,6 @@ module i2c_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[enablehost]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1423,7 +1373,6 @@ module i2c_reg_top (
     .qs     (ctrl_enablehost_qs)
   );
 
-
   //   F[enabletarget]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -1448,7 +1397,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (ctrl_enabletarget_qs)
   );
-
 
   //   F[llpbk]: 2:2
   prim_subreg #(
@@ -1477,7 +1425,6 @@ module i2c_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[fmtfull]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1491,7 +1438,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (status_fmtfull_qs)
   );
-
 
   //   F[rxfull]: 1:1
   prim_subreg_ext #(
@@ -1507,7 +1453,6 @@ module i2c_reg_top (
     .qs     (status_rxfull_qs)
   );
 
-
   //   F[fmtempty]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1521,7 +1466,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (status_fmtempty_qs)
   );
-
 
   //   F[hostidle]: 3:3
   prim_subreg_ext #(
@@ -1537,7 +1481,6 @@ module i2c_reg_top (
     .qs     (status_hostidle_qs)
   );
 
-
   //   F[targetidle]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1551,7 +1494,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (status_targetidle_qs)
   );
-
 
   //   F[rxempty]: 5:5
   prim_subreg_ext #(
@@ -1567,7 +1509,6 @@ module i2c_reg_top (
     .qs     (status_rxempty_qs)
   );
 
-
   //   F[txfull]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -1581,7 +1522,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (status_txfull_qs)
   );
-
 
   //   F[acqfull]: 7:7
   prim_subreg_ext #(
@@ -1597,7 +1537,6 @@ module i2c_reg_top (
     .qs     (status_acqfull_qs)
   );
 
-
   //   F[txempty]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -1611,7 +1550,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (status_txempty_qs)
   );
-
 
   //   F[acqempty]: 9:9
   prim_subreg_ext #(
@@ -1629,7 +1567,6 @@ module i2c_reg_top (
 
 
   // R[rdata]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_rdata (
@@ -1645,7 +1582,6 @@ module i2c_reg_top (
 
 
   // R[fdata]: V(False)
-
   //   F[fbyte]: 7:0
   prim_subreg #(
     .DW      (8),
@@ -1670,7 +1606,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[start]: 8:8
   prim_subreg #(
@@ -1697,7 +1632,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[stop]: 9:9
   prim_subreg #(
     .DW      (1),
@@ -1722,7 +1656,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[read]: 10:10
   prim_subreg #(
@@ -1749,7 +1682,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[rcont]: 11:11
   prim_subreg #(
     .DW      (1),
@@ -1774,7 +1706,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[nakok]: 12:12
   prim_subreg #(
@@ -1803,7 +1734,6 @@ module i2c_reg_top (
 
 
   // R[fifo_ctrl]: V(False)
-
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1828,7 +1758,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[fmtrst]: 1:1
   prim_subreg #(
@@ -1855,7 +1784,6 @@ module i2c_reg_top (
     .qs     ()
   );
 
-
   //   F[rxilvl]: 4:2
   prim_subreg #(
     .DW      (3),
@@ -1880,7 +1808,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
   );
-
 
   //   F[fmtilvl]: 6:5
   prim_subreg #(
@@ -1907,7 +1834,6 @@ module i2c_reg_top (
     .qs     (fifo_ctrl_fmtilvl_qs)
   );
 
-
   //   F[acqrst]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -1932,7 +1858,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[txrst]: 8:8
   prim_subreg #(
@@ -1961,7 +1886,6 @@ module i2c_reg_top (
 
 
   // R[fifo_status]: V(True)
-
   //   F[fmtlvl]: 6:0
   prim_subreg_ext #(
     .DW    (7)
@@ -1975,7 +1899,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (fifo_status_fmtlvl_qs)
   );
-
 
   //   F[txlvl]: 14:8
   prim_subreg_ext #(
@@ -1991,7 +1914,6 @@ module i2c_reg_top (
     .qs     (fifo_status_txlvl_qs)
   );
 
-
   //   F[rxlvl]: 22:16
   prim_subreg_ext #(
     .DW    (7)
@@ -2005,7 +1927,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (fifo_status_rxlvl_qs)
   );
-
 
   //   F[acqlvl]: 30:24
   prim_subreg_ext #(
@@ -2023,7 +1944,6 @@ module i2c_reg_top (
 
 
   // R[ovrd]: V(False)
-
   //   F[txovrden]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2049,7 +1969,6 @@ module i2c_reg_top (
     .qs     (ovrd_txovrden_qs)
   );
 
-
   //   F[sclval]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -2074,7 +1993,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (ovrd_sclval_qs)
   );
-
 
   //   F[sdaval]: 2:2
   prim_subreg #(
@@ -2103,7 +2021,6 @@ module i2c_reg_top (
 
 
   // R[val]: V(True)
-
   //   F[scl_rx]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -2117,7 +2034,6 @@ module i2c_reg_top (
     .q      (),
     .qs     (val_scl_rx_qs)
   );
-
 
   //   F[sda_rx]: 31:16
   prim_subreg_ext #(
@@ -2135,7 +2051,6 @@ module i2c_reg_top (
 
 
   // R[timing0]: V(False)
-
   //   F[thigh]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2160,7 +2075,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (timing0_thigh_qs)
   );
-
 
   //   F[tlow]: 31:16
   prim_subreg #(
@@ -2189,7 +2103,6 @@ module i2c_reg_top (
 
 
   // R[timing1]: V(False)
-
   //   F[t_r]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2214,7 +2127,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (timing1_t_r_qs)
   );
-
 
   //   F[t_f]: 31:16
   prim_subreg #(
@@ -2243,7 +2155,6 @@ module i2c_reg_top (
 
 
   // R[timing2]: V(False)
-
   //   F[tsu_sta]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2268,7 +2179,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (timing2_tsu_sta_qs)
   );
-
 
   //   F[thd_sta]: 31:16
   prim_subreg #(
@@ -2297,7 +2207,6 @@ module i2c_reg_top (
 
 
   // R[timing3]: V(False)
-
   //   F[tsu_dat]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2322,7 +2231,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (timing3_tsu_dat_qs)
   );
-
 
   //   F[thd_dat]: 31:16
   prim_subreg #(
@@ -2351,7 +2259,6 @@ module i2c_reg_top (
 
 
   // R[timing4]: V(False)
-
   //   F[tsu_sto]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2376,7 +2283,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (timing4_tsu_sto_qs)
   );
-
 
   //   F[t_buf]: 31:16
   prim_subreg #(
@@ -2405,7 +2311,6 @@ module i2c_reg_top (
 
 
   // R[timeout_ctrl]: V(False)
-
   //   F[val]: 30:0
   prim_subreg #(
     .DW      (31),
@@ -2430,7 +2335,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (timeout_ctrl_val_qs)
   );
-
 
   //   F[en]: 31:31
   prim_subreg #(
@@ -2459,7 +2363,6 @@ module i2c_reg_top (
 
 
   // R[target_id]: V(False)
-
   //   F[address0]: 6:0
   prim_subreg #(
     .DW      (7),
@@ -2484,7 +2387,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (target_id_address0_qs)
   );
-
 
   //   F[mask0]: 13:7
   prim_subreg #(
@@ -2511,7 +2413,6 @@ module i2c_reg_top (
     .qs     (target_id_mask0_qs)
   );
 
-
   //   F[address1]: 20:14
   prim_subreg #(
     .DW      (7),
@@ -2536,7 +2437,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (target_id_address1_qs)
   );
-
 
   //   F[mask1]: 27:21
   prim_subreg #(
@@ -2565,7 +2465,6 @@ module i2c_reg_top (
 
 
   // R[acqdata]: V(True)
-
   //   F[abyte]: 7:0
   prim_subreg_ext #(
     .DW    (8)
@@ -2579,7 +2478,6 @@ module i2c_reg_top (
     .q      (reg2hw.acqdata.abyte.q),
     .qs     (acqdata_abyte_qs)
   );
-
 
   //   F[signal]: 9:8
   prim_subreg_ext #(
@@ -2597,7 +2495,6 @@ module i2c_reg_top (
 
 
   // R[txdata]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -2624,7 +2521,6 @@ module i2c_reg_top (
 
 
   // R[stretch_ctrl]: V(False)
-
   //   F[en_addr_tx]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2649,7 +2545,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (stretch_ctrl_en_addr_tx_qs)
   );
-
 
   //   F[en_addr_acq]: 1:1
   prim_subreg #(
@@ -2676,7 +2571,6 @@ module i2c_reg_top (
     .qs     (stretch_ctrl_en_addr_acq_qs)
   );
 
-
   //   F[stop_tx]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2701,7 +2595,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (stretch_ctrl_stop_tx_qs)
   );
-
 
   //   F[stop_acq]: 3:3
   prim_subreg #(
@@ -2730,7 +2623,6 @@ module i2c_reg_top (
 
 
   // R[host_timeout_ctrl]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2754,7 +2646,6 @@ module i2c_reg_top (
     // to register interface (read)
     .qs     (host_timeout_ctrl_qs)
   );
-
 
 
 

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -308,7 +308,6 @@ module keymgr_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -335,7 +334,6 @@ module keymgr_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -362,7 +360,6 @@ module keymgr_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -378,7 +375,6 @@ module keymgr_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[fatal_fault_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -392,7 +388,6 @@ module keymgr_reg_top (
     .q      (reg2hw.alert_test.fatal_fault_err.q),
     .qs     ()
   );
-
 
   //   F[recov_operation_err]: 1:1
   prim_subreg_ext #(
@@ -410,7 +405,6 @@ module keymgr_reg_top (
 
 
   // R[cfg_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_cfg_regwen (
@@ -426,7 +420,6 @@ module keymgr_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[start]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -451,7 +444,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (control_start_qs)
   );
-
 
   //   F[operation]: 6:4
   prim_subreg #(
@@ -478,7 +470,6 @@ module keymgr_reg_top (
     .qs     (control_operation_qs)
   );
 
-
   //   F[cdi_sel]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -503,7 +494,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (control_cdi_sel_qs)
   );
-
 
   //   F[dest_sel]: 14:12
   prim_subreg #(
@@ -532,7 +522,6 @@ module keymgr_reg_top (
 
 
   // R[sideload_clear]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -559,7 +548,6 @@ module keymgr_reg_top (
 
 
   // R[reseed_interval_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -592,7 +580,6 @@ module keymgr_reg_top (
 
 
   // R[sw_binding_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_binding_regwen (
@@ -607,10 +594,8 @@ module keymgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -635,9 +620,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_0_qs)
   );
 
+
   // Subregister 1 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -662,9 +647,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_1_qs)
   );
 
+
   // Subregister 2 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -689,9 +674,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_2_qs)
   );
 
+
   // Subregister 3 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -716,9 +701,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_3_qs)
   );
 
+
   // Subregister 4 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -743,9 +728,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_4_qs)
   );
 
+
   // Subregister 5 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -770,9 +755,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_5_qs)
   );
 
+
   // Subregister 6 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -797,9 +782,9 @@ module keymgr_reg_top (
     .qs     (sealing_sw_binding_6_qs)
   );
 
+
   // Subregister 7 of Multireg sealing_sw_binding
   // R[sealing_sw_binding_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -825,10 +810,8 @@ module keymgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg attest_sw_binding
   // R[attest_sw_binding_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -853,9 +836,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_0_qs)
   );
 
+
   // Subregister 1 of Multireg attest_sw_binding
   // R[attest_sw_binding_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -880,9 +863,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_1_qs)
   );
 
+
   // Subregister 2 of Multireg attest_sw_binding
   // R[attest_sw_binding_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -907,9 +890,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_2_qs)
   );
 
+
   // Subregister 3 of Multireg attest_sw_binding
   // R[attest_sw_binding_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -934,9 +917,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_3_qs)
   );
 
+
   // Subregister 4 of Multireg attest_sw_binding
   // R[attest_sw_binding_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -961,9 +944,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_4_qs)
   );
 
+
   // Subregister 5 of Multireg attest_sw_binding
   // R[attest_sw_binding_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -988,9 +971,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_5_qs)
   );
 
+
   // Subregister 6 of Multireg attest_sw_binding
   // R[attest_sw_binding_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1015,9 +998,9 @@ module keymgr_reg_top (
     .qs     (attest_sw_binding_6_qs)
   );
 
+
   // Subregister 7 of Multireg attest_sw_binding
   // R[attest_sw_binding_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1043,10 +1026,8 @@ module keymgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg salt
   // R[salt_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1071,9 +1052,9 @@ module keymgr_reg_top (
     .qs     (salt_0_qs)
   );
 
+
   // Subregister 1 of Multireg salt
   // R[salt_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1098,9 +1079,9 @@ module keymgr_reg_top (
     .qs     (salt_1_qs)
   );
 
+
   // Subregister 2 of Multireg salt
   // R[salt_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1125,9 +1106,9 @@ module keymgr_reg_top (
     .qs     (salt_2_qs)
   );
 
+
   // Subregister 3 of Multireg salt
   // R[salt_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1152,9 +1133,9 @@ module keymgr_reg_top (
     .qs     (salt_3_qs)
   );
 
+
   // Subregister 4 of Multireg salt
   // R[salt_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1179,9 +1160,9 @@ module keymgr_reg_top (
     .qs     (salt_4_qs)
   );
 
+
   // Subregister 5 of Multireg salt
   // R[salt_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1206,9 +1187,9 @@ module keymgr_reg_top (
     .qs     (salt_5_qs)
   );
 
+
   // Subregister 6 of Multireg salt
   // R[salt_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1233,9 +1214,9 @@ module keymgr_reg_top (
     .qs     (salt_6_qs)
   );
 
+
   // Subregister 7 of Multireg salt
   // R[salt_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1261,10 +1242,8 @@ module keymgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg key_version
   // R[key_version]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1291,7 +1270,6 @@ module keymgr_reg_top (
 
 
   // R[max_creator_key_ver_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1318,7 +1296,6 @@ module keymgr_reg_top (
 
 
   // R[max_creator_key_ver_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1351,7 +1328,6 @@ module keymgr_reg_top (
 
 
   // R[max_owner_int_key_ver_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1378,7 +1354,6 @@ module keymgr_reg_top (
 
 
   // R[max_owner_int_key_ver_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1411,7 +1386,6 @@ module keymgr_reg_top (
 
 
   // R[max_owner_key_ver_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1438,7 +1412,6 @@ module keymgr_reg_top (
 
 
   // R[max_owner_key_ver_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1470,10 +1443,8 @@ module keymgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sw_share0_output
   // R[sw_share0_output_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1498,9 +1469,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_0_qs)
   );
 
+
   // Subregister 1 of Multireg sw_share0_output
   // R[sw_share0_output_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1525,9 +1496,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_1_qs)
   );
 
+
   // Subregister 2 of Multireg sw_share0_output
   // R[sw_share0_output_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1552,9 +1523,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_2_qs)
   );
 
+
   // Subregister 3 of Multireg sw_share0_output
   // R[sw_share0_output_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1579,9 +1550,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_3_qs)
   );
 
+
   // Subregister 4 of Multireg sw_share0_output
   // R[sw_share0_output_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1606,9 +1577,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_4_qs)
   );
 
+
   // Subregister 5 of Multireg sw_share0_output
   // R[sw_share0_output_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1633,9 +1604,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_5_qs)
   );
 
+
   // Subregister 6 of Multireg sw_share0_output
   // R[sw_share0_output_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1660,9 +1631,9 @@ module keymgr_reg_top (
     .qs     (sw_share0_output_6_qs)
   );
 
+
   // Subregister 7 of Multireg sw_share0_output
   // R[sw_share0_output_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1688,10 +1659,8 @@ module keymgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sw_share1_output
   // R[sw_share1_output_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1716,9 +1685,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_0_qs)
   );
 
+
   // Subregister 1 of Multireg sw_share1_output
   // R[sw_share1_output_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1743,9 +1712,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_1_qs)
   );
 
+
   // Subregister 2 of Multireg sw_share1_output
   // R[sw_share1_output_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1770,9 +1739,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_2_qs)
   );
 
+
   // Subregister 3 of Multireg sw_share1_output
   // R[sw_share1_output_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1797,9 +1766,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_3_qs)
   );
 
+
   // Subregister 4 of Multireg sw_share1_output
   // R[sw_share1_output_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1824,9 +1793,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_4_qs)
   );
 
+
   // Subregister 5 of Multireg sw_share1_output
   // R[sw_share1_output_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1851,9 +1820,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_5_qs)
   );
 
+
   // Subregister 6 of Multireg sw_share1_output
   // R[sw_share1_output_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1878,9 +1847,9 @@ module keymgr_reg_top (
     .qs     (sw_share1_output_6_qs)
   );
 
+
   // Subregister 7 of Multireg sw_share1_output
   // R[sw_share1_output_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -1907,7 +1876,6 @@ module keymgr_reg_top (
 
 
   // R[working_state]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1934,7 +1902,6 @@ module keymgr_reg_top (
 
 
   // R[op_status]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1961,7 +1928,6 @@ module keymgr_reg_top (
 
 
   // R[err_code]: V(False)
-
   //   F[invalid_op]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1987,7 +1953,6 @@ module keymgr_reg_top (
     .qs     (err_code_invalid_op_qs)
   );
 
-
   //   F[invalid_kmac_input]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -2012,7 +1977,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (err_code_invalid_kmac_input_qs)
   );
-
 
   //   F[invalid_shadow_update]: 2:2
   prim_subreg #(
@@ -2041,7 +2005,6 @@ module keymgr_reg_top (
 
 
   // R[fault_status]: V(False)
-
   //   F[cmd]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2066,7 +2029,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (fault_status_cmd_qs)
   );
-
 
   //   F[kmac_fsm]: 1:1
   prim_subreg #(
@@ -2093,7 +2055,6 @@ module keymgr_reg_top (
     .qs     (fault_status_kmac_fsm_qs)
   );
 
-
   //   F[kmac_op]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2118,7 +2079,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (fault_status_kmac_op_qs)
   );
-
 
   //   F[kmac_out]: 3:3
   prim_subreg #(
@@ -2145,7 +2105,6 @@ module keymgr_reg_top (
     .qs     (fault_status_kmac_out_qs)
   );
 
-
   //   F[regfile_intg]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -2170,7 +2129,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (fault_status_regfile_intg_qs)
   );
-
 
   //   F[shadow]: 5:5
   prim_subreg #(
@@ -2197,7 +2155,6 @@ module keymgr_reg_top (
     .qs     (fault_status_shadow_qs)
   );
 
-
   //   F[ctrl_fsm_intg]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -2223,7 +2180,6 @@ module keymgr_reg_top (
     .qs     (fault_status_ctrl_fsm_intg_qs)
   );
 
-
   //   F[ctrl_fsm_cnt]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -2248,7 +2204,6 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (fault_status_ctrl_fsm_cnt_qs)
   );
-
 
 
 

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -333,7 +333,6 @@ module kmac_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[kmac_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -359,7 +358,6 @@ module kmac_reg_top (
     .qs     (intr_state_kmac_done_qs)
   );
 
-
   //   F[fifo_empty]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -384,7 +382,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (intr_state_fifo_empty_qs)
   );
-
 
   //   F[kmac_err]: 2:2
   prim_subreg #(
@@ -413,7 +410,6 @@ module kmac_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[kmac_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -439,7 +435,6 @@ module kmac_reg_top (
     .qs     (intr_enable_kmac_done_qs)
   );
 
-
   //   F[fifo_empty]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -464,7 +459,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (intr_enable_fifo_empty_qs)
   );
-
 
   //   F[kmac_err]: 2:2
   prim_subreg #(
@@ -493,7 +487,6 @@ module kmac_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[kmac_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -508,7 +501,6 @@ module kmac_reg_top (
     .qs     ()
   );
 
-
   //   F[fifo_empty]: 1:1
   prim_subreg_ext #(
     .DW    (1)
@@ -522,7 +514,6 @@ module kmac_reg_top (
     .q      (reg2hw.intr_test.fifo_empty.q),
     .qs     ()
   );
-
 
   //   F[kmac_err]: 2:2
   prim_subreg_ext #(
@@ -540,7 +531,6 @@ module kmac_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -556,7 +546,6 @@ module kmac_reg_top (
 
 
   // R[cfg_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_cfg_regwen (
@@ -572,7 +561,6 @@ module kmac_reg_top (
 
 
   // R[cfg]: V(False)
-
   //   F[kmac_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -597,7 +585,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_kmac_en_qs)
   );
-
 
   //   F[kstrength]: 3:1
   prim_subreg #(
@@ -624,7 +611,6 @@ module kmac_reg_top (
     .qs     (cfg_kstrength_qs)
   );
 
-
   //   F[mode]: 5:4
   prim_subreg #(
     .DW      (2),
@@ -649,7 +635,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_mode_qs)
   );
-
 
   //   F[msg_endianness]: 8:8
   prim_subreg #(
@@ -676,7 +661,6 @@ module kmac_reg_top (
     .qs     (cfg_msg_endianness_qs)
   );
 
-
   //   F[state_endianness]: 9:9
   prim_subreg #(
     .DW      (1),
@@ -701,7 +685,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_state_endianness_qs)
   );
-
 
   //   F[sideload]: 12:12
   prim_subreg #(
@@ -728,7 +711,6 @@ module kmac_reg_top (
     .qs     (cfg_sideload_qs)
   );
 
-
   //   F[entropy_mode]: 17:16
   prim_subreg #(
     .DW      (2),
@@ -753,7 +735,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_entropy_mode_qs)
   );
-
 
   //   F[entropy_fast_process]: 19:19
   prim_subreg #(
@@ -780,7 +761,6 @@ module kmac_reg_top (
     .qs     (cfg_entropy_fast_process_qs)
   );
 
-
   //   F[entropy_ready]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -805,7 +785,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_entropy_ready_qs)
   );
-
 
   //   F[err_processed]: 25:25
   prim_subreg #(
@@ -834,7 +813,6 @@ module kmac_reg_top (
 
 
   // R[cmd]: V(True)
-
   //   F[cmd]: 3:0
   prim_subreg_ext #(
     .DW    (4)
@@ -849,7 +827,6 @@ module kmac_reg_top (
     .qs     ()
   );
 
-
   //   F[entropy_req]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -863,7 +840,6 @@ module kmac_reg_top (
     .q      (reg2hw.cmd.entropy_req.q),
     .qs     ()
   );
-
 
   //   F[hash_cnt_clr]: 9:9
   prim_subreg_ext #(
@@ -881,7 +857,6 @@ module kmac_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[sha3_idle]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -895,7 +870,6 @@ module kmac_reg_top (
     .q      (),
     .qs     (status_sha3_idle_qs)
   );
-
 
   //   F[sha3_absorb]: 1:1
   prim_subreg_ext #(
@@ -911,7 +885,6 @@ module kmac_reg_top (
     .qs     (status_sha3_absorb_qs)
   );
 
-
   //   F[sha3_squeeze]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -925,7 +898,6 @@ module kmac_reg_top (
     .q      (),
     .qs     (status_sha3_squeeze_qs)
   );
-
 
   //   F[fifo_depth]: 12:8
   prim_subreg_ext #(
@@ -941,7 +913,6 @@ module kmac_reg_top (
     .qs     (status_fifo_depth_qs)
   );
 
-
   //   F[fifo_empty]: 14:14
   prim_subreg_ext #(
     .DW    (1)
@@ -955,7 +926,6 @@ module kmac_reg_top (
     .q      (),
     .qs     (status_fifo_empty_qs)
   );
-
 
   //   F[fifo_full]: 15:15
   prim_subreg_ext #(
@@ -973,7 +943,6 @@ module kmac_reg_top (
 
 
   // R[entropy_period]: V(False)
-
   //   F[prescaler]: 9:0
   prim_subreg #(
     .DW      (10),
@@ -998,7 +967,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (entropy_period_prescaler_qs)
   );
-
 
   //   F[wait_timer]: 31:16
   prim_subreg #(
@@ -1027,7 +995,6 @@ module kmac_reg_top (
 
 
   // R[entropy_refresh]: V(False)
-
   //   F[threshold]: 9:0
   prim_subreg #(
     .DW      (10),
@@ -1052,7 +1019,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (entropy_refresh_threshold_qs)
   );
-
 
   //   F[hash_cnt]: 25:16
   prim_subreg #(
@@ -1081,7 +1047,6 @@ module kmac_reg_top (
 
 
   // R[entropy_seed_lower]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1108,7 +1073,6 @@ module kmac_reg_top (
 
 
   // R[entropy_seed_upper]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1134,10 +1098,8 @@ module kmac_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg key_share0
   // R[key_share0_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_0 (
@@ -1151,9 +1113,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg key_share0
   // R[key_share0_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_1 (
@@ -1167,9 +1129,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg key_share0
   // R[key_share0_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_2 (
@@ -1183,9 +1145,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg key_share0
   // R[key_share0_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_3 (
@@ -1199,9 +1161,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 4 of Multireg key_share0
   // R[key_share0_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_4 (
@@ -1215,9 +1177,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 5 of Multireg key_share0
   // R[key_share0_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_5 (
@@ -1231,9 +1193,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 6 of Multireg key_share0
   // R[key_share0_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_6 (
@@ -1247,9 +1209,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 7 of Multireg key_share0
   // R[key_share0_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_7 (
@@ -1263,9 +1225,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 8 of Multireg key_share0
   // R[key_share0_8]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_8 (
@@ -1279,9 +1241,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 9 of Multireg key_share0
   // R[key_share0_9]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_9 (
@@ -1295,9 +1257,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 10 of Multireg key_share0
   // R[key_share0_10]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_10 (
@@ -1311,9 +1273,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 11 of Multireg key_share0
   // R[key_share0_11]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_11 (
@@ -1327,9 +1289,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 12 of Multireg key_share0
   // R[key_share0_12]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_12 (
@@ -1343,9 +1305,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 13 of Multireg key_share0
   // R[key_share0_13]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_13 (
@@ -1359,9 +1321,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 14 of Multireg key_share0
   // R[key_share0_14]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_14 (
@@ -1375,9 +1337,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 15 of Multireg key_share0
   // R[key_share0_15]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_15 (
@@ -1392,10 +1354,8 @@ module kmac_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg key_share1
   // R[key_share1_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_0 (
@@ -1409,9 +1369,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 1 of Multireg key_share1
   // R[key_share1_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_1 (
@@ -1425,9 +1385,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 2 of Multireg key_share1
   // R[key_share1_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_2 (
@@ -1441,9 +1401,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 3 of Multireg key_share1
   // R[key_share1_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_3 (
@@ -1457,9 +1417,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 4 of Multireg key_share1
   // R[key_share1_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_4 (
@@ -1473,9 +1433,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 5 of Multireg key_share1
   // R[key_share1_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_5 (
@@ -1489,9 +1449,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 6 of Multireg key_share1
   // R[key_share1_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_6 (
@@ -1505,9 +1465,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 7 of Multireg key_share1
   // R[key_share1_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_7 (
@@ -1521,9 +1481,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 8 of Multireg key_share1
   // R[key_share1_8]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_8 (
@@ -1537,9 +1497,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 9 of Multireg key_share1
   // R[key_share1_9]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_9 (
@@ -1553,9 +1513,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 10 of Multireg key_share1
   // R[key_share1_10]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_10 (
@@ -1569,9 +1529,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 11 of Multireg key_share1
   // R[key_share1_11]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_11 (
@@ -1585,9 +1545,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 12 of Multireg key_share1
   // R[key_share1_12]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_12 (
@@ -1601,9 +1561,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 13 of Multireg key_share1
   // R[key_share1_13]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_13 (
@@ -1617,9 +1577,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 14 of Multireg key_share1
   // R[key_share1_14]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_14 (
@@ -1633,9 +1593,9 @@ module kmac_reg_top (
     .qs     ()
   );
 
+
   // Subregister 15 of Multireg key_share1
   // R[key_share1_15]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_15 (
@@ -1651,7 +1611,6 @@ module kmac_reg_top (
 
 
   // R[key_len]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1677,10 +1636,8 @@ module kmac_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg prefix
   // R[prefix_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1705,9 +1662,9 @@ module kmac_reg_top (
     .qs     (prefix_0_qs)
   );
 
+
   // Subregister 1 of Multireg prefix
   // R[prefix_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1732,9 +1689,9 @@ module kmac_reg_top (
     .qs     (prefix_1_qs)
   );
 
+
   // Subregister 2 of Multireg prefix
   // R[prefix_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1759,9 +1716,9 @@ module kmac_reg_top (
     .qs     (prefix_2_qs)
   );
 
+
   // Subregister 3 of Multireg prefix
   // R[prefix_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1786,9 +1743,9 @@ module kmac_reg_top (
     .qs     (prefix_3_qs)
   );
 
+
   // Subregister 4 of Multireg prefix
   // R[prefix_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1813,9 +1770,9 @@ module kmac_reg_top (
     .qs     (prefix_4_qs)
   );
 
+
   // Subregister 5 of Multireg prefix
   // R[prefix_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1840,9 +1797,9 @@ module kmac_reg_top (
     .qs     (prefix_5_qs)
   );
 
+
   // Subregister 6 of Multireg prefix
   // R[prefix_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1867,9 +1824,9 @@ module kmac_reg_top (
     .qs     (prefix_6_qs)
   );
 
+
   // Subregister 7 of Multireg prefix
   // R[prefix_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1894,9 +1851,9 @@ module kmac_reg_top (
     .qs     (prefix_7_qs)
   );
 
+
   // Subregister 8 of Multireg prefix
   // R[prefix_8]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1921,9 +1878,9 @@ module kmac_reg_top (
     .qs     (prefix_8_qs)
   );
 
+
   // Subregister 9 of Multireg prefix
   // R[prefix_9]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1948,9 +1905,9 @@ module kmac_reg_top (
     .qs     (prefix_9_qs)
   );
 
+
   // Subregister 10 of Multireg prefix
   // R[prefix_10]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1977,7 +1934,6 @@ module kmac_reg_top (
 
 
   // R[err_code]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2001,7 +1957,6 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (err_code_qs)
   );
-
 
 
 

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -202,7 +202,6 @@ module lc_ctrl_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   //   F[fatal_prog_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -217,7 +216,6 @@ module lc_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[fatal_state_error]: 1:1
   prim_subreg_ext #(
     .DW    (1)
@@ -231,7 +229,6 @@ module lc_ctrl_reg_top (
     .q      (reg2hw.alert_test.fatal_state_error.q),
     .qs     ()
   );
-
 
   //   F[fatal_bus_integ_error]: 2:2
   prim_subreg_ext #(
@@ -249,7 +246,6 @@ module lc_ctrl_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[ready]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -263,7 +259,6 @@ module lc_ctrl_reg_top (
     .q      (),
     .qs     (status_ready_qs)
   );
-
 
   //   F[transition_successful]: 1:1
   prim_subreg_ext #(
@@ -279,7 +274,6 @@ module lc_ctrl_reg_top (
     .qs     (status_transition_successful_qs)
   );
 
-
   //   F[transition_count_error]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -293,7 +287,6 @@ module lc_ctrl_reg_top (
     .q      (),
     .qs     (status_transition_count_error_qs)
   );
-
 
   //   F[transition_error]: 3:3
   prim_subreg_ext #(
@@ -309,7 +302,6 @@ module lc_ctrl_reg_top (
     .qs     (status_transition_error_qs)
   );
 
-
   //   F[token_error]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -323,7 +315,6 @@ module lc_ctrl_reg_top (
     .q      (),
     .qs     (status_token_error_qs)
   );
-
 
   //   F[flash_rma_error]: 5:5
   prim_subreg_ext #(
@@ -339,7 +330,6 @@ module lc_ctrl_reg_top (
     .qs     (status_flash_rma_error_qs)
   );
 
-
   //   F[otp_error]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -353,7 +343,6 @@ module lc_ctrl_reg_top (
     .q      (),
     .qs     (status_otp_error_qs)
   );
-
 
   //   F[state_error]: 7:7
   prim_subreg_ext #(
@@ -369,7 +358,6 @@ module lc_ctrl_reg_top (
     .qs     (status_state_error_qs)
   );
 
-
   //   F[bus_integ_error]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -383,7 +371,6 @@ module lc_ctrl_reg_top (
     .q      (),
     .qs     (status_bus_integ_error_qs)
   );
-
 
   //   F[otp_partition_error]: 9:9
   prim_subreg_ext #(
@@ -401,7 +388,6 @@ module lc_ctrl_reg_top (
 
 
   // R[claim_transition_if]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_claim_transition_if (
@@ -417,7 +403,6 @@ module lc_ctrl_reg_top (
 
 
   // R[transition_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_transition_regwen (
@@ -433,7 +418,6 @@ module lc_ctrl_reg_top (
 
 
   // R[transition_cmd]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_transition_cmd (
@@ -449,7 +433,6 @@ module lc_ctrl_reg_top (
 
 
   // R[transition_ctrl]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_transition_ctrl (
@@ -464,10 +447,8 @@ module lc_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg transition_token
   // R[transition_token_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_0 (
@@ -481,9 +462,9 @@ module lc_ctrl_reg_top (
     .qs     (transition_token_0_qs)
   );
 
+
   // Subregister 1 of Multireg transition_token
   // R[transition_token_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_1 (
@@ -497,9 +478,9 @@ module lc_ctrl_reg_top (
     .qs     (transition_token_1_qs)
   );
 
+
   // Subregister 2 of Multireg transition_token
   // R[transition_token_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_2 (
@@ -513,9 +494,9 @@ module lc_ctrl_reg_top (
     .qs     (transition_token_2_qs)
   );
 
+
   // Subregister 3 of Multireg transition_token
   // R[transition_token_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_3 (
@@ -531,7 +512,6 @@ module lc_ctrl_reg_top (
 
 
   // R[transition_target]: V(True)
-
   prim_subreg_ext #(
     .DW    (5)
   ) u_transition_target (
@@ -547,7 +527,6 @@ module lc_ctrl_reg_top (
 
 
   // R[otp_vendor_test_ctrl]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_otp_vendor_test_ctrl (
@@ -563,7 +542,6 @@ module lc_ctrl_reg_top (
 
 
   // R[otp_vendor_test_status]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_otp_vendor_test_status (
@@ -579,7 +557,6 @@ module lc_ctrl_reg_top (
 
 
   // R[lc_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (5)
   ) u_lc_state (
@@ -595,7 +572,6 @@ module lc_ctrl_reg_top (
 
 
   // R[lc_transition_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (5)
   ) u_lc_transition_cnt (
@@ -611,7 +587,6 @@ module lc_ctrl_reg_top (
 
 
   // R[lc_id_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (2)
   ) u_lc_id_state (
@@ -626,10 +601,8 @@ module lc_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg device_id
   // R[device_id_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_0 (
@@ -643,9 +616,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_0_qs)
   );
 
+
   // Subregister 1 of Multireg device_id
   // R[device_id_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_1 (
@@ -659,9 +632,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_1_qs)
   );
 
+
   // Subregister 2 of Multireg device_id
   // R[device_id_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_2 (
@@ -675,9 +648,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_2_qs)
   );
 
+
   // Subregister 3 of Multireg device_id
   // R[device_id_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_3 (
@@ -691,9 +664,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_3_qs)
   );
 
+
   // Subregister 4 of Multireg device_id
   // R[device_id_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_4 (
@@ -707,9 +680,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_4_qs)
   );
 
+
   // Subregister 5 of Multireg device_id
   // R[device_id_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_5 (
@@ -723,9 +696,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_5_qs)
   );
 
+
   // Subregister 6 of Multireg device_id
   // R[device_id_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_6 (
@@ -739,9 +712,9 @@ module lc_ctrl_reg_top (
     .qs     (device_id_6_qs)
   );
 
+
   // Subregister 7 of Multireg device_id
   // R[device_id_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_device_id_7 (
@@ -756,10 +729,8 @@ module lc_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg manuf_state
   // R[manuf_state_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_0 (
@@ -773,9 +744,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_0_qs)
   );
 
+
   // Subregister 1 of Multireg manuf_state
   // R[manuf_state_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_1 (
@@ -789,9 +760,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_1_qs)
   );
 
+
   // Subregister 2 of Multireg manuf_state
   // R[manuf_state_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_2 (
@@ -805,9 +776,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_2_qs)
   );
 
+
   // Subregister 3 of Multireg manuf_state
   // R[manuf_state_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_3 (
@@ -821,9 +792,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_3_qs)
   );
 
+
   // Subregister 4 of Multireg manuf_state
   // R[manuf_state_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_4 (
@@ -837,9 +808,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_4_qs)
   );
 
+
   // Subregister 5 of Multireg manuf_state
   // R[manuf_state_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_5 (
@@ -853,9 +824,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_5_qs)
   );
 
+
   // Subregister 6 of Multireg manuf_state
   // R[manuf_state_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_6 (
@@ -869,9 +840,9 @@ module lc_ctrl_reg_top (
     .qs     (manuf_state_6_qs)
   );
 
+
   // Subregister 7 of Multireg manuf_state
   // R[manuf_state_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_manuf_state_7 (
@@ -884,7 +855,6 @@ module lc_ctrl_reg_top (
     .q      (),
     .qs     (manuf_state_7_qs)
   );
-
 
 
 

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -199,7 +199,6 @@ module otbn_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -226,7 +225,6 @@ module otbn_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -253,7 +251,6 @@ module otbn_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -269,7 +266,6 @@ module otbn_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[fatal]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -283,7 +279,6 @@ module otbn_reg_top (
     .q      (reg2hw.alert_test.fatal.q),
     .qs     ()
   );
-
 
   //   F[recov]: 1:1
   prim_subreg_ext #(
@@ -301,7 +296,6 @@ module otbn_reg_top (
 
 
   // R[cmd]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_cmd (
@@ -317,7 +311,6 @@ module otbn_reg_top (
 
 
   // R[status]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_status (
@@ -333,7 +326,6 @@ module otbn_reg_top (
 
 
   // R[err_bits]: V(False)
-
   //   F[bad_data_addr]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -358,7 +350,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (err_bits_bad_data_addr_qs)
   );
-
 
   //   F[bad_insn_addr]: 1:1
   prim_subreg #(
@@ -385,7 +376,6 @@ module otbn_reg_top (
     .qs     (err_bits_bad_insn_addr_qs)
   );
 
-
   //   F[call_stack]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -410,7 +400,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (err_bits_call_stack_qs)
   );
-
 
   //   F[illegal_insn]: 3:3
   prim_subreg #(
@@ -437,7 +426,6 @@ module otbn_reg_top (
     .qs     (err_bits_illegal_insn_qs)
   );
 
-
   //   F[loop]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -462,7 +450,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (err_bits_loop_qs)
   );
-
 
   //   F[fatal_imem]: 5:5
   prim_subreg #(
@@ -489,7 +476,6 @@ module otbn_reg_top (
     .qs     (err_bits_fatal_imem_qs)
   );
 
-
   //   F[fatal_dmem]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -514,7 +500,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (err_bits_fatal_dmem_qs)
   );
-
 
   //   F[fatal_reg]: 7:7
   prim_subreg #(
@@ -541,7 +526,6 @@ module otbn_reg_top (
     .qs     (err_bits_fatal_reg_qs)
   );
 
-
   //   F[fatal_illegal_bus_access]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -566,7 +550,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (err_bits_fatal_illegal_bus_access_qs)
   );
-
 
   //   F[fatal_lifecycle_escalation]: 9:9
   prim_subreg #(
@@ -595,7 +578,6 @@ module otbn_reg_top (
 
 
   // R[start_addr]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -622,7 +604,6 @@ module otbn_reg_top (
 
 
   // R[fatal_alert_cause]: V(False)
-
   //   F[bus_integrity_error]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -647,7 +628,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (fatal_alert_cause_bus_integrity_error_qs)
   );
-
 
   //   F[imem_error]: 1:1
   prim_subreg #(
@@ -674,7 +654,6 @@ module otbn_reg_top (
     .qs     (fatal_alert_cause_imem_error_qs)
   );
 
-
   //   F[dmem_error]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -699,7 +678,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (fatal_alert_cause_dmem_error_qs)
   );
-
 
   //   F[reg_error]: 3:3
   prim_subreg #(
@@ -726,7 +704,6 @@ module otbn_reg_top (
     .qs     (fatal_alert_cause_reg_error_qs)
   );
 
-
   //   F[illegal_bus_access]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -751,7 +728,6 @@ module otbn_reg_top (
     // to register interface (read)
     .qs     (fatal_alert_cause_illegal_bus_access_qs)
   );
-
 
   //   F[lifecycle_escalation]: 5:5
   prim_subreg #(
@@ -780,7 +756,6 @@ module otbn_reg_top (
 
 
   // R[insn_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_insn_cnt (
@@ -793,7 +768,6 @@ module otbn_reg_top (
     .q      (),
     .qs     (insn_cnt_qs)
   );
-
 
 
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -279,7 +279,6 @@ module otp_ctrl_core_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[otp_operation_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -304,7 +303,6 @@ module otp_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_otp_operation_done_qs)
   );
-
 
   //   F[otp_error]: 1:1
   prim_subreg #(
@@ -333,7 +331,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[otp_operation_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -358,7 +355,6 @@ module otp_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_otp_operation_done_qs)
   );
-
 
   //   F[otp_error]: 1:1
   prim_subreg #(
@@ -387,7 +383,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[otp_operation_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -401,7 +396,6 @@ module otp_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.otp_operation_done.q),
     .qs     ()
   );
-
 
   //   F[otp_error]: 1:1
   prim_subreg_ext #(
@@ -419,7 +413,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[fatal_macro_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -434,7 +427,6 @@ module otp_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[fatal_check_error]: 1:1
   prim_subreg_ext #(
     .DW    (1)
@@ -448,7 +440,6 @@ module otp_ctrl_core_reg_top (
     .q      (reg2hw.alert_test.fatal_check_error.q),
     .qs     ()
   );
-
 
   //   F[fatal_bus_integ_error]: 2:2
   prim_subreg_ext #(
@@ -466,7 +457,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[vendor_test_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -480,7 +470,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_vendor_test_error_qs)
   );
-
 
   //   F[creator_sw_cfg_error]: 1:1
   prim_subreg_ext #(
@@ -496,7 +485,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_creator_sw_cfg_error_qs)
   );
 
-
   //   F[owner_sw_cfg_error]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -510,7 +498,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_owner_sw_cfg_error_qs)
   );
-
 
   //   F[hw_cfg_error]: 3:3
   prim_subreg_ext #(
@@ -526,7 +513,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_hw_cfg_error_qs)
   );
 
-
   //   F[secret0_error]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -540,7 +526,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_secret0_error_qs)
   );
-
 
   //   F[secret1_error]: 5:5
   prim_subreg_ext #(
@@ -556,7 +541,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_secret1_error_qs)
   );
 
-
   //   F[secret2_error]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -570,7 +554,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_secret2_error_qs)
   );
-
 
   //   F[life_cycle_error]: 7:7
   prim_subreg_ext #(
@@ -586,7 +569,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_life_cycle_error_qs)
   );
 
-
   //   F[dai_error]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -600,7 +582,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_dai_error_qs)
   );
-
 
   //   F[lci_error]: 9:9
   prim_subreg_ext #(
@@ -616,7 +597,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_lci_error_qs)
   );
 
-
   //   F[timeout_error]: 10:10
   prim_subreg_ext #(
     .DW    (1)
@@ -630,7 +610,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_timeout_error_qs)
   );
-
 
   //   F[lfsr_fsm_error]: 11:11
   prim_subreg_ext #(
@@ -646,7 +625,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_lfsr_fsm_error_qs)
   );
 
-
   //   F[scrambling_fsm_error]: 12:12
   prim_subreg_ext #(
     .DW    (1)
@@ -660,7 +638,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_scrambling_fsm_error_qs)
   );
-
 
   //   F[key_deriv_fsm_error]: 13:13
   prim_subreg_ext #(
@@ -676,7 +653,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_key_deriv_fsm_error_qs)
   );
 
-
   //   F[bus_integ_error]: 14:14
   prim_subreg_ext #(
     .DW    (1)
@@ -691,7 +667,6 @@ module otp_ctrl_core_reg_top (
     .qs     (status_bus_integ_error_qs)
   );
 
-
   //   F[dai_idle]: 15:15
   prim_subreg_ext #(
     .DW    (1)
@@ -705,7 +680,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (status_dai_idle_qs)
   );
-
 
   //   F[check_pending]: 16:16
   prim_subreg_ext #(
@@ -722,11 +696,9 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg err_code
   // R[err_code]: V(True)
-
-  // F[err_code_0]: 2:0
+  //   F[err_code_0]: 2:0
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_0 (
@@ -740,8 +712,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_0_qs)
   );
 
-
-  // F[err_code_1]: 5:3
+  //   F[err_code_1]: 5:3
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_1 (
@@ -755,8 +726,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_1_qs)
   );
 
-
-  // F[err_code_2]: 8:6
+  //   F[err_code_2]: 8:6
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_2 (
@@ -770,8 +740,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_2_qs)
   );
 
-
-  // F[err_code_3]: 11:9
+  //   F[err_code_3]: 11:9
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_3 (
@@ -785,8 +754,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_3_qs)
   );
 
-
-  // F[err_code_4]: 14:12
+  //   F[err_code_4]: 14:12
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_4 (
@@ -800,8 +768,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_4_qs)
   );
 
-
-  // F[err_code_5]: 17:15
+  //   F[err_code_5]: 17:15
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_5 (
@@ -815,8 +782,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_5_qs)
   );
 
-
-  // F[err_code_6]: 20:18
+  //   F[err_code_6]: 20:18
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_6 (
@@ -830,8 +796,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_6_qs)
   );
 
-
-  // F[err_code_7]: 23:21
+  //   F[err_code_7]: 23:21
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_7 (
@@ -845,8 +810,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_7_qs)
   );
 
-
-  // F[err_code_8]: 26:24
+  //   F[err_code_8]: 26:24
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_8 (
@@ -860,8 +824,7 @@ module otp_ctrl_core_reg_top (
     .qs     (err_code_err_code_8_qs)
   );
 
-
-  // F[err_code_9]: 29:27
+  //   F[err_code_9]: 29:27
   prim_subreg_ext #(
     .DW    (3)
   ) u_err_code_err_code_9 (
@@ -876,9 +839,7 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // R[direct_access_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_direct_access_regwen (
@@ -894,7 +855,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[direct_access_cmd]: V(True)
-
   //   F[rd]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -909,7 +869,6 @@ module otp_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[wr]: 1:1
   prim_subreg_ext #(
     .DW    (1)
@@ -923,7 +882,6 @@ module otp_ctrl_core_reg_top (
     .q      (reg2hw.direct_access_cmd.wr.q),
     .qs     ()
   );
-
 
   //   F[digest]: 2:2
   prim_subreg_ext #(
@@ -941,7 +899,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[direct_access_address]: V(False)
-
   prim_subreg #(
     .DW      (11),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -967,10 +924,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg direct_access_wdata
   // R[direct_access_wdata_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -995,9 +950,9 @@ module otp_ctrl_core_reg_top (
     .qs     (direct_access_wdata_0_qs)
   );
 
+
   // Subregister 1 of Multireg direct_access_wdata
   // R[direct_access_wdata_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1023,10 +978,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg direct_access_rdata
   // R[direct_access_rdata_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_direct_access_rdata_0 (
@@ -1040,9 +993,9 @@ module otp_ctrl_core_reg_top (
     .qs     (direct_access_rdata_0_qs)
   );
 
+
   // Subregister 1 of Multireg direct_access_rdata
   // R[direct_access_rdata_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_direct_access_rdata_1 (
@@ -1058,7 +1011,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[check_trigger_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1085,7 +1037,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[check_trigger]: V(True)
-
   //   F[integrity]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1099,7 +1050,6 @@ module otp_ctrl_core_reg_top (
     .q      (reg2hw.check_trigger.integrity.q),
     .qs     ()
   );
-
 
   //   F[consistency]: 1:1
   prim_subreg_ext #(
@@ -1117,7 +1067,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[check_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1144,7 +1093,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[check_timeout]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1171,7 +1119,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[integrity_check_period]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1198,7 +1145,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[consistency_check_period]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1225,7 +1171,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[vendor_test_read_lock]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1252,7 +1197,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[creator_sw_cfg_read_lock]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1279,7 +1223,6 @@ module otp_ctrl_core_reg_top (
 
 
   // R[owner_sw_cfg_read_lock]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1305,10 +1248,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg vendor_test_digest
   // R[vendor_test_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_vendor_test_digest_0 (
@@ -1322,9 +1263,9 @@ module otp_ctrl_core_reg_top (
     .qs     (vendor_test_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg vendor_test_digest
   // R[vendor_test_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_vendor_test_digest_1 (
@@ -1339,10 +1280,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg creator_sw_cfg_digest
   // R[creator_sw_cfg_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_creator_sw_cfg_digest_0 (
@@ -1356,9 +1295,9 @@ module otp_ctrl_core_reg_top (
     .qs     (creator_sw_cfg_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg creator_sw_cfg_digest
   // R[creator_sw_cfg_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_creator_sw_cfg_digest_1 (
@@ -1373,10 +1312,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg owner_sw_cfg_digest
   // R[owner_sw_cfg_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_owner_sw_cfg_digest_0 (
@@ -1390,9 +1327,9 @@ module otp_ctrl_core_reg_top (
     .qs     (owner_sw_cfg_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg owner_sw_cfg_digest
   // R[owner_sw_cfg_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_owner_sw_cfg_digest_1 (
@@ -1407,10 +1344,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg hw_cfg_digest
   // R[hw_cfg_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_hw_cfg_digest_0 (
@@ -1424,9 +1359,9 @@ module otp_ctrl_core_reg_top (
     .qs     (hw_cfg_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg hw_cfg_digest
   // R[hw_cfg_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_hw_cfg_digest_1 (
@@ -1441,10 +1376,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg secret0_digest
   // R[secret0_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_secret0_digest_0 (
@@ -1458,9 +1391,9 @@ module otp_ctrl_core_reg_top (
     .qs     (secret0_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg secret0_digest
   // R[secret0_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_secret0_digest_1 (
@@ -1475,10 +1408,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg secret1_digest
   // R[secret1_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_secret1_digest_0 (
@@ -1492,9 +1423,9 @@ module otp_ctrl_core_reg_top (
     .qs     (secret1_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg secret1_digest
   // R[secret1_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_secret1_digest_1 (
@@ -1509,10 +1440,8 @@ module otp_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg secret2_digest
   // R[secret2_digest_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_secret2_digest_0 (
@@ -1526,9 +1455,9 @@ module otp_ctrl_core_reg_top (
     .qs     (secret2_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg secret2_digest
   // R[secret2_digest_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_secret2_digest_1 (
@@ -1541,7 +1470,6 @@ module otp_ctrl_core_reg_top (
     .q      (),
     .qs     (secret2_digest_1_qs)
   );
-
 
 
 

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -162,7 +162,6 @@ module pattgen_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[done_ch0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -187,7 +186,6 @@ module pattgen_reg_top (
     // to register interface (read)
     .qs     (intr_state_done_ch0_qs)
   );
-
 
   //   F[done_ch1]: 1:1
   prim_subreg #(
@@ -216,7 +214,6 @@ module pattgen_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[done_ch0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -241,7 +238,6 @@ module pattgen_reg_top (
     // to register interface (read)
     .qs     (intr_enable_done_ch0_qs)
   );
-
 
   //   F[done_ch1]: 1:1
   prim_subreg #(
@@ -270,7 +266,6 @@ module pattgen_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[done_ch0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -284,7 +279,6 @@ module pattgen_reg_top (
     .q      (reg2hw.intr_test.done_ch0.q),
     .qs     ()
   );
-
 
   //   F[done_ch1]: 1:1
   prim_subreg_ext #(
@@ -302,7 +296,6 @@ module pattgen_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -318,7 +311,6 @@ module pattgen_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[enable_ch0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -343,7 +335,6 @@ module pattgen_reg_top (
     // to register interface (read)
     .qs     (ctrl_enable_ch0_qs)
   );
-
 
   //   F[enable_ch1]: 1:1
   prim_subreg #(
@@ -370,7 +361,6 @@ module pattgen_reg_top (
     .qs     (ctrl_enable_ch1_qs)
   );
 
-
   //   F[polarity_ch0]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -395,7 +385,6 @@ module pattgen_reg_top (
     // to register interface (read)
     .qs     (ctrl_polarity_ch0_qs)
   );
-
 
   //   F[polarity_ch1]: 3:3
   prim_subreg #(
@@ -424,7 +413,6 @@ module pattgen_reg_top (
 
 
   // R[prediv_ch0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -451,7 +439,6 @@ module pattgen_reg_top (
 
 
   // R[prediv_ch1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -477,10 +464,8 @@ module pattgen_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg data_ch0
   // R[data_ch0_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -505,9 +490,9 @@ module pattgen_reg_top (
     .qs     (data_ch0_0_qs)
   );
 
+
   // Subregister 1 of Multireg data_ch0
   // R[data_ch0_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -533,10 +518,8 @@ module pattgen_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg data_ch1
   // R[data_ch1_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -561,9 +544,9 @@ module pattgen_reg_top (
     .qs     (data_ch1_0_qs)
   );
 
+
   // Subregister 1 of Multireg data_ch1
   // R[data_ch1_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -590,7 +573,6 @@ module pattgen_reg_top (
 
 
   // R[size]: V(False)
-
   //   F[len_ch0]: 5:0
   prim_subreg #(
     .DW      (6),
@@ -615,7 +597,6 @@ module pattgen_reg_top (
     // to register interface (read)
     .qs     (size_len_ch0_qs)
   );
-
 
   //   F[reps_ch0]: 15:6
   prim_subreg #(
@@ -642,7 +623,6 @@ module pattgen_reg_top (
     .qs     (size_reps_ch0_qs)
   );
 
-
   //   F[len_ch1]: 21:16
   prim_subreg #(
     .DW      (6),
@@ -668,7 +648,6 @@ module pattgen_reg_top (
     .qs     (size_len_ch1_qs)
   );
 
-
   //   F[reps_ch1]: 31:22
   prim_subreg #(
     .DW      (10),
@@ -693,7 +672,6 @@ module pattgen_reg_top (
     // to register interface (read)
     .qs     (size_reps_ch1_qs)
   );
-
 
 
 

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -2450,7 +2450,6 @@ module pinmux_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -2465,10 +2464,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2493,9 +2490,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2520,9 +2517,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2547,9 +2544,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2574,9 +2571,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2601,9 +2598,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2628,9 +2625,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2655,9 +2652,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2682,9 +2679,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2709,9 +2706,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2736,9 +2733,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2763,9 +2760,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2790,9 +2787,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2817,9 +2814,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2844,9 +2841,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2871,9 +2868,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2898,9 +2895,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2925,9 +2922,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2952,9 +2949,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2979,9 +2976,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3006,9 +3003,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3033,9 +3030,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3060,9 +3057,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3087,9 +3084,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3114,9 +3111,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3141,9 +3138,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3168,9 +3165,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3195,9 +3192,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3222,9 +3219,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3249,9 +3246,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3276,9 +3273,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3303,9 +3300,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3330,9 +3327,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3358,10 +3355,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_periph_insel
   // R[mio_periph_insel_0]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3386,9 +3381,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_periph_insel
   // R[mio_periph_insel_1]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3413,9 +3408,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_periph_insel
   // R[mio_periph_insel_2]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3440,9 +3435,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_periph_insel
   // R[mio_periph_insel_3]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3467,9 +3462,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_periph_insel
   // R[mio_periph_insel_4]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3494,9 +3489,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_periph_insel
   // R[mio_periph_insel_5]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3521,9 +3516,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_periph_insel
   // R[mio_periph_insel_6]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3548,9 +3543,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_periph_insel
   // R[mio_periph_insel_7]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3575,9 +3570,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_periph_insel
   // R[mio_periph_insel_8]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3602,9 +3597,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_periph_insel
   // R[mio_periph_insel_9]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3629,9 +3624,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_periph_insel
   // R[mio_periph_insel_10]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3656,9 +3651,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_periph_insel
   // R[mio_periph_insel_11]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3683,9 +3678,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_periph_insel
   // R[mio_periph_insel_12]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3710,9 +3705,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_periph_insel
   // R[mio_periph_insel_13]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3737,9 +3732,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_periph_insel
   // R[mio_periph_insel_14]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3764,9 +3759,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_periph_insel
   // R[mio_periph_insel_15]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3791,9 +3786,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_periph_insel
   // R[mio_periph_insel_16]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3818,9 +3813,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_periph_insel
   // R[mio_periph_insel_17]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3845,9 +3840,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_periph_insel
   // R[mio_periph_insel_18]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3872,9 +3867,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_periph_insel
   // R[mio_periph_insel_19]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3899,9 +3894,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_periph_insel
   // R[mio_periph_insel_20]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3926,9 +3921,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_periph_insel
   // R[mio_periph_insel_21]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3953,9 +3948,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_periph_insel
   // R[mio_periph_insel_22]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3980,9 +3975,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_periph_insel
   // R[mio_periph_insel_23]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4007,9 +4002,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_periph_insel
   // R[mio_periph_insel_24]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4034,9 +4029,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_periph_insel
   // R[mio_periph_insel_25]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4061,9 +4056,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_periph_insel
   // R[mio_periph_insel_26]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4088,9 +4083,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_periph_insel
   // R[mio_periph_insel_27]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4115,9 +4110,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_periph_insel
   // R[mio_periph_insel_28]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4142,9 +4137,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_periph_insel
   // R[mio_periph_insel_29]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4169,9 +4164,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_periph_insel
   // R[mio_periph_insel_30]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4196,9 +4191,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_periph_insel
   // R[mio_periph_insel_31]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4223,9 +4218,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_periph_insel
   // R[mio_periph_insel_32]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4251,10 +4246,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4279,9 +4272,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4306,9 +4299,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4333,9 +4326,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4360,9 +4353,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4387,9 +4380,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4414,9 +4407,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4441,9 +4434,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4468,9 +4461,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4495,9 +4488,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4522,9 +4515,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4549,9 +4542,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4576,9 +4569,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4603,9 +4596,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4630,9 +4623,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4657,9 +4650,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4684,9 +4677,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4711,9 +4704,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4738,9 +4731,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4765,9 +4758,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4792,9 +4785,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4819,9 +4812,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4846,9 +4839,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4873,9 +4866,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4900,9 +4893,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4927,9 +4920,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4954,9 +4947,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4981,9 +4974,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -5008,9 +5001,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -5035,9 +5028,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -5062,9 +5055,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -5089,9 +5082,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -5117,10 +5110,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_outsel
   // R[mio_outsel_0]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5145,9 +5136,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_outsel
   // R[mio_outsel_1]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5172,9 +5163,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_outsel
   // R[mio_outsel_2]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5199,9 +5190,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_outsel
   // R[mio_outsel_3]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5226,9 +5217,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_outsel
   // R[mio_outsel_4]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5253,9 +5244,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_outsel
   // R[mio_outsel_5]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5280,9 +5271,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_outsel
   // R[mio_outsel_6]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5307,9 +5298,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_outsel
   // R[mio_outsel_7]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5334,9 +5325,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_outsel
   // R[mio_outsel_8]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5361,9 +5352,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_outsel
   // R[mio_outsel_9]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5388,9 +5379,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_outsel
   // R[mio_outsel_10]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5415,9 +5406,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_outsel
   // R[mio_outsel_11]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5442,9 +5433,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_outsel
   // R[mio_outsel_12]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5469,9 +5460,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_outsel
   // R[mio_outsel_13]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5496,9 +5487,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_outsel
   // R[mio_outsel_14]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5523,9 +5514,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_outsel
   // R[mio_outsel_15]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5550,9 +5541,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_outsel
   // R[mio_outsel_16]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5577,9 +5568,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_outsel
   // R[mio_outsel_17]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5604,9 +5595,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_outsel
   // R[mio_outsel_18]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5631,9 +5622,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_outsel
   // R[mio_outsel_19]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5658,9 +5649,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_outsel
   // R[mio_outsel_20]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5685,9 +5676,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_outsel
   // R[mio_outsel_21]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5712,9 +5703,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_outsel
   // R[mio_outsel_22]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5739,9 +5730,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_outsel
   // R[mio_outsel_23]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5766,9 +5757,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_outsel
   // R[mio_outsel_24]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5793,9 +5784,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_outsel
   // R[mio_outsel_25]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5820,9 +5811,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_outsel
   // R[mio_outsel_26]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5847,9 +5838,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_outsel
   // R[mio_outsel_27]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5874,9 +5865,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_outsel
   // R[mio_outsel_28]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5901,9 +5892,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_outsel
   // R[mio_outsel_29]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5928,9 +5919,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_outsel
   // R[mio_outsel_30]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5955,9 +5946,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_outsel
   // R[mio_outsel_31]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5983,10 +5974,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6011,9 +6000,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6038,9 +6027,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6065,9 +6054,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6092,9 +6081,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6119,9 +6108,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6146,9 +6135,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6173,9 +6162,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6200,9 +6189,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6227,9 +6216,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6254,9 +6243,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6281,9 +6270,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6308,9 +6297,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6335,9 +6324,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6362,9 +6351,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6389,9 +6378,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6416,9 +6405,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6443,9 +6432,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6470,9 +6459,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6497,9 +6486,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6524,9 +6513,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6551,9 +6540,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6578,9 +6567,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6605,9 +6594,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6632,9 +6621,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6659,9 +6648,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6686,9 +6675,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6713,9 +6702,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6740,9 +6729,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6767,9 +6756,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6794,9 +6783,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6821,9 +6810,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6849,10 +6838,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_attr
   // R[mio_pad_attr_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_0 (
@@ -6866,9 +6853,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_attr
   // R[mio_pad_attr_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_1 (
@@ -6882,9 +6869,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_attr
   // R[mio_pad_attr_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_2 (
@@ -6898,9 +6885,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_attr
   // R[mio_pad_attr_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_3 (
@@ -6914,9 +6901,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_attr
   // R[mio_pad_attr_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_4 (
@@ -6930,9 +6917,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_attr
   // R[mio_pad_attr_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_5 (
@@ -6946,9 +6933,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_attr
   // R[mio_pad_attr_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_6 (
@@ -6962,9 +6949,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_attr
   // R[mio_pad_attr_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_7 (
@@ -6978,9 +6965,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_attr
   // R[mio_pad_attr_8]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_8 (
@@ -6994,9 +6981,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_attr
   // R[mio_pad_attr_9]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_9 (
@@ -7010,9 +6997,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_attr
   // R[mio_pad_attr_10]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_10 (
@@ -7026,9 +7013,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_attr
   // R[mio_pad_attr_11]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_11 (
@@ -7042,9 +7029,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_attr
   // R[mio_pad_attr_12]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_12 (
@@ -7058,9 +7045,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_attr
   // R[mio_pad_attr_13]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_13 (
@@ -7074,9 +7061,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_attr
   // R[mio_pad_attr_14]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_14 (
@@ -7090,9 +7077,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_attr
   // R[mio_pad_attr_15]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_15 (
@@ -7106,9 +7093,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_attr
   // R[mio_pad_attr_16]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_16 (
@@ -7122,9 +7109,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_attr
   // R[mio_pad_attr_17]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_17 (
@@ -7138,9 +7125,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_attr
   // R[mio_pad_attr_18]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_18 (
@@ -7154,9 +7141,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_attr
   // R[mio_pad_attr_19]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_19 (
@@ -7170,9 +7157,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_attr
   // R[mio_pad_attr_20]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_20 (
@@ -7186,9 +7173,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_attr
   // R[mio_pad_attr_21]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_21 (
@@ -7202,9 +7189,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_attr
   // R[mio_pad_attr_22]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_22 (
@@ -7218,9 +7205,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_attr
   // R[mio_pad_attr_23]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_23 (
@@ -7234,9 +7221,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_attr
   // R[mio_pad_attr_24]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_24 (
@@ -7250,9 +7237,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_attr
   // R[mio_pad_attr_25]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_25 (
@@ -7266,9 +7253,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_attr
   // R[mio_pad_attr_26]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_26 (
@@ -7282,9 +7269,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_attr
   // R[mio_pad_attr_27]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_27 (
@@ -7298,9 +7285,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_attr
   // R[mio_pad_attr_28]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_28 (
@@ -7314,9 +7301,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_attr
   // R[mio_pad_attr_29]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_29 (
@@ -7330,9 +7317,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_attr
   // R[mio_pad_attr_30]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_30 (
@@ -7346,9 +7333,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_attr
   // R[mio_pad_attr_31]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_31 (
@@ -7363,10 +7350,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7391,9 +7376,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7418,9 +7403,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7445,9 +7430,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7472,9 +7457,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7499,9 +7484,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7526,9 +7511,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7553,9 +7538,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7580,9 +7565,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7607,9 +7592,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7634,9 +7619,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7661,9 +7646,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7688,9 +7673,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7715,9 +7700,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7742,9 +7727,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7769,9 +7754,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7797,10 +7782,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_attr
   // R[dio_pad_attr_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_0 (
@@ -7814,9 +7797,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_attr
   // R[dio_pad_attr_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_1 (
@@ -7830,9 +7813,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_attr
   // R[dio_pad_attr_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_2 (
@@ -7846,9 +7829,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_attr
   // R[dio_pad_attr_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_3 (
@@ -7862,9 +7845,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_attr
   // R[dio_pad_attr_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_4 (
@@ -7878,9 +7861,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_attr
   // R[dio_pad_attr_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_5 (
@@ -7894,9 +7877,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_attr
   // R[dio_pad_attr_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_6 (
@@ -7910,9 +7893,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_attr
   // R[dio_pad_attr_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_7 (
@@ -7926,9 +7909,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_attr
   // R[dio_pad_attr_8]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_8 (
@@ -7942,9 +7925,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_attr
   // R[dio_pad_attr_9]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_9 (
@@ -7958,9 +7941,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_attr
   // R[dio_pad_attr_10]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_10 (
@@ -7974,9 +7957,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_attr
   // R[dio_pad_attr_11]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_11 (
@@ -7990,9 +7973,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_attr
   // R[dio_pad_attr_12]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_12 (
@@ -8006,9 +7989,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_attr
   // R[dio_pad_attr_13]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_13 (
@@ -8022,9 +8005,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_attr
   // R[dio_pad_attr_14]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_14 (
@@ -8038,9 +8021,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_attr
   // R[dio_pad_attr_15]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_15 (
@@ -8055,11 +8038,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_sleep_status
   // R[mio_pad_sleep_status]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8084,8 +8065,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8110,8 +8090,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_1_qs)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8136,8 +8115,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_2_qs)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8162,8 +8140,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_3_qs)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8188,8 +8165,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_4_qs)
   );
 
-
-  // F[en_5]: 5:5
+  //   F[en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8214,8 +8190,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_5_qs)
   );
 
-
-  // F[en_6]: 6:6
+  //   F[en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8240,8 +8215,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_6_qs)
   );
 
-
-  // F[en_7]: 7:7
+  //   F[en_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8266,8 +8240,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_7_qs)
   );
 
-
-  // F[en_8]: 8:8
+  //   F[en_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8292,8 +8265,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_8_qs)
   );
 
-
-  // F[en_9]: 9:9
+  //   F[en_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8318,8 +8290,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_9_qs)
   );
 
-
-  // F[en_10]: 10:10
+  //   F[en_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8344,8 +8315,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_10_qs)
   );
 
-
-  // F[en_11]: 11:11
+  //   F[en_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8370,8 +8340,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_11_qs)
   );
 
-
-  // F[en_12]: 12:12
+  //   F[en_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8396,8 +8365,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_12_qs)
   );
 
-
-  // F[en_13]: 13:13
+  //   F[en_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8422,8 +8390,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_13_qs)
   );
 
-
-  // F[en_14]: 14:14
+  //   F[en_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8448,8 +8415,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_14_qs)
   );
 
-
-  // F[en_15]: 15:15
+  //   F[en_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8474,8 +8440,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_15_qs)
   );
 
-
-  // F[en_16]: 16:16
+  //   F[en_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8500,8 +8465,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_16_qs)
   );
 
-
-  // F[en_17]: 17:17
+  //   F[en_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8526,8 +8490,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_17_qs)
   );
 
-
-  // F[en_18]: 18:18
+  //   F[en_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8552,8 +8515,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_18_qs)
   );
 
-
-  // F[en_19]: 19:19
+  //   F[en_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8578,8 +8540,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_19_qs)
   );
 
-
-  // F[en_20]: 20:20
+  //   F[en_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8604,8 +8565,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_20_qs)
   );
 
-
-  // F[en_21]: 21:21
+  //   F[en_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8630,8 +8590,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_21_qs)
   );
 
-
-  // F[en_22]: 22:22
+  //   F[en_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8656,8 +8615,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_22_qs)
   );
 
-
-  // F[en_23]: 23:23
+  //   F[en_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8682,8 +8640,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_23_qs)
   );
 
-
-  // F[en_24]: 24:24
+  //   F[en_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8708,8 +8665,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_24_qs)
   );
 
-
-  // F[en_25]: 25:25
+  //   F[en_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8734,8 +8690,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_25_qs)
   );
 
-
-  // F[en_26]: 26:26
+  //   F[en_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8760,8 +8715,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_26_qs)
   );
 
-
-  // F[en_27]: 27:27
+  //   F[en_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8786,8 +8740,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_27_qs)
   );
 
-
-  // F[en_28]: 28:28
+  //   F[en_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8812,8 +8765,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_28_qs)
   );
 
-
-  // F[en_29]: 29:29
+  //   F[en_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8838,8 +8790,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_29_qs)
   );
 
-
-  // F[en_30]: 30:30
+  //   F[en_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8864,8 +8815,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_en_30_qs)
   );
 
-
-  // F[en_31]: 31:31
+  //   F[en_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8891,11 +8841,8 @@ module pinmux_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8920,9 +8867,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8947,9 +8894,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8974,9 +8921,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9001,9 +8948,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9028,9 +8975,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9055,9 +9002,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9082,9 +9029,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9109,9 +9056,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9136,9 +9083,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9163,9 +9110,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9190,9 +9137,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9217,9 +9164,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9244,9 +9191,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9271,9 +9218,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9298,9 +9245,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9325,9 +9272,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9352,9 +9299,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9379,9 +9326,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9406,9 +9353,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9433,9 +9380,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9460,9 +9407,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9487,9 +9434,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9514,9 +9461,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9541,9 +9488,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9568,9 +9515,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9595,9 +9542,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9622,9 +9569,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9649,9 +9596,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9676,9 +9623,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9703,9 +9650,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9730,9 +9677,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9758,10 +9705,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9786,9 +9731,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9813,9 +9758,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9840,9 +9785,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9867,9 +9812,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9894,9 +9839,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9921,9 +9866,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9948,9 +9893,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9975,9 +9920,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10002,9 +9947,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10029,9 +9974,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10056,9 +10001,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10083,9 +10028,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10110,9 +10055,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10137,9 +10082,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10164,9 +10109,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10191,9 +10136,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10218,9 +10163,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10245,9 +10190,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10272,9 +10217,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10299,9 +10244,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10326,9 +10271,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10353,9 +10298,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10380,9 +10325,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10407,9 +10352,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10434,9 +10379,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10461,9 +10406,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10488,9 +10433,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10515,9 +10460,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10542,9 +10487,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10569,9 +10514,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10596,9 +10541,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10624,10 +10569,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10652,9 +10595,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_1]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10679,9 +10622,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_2]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10706,9 +10649,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_3]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10733,9 +10676,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_4]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10760,9 +10703,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_5]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10787,9 +10730,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_6]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10814,9 +10757,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_7]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10841,9 +10784,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_8]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10868,9 +10811,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_9]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10895,9 +10838,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_10]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10922,9 +10865,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_11]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10949,9 +10892,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_12]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10976,9 +10919,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_13]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11003,9 +10946,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_14]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11030,9 +10973,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_15]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11057,9 +11000,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_16]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11084,9 +11027,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_17]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11111,9 +11054,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_18]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11138,9 +11081,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_19]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11165,9 +11108,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_20]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11192,9 +11135,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_21]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11219,9 +11162,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_22]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11246,9 +11189,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_23]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11273,9 +11216,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_24]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11300,9 +11243,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_25]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11327,9 +11270,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_26]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11354,9 +11297,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_27]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11381,9 +11324,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_28]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11408,9 +11351,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_29]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11435,9 +11378,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_30]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11462,9 +11405,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_31]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11490,11 +11433,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_sleep_status
   // R[dio_pad_sleep_status]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11519,8 +11460,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11545,8 +11485,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_1_qs)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11571,8 +11510,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_2_qs)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11597,8 +11535,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_3_qs)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11623,8 +11560,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_4_qs)
   );
 
-
-  // F[en_5]: 5:5
+  //   F[en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11649,8 +11585,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_5_qs)
   );
 
-
-  // F[en_6]: 6:6
+  //   F[en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11675,8 +11610,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_6_qs)
   );
 
-
-  // F[en_7]: 7:7
+  //   F[en_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11701,8 +11635,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_7_qs)
   );
 
-
-  // F[en_8]: 8:8
+  //   F[en_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11727,8 +11660,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_8_qs)
   );
 
-
-  // F[en_9]: 9:9
+  //   F[en_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11753,8 +11685,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_9_qs)
   );
 
-
-  // F[en_10]: 10:10
+  //   F[en_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11779,8 +11710,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_10_qs)
   );
 
-
-  // F[en_11]: 11:11
+  //   F[en_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11805,8 +11735,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_11_qs)
   );
 
-
-  // F[en_12]: 12:12
+  //   F[en_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11831,8 +11760,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_12_qs)
   );
 
-
-  // F[en_13]: 13:13
+  //   F[en_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11857,8 +11785,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_13_qs)
   );
 
-
-  // F[en_14]: 14:14
+  //   F[en_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11883,8 +11810,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_14_qs)
   );
 
-
-  // F[en_15]: 15:15
+  //   F[en_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11910,11 +11836,8 @@ module pinmux_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11939,9 +11862,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11966,9 +11889,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11993,9 +11916,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12020,9 +11943,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12047,9 +11970,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12074,9 +11997,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12101,9 +12024,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12128,9 +12051,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12155,9 +12078,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12182,9 +12105,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12209,9 +12132,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12236,9 +12159,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12263,9 +12186,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12290,9 +12213,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12317,9 +12240,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12345,10 +12268,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12373,9 +12294,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12400,9 +12321,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12427,9 +12348,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12454,9 +12375,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12481,9 +12402,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12508,9 +12429,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12535,9 +12456,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12562,9 +12483,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12589,9 +12510,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12616,9 +12537,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12643,9 +12564,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12670,9 +12591,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12697,9 +12618,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12724,9 +12645,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12751,9 +12672,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12779,10 +12700,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12807,9 +12726,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_1]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12834,9 +12753,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_2]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12861,9 +12780,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_3]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12888,9 +12807,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_4]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12915,9 +12834,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_5]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12942,9 +12861,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_6]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12969,9 +12888,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_7]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12996,9 +12915,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_8]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13023,9 +12942,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_9]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13050,9 +12969,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_10]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13077,9 +12996,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_11]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13104,9 +13023,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_12]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13131,9 +13050,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_13]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13158,9 +13077,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_14]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13185,9 +13104,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_15]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13213,10 +13132,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13241,9 +13158,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13268,9 +13185,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13295,9 +13212,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13322,9 +13239,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13349,9 +13266,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13376,9 +13293,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13403,9 +13320,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13431,10 +13348,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector_en
   // R[wkup_detector_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13459,9 +13374,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_0_qs_int)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_en
   // R[wkup_detector_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13486,9 +13401,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_1_qs_int)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_en
   // R[wkup_detector_en_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13513,9 +13428,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_2_qs_int)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_en
   // R[wkup_detector_en_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13540,9 +13455,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_3_qs_int)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_en
   // R[wkup_detector_en_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13567,9 +13482,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_4_qs_int)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_en
   // R[wkup_detector_en_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13594,9 +13509,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_5_qs_int)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_en
   // R[wkup_detector_en_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13621,9 +13536,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_6_qs_int)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_en
   // R[wkup_detector_en_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13649,11 +13564,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector
   // R[wkup_detector_0]: V(False)
-
-  // F[mode_0]: 2:0
+  //   F[mode_0]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13678,8 +13591,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_0_mode_0_qs_int)
   );
 
-
-  // F[filter_0]: 3:3
+  //   F[filter_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13704,8 +13616,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_0_filter_0_qs_int)
   );
 
-
-  // F[miodio_0]: 4:4
+  //   F[miodio_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13733,8 +13644,7 @@ module pinmux_reg_top (
 
   // Subregister 1 of Multireg wkup_detector
   // R[wkup_detector_1]: V(False)
-
-  // F[mode_1]: 2:0
+  //   F[mode_1]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13759,8 +13669,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_1_mode_1_qs_int)
   );
 
-
-  // F[filter_1]: 3:3
+  //   F[filter_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13785,8 +13694,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_1_filter_1_qs_int)
   );
 
-
-  // F[miodio_1]: 4:4
+  //   F[miodio_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13814,8 +13722,7 @@ module pinmux_reg_top (
 
   // Subregister 2 of Multireg wkup_detector
   // R[wkup_detector_2]: V(False)
-
-  // F[mode_2]: 2:0
+  //   F[mode_2]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13840,8 +13747,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_2_mode_2_qs_int)
   );
 
-
-  // F[filter_2]: 3:3
+  //   F[filter_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13866,8 +13772,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_2_filter_2_qs_int)
   );
 
-
-  // F[miodio_2]: 4:4
+  //   F[miodio_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13895,8 +13800,7 @@ module pinmux_reg_top (
 
   // Subregister 3 of Multireg wkup_detector
   // R[wkup_detector_3]: V(False)
-
-  // F[mode_3]: 2:0
+  //   F[mode_3]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13921,8 +13825,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_3_mode_3_qs_int)
   );
 
-
-  // F[filter_3]: 3:3
+  //   F[filter_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13947,8 +13850,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_3_filter_3_qs_int)
   );
 
-
-  // F[miodio_3]: 4:4
+  //   F[miodio_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13976,8 +13878,7 @@ module pinmux_reg_top (
 
   // Subregister 4 of Multireg wkup_detector
   // R[wkup_detector_4]: V(False)
-
-  // F[mode_4]: 2:0
+  //   F[mode_4]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14002,8 +13903,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_4_mode_4_qs_int)
   );
 
-
-  // F[filter_4]: 3:3
+  //   F[filter_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14028,8 +13928,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_4_filter_4_qs_int)
   );
 
-
-  // F[miodio_4]: 4:4
+  //   F[miodio_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14057,8 +13956,7 @@ module pinmux_reg_top (
 
   // Subregister 5 of Multireg wkup_detector
   // R[wkup_detector_5]: V(False)
-
-  // F[mode_5]: 2:0
+  //   F[mode_5]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14083,8 +13981,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_5_mode_5_qs_int)
   );
 
-
-  // F[filter_5]: 3:3
+  //   F[filter_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14109,8 +14006,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_5_filter_5_qs_int)
   );
 
-
-  // F[miodio_5]: 4:4
+  //   F[miodio_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14138,8 +14034,7 @@ module pinmux_reg_top (
 
   // Subregister 6 of Multireg wkup_detector
   // R[wkup_detector_6]: V(False)
-
-  // F[mode_6]: 2:0
+  //   F[mode_6]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14164,8 +14059,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_6_mode_6_qs_int)
   );
 
-
-  // F[filter_6]: 3:3
+  //   F[filter_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14190,8 +14084,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_6_filter_6_qs_int)
   );
 
-
-  // F[miodio_6]: 4:4
+  //   F[miodio_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14219,8 +14112,7 @@ module pinmux_reg_top (
 
   // Subregister 7 of Multireg wkup_detector
   // R[wkup_detector_7]: V(False)
-
-  // F[mode_7]: 2:0
+  //   F[mode_7]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14245,8 +14137,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_7_mode_7_qs_int)
   );
 
-
-  // F[filter_7]: 3:3
+  //   F[filter_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14271,8 +14162,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_7_filter_7_qs_int)
   );
 
-
-  // F[miodio_7]: 4:4
+  //   F[miodio_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14298,11 +14188,8 @@ module pinmux_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_0]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14327,9 +14214,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_0_qs_int)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_1]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14354,9 +14241,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_1_qs_int)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_2]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14381,9 +14268,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_2_qs_int)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_3]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14408,9 +14295,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_3_qs_int)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_4]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14435,9 +14322,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_4_qs_int)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_5]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14462,9 +14349,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_5_qs_int)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_6]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14489,9 +14376,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_6_qs_int)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_7]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14517,10 +14404,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_0]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14545,9 +14430,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_0_qs)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_1]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14572,9 +14457,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_1_qs)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_2]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14599,9 +14484,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_2_qs)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_3]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14626,9 +14511,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_3_qs)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_4]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14653,9 +14538,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_4_qs)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_5]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14680,9 +14565,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_5_qs)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_6]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14707,9 +14592,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_6_qs)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_7]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14735,11 +14620,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_cause
   // R[wkup_cause]: V(False)
-
-  // F[cause_0]: 0:0
+  //   F[cause_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14764,8 +14647,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_0_qs_int)
   );
 
-
-  // F[cause_1]: 1:1
+  //   F[cause_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14790,8 +14672,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_1_qs_int)
   );
 
-
-  // F[cause_2]: 2:2
+  //   F[cause_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14816,8 +14697,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_2_qs_int)
   );
 
-
-  // F[cause_3]: 3:3
+  //   F[cause_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14842,8 +14722,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_3_qs_int)
   );
 
-
-  // F[cause_4]: 4:4
+  //   F[cause_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14868,8 +14747,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_4_qs_int)
   );
 
-
-  // F[cause_5]: 5:5
+  //   F[cause_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14894,8 +14772,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_5_qs_int)
   );
 
-
-  // F[cause_6]: 6:6
+  //   F[cause_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14920,8 +14797,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_6_qs_int)
   );
 
-
-  // F[cause_7]: 7:7
+  //   F[cause_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14945,8 +14821,6 @@ module pinmux_reg_top (
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_7_qs_int)
   );
-
-
 
 
 

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -1033,7 +1033,6 @@ module pwm_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1049,7 +1048,6 @@ module pwm_reg_top (
 
 
   // R[regen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1076,7 +1074,6 @@ module pwm_reg_top (
 
 
   // R[cfg]: V(False)
-
   //   F[clk_div]: 26:0
   prim_subreg #(
     .DW      (27),
@@ -1102,7 +1099,6 @@ module pwm_reg_top (
     .qs     (core_cfg_clk_div_qs_int)
   );
 
-
   //   F[dc_resn]: 30:27
   prim_subreg #(
     .DW      (4),
@@ -1127,7 +1123,6 @@ module pwm_reg_top (
     // to register interface (read)
     .qs     (core_cfg_dc_resn_qs_int)
   );
-
 
   //   F[cntr_en]: 31:31
   prim_subreg #(
@@ -1155,11 +1150,9 @@ module pwm_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg pwm_en
   // R[pwm_en]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1184,8 +1177,7 @@ module pwm_reg_top (
     .qs     (core_pwm_en_en_0_qs_int)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1210,8 +1202,7 @@ module pwm_reg_top (
     .qs     (core_pwm_en_en_1_qs_int)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1236,8 +1227,7 @@ module pwm_reg_top (
     .qs     (core_pwm_en_en_2_qs_int)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1262,8 +1252,7 @@ module pwm_reg_top (
     .qs     (core_pwm_en_en_3_qs_int)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1288,8 +1277,7 @@ module pwm_reg_top (
     .qs     (core_pwm_en_en_4_qs_int)
   );
 
-
-  // F[en_5]: 5:5
+  //   F[en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1315,12 +1303,9 @@ module pwm_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg invert
   // R[invert]: V(False)
-
-  // F[invert_0]: 0:0
+  //   F[invert_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1345,8 +1330,7 @@ module pwm_reg_top (
     .qs     (core_invert_invert_0_qs_int)
   );
 
-
-  // F[invert_1]: 1:1
+  //   F[invert_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1371,8 +1355,7 @@ module pwm_reg_top (
     .qs     (core_invert_invert_1_qs_int)
   );
 
-
-  // F[invert_2]: 2:2
+  //   F[invert_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1397,8 +1380,7 @@ module pwm_reg_top (
     .qs     (core_invert_invert_2_qs_int)
   );
 
-
-  // F[invert_3]: 3:3
+  //   F[invert_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1423,8 +1405,7 @@ module pwm_reg_top (
     .qs     (core_invert_invert_3_qs_int)
   );
 
-
-  // F[invert_4]: 4:4
+  //   F[invert_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1449,8 +1430,7 @@ module pwm_reg_top (
     .qs     (core_invert_invert_4_qs_int)
   );
 
-
-  // F[invert_5]: 5:5
+  //   F[invert_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1476,12 +1456,9 @@ module pwm_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg pwm_param
   // R[pwm_param_0]: V(False)
-
-  // F[phase_delay_0]: 15:0
+  //   F[phase_delay_0]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1506,8 +1483,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_0_phase_delay_0_qs_int)
   );
 
-
-  // F[htbt_en_0]: 30:30
+  //   F[htbt_en_0]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1532,8 +1508,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_0_htbt_en_0_qs_int)
   );
 
-
-  // F[blink_en_0]: 31:31
+  //   F[blink_en_0]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1561,8 +1536,7 @@ module pwm_reg_top (
 
   // Subregister 1 of Multireg pwm_param
   // R[pwm_param_1]: V(False)
-
-  // F[phase_delay_1]: 15:0
+  //   F[phase_delay_1]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1587,8 +1561,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_1_phase_delay_1_qs_int)
   );
 
-
-  // F[htbt_en_1]: 30:30
+  //   F[htbt_en_1]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1613,8 +1586,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_1_htbt_en_1_qs_int)
   );
 
-
-  // F[blink_en_1]: 31:31
+  //   F[blink_en_1]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1642,8 +1614,7 @@ module pwm_reg_top (
 
   // Subregister 2 of Multireg pwm_param
   // R[pwm_param_2]: V(False)
-
-  // F[phase_delay_2]: 15:0
+  //   F[phase_delay_2]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1668,8 +1639,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_2_phase_delay_2_qs_int)
   );
 
-
-  // F[htbt_en_2]: 30:30
+  //   F[htbt_en_2]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1694,8 +1664,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_2_htbt_en_2_qs_int)
   );
 
-
-  // F[blink_en_2]: 31:31
+  //   F[blink_en_2]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1723,8 +1692,7 @@ module pwm_reg_top (
 
   // Subregister 3 of Multireg pwm_param
   // R[pwm_param_3]: V(False)
-
-  // F[phase_delay_3]: 15:0
+  //   F[phase_delay_3]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1749,8 +1717,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_3_phase_delay_3_qs_int)
   );
 
-
-  // F[htbt_en_3]: 30:30
+  //   F[htbt_en_3]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1775,8 +1742,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_3_htbt_en_3_qs_int)
   );
 
-
-  // F[blink_en_3]: 31:31
+  //   F[blink_en_3]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1804,8 +1770,7 @@ module pwm_reg_top (
 
   // Subregister 4 of Multireg pwm_param
   // R[pwm_param_4]: V(False)
-
-  // F[phase_delay_4]: 15:0
+  //   F[phase_delay_4]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1830,8 +1795,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_4_phase_delay_4_qs_int)
   );
 
-
-  // F[htbt_en_4]: 30:30
+  //   F[htbt_en_4]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1856,8 +1820,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_4_htbt_en_4_qs_int)
   );
 
-
-  // F[blink_en_4]: 31:31
+  //   F[blink_en_4]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1885,8 +1848,7 @@ module pwm_reg_top (
 
   // Subregister 5 of Multireg pwm_param
   // R[pwm_param_5]: V(False)
-
-  // F[phase_delay_5]: 15:0
+  //   F[phase_delay_5]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1911,8 +1873,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_5_phase_delay_5_qs_int)
   );
 
-
-  // F[htbt_en_5]: 30:30
+  //   F[htbt_en_5]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1937,8 +1898,7 @@ module pwm_reg_top (
     .qs     (core_pwm_param_5_htbt_en_5_qs_int)
   );
 
-
-  // F[blink_en_5]: 31:31
+  //   F[blink_en_5]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1964,12 +1924,9 @@ module pwm_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg duty_cycle
   // R[duty_cycle_0]: V(False)
-
-  // F[a_0]: 15:0
+  //   F[a_0]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1994,8 +1951,7 @@ module pwm_reg_top (
     .qs     (core_duty_cycle_0_a_0_qs_int)
   );
 
-
-  // F[b_0]: 31:16
+  //   F[b_0]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2023,8 +1979,7 @@ module pwm_reg_top (
 
   // Subregister 1 of Multireg duty_cycle
   // R[duty_cycle_1]: V(False)
-
-  // F[a_1]: 15:0
+  //   F[a_1]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2049,8 +2004,7 @@ module pwm_reg_top (
     .qs     (core_duty_cycle_1_a_1_qs_int)
   );
 
-
-  // F[b_1]: 31:16
+  //   F[b_1]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2078,8 +2032,7 @@ module pwm_reg_top (
 
   // Subregister 2 of Multireg duty_cycle
   // R[duty_cycle_2]: V(False)
-
-  // F[a_2]: 15:0
+  //   F[a_2]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2104,8 +2057,7 @@ module pwm_reg_top (
     .qs     (core_duty_cycle_2_a_2_qs_int)
   );
 
-
-  // F[b_2]: 31:16
+  //   F[b_2]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2133,8 +2085,7 @@ module pwm_reg_top (
 
   // Subregister 3 of Multireg duty_cycle
   // R[duty_cycle_3]: V(False)
-
-  // F[a_3]: 15:0
+  //   F[a_3]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2159,8 +2110,7 @@ module pwm_reg_top (
     .qs     (core_duty_cycle_3_a_3_qs_int)
   );
 
-
-  // F[b_3]: 31:16
+  //   F[b_3]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2188,8 +2138,7 @@ module pwm_reg_top (
 
   // Subregister 4 of Multireg duty_cycle
   // R[duty_cycle_4]: V(False)
-
-  // F[a_4]: 15:0
+  //   F[a_4]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2214,8 +2163,7 @@ module pwm_reg_top (
     .qs     (core_duty_cycle_4_a_4_qs_int)
   );
 
-
-  // F[b_4]: 31:16
+  //   F[b_4]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2243,8 +2191,7 @@ module pwm_reg_top (
 
   // Subregister 5 of Multireg duty_cycle
   // R[duty_cycle_5]: V(False)
-
-  // F[a_5]: 15:0
+  //   F[a_5]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2269,8 +2216,7 @@ module pwm_reg_top (
     .qs     (core_duty_cycle_5_a_5_qs_int)
   );
 
-
-  // F[b_5]: 31:16
+  //   F[b_5]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2296,12 +2242,9 @@ module pwm_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg blink_param
   // R[blink_param_0]: V(False)
-
-  // F[x_0]: 15:0
+  //   F[x_0]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2326,8 +2269,7 @@ module pwm_reg_top (
     .qs     (core_blink_param_0_x_0_qs_int)
   );
 
-
-  // F[y_0]: 31:16
+  //   F[y_0]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2355,8 +2297,7 @@ module pwm_reg_top (
 
   // Subregister 1 of Multireg blink_param
   // R[blink_param_1]: V(False)
-
-  // F[x_1]: 15:0
+  //   F[x_1]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2381,8 +2322,7 @@ module pwm_reg_top (
     .qs     (core_blink_param_1_x_1_qs_int)
   );
 
-
-  // F[y_1]: 31:16
+  //   F[y_1]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2410,8 +2350,7 @@ module pwm_reg_top (
 
   // Subregister 2 of Multireg blink_param
   // R[blink_param_2]: V(False)
-
-  // F[x_2]: 15:0
+  //   F[x_2]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2436,8 +2375,7 @@ module pwm_reg_top (
     .qs     (core_blink_param_2_x_2_qs_int)
   );
 
-
-  // F[y_2]: 31:16
+  //   F[y_2]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2465,8 +2403,7 @@ module pwm_reg_top (
 
   // Subregister 3 of Multireg blink_param
   // R[blink_param_3]: V(False)
-
-  // F[x_3]: 15:0
+  //   F[x_3]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2491,8 +2428,7 @@ module pwm_reg_top (
     .qs     (core_blink_param_3_x_3_qs_int)
   );
 
-
-  // F[y_3]: 31:16
+  //   F[y_3]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2520,8 +2456,7 @@ module pwm_reg_top (
 
   // Subregister 4 of Multireg blink_param
   // R[blink_param_4]: V(False)
-
-  // F[x_4]: 15:0
+  //   F[x_4]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2546,8 +2481,7 @@ module pwm_reg_top (
     .qs     (core_blink_param_4_x_4_qs_int)
   );
 
-
-  // F[y_4]: 31:16
+  //   F[y_4]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2575,8 +2509,7 @@ module pwm_reg_top (
 
   // Subregister 5 of Multireg blink_param
   // R[blink_param_5]: V(False)
-
-  // F[x_5]: 15:0
+  //   F[x_5]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2601,8 +2534,7 @@ module pwm_reg_top (
     .qs     (core_blink_param_5_x_5_qs_int)
   );
 
-
-  // F[y_5]: 31:16
+  //   F[y_5]: 31:16
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2626,8 +2558,6 @@ module pwm_reg_top (
     // to register interface (read)
     .qs     (core_blink_param_5_y_5_qs_int)
   );
-
-
 
 
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -162,7 +162,6 @@ module pwrmgr_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -189,7 +188,6 @@ module pwrmgr_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -216,7 +214,6 @@ module pwrmgr_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -232,7 +229,6 @@ module pwrmgr_reg_top (
 
 
   // R[ctrl_cfg_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_cfg_regwen (
@@ -248,7 +244,6 @@ module pwrmgr_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[low_power_hint]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -273,7 +268,6 @@ module pwrmgr_reg_top (
     // to register interface (read)
     .qs     (control_low_power_hint_qs)
   );
-
 
   //   F[core_clk_en]: 4:4
   prim_subreg #(
@@ -300,7 +294,6 @@ module pwrmgr_reg_top (
     .qs     (control_core_clk_en_qs)
   );
 
-
   //   F[io_clk_en]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -325,7 +318,6 @@ module pwrmgr_reg_top (
     // to register interface (read)
     .qs     (control_io_clk_en_qs)
   );
-
 
   //   F[usb_clk_en_lp]: 6:6
   prim_subreg #(
@@ -352,7 +344,6 @@ module pwrmgr_reg_top (
     .qs     (control_usb_clk_en_lp_qs)
   );
 
-
   //   F[usb_clk_en_active]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -377,7 +368,6 @@ module pwrmgr_reg_top (
     // to register interface (read)
     .qs     (control_usb_clk_en_active_qs)
   );
-
 
   //   F[main_pd_n]: 8:8
   prim_subreg #(
@@ -406,7 +396,6 @@ module pwrmgr_reg_top (
 
 
   // R[cfg_cdc_sync]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -433,7 +422,6 @@ module pwrmgr_reg_top (
 
 
   // R[wakeup_en_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -459,10 +447,8 @@ module pwrmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wakeup_en
   // R[wakeup_en]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -488,10 +474,8 @@ module pwrmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wake_status
   // R[wake_status]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -518,7 +502,6 @@ module pwrmgr_reg_top (
 
 
   // R[reset_en_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -544,10 +527,8 @@ module pwrmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg reset_en
   // R[reset_en]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -573,10 +554,8 @@ module pwrmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg reset_status
   // R[reset_status]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -603,7 +582,6 @@ module pwrmgr_reg_top (
 
 
   // R[wake_info_capture_dis]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -630,7 +608,6 @@ module pwrmgr_reg_top (
 
 
   // R[wake_info]: V(True)
-
   //   F[reasons]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -644,7 +621,6 @@ module pwrmgr_reg_top (
     .q      (reg2hw.wake_info.reasons.q),
     .qs     (wake_info_reasons_qs)
   );
-
 
   //   F[fall_through]: 1:1
   prim_subreg_ext #(
@@ -660,7 +636,6 @@ module pwrmgr_reg_top (
     .qs     (wake_info_fall_through_qs)
   );
 
-
   //   F[abort]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -674,7 +649,6 @@ module pwrmgr_reg_top (
     .q      (reg2hw.wake_info.abort.q),
     .qs     (wake_info_abort_qs)
   );
-
 
 
 

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -131,7 +131,6 @@ module rom_ctrl_regs_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -147,7 +146,6 @@ module rom_ctrl_regs_reg_top (
 
 
   // R[fatal_alert_cause]: V(False)
-
   //   F[checker_error]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -172,7 +170,6 @@ module rom_ctrl_regs_reg_top (
     // to register interface (read)
     .qs     (fatal_alert_cause_checker_error_qs)
   );
-
 
   //   F[integrity_error]: 1:1
   prim_subreg #(
@@ -200,10 +197,8 @@ module rom_ctrl_regs_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg digest
   // R[digest_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -228,9 +223,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg digest
   // R[digest_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -255,9 +250,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_1_qs)
   );
 
+
   // Subregister 2 of Multireg digest
   // R[digest_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -282,9 +277,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_2_qs)
   );
 
+
   // Subregister 3 of Multireg digest
   // R[digest_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -309,9 +304,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_3_qs)
   );
 
+
   // Subregister 4 of Multireg digest
   // R[digest_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -336,9 +331,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_4_qs)
   );
 
+
   // Subregister 5 of Multireg digest
   // R[digest_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -363,9 +358,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_5_qs)
   );
 
+
   // Subregister 6 of Multireg digest
   // R[digest_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -390,9 +385,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (digest_6_qs)
   );
 
+
   // Subregister 7 of Multireg digest
   // R[digest_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -418,10 +413,8 @@ module rom_ctrl_regs_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg exp_digest
   // R[exp_digest_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -446,9 +439,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_0_qs)
   );
 
+
   // Subregister 1 of Multireg exp_digest
   // R[exp_digest_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -473,9 +466,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_1_qs)
   );
 
+
   // Subregister 2 of Multireg exp_digest
   // R[exp_digest_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -500,9 +493,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_2_qs)
   );
 
+
   // Subregister 3 of Multireg exp_digest
   // R[exp_digest_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -527,9 +520,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_3_qs)
   );
 
+
   // Subregister 4 of Multireg exp_digest
   // R[exp_digest_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -554,9 +547,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_4_qs)
   );
 
+
   // Subregister 5 of Multireg exp_digest
   // R[exp_digest_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -581,9 +574,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_5_qs)
   );
 
+
   // Subregister 6 of Multireg exp_digest
   // R[exp_digest_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -608,9 +601,9 @@ module rom_ctrl_regs_reg_top (
     .qs     (exp_digest_6_qs)
   );
 
+
   // Subregister 7 of Multireg exp_digest
   // R[exp_digest_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -634,7 +627,6 @@ module rom_ctrl_regs_reg_top (
     // to register interface (read)
     .qs     (exp_digest_7_qs)
   );
-
 
 
 

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -140,7 +140,6 @@ module rstmgr_reg_top (
 
   // Register instances
   // R[reset_info]: V(False)
-
   //   F[por]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -165,7 +164,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (reset_info_por_qs)
   );
-
 
   //   F[low_power_exit]: 1:1
   prim_subreg #(
@@ -192,7 +190,6 @@ module rstmgr_reg_top (
     .qs     (reset_info_low_power_exit_qs)
   );
 
-
   //   F[ndm_reset]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -217,7 +214,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (reset_info_ndm_reset_qs)
   );
-
 
   //   F[hw_req]: 3:3
   prim_subreg #(
@@ -246,7 +242,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_info_ctrl]: V(False)
-
   //   F[en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -271,7 +266,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (alert_info_ctrl_en_qs)
   );
-
 
   //   F[index]: 7:4
   prim_subreg #(
@@ -300,7 +294,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_info_attr]: V(True)
-
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_info_attr (
@@ -316,7 +309,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_info]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_alert_info (
@@ -331,11 +323,9 @@ module rstmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sw_rst_regen
   // R[sw_rst_regen]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -360,8 +350,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -387,12 +376,9 @@ module rstmgr_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg sw_rst_ctrl_n
   // R[sw_rst_ctrl_n]: V(True)
-
-  // F[val_0]: 0:0
+  //   F[val_0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_0 (
@@ -406,8 +392,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_0_qs)
   );
 
-
-  // F[val_1]: 1:1
+  //   F[val_1]: 1:1
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_1 (
@@ -420,8 +405,6 @@ module rstmgr_reg_top (
     .q      (reg2hw.sw_rst_ctrl_n[1].q),
     .qs     (sw_rst_ctrl_n_val_1_qs)
   );
-
-
 
 
 

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -195,7 +195,6 @@ module rv_core_ibex_cfg_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   //   F[fatal_sw_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -209,7 +208,6 @@ module rv_core_ibex_cfg_reg_top (
     .q      (reg2hw.alert_test.fatal_sw_err.q),
     .qs     ()
   );
-
 
   //   F[recov_sw_err]: 1:1
   prim_subreg_ext #(
@@ -225,7 +223,6 @@ module rv_core_ibex_cfg_reg_top (
     .qs     ()
   );
 
-
   //   F[fatal_hw_err]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -239,7 +236,6 @@ module rv_core_ibex_cfg_reg_top (
     .q      (reg2hw.alert_test.fatal_hw_err.q),
     .qs     ()
   );
-
 
   //   F[recov_hw_err]: 3:3
   prim_subreg_ext #(
@@ -256,10 +252,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sw_alert_regwen
   // R[sw_alert_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -284,9 +278,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (sw_alert_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg sw_alert_regwen
   // R[sw_alert_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -312,10 +306,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sw_alert
   // R[sw_alert_0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -340,9 +332,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (sw_alert_0_qs)
   );
 
+
   // Subregister 1 of Multireg sw_alert
   // R[sw_alert_1]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -368,10 +360,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ibus_regwen
   // R[ibus_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -396,9 +386,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (ibus_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg ibus_regwen
   // R[ibus_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -424,10 +414,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ibus_addr_en
   // R[ibus_addr_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -452,9 +440,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (ibus_addr_en_0_qs)
   );
 
+
   // Subregister 1 of Multireg ibus_addr_en
   // R[ibus_addr_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -480,10 +468,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ibus_addr_matching
   // R[ibus_addr_matching_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -508,9 +494,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (ibus_addr_matching_0_qs)
   );
 
+
   // Subregister 1 of Multireg ibus_addr_matching
   // R[ibus_addr_matching_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -536,10 +522,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ibus_remap_addr
   // R[ibus_remap_addr_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -564,9 +548,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (ibus_remap_addr_0_qs)
   );
 
+
   // Subregister 1 of Multireg ibus_remap_addr
   // R[ibus_remap_addr_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -592,10 +576,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dbus_regwen
   // R[dbus_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -620,9 +602,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (dbus_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg dbus_regwen
   // R[dbus_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -648,10 +630,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dbus_addr_en
   // R[dbus_addr_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -676,9 +656,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (dbus_addr_en_0_qs)
   );
 
+
   // Subregister 1 of Multireg dbus_addr_en
   // R[dbus_addr_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -704,10 +684,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dbus_addr_matching
   // R[dbus_addr_matching_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -732,9 +710,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (dbus_addr_matching_0_qs)
   );
 
+
   // Subregister 1 of Multireg dbus_addr_matching
   // R[dbus_addr_matching_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -760,10 +738,8 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dbus_remap_addr
   // R[dbus_remap_addr_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -788,9 +764,9 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (dbus_remap_addr_0_qs)
   );
 
+
   // Subregister 1 of Multireg dbus_remap_addr
   // R[dbus_remap_addr_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -817,7 +793,6 @@ module rv_core_ibex_cfg_reg_top (
 
 
   // R[nmi_enable]: V(False)
-
   //   F[alert_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -842,7 +817,6 @@ module rv_core_ibex_cfg_reg_top (
     // to register interface (read)
     .qs     (nmi_enable_alert_en_qs)
   );
-
 
   //   F[wdog_en]: 1:1
   prim_subreg #(
@@ -871,7 +845,6 @@ module rv_core_ibex_cfg_reg_top (
 
 
   // R[nmi_state]: V(False)
-
   //   F[alert]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -896,7 +869,6 @@ module rv_core_ibex_cfg_reg_top (
     // to register interface (read)
     .qs     (nmi_state_alert_qs)
   );
-
 
   //   F[wdog]: 1:1
   prim_subreg #(
@@ -925,7 +897,6 @@ module rv_core_ibex_cfg_reg_top (
 
 
   // R[err_status]: V(False)
-
   //   F[reg_intg_err]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -950,7 +921,6 @@ module rv_core_ibex_cfg_reg_top (
     // to register interface (read)
     .qs     (err_status_reg_intg_err_qs)
   );
-
 
   //   F[fatal_intg_err]: 8:8
   prim_subreg #(
@@ -977,7 +947,6 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (err_status_fatal_intg_err_qs)
   );
 
-
   //   F[fatal_core_err]: 9:9
   prim_subreg #(
     .DW      (1),
@@ -1003,7 +972,6 @@ module rv_core_ibex_cfg_reg_top (
     .qs     (err_status_fatal_core_err_qs)
   );
 
-
   //   F[recov_core_err]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -1028,7 +996,6 @@ module rv_core_ibex_cfg_reg_top (
     // to register interface (read)
     .qs     (err_status_recov_core_err_qs)
   );
-
 
 
 

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -112,7 +112,6 @@ module rv_dm_regs_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -125,7 +124,6 @@ module rv_dm_regs_reg_top (
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
-
 
 
 

--- a/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/ip/rv_plic/rtl/rv_plic_reg_top.sv
@@ -380,11 +380,9 @@ module rv_plic_reg_top (
   logic alert_test_wd;
 
   // Register instances
-
   // Subregister 0 of Multireg ip
   // R[ip]: V(False)
-
-  // F[p_0]: 0:0
+  //   F[p_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -409,8 +407,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_0_qs)
   );
 
-
-  // F[p_1]: 1:1
+  //   F[p_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -435,8 +432,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_1_qs)
   );
 
-
-  // F[p_2]: 2:2
+  //   F[p_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -461,8 +457,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_2_qs)
   );
 
-
-  // F[p_3]: 3:3
+  //   F[p_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -487,8 +482,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_3_qs)
   );
 
-
-  // F[p_4]: 4:4
+  //   F[p_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -513,8 +507,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_4_qs)
   );
 
-
-  // F[p_5]: 5:5
+  //   F[p_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -539,8 +532,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_5_qs)
   );
 
-
-  // F[p_6]: 6:6
+  //   F[p_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -565,8 +557,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_6_qs)
   );
 
-
-  // F[p_7]: 7:7
+  //   F[p_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -591,8 +582,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_7_qs)
   );
 
-
-  // F[p_8]: 8:8
+  //   F[p_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -617,8 +607,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_8_qs)
   );
 
-
-  // F[p_9]: 9:9
+  //   F[p_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -643,8 +632,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_9_qs)
   );
 
-
-  // F[p_10]: 10:10
+  //   F[p_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -669,8 +657,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_10_qs)
   );
 
-
-  // F[p_11]: 11:11
+  //   F[p_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -695,8 +682,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_11_qs)
   );
 
-
-  // F[p_12]: 12:12
+  //   F[p_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -721,8 +707,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_12_qs)
   );
 
-
-  // F[p_13]: 13:13
+  //   F[p_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -747,8 +732,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_13_qs)
   );
 
-
-  // F[p_14]: 14:14
+  //   F[p_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -773,8 +757,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_14_qs)
   );
 
-
-  // F[p_15]: 15:15
+  //   F[p_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -799,8 +782,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_15_qs)
   );
 
-
-  // F[p_16]: 16:16
+  //   F[p_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -825,8 +807,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_16_qs)
   );
 
-
-  // F[p_17]: 17:17
+  //   F[p_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -851,8 +832,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_17_qs)
   );
 
-
-  // F[p_18]: 18:18
+  //   F[p_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -877,8 +857,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_18_qs)
   );
 
-
-  // F[p_19]: 19:19
+  //   F[p_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -903,8 +882,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_19_qs)
   );
 
-
-  // F[p_20]: 20:20
+  //   F[p_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -929,8 +907,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_20_qs)
   );
 
-
-  // F[p_21]: 21:21
+  //   F[p_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -955,8 +932,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_21_qs)
   );
 
-
-  // F[p_22]: 22:22
+  //   F[p_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -981,8 +957,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_22_qs)
   );
 
-
-  // F[p_23]: 23:23
+  //   F[p_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1007,8 +982,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_23_qs)
   );
 
-
-  // F[p_24]: 24:24
+  //   F[p_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1033,8 +1007,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_24_qs)
   );
 
-
-  // F[p_25]: 25:25
+  //   F[p_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1059,8 +1032,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_25_qs)
   );
 
-
-  // F[p_26]: 26:26
+  //   F[p_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1085,8 +1057,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_26_qs)
   );
 
-
-  // F[p_27]: 27:27
+  //   F[p_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1111,8 +1082,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_27_qs)
   );
 
-
-  // F[p_28]: 28:28
+  //   F[p_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1137,8 +1107,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_28_qs)
   );
 
-
-  // F[p_29]: 29:29
+  //   F[p_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1163,8 +1132,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_29_qs)
   );
 
-
-  // F[p_30]: 30:30
+  //   F[p_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1189,8 +1157,7 @@ module rv_plic_reg_top (
     .qs     (ip_p_30_qs)
   );
 
-
-  // F[p_31]: 31:31
+  //   F[p_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1216,12 +1183,9 @@ module rv_plic_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg le
   // R[le]: V(False)
-
-  // F[le_0]: 0:0
+  //   F[le_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1246,8 +1210,7 @@ module rv_plic_reg_top (
     .qs     (le_le_0_qs)
   );
 
-
-  // F[le_1]: 1:1
+  //   F[le_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1272,8 +1235,7 @@ module rv_plic_reg_top (
     .qs     (le_le_1_qs)
   );
 
-
-  // F[le_2]: 2:2
+  //   F[le_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1298,8 +1260,7 @@ module rv_plic_reg_top (
     .qs     (le_le_2_qs)
   );
 
-
-  // F[le_3]: 3:3
+  //   F[le_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1324,8 +1285,7 @@ module rv_plic_reg_top (
     .qs     (le_le_3_qs)
   );
 
-
-  // F[le_4]: 4:4
+  //   F[le_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1350,8 +1310,7 @@ module rv_plic_reg_top (
     .qs     (le_le_4_qs)
   );
 
-
-  // F[le_5]: 5:5
+  //   F[le_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1376,8 +1335,7 @@ module rv_plic_reg_top (
     .qs     (le_le_5_qs)
   );
 
-
-  // F[le_6]: 6:6
+  //   F[le_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1402,8 +1360,7 @@ module rv_plic_reg_top (
     .qs     (le_le_6_qs)
   );
 
-
-  // F[le_7]: 7:7
+  //   F[le_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1428,8 +1385,7 @@ module rv_plic_reg_top (
     .qs     (le_le_7_qs)
   );
 
-
-  // F[le_8]: 8:8
+  //   F[le_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1454,8 +1410,7 @@ module rv_plic_reg_top (
     .qs     (le_le_8_qs)
   );
 
-
-  // F[le_9]: 9:9
+  //   F[le_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1480,8 +1435,7 @@ module rv_plic_reg_top (
     .qs     (le_le_9_qs)
   );
 
-
-  // F[le_10]: 10:10
+  //   F[le_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1506,8 +1460,7 @@ module rv_plic_reg_top (
     .qs     (le_le_10_qs)
   );
 
-
-  // F[le_11]: 11:11
+  //   F[le_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1532,8 +1485,7 @@ module rv_plic_reg_top (
     .qs     (le_le_11_qs)
   );
 
-
-  // F[le_12]: 12:12
+  //   F[le_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1558,8 +1510,7 @@ module rv_plic_reg_top (
     .qs     (le_le_12_qs)
   );
 
-
-  // F[le_13]: 13:13
+  //   F[le_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1584,8 +1535,7 @@ module rv_plic_reg_top (
     .qs     (le_le_13_qs)
   );
 
-
-  // F[le_14]: 14:14
+  //   F[le_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1610,8 +1560,7 @@ module rv_plic_reg_top (
     .qs     (le_le_14_qs)
   );
 
-
-  // F[le_15]: 15:15
+  //   F[le_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1636,8 +1585,7 @@ module rv_plic_reg_top (
     .qs     (le_le_15_qs)
   );
 
-
-  // F[le_16]: 16:16
+  //   F[le_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1662,8 +1610,7 @@ module rv_plic_reg_top (
     .qs     (le_le_16_qs)
   );
 
-
-  // F[le_17]: 17:17
+  //   F[le_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1688,8 +1635,7 @@ module rv_plic_reg_top (
     .qs     (le_le_17_qs)
   );
 
-
-  // F[le_18]: 18:18
+  //   F[le_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1714,8 +1660,7 @@ module rv_plic_reg_top (
     .qs     (le_le_18_qs)
   );
 
-
-  // F[le_19]: 19:19
+  //   F[le_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1740,8 +1685,7 @@ module rv_plic_reg_top (
     .qs     (le_le_19_qs)
   );
 
-
-  // F[le_20]: 20:20
+  //   F[le_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1766,8 +1710,7 @@ module rv_plic_reg_top (
     .qs     (le_le_20_qs)
   );
 
-
-  // F[le_21]: 21:21
+  //   F[le_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1792,8 +1735,7 @@ module rv_plic_reg_top (
     .qs     (le_le_21_qs)
   );
 
-
-  // F[le_22]: 22:22
+  //   F[le_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1818,8 +1760,7 @@ module rv_plic_reg_top (
     .qs     (le_le_22_qs)
   );
 
-
-  // F[le_23]: 23:23
+  //   F[le_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1844,8 +1785,7 @@ module rv_plic_reg_top (
     .qs     (le_le_23_qs)
   );
 
-
-  // F[le_24]: 24:24
+  //   F[le_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1870,8 +1810,7 @@ module rv_plic_reg_top (
     .qs     (le_le_24_qs)
   );
 
-
-  // F[le_25]: 25:25
+  //   F[le_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1896,8 +1835,7 @@ module rv_plic_reg_top (
     .qs     (le_le_25_qs)
   );
 
-
-  // F[le_26]: 26:26
+  //   F[le_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1922,8 +1860,7 @@ module rv_plic_reg_top (
     .qs     (le_le_26_qs)
   );
 
-
-  // F[le_27]: 27:27
+  //   F[le_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1948,8 +1885,7 @@ module rv_plic_reg_top (
     .qs     (le_le_27_qs)
   );
 
-
-  // F[le_28]: 28:28
+  //   F[le_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1974,8 +1910,7 @@ module rv_plic_reg_top (
     .qs     (le_le_28_qs)
   );
 
-
-  // F[le_29]: 29:29
+  //   F[le_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2000,8 +1935,7 @@ module rv_plic_reg_top (
     .qs     (le_le_29_qs)
   );
 
-
-  // F[le_30]: 30:30
+  //   F[le_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2026,8 +1960,7 @@ module rv_plic_reg_top (
     .qs     (le_le_30_qs)
   );
 
-
-  // F[le_31]: 31:31
+  //   F[le_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2053,9 +1986,7 @@ module rv_plic_reg_top (
   );
 
 
-
   // R[prio0]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2082,7 +2013,6 @@ module rv_plic_reg_top (
 
 
   // R[prio1]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2109,7 +2039,6 @@ module rv_plic_reg_top (
 
 
   // R[prio2]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2136,7 +2065,6 @@ module rv_plic_reg_top (
 
 
   // R[prio3]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2163,7 +2091,6 @@ module rv_plic_reg_top (
 
 
   // R[prio4]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2190,7 +2117,6 @@ module rv_plic_reg_top (
 
 
   // R[prio5]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2217,7 +2143,6 @@ module rv_plic_reg_top (
 
 
   // R[prio6]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2244,7 +2169,6 @@ module rv_plic_reg_top (
 
 
   // R[prio7]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2271,7 +2195,6 @@ module rv_plic_reg_top (
 
 
   // R[prio8]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2298,7 +2221,6 @@ module rv_plic_reg_top (
 
 
   // R[prio9]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2325,7 +2247,6 @@ module rv_plic_reg_top (
 
 
   // R[prio10]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2352,7 +2273,6 @@ module rv_plic_reg_top (
 
 
   // R[prio11]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2379,7 +2299,6 @@ module rv_plic_reg_top (
 
 
   // R[prio12]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2406,7 +2325,6 @@ module rv_plic_reg_top (
 
 
   // R[prio13]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2433,7 +2351,6 @@ module rv_plic_reg_top (
 
 
   // R[prio14]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2460,7 +2377,6 @@ module rv_plic_reg_top (
 
 
   // R[prio15]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2487,7 +2403,6 @@ module rv_plic_reg_top (
 
 
   // R[prio16]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2514,7 +2429,6 @@ module rv_plic_reg_top (
 
 
   // R[prio17]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2541,7 +2455,6 @@ module rv_plic_reg_top (
 
 
   // R[prio18]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2568,7 +2481,6 @@ module rv_plic_reg_top (
 
 
   // R[prio19]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2595,7 +2507,6 @@ module rv_plic_reg_top (
 
 
   // R[prio20]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2622,7 +2533,6 @@ module rv_plic_reg_top (
 
 
   // R[prio21]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2649,7 +2559,6 @@ module rv_plic_reg_top (
 
 
   // R[prio22]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2676,7 +2585,6 @@ module rv_plic_reg_top (
 
 
   // R[prio23]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2703,7 +2611,6 @@ module rv_plic_reg_top (
 
 
   // R[prio24]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2730,7 +2637,6 @@ module rv_plic_reg_top (
 
 
   // R[prio25]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2757,7 +2663,6 @@ module rv_plic_reg_top (
 
 
   // R[prio26]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2784,7 +2689,6 @@ module rv_plic_reg_top (
 
 
   // R[prio27]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2811,7 +2715,6 @@ module rv_plic_reg_top (
 
 
   // R[prio28]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2838,7 +2741,6 @@ module rv_plic_reg_top (
 
 
   // R[prio29]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2865,7 +2767,6 @@ module rv_plic_reg_top (
 
 
   // R[prio30]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2892,7 +2793,6 @@ module rv_plic_reg_top (
 
 
   // R[prio31]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2918,11 +2818,9 @@ module rv_plic_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ie0
   // R[ie0]: V(False)
-
-  // F[e_0]: 0:0
+  //   F[e_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2947,8 +2845,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_0_qs)
   );
 
-
-  // F[e_1]: 1:1
+  //   F[e_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2973,8 +2870,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_1_qs)
   );
 
-
-  // F[e_2]: 2:2
+  //   F[e_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2999,8 +2895,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_2_qs)
   );
 
-
-  // F[e_3]: 3:3
+  //   F[e_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3025,8 +2920,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_3_qs)
   );
 
-
-  // F[e_4]: 4:4
+  //   F[e_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3051,8 +2945,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_4_qs)
   );
 
-
-  // F[e_5]: 5:5
+  //   F[e_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3077,8 +2970,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_5_qs)
   );
 
-
-  // F[e_6]: 6:6
+  //   F[e_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3103,8 +2995,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_6_qs)
   );
 
-
-  // F[e_7]: 7:7
+  //   F[e_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3129,8 +3020,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_7_qs)
   );
 
-
-  // F[e_8]: 8:8
+  //   F[e_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3155,8 +3045,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_8_qs)
   );
 
-
-  // F[e_9]: 9:9
+  //   F[e_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3181,8 +3070,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_9_qs)
   );
 
-
-  // F[e_10]: 10:10
+  //   F[e_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3207,8 +3095,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_10_qs)
   );
 
-
-  // F[e_11]: 11:11
+  //   F[e_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3233,8 +3120,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_11_qs)
   );
 
-
-  // F[e_12]: 12:12
+  //   F[e_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3259,8 +3145,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_12_qs)
   );
 
-
-  // F[e_13]: 13:13
+  //   F[e_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3285,8 +3170,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_13_qs)
   );
 
-
-  // F[e_14]: 14:14
+  //   F[e_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3311,8 +3195,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_14_qs)
   );
 
-
-  // F[e_15]: 15:15
+  //   F[e_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3337,8 +3220,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_15_qs)
   );
 
-
-  // F[e_16]: 16:16
+  //   F[e_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3363,8 +3245,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_16_qs)
   );
 
-
-  // F[e_17]: 17:17
+  //   F[e_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3389,8 +3270,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_17_qs)
   );
 
-
-  // F[e_18]: 18:18
+  //   F[e_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3415,8 +3295,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_18_qs)
   );
 
-
-  // F[e_19]: 19:19
+  //   F[e_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3441,8 +3320,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_19_qs)
   );
 
-
-  // F[e_20]: 20:20
+  //   F[e_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3467,8 +3345,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_20_qs)
   );
 
-
-  // F[e_21]: 21:21
+  //   F[e_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3493,8 +3370,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_21_qs)
   );
 
-
-  // F[e_22]: 22:22
+  //   F[e_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3519,8 +3395,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_22_qs)
   );
 
-
-  // F[e_23]: 23:23
+  //   F[e_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3545,8 +3420,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_23_qs)
   );
 
-
-  // F[e_24]: 24:24
+  //   F[e_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3571,8 +3445,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_24_qs)
   );
 
-
-  // F[e_25]: 25:25
+  //   F[e_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3597,8 +3470,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_25_qs)
   );
 
-
-  // F[e_26]: 26:26
+  //   F[e_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3623,8 +3495,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_26_qs)
   );
 
-
-  // F[e_27]: 27:27
+  //   F[e_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3649,8 +3520,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_27_qs)
   );
 
-
-  // F[e_28]: 28:28
+  //   F[e_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3675,8 +3545,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_28_qs)
   );
 
-
-  // F[e_29]: 29:29
+  //   F[e_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3701,8 +3570,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_29_qs)
   );
 
-
-  // F[e_30]: 30:30
+  //   F[e_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3727,8 +3595,7 @@ module rv_plic_reg_top (
     .qs     (ie0_e_30_qs)
   );
 
-
-  // F[e_31]: 31:31
+  //   F[e_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3754,9 +3621,7 @@ module rv_plic_reg_top (
   );
 
 
-
   // R[threshold0]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3783,7 +3648,6 @@ module rv_plic_reg_top (
 
 
   // R[cc0]: V(True)
-
   prim_subreg_ext #(
     .DW    (5)
   ) u_cc0 (
@@ -3799,7 +3663,6 @@ module rv_plic_reg_top (
 
 
   // R[msip0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3826,7 +3689,6 @@ module rv_plic_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -3839,7 +3701,6 @@ module rv_plic_reg_top (
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
-
 
 
 

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -141,7 +141,6 @@ module rv_timer_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -156,10 +155,8 @@ module rv_timer_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ctrl
   // R[ctrl]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -186,7 +183,6 @@ module rv_timer_reg_top (
 
 
   // R[cfg0]: V(False)
-
   //   F[prescale]: 11:0
   prim_subreg #(
     .DW      (12),
@@ -211,7 +207,6 @@ module rv_timer_reg_top (
     // to register interface (read)
     .qs     (cfg0_prescale_qs)
   );
-
 
   //   F[step]: 23:16
   prim_subreg #(
@@ -240,7 +235,6 @@ module rv_timer_reg_top (
 
 
   // R[timer_v_lower0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -267,7 +261,6 @@ module rv_timer_reg_top (
 
 
   // R[timer_v_upper0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -294,7 +287,6 @@ module rv_timer_reg_top (
 
 
   // R[compare_lower0_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -321,7 +313,6 @@ module rv_timer_reg_top (
 
 
   // R[compare_upper0_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -347,10 +338,8 @@ module rv_timer_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg intr_enable0
   // R[intr_enable0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -376,10 +365,8 @@ module rv_timer_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg intr_state0
   // R[intr_state0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -405,10 +392,8 @@ module rv_timer_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg intr_test0
   // R[intr_test0]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test0 (
@@ -421,7 +406,6 @@ module rv_timer_reg_top (
     .q      (reg2hw.intr_test0[0].q),
     .qs     ()
   );
-
 
 
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1354,7 +1354,6 @@ module spi_device_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[rxf]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1379,7 +1378,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (intr_state_rxf_qs)
   );
-
 
   //   F[rxlvl]: 1:1
   prim_subreg #(
@@ -1406,7 +1404,6 @@ module spi_device_reg_top (
     .qs     (intr_state_rxlvl_qs)
   );
 
-
   //   F[txlvl]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1431,7 +1428,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (intr_state_txlvl_qs)
   );
-
 
   //   F[rxerr]: 3:3
   prim_subreg #(
@@ -1458,7 +1454,6 @@ module spi_device_reg_top (
     .qs     (intr_state_rxerr_qs)
   );
 
-
   //   F[rxoverflow]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1483,7 +1478,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (intr_state_rxoverflow_qs)
   );
-
 
   //   F[txunderflow]: 5:5
   prim_subreg #(
@@ -1512,7 +1506,6 @@ module spi_device_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[rxf]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1537,7 +1530,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rxf_qs)
   );
-
 
   //   F[rxlvl]: 1:1
   prim_subreg #(
@@ -1564,7 +1556,6 @@ module spi_device_reg_top (
     .qs     (intr_enable_rxlvl_qs)
   );
 
-
   //   F[txlvl]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1589,7 +1580,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (intr_enable_txlvl_qs)
   );
-
 
   //   F[rxerr]: 3:3
   prim_subreg #(
@@ -1616,7 +1606,6 @@ module spi_device_reg_top (
     .qs     (intr_enable_rxerr_qs)
   );
 
-
   //   F[rxoverflow]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1641,7 +1630,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rxoverflow_qs)
   );
-
 
   //   F[txunderflow]: 5:5
   prim_subreg #(
@@ -1670,7 +1658,6 @@ module spi_device_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[rxf]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1684,7 +1671,6 @@ module spi_device_reg_top (
     .q      (reg2hw.intr_test.rxf.q),
     .qs     ()
   );
-
 
   //   F[rxlvl]: 1:1
   prim_subreg_ext #(
@@ -1700,7 +1686,6 @@ module spi_device_reg_top (
     .qs     ()
   );
 
-
   //   F[txlvl]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1714,7 +1699,6 @@ module spi_device_reg_top (
     .q      (reg2hw.intr_test.txlvl.q),
     .qs     ()
   );
-
 
   //   F[rxerr]: 3:3
   prim_subreg_ext #(
@@ -1730,7 +1714,6 @@ module spi_device_reg_top (
     .qs     ()
   );
 
-
   //   F[rxoverflow]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1744,7 +1727,6 @@ module spi_device_reg_top (
     .q      (reg2hw.intr_test.rxoverflow.q),
     .qs     ()
   );
-
 
   //   F[txunderflow]: 5:5
   prim_subreg_ext #(
@@ -1762,7 +1744,6 @@ module spi_device_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1778,7 +1759,6 @@ module spi_device_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[abort]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1803,7 +1783,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (control_abort_qs)
   );
-
 
   //   F[mode]: 5:4
   prim_subreg #(
@@ -1830,7 +1809,6 @@ module spi_device_reg_top (
     .qs     (control_mode_qs)
   );
 
-
   //   F[rst_txfifo]: 16:16
   prim_subreg #(
     .DW      (1),
@@ -1856,7 +1834,6 @@ module spi_device_reg_top (
     .qs     (control_rst_txfifo_qs)
   );
 
-
   //   F[rst_rxfifo]: 17:17
   prim_subreg #(
     .DW      (1),
@@ -1881,7 +1858,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (control_rst_rxfifo_qs)
   );
-
 
   //   F[sram_clk_en]: 31:31
   prim_subreg #(
@@ -1910,7 +1886,6 @@ module spi_device_reg_top (
 
 
   // R[cfg]: V(False)
-
   //   F[cpol]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1935,7 +1910,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (cfg_cpol_qs)
   );
-
 
   //   F[cpha]: 1:1
   prim_subreg #(
@@ -1962,7 +1936,6 @@ module spi_device_reg_top (
     .qs     (cfg_cpha_qs)
   );
 
-
   //   F[tx_order]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1987,7 +1960,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (cfg_tx_order_qs)
   );
-
 
   //   F[rx_order]: 3:3
   prim_subreg #(
@@ -2014,7 +1986,6 @@ module spi_device_reg_top (
     .qs     (cfg_rx_order_qs)
   );
 
-
   //   F[timer_v]: 15:8
   prim_subreg #(
     .DW      (8),
@@ -2039,7 +2010,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (cfg_timer_v_qs)
   );
-
 
   //   F[addr_4b_en]: 16:16
   prim_subreg #(
@@ -2068,7 +2038,6 @@ module spi_device_reg_top (
 
 
   // R[fifo_level]: V(False)
-
   //   F[rxlvl]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2093,7 +2062,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (fifo_level_rxlvl_qs)
   );
-
 
   //   F[txlvl]: 31:16
   prim_subreg #(
@@ -2122,7 +2090,6 @@ module spi_device_reg_top (
 
 
   // R[async_fifo_level]: V(True)
-
   //   F[rxlvl]: 7:0
   prim_subreg_ext #(
     .DW    (8)
@@ -2136,7 +2103,6 @@ module spi_device_reg_top (
     .q      (),
     .qs     (async_fifo_level_rxlvl_qs)
   );
-
 
   //   F[txlvl]: 23:16
   prim_subreg_ext #(
@@ -2154,7 +2120,6 @@ module spi_device_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[rxf_full]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -2168,7 +2133,6 @@ module spi_device_reg_top (
     .q      (),
     .qs     (status_rxf_full_qs)
   );
-
 
   //   F[rxf_empty]: 1:1
   prim_subreg_ext #(
@@ -2184,7 +2148,6 @@ module spi_device_reg_top (
     .qs     (status_rxf_empty_qs)
   );
 
-
   //   F[txf_full]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -2198,7 +2161,6 @@ module spi_device_reg_top (
     .q      (),
     .qs     (status_txf_full_qs)
   );
-
 
   //   F[txf_empty]: 3:3
   prim_subreg_ext #(
@@ -2214,7 +2176,6 @@ module spi_device_reg_top (
     .qs     (status_txf_empty_qs)
   );
 
-
   //   F[abort_done]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -2228,7 +2189,6 @@ module spi_device_reg_top (
     .q      (),
     .qs     (status_abort_done_qs)
   );
-
 
   //   F[csb]: 5:5
   prim_subreg_ext #(
@@ -2246,7 +2206,6 @@ module spi_device_reg_top (
 
 
   // R[rxf_ptr]: V(False)
-
   //   F[rptr]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2271,7 +2230,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (rxf_ptr_rptr_qs)
   );
-
 
   //   F[wptr]: 31:16
   prim_subreg #(
@@ -2300,7 +2258,6 @@ module spi_device_reg_top (
 
 
   // R[txf_ptr]: V(False)
-
   //   F[rptr]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2325,7 +2282,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (txf_ptr_rptr_qs)
   );
-
 
   //   F[wptr]: 31:16
   prim_subreg #(
@@ -2354,7 +2310,6 @@ module spi_device_reg_top (
 
 
   // R[rxf_addr]: V(False)
-
   //   F[base]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2379,7 +2334,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (rxf_addr_base_qs)
   );
-
 
   //   F[limit]: 31:16
   prim_subreg #(
@@ -2408,7 +2362,6 @@ module spi_device_reg_top (
 
 
   // R[txf_addr]: V(False)
-
   //   F[base]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2433,7 +2386,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (txf_addr_base_qs)
   );
-
 
   //   F[limit]: 31:16
   prim_subreg #(
@@ -2462,7 +2414,6 @@ module spi_device_reg_top (
 
 
   // R[last_read_addr]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_last_read_addr (
@@ -2478,7 +2429,6 @@ module spi_device_reg_top (
 
 
   // R[flash_status]: V(True)
-
   //   F[busy]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -2492,7 +2442,6 @@ module spi_device_reg_top (
     .q      (reg2hw.flash_status.busy.q),
     .qs     (flash_status_busy_qs)
   );
-
 
   //   F[status]: 23:1
   prim_subreg_ext #(
@@ -2510,7 +2459,6 @@ module spi_device_reg_top (
 
 
   // R[jedec_id]: V(False)
-
   //   F[id]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2535,7 +2483,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (jedec_id_id_qs)
   );
-
 
   //   F[mf]: 23:16
   prim_subreg #(
@@ -2564,7 +2511,6 @@ module spi_device_reg_top (
 
 
   // R[read_threshold]: V(False)
-
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2591,7 +2537,6 @@ module spi_device_reg_top (
 
 
   // R[upload_status]: V(False)
-
   //   F[cmdfifo_depth]: 4:0
   prim_subreg #(
     .DW      (5),
@@ -2616,7 +2561,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (upload_status_cmdfifo_depth_qs)
   );
-
 
   //   F[cmdfifo_notempty]: 7:7
   prim_subreg #(
@@ -2643,7 +2587,6 @@ module spi_device_reg_top (
     .qs     (upload_status_cmdfifo_notempty_qs)
   );
 
-
   //   F[addrfifo_depth]: 12:8
   prim_subreg #(
     .DW      (5),
@@ -2669,7 +2612,6 @@ module spi_device_reg_top (
     .qs     (upload_status_addrfifo_depth_qs)
   );
 
-
   //   F[addrfifo_notempty]: 15:15
   prim_subreg #(
     .DW      (1),
@@ -2694,7 +2636,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (upload_status_addrfifo_notempty_qs)
   );
-
 
   //   F[payload_depth]: 24:16
   prim_subreg #(
@@ -2723,7 +2664,6 @@ module spi_device_reg_top (
 
 
   // R[upload_cmdfifo]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_upload_cmdfifo (
@@ -2739,7 +2679,6 @@ module spi_device_reg_top (
 
 
   // R[upload_addrfifo]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_upload_addrfifo (
@@ -2754,11 +2693,9 @@ module spi_device_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg cmd_filter
   // R[cmd_filter_0]: V(False)
-
-  // F[filter_0]: 0:0
+  //   F[filter_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2783,8 +2720,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_0_qs)
   );
 
-
-  // F[filter_1]: 1:1
+  //   F[filter_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2809,8 +2745,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_1_qs)
   );
 
-
-  // F[filter_2]: 2:2
+  //   F[filter_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2835,8 +2770,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_2_qs)
   );
 
-
-  // F[filter_3]: 3:3
+  //   F[filter_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2861,8 +2795,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_3_qs)
   );
 
-
-  // F[filter_4]: 4:4
+  //   F[filter_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2887,8 +2820,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_4_qs)
   );
 
-
-  // F[filter_5]: 5:5
+  //   F[filter_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2913,8 +2845,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_5_qs)
   );
 
-
-  // F[filter_6]: 6:6
+  //   F[filter_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2939,8 +2870,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_6_qs)
   );
 
-
-  // F[filter_7]: 7:7
+  //   F[filter_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2965,8 +2895,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_7_qs)
   );
 
-
-  // F[filter_8]: 8:8
+  //   F[filter_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2991,8 +2920,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_8_qs)
   );
 
-
-  // F[filter_9]: 9:9
+  //   F[filter_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3017,8 +2945,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_9_qs)
   );
 
-
-  // F[filter_10]: 10:10
+  //   F[filter_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3043,8 +2970,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_10_qs)
   );
 
-
-  // F[filter_11]: 11:11
+  //   F[filter_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3069,8 +2995,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_11_qs)
   );
 
-
-  // F[filter_12]: 12:12
+  //   F[filter_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3095,8 +3020,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_12_qs)
   );
 
-
-  // F[filter_13]: 13:13
+  //   F[filter_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3121,8 +3045,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_13_qs)
   );
 
-
-  // F[filter_14]: 14:14
+  //   F[filter_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3147,8 +3070,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_14_qs)
   );
 
-
-  // F[filter_15]: 15:15
+  //   F[filter_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3173,8 +3095,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_15_qs)
   );
 
-
-  // F[filter_16]: 16:16
+  //   F[filter_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3199,8 +3120,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_16_qs)
   );
 
-
-  // F[filter_17]: 17:17
+  //   F[filter_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3225,8 +3145,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_17_qs)
   );
 
-
-  // F[filter_18]: 18:18
+  //   F[filter_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3251,8 +3170,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_18_qs)
   );
 
-
-  // F[filter_19]: 19:19
+  //   F[filter_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3277,8 +3195,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_19_qs)
   );
 
-
-  // F[filter_20]: 20:20
+  //   F[filter_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3303,8 +3220,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_20_qs)
   );
 
-
-  // F[filter_21]: 21:21
+  //   F[filter_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3329,8 +3245,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_21_qs)
   );
 
-
-  // F[filter_22]: 22:22
+  //   F[filter_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3355,8 +3270,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_22_qs)
   );
 
-
-  // F[filter_23]: 23:23
+  //   F[filter_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3381,8 +3295,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_23_qs)
   );
 
-
-  // F[filter_24]: 24:24
+  //   F[filter_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3407,8 +3320,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_24_qs)
   );
 
-
-  // F[filter_25]: 25:25
+  //   F[filter_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3433,8 +3345,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_25_qs)
   );
 
-
-  // F[filter_26]: 26:26
+  //   F[filter_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3459,8 +3370,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_26_qs)
   );
 
-
-  // F[filter_27]: 27:27
+  //   F[filter_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3485,8 +3395,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_27_qs)
   );
 
-
-  // F[filter_28]: 28:28
+  //   F[filter_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3511,8 +3420,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_28_qs)
   );
 
-
-  // F[filter_29]: 29:29
+  //   F[filter_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3537,8 +3445,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_29_qs)
   );
 
-
-  // F[filter_30]: 30:30
+  //   F[filter_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3563,8 +3470,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_0_filter_30_qs)
   );
 
-
-  // F[filter_31]: 31:31
+  //   F[filter_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3590,10 +3496,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 32 of Multireg cmd_filter
+  // Subregister 1 of Multireg cmd_filter
   // R[cmd_filter_1]: V(False)
-
-  // F[filter_32]: 0:0
+  //   F[filter_32]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3618,8 +3523,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_32_qs)
   );
 
-
-  // F[filter_33]: 1:1
+  //   F[filter_33]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3644,8 +3548,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_33_qs)
   );
 
-
-  // F[filter_34]: 2:2
+  //   F[filter_34]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3670,8 +3573,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_34_qs)
   );
 
-
-  // F[filter_35]: 3:3
+  //   F[filter_35]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3696,8 +3598,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_35_qs)
   );
 
-
-  // F[filter_36]: 4:4
+  //   F[filter_36]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3722,8 +3623,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_36_qs)
   );
 
-
-  // F[filter_37]: 5:5
+  //   F[filter_37]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3748,8 +3648,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_37_qs)
   );
 
-
-  // F[filter_38]: 6:6
+  //   F[filter_38]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3774,8 +3673,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_38_qs)
   );
 
-
-  // F[filter_39]: 7:7
+  //   F[filter_39]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3800,8 +3698,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_39_qs)
   );
 
-
-  // F[filter_40]: 8:8
+  //   F[filter_40]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3826,8 +3723,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_40_qs)
   );
 
-
-  // F[filter_41]: 9:9
+  //   F[filter_41]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3852,8 +3748,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_41_qs)
   );
 
-
-  // F[filter_42]: 10:10
+  //   F[filter_42]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3878,8 +3773,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_42_qs)
   );
 
-
-  // F[filter_43]: 11:11
+  //   F[filter_43]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3904,8 +3798,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_43_qs)
   );
 
-
-  // F[filter_44]: 12:12
+  //   F[filter_44]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3930,8 +3823,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_44_qs)
   );
 
-
-  // F[filter_45]: 13:13
+  //   F[filter_45]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3956,8 +3848,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_45_qs)
   );
 
-
-  // F[filter_46]: 14:14
+  //   F[filter_46]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3982,8 +3873,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_46_qs)
   );
 
-
-  // F[filter_47]: 15:15
+  //   F[filter_47]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4008,8 +3898,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_47_qs)
   );
 
-
-  // F[filter_48]: 16:16
+  //   F[filter_48]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4034,8 +3923,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_48_qs)
   );
 
-
-  // F[filter_49]: 17:17
+  //   F[filter_49]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4060,8 +3948,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_49_qs)
   );
 
-
-  // F[filter_50]: 18:18
+  //   F[filter_50]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4086,8 +3973,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_50_qs)
   );
 
-
-  // F[filter_51]: 19:19
+  //   F[filter_51]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4112,8 +3998,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_51_qs)
   );
 
-
-  // F[filter_52]: 20:20
+  //   F[filter_52]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4138,8 +4023,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_52_qs)
   );
 
-
-  // F[filter_53]: 21:21
+  //   F[filter_53]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4164,8 +4048,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_53_qs)
   );
 
-
-  // F[filter_54]: 22:22
+  //   F[filter_54]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4190,8 +4073,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_54_qs)
   );
 
-
-  // F[filter_55]: 23:23
+  //   F[filter_55]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4216,8 +4098,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_55_qs)
   );
 
-
-  // F[filter_56]: 24:24
+  //   F[filter_56]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4242,8 +4123,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_56_qs)
   );
 
-
-  // F[filter_57]: 25:25
+  //   F[filter_57]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4268,8 +4148,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_57_qs)
   );
 
-
-  // F[filter_58]: 26:26
+  //   F[filter_58]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4294,8 +4173,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_58_qs)
   );
 
-
-  // F[filter_59]: 27:27
+  //   F[filter_59]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4320,8 +4198,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_59_qs)
   );
 
-
-  // F[filter_60]: 28:28
+  //   F[filter_60]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4346,8 +4223,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_60_qs)
   );
 
-
-  // F[filter_61]: 29:29
+  //   F[filter_61]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4372,8 +4248,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_61_qs)
   );
 
-
-  // F[filter_62]: 30:30
+  //   F[filter_62]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4398,8 +4273,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_1_filter_62_qs)
   );
 
-
-  // F[filter_63]: 31:31
+  //   F[filter_63]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4425,10 +4299,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 64 of Multireg cmd_filter
+  // Subregister 2 of Multireg cmd_filter
   // R[cmd_filter_2]: V(False)
-
-  // F[filter_64]: 0:0
+  //   F[filter_64]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4453,8 +4326,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_64_qs)
   );
 
-
-  // F[filter_65]: 1:1
+  //   F[filter_65]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4479,8 +4351,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_65_qs)
   );
 
-
-  // F[filter_66]: 2:2
+  //   F[filter_66]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4505,8 +4376,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_66_qs)
   );
 
-
-  // F[filter_67]: 3:3
+  //   F[filter_67]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4531,8 +4401,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_67_qs)
   );
 
-
-  // F[filter_68]: 4:4
+  //   F[filter_68]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4557,8 +4426,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_68_qs)
   );
 
-
-  // F[filter_69]: 5:5
+  //   F[filter_69]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4583,8 +4451,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_69_qs)
   );
 
-
-  // F[filter_70]: 6:6
+  //   F[filter_70]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4609,8 +4476,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_70_qs)
   );
 
-
-  // F[filter_71]: 7:7
+  //   F[filter_71]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4635,8 +4501,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_71_qs)
   );
 
-
-  // F[filter_72]: 8:8
+  //   F[filter_72]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4661,8 +4526,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_72_qs)
   );
 
-
-  // F[filter_73]: 9:9
+  //   F[filter_73]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4687,8 +4551,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_73_qs)
   );
 
-
-  // F[filter_74]: 10:10
+  //   F[filter_74]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4713,8 +4576,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_74_qs)
   );
 
-
-  // F[filter_75]: 11:11
+  //   F[filter_75]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4739,8 +4601,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_75_qs)
   );
 
-
-  // F[filter_76]: 12:12
+  //   F[filter_76]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4765,8 +4626,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_76_qs)
   );
 
-
-  // F[filter_77]: 13:13
+  //   F[filter_77]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4791,8 +4651,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_77_qs)
   );
 
-
-  // F[filter_78]: 14:14
+  //   F[filter_78]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4817,8 +4676,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_78_qs)
   );
 
-
-  // F[filter_79]: 15:15
+  //   F[filter_79]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4843,8 +4701,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_79_qs)
   );
 
-
-  // F[filter_80]: 16:16
+  //   F[filter_80]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4869,8 +4726,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_80_qs)
   );
 
-
-  // F[filter_81]: 17:17
+  //   F[filter_81]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4895,8 +4751,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_81_qs)
   );
 
-
-  // F[filter_82]: 18:18
+  //   F[filter_82]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4921,8 +4776,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_82_qs)
   );
 
-
-  // F[filter_83]: 19:19
+  //   F[filter_83]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4947,8 +4801,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_83_qs)
   );
 
-
-  // F[filter_84]: 20:20
+  //   F[filter_84]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4973,8 +4826,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_84_qs)
   );
 
-
-  // F[filter_85]: 21:21
+  //   F[filter_85]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4999,8 +4851,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_85_qs)
   );
 
-
-  // F[filter_86]: 22:22
+  //   F[filter_86]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5025,8 +4876,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_86_qs)
   );
 
-
-  // F[filter_87]: 23:23
+  //   F[filter_87]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5051,8 +4901,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_87_qs)
   );
 
-
-  // F[filter_88]: 24:24
+  //   F[filter_88]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5077,8 +4926,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_88_qs)
   );
 
-
-  // F[filter_89]: 25:25
+  //   F[filter_89]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5103,8 +4951,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_89_qs)
   );
 
-
-  // F[filter_90]: 26:26
+  //   F[filter_90]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5129,8 +4976,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_90_qs)
   );
 
-
-  // F[filter_91]: 27:27
+  //   F[filter_91]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5155,8 +5001,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_91_qs)
   );
 
-
-  // F[filter_92]: 28:28
+  //   F[filter_92]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5181,8 +5026,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_92_qs)
   );
 
-
-  // F[filter_93]: 29:29
+  //   F[filter_93]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5207,8 +5051,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_93_qs)
   );
 
-
-  // F[filter_94]: 30:30
+  //   F[filter_94]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5233,8 +5076,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_2_filter_94_qs)
   );
 
-
-  // F[filter_95]: 31:31
+  //   F[filter_95]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5260,10 +5102,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 96 of Multireg cmd_filter
+  // Subregister 3 of Multireg cmd_filter
   // R[cmd_filter_3]: V(False)
-
-  // F[filter_96]: 0:0
+  //   F[filter_96]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5288,8 +5129,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_96_qs)
   );
 
-
-  // F[filter_97]: 1:1
+  //   F[filter_97]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5314,8 +5154,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_97_qs)
   );
 
-
-  // F[filter_98]: 2:2
+  //   F[filter_98]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5340,8 +5179,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_98_qs)
   );
 
-
-  // F[filter_99]: 3:3
+  //   F[filter_99]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5366,8 +5204,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_99_qs)
   );
 
-
-  // F[filter_100]: 4:4
+  //   F[filter_100]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5392,8 +5229,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_100_qs)
   );
 
-
-  // F[filter_101]: 5:5
+  //   F[filter_101]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5418,8 +5254,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_101_qs)
   );
 
-
-  // F[filter_102]: 6:6
+  //   F[filter_102]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5444,8 +5279,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_102_qs)
   );
 
-
-  // F[filter_103]: 7:7
+  //   F[filter_103]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5470,8 +5304,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_103_qs)
   );
 
-
-  // F[filter_104]: 8:8
+  //   F[filter_104]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5496,8 +5329,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_104_qs)
   );
 
-
-  // F[filter_105]: 9:9
+  //   F[filter_105]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5522,8 +5354,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_105_qs)
   );
 
-
-  // F[filter_106]: 10:10
+  //   F[filter_106]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5548,8 +5379,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_106_qs)
   );
 
-
-  // F[filter_107]: 11:11
+  //   F[filter_107]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5574,8 +5404,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_107_qs)
   );
 
-
-  // F[filter_108]: 12:12
+  //   F[filter_108]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5600,8 +5429,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_108_qs)
   );
 
-
-  // F[filter_109]: 13:13
+  //   F[filter_109]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5626,8 +5454,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_109_qs)
   );
 
-
-  // F[filter_110]: 14:14
+  //   F[filter_110]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5652,8 +5479,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_110_qs)
   );
 
-
-  // F[filter_111]: 15:15
+  //   F[filter_111]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5678,8 +5504,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_111_qs)
   );
 
-
-  // F[filter_112]: 16:16
+  //   F[filter_112]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5704,8 +5529,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_112_qs)
   );
 
-
-  // F[filter_113]: 17:17
+  //   F[filter_113]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5730,8 +5554,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_113_qs)
   );
 
-
-  // F[filter_114]: 18:18
+  //   F[filter_114]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5756,8 +5579,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_114_qs)
   );
 
-
-  // F[filter_115]: 19:19
+  //   F[filter_115]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5782,8 +5604,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_115_qs)
   );
 
-
-  // F[filter_116]: 20:20
+  //   F[filter_116]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5808,8 +5629,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_116_qs)
   );
 
-
-  // F[filter_117]: 21:21
+  //   F[filter_117]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5834,8 +5654,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_117_qs)
   );
 
-
-  // F[filter_118]: 22:22
+  //   F[filter_118]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5860,8 +5679,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_118_qs)
   );
 
-
-  // F[filter_119]: 23:23
+  //   F[filter_119]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5886,8 +5704,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_119_qs)
   );
 
-
-  // F[filter_120]: 24:24
+  //   F[filter_120]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5912,8 +5729,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_120_qs)
   );
 
-
-  // F[filter_121]: 25:25
+  //   F[filter_121]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5938,8 +5754,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_121_qs)
   );
 
-
-  // F[filter_122]: 26:26
+  //   F[filter_122]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5964,8 +5779,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_122_qs)
   );
 
-
-  // F[filter_123]: 27:27
+  //   F[filter_123]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5990,8 +5804,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_123_qs)
   );
 
-
-  // F[filter_124]: 28:28
+  //   F[filter_124]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6016,8 +5829,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_124_qs)
   );
 
-
-  // F[filter_125]: 29:29
+  //   F[filter_125]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6042,8 +5854,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_125_qs)
   );
 
-
-  // F[filter_126]: 30:30
+  //   F[filter_126]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6068,8 +5879,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_3_filter_126_qs)
   );
 
-
-  // F[filter_127]: 31:31
+  //   F[filter_127]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6095,10 +5905,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 128 of Multireg cmd_filter
+  // Subregister 4 of Multireg cmd_filter
   // R[cmd_filter_4]: V(False)
-
-  // F[filter_128]: 0:0
+  //   F[filter_128]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6123,8 +5932,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_128_qs)
   );
 
-
-  // F[filter_129]: 1:1
+  //   F[filter_129]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6149,8 +5957,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_129_qs)
   );
 
-
-  // F[filter_130]: 2:2
+  //   F[filter_130]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6175,8 +5982,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_130_qs)
   );
 
-
-  // F[filter_131]: 3:3
+  //   F[filter_131]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6201,8 +6007,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_131_qs)
   );
 
-
-  // F[filter_132]: 4:4
+  //   F[filter_132]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6227,8 +6032,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_132_qs)
   );
 
-
-  // F[filter_133]: 5:5
+  //   F[filter_133]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6253,8 +6057,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_133_qs)
   );
 
-
-  // F[filter_134]: 6:6
+  //   F[filter_134]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6279,8 +6082,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_134_qs)
   );
 
-
-  // F[filter_135]: 7:7
+  //   F[filter_135]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6305,8 +6107,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_135_qs)
   );
 
-
-  // F[filter_136]: 8:8
+  //   F[filter_136]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6331,8 +6132,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_136_qs)
   );
 
-
-  // F[filter_137]: 9:9
+  //   F[filter_137]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6357,8 +6157,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_137_qs)
   );
 
-
-  // F[filter_138]: 10:10
+  //   F[filter_138]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6383,8 +6182,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_138_qs)
   );
 
-
-  // F[filter_139]: 11:11
+  //   F[filter_139]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6409,8 +6207,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_139_qs)
   );
 
-
-  // F[filter_140]: 12:12
+  //   F[filter_140]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6435,8 +6232,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_140_qs)
   );
 
-
-  // F[filter_141]: 13:13
+  //   F[filter_141]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6461,8 +6257,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_141_qs)
   );
 
-
-  // F[filter_142]: 14:14
+  //   F[filter_142]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6487,8 +6282,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_142_qs)
   );
 
-
-  // F[filter_143]: 15:15
+  //   F[filter_143]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6513,8 +6307,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_143_qs)
   );
 
-
-  // F[filter_144]: 16:16
+  //   F[filter_144]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6539,8 +6332,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_144_qs)
   );
 
-
-  // F[filter_145]: 17:17
+  //   F[filter_145]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6565,8 +6357,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_145_qs)
   );
 
-
-  // F[filter_146]: 18:18
+  //   F[filter_146]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6591,8 +6382,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_146_qs)
   );
 
-
-  // F[filter_147]: 19:19
+  //   F[filter_147]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6617,8 +6407,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_147_qs)
   );
 
-
-  // F[filter_148]: 20:20
+  //   F[filter_148]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6643,8 +6432,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_148_qs)
   );
 
-
-  // F[filter_149]: 21:21
+  //   F[filter_149]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6669,8 +6457,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_149_qs)
   );
 
-
-  // F[filter_150]: 22:22
+  //   F[filter_150]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6695,8 +6482,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_150_qs)
   );
 
-
-  // F[filter_151]: 23:23
+  //   F[filter_151]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6721,8 +6507,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_151_qs)
   );
 
-
-  // F[filter_152]: 24:24
+  //   F[filter_152]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6747,8 +6532,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_152_qs)
   );
 
-
-  // F[filter_153]: 25:25
+  //   F[filter_153]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6773,8 +6557,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_153_qs)
   );
 
-
-  // F[filter_154]: 26:26
+  //   F[filter_154]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6799,8 +6582,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_154_qs)
   );
 
-
-  // F[filter_155]: 27:27
+  //   F[filter_155]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6825,8 +6607,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_155_qs)
   );
 
-
-  // F[filter_156]: 28:28
+  //   F[filter_156]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6851,8 +6632,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_156_qs)
   );
 
-
-  // F[filter_157]: 29:29
+  //   F[filter_157]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6877,8 +6657,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_157_qs)
   );
 
-
-  // F[filter_158]: 30:30
+  //   F[filter_158]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6903,8 +6682,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_4_filter_158_qs)
   );
 
-
-  // F[filter_159]: 31:31
+  //   F[filter_159]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6930,10 +6708,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 160 of Multireg cmd_filter
+  // Subregister 5 of Multireg cmd_filter
   // R[cmd_filter_5]: V(False)
-
-  // F[filter_160]: 0:0
+  //   F[filter_160]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6958,8 +6735,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_160_qs)
   );
 
-
-  // F[filter_161]: 1:1
+  //   F[filter_161]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6984,8 +6760,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_161_qs)
   );
 
-
-  // F[filter_162]: 2:2
+  //   F[filter_162]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7010,8 +6785,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_162_qs)
   );
 
-
-  // F[filter_163]: 3:3
+  //   F[filter_163]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7036,8 +6810,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_163_qs)
   );
 
-
-  // F[filter_164]: 4:4
+  //   F[filter_164]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7062,8 +6835,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_164_qs)
   );
 
-
-  // F[filter_165]: 5:5
+  //   F[filter_165]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7088,8 +6860,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_165_qs)
   );
 
-
-  // F[filter_166]: 6:6
+  //   F[filter_166]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7114,8 +6885,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_166_qs)
   );
 
-
-  // F[filter_167]: 7:7
+  //   F[filter_167]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7140,8 +6910,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_167_qs)
   );
 
-
-  // F[filter_168]: 8:8
+  //   F[filter_168]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7166,8 +6935,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_168_qs)
   );
 
-
-  // F[filter_169]: 9:9
+  //   F[filter_169]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7192,8 +6960,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_169_qs)
   );
 
-
-  // F[filter_170]: 10:10
+  //   F[filter_170]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7218,8 +6985,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_170_qs)
   );
 
-
-  // F[filter_171]: 11:11
+  //   F[filter_171]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7244,8 +7010,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_171_qs)
   );
 
-
-  // F[filter_172]: 12:12
+  //   F[filter_172]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7270,8 +7035,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_172_qs)
   );
 
-
-  // F[filter_173]: 13:13
+  //   F[filter_173]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7296,8 +7060,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_173_qs)
   );
 
-
-  // F[filter_174]: 14:14
+  //   F[filter_174]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7322,8 +7085,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_174_qs)
   );
 
-
-  // F[filter_175]: 15:15
+  //   F[filter_175]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7348,8 +7110,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_175_qs)
   );
 
-
-  // F[filter_176]: 16:16
+  //   F[filter_176]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7374,8 +7135,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_176_qs)
   );
 
-
-  // F[filter_177]: 17:17
+  //   F[filter_177]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7400,8 +7160,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_177_qs)
   );
 
-
-  // F[filter_178]: 18:18
+  //   F[filter_178]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7426,8 +7185,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_178_qs)
   );
 
-
-  // F[filter_179]: 19:19
+  //   F[filter_179]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7452,8 +7210,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_179_qs)
   );
 
-
-  // F[filter_180]: 20:20
+  //   F[filter_180]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7478,8 +7235,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_180_qs)
   );
 
-
-  // F[filter_181]: 21:21
+  //   F[filter_181]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7504,8 +7260,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_181_qs)
   );
 
-
-  // F[filter_182]: 22:22
+  //   F[filter_182]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7530,8 +7285,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_182_qs)
   );
 
-
-  // F[filter_183]: 23:23
+  //   F[filter_183]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7556,8 +7310,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_183_qs)
   );
 
-
-  // F[filter_184]: 24:24
+  //   F[filter_184]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7582,8 +7335,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_184_qs)
   );
 
-
-  // F[filter_185]: 25:25
+  //   F[filter_185]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7608,8 +7360,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_185_qs)
   );
 
-
-  // F[filter_186]: 26:26
+  //   F[filter_186]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7634,8 +7385,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_186_qs)
   );
 
-
-  // F[filter_187]: 27:27
+  //   F[filter_187]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7660,8 +7410,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_187_qs)
   );
 
-
-  // F[filter_188]: 28:28
+  //   F[filter_188]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7686,8 +7435,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_188_qs)
   );
 
-
-  // F[filter_189]: 29:29
+  //   F[filter_189]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7712,8 +7460,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_189_qs)
   );
 
-
-  // F[filter_190]: 30:30
+  //   F[filter_190]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7738,8 +7485,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_5_filter_190_qs)
   );
 
-
-  // F[filter_191]: 31:31
+  //   F[filter_191]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7765,10 +7511,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 192 of Multireg cmd_filter
+  // Subregister 6 of Multireg cmd_filter
   // R[cmd_filter_6]: V(False)
-
-  // F[filter_192]: 0:0
+  //   F[filter_192]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7793,8 +7538,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_192_qs)
   );
 
-
-  // F[filter_193]: 1:1
+  //   F[filter_193]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7819,8 +7563,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_193_qs)
   );
 
-
-  // F[filter_194]: 2:2
+  //   F[filter_194]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7845,8 +7588,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_194_qs)
   );
 
-
-  // F[filter_195]: 3:3
+  //   F[filter_195]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7871,8 +7613,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_195_qs)
   );
 
-
-  // F[filter_196]: 4:4
+  //   F[filter_196]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7897,8 +7638,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_196_qs)
   );
 
-
-  // F[filter_197]: 5:5
+  //   F[filter_197]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7923,8 +7663,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_197_qs)
   );
 
-
-  // F[filter_198]: 6:6
+  //   F[filter_198]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7949,8 +7688,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_198_qs)
   );
 
-
-  // F[filter_199]: 7:7
+  //   F[filter_199]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7975,8 +7713,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_199_qs)
   );
 
-
-  // F[filter_200]: 8:8
+  //   F[filter_200]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8001,8 +7738,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_200_qs)
   );
 
-
-  // F[filter_201]: 9:9
+  //   F[filter_201]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8027,8 +7763,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_201_qs)
   );
 
-
-  // F[filter_202]: 10:10
+  //   F[filter_202]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8053,8 +7788,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_202_qs)
   );
 
-
-  // F[filter_203]: 11:11
+  //   F[filter_203]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8079,8 +7813,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_203_qs)
   );
 
-
-  // F[filter_204]: 12:12
+  //   F[filter_204]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8105,8 +7838,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_204_qs)
   );
 
-
-  // F[filter_205]: 13:13
+  //   F[filter_205]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8131,8 +7863,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_205_qs)
   );
 
-
-  // F[filter_206]: 14:14
+  //   F[filter_206]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8157,8 +7888,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_206_qs)
   );
 
-
-  // F[filter_207]: 15:15
+  //   F[filter_207]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8183,8 +7913,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_207_qs)
   );
 
-
-  // F[filter_208]: 16:16
+  //   F[filter_208]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8209,8 +7938,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_208_qs)
   );
 
-
-  // F[filter_209]: 17:17
+  //   F[filter_209]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8235,8 +7963,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_209_qs)
   );
 
-
-  // F[filter_210]: 18:18
+  //   F[filter_210]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8261,8 +7988,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_210_qs)
   );
 
-
-  // F[filter_211]: 19:19
+  //   F[filter_211]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8287,8 +8013,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_211_qs)
   );
 
-
-  // F[filter_212]: 20:20
+  //   F[filter_212]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8313,8 +8038,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_212_qs)
   );
 
-
-  // F[filter_213]: 21:21
+  //   F[filter_213]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8339,8 +8063,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_213_qs)
   );
 
-
-  // F[filter_214]: 22:22
+  //   F[filter_214]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8365,8 +8088,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_214_qs)
   );
 
-
-  // F[filter_215]: 23:23
+  //   F[filter_215]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8391,8 +8113,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_215_qs)
   );
 
-
-  // F[filter_216]: 24:24
+  //   F[filter_216]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8417,8 +8138,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_216_qs)
   );
 
-
-  // F[filter_217]: 25:25
+  //   F[filter_217]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8443,8 +8163,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_217_qs)
   );
 
-
-  // F[filter_218]: 26:26
+  //   F[filter_218]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8469,8 +8188,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_218_qs)
   );
 
-
-  // F[filter_219]: 27:27
+  //   F[filter_219]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8495,8 +8213,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_219_qs)
   );
 
-
-  // F[filter_220]: 28:28
+  //   F[filter_220]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8521,8 +8238,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_220_qs)
   );
 
-
-  // F[filter_221]: 29:29
+  //   F[filter_221]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8547,8 +8263,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_221_qs)
   );
 
-
-  // F[filter_222]: 30:30
+  //   F[filter_222]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8573,8 +8288,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_6_filter_222_qs)
   );
 
-
-  // F[filter_223]: 31:31
+  //   F[filter_223]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8600,10 +8314,9 @@ module spi_device_reg_top (
   );
 
 
-  // Subregister 224 of Multireg cmd_filter
+  // Subregister 7 of Multireg cmd_filter
   // R[cmd_filter_7]: V(False)
-
-  // F[filter_224]: 0:0
+  //   F[filter_224]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8628,8 +8341,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_224_qs)
   );
 
-
-  // F[filter_225]: 1:1
+  //   F[filter_225]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8654,8 +8366,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_225_qs)
   );
 
-
-  // F[filter_226]: 2:2
+  //   F[filter_226]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8680,8 +8391,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_226_qs)
   );
 
-
-  // F[filter_227]: 3:3
+  //   F[filter_227]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8706,8 +8416,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_227_qs)
   );
 
-
-  // F[filter_228]: 4:4
+  //   F[filter_228]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8732,8 +8441,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_228_qs)
   );
 
-
-  // F[filter_229]: 5:5
+  //   F[filter_229]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8758,8 +8466,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_229_qs)
   );
 
-
-  // F[filter_230]: 6:6
+  //   F[filter_230]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8784,8 +8491,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_230_qs)
   );
 
-
-  // F[filter_231]: 7:7
+  //   F[filter_231]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8810,8 +8516,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_231_qs)
   );
 
-
-  // F[filter_232]: 8:8
+  //   F[filter_232]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8836,8 +8541,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_232_qs)
   );
 
-
-  // F[filter_233]: 9:9
+  //   F[filter_233]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8862,8 +8566,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_233_qs)
   );
 
-
-  // F[filter_234]: 10:10
+  //   F[filter_234]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8888,8 +8591,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_234_qs)
   );
 
-
-  // F[filter_235]: 11:11
+  //   F[filter_235]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8914,8 +8616,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_235_qs)
   );
 
-
-  // F[filter_236]: 12:12
+  //   F[filter_236]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8940,8 +8641,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_236_qs)
   );
 
-
-  // F[filter_237]: 13:13
+  //   F[filter_237]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8966,8 +8666,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_237_qs)
   );
 
-
-  // F[filter_238]: 14:14
+  //   F[filter_238]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8992,8 +8691,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_238_qs)
   );
 
-
-  // F[filter_239]: 15:15
+  //   F[filter_239]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9018,8 +8716,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_239_qs)
   );
 
-
-  // F[filter_240]: 16:16
+  //   F[filter_240]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9044,8 +8741,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_240_qs)
   );
 
-
-  // F[filter_241]: 17:17
+  //   F[filter_241]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9070,8 +8766,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_241_qs)
   );
 
-
-  // F[filter_242]: 18:18
+  //   F[filter_242]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9096,8 +8791,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_242_qs)
   );
 
-
-  // F[filter_243]: 19:19
+  //   F[filter_243]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9122,8 +8816,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_243_qs)
   );
 
-
-  // F[filter_244]: 20:20
+  //   F[filter_244]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9148,8 +8841,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_244_qs)
   );
 
-
-  // F[filter_245]: 21:21
+  //   F[filter_245]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9174,8 +8866,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_245_qs)
   );
 
-
-  // F[filter_246]: 22:22
+  //   F[filter_246]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9200,8 +8891,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_246_qs)
   );
 
-
-  // F[filter_247]: 23:23
+  //   F[filter_247]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9226,8 +8916,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_247_qs)
   );
 
-
-  // F[filter_248]: 24:24
+  //   F[filter_248]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9252,8 +8941,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_248_qs)
   );
 
-
-  // F[filter_249]: 25:25
+  //   F[filter_249]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9278,8 +8966,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_249_qs)
   );
 
-
-  // F[filter_250]: 26:26
+  //   F[filter_250]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9304,8 +8991,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_250_qs)
   );
 
-
-  // F[filter_251]: 27:27
+  //   F[filter_251]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9330,8 +9016,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_251_qs)
   );
 
-
-  // F[filter_252]: 28:28
+  //   F[filter_252]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9356,8 +9041,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_252_qs)
   );
 
-
-  // F[filter_253]: 29:29
+  //   F[filter_253]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9382,8 +9066,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_253_qs)
   );
 
-
-  // F[filter_254]: 30:30
+  //   F[filter_254]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9408,8 +9091,7 @@ module spi_device_reg_top (
     .qs     (cmd_filter_7_filter_254_qs)
   );
 
-
-  // F[filter_255]: 31:31
+  //   F[filter_255]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9435,9 +9117,7 @@ module spi_device_reg_top (
   );
 
 
-
   // R[addr_swap_mask]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9464,7 +9144,6 @@ module spi_device_reg_top (
 
 
   // R[addr_swap_data]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9490,11 +9169,9 @@ module spi_device_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg cmd_info
   // R[cmd_info_0]: V(False)
-
-  // F[opcode_0]: 7:0
+  //   F[opcode_0]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9519,8 +9196,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_opcode_0_qs)
   );
 
-
-  // F[addr_en_0]: 8:8
+  //   F[addr_en_0]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9545,8 +9221,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_addr_en_0_qs)
   );
 
-
-  // F[addr_swap_en_0]: 9:9
+  //   F[addr_swap_en_0]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9571,8 +9246,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_addr_swap_en_0_qs)
   );
 
-
-  // F[addr_4b_affected_0]: 10:10
+  //   F[addr_4b_affected_0]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9597,8 +9271,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_addr_4b_affected_0_qs)
   );
 
-
-  // F[mbyte_en_0]: 11:11
+  //   F[mbyte_en_0]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9623,8 +9296,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_mbyte_en_0_qs)
   );
 
-
-  // F[dummy_size_0]: 14:12
+  //   F[dummy_size_0]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9649,8 +9321,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_dummy_size_0_qs)
   );
 
-
-  // F[dummy_en_0]: 15:15
+  //   F[dummy_en_0]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9675,8 +9346,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_dummy_en_0_qs)
   );
 
-
-  // F[payload_en_0]: 19:16
+  //   F[payload_en_0]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9701,8 +9371,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_payload_en_0_qs)
   );
 
-
-  // F[payload_dir_0]: 20:20
+  //   F[payload_dir_0]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9727,8 +9396,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_payload_dir_0_qs)
   );
 
-
-  // F[upload_0]: 24:24
+  //   F[upload_0]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9753,8 +9421,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_0_upload_0_qs)
   );
 
-
-  // F[busy_0]: 25:25
+  //   F[busy_0]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9782,8 +9449,7 @@ module spi_device_reg_top (
 
   // Subregister 1 of Multireg cmd_info
   // R[cmd_info_1]: V(False)
-
-  // F[opcode_1]: 7:0
+  //   F[opcode_1]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9808,8 +9474,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_opcode_1_qs)
   );
 
-
-  // F[addr_en_1]: 8:8
+  //   F[addr_en_1]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9834,8 +9499,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_addr_en_1_qs)
   );
 
-
-  // F[addr_swap_en_1]: 9:9
+  //   F[addr_swap_en_1]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9860,8 +9524,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_addr_swap_en_1_qs)
   );
 
-
-  // F[addr_4b_affected_1]: 10:10
+  //   F[addr_4b_affected_1]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9886,8 +9549,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_addr_4b_affected_1_qs)
   );
 
-
-  // F[mbyte_en_1]: 11:11
+  //   F[mbyte_en_1]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9912,8 +9574,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_mbyte_en_1_qs)
   );
 
-
-  // F[dummy_size_1]: 14:12
+  //   F[dummy_size_1]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9938,8 +9599,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_dummy_size_1_qs)
   );
 
-
-  // F[dummy_en_1]: 15:15
+  //   F[dummy_en_1]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9964,8 +9624,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_dummy_en_1_qs)
   );
 
-
-  // F[payload_en_1]: 19:16
+  //   F[payload_en_1]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9990,8 +9649,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_payload_en_1_qs)
   );
 
-
-  // F[payload_dir_1]: 20:20
+  //   F[payload_dir_1]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10016,8 +9674,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_payload_dir_1_qs)
   );
 
-
-  // F[upload_1]: 24:24
+  //   F[upload_1]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10042,8 +9699,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_upload_1_qs)
   );
 
-
-  // F[busy_1]: 25:25
+  //   F[busy_1]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10071,8 +9727,7 @@ module spi_device_reg_top (
 
   // Subregister 2 of Multireg cmd_info
   // R[cmd_info_2]: V(False)
-
-  // F[opcode_2]: 7:0
+  //   F[opcode_2]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10097,8 +9752,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_opcode_2_qs)
   );
 
-
-  // F[addr_en_2]: 8:8
+  //   F[addr_en_2]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10123,8 +9777,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_addr_en_2_qs)
   );
 
-
-  // F[addr_swap_en_2]: 9:9
+  //   F[addr_swap_en_2]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10149,8 +9802,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_addr_swap_en_2_qs)
   );
 
-
-  // F[addr_4b_affected_2]: 10:10
+  //   F[addr_4b_affected_2]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10175,8 +9827,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_addr_4b_affected_2_qs)
   );
 
-
-  // F[mbyte_en_2]: 11:11
+  //   F[mbyte_en_2]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10201,8 +9852,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_mbyte_en_2_qs)
   );
 
-
-  // F[dummy_size_2]: 14:12
+  //   F[dummy_size_2]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10227,8 +9877,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_dummy_size_2_qs)
   );
 
-
-  // F[dummy_en_2]: 15:15
+  //   F[dummy_en_2]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10253,8 +9902,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_dummy_en_2_qs)
   );
 
-
-  // F[payload_en_2]: 19:16
+  //   F[payload_en_2]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10279,8 +9927,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_payload_en_2_qs)
   );
 
-
-  // F[payload_dir_2]: 20:20
+  //   F[payload_dir_2]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10305,8 +9952,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_payload_dir_2_qs)
   );
 
-
-  // F[upload_2]: 24:24
+  //   F[upload_2]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10331,8 +9977,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_2_upload_2_qs)
   );
 
-
-  // F[busy_2]: 25:25
+  //   F[busy_2]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10360,8 +10005,7 @@ module spi_device_reg_top (
 
   // Subregister 3 of Multireg cmd_info
   // R[cmd_info_3]: V(False)
-
-  // F[opcode_3]: 7:0
+  //   F[opcode_3]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10386,8 +10030,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_opcode_3_qs)
   );
 
-
-  // F[addr_en_3]: 8:8
+  //   F[addr_en_3]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10412,8 +10055,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_addr_en_3_qs)
   );
 
-
-  // F[addr_swap_en_3]: 9:9
+  //   F[addr_swap_en_3]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10438,8 +10080,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_addr_swap_en_3_qs)
   );
 
-
-  // F[addr_4b_affected_3]: 10:10
+  //   F[addr_4b_affected_3]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10464,8 +10105,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_addr_4b_affected_3_qs)
   );
 
-
-  // F[mbyte_en_3]: 11:11
+  //   F[mbyte_en_3]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10490,8 +10130,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_mbyte_en_3_qs)
   );
 
-
-  // F[dummy_size_3]: 14:12
+  //   F[dummy_size_3]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10516,8 +10155,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_dummy_size_3_qs)
   );
 
-
-  // F[dummy_en_3]: 15:15
+  //   F[dummy_en_3]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10542,8 +10180,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_dummy_en_3_qs)
   );
 
-
-  // F[payload_en_3]: 19:16
+  //   F[payload_en_3]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10568,8 +10205,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_payload_en_3_qs)
   );
 
-
-  // F[payload_dir_3]: 20:20
+  //   F[payload_dir_3]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10594,8 +10230,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_payload_dir_3_qs)
   );
 
-
-  // F[upload_3]: 24:24
+  //   F[upload_3]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10620,8 +10255,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_upload_3_qs)
   );
 
-
-  // F[busy_3]: 25:25
+  //   F[busy_3]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10649,8 +10283,7 @@ module spi_device_reg_top (
 
   // Subregister 4 of Multireg cmd_info
   // R[cmd_info_4]: V(False)
-
-  // F[opcode_4]: 7:0
+  //   F[opcode_4]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10675,8 +10308,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_opcode_4_qs)
   );
 
-
-  // F[addr_en_4]: 8:8
+  //   F[addr_en_4]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10701,8 +10333,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_addr_en_4_qs)
   );
 
-
-  // F[addr_swap_en_4]: 9:9
+  //   F[addr_swap_en_4]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10727,8 +10358,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_addr_swap_en_4_qs)
   );
 
-
-  // F[addr_4b_affected_4]: 10:10
+  //   F[addr_4b_affected_4]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10753,8 +10383,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_addr_4b_affected_4_qs)
   );
 
-
-  // F[mbyte_en_4]: 11:11
+  //   F[mbyte_en_4]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10779,8 +10408,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_mbyte_en_4_qs)
   );
 
-
-  // F[dummy_size_4]: 14:12
+  //   F[dummy_size_4]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10805,8 +10433,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_dummy_size_4_qs)
   );
 
-
-  // F[dummy_en_4]: 15:15
+  //   F[dummy_en_4]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10831,8 +10458,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_dummy_en_4_qs)
   );
 
-
-  // F[payload_en_4]: 19:16
+  //   F[payload_en_4]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10857,8 +10483,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_payload_en_4_qs)
   );
 
-
-  // F[payload_dir_4]: 20:20
+  //   F[payload_dir_4]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10883,8 +10508,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_payload_dir_4_qs)
   );
 
-
-  // F[upload_4]: 24:24
+  //   F[upload_4]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10909,8 +10533,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_4_upload_4_qs)
   );
 
-
-  // F[busy_4]: 25:25
+  //   F[busy_4]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10938,8 +10561,7 @@ module spi_device_reg_top (
 
   // Subregister 5 of Multireg cmd_info
   // R[cmd_info_5]: V(False)
-
-  // F[opcode_5]: 7:0
+  //   F[opcode_5]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10964,8 +10586,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_opcode_5_qs)
   );
 
-
-  // F[addr_en_5]: 8:8
+  //   F[addr_en_5]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10990,8 +10611,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_addr_en_5_qs)
   );
 
-
-  // F[addr_swap_en_5]: 9:9
+  //   F[addr_swap_en_5]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11016,8 +10636,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_addr_swap_en_5_qs)
   );
 
-
-  // F[addr_4b_affected_5]: 10:10
+  //   F[addr_4b_affected_5]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11042,8 +10661,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_addr_4b_affected_5_qs)
   );
 
-
-  // F[mbyte_en_5]: 11:11
+  //   F[mbyte_en_5]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11068,8 +10686,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_mbyte_en_5_qs)
   );
 
-
-  // F[dummy_size_5]: 14:12
+  //   F[dummy_size_5]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11094,8 +10711,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_dummy_size_5_qs)
   );
 
-
-  // F[dummy_en_5]: 15:15
+  //   F[dummy_en_5]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11120,8 +10736,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_dummy_en_5_qs)
   );
 
-
-  // F[payload_en_5]: 19:16
+  //   F[payload_en_5]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11146,8 +10761,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_payload_en_5_qs)
   );
 
-
-  // F[payload_dir_5]: 20:20
+  //   F[payload_dir_5]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11172,8 +10786,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_payload_dir_5_qs)
   );
 
-
-  // F[upload_5]: 24:24
+  //   F[upload_5]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11198,8 +10811,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_upload_5_qs)
   );
 
-
-  // F[busy_5]: 25:25
+  //   F[busy_5]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11227,8 +10839,7 @@ module spi_device_reg_top (
 
   // Subregister 6 of Multireg cmd_info
   // R[cmd_info_6]: V(False)
-
-  // F[opcode_6]: 7:0
+  //   F[opcode_6]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11253,8 +10864,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_opcode_6_qs)
   );
 
-
-  // F[addr_en_6]: 8:8
+  //   F[addr_en_6]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11279,8 +10889,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_addr_en_6_qs)
   );
 
-
-  // F[addr_swap_en_6]: 9:9
+  //   F[addr_swap_en_6]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11305,8 +10914,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_addr_swap_en_6_qs)
   );
 
-
-  // F[addr_4b_affected_6]: 10:10
+  //   F[addr_4b_affected_6]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11331,8 +10939,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_addr_4b_affected_6_qs)
   );
 
-
-  // F[mbyte_en_6]: 11:11
+  //   F[mbyte_en_6]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11357,8 +10964,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_mbyte_en_6_qs)
   );
 
-
-  // F[dummy_size_6]: 14:12
+  //   F[dummy_size_6]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11383,8 +10989,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_dummy_size_6_qs)
   );
 
-
-  // F[dummy_en_6]: 15:15
+  //   F[dummy_en_6]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11409,8 +11014,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_dummy_en_6_qs)
   );
 
-
-  // F[payload_en_6]: 19:16
+  //   F[payload_en_6]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11435,8 +11039,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_payload_en_6_qs)
   );
 
-
-  // F[payload_dir_6]: 20:20
+  //   F[payload_dir_6]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11461,8 +11064,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_payload_dir_6_qs)
   );
 
-
-  // F[upload_6]: 24:24
+  //   F[upload_6]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11487,8 +11089,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_6_upload_6_qs)
   );
 
-
-  // F[busy_6]: 25:25
+  //   F[busy_6]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11516,8 +11117,7 @@ module spi_device_reg_top (
 
   // Subregister 7 of Multireg cmd_info
   // R[cmd_info_7]: V(False)
-
-  // F[opcode_7]: 7:0
+  //   F[opcode_7]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11542,8 +11142,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_opcode_7_qs)
   );
 
-
-  // F[addr_en_7]: 8:8
+  //   F[addr_en_7]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11568,8 +11167,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_addr_en_7_qs)
   );
 
-
-  // F[addr_swap_en_7]: 9:9
+  //   F[addr_swap_en_7]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11594,8 +11192,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_addr_swap_en_7_qs)
   );
 
-
-  // F[addr_4b_affected_7]: 10:10
+  //   F[addr_4b_affected_7]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11620,8 +11217,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_addr_4b_affected_7_qs)
   );
 
-
-  // F[mbyte_en_7]: 11:11
+  //   F[mbyte_en_7]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11646,8 +11242,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_mbyte_en_7_qs)
   );
 
-
-  // F[dummy_size_7]: 14:12
+  //   F[dummy_size_7]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11672,8 +11267,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_dummy_size_7_qs)
   );
 
-
-  // F[dummy_en_7]: 15:15
+  //   F[dummy_en_7]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11698,8 +11292,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_dummy_en_7_qs)
   );
 
-
-  // F[payload_en_7]: 19:16
+  //   F[payload_en_7]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11724,8 +11317,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_payload_en_7_qs)
   );
 
-
-  // F[payload_dir_7]: 20:20
+  //   F[payload_dir_7]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11750,8 +11342,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_payload_dir_7_qs)
   );
 
-
-  // F[upload_7]: 24:24
+  //   F[upload_7]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11776,8 +11367,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_upload_7_qs)
   );
 
-
-  // F[busy_7]: 25:25
+  //   F[busy_7]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11805,8 +11395,7 @@ module spi_device_reg_top (
 
   // Subregister 8 of Multireg cmd_info
   // R[cmd_info_8]: V(False)
-
-  // F[opcode_8]: 7:0
+  //   F[opcode_8]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11831,8 +11420,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_opcode_8_qs)
   );
 
-
-  // F[addr_en_8]: 8:8
+  //   F[addr_en_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11857,8 +11445,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_addr_en_8_qs)
   );
 
-
-  // F[addr_swap_en_8]: 9:9
+  //   F[addr_swap_en_8]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11883,8 +11470,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_addr_swap_en_8_qs)
   );
 
-
-  // F[addr_4b_affected_8]: 10:10
+  //   F[addr_4b_affected_8]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11909,8 +11495,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_addr_4b_affected_8_qs)
   );
 
-
-  // F[mbyte_en_8]: 11:11
+  //   F[mbyte_en_8]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11935,8 +11520,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_mbyte_en_8_qs)
   );
 
-
-  // F[dummy_size_8]: 14:12
+  //   F[dummy_size_8]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11961,8 +11545,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_dummy_size_8_qs)
   );
 
-
-  // F[dummy_en_8]: 15:15
+  //   F[dummy_en_8]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11987,8 +11570,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_dummy_en_8_qs)
   );
 
-
-  // F[payload_en_8]: 19:16
+  //   F[payload_en_8]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12013,8 +11595,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_payload_en_8_qs)
   );
 
-
-  // F[payload_dir_8]: 20:20
+  //   F[payload_dir_8]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12039,8 +11620,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_payload_dir_8_qs)
   );
 
-
-  // F[upload_8]: 24:24
+  //   F[upload_8]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12065,8 +11645,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_8_upload_8_qs)
   );
 
-
-  // F[busy_8]: 25:25
+  //   F[busy_8]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12094,8 +11673,7 @@ module spi_device_reg_top (
 
   // Subregister 9 of Multireg cmd_info
   // R[cmd_info_9]: V(False)
-
-  // F[opcode_9]: 7:0
+  //   F[opcode_9]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12120,8 +11698,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_opcode_9_qs)
   );
 
-
-  // F[addr_en_9]: 8:8
+  //   F[addr_en_9]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12146,8 +11723,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_addr_en_9_qs)
   );
 
-
-  // F[addr_swap_en_9]: 9:9
+  //   F[addr_swap_en_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12172,8 +11748,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_addr_swap_en_9_qs)
   );
 
-
-  // F[addr_4b_affected_9]: 10:10
+  //   F[addr_4b_affected_9]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12198,8 +11773,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_addr_4b_affected_9_qs)
   );
 
-
-  // F[mbyte_en_9]: 11:11
+  //   F[mbyte_en_9]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12224,8 +11798,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_mbyte_en_9_qs)
   );
 
-
-  // F[dummy_size_9]: 14:12
+  //   F[dummy_size_9]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12250,8 +11823,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_dummy_size_9_qs)
   );
 
-
-  // F[dummy_en_9]: 15:15
+  //   F[dummy_en_9]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12276,8 +11848,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_dummy_en_9_qs)
   );
 
-
-  // F[payload_en_9]: 19:16
+  //   F[payload_en_9]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12302,8 +11873,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_payload_en_9_qs)
   );
 
-
-  // F[payload_dir_9]: 20:20
+  //   F[payload_dir_9]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12328,8 +11898,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_payload_dir_9_qs)
   );
 
-
-  // F[upload_9]: 24:24
+  //   F[upload_9]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12354,8 +11923,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_upload_9_qs)
   );
 
-
-  // F[busy_9]: 25:25
+  //   F[busy_9]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12383,8 +11951,7 @@ module spi_device_reg_top (
 
   // Subregister 10 of Multireg cmd_info
   // R[cmd_info_10]: V(False)
-
-  // F[opcode_10]: 7:0
+  //   F[opcode_10]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12409,8 +11976,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_opcode_10_qs)
   );
 
-
-  // F[addr_en_10]: 8:8
+  //   F[addr_en_10]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12435,8 +12001,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_addr_en_10_qs)
   );
 
-
-  // F[addr_swap_en_10]: 9:9
+  //   F[addr_swap_en_10]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12461,8 +12026,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_addr_swap_en_10_qs)
   );
 
-
-  // F[addr_4b_affected_10]: 10:10
+  //   F[addr_4b_affected_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12487,8 +12051,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_addr_4b_affected_10_qs)
   );
 
-
-  // F[mbyte_en_10]: 11:11
+  //   F[mbyte_en_10]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12513,8 +12076,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_mbyte_en_10_qs)
   );
 
-
-  // F[dummy_size_10]: 14:12
+  //   F[dummy_size_10]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12539,8 +12101,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_dummy_size_10_qs)
   );
 
-
-  // F[dummy_en_10]: 15:15
+  //   F[dummy_en_10]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12565,8 +12126,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_dummy_en_10_qs)
   );
 
-
-  // F[payload_en_10]: 19:16
+  //   F[payload_en_10]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12591,8 +12151,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_payload_en_10_qs)
   );
 
-
-  // F[payload_dir_10]: 20:20
+  //   F[payload_dir_10]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12617,8 +12176,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_payload_dir_10_qs)
   );
 
-
-  // F[upload_10]: 24:24
+  //   F[upload_10]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12643,8 +12201,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_10_upload_10_qs)
   );
 
-
-  // F[busy_10]: 25:25
+  //   F[busy_10]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12672,8 +12229,7 @@ module spi_device_reg_top (
 
   // Subregister 11 of Multireg cmd_info
   // R[cmd_info_11]: V(False)
-
-  // F[opcode_11]: 7:0
+  //   F[opcode_11]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12698,8 +12254,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_opcode_11_qs)
   );
 
-
-  // F[addr_en_11]: 8:8
+  //   F[addr_en_11]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12724,8 +12279,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_addr_en_11_qs)
   );
 
-
-  // F[addr_swap_en_11]: 9:9
+  //   F[addr_swap_en_11]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12750,8 +12304,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_addr_swap_en_11_qs)
   );
 
-
-  // F[addr_4b_affected_11]: 10:10
+  //   F[addr_4b_affected_11]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12776,8 +12329,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_addr_4b_affected_11_qs)
   );
 
-
-  // F[mbyte_en_11]: 11:11
+  //   F[mbyte_en_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12802,8 +12354,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_mbyte_en_11_qs)
   );
 
-
-  // F[dummy_size_11]: 14:12
+  //   F[dummy_size_11]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12828,8 +12379,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_dummy_size_11_qs)
   );
 
-
-  // F[dummy_en_11]: 15:15
+  //   F[dummy_en_11]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12854,8 +12404,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_dummy_en_11_qs)
   );
 
-
-  // F[payload_en_11]: 19:16
+  //   F[payload_en_11]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12880,8 +12429,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_payload_en_11_qs)
   );
 
-
-  // F[payload_dir_11]: 20:20
+  //   F[payload_dir_11]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12906,8 +12454,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_payload_dir_11_qs)
   );
 
-
-  // F[upload_11]: 24:24
+  //   F[upload_11]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12932,8 +12479,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_upload_11_qs)
   );
 
-
-  // F[busy_11]: 25:25
+  //   F[busy_11]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12961,8 +12507,7 @@ module spi_device_reg_top (
 
   // Subregister 12 of Multireg cmd_info
   // R[cmd_info_12]: V(False)
-
-  // F[opcode_12]: 7:0
+  //   F[opcode_12]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12987,8 +12532,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_opcode_12_qs)
   );
 
-
-  // F[addr_en_12]: 8:8
+  //   F[addr_en_12]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13013,8 +12557,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_addr_en_12_qs)
   );
 
-
-  // F[addr_swap_en_12]: 9:9
+  //   F[addr_swap_en_12]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13039,8 +12582,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_addr_swap_en_12_qs)
   );
 
-
-  // F[addr_4b_affected_12]: 10:10
+  //   F[addr_4b_affected_12]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13065,8 +12607,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_addr_4b_affected_12_qs)
   );
 
-
-  // F[mbyte_en_12]: 11:11
+  //   F[mbyte_en_12]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13091,8 +12632,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_mbyte_en_12_qs)
   );
 
-
-  // F[dummy_size_12]: 14:12
+  //   F[dummy_size_12]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13117,8 +12657,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_dummy_size_12_qs)
   );
 
-
-  // F[dummy_en_12]: 15:15
+  //   F[dummy_en_12]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13143,8 +12682,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_dummy_en_12_qs)
   );
 
-
-  // F[payload_en_12]: 19:16
+  //   F[payload_en_12]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13169,8 +12707,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_payload_en_12_qs)
   );
 
-
-  // F[payload_dir_12]: 20:20
+  //   F[payload_dir_12]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13195,8 +12732,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_payload_dir_12_qs)
   );
 
-
-  // F[upload_12]: 24:24
+  //   F[upload_12]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13221,8 +12757,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_12_upload_12_qs)
   );
 
-
-  // F[busy_12]: 25:25
+  //   F[busy_12]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13250,8 +12785,7 @@ module spi_device_reg_top (
 
   // Subregister 13 of Multireg cmd_info
   // R[cmd_info_13]: V(False)
-
-  // F[opcode_13]: 7:0
+  //   F[opcode_13]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13276,8 +12810,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_opcode_13_qs)
   );
 
-
-  // F[addr_en_13]: 8:8
+  //   F[addr_en_13]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13302,8 +12835,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_addr_en_13_qs)
   );
 
-
-  // F[addr_swap_en_13]: 9:9
+  //   F[addr_swap_en_13]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13328,8 +12860,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_addr_swap_en_13_qs)
   );
 
-
-  // F[addr_4b_affected_13]: 10:10
+  //   F[addr_4b_affected_13]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13354,8 +12885,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_addr_4b_affected_13_qs)
   );
 
-
-  // F[mbyte_en_13]: 11:11
+  //   F[mbyte_en_13]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13380,8 +12910,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_mbyte_en_13_qs)
   );
 
-
-  // F[dummy_size_13]: 14:12
+  //   F[dummy_size_13]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13406,8 +12935,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_dummy_size_13_qs)
   );
 
-
-  // F[dummy_en_13]: 15:15
+  //   F[dummy_en_13]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13432,8 +12960,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_dummy_en_13_qs)
   );
 
-
-  // F[payload_en_13]: 19:16
+  //   F[payload_en_13]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13458,8 +12985,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_payload_en_13_qs)
   );
 
-
-  // F[payload_dir_13]: 20:20
+  //   F[payload_dir_13]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13484,8 +13010,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_payload_dir_13_qs)
   );
 
-
-  // F[upload_13]: 24:24
+  //   F[upload_13]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13510,8 +13035,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_upload_13_qs)
   );
 
-
-  // F[busy_13]: 25:25
+  //   F[busy_13]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13539,8 +13063,7 @@ module spi_device_reg_top (
 
   // Subregister 14 of Multireg cmd_info
   // R[cmd_info_14]: V(False)
-
-  // F[opcode_14]: 7:0
+  //   F[opcode_14]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13565,8 +13088,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_opcode_14_qs)
   );
 
-
-  // F[addr_en_14]: 8:8
+  //   F[addr_en_14]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13591,8 +13113,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_addr_en_14_qs)
   );
 
-
-  // F[addr_swap_en_14]: 9:9
+  //   F[addr_swap_en_14]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13617,8 +13138,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_addr_swap_en_14_qs)
   );
 
-
-  // F[addr_4b_affected_14]: 10:10
+  //   F[addr_4b_affected_14]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13643,8 +13163,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_addr_4b_affected_14_qs)
   );
 
-
-  // F[mbyte_en_14]: 11:11
+  //   F[mbyte_en_14]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13669,8 +13188,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_mbyte_en_14_qs)
   );
 
-
-  // F[dummy_size_14]: 14:12
+  //   F[dummy_size_14]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13695,8 +13213,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_dummy_size_14_qs)
   );
 
-
-  // F[dummy_en_14]: 15:15
+  //   F[dummy_en_14]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13721,8 +13238,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_dummy_en_14_qs)
   );
 
-
-  // F[payload_en_14]: 19:16
+  //   F[payload_en_14]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13747,8 +13263,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_payload_en_14_qs)
   );
 
-
-  // F[payload_dir_14]: 20:20
+  //   F[payload_dir_14]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13773,8 +13288,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_payload_dir_14_qs)
   );
 
-
-  // F[upload_14]: 24:24
+  //   F[upload_14]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13799,8 +13313,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_14_upload_14_qs)
   );
 
-
-  // F[busy_14]: 25:25
+  //   F[busy_14]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13828,8 +13341,7 @@ module spi_device_reg_top (
 
   // Subregister 15 of Multireg cmd_info
   // R[cmd_info_15]: V(False)
-
-  // F[opcode_15]: 7:0
+  //   F[opcode_15]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13854,8 +13366,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_opcode_15_qs)
   );
 
-
-  // F[addr_en_15]: 8:8
+  //   F[addr_en_15]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13880,8 +13391,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_addr_en_15_qs)
   );
 
-
-  // F[addr_swap_en_15]: 9:9
+  //   F[addr_swap_en_15]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13906,8 +13416,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_addr_swap_en_15_qs)
   );
 
-
-  // F[addr_4b_affected_15]: 10:10
+  //   F[addr_4b_affected_15]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13932,8 +13441,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_addr_4b_affected_15_qs)
   );
 
-
-  // F[mbyte_en_15]: 11:11
+  //   F[mbyte_en_15]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13958,8 +13466,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_mbyte_en_15_qs)
   );
 
-
-  // F[dummy_size_15]: 14:12
+  //   F[dummy_size_15]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13984,8 +13491,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_dummy_size_15_qs)
   );
 
-
-  // F[dummy_en_15]: 15:15
+  //   F[dummy_en_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14010,8 +13516,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_dummy_en_15_qs)
   );
 
-
-  // F[payload_en_15]: 19:16
+  //   F[payload_en_15]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14036,8 +13541,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_payload_en_15_qs)
   );
 
-
-  // F[payload_dir_15]: 20:20
+  //   F[payload_dir_15]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14062,8 +13566,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_payload_dir_15_qs)
   );
 
-
-  // F[upload_15]: 24:24
+  //   F[upload_15]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14088,8 +13591,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_upload_15_qs)
   );
 
-
-  // F[busy_15]: 25:25
+  //   F[busy_15]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14117,8 +13619,7 @@ module spi_device_reg_top (
 
   // Subregister 16 of Multireg cmd_info
   // R[cmd_info_16]: V(False)
-
-  // F[opcode_16]: 7:0
+  //   F[opcode_16]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14143,8 +13644,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_opcode_16_qs)
   );
 
-
-  // F[addr_en_16]: 8:8
+  //   F[addr_en_16]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14169,8 +13669,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_addr_en_16_qs)
   );
 
-
-  // F[addr_swap_en_16]: 9:9
+  //   F[addr_swap_en_16]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14195,8 +13694,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_addr_swap_en_16_qs)
   );
 
-
-  // F[addr_4b_affected_16]: 10:10
+  //   F[addr_4b_affected_16]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14221,8 +13719,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_addr_4b_affected_16_qs)
   );
 
-
-  // F[mbyte_en_16]: 11:11
+  //   F[mbyte_en_16]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14247,8 +13744,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_mbyte_en_16_qs)
   );
 
-
-  // F[dummy_size_16]: 14:12
+  //   F[dummy_size_16]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14273,8 +13769,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_dummy_size_16_qs)
   );
 
-
-  // F[dummy_en_16]: 15:15
+  //   F[dummy_en_16]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14299,8 +13794,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_dummy_en_16_qs)
   );
 
-
-  // F[payload_en_16]: 19:16
+  //   F[payload_en_16]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14325,8 +13819,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_payload_en_16_qs)
   );
 
-
-  // F[payload_dir_16]: 20:20
+  //   F[payload_dir_16]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14351,8 +13844,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_payload_dir_16_qs)
   );
 
-
-  // F[upload_16]: 24:24
+  //   F[upload_16]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14377,8 +13869,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_16_upload_16_qs)
   );
 
-
-  // F[busy_16]: 25:25
+  //   F[busy_16]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14406,8 +13897,7 @@ module spi_device_reg_top (
 
   // Subregister 17 of Multireg cmd_info
   // R[cmd_info_17]: V(False)
-
-  // F[opcode_17]: 7:0
+  //   F[opcode_17]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14432,8 +13922,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_opcode_17_qs)
   );
 
-
-  // F[addr_en_17]: 8:8
+  //   F[addr_en_17]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14458,8 +13947,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_addr_en_17_qs)
   );
 
-
-  // F[addr_swap_en_17]: 9:9
+  //   F[addr_swap_en_17]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14484,8 +13972,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_addr_swap_en_17_qs)
   );
 
-
-  // F[addr_4b_affected_17]: 10:10
+  //   F[addr_4b_affected_17]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14510,8 +13997,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_addr_4b_affected_17_qs)
   );
 
-
-  // F[mbyte_en_17]: 11:11
+  //   F[mbyte_en_17]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14536,8 +14022,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_mbyte_en_17_qs)
   );
 
-
-  // F[dummy_size_17]: 14:12
+  //   F[dummy_size_17]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14562,8 +14047,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_dummy_size_17_qs)
   );
 
-
-  // F[dummy_en_17]: 15:15
+  //   F[dummy_en_17]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14588,8 +14072,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_dummy_en_17_qs)
   );
 
-
-  // F[payload_en_17]: 19:16
+  //   F[payload_en_17]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14614,8 +14097,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_payload_en_17_qs)
   );
 
-
-  // F[payload_dir_17]: 20:20
+  //   F[payload_dir_17]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14640,8 +14122,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_payload_dir_17_qs)
   );
 
-
-  // F[upload_17]: 24:24
+  //   F[upload_17]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14666,8 +14147,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_upload_17_qs)
   );
 
-
-  // F[busy_17]: 25:25
+  //   F[busy_17]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14695,8 +14175,7 @@ module spi_device_reg_top (
 
   // Subregister 18 of Multireg cmd_info
   // R[cmd_info_18]: V(False)
-
-  // F[opcode_18]: 7:0
+  //   F[opcode_18]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14721,8 +14200,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_opcode_18_qs)
   );
 
-
-  // F[addr_en_18]: 8:8
+  //   F[addr_en_18]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14747,8 +14225,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_addr_en_18_qs)
   );
 
-
-  // F[addr_swap_en_18]: 9:9
+  //   F[addr_swap_en_18]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14773,8 +14250,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_addr_swap_en_18_qs)
   );
 
-
-  // F[addr_4b_affected_18]: 10:10
+  //   F[addr_4b_affected_18]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14799,8 +14275,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_addr_4b_affected_18_qs)
   );
 
-
-  // F[mbyte_en_18]: 11:11
+  //   F[mbyte_en_18]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14825,8 +14300,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_mbyte_en_18_qs)
   );
 
-
-  // F[dummy_size_18]: 14:12
+  //   F[dummy_size_18]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14851,8 +14325,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_dummy_size_18_qs)
   );
 
-
-  // F[dummy_en_18]: 15:15
+  //   F[dummy_en_18]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14877,8 +14350,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_dummy_en_18_qs)
   );
 
-
-  // F[payload_en_18]: 19:16
+  //   F[payload_en_18]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14903,8 +14375,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_payload_en_18_qs)
   );
 
-
-  // F[payload_dir_18]: 20:20
+  //   F[payload_dir_18]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14929,8 +14400,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_payload_dir_18_qs)
   );
 
-
-  // F[upload_18]: 24:24
+  //   F[upload_18]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14955,8 +14425,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_18_upload_18_qs)
   );
 
-
-  // F[busy_18]: 25:25
+  //   F[busy_18]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14984,8 +14453,7 @@ module spi_device_reg_top (
 
   // Subregister 19 of Multireg cmd_info
   // R[cmd_info_19]: V(False)
-
-  // F[opcode_19]: 7:0
+  //   F[opcode_19]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15010,8 +14478,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_opcode_19_qs)
   );
 
-
-  // F[addr_en_19]: 8:8
+  //   F[addr_en_19]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15036,8 +14503,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_addr_en_19_qs)
   );
 
-
-  // F[addr_swap_en_19]: 9:9
+  //   F[addr_swap_en_19]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15062,8 +14528,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_addr_swap_en_19_qs)
   );
 
-
-  // F[addr_4b_affected_19]: 10:10
+  //   F[addr_4b_affected_19]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15088,8 +14553,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_addr_4b_affected_19_qs)
   );
 
-
-  // F[mbyte_en_19]: 11:11
+  //   F[mbyte_en_19]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15114,8 +14578,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_mbyte_en_19_qs)
   );
 
-
-  // F[dummy_size_19]: 14:12
+  //   F[dummy_size_19]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15140,8 +14603,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_dummy_size_19_qs)
   );
 
-
-  // F[dummy_en_19]: 15:15
+  //   F[dummy_en_19]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15166,8 +14628,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_dummy_en_19_qs)
   );
 
-
-  // F[payload_en_19]: 19:16
+  //   F[payload_en_19]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15192,8 +14653,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_payload_en_19_qs)
   );
 
-
-  // F[payload_dir_19]: 20:20
+  //   F[payload_dir_19]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15218,8 +14678,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_payload_dir_19_qs)
   );
 
-
-  // F[upload_19]: 24:24
+  //   F[upload_19]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15244,8 +14703,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_upload_19_qs)
   );
 
-
-  // F[busy_19]: 25:25
+  //   F[busy_19]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15273,8 +14731,7 @@ module spi_device_reg_top (
 
   // Subregister 20 of Multireg cmd_info
   // R[cmd_info_20]: V(False)
-
-  // F[opcode_20]: 7:0
+  //   F[opcode_20]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15299,8 +14756,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_opcode_20_qs)
   );
 
-
-  // F[addr_en_20]: 8:8
+  //   F[addr_en_20]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15325,8 +14781,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_addr_en_20_qs)
   );
 
-
-  // F[addr_swap_en_20]: 9:9
+  //   F[addr_swap_en_20]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15351,8 +14806,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_addr_swap_en_20_qs)
   );
 
-
-  // F[addr_4b_affected_20]: 10:10
+  //   F[addr_4b_affected_20]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15377,8 +14831,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_addr_4b_affected_20_qs)
   );
 
-
-  // F[mbyte_en_20]: 11:11
+  //   F[mbyte_en_20]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15403,8 +14856,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_mbyte_en_20_qs)
   );
 
-
-  // F[dummy_size_20]: 14:12
+  //   F[dummy_size_20]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15429,8 +14881,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_dummy_size_20_qs)
   );
 
-
-  // F[dummy_en_20]: 15:15
+  //   F[dummy_en_20]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15455,8 +14906,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_dummy_en_20_qs)
   );
 
-
-  // F[payload_en_20]: 19:16
+  //   F[payload_en_20]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15481,8 +14931,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_payload_en_20_qs)
   );
 
-
-  // F[payload_dir_20]: 20:20
+  //   F[payload_dir_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15507,8 +14956,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_payload_dir_20_qs)
   );
 
-
-  // F[upload_20]: 24:24
+  //   F[upload_20]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15533,8 +14981,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_20_upload_20_qs)
   );
 
-
-  // F[busy_20]: 25:25
+  //   F[busy_20]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15562,8 +15009,7 @@ module spi_device_reg_top (
 
   // Subregister 21 of Multireg cmd_info
   // R[cmd_info_21]: V(False)
-
-  // F[opcode_21]: 7:0
+  //   F[opcode_21]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15588,8 +15034,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_opcode_21_qs)
   );
 
-
-  // F[addr_en_21]: 8:8
+  //   F[addr_en_21]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15614,8 +15059,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_addr_en_21_qs)
   );
 
-
-  // F[addr_swap_en_21]: 9:9
+  //   F[addr_swap_en_21]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15640,8 +15084,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_addr_swap_en_21_qs)
   );
 
-
-  // F[addr_4b_affected_21]: 10:10
+  //   F[addr_4b_affected_21]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15666,8 +15109,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_addr_4b_affected_21_qs)
   );
 
-
-  // F[mbyte_en_21]: 11:11
+  //   F[mbyte_en_21]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15692,8 +15134,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_mbyte_en_21_qs)
   );
 
-
-  // F[dummy_size_21]: 14:12
+  //   F[dummy_size_21]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15718,8 +15159,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_dummy_size_21_qs)
   );
 
-
-  // F[dummy_en_21]: 15:15
+  //   F[dummy_en_21]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15744,8 +15184,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_dummy_en_21_qs)
   );
 
-
-  // F[payload_en_21]: 19:16
+  //   F[payload_en_21]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15770,8 +15209,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_payload_en_21_qs)
   );
 
-
-  // F[payload_dir_21]: 20:20
+  //   F[payload_dir_21]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15796,8 +15234,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_payload_dir_21_qs)
   );
 
-
-  // F[upload_21]: 24:24
+  //   F[upload_21]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15822,8 +15259,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_upload_21_qs)
   );
 
-
-  // F[busy_21]: 25:25
+  //   F[busy_21]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15851,8 +15287,7 @@ module spi_device_reg_top (
 
   // Subregister 22 of Multireg cmd_info
   // R[cmd_info_22]: V(False)
-
-  // F[opcode_22]: 7:0
+  //   F[opcode_22]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15877,8 +15312,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_opcode_22_qs)
   );
 
-
-  // F[addr_en_22]: 8:8
+  //   F[addr_en_22]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15903,8 +15337,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_addr_en_22_qs)
   );
 
-
-  // F[addr_swap_en_22]: 9:9
+  //   F[addr_swap_en_22]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15929,8 +15362,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_addr_swap_en_22_qs)
   );
 
-
-  // F[addr_4b_affected_22]: 10:10
+  //   F[addr_4b_affected_22]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15955,8 +15387,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_addr_4b_affected_22_qs)
   );
 
-
-  // F[mbyte_en_22]: 11:11
+  //   F[mbyte_en_22]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15981,8 +15412,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_mbyte_en_22_qs)
   );
 
-
-  // F[dummy_size_22]: 14:12
+  //   F[dummy_size_22]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16007,8 +15437,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_dummy_size_22_qs)
   );
 
-
-  // F[dummy_en_22]: 15:15
+  //   F[dummy_en_22]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16033,8 +15462,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_dummy_en_22_qs)
   );
 
-
-  // F[payload_en_22]: 19:16
+  //   F[payload_en_22]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16059,8 +15487,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_payload_en_22_qs)
   );
 
-
-  // F[payload_dir_22]: 20:20
+  //   F[payload_dir_22]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16085,8 +15512,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_payload_dir_22_qs)
   );
 
-
-  // F[upload_22]: 24:24
+  //   F[upload_22]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16111,8 +15537,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_upload_22_qs)
   );
 
-
-  // F[busy_22]: 25:25
+  //   F[busy_22]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16140,8 +15565,7 @@ module spi_device_reg_top (
 
   // Subregister 23 of Multireg cmd_info
   // R[cmd_info_23]: V(False)
-
-  // F[opcode_23]: 7:0
+  //   F[opcode_23]: 7:0
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16166,8 +15590,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_opcode_23_qs)
   );
 
-
-  // F[addr_en_23]: 8:8
+  //   F[addr_en_23]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16192,8 +15615,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_addr_en_23_qs)
   );
 
-
-  // F[addr_swap_en_23]: 9:9
+  //   F[addr_swap_en_23]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16218,8 +15640,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_addr_swap_en_23_qs)
   );
 
-
-  // F[addr_4b_affected_23]: 10:10
+  //   F[addr_4b_affected_23]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16244,8 +15665,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_addr_4b_affected_23_qs)
   );
 
-
-  // F[mbyte_en_23]: 11:11
+  //   F[mbyte_en_23]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16270,8 +15690,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_mbyte_en_23_qs)
   );
 
-
-  // F[dummy_size_23]: 14:12
+  //   F[dummy_size_23]: 14:12
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16296,8 +15715,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_dummy_size_23_qs)
   );
 
-
-  // F[dummy_en_23]: 15:15
+  //   F[dummy_en_23]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16322,8 +15740,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_dummy_en_23_qs)
   );
 
-
-  // F[payload_en_23]: 19:16
+  //   F[payload_en_23]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16348,8 +15765,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_payload_en_23_qs)
   );
 
-
-  // F[payload_dir_23]: 20:20
+  //   F[payload_dir_23]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16374,8 +15790,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_payload_dir_23_qs)
   );
 
-
-  // F[upload_23]: 24:24
+  //   F[upload_23]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16400,8 +15815,7 @@ module spi_device_reg_top (
     .qs     (cmd_info_23_upload_23_qs)
   );
 
-
-  // F[busy_23]: 25:25
+  //   F[busy_23]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16425,8 +15839,6 @@ module spi_device_reg_top (
     // to register interface (read)
     .qs     (cmd_info_23_busy_23_qs)
   );
-
-
 
 
 

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -258,7 +258,6 @@ module spi_host_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[error]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -283,7 +282,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (intr_state_error_qs)
   );
-
 
   //   F[spi_event]: 1:1
   prim_subreg #(
@@ -312,7 +310,6 @@ module spi_host_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[error]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -337,7 +334,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (intr_enable_error_qs)
   );
-
 
   //   F[spi_event]: 1:1
   prim_subreg #(
@@ -366,7 +362,6 @@ module spi_host_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -380,7 +375,6 @@ module spi_host_reg_top (
     .q      (reg2hw.intr_test.error.q),
     .qs     ()
   );
-
 
   //   F[spi_event]: 1:1
   prim_subreg_ext #(
@@ -398,7 +392,6 @@ module spi_host_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -414,7 +407,6 @@ module spi_host_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[rx_watermark]: 7:0
   prim_subreg #(
     .DW      (8),
@@ -439,7 +431,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (control_rx_watermark_qs)
   );
-
 
   //   F[tx_watermark]: 15:8
   prim_subreg #(
@@ -466,7 +457,6 @@ module spi_host_reg_top (
     .qs     (control_tx_watermark_qs)
   );
 
-
   //   F[sw_rst]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -491,7 +481,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (control_sw_rst_qs)
   );
-
 
   //   F[spien]: 31:31
   prim_subreg #(
@@ -520,7 +509,6 @@ module spi_host_reg_top (
 
 
   // R[status]: V(False)
-
   //   F[txqd]: 7:0
   prim_subreg #(
     .DW      (8),
@@ -545,7 +533,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (status_txqd_qs)
   );
-
 
   //   F[rxqd]: 15:8
   prim_subreg #(
@@ -572,7 +559,6 @@ module spi_host_reg_top (
     .qs     (status_rxqd_qs)
   );
 
-
   //   F[rxwm]: 20:20
   prim_subreg #(
     .DW      (1),
@@ -597,7 +583,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (status_rxwm_qs)
   );
-
 
   //   F[byteorder]: 22:22
   prim_subreg #(
@@ -624,7 +609,6 @@ module spi_host_reg_top (
     .qs     (status_byteorder_qs)
   );
 
-
   //   F[rxstall]: 23:23
   prim_subreg #(
     .DW      (1),
@@ -649,7 +633,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (status_rxstall_qs)
   );
-
 
   //   F[rxempty]: 24:24
   prim_subreg #(
@@ -676,7 +659,6 @@ module spi_host_reg_top (
     .qs     (status_rxempty_qs)
   );
 
-
   //   F[rxfull]: 25:25
   prim_subreg #(
     .DW      (1),
@@ -701,7 +683,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (status_rxfull_qs)
   );
-
 
   //   F[txwm]: 26:26
   prim_subreg #(
@@ -728,7 +709,6 @@ module spi_host_reg_top (
     .qs     (status_txwm_qs)
   );
 
-
   //   F[txstall]: 27:27
   prim_subreg #(
     .DW      (1),
@@ -753,7 +733,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (status_txstall_qs)
   );
-
 
   //   F[txempty]: 28:28
   prim_subreg #(
@@ -780,7 +759,6 @@ module spi_host_reg_top (
     .qs     (status_txempty_qs)
   );
 
-
   //   F[txfull]: 29:29
   prim_subreg #(
     .DW      (1),
@@ -806,7 +784,6 @@ module spi_host_reg_top (
     .qs     (status_txfull_qs)
   );
 
-
   //   F[active]: 30:30
   prim_subreg #(
     .DW      (1),
@@ -831,7 +808,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (status_active_qs)
   );
-
 
   //   F[ready]: 31:31
   prim_subreg #(
@@ -859,11 +835,9 @@ module spi_host_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg configopts
   // R[configopts]: V(False)
-
-  // F[clkdiv_0]: 15:0
+  //   F[clkdiv_0]: 15:0
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -888,8 +862,7 @@ module spi_host_reg_top (
     .qs     (configopts_clkdiv_0_qs)
   );
 
-
-  // F[csnidle_0]: 19:16
+  //   F[csnidle_0]: 19:16
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -914,8 +887,7 @@ module spi_host_reg_top (
     .qs     (configopts_csnidle_0_qs)
   );
 
-
-  // F[csntrail_0]: 23:20
+  //   F[csntrail_0]: 23:20
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -940,8 +912,7 @@ module spi_host_reg_top (
     .qs     (configopts_csntrail_0_qs)
   );
 
-
-  // F[csnlead_0]: 27:24
+  //   F[csnlead_0]: 27:24
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -966,8 +937,7 @@ module spi_host_reg_top (
     .qs     (configopts_csnlead_0_qs)
   );
 
-
-  // F[fullcyc_0]: 29:29
+  //   F[fullcyc_0]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -992,8 +962,7 @@ module spi_host_reg_top (
     .qs     (configopts_fullcyc_0_qs)
   );
 
-
-  // F[cpha_0]: 30:30
+  //   F[cpha_0]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1018,8 +987,7 @@ module spi_host_reg_top (
     .qs     (configopts_cpha_0_qs)
   );
 
-
-  // F[cpol_0]: 31:31
+  //   F[cpol_0]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1045,9 +1013,7 @@ module spi_host_reg_top (
   );
 
 
-
   // R[csid]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1074,7 +1040,6 @@ module spi_host_reg_top (
 
 
   // R[command]: V(False)
-
   //   F[len]: 8:0
   prim_subreg #(
     .DW      (9),
@@ -1099,7 +1064,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (command_len_qs)
   );
-
 
   //   F[csaat]: 9:9
   prim_subreg #(
@@ -1126,7 +1090,6 @@ module spi_host_reg_top (
     .qs     (command_csaat_qs)
   );
 
-
   //   F[speed]: 11:10
   prim_subreg #(
     .DW      (2),
@@ -1151,7 +1114,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (command_speed_qs)
   );
-
 
   //   F[direction]: 13:12
   prim_subreg #(
@@ -1180,7 +1142,6 @@ module spi_host_reg_top (
 
 
   // R[error_enable]: V(False)
-
   //   F[cmdbusy]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1205,7 +1166,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (error_enable_cmdbusy_qs)
   );
-
 
   //   F[overflow]: 1:1
   prim_subreg #(
@@ -1232,7 +1192,6 @@ module spi_host_reg_top (
     .qs     (error_enable_overflow_qs)
   );
 
-
   //   F[underflow]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1258,7 +1217,6 @@ module spi_host_reg_top (
     .qs     (error_enable_underflow_qs)
   );
 
-
   //   F[cmdinval]: 3:3
   prim_subreg #(
     .DW      (1),
@@ -1283,7 +1241,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (error_enable_cmdinval_qs)
   );
-
 
   //   F[csidinval]: 4:4
   prim_subreg #(
@@ -1312,7 +1269,6 @@ module spi_host_reg_top (
 
 
   // R[error_status]: V(False)
-
   //   F[cmdbusy]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1337,7 +1293,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (error_status_cmdbusy_qs)
   );
-
 
   //   F[overflow]: 1:1
   prim_subreg #(
@@ -1364,7 +1319,6 @@ module spi_host_reg_top (
     .qs     (error_status_overflow_qs)
   );
 
-
   //   F[underflow]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1390,7 +1344,6 @@ module spi_host_reg_top (
     .qs     (error_status_underflow_qs)
   );
 
-
   //   F[cmdinval]: 3:3
   prim_subreg #(
     .DW      (1),
@@ -1415,7 +1368,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (error_status_cmdinval_qs)
   );
-
 
   //   F[csidinval]: 4:4
   prim_subreg #(
@@ -1444,7 +1396,6 @@ module spi_host_reg_top (
 
 
   // R[event_enable]: V(False)
-
   //   F[rxfull]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1469,7 +1420,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (event_enable_rxfull_qs)
   );
-
 
   //   F[txempty]: 1:1
   prim_subreg #(
@@ -1496,7 +1446,6 @@ module spi_host_reg_top (
     .qs     (event_enable_txempty_qs)
   );
 
-
   //   F[rxwm]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1521,7 +1470,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (event_enable_rxwm_qs)
   );
-
 
   //   F[txwm]: 3:3
   prim_subreg #(
@@ -1548,7 +1496,6 @@ module spi_host_reg_top (
     .qs     (event_enable_txwm_qs)
   );
 
-
   //   F[ready]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1574,7 +1521,6 @@ module spi_host_reg_top (
     .qs     (event_enable_ready_qs)
   );
 
-
   //   F[idle]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -1599,7 +1545,6 @@ module spi_host_reg_top (
     // to register interface (read)
     .qs     (event_enable_idle_qs)
   );
-
 
 
 

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -131,7 +131,6 @@ module sram_ctrl_regs_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -147,7 +146,6 @@ module sram_ctrl_regs_reg_top (
 
 
   // R[status]: V(False)
-
   //   F[bus_integ_error]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -172,7 +170,6 @@ module sram_ctrl_regs_reg_top (
     // to register interface (read)
     .qs     (status_bus_integ_error_qs)
   );
-
 
   //   F[init_error]: 1:1
   prim_subreg #(
@@ -199,7 +196,6 @@ module sram_ctrl_regs_reg_top (
     .qs     (status_init_error_qs)
   );
 
-
   //   F[escalated]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -224,7 +220,6 @@ module sram_ctrl_regs_reg_top (
     // to register interface (read)
     .qs     (status_escalated_qs)
   );
-
 
   //   F[scr_key_valid]: 3:3
   prim_subreg #(
@@ -251,7 +246,6 @@ module sram_ctrl_regs_reg_top (
     .qs     (status_scr_key_valid_qs)
   );
 
-
   //   F[scr_key_seed_valid]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -276,7 +270,6 @@ module sram_ctrl_regs_reg_top (
     // to register interface (read)
     .qs     (status_scr_key_seed_valid_qs)
   );
-
 
   //   F[init_done]: 5:5
   prim_subreg #(
@@ -305,7 +298,6 @@ module sram_ctrl_regs_reg_top (
 
 
   // R[exec_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -332,7 +324,6 @@ module sram_ctrl_regs_reg_top (
 
 
   // R[exec]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -359,7 +350,6 @@ module sram_ctrl_regs_reg_top (
 
 
   // R[ctrl_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -386,7 +376,6 @@ module sram_ctrl_regs_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[renew_scr_key]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -412,7 +401,6 @@ module sram_ctrl_regs_reg_top (
     .qs     ()
   );
 
-
   //   F[init]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -437,7 +425,6 @@ module sram_ctrl_regs_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
 
 

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -1466,7 +1466,6 @@ module sysrst_ctrl_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1493,7 +1492,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1520,7 +1518,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -1536,7 +1533,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1552,7 +1548,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1579,7 +1574,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ec_rst_ctl]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1606,7 +1600,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ulp_ac_debounce_ctl]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1633,7 +1626,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ulp_lid_debounce_ctl]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1660,7 +1652,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ulp_pwrb_debounce_ctl]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1687,7 +1678,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ulp_ctl]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1714,7 +1704,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[ulp_status]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1741,7 +1730,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[wkup_status]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1768,7 +1756,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[key_invert_ctl]: V(False)
-
   //   F[key0_in]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1793,7 +1780,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key0_in_qs_int)
   );
-
 
   //   F[key0_out]: 1:1
   prim_subreg #(
@@ -1820,7 +1806,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_invert_ctl_key0_out_qs_int)
   );
 
-
   //   F[key1_in]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1845,7 +1830,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key1_in_qs_int)
   );
-
 
   //   F[key1_out]: 3:3
   prim_subreg #(
@@ -1872,7 +1856,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_invert_ctl_key1_out_qs_int)
   );
 
-
   //   F[key2_in]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1897,7 +1880,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_invert_ctl_key2_in_qs_int)
   );
-
 
   //   F[key2_out]: 5:5
   prim_subreg #(
@@ -1924,7 +1906,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_invert_ctl_key2_out_qs_int)
   );
 
-
   //   F[pwrb_in]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -1949,7 +1930,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_invert_ctl_pwrb_in_qs_int)
   );
-
 
   //   F[pwrb_out]: 7:7
   prim_subreg #(
@@ -1976,7 +1956,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_invert_ctl_pwrb_out_qs_int)
   );
 
-
   //   F[ac_present]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -2001,7 +1980,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_invert_ctl_ac_present_qs_int)
   );
-
 
   //   F[bat_disable]: 9:9
   prim_subreg #(
@@ -2028,7 +2006,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_invert_ctl_bat_disable_qs_int)
   );
 
-
   //   F[lid_open]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -2053,7 +2030,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_invert_ctl_lid_open_qs_int)
   );
-
 
   //   F[z3_wakeup]: 11:11
   prim_subreg #(
@@ -2082,7 +2058,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[pin_allowed_ctl]: V(False)
-
   //   F[bat_disable_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2107,7 +2082,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_bat_disable_0_qs_int)
   );
-
 
   //   F[ec_rst_l_0]: 1:1
   prim_subreg #(
@@ -2134,7 +2108,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_ec_rst_l_0_qs_int)
   );
 
-
   //   F[pwrb_out_0]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2159,7 +2132,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_pwrb_out_0_qs_int)
   );
-
 
   //   F[key0_out_0]: 3:3
   prim_subreg #(
@@ -2186,7 +2158,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_key0_out_0_qs_int)
   );
 
-
   //   F[key1_out_0]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -2211,7 +2182,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key1_out_0_qs_int)
   );
-
 
   //   F[key2_out_0]: 5:5
   prim_subreg #(
@@ -2238,7 +2208,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_key2_out_0_qs_int)
   );
 
-
   //   F[z3_wakeup_0]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -2263,7 +2232,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_z3_wakeup_0_qs_int)
   );
-
 
   //   F[flash_wp_l_0]: 7:7
   prim_subreg #(
@@ -2290,7 +2258,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_flash_wp_l_0_qs_int)
   );
 
-
   //   F[bat_disable_1]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -2315,7 +2282,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_bat_disable_1_qs_int)
   );
-
 
   //   F[ec_rst_l_1]: 9:9
   prim_subreg #(
@@ -2342,7 +2308,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_ec_rst_l_1_qs_int)
   );
 
-
   //   F[pwrb_out_1]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -2367,7 +2332,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_pwrb_out_1_qs_int)
   );
-
 
   //   F[key0_out_1]: 11:11
   prim_subreg #(
@@ -2394,7 +2358,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_key0_out_1_qs_int)
   );
 
-
   //   F[key1_out_1]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -2419,7 +2382,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_key1_out_1_qs_int)
   );
-
 
   //   F[key2_out_1]: 13:13
   prim_subreg #(
@@ -2446,7 +2408,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_allowed_ctl_key2_out_1_qs_int)
   );
 
-
   //   F[z3_wakeup_1]: 14:14
   prim_subreg #(
     .DW      (1),
@@ -2471,7 +2432,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_allowed_ctl_z3_wakeup_1_qs_int)
   );
-
 
   //   F[flash_wp_l_1]: 15:15
   prim_subreg #(
@@ -2500,7 +2460,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[pin_out_ctl]: V(False)
-
   //   F[bat_disable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2525,7 +2484,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_ctl_bat_disable_qs_int)
   );
-
 
   //   F[ec_rst_l]: 1:1
   prim_subreg #(
@@ -2552,7 +2510,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_out_ctl_ec_rst_l_qs_int)
   );
 
-
   //   F[pwrb_out]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2577,7 +2534,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_ctl_pwrb_out_qs_int)
   );
-
 
   //   F[key0_out]: 3:3
   prim_subreg #(
@@ -2604,7 +2560,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_out_ctl_key0_out_qs_int)
   );
 
-
   //   F[key1_out]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -2629,7 +2584,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_ctl_key1_out_qs_int)
   );
-
 
   //   F[key2_out]: 5:5
   prim_subreg #(
@@ -2656,7 +2610,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_out_ctl_key2_out_qs_int)
   );
 
-
   //   F[z3_wakeup]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -2681,7 +2634,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_ctl_z3_wakeup_qs_int)
   );
-
 
   //   F[flash_wp_l]: 7:7
   prim_subreg #(
@@ -2710,7 +2662,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[pin_out_value]: V(False)
-
   //   F[bat_disable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2735,7 +2686,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_value_bat_disable_qs_int)
   );
-
 
   //   F[ec_rst_l]: 1:1
   prim_subreg #(
@@ -2762,7 +2712,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_out_value_ec_rst_l_qs_int)
   );
 
-
   //   F[pwrb_out]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2787,7 +2736,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_value_pwrb_out_qs_int)
   );
-
 
   //   F[key0_out]: 3:3
   prim_subreg #(
@@ -2814,7 +2762,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_out_value_key0_out_qs_int)
   );
 
-
   //   F[key1_out]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -2839,7 +2786,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_value_key1_out_qs_int)
   );
-
 
   //   F[key2_out]: 5:5
   prim_subreg #(
@@ -2866,7 +2812,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_pin_out_value_key2_out_qs_int)
   );
 
-
   //   F[z3_wakeup]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -2891,7 +2836,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_pin_out_value_z3_wakeup_qs_int)
   );
-
 
   //   F[flash_wp_l]: 7:7
   prim_subreg #(
@@ -2920,7 +2864,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[pin_in_value]: V(False)
-
   //   F[ac_present]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -2945,7 +2888,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (pin_in_value_ac_present_qs)
   );
-
 
   //   F[ec_rst_l]: 1:1
   prim_subreg #(
@@ -2972,7 +2914,6 @@ module sysrst_ctrl_reg_top (
     .qs     (pin_in_value_ec_rst_l_qs)
   );
 
-
   //   F[pwrb_in]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -2997,7 +2938,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (pin_in_value_pwrb_in_qs)
   );
-
 
   //   F[key0_in]: 3:3
   prim_subreg #(
@@ -3024,7 +2964,6 @@ module sysrst_ctrl_reg_top (
     .qs     (pin_in_value_key0_in_qs)
   );
 
-
   //   F[key1_in]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -3050,7 +2989,6 @@ module sysrst_ctrl_reg_top (
     .qs     (pin_in_value_key1_in_qs)
   );
 
-
   //   F[key2_in]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -3075,7 +3013,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (pin_in_value_key2_in_qs)
   );
-
 
   //   F[lid_open]: 6:6
   prim_subreg #(
@@ -3104,7 +3041,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[key_intr_ctl]: V(False)
-
   //   F[pwrb_in_h2l]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -3129,7 +3065,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_ctl_pwrb_in_h2l_qs_int)
   );
-
 
   //   F[key0_in_h2l]: 1:1
   prim_subreg #(
@@ -3156,7 +3091,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_ctl_key0_in_h2l_qs_int)
   );
 
-
   //   F[key1_in_h2l]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -3181,7 +3115,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key1_in_h2l_qs_int)
   );
-
 
   //   F[key2_in_h2l]: 3:3
   prim_subreg #(
@@ -3208,7 +3141,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_ctl_key2_in_h2l_qs_int)
   );
 
-
   //   F[ac_present_h2l]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -3233,7 +3165,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_ctl_ac_present_h2l_qs_int)
   );
-
 
   //   F[ec_rst_l_h2l]: 5:5
   prim_subreg #(
@@ -3260,7 +3191,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_ctl_ec_rst_l_h2l_qs_int)
   );
 
-
   //   F[pwrb_in_l2h]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -3285,7 +3215,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_ctl_pwrb_in_l2h_qs_int)
   );
-
 
   //   F[key0_in_l2h]: 9:9
   prim_subreg #(
@@ -3312,7 +3241,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_ctl_key0_in_l2h_qs_int)
   );
 
-
   //   F[key1_in_l2h]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -3337,7 +3265,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_ctl_key1_in_l2h_qs_int)
   );
-
 
   //   F[key2_in_l2h]: 11:11
   prim_subreg #(
@@ -3364,7 +3291,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_ctl_key2_in_l2h_qs_int)
   );
 
-
   //   F[ac_present_l2h]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -3389,7 +3315,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_ctl_ac_present_l2h_qs_int)
   );
-
 
   //   F[ec_rst_l_l2h]: 13:13
   prim_subreg #(
@@ -3418,7 +3343,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[key_intr_debounce_ctl]: V(False)
-
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3445,7 +3369,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[auto_block_debounce_ctl]: V(False)
-
   //   F[debounce_timer]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -3470,7 +3393,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_auto_block_debounce_ctl_debounce_timer_qs_int)
   );
-
 
   //   F[auto_block_enable]: 16:16
   prim_subreg #(
@@ -3499,7 +3421,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[auto_block_out_ctl]: V(False)
-
   //   F[key0_out_sel]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -3524,7 +3445,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key0_out_sel_qs_int)
   );
-
 
   //   F[key1_out_sel]: 1:1
   prim_subreg #(
@@ -3551,7 +3471,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_auto_block_out_ctl_key1_out_sel_qs_int)
   );
 
-
   //   F[key2_out_sel]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -3576,7 +3495,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key2_out_sel_qs_int)
   );
-
 
   //   F[key0_out_value]: 4:4
   prim_subreg #(
@@ -3603,7 +3521,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_auto_block_out_ctl_key0_out_value_qs_int)
   );
 
-
   //   F[key1_out_value]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -3628,7 +3545,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_auto_block_out_ctl_key1_out_value_qs_int)
   );
-
 
   //   F[key2_out_value]: 6:6
   prim_subreg #(
@@ -3656,11 +3572,9 @@ module sysrst_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg com_sel_ctl
   // R[com_sel_ctl_0]: V(False)
-
-  // F[key0_in_sel_0]: 0:0
+  //   F[key0_in_sel_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3685,8 +3599,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_0_key0_in_sel_0_qs_int)
   );
 
-
-  // F[key1_in_sel_0]: 1:1
+  //   F[key1_in_sel_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3711,8 +3624,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_0_key1_in_sel_0_qs_int)
   );
 
-
-  // F[key2_in_sel_0]: 2:2
+  //   F[key2_in_sel_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3737,8 +3649,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_0_key2_in_sel_0_qs_int)
   );
 
-
-  // F[pwrb_in_sel_0]: 3:3
+  //   F[pwrb_in_sel_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3763,8 +3674,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_0_pwrb_in_sel_0_qs_int)
   );
 
-
-  // F[ac_present_sel_0]: 4:4
+  //   F[ac_present_sel_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3792,8 +3702,7 @@ module sysrst_ctrl_reg_top (
 
   // Subregister 1 of Multireg com_sel_ctl
   // R[com_sel_ctl_1]: V(False)
-
-  // F[key0_in_sel_1]: 0:0
+  //   F[key0_in_sel_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3818,8 +3727,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_1_key0_in_sel_1_qs_int)
   );
 
-
-  // F[key1_in_sel_1]: 1:1
+  //   F[key1_in_sel_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3844,8 +3752,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_1_key1_in_sel_1_qs_int)
   );
 
-
-  // F[key2_in_sel_1]: 2:2
+  //   F[key2_in_sel_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3870,8 +3777,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_1_key2_in_sel_1_qs_int)
   );
 
-
-  // F[pwrb_in_sel_1]: 3:3
+  //   F[pwrb_in_sel_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3896,8 +3802,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_1_pwrb_in_sel_1_qs_int)
   );
 
-
-  // F[ac_present_sel_1]: 4:4
+  //   F[ac_present_sel_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3925,8 +3830,7 @@ module sysrst_ctrl_reg_top (
 
   // Subregister 2 of Multireg com_sel_ctl
   // R[com_sel_ctl_2]: V(False)
-
-  // F[key0_in_sel_2]: 0:0
+  //   F[key0_in_sel_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3951,8 +3855,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_2_key0_in_sel_2_qs_int)
   );
 
-
-  // F[key1_in_sel_2]: 1:1
+  //   F[key1_in_sel_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3977,8 +3880,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_2_key1_in_sel_2_qs_int)
   );
 
-
-  // F[key2_in_sel_2]: 2:2
+  //   F[key2_in_sel_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4003,8 +3905,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_2_key2_in_sel_2_qs_int)
   );
 
-
-  // F[pwrb_in_sel_2]: 3:3
+  //   F[pwrb_in_sel_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4029,8 +3930,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_2_pwrb_in_sel_2_qs_int)
   );
 
-
-  // F[ac_present_sel_2]: 4:4
+  //   F[ac_present_sel_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4058,8 +3958,7 @@ module sysrst_ctrl_reg_top (
 
   // Subregister 3 of Multireg com_sel_ctl
   // R[com_sel_ctl_3]: V(False)
-
-  // F[key0_in_sel_3]: 0:0
+  //   F[key0_in_sel_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4084,8 +3983,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_3_key0_in_sel_3_qs_int)
   );
 
-
-  // F[key1_in_sel_3]: 1:1
+  //   F[key1_in_sel_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4110,8 +4008,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_3_key1_in_sel_3_qs_int)
   );
 
-
-  // F[key2_in_sel_3]: 2:2
+  //   F[key2_in_sel_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4136,8 +4033,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_3_key2_in_sel_3_qs_int)
   );
 
-
-  // F[pwrb_in_sel_3]: 3:3
+  //   F[pwrb_in_sel_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4162,8 +4058,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_sel_ctl_3_pwrb_in_sel_3_qs_int)
   );
 
-
-  // F[ac_present_sel_3]: 4:4
+  //   F[ac_present_sel_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4189,11 +4084,8 @@ module sysrst_ctrl_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg com_det_ctl
   // R[com_det_ctl_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4218,9 +4110,9 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_det_ctl_0_qs_int)
   );
 
+
   // Subregister 1 of Multireg com_det_ctl
   // R[com_det_ctl_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4245,9 +4137,9 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_det_ctl_1_qs_int)
   );
 
+
   // Subregister 2 of Multireg com_det_ctl
   // R[com_det_ctl_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4272,9 +4164,9 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_det_ctl_2_qs_int)
   );
 
+
   // Subregister 3 of Multireg com_det_ctl
   // R[com_det_ctl_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4300,11 +4192,9 @@ module sysrst_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg com_out_ctl
   // R[com_out_ctl_0]: V(False)
-
-  // F[bat_disable_0]: 0:0
+  //   F[bat_disable_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4329,8 +4219,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_0_bat_disable_0_qs_int)
   );
 
-
-  // F[interrupt_0]: 1:1
+  //   F[interrupt_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4355,8 +4244,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_0_interrupt_0_qs_int)
   );
 
-
-  // F[ec_rst_0]: 2:2
+  //   F[ec_rst_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4381,8 +4269,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_0_ec_rst_0_qs_int)
   );
 
-
-  // F[rst_req_0]: 3:3
+  //   F[rst_req_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4410,8 +4297,7 @@ module sysrst_ctrl_reg_top (
 
   // Subregister 1 of Multireg com_out_ctl
   // R[com_out_ctl_1]: V(False)
-
-  // F[bat_disable_1]: 0:0
+  //   F[bat_disable_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4436,8 +4322,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_1_bat_disable_1_qs_int)
   );
 
-
-  // F[interrupt_1]: 1:1
+  //   F[interrupt_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4462,8 +4347,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_1_interrupt_1_qs_int)
   );
 
-
-  // F[ec_rst_1]: 2:2
+  //   F[ec_rst_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4488,8 +4372,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_1_ec_rst_1_qs_int)
   );
 
-
-  // F[rst_req_1]: 3:3
+  //   F[rst_req_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4517,8 +4400,7 @@ module sysrst_ctrl_reg_top (
 
   // Subregister 2 of Multireg com_out_ctl
   // R[com_out_ctl_2]: V(False)
-
-  // F[bat_disable_2]: 0:0
+  //   F[bat_disable_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4543,8 +4425,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_2_bat_disable_2_qs_int)
   );
 
-
-  // F[interrupt_2]: 1:1
+  //   F[interrupt_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4569,8 +4450,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_2_interrupt_2_qs_int)
   );
 
-
-  // F[ec_rst_2]: 2:2
+  //   F[ec_rst_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4595,8 +4475,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_2_ec_rst_2_qs_int)
   );
 
-
-  // F[rst_req_2]: 3:3
+  //   F[rst_req_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4624,8 +4503,7 @@ module sysrst_ctrl_reg_top (
 
   // Subregister 3 of Multireg com_out_ctl
   // R[com_out_ctl_3]: V(False)
-
-  // F[bat_disable_3]: 0:0
+  //   F[bat_disable_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4650,8 +4528,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_3_bat_disable_3_qs_int)
   );
 
-
-  // F[interrupt_3]: 1:1
+  //   F[interrupt_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4676,8 +4553,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_3_interrupt_3_qs_int)
   );
 
-
-  // F[ec_rst_3]: 2:2
+  //   F[ec_rst_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4702,8 +4578,7 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_com_out_ctl_3_ec_rst_3_qs_int)
   );
 
-
-  // F[rst_req_3]: 3:3
+  //   F[rst_req_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4729,9 +4604,7 @@ module sysrst_ctrl_reg_top (
   );
 
 
-
   // R[combo_intr_status]: V(False)
-
   //   F[combo0_h2l]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -4756,7 +4629,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_combo_intr_status_combo0_h2l_qs_int)
   );
-
 
   //   F[combo1_h2l]: 1:1
   prim_subreg #(
@@ -4783,7 +4655,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_combo_intr_status_combo1_h2l_qs_int)
   );
 
-
   //   F[combo2_h2l]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -4808,7 +4679,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_combo_intr_status_combo2_h2l_qs_int)
   );
-
 
   //   F[combo3_h2l]: 3:3
   prim_subreg #(
@@ -4837,7 +4707,6 @@ module sysrst_ctrl_reg_top (
 
 
   // R[key_intr_status]: V(False)
-
   //   F[pwrb_h2l]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -4862,7 +4731,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_status_pwrb_h2l_qs_int)
   );
-
 
   //   F[key0_in_h2l]: 1:1
   prim_subreg #(
@@ -4889,7 +4757,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_status_key0_in_h2l_qs_int)
   );
 
-
   //   F[key1_in_h2l]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -4914,7 +4781,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_status_key1_in_h2l_qs_int)
   );
-
 
   //   F[key2_in_h2l]: 3:3
   prim_subreg #(
@@ -4941,7 +4807,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_status_key2_in_h2l_qs_int)
   );
 
-
   //   F[ac_present_h2l]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -4966,7 +4831,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_status_ac_present_h2l_qs_int)
   );
-
 
   //   F[ec_rst_l_h2l]: 5:5
   prim_subreg #(
@@ -4993,7 +4857,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_status_ec_rst_l_h2l_qs_int)
   );
 
-
   //   F[pwrb_l2h]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -5018,7 +4881,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_status_pwrb_l2h_qs_int)
   );
-
 
   //   F[key0_in_l2h]: 7:7
   prim_subreg #(
@@ -5045,7 +4907,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_status_key0_in_l2h_qs_int)
   );
 
-
   //   F[key1_in_l2h]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -5070,7 +4931,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_status_key1_in_l2h_qs_int)
   );
-
 
   //   F[key2_in_l2h]: 9:9
   prim_subreg #(
@@ -5097,7 +4957,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_status_key2_in_l2h_qs_int)
   );
 
-
   //   F[ac_present_l2h]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -5123,7 +4982,6 @@ module sysrst_ctrl_reg_top (
     .qs     (aon_key_intr_status_ac_present_l2h_qs_int)
   );
 
-
   //   F[ec_rst_l_l2h]: 11:11
   prim_subreg #(
     .DW      (1),
@@ -5148,7 +5006,6 @@ module sysrst_ctrl_reg_top (
     // to register interface (read)
     .qs     (aon_key_intr_status_ec_rst_l_l2h_qs_int)
   );
-
 
 
 

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -190,7 +190,6 @@ module trial1_reg_top (
 
   // Register instances
   // R[rwtype0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -217,7 +216,6 @@ module trial1_reg_top (
 
 
   // R[rwtype1]: V(False)
-
   //   F[field0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -242,7 +240,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (rwtype1_field0_qs)
   );
-
 
   //   F[field1]: 1:1
   prim_subreg #(
@@ -269,7 +266,6 @@ module trial1_reg_top (
     .qs     (rwtype1_field1_qs)
   );
 
-
   //   F[field4]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -294,7 +290,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (rwtype1_field4_qs)
   );
-
 
   //   F[field15_8]: 15:8
   prim_subreg #(
@@ -323,7 +318,6 @@ module trial1_reg_top (
 
 
   // R[rwtype2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -350,7 +344,6 @@ module trial1_reg_top (
 
 
   // R[rwtype3]: V(False)
-
   //   F[field0]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -375,7 +368,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (rwtype3_field0_qs)
   );
-
 
   //   F[field1]: 31:16
   prim_subreg #(
@@ -404,7 +396,6 @@ module trial1_reg_top (
 
 
   // R[rwtype4]: V(False)
-
   //   F[field0]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -429,7 +420,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (rwtype4_field0_qs)
   );
-
 
   //   F[field1]: 31:16
   prim_subreg #(
@@ -458,7 +448,6 @@ module trial1_reg_top (
 
 
   // R[rotype0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -485,7 +474,6 @@ module trial1_reg_top (
 
 
   // R[w1ctype0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -512,7 +500,6 @@ module trial1_reg_top (
 
 
   // R[w1ctype1]: V(False)
-
   //   F[field0]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -537,7 +524,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (w1ctype1_field0_qs)
   );
-
 
   //   F[field1]: 31:16
   prim_subreg #(
@@ -566,7 +552,6 @@ module trial1_reg_top (
 
 
   // R[w1ctype2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -593,7 +578,6 @@ module trial1_reg_top (
 
 
   // R[w1stype2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -620,7 +604,6 @@ module trial1_reg_top (
 
 
   // R[w0ctype2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -647,7 +630,6 @@ module trial1_reg_top (
 
 
   // R[r0w1ctype2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -674,7 +656,6 @@ module trial1_reg_top (
 
 
   // R[rctype0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRC),
@@ -701,7 +682,6 @@ module trial1_reg_top (
 
 
   // R[wotype0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -728,7 +708,6 @@ module trial1_reg_top (
 
 
   // R[mixtype0]: V(False)
-
   //   F[field0]: 3:0
   prim_subreg #(
     .DW      (4),
@@ -753,7 +732,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (mixtype0_field0_qs)
   );
-
 
   //   F[field1]: 7:4
   prim_subreg #(
@@ -780,7 +758,6 @@ module trial1_reg_top (
     .qs     (mixtype0_field1_qs)
   );
 
-
   //   F[field2]: 11:8
   prim_subreg #(
     .DW      (4),
@@ -805,7 +782,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (mixtype0_field2_qs)
   );
-
 
   //   F[field3]: 15:12
   prim_subreg #(
@@ -832,7 +808,6 @@ module trial1_reg_top (
     .qs     (mixtype0_field3_qs)
   );
 
-
   //   F[field4]: 19:16
   prim_subreg #(
     .DW      (4),
@@ -857,7 +832,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (mixtype0_field4_qs)
   );
-
 
   //   F[field5]: 23:20
   prim_subreg #(
@@ -884,7 +858,6 @@ module trial1_reg_top (
     .qs     (mixtype0_field5_qs)
   );
 
-
   //   F[field6]: 27:24
   prim_subreg #(
     .DW      (4),
@@ -909,7 +882,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (mixtype0_field6_qs)
   );
-
 
   //   F[field7]: 31:28
   prim_subreg #(
@@ -938,7 +910,6 @@ module trial1_reg_top (
 
 
   // R[rwtype5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -965,7 +936,6 @@ module trial1_reg_top (
 
 
   // R[rwtype6]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_rwtype6 (
@@ -981,7 +951,6 @@ module trial1_reg_top (
 
 
   // R[rotype1]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_rotype1 (
@@ -997,16 +966,13 @@ module trial1_reg_top (
 
 
   // R[rotype2]: V(False)
-
   //   F[field0]: 7:0
   // constant-only read
   assign rotype2_field0_qs = 8'h79;
 
-
   //   F[field1]: 15:8
   // constant-only read
   assign rotype2_field1_qs = 8'h8a;
-
 
   //   F[field2]: 31:20
   // constant-only read
@@ -1014,7 +980,6 @@ module trial1_reg_top (
 
 
   // R[rwtype7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1038,7 +1003,6 @@ module trial1_reg_top (
     // to register interface (read)
     .qs     (rwtype7_qs)
   );
-
 
 
 

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -208,7 +208,6 @@ module uart_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[tx_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -233,7 +232,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_state_tx_watermark_qs)
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg #(
@@ -260,7 +258,6 @@ module uart_reg_top (
     .qs     (intr_state_rx_watermark_qs)
   );
 
-
   //   F[tx_empty]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -285,7 +282,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_state_tx_empty_qs)
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg #(
@@ -312,7 +308,6 @@ module uart_reg_top (
     .qs     (intr_state_rx_overflow_qs)
   );
 
-
   //   F[rx_frame_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -337,7 +332,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_state_rx_frame_err_qs)
   );
-
 
   //   F[rx_break_err]: 5:5
   prim_subreg #(
@@ -364,7 +358,6 @@ module uart_reg_top (
     .qs     (intr_state_rx_break_err_qs)
   );
 
-
   //   F[rx_timeout]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -389,7 +382,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_state_rx_timeout_qs)
   );
-
 
   //   F[rx_parity_err]: 7:7
   prim_subreg #(
@@ -418,7 +410,6 @@ module uart_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[tx_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -443,7 +434,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_tx_watermark_qs)
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg #(
@@ -470,7 +460,6 @@ module uart_reg_top (
     .qs     (intr_enable_rx_watermark_qs)
   );
 
-
   //   F[tx_empty]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -495,7 +484,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_tx_empty_qs)
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg #(
@@ -522,7 +510,6 @@ module uart_reg_top (
     .qs     (intr_enable_rx_overflow_qs)
   );
 
-
   //   F[rx_frame_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -547,7 +534,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rx_frame_err_qs)
   );
-
 
   //   F[rx_break_err]: 5:5
   prim_subreg #(
@@ -574,7 +560,6 @@ module uart_reg_top (
     .qs     (intr_enable_rx_break_err_qs)
   );
 
-
   //   F[rx_timeout]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -599,7 +584,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rx_timeout_qs)
   );
-
 
   //   F[rx_parity_err]: 7:7
   prim_subreg #(
@@ -628,7 +612,6 @@ module uart_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[tx_watermark]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -642,7 +625,6 @@ module uart_reg_top (
     .q      (reg2hw.intr_test.tx_watermark.q),
     .qs     ()
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -658,7 +640,6 @@ module uart_reg_top (
     .qs     ()
   );
 
-
   //   F[tx_empty]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -672,7 +653,6 @@ module uart_reg_top (
     .q      (reg2hw.intr_test.tx_empty.q),
     .qs     ()
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg_ext #(
@@ -688,7 +668,6 @@ module uart_reg_top (
     .qs     ()
   );
 
-
   //   F[rx_frame_err]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -702,7 +681,6 @@ module uart_reg_top (
     .q      (reg2hw.intr_test.rx_frame_err.q),
     .qs     ()
   );
-
 
   //   F[rx_break_err]: 5:5
   prim_subreg_ext #(
@@ -718,7 +696,6 @@ module uart_reg_top (
     .qs     ()
   );
 
-
   //   F[rx_timeout]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -732,7 +709,6 @@ module uart_reg_top (
     .q      (reg2hw.intr_test.rx_timeout.q),
     .qs     ()
   );
-
 
   //   F[rx_parity_err]: 7:7
   prim_subreg_ext #(
@@ -750,7 +726,6 @@ module uart_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -766,7 +741,6 @@ module uart_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[tx]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -791,7 +765,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (ctrl_tx_qs)
   );
-
 
   //   F[rx]: 1:1
   prim_subreg #(
@@ -818,7 +791,6 @@ module uart_reg_top (
     .qs     (ctrl_rx_qs)
   );
 
-
   //   F[nf]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -843,7 +815,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (ctrl_nf_qs)
   );
-
 
   //   F[slpbk]: 4:4
   prim_subreg #(
@@ -870,7 +841,6 @@ module uart_reg_top (
     .qs     (ctrl_slpbk_qs)
   );
 
-
   //   F[llpbk]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -895,7 +865,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (ctrl_llpbk_qs)
   );
-
 
   //   F[parity_en]: 6:6
   prim_subreg #(
@@ -922,7 +891,6 @@ module uart_reg_top (
     .qs     (ctrl_parity_en_qs)
   );
 
-
   //   F[parity_odd]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -948,7 +916,6 @@ module uart_reg_top (
     .qs     (ctrl_parity_odd_qs)
   );
 
-
   //   F[rxblvl]: 9:8
   prim_subreg #(
     .DW      (2),
@@ -973,7 +940,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (ctrl_rxblvl_qs)
   );
-
 
   //   F[nco]: 31:16
   prim_subreg #(
@@ -1002,7 +968,6 @@ module uart_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[txfull]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1016,7 +981,6 @@ module uart_reg_top (
     .q      (reg2hw.status.txfull.q),
     .qs     (status_txfull_qs)
   );
-
 
   //   F[rxfull]: 1:1
   prim_subreg_ext #(
@@ -1032,7 +996,6 @@ module uart_reg_top (
     .qs     (status_rxfull_qs)
   );
 
-
   //   F[txempty]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1046,7 +1009,6 @@ module uart_reg_top (
     .q      (reg2hw.status.txempty.q),
     .qs     (status_txempty_qs)
   );
-
 
   //   F[txidle]: 3:3
   prim_subreg_ext #(
@@ -1062,7 +1024,6 @@ module uart_reg_top (
     .qs     (status_txidle_qs)
   );
 
-
   //   F[rxidle]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1076,7 +1037,6 @@ module uart_reg_top (
     .q      (reg2hw.status.rxidle.q),
     .qs     (status_rxidle_qs)
   );
-
 
   //   F[rxempty]: 5:5
   prim_subreg_ext #(
@@ -1094,7 +1054,6 @@ module uart_reg_top (
 
 
   // R[rdata]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_rdata (
@@ -1110,7 +1069,6 @@ module uart_reg_top (
 
 
   // R[wdata]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1137,7 +1095,6 @@ module uart_reg_top (
 
 
   // R[fifo_ctrl]: V(False)
-
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1162,7 +1119,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     ()
   );
-
 
   //   F[txrst]: 1:1
   prim_subreg #(
@@ -1189,7 +1145,6 @@ module uart_reg_top (
     .qs     ()
   );
 
-
   //   F[rxilvl]: 4:2
   prim_subreg #(
     .DW      (3),
@@ -1214,7 +1169,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
   );
-
 
   //   F[txilvl]: 6:5
   prim_subreg #(
@@ -1243,7 +1197,6 @@ module uart_reg_top (
 
 
   // R[fifo_status]: V(True)
-
   //   F[txlvl]: 5:0
   prim_subreg_ext #(
     .DW    (6)
@@ -1257,7 +1210,6 @@ module uart_reg_top (
     .q      (),
     .qs     (fifo_status_txlvl_qs)
   );
-
 
   //   F[rxlvl]: 21:16
   prim_subreg_ext #(
@@ -1275,7 +1227,6 @@ module uart_reg_top (
 
 
   // R[ovrd]: V(False)
-
   //   F[txen]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1300,7 +1251,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (ovrd_txen_qs)
   );
-
 
   //   F[txval]: 1:1
   prim_subreg #(
@@ -1329,7 +1279,6 @@ module uart_reg_top (
 
 
   // R[val]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_val (
@@ -1345,7 +1294,6 @@ module uart_reg_top (
 
 
   // R[timeout_ctrl]: V(False)
-
   //   F[val]: 23:0
   prim_subreg #(
     .DW      (24),
@@ -1371,7 +1319,6 @@ module uart_reg_top (
     .qs     (timeout_ctrl_val_qs)
   );
 
-
   //   F[en]: 31:31
   prim_subreg #(
     .DW      (1),
@@ -1396,7 +1343,6 @@ module uart_reg_top (
     // to register interface (read)
     .qs     (timeout_ctrl_en_qs)
   );
-
 
 
 

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -571,7 +571,6 @@ module usbdev_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[pkt_received]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -596,7 +595,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_pkt_received_qs)
   );
-
 
   //   F[pkt_sent]: 1:1
   prim_subreg #(
@@ -623,7 +621,6 @@ module usbdev_reg_top (
     .qs     (intr_state_pkt_sent_qs)
   );
 
-
   //   F[disconnected]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -648,7 +645,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_disconnected_qs)
   );
-
 
   //   F[host_lost]: 3:3
   prim_subreg #(
@@ -675,7 +671,6 @@ module usbdev_reg_top (
     .qs     (intr_state_host_lost_qs)
   );
 
-
   //   F[link_reset]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -700,7 +695,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_link_reset_qs)
   );
-
 
   //   F[link_suspend]: 5:5
   prim_subreg #(
@@ -727,7 +721,6 @@ module usbdev_reg_top (
     .qs     (intr_state_link_suspend_qs)
   );
 
-
   //   F[link_resume]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -752,7 +745,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_link_resume_qs)
   );
-
 
   //   F[av_empty]: 7:7
   prim_subreg #(
@@ -779,7 +771,6 @@ module usbdev_reg_top (
     .qs     (intr_state_av_empty_qs)
   );
 
-
   //   F[rx_full]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -804,7 +795,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_rx_full_qs)
   );
-
 
   //   F[av_overflow]: 9:9
   prim_subreg #(
@@ -831,7 +821,6 @@ module usbdev_reg_top (
     .qs     (intr_state_av_overflow_qs)
   );
 
-
   //   F[link_in_err]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -856,7 +845,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_link_in_err_qs)
   );
-
 
   //   F[rx_crc_err]: 11:11
   prim_subreg #(
@@ -883,7 +871,6 @@ module usbdev_reg_top (
     .qs     (intr_state_rx_crc_err_qs)
   );
 
-
   //   F[rx_pid_err]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -908,7 +895,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_rx_pid_err_qs)
   );
-
 
   //   F[rx_bitstuff_err]: 13:13
   prim_subreg #(
@@ -935,7 +921,6 @@ module usbdev_reg_top (
     .qs     (intr_state_rx_bitstuff_err_qs)
   );
 
-
   //   F[frame]: 14:14
   prim_subreg #(
     .DW      (1),
@@ -961,7 +946,6 @@ module usbdev_reg_top (
     .qs     (intr_state_frame_qs)
   );
 
-
   //   F[connected]: 15:15
   prim_subreg #(
     .DW      (1),
@@ -986,7 +970,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_state_connected_qs)
   );
-
 
   //   F[link_out_err]: 16:16
   prim_subreg #(
@@ -1015,7 +998,6 @@ module usbdev_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[pkt_received]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1040,7 +1022,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_pkt_received_qs)
   );
-
 
   //   F[pkt_sent]: 1:1
   prim_subreg #(
@@ -1067,7 +1048,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_pkt_sent_qs)
   );
 
-
   //   F[disconnected]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1092,7 +1072,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_disconnected_qs)
   );
-
 
   //   F[host_lost]: 3:3
   prim_subreg #(
@@ -1119,7 +1098,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_host_lost_qs)
   );
 
-
   //   F[link_reset]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1144,7 +1122,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_link_reset_qs)
   );
-
 
   //   F[link_suspend]: 5:5
   prim_subreg #(
@@ -1171,7 +1148,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_link_suspend_qs)
   );
 
-
   //   F[link_resume]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -1196,7 +1172,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_link_resume_qs)
   );
-
 
   //   F[av_empty]: 7:7
   prim_subreg #(
@@ -1223,7 +1198,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_av_empty_qs)
   );
 
-
   //   F[rx_full]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -1248,7 +1222,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rx_full_qs)
   );
-
 
   //   F[av_overflow]: 9:9
   prim_subreg #(
@@ -1275,7 +1248,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_av_overflow_qs)
   );
 
-
   //   F[link_in_err]: 10:10
   prim_subreg #(
     .DW      (1),
@@ -1300,7 +1272,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_link_in_err_qs)
   );
-
 
   //   F[rx_crc_err]: 11:11
   prim_subreg #(
@@ -1327,7 +1298,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_rx_crc_err_qs)
   );
 
-
   //   F[rx_pid_err]: 12:12
   prim_subreg #(
     .DW      (1),
@@ -1352,7 +1322,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rx_pid_err_qs)
   );
-
 
   //   F[rx_bitstuff_err]: 13:13
   prim_subreg #(
@@ -1379,7 +1348,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_rx_bitstuff_err_qs)
   );
 
-
   //   F[frame]: 14:14
   prim_subreg #(
     .DW      (1),
@@ -1405,7 +1373,6 @@ module usbdev_reg_top (
     .qs     (intr_enable_frame_qs)
   );
 
-
   //   F[connected]: 15:15
   prim_subreg #(
     .DW      (1),
@@ -1430,7 +1397,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (intr_enable_connected_qs)
   );
-
 
   //   F[link_out_err]: 16:16
   prim_subreg #(
@@ -1459,7 +1425,6 @@ module usbdev_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[pkt_received]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1473,7 +1438,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.pkt_received.q),
     .qs     ()
   );
-
 
   //   F[pkt_sent]: 1:1
   prim_subreg_ext #(
@@ -1489,7 +1453,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[disconnected]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1503,7 +1466,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.disconnected.q),
     .qs     ()
   );
-
 
   //   F[host_lost]: 3:3
   prim_subreg_ext #(
@@ -1519,7 +1481,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[link_reset]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1533,7 +1494,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.link_reset.q),
     .qs     ()
   );
-
 
   //   F[link_suspend]: 5:5
   prim_subreg_ext #(
@@ -1549,7 +1509,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[link_resume]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -1563,7 +1522,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.link_resume.q),
     .qs     ()
   );
-
 
   //   F[av_empty]: 7:7
   prim_subreg_ext #(
@@ -1579,7 +1537,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[rx_full]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -1593,7 +1550,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.rx_full.q),
     .qs     ()
   );
-
 
   //   F[av_overflow]: 9:9
   prim_subreg_ext #(
@@ -1609,7 +1565,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[link_in_err]: 10:10
   prim_subreg_ext #(
     .DW    (1)
@@ -1623,7 +1578,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.link_in_err.q),
     .qs     ()
   );
-
 
   //   F[rx_crc_err]: 11:11
   prim_subreg_ext #(
@@ -1639,7 +1593,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[rx_pid_err]: 12:12
   prim_subreg_ext #(
     .DW    (1)
@@ -1653,7 +1606,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.rx_pid_err.q),
     .qs     ()
   );
-
 
   //   F[rx_bitstuff_err]: 13:13
   prim_subreg_ext #(
@@ -1669,7 +1621,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[frame]: 14:14
   prim_subreg_ext #(
     .DW    (1)
@@ -1684,7 +1635,6 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
   //   F[connected]: 15:15
   prim_subreg_ext #(
     .DW    (1)
@@ -1698,7 +1648,6 @@ module usbdev_reg_top (
     .q      (reg2hw.intr_test.connected.q),
     .qs     ()
   );
-
 
   //   F[link_out_err]: 16:16
   prim_subreg_ext #(
@@ -1716,7 +1665,6 @@ module usbdev_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1732,7 +1680,6 @@ module usbdev_reg_top (
 
 
   // R[usbctrl]: V(False)
-
   //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1757,7 +1704,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (usbctrl_enable_qs)
   );
-
 
   //   F[device_address]: 22:16
   prim_subreg #(
@@ -1786,7 +1732,6 @@ module usbdev_reg_top (
 
 
   // R[usbstat]: V(True)
-
   //   F[frame]: 10:0
   prim_subreg_ext #(
     .DW    (11)
@@ -1800,7 +1745,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (usbstat_frame_qs)
   );
-
 
   //   F[host_lost]: 11:11
   prim_subreg_ext #(
@@ -1816,7 +1760,6 @@ module usbdev_reg_top (
     .qs     (usbstat_host_lost_qs)
   );
 
-
   //   F[link_state]: 14:12
   prim_subreg_ext #(
     .DW    (3)
@@ -1830,7 +1773,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (usbstat_link_state_qs)
   );
-
 
   //   F[sense]: 15:15
   prim_subreg_ext #(
@@ -1846,7 +1788,6 @@ module usbdev_reg_top (
     .qs     (usbstat_sense_qs)
   );
 
-
   //   F[av_depth]: 18:16
   prim_subreg_ext #(
     .DW    (3)
@@ -1860,7 +1801,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (usbstat_av_depth_qs)
   );
-
 
   //   F[av_full]: 23:23
   prim_subreg_ext #(
@@ -1876,7 +1816,6 @@ module usbdev_reg_top (
     .qs     (usbstat_av_full_qs)
   );
 
-
   //   F[rx_depth]: 26:24
   prim_subreg_ext #(
     .DW    (3)
@@ -1890,7 +1829,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (usbstat_rx_depth_qs)
   );
-
 
   //   F[rx_empty]: 31:31
   prim_subreg_ext #(
@@ -1908,7 +1846,6 @@ module usbdev_reg_top (
 
 
   // R[avbuffer]: V(False)
-
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1935,7 +1872,6 @@ module usbdev_reg_top (
 
 
   // R[rxfifo]: V(True)
-
   //   F[buffer]: 4:0
   prim_subreg_ext #(
     .DW    (5)
@@ -1949,7 +1885,6 @@ module usbdev_reg_top (
     .q      (reg2hw.rxfifo.buffer.q),
     .qs     (rxfifo_buffer_qs)
   );
-
 
   //   F[size]: 14:8
   prim_subreg_ext #(
@@ -1965,7 +1900,6 @@ module usbdev_reg_top (
     .qs     (rxfifo_size_qs)
   );
 
-
   //   F[setup]: 19:19
   prim_subreg_ext #(
     .DW    (1)
@@ -1979,7 +1913,6 @@ module usbdev_reg_top (
     .q      (reg2hw.rxfifo.setup.q),
     .qs     (rxfifo_setup_qs)
   );
-
 
   //   F[ep]: 23:20
   prim_subreg_ext #(
@@ -1996,11 +1929,9 @@ module usbdev_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg rxenable_setup
   // R[rxenable_setup]: V(False)
-
-  // F[setup_0]: 0:0
+  //   F[setup_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2025,8 +1956,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_0_qs)
   );
 
-
-  // F[setup_1]: 1:1
+  //   F[setup_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2051,8 +1981,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_1_qs)
   );
 
-
-  // F[setup_2]: 2:2
+  //   F[setup_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2077,8 +2006,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_2_qs)
   );
 
-
-  // F[setup_3]: 3:3
+  //   F[setup_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2103,8 +2031,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_3_qs)
   );
 
-
-  // F[setup_4]: 4:4
+  //   F[setup_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2129,8 +2056,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_4_qs)
   );
 
-
-  // F[setup_5]: 5:5
+  //   F[setup_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2155,8 +2081,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_5_qs)
   );
 
-
-  // F[setup_6]: 6:6
+  //   F[setup_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2181,8 +2106,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_6_qs)
   );
 
-
-  // F[setup_7]: 7:7
+  //   F[setup_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2207,8 +2131,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_7_qs)
   );
 
-
-  // F[setup_8]: 8:8
+  //   F[setup_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2233,8 +2156,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_8_qs)
   );
 
-
-  // F[setup_9]: 9:9
+  //   F[setup_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2259,8 +2181,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_9_qs)
   );
 
-
-  // F[setup_10]: 10:10
+  //   F[setup_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2285,8 +2206,7 @@ module usbdev_reg_top (
     .qs     (rxenable_setup_setup_10_qs)
   );
 
-
-  // F[setup_11]: 11:11
+  //   F[setup_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2312,12 +2232,9 @@ module usbdev_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg rxenable_out
   // R[rxenable_out]: V(False)
-
-  // F[out_0]: 0:0
+  //   F[out_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2342,8 +2259,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_0_qs)
   );
 
-
-  // F[out_1]: 1:1
+  //   F[out_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2368,8 +2284,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_1_qs)
   );
 
-
-  // F[out_2]: 2:2
+  //   F[out_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2394,8 +2309,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_2_qs)
   );
 
-
-  // F[out_3]: 3:3
+  //   F[out_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2420,8 +2334,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_3_qs)
   );
 
-
-  // F[out_4]: 4:4
+  //   F[out_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2446,8 +2359,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_4_qs)
   );
 
-
-  // F[out_5]: 5:5
+  //   F[out_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2472,8 +2384,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_5_qs)
   );
 
-
-  // F[out_6]: 6:6
+  //   F[out_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2498,8 +2409,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_6_qs)
   );
 
-
-  // F[out_7]: 7:7
+  //   F[out_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2524,8 +2434,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_7_qs)
   );
 
-
-  // F[out_8]: 8:8
+  //   F[out_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2550,8 +2459,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_8_qs)
   );
 
-
-  // F[out_9]: 9:9
+  //   F[out_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2576,8 +2484,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_9_qs)
   );
 
-
-  // F[out_10]: 10:10
+  //   F[out_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2602,8 +2509,7 @@ module usbdev_reg_top (
     .qs     (rxenable_out_out_10_qs)
   );
 
-
-  // F[out_11]: 11:11
+  //   F[out_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2629,12 +2535,9 @@ module usbdev_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg in_sent
   // R[in_sent]: V(False)
-
-  // F[sent_0]: 0:0
+  //   F[sent_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2659,8 +2562,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_0_qs)
   );
 
-
-  // F[sent_1]: 1:1
+  //   F[sent_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2685,8 +2587,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_1_qs)
   );
 
-
-  // F[sent_2]: 2:2
+  //   F[sent_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2711,8 +2612,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_2_qs)
   );
 
-
-  // F[sent_3]: 3:3
+  //   F[sent_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2737,8 +2637,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_3_qs)
   );
 
-
-  // F[sent_4]: 4:4
+  //   F[sent_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2763,8 +2662,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_4_qs)
   );
 
-
-  // F[sent_5]: 5:5
+  //   F[sent_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2789,8 +2687,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_5_qs)
   );
 
-
-  // F[sent_6]: 6:6
+  //   F[sent_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2815,8 +2712,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_6_qs)
   );
 
-
-  // F[sent_7]: 7:7
+  //   F[sent_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2841,8 +2737,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_7_qs)
   );
 
-
-  // F[sent_8]: 8:8
+  //   F[sent_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2867,8 +2762,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_8_qs)
   );
 
-
-  // F[sent_9]: 9:9
+  //   F[sent_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2893,8 +2787,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_9_qs)
   );
 
-
-  // F[sent_10]: 10:10
+  //   F[sent_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2919,8 +2812,7 @@ module usbdev_reg_top (
     .qs     (in_sent_sent_10_qs)
   );
 
-
-  // F[sent_11]: 11:11
+  //   F[sent_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -2946,12 +2838,9 @@ module usbdev_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg stall
   // R[stall]: V(False)
-
-  // F[stall_0]: 0:0
+  //   F[stall_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2976,8 +2865,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_0_qs)
   );
 
-
-  // F[stall_1]: 1:1
+  //   F[stall_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3002,8 +2890,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_1_qs)
   );
 
-
-  // F[stall_2]: 2:2
+  //   F[stall_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3028,8 +2915,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_2_qs)
   );
 
-
-  // F[stall_3]: 3:3
+  //   F[stall_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3054,8 +2940,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_3_qs)
   );
 
-
-  // F[stall_4]: 4:4
+  //   F[stall_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3080,8 +2965,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_4_qs)
   );
 
-
-  // F[stall_5]: 5:5
+  //   F[stall_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3106,8 +2990,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_5_qs)
   );
 
-
-  // F[stall_6]: 6:6
+  //   F[stall_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3132,8 +3015,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_6_qs)
   );
 
-
-  // F[stall_7]: 7:7
+  //   F[stall_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3158,8 +3040,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_7_qs)
   );
 
-
-  // F[stall_8]: 8:8
+  //   F[stall_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3184,8 +3065,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_8_qs)
   );
 
-
-  // F[stall_9]: 9:9
+  //   F[stall_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3210,8 +3090,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_9_qs)
   );
 
-
-  // F[stall_10]: 10:10
+  //   F[stall_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3236,8 +3115,7 @@ module usbdev_reg_top (
     .qs     (stall_stall_10_qs)
   );
 
-
-  // F[stall_11]: 11:11
+  //   F[stall_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3263,12 +3141,9 @@ module usbdev_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg configin
   // R[configin_0]: V(False)
-
-  // F[buffer_0]: 4:0
+  //   F[buffer_0]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3293,8 +3168,7 @@ module usbdev_reg_top (
     .qs     (configin_0_buffer_0_qs)
   );
 
-
-  // F[size_0]: 14:8
+  //   F[size_0]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3319,8 +3193,7 @@ module usbdev_reg_top (
     .qs     (configin_0_size_0_qs)
   );
 
-
-  // F[pend_0]: 30:30
+  //   F[pend_0]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3345,8 +3218,7 @@ module usbdev_reg_top (
     .qs     (configin_0_pend_0_qs)
   );
 
-
-  // F[rdy_0]: 31:31
+  //   F[rdy_0]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3374,8 +3246,7 @@ module usbdev_reg_top (
 
   // Subregister 1 of Multireg configin
   // R[configin_1]: V(False)
-
-  // F[buffer_1]: 4:0
+  //   F[buffer_1]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3400,8 +3271,7 @@ module usbdev_reg_top (
     .qs     (configin_1_buffer_1_qs)
   );
 
-
-  // F[size_1]: 14:8
+  //   F[size_1]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3426,8 +3296,7 @@ module usbdev_reg_top (
     .qs     (configin_1_size_1_qs)
   );
 
-
-  // F[pend_1]: 30:30
+  //   F[pend_1]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3452,8 +3321,7 @@ module usbdev_reg_top (
     .qs     (configin_1_pend_1_qs)
   );
 
-
-  // F[rdy_1]: 31:31
+  //   F[rdy_1]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3481,8 +3349,7 @@ module usbdev_reg_top (
 
   // Subregister 2 of Multireg configin
   // R[configin_2]: V(False)
-
-  // F[buffer_2]: 4:0
+  //   F[buffer_2]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3507,8 +3374,7 @@ module usbdev_reg_top (
     .qs     (configin_2_buffer_2_qs)
   );
 
-
-  // F[size_2]: 14:8
+  //   F[size_2]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3533,8 +3399,7 @@ module usbdev_reg_top (
     .qs     (configin_2_size_2_qs)
   );
 
-
-  // F[pend_2]: 30:30
+  //   F[pend_2]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3559,8 +3424,7 @@ module usbdev_reg_top (
     .qs     (configin_2_pend_2_qs)
   );
 
-
-  // F[rdy_2]: 31:31
+  //   F[rdy_2]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3588,8 +3452,7 @@ module usbdev_reg_top (
 
   // Subregister 3 of Multireg configin
   // R[configin_3]: V(False)
-
-  // F[buffer_3]: 4:0
+  //   F[buffer_3]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3614,8 +3477,7 @@ module usbdev_reg_top (
     .qs     (configin_3_buffer_3_qs)
   );
 
-
-  // F[size_3]: 14:8
+  //   F[size_3]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3640,8 +3502,7 @@ module usbdev_reg_top (
     .qs     (configin_3_size_3_qs)
   );
 
-
-  // F[pend_3]: 30:30
+  //   F[pend_3]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3666,8 +3527,7 @@ module usbdev_reg_top (
     .qs     (configin_3_pend_3_qs)
   );
 
-
-  // F[rdy_3]: 31:31
+  //   F[rdy_3]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3695,8 +3555,7 @@ module usbdev_reg_top (
 
   // Subregister 4 of Multireg configin
   // R[configin_4]: V(False)
-
-  // F[buffer_4]: 4:0
+  //   F[buffer_4]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3721,8 +3580,7 @@ module usbdev_reg_top (
     .qs     (configin_4_buffer_4_qs)
   );
 
-
-  // F[size_4]: 14:8
+  //   F[size_4]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3747,8 +3605,7 @@ module usbdev_reg_top (
     .qs     (configin_4_size_4_qs)
   );
 
-
-  // F[pend_4]: 30:30
+  //   F[pend_4]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3773,8 +3630,7 @@ module usbdev_reg_top (
     .qs     (configin_4_pend_4_qs)
   );
 
-
-  // F[rdy_4]: 31:31
+  //   F[rdy_4]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3802,8 +3658,7 @@ module usbdev_reg_top (
 
   // Subregister 5 of Multireg configin
   // R[configin_5]: V(False)
-
-  // F[buffer_5]: 4:0
+  //   F[buffer_5]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3828,8 +3683,7 @@ module usbdev_reg_top (
     .qs     (configin_5_buffer_5_qs)
   );
 
-
-  // F[size_5]: 14:8
+  //   F[size_5]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3854,8 +3708,7 @@ module usbdev_reg_top (
     .qs     (configin_5_size_5_qs)
   );
 
-
-  // F[pend_5]: 30:30
+  //   F[pend_5]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3880,8 +3733,7 @@ module usbdev_reg_top (
     .qs     (configin_5_pend_5_qs)
   );
 
-
-  // F[rdy_5]: 31:31
+  //   F[rdy_5]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3909,8 +3761,7 @@ module usbdev_reg_top (
 
   // Subregister 6 of Multireg configin
   // R[configin_6]: V(False)
-
-  // F[buffer_6]: 4:0
+  //   F[buffer_6]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3935,8 +3786,7 @@ module usbdev_reg_top (
     .qs     (configin_6_buffer_6_qs)
   );
 
-
-  // F[size_6]: 14:8
+  //   F[size_6]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3961,8 +3811,7 @@ module usbdev_reg_top (
     .qs     (configin_6_size_6_qs)
   );
 
-
-  // F[pend_6]: 30:30
+  //   F[pend_6]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -3987,8 +3836,7 @@ module usbdev_reg_top (
     .qs     (configin_6_pend_6_qs)
   );
 
-
-  // F[rdy_6]: 31:31
+  //   F[rdy_6]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4016,8 +3864,7 @@ module usbdev_reg_top (
 
   // Subregister 7 of Multireg configin
   // R[configin_7]: V(False)
-
-  // F[buffer_7]: 4:0
+  //   F[buffer_7]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4042,8 +3889,7 @@ module usbdev_reg_top (
     .qs     (configin_7_buffer_7_qs)
   );
 
-
-  // F[size_7]: 14:8
+  //   F[size_7]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4068,8 +3914,7 @@ module usbdev_reg_top (
     .qs     (configin_7_size_7_qs)
   );
 
-
-  // F[pend_7]: 30:30
+  //   F[pend_7]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -4094,8 +3939,7 @@ module usbdev_reg_top (
     .qs     (configin_7_pend_7_qs)
   );
 
-
-  // F[rdy_7]: 31:31
+  //   F[rdy_7]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4123,8 +3967,7 @@ module usbdev_reg_top (
 
   // Subregister 8 of Multireg configin
   // R[configin_8]: V(False)
-
-  // F[buffer_8]: 4:0
+  //   F[buffer_8]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4149,8 +3992,7 @@ module usbdev_reg_top (
     .qs     (configin_8_buffer_8_qs)
   );
 
-
-  // F[size_8]: 14:8
+  //   F[size_8]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4175,8 +4017,7 @@ module usbdev_reg_top (
     .qs     (configin_8_size_8_qs)
   );
 
-
-  // F[pend_8]: 30:30
+  //   F[pend_8]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -4201,8 +4042,7 @@ module usbdev_reg_top (
     .qs     (configin_8_pend_8_qs)
   );
 
-
-  // F[rdy_8]: 31:31
+  //   F[rdy_8]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4230,8 +4070,7 @@ module usbdev_reg_top (
 
   // Subregister 9 of Multireg configin
   // R[configin_9]: V(False)
-
-  // F[buffer_9]: 4:0
+  //   F[buffer_9]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4256,8 +4095,7 @@ module usbdev_reg_top (
     .qs     (configin_9_buffer_9_qs)
   );
 
-
-  // F[size_9]: 14:8
+  //   F[size_9]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4282,8 +4120,7 @@ module usbdev_reg_top (
     .qs     (configin_9_size_9_qs)
   );
 
-
-  // F[pend_9]: 30:30
+  //   F[pend_9]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -4308,8 +4145,7 @@ module usbdev_reg_top (
     .qs     (configin_9_pend_9_qs)
   );
 
-
-  // F[rdy_9]: 31:31
+  //   F[rdy_9]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4337,8 +4173,7 @@ module usbdev_reg_top (
 
   // Subregister 10 of Multireg configin
   // R[configin_10]: V(False)
-
-  // F[buffer_10]: 4:0
+  //   F[buffer_10]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4363,8 +4198,7 @@ module usbdev_reg_top (
     .qs     (configin_10_buffer_10_qs)
   );
 
-
-  // F[size_10]: 14:8
+  //   F[size_10]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4389,8 +4223,7 @@ module usbdev_reg_top (
     .qs     (configin_10_size_10_qs)
   );
 
-
-  // F[pend_10]: 30:30
+  //   F[pend_10]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -4415,8 +4248,7 @@ module usbdev_reg_top (
     .qs     (configin_10_pend_10_qs)
   );
 
-
-  // F[rdy_10]: 31:31
+  //   F[rdy_10]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4444,8 +4276,7 @@ module usbdev_reg_top (
 
   // Subregister 11 of Multireg configin
   // R[configin_11]: V(False)
-
-  // F[buffer_11]: 4:0
+  //   F[buffer_11]: 4:0
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4470,8 +4301,7 @@ module usbdev_reg_top (
     .qs     (configin_11_buffer_11_qs)
   );
 
-
-  // F[size_11]: 14:8
+  //   F[size_11]: 14:8
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4496,8 +4326,7 @@ module usbdev_reg_top (
     .qs     (configin_11_size_11_qs)
   );
 
-
-  // F[pend_11]: 30:30
+  //   F[pend_11]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -4522,8 +4351,7 @@ module usbdev_reg_top (
     .qs     (configin_11_pend_11_qs)
   );
 
-
-  // F[rdy_11]: 31:31
+  //   F[rdy_11]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4549,12 +4377,9 @@ module usbdev_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg iso
   // R[iso]: V(False)
-
-  // F[iso_0]: 0:0
+  //   F[iso_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4579,8 +4404,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_0_qs)
   );
 
-
-  // F[iso_1]: 1:1
+  //   F[iso_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4605,8 +4429,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_1_qs)
   );
 
-
-  // F[iso_2]: 2:2
+  //   F[iso_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4631,8 +4454,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_2_qs)
   );
 
-
-  // F[iso_3]: 3:3
+  //   F[iso_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4657,8 +4479,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_3_qs)
   );
 
-
-  // F[iso_4]: 4:4
+  //   F[iso_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4683,8 +4504,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_4_qs)
   );
 
-
-  // F[iso_5]: 5:5
+  //   F[iso_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4709,8 +4529,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_5_qs)
   );
 
-
-  // F[iso_6]: 6:6
+  //   F[iso_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4735,8 +4554,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_6_qs)
   );
 
-
-  // F[iso_7]: 7:7
+  //   F[iso_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4761,8 +4579,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_7_qs)
   );
 
-
-  // F[iso_8]: 8:8
+  //   F[iso_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4787,8 +4604,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_8_qs)
   );
 
-
-  // F[iso_9]: 9:9
+  //   F[iso_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4813,8 +4629,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_9_qs)
   );
 
-
-  // F[iso_10]: 10:10
+  //   F[iso_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4839,8 +4654,7 @@ module usbdev_reg_top (
     .qs     (iso_iso_10_qs)
   );
 
-
-  // F[iso_11]: 11:11
+  //   F[iso_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4866,12 +4680,9 @@ module usbdev_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg data_toggle_clear
   // R[data_toggle_clear]: V(False)
-
-  // F[clear_0]: 0:0
+  //   F[clear_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -4896,8 +4707,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_1]: 1:1
+  //   F[clear_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -4922,8 +4732,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_2]: 2:2
+  //   F[clear_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -4948,8 +4757,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_3]: 3:3
+  //   F[clear_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -4974,8 +4782,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_4]: 4:4
+  //   F[clear_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5000,8 +4807,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_5]: 5:5
+  //   F[clear_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5026,8 +4832,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_6]: 6:6
+  //   F[clear_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5052,8 +4857,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_7]: 7:7
+  //   F[clear_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5078,8 +4882,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_8]: 8:8
+  //   F[clear_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5104,8 +4907,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_9]: 9:9
+  //   F[clear_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5130,8 +4932,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_10]: 10:10
+  //   F[clear_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5156,8 +4957,7 @@ module usbdev_reg_top (
     .qs     ()
   );
 
-
-  // F[clear_11]: 11:11
+  //   F[clear_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -5183,9 +4983,7 @@ module usbdev_reg_top (
   );
 
 
-
   // R[phy_pins_sense]: V(True)
-
   //   F[rx_dp_i]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -5199,7 +4997,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (phy_pins_sense_rx_dp_i_qs)
   );
-
 
   //   F[rx_dn_i]: 1:1
   prim_subreg_ext #(
@@ -5215,7 +5012,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_sense_rx_dn_i_qs)
   );
 
-
   //   F[rx_d_i]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -5229,7 +5025,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (phy_pins_sense_rx_d_i_qs)
   );
-
 
   //   F[tx_dp_o]: 8:8
   prim_subreg_ext #(
@@ -5245,7 +5040,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_sense_tx_dp_o_qs)
   );
 
-
   //   F[tx_dn_o]: 9:9
   prim_subreg_ext #(
     .DW    (1)
@@ -5259,7 +5053,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (phy_pins_sense_tx_dn_o_qs)
   );
-
 
   //   F[tx_d_o]: 10:10
   prim_subreg_ext #(
@@ -5275,7 +5068,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_sense_tx_d_o_qs)
   );
 
-
   //   F[tx_se0_o]: 11:11
   prim_subreg_ext #(
     .DW    (1)
@@ -5289,7 +5081,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (phy_pins_sense_tx_se0_o_qs)
   );
-
 
   //   F[tx_oe_o]: 12:12
   prim_subreg_ext #(
@@ -5305,7 +5096,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_sense_tx_oe_o_qs)
   );
 
-
   //   F[suspend_o]: 13:13
   prim_subreg_ext #(
     .DW    (1)
@@ -5319,7 +5109,6 @@ module usbdev_reg_top (
     .q      (),
     .qs     (phy_pins_sense_suspend_o_qs)
   );
-
 
   //   F[pwr_sense]: 16:16
   prim_subreg_ext #(
@@ -5337,7 +5126,6 @@ module usbdev_reg_top (
 
 
   // R[phy_pins_drive]: V(False)
-
   //   F[dp_o]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -5362,7 +5150,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_pins_drive_dp_o_qs)
   );
-
 
   //   F[dn_o]: 1:1
   prim_subreg #(
@@ -5389,7 +5176,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_drive_dn_o_qs)
   );
 
-
   //   F[d_o]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -5414,7 +5200,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_pins_drive_d_o_qs)
   );
-
 
   //   F[se0_o]: 3:3
   prim_subreg #(
@@ -5441,7 +5226,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_drive_se0_o_qs)
   );
 
-
   //   F[oe_o]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -5466,7 +5250,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_pins_drive_oe_o_qs)
   );
-
 
   //   F[tx_mode_se_o]: 5:5
   prim_subreg #(
@@ -5493,7 +5276,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_drive_tx_mode_se_o_qs)
   );
 
-
   //   F[dp_pullup_en_o]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -5518,7 +5300,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_pins_drive_dp_pullup_en_o_qs)
   );
-
 
   //   F[dn_pullup_en_o]: 7:7
   prim_subreg #(
@@ -5545,7 +5326,6 @@ module usbdev_reg_top (
     .qs     (phy_pins_drive_dn_pullup_en_o_qs)
   );
 
-
   //   F[suspend_o]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -5570,7 +5350,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_pins_drive_suspend_o_qs)
   );
-
 
   //   F[en]: 16:16
   prim_subreg #(
@@ -5599,7 +5378,6 @@ module usbdev_reg_top (
 
 
   // R[phy_config]: V(False)
-
   //   F[rx_differential_mode]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -5624,7 +5402,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_config_rx_differential_mode_qs)
   );
-
 
   //   F[tx_differential_mode]: 1:1
   prim_subreg #(
@@ -5651,7 +5428,6 @@ module usbdev_reg_top (
     .qs     (phy_config_tx_differential_mode_qs)
   );
 
-
   //   F[eop_single_bit]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -5676,7 +5452,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_config_eop_single_bit_qs)
   );
-
 
   //   F[override_pwr_sense_en]: 3:3
   prim_subreg #(
@@ -5703,7 +5478,6 @@ module usbdev_reg_top (
     .qs     (phy_config_override_pwr_sense_en_qs)
   );
 
-
   //   F[override_pwr_sense_val]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -5728,7 +5502,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_config_override_pwr_sense_val_qs)
   );
-
 
   //   F[pinflip]: 5:5
   prim_subreg #(
@@ -5755,7 +5528,6 @@ module usbdev_reg_top (
     .qs     (phy_config_pinflip_qs)
   );
 
-
   //   F[usb_ref_disable]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -5780,7 +5552,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (phy_config_usb_ref_disable_qs)
   );
-
 
   //   F[tx_osc_test_mode]: 7:7
   prim_subreg #(
@@ -5809,7 +5580,6 @@ module usbdev_reg_top (
 
 
   // R[wake_config]: V(False)
-
   //   F[wake_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -5834,7 +5604,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (wake_config_wake_en_qs)
   );
-
 
   //   F[wake_ack]: 1:1
   prim_subreg #(
@@ -5863,7 +5632,6 @@ module usbdev_reg_top (
 
 
   // R[wake_debug]: V(False)
-
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5887,7 +5655,6 @@ module usbdev_reg_top (
     // to register interface (read)
     .qs     (wake_debug_qs)
   );
-
 
 
 

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -218,7 +218,6 @@ module usbuart_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[tx_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -243,7 +242,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_state_tx_watermark_qs)
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg #(
@@ -270,7 +268,6 @@ module usbuart_reg_top (
     .qs     (intr_state_rx_watermark_qs)
   );
 
-
   //   F[tx_overflow]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -295,7 +292,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_state_tx_overflow_qs)
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg #(
@@ -322,7 +318,6 @@ module usbuart_reg_top (
     .qs     (intr_state_rx_overflow_qs)
   );
 
-
   //   F[rx_frame_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -347,7 +342,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_state_rx_frame_err_qs)
   );
-
 
   //   F[rx_break_err]: 5:5
   prim_subreg #(
@@ -374,7 +368,6 @@ module usbuart_reg_top (
     .qs     (intr_state_rx_break_err_qs)
   );
 
-
   //   F[rx_timeout]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -399,7 +392,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_state_rx_timeout_qs)
   );
-
 
   //   F[rx_parity_err]: 7:7
   prim_subreg #(
@@ -428,7 +420,6 @@ module usbuart_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[tx_watermark]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -453,7 +444,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_tx_watermark_qs)
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg #(
@@ -480,7 +470,6 @@ module usbuart_reg_top (
     .qs     (intr_enable_rx_watermark_qs)
   );
 
-
   //   F[tx_overflow]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -505,7 +494,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_tx_overflow_qs)
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg #(
@@ -532,7 +520,6 @@ module usbuart_reg_top (
     .qs     (intr_enable_rx_overflow_qs)
   );
 
-
   //   F[rx_frame_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -557,7 +544,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rx_frame_err_qs)
   );
-
 
   //   F[rx_break_err]: 5:5
   prim_subreg #(
@@ -584,7 +570,6 @@ module usbuart_reg_top (
     .qs     (intr_enable_rx_break_err_qs)
   );
 
-
   //   F[rx_timeout]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -609,7 +594,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rx_timeout_qs)
   );
-
 
   //   F[rx_parity_err]: 7:7
   prim_subreg #(
@@ -638,7 +622,6 @@ module usbuart_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[tx_watermark]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -652,7 +635,6 @@ module usbuart_reg_top (
     .q      (reg2hw.intr_test.tx_watermark.q),
     .qs     ()
   );
-
 
   //   F[rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -668,7 +650,6 @@ module usbuart_reg_top (
     .qs     ()
   );
 
-
   //   F[tx_overflow]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -682,7 +663,6 @@ module usbuart_reg_top (
     .q      (reg2hw.intr_test.tx_overflow.q),
     .qs     ()
   );
-
 
   //   F[rx_overflow]: 3:3
   prim_subreg_ext #(
@@ -698,7 +678,6 @@ module usbuart_reg_top (
     .qs     ()
   );
 
-
   //   F[rx_frame_err]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -712,7 +691,6 @@ module usbuart_reg_top (
     .q      (reg2hw.intr_test.rx_frame_err.q),
     .qs     ()
   );
-
 
   //   F[rx_break_err]: 5:5
   prim_subreg_ext #(
@@ -728,7 +706,6 @@ module usbuart_reg_top (
     .qs     ()
   );
 
-
   //   F[rx_timeout]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -742,7 +719,6 @@ module usbuart_reg_top (
     .q      (reg2hw.intr_test.rx_timeout.q),
     .qs     ()
   );
-
 
   //   F[rx_parity_err]: 7:7
   prim_subreg_ext #(
@@ -760,7 +736,6 @@ module usbuart_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -776,7 +751,6 @@ module usbuart_reg_top (
 
 
   // R[ctrl]: V(False)
-
   //   F[tx]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -801,7 +775,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (ctrl_tx_qs)
   );
-
 
   //   F[rx]: 1:1
   prim_subreg #(
@@ -828,7 +801,6 @@ module usbuart_reg_top (
     .qs     (ctrl_rx_qs)
   );
 
-
   //   F[nf]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -853,7 +825,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (ctrl_nf_qs)
   );
-
 
   //   F[slpbk]: 4:4
   prim_subreg #(
@@ -880,7 +851,6 @@ module usbuart_reg_top (
     .qs     (ctrl_slpbk_qs)
   );
 
-
   //   F[llpbk]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -905,7 +875,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (ctrl_llpbk_qs)
   );
-
 
   //   F[parity_en]: 6:6
   prim_subreg #(
@@ -932,7 +901,6 @@ module usbuart_reg_top (
     .qs     (ctrl_parity_en_qs)
   );
 
-
   //   F[parity_odd]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -958,7 +926,6 @@ module usbuart_reg_top (
     .qs     (ctrl_parity_odd_qs)
   );
 
-
   //   F[rxblvl]: 9:8
   prim_subreg #(
     .DW      (2),
@@ -983,7 +950,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (ctrl_rxblvl_qs)
   );
-
 
   //   F[nco]: 31:16
   prim_subreg #(
@@ -1012,7 +978,6 @@ module usbuart_reg_top (
 
 
   // R[status]: V(True)
-
   //   F[txfull]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1026,7 +991,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (status_txfull_qs)
   );
-
 
   //   F[rxfull]: 1:1
   prim_subreg_ext #(
@@ -1042,7 +1006,6 @@ module usbuart_reg_top (
     .qs     (status_rxfull_qs)
   );
 
-
   //   F[txempty]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1056,7 +1019,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (status_txempty_qs)
   );
-
 
   //   F[txidle]: 3:3
   prim_subreg_ext #(
@@ -1072,7 +1034,6 @@ module usbuart_reg_top (
     .qs     (status_txidle_qs)
   );
 
-
   //   F[rxidle]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1086,7 +1047,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (status_rxidle_qs)
   );
-
 
   //   F[rxempty]: 5:5
   prim_subreg_ext #(
@@ -1104,7 +1064,6 @@ module usbuart_reg_top (
 
 
   // R[rdata]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_rdata (
@@ -1120,7 +1079,6 @@ module usbuart_reg_top (
 
 
   // R[wdata]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1147,7 +1105,6 @@ module usbuart_reg_top (
 
 
   // R[fifo_ctrl]: V(False)
-
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1172,7 +1129,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (fifo_ctrl_rxrst_qs)
   );
-
 
   //   F[txrst]: 1:1
   prim_subreg #(
@@ -1199,7 +1155,6 @@ module usbuart_reg_top (
     .qs     (fifo_ctrl_txrst_qs)
   );
 
-
   //   F[rxilvl]: 4:2
   prim_subreg #(
     .DW      (3),
@@ -1224,7 +1179,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
   );
-
 
   //   F[txilvl]: 6:5
   prim_subreg #(
@@ -1253,7 +1207,6 @@ module usbuart_reg_top (
 
 
   // R[fifo_status]: V(True)
-
   //   F[txlvl]: 5:0
   prim_subreg_ext #(
     .DW    (6)
@@ -1267,7 +1220,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (fifo_status_txlvl_qs)
   );
-
 
   //   F[rxlvl]: 21:16
   prim_subreg_ext #(
@@ -1285,7 +1237,6 @@ module usbuart_reg_top (
 
 
   // R[ovrd]: V(False)
-
   //   F[txen]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1310,7 +1261,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (ovrd_txen_qs)
   );
-
 
   //   F[txval]: 1:1
   prim_subreg #(
@@ -1339,7 +1289,6 @@ module usbuart_reg_top (
 
 
   // R[val]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_val (
@@ -1355,7 +1304,6 @@ module usbuart_reg_top (
 
 
   // R[timeout_ctrl]: V(False)
-
   //   F[val]: 23:0
   prim_subreg #(
     .DW      (24),
@@ -1380,7 +1328,6 @@ module usbuart_reg_top (
     // to register interface (read)
     .qs     (timeout_ctrl_val_qs)
   );
-
 
   //   F[en]: 31:31
   prim_subreg #(
@@ -1409,7 +1356,6 @@ module usbuart_reg_top (
 
 
   // R[usbstat]: V(True)
-
   //   F[frame]: 10:0
   prim_subreg_ext #(
     .DW    (11)
@@ -1423,7 +1369,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (usbstat_frame_qs)
   );
-
 
   //   F[host_timeout]: 14:14
   prim_subreg_ext #(
@@ -1439,7 +1384,6 @@ module usbuart_reg_top (
     .qs     (usbstat_host_timeout_qs)
   );
 
-
   //   F[host_lost]: 15:15
   prim_subreg_ext #(
     .DW    (1)
@@ -1453,7 +1397,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (usbstat_host_lost_qs)
   );
-
 
   //   F[device_address]: 22:16
   prim_subreg_ext #(
@@ -1471,7 +1414,6 @@ module usbuart_reg_top (
 
 
   // R[usbparam]: V(True)
-
   //   F[baud_req]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1486,7 +1428,6 @@ module usbuart_reg_top (
     .qs     (usbparam_baud_req_qs)
   );
 
-
   //   F[parity_req]: 17:16
   prim_subreg_ext #(
     .DW    (2)
@@ -1500,7 +1441,6 @@ module usbuart_reg_top (
     .q      (),
     .qs     (usbparam_parity_req_qs)
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_top.sv
@@ -1488,7 +1488,6 @@ module alert_handler_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[classa]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1513,7 +1512,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_state_classa_qs)
   );
-
 
   //   F[classb]: 1:1
   prim_subreg #(
@@ -1540,7 +1538,6 @@ module alert_handler_reg_top (
     .qs     (intr_state_classb_qs)
   );
 
-
   //   F[classc]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1565,7 +1562,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_state_classc_qs)
   );
-
 
   //   F[classd]: 3:3
   prim_subreg #(
@@ -1594,7 +1590,6 @@ module alert_handler_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[classa]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1619,7 +1614,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_enable_classa_qs)
   );
-
 
   //   F[classb]: 1:1
   prim_subreg #(
@@ -1646,7 +1640,6 @@ module alert_handler_reg_top (
     .qs     (intr_enable_classb_qs)
   );
 
-
   //   F[classc]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1671,7 +1664,6 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (intr_enable_classc_qs)
   );
-
 
   //   F[classd]: 3:3
   prim_subreg #(
@@ -1700,7 +1692,6 @@ module alert_handler_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[classa]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1714,7 +1705,6 @@ module alert_handler_reg_top (
     .q      (reg2hw.intr_test.classa.q),
     .qs     ()
   );
-
 
   //   F[classb]: 1:1
   prim_subreg_ext #(
@@ -1730,7 +1720,6 @@ module alert_handler_reg_top (
     .qs     ()
   );
 
-
   //   F[classc]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1744,7 +1733,6 @@ module alert_handler_reg_top (
     .q      (reg2hw.intr_test.classc.q),
     .qs     ()
   );
-
 
   //   F[classd]: 3:3
   prim_subreg_ext #(
@@ -1762,7 +1750,6 @@ module alert_handler_reg_top (
 
 
   // R[ping_timer_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1789,7 +1776,6 @@ module alert_handler_reg_top (
 
 
   // R[ping_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1822,7 +1808,6 @@ module alert_handler_reg_top (
 
 
   // R[ping_timer_en_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -1854,10 +1839,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_regwen
   // R[alert_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1882,9 +1865,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg alert_regwen
   // R[alert_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1909,9 +1892,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg alert_regwen
   // R[alert_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1936,9 +1919,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg alert_regwen
   // R[alert_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1963,9 +1946,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg alert_regwen
   // R[alert_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1990,9 +1973,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg alert_regwen
   // R[alert_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2017,9 +2000,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg alert_regwen
   // R[alert_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2044,9 +2027,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg alert_regwen
   // R[alert_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2071,9 +2054,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg alert_regwen
   // R[alert_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2098,9 +2081,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg alert_regwen
   // R[alert_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2125,9 +2108,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg alert_regwen
   // R[alert_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2152,9 +2135,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg alert_regwen
   // R[alert_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2179,9 +2162,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg alert_regwen
   // R[alert_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2206,9 +2189,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg alert_regwen
   // R[alert_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2233,9 +2216,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg alert_regwen
   // R[alert_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2260,9 +2243,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg alert_regwen
   // R[alert_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2287,9 +2270,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg alert_regwen
   // R[alert_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2314,9 +2297,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg alert_regwen
   // R[alert_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2341,9 +2324,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg alert_regwen
   // R[alert_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2368,9 +2351,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg alert_regwen
   // R[alert_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2395,9 +2378,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg alert_regwen
   // R[alert_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2422,9 +2405,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg alert_regwen
   // R[alert_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2449,9 +2432,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg alert_regwen
   // R[alert_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2476,9 +2459,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg alert_regwen
   // R[alert_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2503,9 +2486,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg alert_regwen
   // R[alert_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2530,9 +2513,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg alert_regwen
   // R[alert_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2557,9 +2540,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg alert_regwen
   // R[alert_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2584,9 +2567,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg alert_regwen
   // R[alert_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2611,9 +2594,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg alert_regwen
   // R[alert_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2638,9 +2621,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg alert_regwen
   // R[alert_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2665,9 +2648,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg alert_regwen
   // R[alert_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2692,9 +2675,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg alert_regwen
   // R[alert_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2719,9 +2702,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_31_qs)
   );
 
+
   // Subregister 32 of Multireg alert_regwen
   // R[alert_regwen_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2746,9 +2729,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_32_qs)
   );
 
+
   // Subregister 33 of Multireg alert_regwen
   // R[alert_regwen_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2773,9 +2756,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_33_qs)
   );
 
+
   // Subregister 34 of Multireg alert_regwen
   // R[alert_regwen_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2800,9 +2783,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_34_qs)
   );
 
+
   // Subregister 35 of Multireg alert_regwen
   // R[alert_regwen_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2827,9 +2810,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_35_qs)
   );
 
+
   // Subregister 36 of Multireg alert_regwen
   // R[alert_regwen_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2854,9 +2837,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_36_qs)
   );
 
+
   // Subregister 37 of Multireg alert_regwen
   // R[alert_regwen_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2881,9 +2864,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_37_qs)
   );
 
+
   // Subregister 38 of Multireg alert_regwen
   // R[alert_regwen_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2908,9 +2891,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_38_qs)
   );
 
+
   // Subregister 39 of Multireg alert_regwen
   // R[alert_regwen_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2935,9 +2918,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_39_qs)
   );
 
+
   // Subregister 40 of Multireg alert_regwen
   // R[alert_regwen_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2962,9 +2945,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_40_qs)
   );
 
+
   // Subregister 41 of Multireg alert_regwen
   // R[alert_regwen_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2989,9 +2972,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_41_qs)
   );
 
+
   // Subregister 42 of Multireg alert_regwen
   // R[alert_regwen_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3016,9 +2999,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_42_qs)
   );
 
+
   // Subregister 43 of Multireg alert_regwen
   // R[alert_regwen_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3043,9 +3026,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_43_qs)
   );
 
+
   // Subregister 44 of Multireg alert_regwen
   // R[alert_regwen_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3070,9 +3053,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_44_qs)
   );
 
+
   // Subregister 45 of Multireg alert_regwen
   // R[alert_regwen_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3097,9 +3080,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_45_qs)
   );
 
+
   // Subregister 46 of Multireg alert_regwen
   // R[alert_regwen_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3124,9 +3107,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_46_qs)
   );
 
+
   // Subregister 47 of Multireg alert_regwen
   // R[alert_regwen_47]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3151,9 +3134,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_47_qs)
   );
 
+
   // Subregister 48 of Multireg alert_regwen
   // R[alert_regwen_48]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3178,9 +3161,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_48_qs)
   );
 
+
   // Subregister 49 of Multireg alert_regwen
   // R[alert_regwen_49]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3205,9 +3188,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_49_qs)
   );
 
+
   // Subregister 50 of Multireg alert_regwen
   // R[alert_regwen_50]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3232,9 +3215,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_50_qs)
   );
 
+
   // Subregister 51 of Multireg alert_regwen
   // R[alert_regwen_51]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3259,9 +3242,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_51_qs)
   );
 
+
   // Subregister 52 of Multireg alert_regwen
   // R[alert_regwen_52]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3286,9 +3269,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_52_qs)
   );
 
+
   // Subregister 53 of Multireg alert_regwen
   // R[alert_regwen_53]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3313,9 +3296,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_53_qs)
   );
 
+
   // Subregister 54 of Multireg alert_regwen
   // R[alert_regwen_54]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3340,9 +3323,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_54_qs)
   );
 
+
   // Subregister 55 of Multireg alert_regwen
   // R[alert_regwen_55]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3367,9 +3350,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_55_qs)
   );
 
+
   // Subregister 56 of Multireg alert_regwen
   // R[alert_regwen_56]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3394,9 +3377,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_56_qs)
   );
 
+
   // Subregister 57 of Multireg alert_regwen
   // R[alert_regwen_57]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3421,9 +3404,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_57_qs)
   );
 
+
   // Subregister 58 of Multireg alert_regwen
   // R[alert_regwen_58]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3448,9 +3431,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_58_qs)
   );
 
+
   // Subregister 59 of Multireg alert_regwen
   // R[alert_regwen_59]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3475,9 +3458,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_59_qs)
   );
 
+
   // Subregister 60 of Multireg alert_regwen
   // R[alert_regwen_60]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3502,9 +3485,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_60_qs)
   );
 
+
   // Subregister 61 of Multireg alert_regwen
   // R[alert_regwen_61]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3529,9 +3512,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_61_qs)
   );
 
+
   // Subregister 62 of Multireg alert_regwen
   // R[alert_regwen_62]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3556,9 +3539,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_62_qs)
   );
 
+
   // Subregister 63 of Multireg alert_regwen
   // R[alert_regwen_63]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3583,9 +3566,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_63_qs)
   );
 
+
   // Subregister 64 of Multireg alert_regwen
   // R[alert_regwen_64]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3610,9 +3593,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_64_qs)
   );
 
+
   // Subregister 65 of Multireg alert_regwen
   // R[alert_regwen_65]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3637,9 +3620,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_65_qs)
   );
 
+
   // Subregister 66 of Multireg alert_regwen
   // R[alert_regwen_66]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3664,9 +3647,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_66_qs)
   );
 
+
   // Subregister 67 of Multireg alert_regwen
   // R[alert_regwen_67]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3691,9 +3674,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_67_qs)
   );
 
+
   // Subregister 68 of Multireg alert_regwen
   // R[alert_regwen_68]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3718,9 +3701,9 @@ module alert_handler_reg_top (
     .qs     (alert_regwen_68_qs)
   );
 
+
   // Subregister 69 of Multireg alert_regwen
   // R[alert_regwen_69]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3746,10 +3729,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3780,9 +3761,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3813,9 +3794,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3846,9 +3827,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3879,9 +3860,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[3].err_storage)
   );
 
+
   // Subregister 4 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_4]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3912,9 +3893,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[4].err_storage)
   );
 
+
   // Subregister 5 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_5]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3945,9 +3926,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[5].err_storage)
   );
 
+
   // Subregister 6 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_6]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3978,9 +3959,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[6].err_storage)
   );
 
+
   // Subregister 7 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_7]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4011,9 +3992,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[7].err_storage)
   );
 
+
   // Subregister 8 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_8]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4044,9 +4025,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[8].err_storage)
   );
 
+
   // Subregister 9 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_9]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4077,9 +4058,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[9].err_storage)
   );
 
+
   // Subregister 10 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_10]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4110,9 +4091,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[10].err_storage)
   );
 
+
   // Subregister 11 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_11]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4143,9 +4124,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[11].err_storage)
   );
 
+
   // Subregister 12 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_12]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4176,9 +4157,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[12].err_storage)
   );
 
+
   // Subregister 13 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_13]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4209,9 +4190,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[13].err_storage)
   );
 
+
   // Subregister 14 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_14]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4242,9 +4223,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[14].err_storage)
   );
 
+
   // Subregister 15 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_15]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4275,9 +4256,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[15].err_storage)
   );
 
+
   // Subregister 16 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_16]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4308,9 +4289,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[16].err_storage)
   );
 
+
   // Subregister 17 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_17]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4341,9 +4322,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[17].err_storage)
   );
 
+
   // Subregister 18 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_18]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4374,9 +4355,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[18].err_storage)
   );
 
+
   // Subregister 19 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_19]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4407,9 +4388,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[19].err_storage)
   );
 
+
   // Subregister 20 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_20]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4440,9 +4421,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[20].err_storage)
   );
 
+
   // Subregister 21 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_21]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4473,9 +4454,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[21].err_storage)
   );
 
+
   // Subregister 22 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_22]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4506,9 +4487,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[22].err_storage)
   );
 
+
   // Subregister 23 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_23]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4539,9 +4520,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[23].err_storage)
   );
 
+
   // Subregister 24 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_24]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4572,9 +4553,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[24].err_storage)
   );
 
+
   // Subregister 25 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_25]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4605,9 +4586,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[25].err_storage)
   );
 
+
   // Subregister 26 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_26]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4638,9 +4619,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[26].err_storage)
   );
 
+
   // Subregister 27 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_27]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4671,9 +4652,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[27].err_storage)
   );
 
+
   // Subregister 28 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_28]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4704,9 +4685,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[28].err_storage)
   );
 
+
   // Subregister 29 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_29]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4737,9 +4718,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[29].err_storage)
   );
 
+
   // Subregister 30 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_30]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4770,9 +4751,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[30].err_storage)
   );
 
+
   // Subregister 31 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_31]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4803,9 +4784,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[31].err_storage)
   );
 
+
   // Subregister 32 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_32]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4836,9 +4817,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[32].err_storage)
   );
 
+
   // Subregister 33 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_33]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4869,9 +4850,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[33].err_storage)
   );
 
+
   // Subregister 34 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_34]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4902,9 +4883,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[34].err_storage)
   );
 
+
   // Subregister 35 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_35]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4935,9 +4916,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[35].err_storage)
   );
 
+
   // Subregister 36 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_36]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4968,9 +4949,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[36].err_storage)
   );
 
+
   // Subregister 37 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_37]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5001,9 +4982,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[37].err_storage)
   );
 
+
   // Subregister 38 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_38]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5034,9 +5015,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[38].err_storage)
   );
 
+
   // Subregister 39 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_39]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5067,9 +5048,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[39].err_storage)
   );
 
+
   // Subregister 40 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_40]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5100,9 +5081,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[40].err_storage)
   );
 
+
   // Subregister 41 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_41]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5133,9 +5114,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[41].err_storage)
   );
 
+
   // Subregister 42 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_42]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5166,9 +5147,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[42].err_storage)
   );
 
+
   // Subregister 43 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_43]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5199,9 +5180,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[43].err_storage)
   );
 
+
   // Subregister 44 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_44]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5232,9 +5213,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[44].err_storage)
   );
 
+
   // Subregister 45 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_45]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5265,9 +5246,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[45].err_storage)
   );
 
+
   // Subregister 46 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_46]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5298,9 +5279,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[46].err_storage)
   );
 
+
   // Subregister 47 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_47]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5331,9 +5312,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[47].err_storage)
   );
 
+
   // Subregister 48 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_48]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5364,9 +5345,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[48].err_storage)
   );
 
+
   // Subregister 49 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_49]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5397,9 +5378,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[49].err_storage)
   );
 
+
   // Subregister 50 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_50]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5430,9 +5411,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[50].err_storage)
   );
 
+
   // Subregister 51 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_51]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5463,9 +5444,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[51].err_storage)
   );
 
+
   // Subregister 52 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_52]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5496,9 +5477,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[52].err_storage)
   );
 
+
   // Subregister 53 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_53]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5529,9 +5510,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[53].err_storage)
   );
 
+
   // Subregister 54 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_54]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5562,9 +5543,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[54].err_storage)
   );
 
+
   // Subregister 55 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_55]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5595,9 +5576,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[55].err_storage)
   );
 
+
   // Subregister 56 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_56]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5628,9 +5609,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[56].err_storage)
   );
 
+
   // Subregister 57 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_57]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5661,9 +5642,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[57].err_storage)
   );
 
+
   // Subregister 58 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_58]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5694,9 +5675,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[58].err_storage)
   );
 
+
   // Subregister 59 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_59]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5727,9 +5708,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[59].err_storage)
   );
 
+
   // Subregister 60 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_60]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5760,9 +5741,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[60].err_storage)
   );
 
+
   // Subregister 61 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_61]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5793,9 +5774,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[61].err_storage)
   );
 
+
   // Subregister 62 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_62]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5826,9 +5807,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[62].err_storage)
   );
 
+
   // Subregister 63 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_63]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5859,9 +5840,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[63].err_storage)
   );
 
+
   // Subregister 64 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_64]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5892,9 +5873,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[64].err_storage)
   );
 
+
   // Subregister 65 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_65]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5925,9 +5906,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[65].err_storage)
   );
 
+
   // Subregister 66 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_66]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5958,9 +5939,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[66].err_storage)
   );
 
+
   // Subregister 67 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_67]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5991,9 +5972,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[67].err_storage)
   );
 
+
   // Subregister 68 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_68]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6024,9 +6005,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_en_shadowed[68].err_storage)
   );
 
+
   // Subregister 69 of Multireg alert_en_shadowed
   // R[alert_en_shadowed_69]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6058,10 +6039,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6092,9 +6071,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6125,9 +6104,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6158,9 +6137,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6191,9 +6170,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[3].err_storage)
   );
 
+
   // Subregister 4 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_4]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6224,9 +6203,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[4].err_storage)
   );
 
+
   // Subregister 5 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_5]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6257,9 +6236,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[5].err_storage)
   );
 
+
   // Subregister 6 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_6]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6290,9 +6269,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[6].err_storage)
   );
 
+
   // Subregister 7 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_7]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6323,9 +6302,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[7].err_storage)
   );
 
+
   // Subregister 8 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_8]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6356,9 +6335,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[8].err_storage)
   );
 
+
   // Subregister 9 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_9]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6389,9 +6368,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[9].err_storage)
   );
 
+
   // Subregister 10 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_10]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6422,9 +6401,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[10].err_storage)
   );
 
+
   // Subregister 11 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_11]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6455,9 +6434,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[11].err_storage)
   );
 
+
   // Subregister 12 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_12]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6488,9 +6467,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[12].err_storage)
   );
 
+
   // Subregister 13 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_13]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6521,9 +6500,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[13].err_storage)
   );
 
+
   // Subregister 14 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_14]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6554,9 +6533,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[14].err_storage)
   );
 
+
   // Subregister 15 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_15]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6587,9 +6566,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[15].err_storage)
   );
 
+
   // Subregister 16 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_16]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6620,9 +6599,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[16].err_storage)
   );
 
+
   // Subregister 17 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_17]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6653,9 +6632,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[17].err_storage)
   );
 
+
   // Subregister 18 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_18]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6686,9 +6665,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[18].err_storage)
   );
 
+
   // Subregister 19 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_19]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6719,9 +6698,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[19].err_storage)
   );
 
+
   // Subregister 20 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_20]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6752,9 +6731,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[20].err_storage)
   );
 
+
   // Subregister 21 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_21]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6785,9 +6764,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[21].err_storage)
   );
 
+
   // Subregister 22 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_22]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6818,9 +6797,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[22].err_storage)
   );
 
+
   // Subregister 23 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_23]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6851,9 +6830,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[23].err_storage)
   );
 
+
   // Subregister 24 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_24]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6884,9 +6863,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[24].err_storage)
   );
 
+
   // Subregister 25 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_25]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6917,9 +6896,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[25].err_storage)
   );
 
+
   // Subregister 26 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_26]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6950,9 +6929,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[26].err_storage)
   );
 
+
   // Subregister 27 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_27]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6983,9 +6962,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[27].err_storage)
   );
 
+
   // Subregister 28 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_28]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7016,9 +6995,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[28].err_storage)
   );
 
+
   // Subregister 29 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_29]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7049,9 +7028,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[29].err_storage)
   );
 
+
   // Subregister 30 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_30]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7082,9 +7061,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[30].err_storage)
   );
 
+
   // Subregister 31 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_31]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7115,9 +7094,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[31].err_storage)
   );
 
+
   // Subregister 32 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_32]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7148,9 +7127,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[32].err_storage)
   );
 
+
   // Subregister 33 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_33]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7181,9 +7160,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[33].err_storage)
   );
 
+
   // Subregister 34 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_34]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7214,9 +7193,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[34].err_storage)
   );
 
+
   // Subregister 35 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_35]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7247,9 +7226,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[35].err_storage)
   );
 
+
   // Subregister 36 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_36]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7280,9 +7259,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[36].err_storage)
   );
 
+
   // Subregister 37 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_37]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7313,9 +7292,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[37].err_storage)
   );
 
+
   // Subregister 38 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_38]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7346,9 +7325,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[38].err_storage)
   );
 
+
   // Subregister 39 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_39]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7379,9 +7358,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[39].err_storage)
   );
 
+
   // Subregister 40 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_40]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7412,9 +7391,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[40].err_storage)
   );
 
+
   // Subregister 41 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_41]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7445,9 +7424,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[41].err_storage)
   );
 
+
   // Subregister 42 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_42]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7478,9 +7457,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[42].err_storage)
   );
 
+
   // Subregister 43 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_43]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7511,9 +7490,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[43].err_storage)
   );
 
+
   // Subregister 44 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_44]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7544,9 +7523,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[44].err_storage)
   );
 
+
   // Subregister 45 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_45]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7577,9 +7556,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[45].err_storage)
   );
 
+
   // Subregister 46 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_46]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7610,9 +7589,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[46].err_storage)
   );
 
+
   // Subregister 47 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_47]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7643,9 +7622,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[47].err_storage)
   );
 
+
   // Subregister 48 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_48]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7676,9 +7655,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[48].err_storage)
   );
 
+
   // Subregister 49 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_49]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7709,9 +7688,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[49].err_storage)
   );
 
+
   // Subregister 50 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_50]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7742,9 +7721,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[50].err_storage)
   );
 
+
   // Subregister 51 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_51]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7775,9 +7754,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[51].err_storage)
   );
 
+
   // Subregister 52 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_52]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7808,9 +7787,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[52].err_storage)
   );
 
+
   // Subregister 53 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_53]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7841,9 +7820,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[53].err_storage)
   );
 
+
   // Subregister 54 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_54]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7874,9 +7853,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[54].err_storage)
   );
 
+
   // Subregister 55 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_55]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7907,9 +7886,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[55].err_storage)
   );
 
+
   // Subregister 56 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_56]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7940,9 +7919,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[56].err_storage)
   );
 
+
   // Subregister 57 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_57]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7973,9 +7952,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[57].err_storage)
   );
 
+
   // Subregister 58 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_58]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8006,9 +7985,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[58].err_storage)
   );
 
+
   // Subregister 59 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_59]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8039,9 +8018,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[59].err_storage)
   );
 
+
   // Subregister 60 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_60]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8072,9 +8051,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[60].err_storage)
   );
 
+
   // Subregister 61 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_61]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8105,9 +8084,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[61].err_storage)
   );
 
+
   // Subregister 62 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_62]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8138,9 +8117,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[62].err_storage)
   );
 
+
   // Subregister 63 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_63]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8171,9 +8150,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[63].err_storage)
   );
 
+
   // Subregister 64 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_64]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8204,9 +8183,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[64].err_storage)
   );
 
+
   // Subregister 65 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_65]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8237,9 +8216,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[65].err_storage)
   );
 
+
   // Subregister 66 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_66]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8270,9 +8249,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[66].err_storage)
   );
 
+
   // Subregister 67 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_67]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8303,9 +8282,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[67].err_storage)
   );
 
+
   // Subregister 68 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_68]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8336,9 +8315,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.alert_class_shadowed[68].err_storage)
   );
 
+
   // Subregister 69 of Multireg alert_class_shadowed
   // R[alert_class_shadowed_69]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8370,10 +8349,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg alert_cause
   // R[alert_cause_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8398,9 +8375,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_0_qs)
   );
 
+
   // Subregister 1 of Multireg alert_cause
   // R[alert_cause_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8425,9 +8402,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_1_qs)
   );
 
+
   // Subregister 2 of Multireg alert_cause
   // R[alert_cause_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8452,9 +8429,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_2_qs)
   );
 
+
   // Subregister 3 of Multireg alert_cause
   // R[alert_cause_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8479,9 +8456,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_3_qs)
   );
 
+
   // Subregister 4 of Multireg alert_cause
   // R[alert_cause_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8506,9 +8483,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_4_qs)
   );
 
+
   // Subregister 5 of Multireg alert_cause
   // R[alert_cause_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8533,9 +8510,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_5_qs)
   );
 
+
   // Subregister 6 of Multireg alert_cause
   // R[alert_cause_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8560,9 +8537,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_6_qs)
   );
 
+
   // Subregister 7 of Multireg alert_cause
   // R[alert_cause_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8587,9 +8564,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_7_qs)
   );
 
+
   // Subregister 8 of Multireg alert_cause
   // R[alert_cause_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8614,9 +8591,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_8_qs)
   );
 
+
   // Subregister 9 of Multireg alert_cause
   // R[alert_cause_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8641,9 +8618,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_9_qs)
   );
 
+
   // Subregister 10 of Multireg alert_cause
   // R[alert_cause_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8668,9 +8645,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_10_qs)
   );
 
+
   // Subregister 11 of Multireg alert_cause
   // R[alert_cause_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8695,9 +8672,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_11_qs)
   );
 
+
   // Subregister 12 of Multireg alert_cause
   // R[alert_cause_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8722,9 +8699,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_12_qs)
   );
 
+
   // Subregister 13 of Multireg alert_cause
   // R[alert_cause_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8749,9 +8726,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_13_qs)
   );
 
+
   // Subregister 14 of Multireg alert_cause
   // R[alert_cause_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8776,9 +8753,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_14_qs)
   );
 
+
   // Subregister 15 of Multireg alert_cause
   // R[alert_cause_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8803,9 +8780,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_15_qs)
   );
 
+
   // Subregister 16 of Multireg alert_cause
   // R[alert_cause_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8830,9 +8807,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_16_qs)
   );
 
+
   // Subregister 17 of Multireg alert_cause
   // R[alert_cause_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8857,9 +8834,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_17_qs)
   );
 
+
   // Subregister 18 of Multireg alert_cause
   // R[alert_cause_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8884,9 +8861,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_18_qs)
   );
 
+
   // Subregister 19 of Multireg alert_cause
   // R[alert_cause_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8911,9 +8888,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_19_qs)
   );
 
+
   // Subregister 20 of Multireg alert_cause
   // R[alert_cause_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8938,9 +8915,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_20_qs)
   );
 
+
   // Subregister 21 of Multireg alert_cause
   // R[alert_cause_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8965,9 +8942,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_21_qs)
   );
 
+
   // Subregister 22 of Multireg alert_cause
   // R[alert_cause_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -8992,9 +8969,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_22_qs)
   );
 
+
   // Subregister 23 of Multireg alert_cause
   // R[alert_cause_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9019,9 +8996,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_23_qs)
   );
 
+
   // Subregister 24 of Multireg alert_cause
   // R[alert_cause_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9046,9 +9023,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_24_qs)
   );
 
+
   // Subregister 25 of Multireg alert_cause
   // R[alert_cause_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9073,9 +9050,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_25_qs)
   );
 
+
   // Subregister 26 of Multireg alert_cause
   // R[alert_cause_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9100,9 +9077,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_26_qs)
   );
 
+
   // Subregister 27 of Multireg alert_cause
   // R[alert_cause_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9127,9 +9104,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_27_qs)
   );
 
+
   // Subregister 28 of Multireg alert_cause
   // R[alert_cause_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9154,9 +9131,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_28_qs)
   );
 
+
   // Subregister 29 of Multireg alert_cause
   // R[alert_cause_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9181,9 +9158,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_29_qs)
   );
 
+
   // Subregister 30 of Multireg alert_cause
   // R[alert_cause_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9208,9 +9185,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_30_qs)
   );
 
+
   // Subregister 31 of Multireg alert_cause
   // R[alert_cause_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9235,9 +9212,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_31_qs)
   );
 
+
   // Subregister 32 of Multireg alert_cause
   // R[alert_cause_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9262,9 +9239,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_32_qs)
   );
 
+
   // Subregister 33 of Multireg alert_cause
   // R[alert_cause_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9289,9 +9266,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_33_qs)
   );
 
+
   // Subregister 34 of Multireg alert_cause
   // R[alert_cause_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9316,9 +9293,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_34_qs)
   );
 
+
   // Subregister 35 of Multireg alert_cause
   // R[alert_cause_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9343,9 +9320,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_35_qs)
   );
 
+
   // Subregister 36 of Multireg alert_cause
   // R[alert_cause_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9370,9 +9347,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_36_qs)
   );
 
+
   // Subregister 37 of Multireg alert_cause
   // R[alert_cause_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9397,9 +9374,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_37_qs)
   );
 
+
   // Subregister 38 of Multireg alert_cause
   // R[alert_cause_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9424,9 +9401,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_38_qs)
   );
 
+
   // Subregister 39 of Multireg alert_cause
   // R[alert_cause_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9451,9 +9428,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_39_qs)
   );
 
+
   // Subregister 40 of Multireg alert_cause
   // R[alert_cause_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9478,9 +9455,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_40_qs)
   );
 
+
   // Subregister 41 of Multireg alert_cause
   // R[alert_cause_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9505,9 +9482,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_41_qs)
   );
 
+
   // Subregister 42 of Multireg alert_cause
   // R[alert_cause_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9532,9 +9509,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_42_qs)
   );
 
+
   // Subregister 43 of Multireg alert_cause
   // R[alert_cause_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9559,9 +9536,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_43_qs)
   );
 
+
   // Subregister 44 of Multireg alert_cause
   // R[alert_cause_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9586,9 +9563,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_44_qs)
   );
 
+
   // Subregister 45 of Multireg alert_cause
   // R[alert_cause_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9613,9 +9590,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_45_qs)
   );
 
+
   // Subregister 46 of Multireg alert_cause
   // R[alert_cause_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9640,9 +9617,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_46_qs)
   );
 
+
   // Subregister 47 of Multireg alert_cause
   // R[alert_cause_47]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9667,9 +9644,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_47_qs)
   );
 
+
   // Subregister 48 of Multireg alert_cause
   // R[alert_cause_48]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9694,9 +9671,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_48_qs)
   );
 
+
   // Subregister 49 of Multireg alert_cause
   // R[alert_cause_49]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9721,9 +9698,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_49_qs)
   );
 
+
   // Subregister 50 of Multireg alert_cause
   // R[alert_cause_50]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9748,9 +9725,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_50_qs)
   );
 
+
   // Subregister 51 of Multireg alert_cause
   // R[alert_cause_51]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9775,9 +9752,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_51_qs)
   );
 
+
   // Subregister 52 of Multireg alert_cause
   // R[alert_cause_52]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9802,9 +9779,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_52_qs)
   );
 
+
   // Subregister 53 of Multireg alert_cause
   // R[alert_cause_53]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9829,9 +9806,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_53_qs)
   );
 
+
   // Subregister 54 of Multireg alert_cause
   // R[alert_cause_54]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9856,9 +9833,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_54_qs)
   );
 
+
   // Subregister 55 of Multireg alert_cause
   // R[alert_cause_55]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9883,9 +9860,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_55_qs)
   );
 
+
   // Subregister 56 of Multireg alert_cause
   // R[alert_cause_56]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9910,9 +9887,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_56_qs)
   );
 
+
   // Subregister 57 of Multireg alert_cause
   // R[alert_cause_57]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9937,9 +9914,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_57_qs)
   );
 
+
   // Subregister 58 of Multireg alert_cause
   // R[alert_cause_58]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9964,9 +9941,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_58_qs)
   );
 
+
   // Subregister 59 of Multireg alert_cause
   // R[alert_cause_59]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -9991,9 +9968,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_59_qs)
   );
 
+
   // Subregister 60 of Multireg alert_cause
   // R[alert_cause_60]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10018,9 +9995,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_60_qs)
   );
 
+
   // Subregister 61 of Multireg alert_cause
   // R[alert_cause_61]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10045,9 +10022,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_61_qs)
   );
 
+
   // Subregister 62 of Multireg alert_cause
   // R[alert_cause_62]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10072,9 +10049,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_62_qs)
   );
 
+
   // Subregister 63 of Multireg alert_cause
   // R[alert_cause_63]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10099,9 +10076,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_63_qs)
   );
 
+
   // Subregister 64 of Multireg alert_cause
   // R[alert_cause_64]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10126,9 +10103,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_64_qs)
   );
 
+
   // Subregister 65 of Multireg alert_cause
   // R[alert_cause_65]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10153,9 +10130,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_65_qs)
   );
 
+
   // Subregister 66 of Multireg alert_cause
   // R[alert_cause_66]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10180,9 +10157,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_66_qs)
   );
 
+
   // Subregister 67 of Multireg alert_cause
   // R[alert_cause_67]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10207,9 +10184,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_67_qs)
   );
 
+
   // Subregister 68 of Multireg alert_cause
   // R[alert_cause_68]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10234,9 +10211,9 @@ module alert_handler_reg_top (
     .qs     (alert_cause_68_qs)
   );
 
+
   // Subregister 69 of Multireg alert_cause
   // R[alert_cause_69]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10262,10 +10239,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10290,9 +10265,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10317,9 +10292,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10344,9 +10319,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10371,9 +10346,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10398,9 +10373,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10425,9 +10400,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg loc_alert_regwen
   // R[loc_alert_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10453,10 +10428,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10487,9 +10460,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10520,9 +10493,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10553,9 +10526,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10586,9 +10559,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[3].err_storage)
   );
 
+
   // Subregister 4 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_4]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10619,9 +10592,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[4].err_storage)
   );
 
+
   // Subregister 5 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_5]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10652,9 +10625,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_en_shadowed[5].err_storage)
   );
 
+
   // Subregister 6 of Multireg loc_alert_en_shadowed
   // R[loc_alert_en_shadowed_6]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10686,10 +10659,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_0]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10720,9 +10691,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[0].err_storage)
   );
 
+
   // Subregister 1 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_1]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10753,9 +10724,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[1].err_storage)
   );
 
+
   // Subregister 2 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_2]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10786,9 +10757,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[2].err_storage)
   );
 
+
   // Subregister 3 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_3]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10819,9 +10790,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[3].err_storage)
   );
 
+
   // Subregister 4 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_4]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10852,9 +10823,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[4].err_storage)
   );
 
+
   // Subregister 5 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_5]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10885,9 +10856,9 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.loc_alert_class_shadowed[5].err_storage)
   );
 
+
   // Subregister 6 of Multireg loc_alert_class_shadowed
   // R[loc_alert_class_shadowed_6]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10919,10 +10890,8 @@ module alert_handler_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg loc_alert_cause
   // R[loc_alert_cause_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10947,9 +10916,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_0_qs)
   );
 
+
   // Subregister 1 of Multireg loc_alert_cause
   // R[loc_alert_cause_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10974,9 +10943,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_1_qs)
   );
 
+
   // Subregister 2 of Multireg loc_alert_cause
   // R[loc_alert_cause_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -11001,9 +10970,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_2_qs)
   );
 
+
   // Subregister 3 of Multireg loc_alert_cause
   // R[loc_alert_cause_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -11028,9 +10997,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_3_qs)
   );
 
+
   // Subregister 4 of Multireg loc_alert_cause
   // R[loc_alert_cause_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -11055,9 +11024,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_4_qs)
   );
 
+
   // Subregister 5 of Multireg loc_alert_cause
   // R[loc_alert_cause_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -11082,9 +11051,9 @@ module alert_handler_reg_top (
     .qs     (loc_alert_cause_5_qs)
   );
 
+
   // Subregister 6 of Multireg loc_alert_cause
   // R[loc_alert_cause_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -11111,7 +11080,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11138,7 +11106,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -11169,7 +11136,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -11202,7 +11168,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -11233,7 +11198,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -11266,7 +11230,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -11297,7 +11260,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -11330,7 +11292,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -11361,7 +11322,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -11394,7 +11354,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -11425,7 +11384,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -11460,7 +11418,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11487,7 +11444,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11520,7 +11476,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classa_accum_cnt (
@@ -11536,7 +11491,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11569,7 +11523,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11602,7 +11555,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11635,7 +11587,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11668,7 +11619,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11701,7 +11651,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11734,7 +11683,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11767,7 +11715,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classa_esc_cnt (
@@ -11783,7 +11730,6 @@ module alert_handler_reg_top (
 
 
   // R[classa_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classa_state (
@@ -11799,7 +11745,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11826,7 +11771,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -11857,7 +11801,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -11890,7 +11833,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -11921,7 +11863,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -11954,7 +11895,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -11985,7 +11925,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -12018,7 +11957,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -12049,7 +11987,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -12082,7 +12019,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -12113,7 +12049,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -12148,7 +12083,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12175,7 +12109,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12208,7 +12141,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classb_accum_cnt (
@@ -12224,7 +12156,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12257,7 +12188,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12290,7 +12220,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12323,7 +12252,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12356,7 +12284,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12389,7 +12316,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12422,7 +12348,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12455,7 +12380,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classb_esc_cnt (
@@ -12471,7 +12395,6 @@ module alert_handler_reg_top (
 
 
   // R[classb_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classb_state (
@@ -12487,7 +12410,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12514,7 +12436,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -12545,7 +12466,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -12578,7 +12498,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -12609,7 +12528,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -12642,7 +12560,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -12673,7 +12590,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -12706,7 +12622,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -12737,7 +12652,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -12770,7 +12684,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -12801,7 +12714,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -12836,7 +12748,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12863,7 +12774,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12896,7 +12806,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classc_accum_cnt (
@@ -12912,7 +12821,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12945,7 +12853,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12978,7 +12885,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13011,7 +12917,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13044,7 +12949,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13077,7 +12981,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13110,7 +13013,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13143,7 +13045,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classc_esc_cnt (
@@ -13159,7 +13060,6 @@ module alert_handler_reg_top (
 
 
   // R[classc_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classc_state (
@@ -13175,7 +13075,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13202,7 +13101,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_ctrl_shadowed]: V(False)
-
   //   F[en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -13233,7 +13131,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en.err_storage)
   );
-
 
   //   F[lock]: 1:1
   prim_subreg_shadow #(
@@ -13266,7 +13163,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.lock.err_storage)
   );
 
-
   //   F[en_e0]: 2:2
   prim_subreg_shadow #(
     .DW      (1),
@@ -13297,7 +13193,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e0.err_storage)
   );
-
 
   //   F[en_e1]: 3:3
   prim_subreg_shadow #(
@@ -13330,7 +13225,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e1.err_storage)
   );
 
-
   //   F[en_e2]: 4:4
   prim_subreg_shadow #(
     .DW      (1),
@@ -13361,7 +13255,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e2.err_storage)
   );
-
 
   //   F[en_e3]: 5:5
   prim_subreg_shadow #(
@@ -13394,7 +13287,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e3.err_storage)
   );
 
-
   //   F[map_e0]: 7:6
   prim_subreg_shadow #(
     .DW      (2),
@@ -13425,7 +13317,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e0.err_storage)
   );
-
 
   //   F[map_e1]: 9:8
   prim_subreg_shadow #(
@@ -13458,7 +13349,6 @@ module alert_handler_reg_top (
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e1.err_storage)
   );
 
-
   //   F[map_e2]: 11:10
   prim_subreg_shadow #(
     .DW      (2),
@@ -13489,7 +13379,6 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e2.err_storage)
   );
-
 
   //   F[map_e3]: 13:12
   prim_subreg_shadow #(
@@ -13524,7 +13413,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_clr_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13551,7 +13439,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_clr_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13584,7 +13471,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_accum_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (16)
   ) u_classd_accum_cnt (
@@ -13600,7 +13486,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_accum_thresh_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13633,7 +13518,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_timeout_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13666,7 +13550,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_crashdump_trigger_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13699,7 +13582,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase0_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13732,7 +13614,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase1_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13765,7 +13646,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase2_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13798,7 +13678,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_phase3_cyc_shadowed]: V(False)
-
   prim_subreg_shadow #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13831,7 +13710,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_esc_cnt]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_classd_esc_cnt (
@@ -13847,7 +13725,6 @@ module alert_handler_reg_top (
 
 
   // R[classd_state]: V(True)
-
   prim_subreg_ext #(
     .DW    (3)
   ) u_classd_state (
@@ -13860,7 +13737,6 @@ module alert_handler_reg_top (
     .q      (),
     .qs     (classd_state_qs)
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -292,7 +292,6 @@ module ast_reg_top (
 
   // Register instances
   // R[revid]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -318,10 +317,8 @@ module ast_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg rega
   // R[rega_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -346,9 +343,9 @@ module ast_reg_top (
     .qs     (rega_0_qs)
   );
 
+
   // Subregister 1 of Multireg rega
   // R[rega_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -373,9 +370,9 @@ module ast_reg_top (
     .qs     (rega_1_qs)
   );
 
+
   // Subregister 2 of Multireg rega
   // R[rega_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -400,9 +397,9 @@ module ast_reg_top (
     .qs     (rega_2_qs)
   );
 
+
   // Subregister 3 of Multireg rega
   // R[rega_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -427,9 +424,9 @@ module ast_reg_top (
     .qs     (rega_3_qs)
   );
 
+
   // Subregister 4 of Multireg rega
   // R[rega_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -454,9 +451,9 @@ module ast_reg_top (
     .qs     (rega_4_qs)
   );
 
+
   // Subregister 5 of Multireg rega
   // R[rega_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -481,9 +478,9 @@ module ast_reg_top (
     .qs     (rega_5_qs)
   );
 
+
   // Subregister 6 of Multireg rega
   // R[rega_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -508,9 +505,9 @@ module ast_reg_top (
     .qs     (rega_6_qs)
   );
 
+
   // Subregister 7 of Multireg rega
   // R[rega_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -535,9 +532,9 @@ module ast_reg_top (
     .qs     (rega_7_qs)
   );
 
+
   // Subregister 8 of Multireg rega
   // R[rega_8]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -562,9 +559,9 @@ module ast_reg_top (
     .qs     (rega_8_qs)
   );
 
+
   // Subregister 9 of Multireg rega
   // R[rega_9]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -589,9 +586,9 @@ module ast_reg_top (
     .qs     (rega_9_qs)
   );
 
+
   // Subregister 10 of Multireg rega
   // R[rega_10]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -616,9 +613,9 @@ module ast_reg_top (
     .qs     (rega_10_qs)
   );
 
+
   // Subregister 11 of Multireg rega
   // R[rega_11]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -643,9 +640,9 @@ module ast_reg_top (
     .qs     (rega_11_qs)
   );
 
+
   // Subregister 12 of Multireg rega
   // R[rega_12]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -670,9 +667,9 @@ module ast_reg_top (
     .qs     (rega_12_qs)
   );
 
+
   // Subregister 13 of Multireg rega
   // R[rega_13]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -697,9 +694,9 @@ module ast_reg_top (
     .qs     (rega_13_qs)
   );
 
+
   // Subregister 14 of Multireg rega
   // R[rega_14]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -724,9 +721,9 @@ module ast_reg_top (
     .qs     (rega_14_qs)
   );
 
+
   // Subregister 15 of Multireg rega
   // R[rega_15]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -751,9 +748,9 @@ module ast_reg_top (
     .qs     (rega_15_qs)
   );
 
+
   // Subregister 16 of Multireg rega
   // R[rega_16]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -778,9 +775,9 @@ module ast_reg_top (
     .qs     (rega_16_qs)
   );
 
+
   // Subregister 17 of Multireg rega
   // R[rega_17]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -805,9 +802,9 @@ module ast_reg_top (
     .qs     (rega_17_qs)
   );
 
+
   // Subregister 18 of Multireg rega
   // R[rega_18]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -832,9 +829,9 @@ module ast_reg_top (
     .qs     (rega_18_qs)
   );
 
+
   // Subregister 19 of Multireg rega
   // R[rega_19]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -859,9 +856,9 @@ module ast_reg_top (
     .qs     (rega_19_qs)
   );
 
+
   // Subregister 20 of Multireg rega
   // R[rega_20]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -886,9 +883,9 @@ module ast_reg_top (
     .qs     (rega_20_qs)
   );
 
+
   // Subregister 21 of Multireg rega
   // R[rega_21]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -913,9 +910,9 @@ module ast_reg_top (
     .qs     (rega_21_qs)
   );
 
+
   // Subregister 22 of Multireg rega
   // R[rega_22]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -940,9 +937,9 @@ module ast_reg_top (
     .qs     (rega_22_qs)
   );
 
+
   // Subregister 23 of Multireg rega
   // R[rega_23]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -967,9 +964,9 @@ module ast_reg_top (
     .qs     (rega_23_qs)
   );
 
+
   // Subregister 24 of Multireg rega
   // R[rega_24]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -994,9 +991,9 @@ module ast_reg_top (
     .qs     (rega_24_qs)
   );
 
+
   // Subregister 25 of Multireg rega
   // R[rega_25]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1021,9 +1018,9 @@ module ast_reg_top (
     .qs     (rega_25_qs)
   );
 
+
   // Subregister 26 of Multireg rega
   // R[rega_26]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1048,9 +1045,9 @@ module ast_reg_top (
     .qs     (rega_26_qs)
   );
 
+
   // Subregister 27 of Multireg rega
   // R[rega_27]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1075,9 +1072,9 @@ module ast_reg_top (
     .qs     (rega_27_qs)
   );
 
+
   // Subregister 28 of Multireg rega
   // R[rega_28]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1102,9 +1099,9 @@ module ast_reg_top (
     .qs     (rega_28_qs)
   );
 
+
   // Subregister 29 of Multireg rega
   // R[rega_29]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1129,9 +1126,9 @@ module ast_reg_top (
     .qs     (rega_29_qs)
   );
 
+
   // Subregister 30 of Multireg rega
   // R[rega_30]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1156,9 +1153,9 @@ module ast_reg_top (
     .qs     (rega_30_qs)
   );
 
+
   // Subregister 31 of Multireg rega
   // R[rega_31]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1183,9 +1180,9 @@ module ast_reg_top (
     .qs     (rega_31_qs)
   );
 
+
   // Subregister 32 of Multireg rega
   // R[rega_32]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1210,9 +1207,9 @@ module ast_reg_top (
     .qs     (rega_32_qs)
   );
 
+
   // Subregister 33 of Multireg rega
   // R[rega_33]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1237,9 +1234,9 @@ module ast_reg_top (
     .qs     (rega_33_qs)
   );
 
+
   // Subregister 34 of Multireg rega
   // R[rega_34]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1264,9 +1261,9 @@ module ast_reg_top (
     .qs     (rega_34_qs)
   );
 
+
   // Subregister 35 of Multireg rega
   // R[rega_35]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1291,9 +1288,9 @@ module ast_reg_top (
     .qs     (rega_35_qs)
   );
 
+
   // Subregister 36 of Multireg rega
   // R[rega_36]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1318,9 +1315,9 @@ module ast_reg_top (
     .qs     (rega_36_qs)
   );
 
+
   // Subregister 37 of Multireg rega
   // R[rega_37]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1345,9 +1342,9 @@ module ast_reg_top (
     .qs     (rega_37_qs)
   );
 
+
   // Subregister 38 of Multireg rega
   // R[rega_38]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1372,9 +1369,9 @@ module ast_reg_top (
     .qs     (rega_38_qs)
   );
 
+
   // Subregister 39 of Multireg rega
   // R[rega_39]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1399,9 +1396,9 @@ module ast_reg_top (
     .qs     (rega_39_qs)
   );
 
+
   // Subregister 40 of Multireg rega
   // R[rega_40]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1426,9 +1423,9 @@ module ast_reg_top (
     .qs     (rega_40_qs)
   );
 
+
   // Subregister 41 of Multireg rega
   // R[rega_41]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1453,9 +1450,9 @@ module ast_reg_top (
     .qs     (rega_41_qs)
   );
 
+
   // Subregister 42 of Multireg rega
   // R[rega_42]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1480,9 +1477,9 @@ module ast_reg_top (
     .qs     (rega_42_qs)
   );
 
+
   // Subregister 43 of Multireg rega
   // R[rega_43]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1507,9 +1504,9 @@ module ast_reg_top (
     .qs     (rega_43_qs)
   );
 
+
   // Subregister 44 of Multireg rega
   // R[rega_44]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1534,9 +1531,9 @@ module ast_reg_top (
     .qs     (rega_44_qs)
   );
 
+
   // Subregister 45 of Multireg rega
   // R[rega_45]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1561,9 +1558,9 @@ module ast_reg_top (
     .qs     (rega_45_qs)
   );
 
+
   // Subregister 46 of Multireg rega
   // R[rega_46]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1588,9 +1585,9 @@ module ast_reg_top (
     .qs     (rega_46_qs)
   );
 
+
   // Subregister 47 of Multireg rega
   // R[rega_47]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1615,9 +1612,9 @@ module ast_reg_top (
     .qs     (rega_47_qs)
   );
 
+
   // Subregister 48 of Multireg rega
   // R[rega_48]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1642,9 +1639,9 @@ module ast_reg_top (
     .qs     (rega_48_qs)
   );
 
+
   // Subregister 49 of Multireg rega
   // R[rega_49]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1670,10 +1667,8 @@ module ast_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg regb
   // R[regb_0]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1698,9 +1693,9 @@ module ast_reg_top (
     .qs     (regb_0_qs)
   );
 
+
   // Subregister 1 of Multireg regb
   // R[regb_1]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1725,9 +1720,9 @@ module ast_reg_top (
     .qs     (regb_1_qs)
   );
 
+
   // Subregister 2 of Multireg regb
   // R[regb_2]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1752,9 +1747,9 @@ module ast_reg_top (
     .qs     (regb_2_qs)
   );
 
+
   // Subregister 3 of Multireg regb
   // R[regb_3]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1779,9 +1774,9 @@ module ast_reg_top (
     .qs     (regb_3_qs)
   );
 
+
   // Subregister 4 of Multireg regb
   // R[regb_4]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1806,9 +1801,9 @@ module ast_reg_top (
     .qs     (regb_4_qs)
   );
 
+
   // Subregister 5 of Multireg regb
   // R[regb_5]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1833,9 +1828,9 @@ module ast_reg_top (
     .qs     (regb_5_qs)
   );
 
+
   // Subregister 6 of Multireg regb
   // R[regb_6]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1860,9 +1855,9 @@ module ast_reg_top (
     .qs     (regb_6_qs)
   );
 
+
   // Subregister 7 of Multireg regb
   // R[regb_7]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1887,9 +1882,9 @@ module ast_reg_top (
     .qs     (regb_7_qs)
   );
 
+
   // Subregister 8 of Multireg regb
   // R[regb_8]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1914,9 +1909,9 @@ module ast_reg_top (
     .qs     (regb_8_qs)
   );
 
+
   // Subregister 9 of Multireg regb
   // R[regb_9]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1940,7 +1935,6 @@ module ast_reg_top (
     // to register interface (read)
     .qs     (regb_9_qs)
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -147,7 +147,6 @@ module clkmgr_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -163,7 +162,6 @@ module clkmgr_reg_top (
 
 
   // R[extclk_sel_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -190,7 +188,6 @@ module clkmgr_reg_top (
 
 
   // R[extclk_sel]: V(False)
-
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -217,7 +214,6 @@ module clkmgr_reg_top (
 
 
   // R[jitter_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -244,7 +240,6 @@ module clkmgr_reg_top (
 
 
   // R[clk_enables]: V(False)
-
   //   F[clk_io_div4_peri_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -269,7 +264,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_enables_clk_io_div4_peri_en_qs)
   );
-
 
   //   F[clk_io_div2_peri_en]: 1:1
   prim_subreg #(
@@ -296,7 +290,6 @@ module clkmgr_reg_top (
     .qs     (clk_enables_clk_io_div2_peri_en_qs)
   );
 
-
   //   F[clk_io_peri_en]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -321,7 +314,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_enables_clk_io_peri_en_qs)
   );
-
 
   //   F[clk_usb_peri_en]: 3:3
   prim_subreg #(
@@ -350,7 +342,6 @@ module clkmgr_reg_top (
 
 
   // R[clk_hints]: V(False)
-
   //   F[clk_main_aes_hint]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -375,7 +366,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_clk_main_aes_hint_qs)
   );
-
 
   //   F[clk_main_hmac_hint]: 1:1
   prim_subreg #(
@@ -402,7 +392,6 @@ module clkmgr_reg_top (
     .qs     (clk_hints_clk_main_hmac_hint_qs)
   );
 
-
   //   F[clk_main_kmac_hint]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -428,7 +417,6 @@ module clkmgr_reg_top (
     .qs     (clk_hints_clk_main_kmac_hint_qs)
   );
 
-
   //   F[clk_io_div4_otbn_hint]: 3:3
   prim_subreg #(
     .DW      (1),
@@ -453,7 +441,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_clk_io_div4_otbn_hint_qs)
   );
-
 
   //   F[clk_main_otbn_hint]: 4:4
   prim_subreg #(
@@ -482,7 +469,6 @@ module clkmgr_reg_top (
 
 
   // R[clk_hints_status]: V(False)
-
   //   F[clk_main_aes_val]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -507,7 +493,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_status_clk_main_aes_val_qs)
   );
-
 
   //   F[clk_main_hmac_val]: 1:1
   prim_subreg #(
@@ -534,7 +519,6 @@ module clkmgr_reg_top (
     .qs     (clk_hints_status_clk_main_hmac_val_qs)
   );
 
-
   //   F[clk_main_kmac_val]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -559,7 +543,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_status_clk_main_kmac_val_qs)
   );
-
 
   //   F[clk_io_div4_otbn_val]: 3:3
   prim_subreg #(
@@ -586,7 +569,6 @@ module clkmgr_reg_top (
     .qs     (clk_hints_status_clk_io_div4_otbn_val_qs)
   );
 
-
   //   F[clk_main_otbn_val]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -611,7 +593,6 @@ module clkmgr_reg_top (
     // to register interface (read)
     .qs     (clk_hints_status_clk_main_otbn_val_qs)
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -973,7 +973,6 @@ module flash_ctrl_core_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -998,7 +997,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_prog_empty_qs)
   );
-
 
   //   F[prog_lvl]: 1:1
   prim_subreg #(
@@ -1025,7 +1023,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_state_prog_lvl_qs)
   );
 
-
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1050,7 +1047,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_rd_full_qs)
   );
-
 
   //   F[rd_lvl]: 3:3
   prim_subreg #(
@@ -1077,7 +1073,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_state_rd_lvl_qs)
   );
 
-
   //   F[op_done]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1102,7 +1097,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_state_op_done_qs)
   );
-
 
   //   F[err]: 5:5
   prim_subreg #(
@@ -1131,7 +1125,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   //   F[prog_empty]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1156,7 +1149,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_prog_empty_qs)
   );
-
 
   //   F[prog_lvl]: 1:1
   prim_subreg #(
@@ -1183,7 +1175,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_enable_prog_lvl_qs)
   );
 
-
   //   F[rd_full]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -1208,7 +1199,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_rd_full_qs)
   );
-
 
   //   F[rd_lvl]: 3:3
   prim_subreg #(
@@ -1235,7 +1225,6 @@ module flash_ctrl_core_reg_top (
     .qs     (intr_enable_rd_lvl_qs)
   );
 
-
   //   F[op_done]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -1260,7 +1249,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (intr_enable_op_done_qs)
   );
-
 
   //   F[err]: 5:5
   prim_subreg #(
@@ -1289,7 +1277,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[intr_test]: V(True)
-
   //   F[prog_empty]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1303,7 +1290,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.prog_empty.q),
     .qs     ()
   );
-
 
   //   F[prog_lvl]: 1:1
   prim_subreg_ext #(
@@ -1319,7 +1305,6 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[rd_full]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1333,7 +1318,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.rd_full.q),
     .qs     ()
   );
-
 
   //   F[rd_lvl]: 3:3
   prim_subreg_ext #(
@@ -1349,7 +1333,6 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[op_done]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -1363,7 +1346,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.intr_test.op_done.q),
     .qs     ()
   );
-
 
   //   F[err]: 5:5
   prim_subreg_ext #(
@@ -1381,7 +1363,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[alert_test]: V(True)
-
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1395,7 +1376,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.alert_test.recov_err.q),
     .qs     ()
   );
-
 
   //   F[recov_mp_err]: 1:1
   prim_subreg_ext #(
@@ -1411,7 +1391,6 @@ module flash_ctrl_core_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_ecc_err]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -1425,7 +1404,6 @@ module flash_ctrl_core_reg_top (
     .q      (reg2hw.alert_test.recov_ecc_err.q),
     .qs     ()
   );
-
 
   //   F[fatal_intg_err]: 3:3
   prim_subreg_ext #(
@@ -1443,7 +1421,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[flash_disable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -1470,7 +1447,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[init]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1S),
@@ -1497,7 +1473,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[ctrl_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_regwen (
@@ -1513,7 +1488,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[start]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1538,7 +1512,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (control_start_qs)
   );
-
 
   //   F[op]: 5:4
   prim_subreg #(
@@ -1565,7 +1538,6 @@ module flash_ctrl_core_reg_top (
     .qs     (control_op_qs)
   );
 
-
   //   F[prog_sel]: 6:6
   prim_subreg #(
     .DW      (1),
@@ -1590,7 +1562,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (control_prog_sel_qs)
   );
-
 
   //   F[erase_sel]: 7:7
   prim_subreg #(
@@ -1617,7 +1588,6 @@ module flash_ctrl_core_reg_top (
     .qs     (control_erase_sel_qs)
   );
 
-
   //   F[partition_sel]: 8:8
   prim_subreg #(
     .DW      (1),
@@ -1643,7 +1613,6 @@ module flash_ctrl_core_reg_top (
     .qs     (control_partition_sel_qs)
   );
 
-
   //   F[info_sel]: 10:9
   prim_subreg #(
     .DW      (2),
@@ -1668,7 +1637,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (control_info_sel_qs)
   );
-
 
   //   F[num]: 27:16
   prim_subreg #(
@@ -1697,7 +1665,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[addr]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1724,7 +1691,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[prog_type_en]: V(False)
-
   //   F[normal]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1749,7 +1715,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (prog_type_en_normal_qs)
   );
-
 
   //   F[repair]: 1:1
   prim_subreg #(
@@ -1778,7 +1743,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[erase_suspend]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1804,10 +1768,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1832,9 +1794,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1859,9 +1821,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1886,9 +1848,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1913,9 +1875,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1940,9 +1902,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1967,9 +1929,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -1994,9 +1956,9 @@ module flash_ctrl_core_reg_top (
     .qs     (region_cfg_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg region_cfg_regwen
   // R[region_cfg_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -2022,11 +1984,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mp_region_cfg
   // R[mp_region_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2051,8 +2011,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2077,8 +2036,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2103,8 +2061,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2129,8 +2086,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2155,8 +2111,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2181,8 +2136,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2207,8 +2161,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_he_en_0_qs)
   );
 
-
-  // F[base_0]: 16:8
+  //   F[base_0]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2233,8 +2186,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_0_base_0_qs)
   );
 
-
-  // F[size_0]: 26:17
+  //   F[size_0]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2262,8 +2214,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg mp_region_cfg
   // R[mp_region_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2288,8 +2239,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2314,8 +2264,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2340,8 +2289,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2366,8 +2314,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2392,8 +2339,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2418,8 +2364,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2444,8 +2389,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_he_en_1_qs)
   );
 
-
-  // F[base_1]: 16:8
+  //   F[base_1]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2470,8 +2414,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_1_base_1_qs)
   );
 
-
-  // F[size_1]: 26:17
+  //   F[size_1]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2499,8 +2442,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 2 of Multireg mp_region_cfg
   // R[mp_region_cfg_2]: V(False)
-
-  // F[en_2]: 0:0
+  //   F[en_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2525,8 +2467,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_en_2_qs)
   );
 
-
-  // F[rd_en_2]: 1:1
+  //   F[rd_en_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2551,8 +2492,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_rd_en_2_qs)
   );
 
-
-  // F[prog_en_2]: 2:2
+  //   F[prog_en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2577,8 +2517,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_prog_en_2_qs)
   );
 
-
-  // F[erase_en_2]: 3:3
+  //   F[erase_en_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2603,8 +2542,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_erase_en_2_qs)
   );
 
-
-  // F[scramble_en_2]: 4:4
+  //   F[scramble_en_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2629,8 +2567,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_scramble_en_2_qs)
   );
 
-
-  // F[ecc_en_2]: 5:5
+  //   F[ecc_en_2]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2655,8 +2592,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_ecc_en_2_qs)
   );
 
-
-  // F[he_en_2]: 6:6
+  //   F[he_en_2]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2681,8 +2617,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_he_en_2_qs)
   );
 
-
-  // F[base_2]: 16:8
+  //   F[base_2]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2707,8 +2642,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_2_base_2_qs)
   );
 
-
-  // F[size_2]: 26:17
+  //   F[size_2]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2736,8 +2670,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 3 of Multireg mp_region_cfg
   // R[mp_region_cfg_3]: V(False)
-
-  // F[en_3]: 0:0
+  //   F[en_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2762,8 +2695,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_en_3_qs)
   );
 
-
-  // F[rd_en_3]: 1:1
+  //   F[rd_en_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2788,8 +2720,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_rd_en_3_qs)
   );
 
-
-  // F[prog_en_3]: 2:2
+  //   F[prog_en_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2814,8 +2745,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_prog_en_3_qs)
   );
 
-
-  // F[erase_en_3]: 3:3
+  //   F[erase_en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2840,8 +2770,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_erase_en_3_qs)
   );
 
-
-  // F[scramble_en_3]: 4:4
+  //   F[scramble_en_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2866,8 +2795,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_scramble_en_3_qs)
   );
 
-
-  // F[ecc_en_3]: 5:5
+  //   F[ecc_en_3]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2892,8 +2820,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_ecc_en_3_qs)
   );
 
-
-  // F[he_en_3]: 6:6
+  //   F[he_en_3]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2918,8 +2845,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_he_en_3_qs)
   );
 
-
-  // F[base_3]: 16:8
+  //   F[base_3]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2944,8 +2870,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_3_base_3_qs)
   );
 
-
-  // F[size_3]: 26:17
+  //   F[size_3]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2973,8 +2898,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 4 of Multireg mp_region_cfg
   // R[mp_region_cfg_4]: V(False)
-
-  // F[en_4]: 0:0
+  //   F[en_4]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2999,8 +2923,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_en_4_qs)
   );
 
-
-  // F[rd_en_4]: 1:1
+  //   F[rd_en_4]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3025,8 +2948,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_rd_en_4_qs)
   );
 
-
-  // F[prog_en_4]: 2:2
+  //   F[prog_en_4]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3051,8 +2973,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_prog_en_4_qs)
   );
 
-
-  // F[erase_en_4]: 3:3
+  //   F[erase_en_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3077,8 +2998,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_erase_en_4_qs)
   );
 
-
-  // F[scramble_en_4]: 4:4
+  //   F[scramble_en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3103,8 +3023,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_scramble_en_4_qs)
   );
 
-
-  // F[ecc_en_4]: 5:5
+  //   F[ecc_en_4]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3129,8 +3048,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_ecc_en_4_qs)
   );
 
-
-  // F[he_en_4]: 6:6
+  //   F[he_en_4]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3155,8 +3073,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_he_en_4_qs)
   );
 
-
-  // F[base_4]: 16:8
+  //   F[base_4]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3181,8 +3098,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_4_base_4_qs)
   );
 
-
-  // F[size_4]: 26:17
+  //   F[size_4]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3210,8 +3126,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 5 of Multireg mp_region_cfg
   // R[mp_region_cfg_5]: V(False)
-
-  // F[en_5]: 0:0
+  //   F[en_5]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3236,8 +3151,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_en_5_qs)
   );
 
-
-  // F[rd_en_5]: 1:1
+  //   F[rd_en_5]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3262,8 +3176,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_rd_en_5_qs)
   );
 
-
-  // F[prog_en_5]: 2:2
+  //   F[prog_en_5]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3288,8 +3201,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_prog_en_5_qs)
   );
 
-
-  // F[erase_en_5]: 3:3
+  //   F[erase_en_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3314,8 +3226,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_erase_en_5_qs)
   );
 
-
-  // F[scramble_en_5]: 4:4
+  //   F[scramble_en_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3340,8 +3251,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_scramble_en_5_qs)
   );
 
-
-  // F[ecc_en_5]: 5:5
+  //   F[ecc_en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3366,8 +3276,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_ecc_en_5_qs)
   );
 
-
-  // F[he_en_5]: 6:6
+  //   F[he_en_5]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3392,8 +3301,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_he_en_5_qs)
   );
 
-
-  // F[base_5]: 16:8
+  //   F[base_5]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3418,8 +3326,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_5_base_5_qs)
   );
 
-
-  // F[size_5]: 26:17
+  //   F[size_5]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3447,8 +3354,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 6 of Multireg mp_region_cfg
   // R[mp_region_cfg_6]: V(False)
-
-  // F[en_6]: 0:0
+  //   F[en_6]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3473,8 +3379,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_en_6_qs)
   );
 
-
-  // F[rd_en_6]: 1:1
+  //   F[rd_en_6]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3499,8 +3404,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_rd_en_6_qs)
   );
 
-
-  // F[prog_en_6]: 2:2
+  //   F[prog_en_6]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3525,8 +3429,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_prog_en_6_qs)
   );
 
-
-  // F[erase_en_6]: 3:3
+  //   F[erase_en_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3551,8 +3454,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_erase_en_6_qs)
   );
 
-
-  // F[scramble_en_6]: 4:4
+  //   F[scramble_en_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3577,8 +3479,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_scramble_en_6_qs)
   );
 
-
-  // F[ecc_en_6]: 5:5
+  //   F[ecc_en_6]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3603,8 +3504,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_ecc_en_6_qs)
   );
 
-
-  // F[he_en_6]: 6:6
+  //   F[he_en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3629,8 +3529,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_he_en_6_qs)
   );
 
-
-  // F[base_6]: 16:8
+  //   F[base_6]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3655,8 +3554,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_6_base_6_qs)
   );
 
-
-  // F[size_6]: 26:17
+  //   F[size_6]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3684,8 +3582,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 7 of Multireg mp_region_cfg
   // R[mp_region_cfg_7]: V(False)
-
-  // F[en_7]: 0:0
+  //   F[en_7]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3710,8 +3607,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_en_7_qs)
   );
 
-
-  // F[rd_en_7]: 1:1
+  //   F[rd_en_7]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3736,8 +3632,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_rd_en_7_qs)
   );
 
-
-  // F[prog_en_7]: 2:2
+  //   F[prog_en_7]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3762,8 +3657,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_prog_en_7_qs)
   );
 
-
-  // F[erase_en_7]: 3:3
+  //   F[erase_en_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3788,8 +3682,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_erase_en_7_qs)
   );
 
-
-  // F[scramble_en_7]: 4:4
+  //   F[scramble_en_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3814,8 +3707,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_scramble_en_7_qs)
   );
 
-
-  // F[ecc_en_7]: 5:5
+  //   F[ecc_en_7]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3840,8 +3732,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_ecc_en_7_qs)
   );
 
-
-  // F[he_en_7]: 6:6
+  //   F[he_en_7]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3866,8 +3757,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_he_en_7_qs)
   );
 
-
-  // F[base_7]: 16:8
+  //   F[base_7]: 16:8
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3892,8 +3782,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_region_cfg_7_base_7_qs)
   );
 
-
-  // F[size_7]: 26:17
+  //   F[size_7]: 26:17
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -3919,9 +3808,7 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // R[default_region]: V(False)
-
   //   F[rd_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -3946,7 +3833,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_rd_en_qs)
   );
-
 
   //   F[prog_en]: 1:1
   prim_subreg #(
@@ -3973,7 +3859,6 @@ module flash_ctrl_core_reg_top (
     .qs     (default_region_prog_en_qs)
   );
 
-
   //   F[erase_en]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -3998,7 +3883,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_erase_en_qs)
   );
-
 
   //   F[scramble_en]: 3:3
   prim_subreg #(
@@ -4025,7 +3909,6 @@ module flash_ctrl_core_reg_top (
     .qs     (default_region_scramble_en_qs)
   );
 
-
   //   F[ecc_en]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -4050,7 +3933,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_ecc_en_qs)
   );
-
 
   //   F[he_en]: 5:5
   prim_subreg #(
@@ -4078,10 +3960,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4106,9 +3986,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4133,9 +4013,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4160,9 +4040,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4187,9 +4067,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4214,9 +4094,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4241,9 +4121,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4268,9 +4148,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4295,9 +4175,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4322,9 +4202,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg bank0_info0_regwen
   // R[bank0_info0_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4350,11 +4230,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4379,8 +4257,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4405,8 +4282,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4431,8 +4307,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4457,8 +4332,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4483,8 +4357,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4509,8 +4382,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4538,8 +4410,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4564,8 +4435,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4590,8 +4460,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4616,8 +4485,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4642,8 +4510,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4668,8 +4535,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4694,8 +4560,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4723,8 +4588,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 2 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_2]: V(False)
-
-  // F[en_2]: 0:0
+  //   F[en_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4749,8 +4613,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_en_2_qs)
   );
 
-
-  // F[rd_en_2]: 1:1
+  //   F[rd_en_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4775,8 +4638,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_rd_en_2_qs)
   );
 
-
-  // F[prog_en_2]: 2:2
+  //   F[prog_en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4801,8 +4663,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_prog_en_2_qs)
   );
 
-
-  // F[erase_en_2]: 3:3
+  //   F[erase_en_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4827,8 +4688,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_erase_en_2_qs)
   );
 
-
-  // F[scramble_en_2]: 4:4
+  //   F[scramble_en_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4853,8 +4713,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
   );
 
-
-  // F[ecc_en_2]: 5:5
+  //   F[ecc_en_2]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4879,8 +4738,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
   );
 
-
-  // F[he_en_2]: 6:6
+  //   F[he_en_2]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4908,8 +4766,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 3 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_3]: V(False)
-
-  // F[en_3]: 0:0
+  //   F[en_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4934,8 +4791,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_en_3_qs)
   );
 
-
-  // F[rd_en_3]: 1:1
+  //   F[rd_en_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4960,8 +4816,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_rd_en_3_qs)
   );
 
-
-  // F[prog_en_3]: 2:2
+  //   F[prog_en_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4986,8 +4841,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_prog_en_3_qs)
   );
 
-
-  // F[erase_en_3]: 3:3
+  //   F[erase_en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5012,8 +4866,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
   );
 
-
-  // F[scramble_en_3]: 4:4
+  //   F[scramble_en_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5038,8 +4891,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
   );
 
-
-  // F[ecc_en_3]: 5:5
+  //   F[ecc_en_3]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5064,8 +4916,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
   );
 
-
-  // F[he_en_3]: 6:6
+  //   F[he_en_3]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5093,8 +4944,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 4 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_4]: V(False)
-
-  // F[en_4]: 0:0
+  //   F[en_4]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5119,8 +4969,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_en_4_qs)
   );
 
-
-  // F[rd_en_4]: 1:1
+  //   F[rd_en_4]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5145,8 +4994,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_rd_en_4_qs)
   );
 
-
-  // F[prog_en_4]: 2:2
+  //   F[prog_en_4]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5171,8 +5019,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_prog_en_4_qs)
   );
 
-
-  // F[erase_en_4]: 3:3
+  //   F[erase_en_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5197,8 +5044,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_erase_en_4_qs)
   );
 
-
-  // F[scramble_en_4]: 4:4
+  //   F[scramble_en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5223,8 +5069,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_scramble_en_4_qs)
   );
 
-
-  // F[ecc_en_4]: 5:5
+  //   F[ecc_en_4]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5249,8 +5094,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_4_ecc_en_4_qs)
   );
 
-
-  // F[he_en_4]: 6:6
+  //   F[he_en_4]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5278,8 +5122,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 5 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_5]: V(False)
-
-  // F[en_5]: 0:0
+  //   F[en_5]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5304,8 +5147,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_en_5_qs)
   );
 
-
-  // F[rd_en_5]: 1:1
+  //   F[rd_en_5]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5330,8 +5172,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_rd_en_5_qs)
   );
 
-
-  // F[prog_en_5]: 2:2
+  //   F[prog_en_5]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5356,8 +5197,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_prog_en_5_qs)
   );
 
-
-  // F[erase_en_5]: 3:3
+  //   F[erase_en_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5382,8 +5222,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_erase_en_5_qs)
   );
 
-
-  // F[scramble_en_5]: 4:4
+  //   F[scramble_en_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5408,8 +5247,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_scramble_en_5_qs)
   );
 
-
-  // F[ecc_en_5]: 5:5
+  //   F[ecc_en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5434,8 +5272,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_5_ecc_en_5_qs)
   );
 
-
-  // F[he_en_5]: 6:6
+  //   F[he_en_5]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5463,8 +5300,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 6 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_6]: V(False)
-
-  // F[en_6]: 0:0
+  //   F[en_6]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5489,8 +5325,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_en_6_qs)
   );
 
-
-  // F[rd_en_6]: 1:1
+  //   F[rd_en_6]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5515,8 +5350,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_rd_en_6_qs)
   );
 
-
-  // F[prog_en_6]: 2:2
+  //   F[prog_en_6]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5541,8 +5375,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_prog_en_6_qs)
   );
 
-
-  // F[erase_en_6]: 3:3
+  //   F[erase_en_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5567,8 +5400,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_erase_en_6_qs)
   );
 
-
-  // F[scramble_en_6]: 4:4
+  //   F[scramble_en_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5593,8 +5425,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_scramble_en_6_qs)
   );
 
-
-  // F[ecc_en_6]: 5:5
+  //   F[ecc_en_6]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5619,8 +5450,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_6_ecc_en_6_qs)
   );
 
-
-  // F[he_en_6]: 6:6
+  //   F[he_en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5648,8 +5478,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 7 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_7]: V(False)
-
-  // F[en_7]: 0:0
+  //   F[en_7]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5674,8 +5503,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_en_7_qs)
   );
 
-
-  // F[rd_en_7]: 1:1
+  //   F[rd_en_7]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5700,8 +5528,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_rd_en_7_qs)
   );
 
-
-  // F[prog_en_7]: 2:2
+  //   F[prog_en_7]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5726,8 +5553,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_prog_en_7_qs)
   );
 
-
-  // F[erase_en_7]: 3:3
+  //   F[erase_en_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5752,8 +5578,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_erase_en_7_qs)
   );
 
-
-  // F[scramble_en_7]: 4:4
+  //   F[scramble_en_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5778,8 +5603,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_scramble_en_7_qs)
   );
 
-
-  // F[ecc_en_7]: 5:5
+  //   F[ecc_en_7]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5804,8 +5628,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_7_ecc_en_7_qs)
   );
 
-
-  // F[he_en_7]: 6:6
+  //   F[he_en_7]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5833,8 +5656,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 8 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_8]: V(False)
-
-  // F[en_8]: 0:0
+  //   F[en_8]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5859,8 +5681,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_en_8_qs)
   );
 
-
-  // F[rd_en_8]: 1:1
+  //   F[rd_en_8]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5885,8 +5706,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_rd_en_8_qs)
   );
 
-
-  // F[prog_en_8]: 2:2
+  //   F[prog_en_8]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5911,8 +5731,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_prog_en_8_qs)
   );
 
-
-  // F[erase_en_8]: 3:3
+  //   F[erase_en_8]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5937,8 +5756,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_erase_en_8_qs)
   );
 
-
-  // F[scramble_en_8]: 4:4
+  //   F[scramble_en_8]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5963,8 +5781,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_scramble_en_8_qs)
   );
 
-
-  // F[ecc_en_8]: 5:5
+  //   F[ecc_en_8]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5989,8 +5806,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_8_ecc_en_8_qs)
   );
 
-
-  // F[he_en_8]: 6:6
+  //   F[he_en_8]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6018,8 +5834,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 9 of Multireg bank0_info0_page_cfg
   // R[bank0_info0_page_cfg_9]: V(False)
-
-  // F[en_9]: 0:0
+  //   F[en_9]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6044,8 +5859,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_en_9_qs)
   );
 
-
-  // F[rd_en_9]: 1:1
+  //   F[rd_en_9]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6070,8 +5884,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_rd_en_9_qs)
   );
 
-
-  // F[prog_en_9]: 2:2
+  //   F[prog_en_9]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6096,8 +5909,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_prog_en_9_qs)
   );
 
-
-  // F[erase_en_9]: 3:3
+  //   F[erase_en_9]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6122,8 +5934,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_erase_en_9_qs)
   );
 
-
-  // F[scramble_en_9]: 4:4
+  //   F[scramble_en_9]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6148,8 +5959,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_scramble_en_9_qs)
   );
 
-
-  // F[ecc_en_9]: 5:5
+  //   F[ecc_en_9]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6174,8 +5984,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info0_page_cfg_9_ecc_en_9_qs)
   );
 
-
-  // F[he_en_9]: 6:6
+  //   F[he_en_9]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6201,11 +6010,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank0_info1_regwen
   // R[bank0_info1_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6231,11 +6037,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info1_page_cfg
   // R[bank0_info1_page_cfg]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6260,8 +6064,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6286,8 +6089,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6312,8 +6114,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6338,8 +6139,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6364,8 +6164,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6390,8 +6189,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info1_page_cfg_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6417,11 +6215,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank0_info2_regwen
   // R[bank0_info2_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6446,9 +6241,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank0_info2_regwen
   // R[bank0_info2_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6474,11 +6269,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank0_info2_page_cfg
   // R[bank0_info2_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6503,8 +6296,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6529,8 +6321,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6555,8 +6346,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6581,8 +6371,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6607,8 +6396,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6633,8 +6421,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6662,8 +6449,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank0_info2_page_cfg
   // R[bank0_info2_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6688,8 +6474,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6714,8 +6499,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6740,8 +6524,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6766,8 +6549,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6792,8 +6574,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6818,8 +6599,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank0_info2_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6845,11 +6625,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6874,9 +6651,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6901,9 +6678,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6928,9 +6705,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6955,9 +6732,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6982,9 +6759,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7009,9 +6786,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7036,9 +6813,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7063,9 +6840,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7090,9 +6867,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg bank1_info0_regwen
   // R[bank1_info0_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7118,11 +6895,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7147,8 +6922,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7173,8 +6947,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7199,8 +6972,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7225,8 +6997,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7251,8 +7022,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7277,8 +7047,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7306,8 +7075,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7332,8 +7100,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7358,8 +7125,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7384,8 +7150,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7410,8 +7175,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7436,8 +7200,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7462,8 +7225,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7491,8 +7253,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 2 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_2]: V(False)
-
-  // F[en_2]: 0:0
+  //   F[en_2]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7517,8 +7278,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_en_2_qs)
   );
 
-
-  // F[rd_en_2]: 1:1
+  //   F[rd_en_2]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7543,8 +7303,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_rd_en_2_qs)
   );
 
-
-  // F[prog_en_2]: 2:2
+  //   F[prog_en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7569,8 +7328,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_prog_en_2_qs)
   );
 
-
-  // F[erase_en_2]: 3:3
+  //   F[erase_en_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7595,8 +7353,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_erase_en_2_qs)
   );
 
-
-  // F[scramble_en_2]: 4:4
+  //   F[scramble_en_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7621,8 +7378,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
   );
 
-
-  // F[ecc_en_2]: 5:5
+  //   F[ecc_en_2]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7647,8 +7403,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
   );
 
-
-  // F[he_en_2]: 6:6
+  //   F[he_en_2]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7676,8 +7431,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 3 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_3]: V(False)
-
-  // F[en_3]: 0:0
+  //   F[en_3]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7702,8 +7456,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_en_3_qs)
   );
 
-
-  // F[rd_en_3]: 1:1
+  //   F[rd_en_3]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7728,8 +7481,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_rd_en_3_qs)
   );
 
-
-  // F[prog_en_3]: 2:2
+  //   F[prog_en_3]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7754,8 +7506,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_prog_en_3_qs)
   );
 
-
-  // F[erase_en_3]: 3:3
+  //   F[erase_en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7780,8 +7531,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
   );
 
-
-  // F[scramble_en_3]: 4:4
+  //   F[scramble_en_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7806,8 +7556,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
   );
 
-
-  // F[ecc_en_3]: 5:5
+  //   F[ecc_en_3]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7832,8 +7581,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
   );
 
-
-  // F[he_en_3]: 6:6
+  //   F[he_en_3]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7861,8 +7609,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 4 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_4]: V(False)
-
-  // F[en_4]: 0:0
+  //   F[en_4]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7887,8 +7634,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_en_4_qs)
   );
 
-
-  // F[rd_en_4]: 1:1
+  //   F[rd_en_4]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7913,8 +7659,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_rd_en_4_qs)
   );
 
-
-  // F[prog_en_4]: 2:2
+  //   F[prog_en_4]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7939,8 +7684,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_prog_en_4_qs)
   );
 
-
-  // F[erase_en_4]: 3:3
+  //   F[erase_en_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7965,8 +7709,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_erase_en_4_qs)
   );
 
-
-  // F[scramble_en_4]: 4:4
+  //   F[scramble_en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7991,8 +7734,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_scramble_en_4_qs)
   );
 
-
-  // F[ecc_en_4]: 5:5
+  //   F[ecc_en_4]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8017,8 +7759,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_4_ecc_en_4_qs)
   );
 
-
-  // F[he_en_4]: 6:6
+  //   F[he_en_4]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8046,8 +7787,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 5 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_5]: V(False)
-
-  // F[en_5]: 0:0
+  //   F[en_5]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8072,8 +7812,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_en_5_qs)
   );
 
-
-  // F[rd_en_5]: 1:1
+  //   F[rd_en_5]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8098,8 +7837,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_rd_en_5_qs)
   );
 
-
-  // F[prog_en_5]: 2:2
+  //   F[prog_en_5]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8124,8 +7862,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_prog_en_5_qs)
   );
 
-
-  // F[erase_en_5]: 3:3
+  //   F[erase_en_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8150,8 +7887,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_erase_en_5_qs)
   );
 
-
-  // F[scramble_en_5]: 4:4
+  //   F[scramble_en_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8176,8 +7912,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_scramble_en_5_qs)
   );
 
-
-  // F[ecc_en_5]: 5:5
+  //   F[ecc_en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8202,8 +7937,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_5_ecc_en_5_qs)
   );
 
-
-  // F[he_en_5]: 6:6
+  //   F[he_en_5]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8231,8 +7965,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 6 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_6]: V(False)
-
-  // F[en_6]: 0:0
+  //   F[en_6]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8257,8 +7990,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_en_6_qs)
   );
 
-
-  // F[rd_en_6]: 1:1
+  //   F[rd_en_6]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8283,8 +8015,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_rd_en_6_qs)
   );
 
-
-  // F[prog_en_6]: 2:2
+  //   F[prog_en_6]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8309,8 +8040,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_prog_en_6_qs)
   );
 
-
-  // F[erase_en_6]: 3:3
+  //   F[erase_en_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8335,8 +8065,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_erase_en_6_qs)
   );
 
-
-  // F[scramble_en_6]: 4:4
+  //   F[scramble_en_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8361,8 +8090,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_scramble_en_6_qs)
   );
 
-
-  // F[ecc_en_6]: 5:5
+  //   F[ecc_en_6]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8387,8 +8115,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_6_ecc_en_6_qs)
   );
 
-
-  // F[he_en_6]: 6:6
+  //   F[he_en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8416,8 +8143,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 7 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_7]: V(False)
-
-  // F[en_7]: 0:0
+  //   F[en_7]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8442,8 +8168,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_en_7_qs)
   );
 
-
-  // F[rd_en_7]: 1:1
+  //   F[rd_en_7]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8468,8 +8193,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_rd_en_7_qs)
   );
 
-
-  // F[prog_en_7]: 2:2
+  //   F[prog_en_7]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8494,8 +8218,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_prog_en_7_qs)
   );
 
-
-  // F[erase_en_7]: 3:3
+  //   F[erase_en_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8520,8 +8243,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_erase_en_7_qs)
   );
 
-
-  // F[scramble_en_7]: 4:4
+  //   F[scramble_en_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8546,8 +8268,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_scramble_en_7_qs)
   );
 
-
-  // F[ecc_en_7]: 5:5
+  //   F[ecc_en_7]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8572,8 +8293,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_7_ecc_en_7_qs)
   );
 
-
-  // F[he_en_7]: 6:6
+  //   F[he_en_7]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8601,8 +8321,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 8 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_8]: V(False)
-
-  // F[en_8]: 0:0
+  //   F[en_8]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8627,8 +8346,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_en_8_qs)
   );
 
-
-  // F[rd_en_8]: 1:1
+  //   F[rd_en_8]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8653,8 +8371,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_rd_en_8_qs)
   );
 
-
-  // F[prog_en_8]: 2:2
+  //   F[prog_en_8]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8679,8 +8396,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_prog_en_8_qs)
   );
 
-
-  // F[erase_en_8]: 3:3
+  //   F[erase_en_8]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8705,8 +8421,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_erase_en_8_qs)
   );
 
-
-  // F[scramble_en_8]: 4:4
+  //   F[scramble_en_8]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8731,8 +8446,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_scramble_en_8_qs)
   );
 
-
-  // F[ecc_en_8]: 5:5
+  //   F[ecc_en_8]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8757,8 +8471,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_8_ecc_en_8_qs)
   );
 
-
-  // F[he_en_8]: 6:6
+  //   F[he_en_8]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8786,8 +8499,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 9 of Multireg bank1_info0_page_cfg
   // R[bank1_info0_page_cfg_9]: V(False)
-
-  // F[en_9]: 0:0
+  //   F[en_9]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8812,8 +8524,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_en_9_qs)
   );
 
-
-  // F[rd_en_9]: 1:1
+  //   F[rd_en_9]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8838,8 +8549,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_rd_en_9_qs)
   );
 
-
-  // F[prog_en_9]: 2:2
+  //   F[prog_en_9]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8864,8 +8574,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_prog_en_9_qs)
   );
 
-
-  // F[erase_en_9]: 3:3
+  //   F[erase_en_9]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8890,8 +8599,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_erase_en_9_qs)
   );
 
-
-  // F[scramble_en_9]: 4:4
+  //   F[scramble_en_9]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8916,8 +8624,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_scramble_en_9_qs)
   );
 
-
-  // F[ecc_en_9]: 5:5
+  //   F[ecc_en_9]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8942,8 +8649,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info0_page_cfg_9_ecc_en_9_qs)
   );
 
-
-  // F[he_en_9]: 6:6
+  //   F[he_en_9]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8969,11 +8675,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank1_info1_regwen
   // R[bank1_info1_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8999,11 +8702,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank1_info1_page_cfg
   // R[bank1_info1_page_cfg]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9028,8 +8729,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9054,8 +8754,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9080,8 +8779,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9106,8 +8804,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9132,8 +8829,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9158,8 +8854,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info1_page_cfg_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9185,11 +8880,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg bank1_info2_regwen
   // R[bank1_info2_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9214,9 +8906,9 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg bank1_info2_regwen
   // R[bank1_info2_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9242,11 +8934,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg bank1_info2_page_cfg
   // R[bank1_info2_page_cfg_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9271,8 +8961,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_en_0_qs)
   );
 
-
-  // F[rd_en_0]: 1:1
+  //   F[rd_en_0]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9297,8 +8986,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_rd_en_0_qs)
   );
 
-
-  // F[prog_en_0]: 2:2
+  //   F[prog_en_0]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9323,8 +9011,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_prog_en_0_qs)
   );
 
-
-  // F[erase_en_0]: 3:3
+  //   F[erase_en_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9349,8 +9036,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_erase_en_0_qs)
   );
 
-
-  // F[scramble_en_0]: 4:4
+  //   F[scramble_en_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9375,8 +9061,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_scramble_en_0_qs)
   );
 
-
-  // F[ecc_en_0]: 5:5
+  //   F[ecc_en_0]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9401,8 +9086,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_0_ecc_en_0_qs)
   );
 
-
-  // F[he_en_0]: 6:6
+  //   F[he_en_0]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9430,8 +9114,7 @@ module flash_ctrl_core_reg_top (
 
   // Subregister 1 of Multireg bank1_info2_page_cfg
   // R[bank1_info2_page_cfg_1]: V(False)
-
-  // F[en_1]: 0:0
+  //   F[en_1]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9456,8 +9139,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_en_1_qs)
   );
 
-
-  // F[rd_en_1]: 1:1
+  //   F[rd_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9482,8 +9164,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_rd_en_1_qs)
   );
 
-
-  // F[prog_en_1]: 2:2
+  //   F[prog_en_1]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9508,8 +9189,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_prog_en_1_qs)
   );
 
-
-  // F[erase_en_1]: 3:3
+  //   F[erase_en_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9534,8 +9214,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_erase_en_1_qs)
   );
 
-
-  // F[scramble_en_1]: 4:4
+  //   F[scramble_en_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9560,8 +9239,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_scramble_en_1_qs)
   );
 
-
-  // F[ecc_en_1]: 5:5
+  //   F[ecc_en_1]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9586,8 +9264,7 @@ module flash_ctrl_core_reg_top (
     .qs     (bank1_info2_page_cfg_1_ecc_en_1_qs)
   );
 
-
-  // F[he_en_1]: 6:6
+  //   F[he_en_1]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9613,9 +9290,7 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // R[bank_cfg_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9641,11 +9316,9 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mp_bank_cfg
   // R[mp_bank_cfg]: V(False)
-
-  // F[erase_en_0]: 0:0
+  //   F[erase_en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9670,8 +9343,7 @@ module flash_ctrl_core_reg_top (
     .qs     (mp_bank_cfg_erase_en_0_qs)
   );
 
-
-  // F[erase_en_1]: 1:1
+  //   F[erase_en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9697,9 +9369,7 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // R[op_status]: V(False)
-
   //   F[done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -9724,7 +9394,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (op_status_done_qs)
   );
-
 
   //   F[err]: 1:1
   prim_subreg #(
@@ -9753,7 +9422,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[status]: V(False)
-
   //   F[rd_full]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -9778,7 +9446,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (status_rd_full_qs)
   );
-
 
   //   F[rd_empty]: 1:1
   prim_subreg #(
@@ -9805,7 +9472,6 @@ module flash_ctrl_core_reg_top (
     .qs     (status_rd_empty_qs)
   );
 
-
   //   F[prog_full]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -9831,7 +9497,6 @@ module flash_ctrl_core_reg_top (
     .qs     (status_prog_full_qs)
   );
 
-
   //   F[prog_empty]: 3:3
   prim_subreg #(
     .DW      (1),
@@ -9856,7 +9521,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (status_prog_empty_qs)
   );
-
 
   //   F[init_wip]: 4:4
   prim_subreg #(
@@ -9885,7 +9549,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_code_intr_en]: V(False)
-
   //   F[flash_err_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -9910,7 +9573,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_intr_en_flash_err_en_qs)
   );
-
 
   //   F[flash_alert_en]: 1:1
   prim_subreg #(
@@ -9937,7 +9599,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_intr_en_flash_alert_en_qs)
   );
 
-
   //   F[oob_err]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -9962,7 +9623,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_intr_en_oob_err_qs)
   );
-
 
   //   F[mp_err]: 3:3
   prim_subreg #(
@@ -9989,7 +9649,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_intr_en_mp_err_qs)
   );
 
-
   //   F[ecc_single_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -10014,7 +9673,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_intr_en_ecc_single_err_qs)
   );
-
 
   //   F[ecc_multi_err]: 5:5
   prim_subreg #(
@@ -10043,7 +9701,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_code]: V(False)
-
   //   F[flash_err]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -10068,7 +9725,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_flash_err_qs)
   );
-
 
   //   F[flash_alert]: 1:1
   prim_subreg #(
@@ -10095,7 +9751,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_flash_alert_qs)
   );
 
-
   //   F[oob_err]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -10120,7 +9775,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_oob_err_qs)
   );
-
 
   //   F[mp_err]: 3:3
   prim_subreg #(
@@ -10147,7 +9801,6 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_mp_err_qs)
   );
 
-
   //   F[ecc_single_err]: 4:4
   prim_subreg #(
     .DW      (1),
@@ -10172,7 +9825,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (err_code_ecc_single_err_qs)
   );
-
 
   //   F[ecc_multi_err]: 5:5
   prim_subreg #(
@@ -10201,7 +9853,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_addr]: V(False)
-
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10228,7 +9879,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[ecc_single_err_cnt]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10254,10 +9904,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ecc_single_err_addr
   // R[ecc_single_err_addr_0]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10282,9 +9930,9 @@ module flash_ctrl_core_reg_top (
     .qs     (ecc_single_err_addr_0_qs)
   );
 
+
   // Subregister 1 of Multireg ecc_single_err_addr
   // R[ecc_single_err_addr_1]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10311,7 +9959,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[ecc_multi_err_cnt]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -10337,10 +9984,8 @@ module flash_ctrl_core_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ecc_multi_err_addr
   // R[ecc_multi_err_addr_0]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10365,9 +10010,9 @@ module flash_ctrl_core_reg_top (
     .qs     (ecc_multi_err_addr_0_qs)
   );
 
+
   // Subregister 1 of Multireg ecc_multi_err_addr
   // R[ecc_multi_err_addr_1]: V(False)
-
   prim_subreg #(
     .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -10394,7 +10039,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_err_cfg_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10421,7 +10065,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_err_cfg]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10448,7 +10091,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_alert_cfg]: V(False)
-
   //   F[alert_ack]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -10473,7 +10115,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (phy_alert_cfg_alert_ack_qs)
   );
-
 
   //   F[alert_trig]: 1:1
   prim_subreg #(
@@ -10502,7 +10143,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[phy_status]: V(False)
-
   //   F[init_wip]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -10528,7 +10168,6 @@ module flash_ctrl_core_reg_top (
     .qs     (phy_status_init_wip_qs)
   );
 
-
   //   F[prog_normal_avail]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -10553,7 +10192,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (phy_status_prog_normal_avail_qs)
   );
-
 
   //   F[prog_repair_avail]: 2:2
   prim_subreg #(
@@ -10582,7 +10220,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[scratch]: V(False)
-
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10609,7 +10246,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[fifo_lvl]: V(False)
-
   //   F[prog]: 4:0
   prim_subreg #(
     .DW      (5),
@@ -10634,7 +10270,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (fifo_lvl_prog_qs)
   );
-
 
   //   F[rd]: 12:8
   prim_subreg #(
@@ -10663,7 +10298,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[fifo_rst]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10687,7 +10321,6 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (fifo_rst_qs)
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -3087,7 +3087,6 @@ module pinmux_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -3102,10 +3101,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3130,9 +3127,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3157,9 +3154,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3184,9 +3181,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3211,9 +3208,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3238,9 +3235,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3265,9 +3262,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3292,9 +3289,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3319,9 +3316,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3346,9 +3343,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3373,9 +3370,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3400,9 +3397,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3427,9 +3424,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3454,9 +3451,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3481,9 +3478,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3508,9 +3505,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3535,9 +3532,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3562,9 +3559,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3589,9 +3586,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3616,9 +3613,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3643,9 +3640,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3670,9 +3667,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3697,9 +3694,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3724,9 +3721,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3751,9 +3748,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3778,9 +3775,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3805,9 +3802,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3832,9 +3829,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3859,9 +3856,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3886,9 +3883,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3913,9 +3910,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3940,9 +3937,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3967,9 +3964,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -3994,9 +3991,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4021,9 +4018,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4048,9 +4045,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4075,9 +4072,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4102,9 +4099,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4129,9 +4126,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4156,9 +4153,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4183,9 +4180,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4210,9 +4207,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4237,9 +4234,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4264,9 +4261,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4291,9 +4288,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4318,9 +4315,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4345,9 +4342,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4372,9 +4369,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_46_qs)
   );
 
+
   // Subregister 47 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_47]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4399,9 +4396,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_47_qs)
   );
 
+
   // Subregister 48 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_48]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4426,9 +4423,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_48_qs)
   );
 
+
   // Subregister 49 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_49]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4453,9 +4450,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_49_qs)
   );
 
+
   // Subregister 50 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_50]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4480,9 +4477,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_50_qs)
   );
 
+
   // Subregister 51 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_51]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4507,9 +4504,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_51_qs)
   );
 
+
   // Subregister 52 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_52]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4534,9 +4531,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_52_qs)
   );
 
+
   // Subregister 53 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_53]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4561,9 +4558,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_regwen_53_qs)
   );
 
+
   // Subregister 54 of Multireg mio_periph_insel_regwen
   // R[mio_periph_insel_regwen_54]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -4589,10 +4586,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_periph_insel
   // R[mio_periph_insel_0]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4617,9 +4612,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_periph_insel
   // R[mio_periph_insel_1]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4644,9 +4639,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_periph_insel
   // R[mio_periph_insel_2]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4671,9 +4666,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_periph_insel
   // R[mio_periph_insel_3]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4698,9 +4693,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_periph_insel
   // R[mio_periph_insel_4]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4725,9 +4720,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_periph_insel
   // R[mio_periph_insel_5]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4752,9 +4747,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_periph_insel
   // R[mio_periph_insel_6]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4779,9 +4774,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_periph_insel
   // R[mio_periph_insel_7]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4806,9 +4801,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_periph_insel
   // R[mio_periph_insel_8]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4833,9 +4828,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_periph_insel
   // R[mio_periph_insel_9]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4860,9 +4855,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_periph_insel
   // R[mio_periph_insel_10]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4887,9 +4882,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_periph_insel
   // R[mio_periph_insel_11]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4914,9 +4909,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_periph_insel
   // R[mio_periph_insel_12]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4941,9 +4936,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_periph_insel
   // R[mio_periph_insel_13]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4968,9 +4963,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_periph_insel
   // R[mio_periph_insel_14]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -4995,9 +4990,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_periph_insel
   // R[mio_periph_insel_15]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5022,9 +5017,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_periph_insel
   // R[mio_periph_insel_16]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5049,9 +5044,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_periph_insel
   // R[mio_periph_insel_17]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5076,9 +5071,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_periph_insel
   // R[mio_periph_insel_18]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5103,9 +5098,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_periph_insel
   // R[mio_periph_insel_19]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5130,9 +5125,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_periph_insel
   // R[mio_periph_insel_20]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5157,9 +5152,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_periph_insel
   // R[mio_periph_insel_21]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5184,9 +5179,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_periph_insel
   // R[mio_periph_insel_22]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5211,9 +5206,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_periph_insel
   // R[mio_periph_insel_23]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5238,9 +5233,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_periph_insel
   // R[mio_periph_insel_24]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5265,9 +5260,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_periph_insel
   // R[mio_periph_insel_25]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5292,9 +5287,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_periph_insel
   // R[mio_periph_insel_26]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5319,9 +5314,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_periph_insel
   // R[mio_periph_insel_27]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5346,9 +5341,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_periph_insel
   // R[mio_periph_insel_28]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5373,9 +5368,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_periph_insel
   // R[mio_periph_insel_29]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5400,9 +5395,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_periph_insel
   // R[mio_periph_insel_30]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5427,9 +5422,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_periph_insel
   // R[mio_periph_insel_31]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5454,9 +5449,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_periph_insel
   // R[mio_periph_insel_32]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5481,9 +5476,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_periph_insel
   // R[mio_periph_insel_33]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5508,9 +5503,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_periph_insel
   // R[mio_periph_insel_34]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5535,9 +5530,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_periph_insel
   // R[mio_periph_insel_35]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5562,9 +5557,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_periph_insel
   // R[mio_periph_insel_36]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5589,9 +5584,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_periph_insel
   // R[mio_periph_insel_37]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5616,9 +5611,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_periph_insel
   // R[mio_periph_insel_38]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5643,9 +5638,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_periph_insel
   // R[mio_periph_insel_39]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5670,9 +5665,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_periph_insel
   // R[mio_periph_insel_40]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5697,9 +5692,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_periph_insel
   // R[mio_periph_insel_41]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5724,9 +5719,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_periph_insel
   // R[mio_periph_insel_42]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5751,9 +5746,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_periph_insel
   // R[mio_periph_insel_43]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5778,9 +5773,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_periph_insel
   // R[mio_periph_insel_44]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5805,9 +5800,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_periph_insel
   // R[mio_periph_insel_45]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5832,9 +5827,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_periph_insel
   // R[mio_periph_insel_46]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5859,9 +5854,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_46_qs)
   );
 
+
   // Subregister 47 of Multireg mio_periph_insel
   // R[mio_periph_insel_47]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5886,9 +5881,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_47_qs)
   );
 
+
   // Subregister 48 of Multireg mio_periph_insel
   // R[mio_periph_insel_48]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5913,9 +5908,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_48_qs)
   );
 
+
   // Subregister 49 of Multireg mio_periph_insel
   // R[mio_periph_insel_49]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5940,9 +5935,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_49_qs)
   );
 
+
   // Subregister 50 of Multireg mio_periph_insel
   // R[mio_periph_insel_50]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5967,9 +5962,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_50_qs)
   );
 
+
   // Subregister 51 of Multireg mio_periph_insel
   // R[mio_periph_insel_51]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -5994,9 +5989,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_51_qs)
   );
 
+
   // Subregister 52 of Multireg mio_periph_insel
   // R[mio_periph_insel_52]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6021,9 +6016,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_52_qs)
   );
 
+
   // Subregister 53 of Multireg mio_periph_insel
   // R[mio_periph_insel_53]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6048,9 +6043,9 @@ module pinmux_reg_top (
     .qs     (mio_periph_insel_53_qs)
   );
 
+
   // Subregister 54 of Multireg mio_periph_insel
   // R[mio_periph_insel_54]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6076,10 +6071,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6104,9 +6097,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6131,9 +6124,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6158,9 +6151,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6185,9 +6178,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6212,9 +6205,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6239,9 +6232,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6266,9 +6259,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6293,9 +6286,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6320,9 +6313,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6347,9 +6340,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6374,9 +6367,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6401,9 +6394,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6428,9 +6421,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6455,9 +6448,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6482,9 +6475,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6509,9 +6502,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6536,9 +6529,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6563,9 +6556,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6590,9 +6583,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6617,9 +6610,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6644,9 +6637,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6671,9 +6664,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6698,9 +6691,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6725,9 +6718,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6752,9 +6745,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6779,9 +6772,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6806,9 +6799,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6833,9 +6826,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6860,9 +6853,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6887,9 +6880,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6914,9 +6907,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6941,9 +6934,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6968,9 +6961,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -6995,9 +6988,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7022,9 +7015,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7049,9 +7042,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7076,9 +7069,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7103,9 +7096,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7130,9 +7123,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7157,9 +7150,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7184,9 +7177,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7211,9 +7204,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7238,9 +7231,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7265,9 +7258,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7292,9 +7285,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7319,9 +7312,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_regwen_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_outsel_regwen
   // R[mio_outsel_regwen_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -7347,10 +7340,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_outsel
   // R[mio_outsel_0]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7375,9 +7366,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_outsel
   // R[mio_outsel_1]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7402,9 +7393,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_outsel
   // R[mio_outsel_2]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7429,9 +7420,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_outsel
   // R[mio_outsel_3]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7456,9 +7447,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_outsel
   // R[mio_outsel_4]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7483,9 +7474,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_outsel
   // R[mio_outsel_5]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7510,9 +7501,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_outsel
   // R[mio_outsel_6]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7537,9 +7528,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_outsel
   // R[mio_outsel_7]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7564,9 +7555,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_outsel
   // R[mio_outsel_8]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7591,9 +7582,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_outsel
   // R[mio_outsel_9]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7618,9 +7609,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_outsel
   // R[mio_outsel_10]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7645,9 +7636,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_outsel
   // R[mio_outsel_11]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7672,9 +7663,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_outsel
   // R[mio_outsel_12]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7699,9 +7690,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_outsel
   // R[mio_outsel_13]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7726,9 +7717,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_outsel
   // R[mio_outsel_14]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7753,9 +7744,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_outsel
   // R[mio_outsel_15]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7780,9 +7771,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_outsel
   // R[mio_outsel_16]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7807,9 +7798,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_outsel
   // R[mio_outsel_17]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7834,9 +7825,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_outsel
   // R[mio_outsel_18]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7861,9 +7852,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_outsel
   // R[mio_outsel_19]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7888,9 +7879,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_outsel
   // R[mio_outsel_20]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7915,9 +7906,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_outsel
   // R[mio_outsel_21]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7942,9 +7933,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_outsel
   // R[mio_outsel_22]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7969,9 +7960,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_outsel
   // R[mio_outsel_23]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7996,9 +7987,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_outsel
   // R[mio_outsel_24]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8023,9 +8014,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_outsel
   // R[mio_outsel_25]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8050,9 +8041,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_outsel
   // R[mio_outsel_26]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8077,9 +8068,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_outsel
   // R[mio_outsel_27]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8104,9 +8095,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_outsel
   // R[mio_outsel_28]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8131,9 +8122,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_outsel
   // R[mio_outsel_29]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8158,9 +8149,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_outsel
   // R[mio_outsel_30]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8185,9 +8176,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_outsel
   // R[mio_outsel_31]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8212,9 +8203,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_outsel
   // R[mio_outsel_32]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8239,9 +8230,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_outsel
   // R[mio_outsel_33]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8266,9 +8257,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_outsel
   // R[mio_outsel_34]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8293,9 +8284,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_outsel
   // R[mio_outsel_35]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8320,9 +8311,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_outsel
   // R[mio_outsel_36]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8347,9 +8338,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_outsel
   // R[mio_outsel_37]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8374,9 +8365,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_outsel
   // R[mio_outsel_38]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8401,9 +8392,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_outsel
   // R[mio_outsel_39]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8428,9 +8419,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_outsel
   // R[mio_outsel_40]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8455,9 +8446,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_outsel
   // R[mio_outsel_41]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8482,9 +8473,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_outsel
   // R[mio_outsel_42]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8509,9 +8500,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_outsel
   // R[mio_outsel_43]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8536,9 +8527,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_outsel
   // R[mio_outsel_44]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8563,9 +8554,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_outsel
   // R[mio_outsel_45]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8590,9 +8581,9 @@ module pinmux_reg_top (
     .qs     (mio_outsel_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_outsel
   // R[mio_outsel_46]: V(False)
-
   prim_subreg #(
     .DW      (7),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8618,10 +8609,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8646,9 +8635,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8673,9 +8662,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8700,9 +8689,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8727,9 +8716,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8754,9 +8743,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8781,9 +8770,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8808,9 +8797,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8835,9 +8824,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8862,9 +8851,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8889,9 +8878,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8916,9 +8905,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8943,9 +8932,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8970,9 +8959,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -8997,9 +8986,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9024,9 +9013,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9051,9 +9040,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9078,9 +9067,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9105,9 +9094,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9132,9 +9121,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9159,9 +9148,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9186,9 +9175,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9213,9 +9202,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9240,9 +9229,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9267,9 +9256,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9294,9 +9283,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9321,9 +9310,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9348,9 +9337,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9375,9 +9364,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9402,9 +9391,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9429,9 +9418,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9456,9 +9445,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9483,9 +9472,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9510,9 +9499,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9537,9 +9526,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9564,9 +9553,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9591,9 +9580,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9618,9 +9607,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9645,9 +9634,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9672,9 +9661,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9699,9 +9688,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9726,9 +9715,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9753,9 +9742,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9780,9 +9769,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9807,9 +9796,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9834,9 +9823,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9861,9 +9850,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_regwen_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_pad_attr_regwen
   // R[mio_pad_attr_regwen_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -9889,10 +9878,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_attr
   // R[mio_pad_attr_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_0 (
@@ -9906,9 +9893,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_attr
   // R[mio_pad_attr_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_1 (
@@ -9922,9 +9909,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_attr
   // R[mio_pad_attr_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_2 (
@@ -9938,9 +9925,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_attr
   // R[mio_pad_attr_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_3 (
@@ -9954,9 +9941,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_attr
   // R[mio_pad_attr_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_4 (
@@ -9970,9 +9957,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_attr
   // R[mio_pad_attr_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_5 (
@@ -9986,9 +9973,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_attr
   // R[mio_pad_attr_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_6 (
@@ -10002,9 +9989,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_attr
   // R[mio_pad_attr_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_7 (
@@ -10018,9 +10005,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_attr
   // R[mio_pad_attr_8]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_8 (
@@ -10034,9 +10021,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_attr
   // R[mio_pad_attr_9]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_9 (
@@ -10050,9 +10037,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_attr
   // R[mio_pad_attr_10]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_10 (
@@ -10066,9 +10053,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_attr
   // R[mio_pad_attr_11]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_11 (
@@ -10082,9 +10069,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_attr
   // R[mio_pad_attr_12]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_12 (
@@ -10098,9 +10085,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_attr
   // R[mio_pad_attr_13]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_13 (
@@ -10114,9 +10101,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_attr
   // R[mio_pad_attr_14]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_14 (
@@ -10130,9 +10117,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_attr
   // R[mio_pad_attr_15]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_15 (
@@ -10146,9 +10133,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_attr
   // R[mio_pad_attr_16]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_16 (
@@ -10162,9 +10149,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_attr
   // R[mio_pad_attr_17]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_17 (
@@ -10178,9 +10165,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_attr
   // R[mio_pad_attr_18]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_18 (
@@ -10194,9 +10181,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_attr
   // R[mio_pad_attr_19]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_19 (
@@ -10210,9 +10197,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_attr
   // R[mio_pad_attr_20]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_20 (
@@ -10226,9 +10213,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_attr
   // R[mio_pad_attr_21]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_21 (
@@ -10242,9 +10229,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_attr
   // R[mio_pad_attr_22]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_22 (
@@ -10258,9 +10245,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_attr
   // R[mio_pad_attr_23]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_23 (
@@ -10274,9 +10261,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_attr
   // R[mio_pad_attr_24]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_24 (
@@ -10290,9 +10277,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_attr
   // R[mio_pad_attr_25]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_25 (
@@ -10306,9 +10293,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_attr
   // R[mio_pad_attr_26]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_26 (
@@ -10322,9 +10309,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_attr
   // R[mio_pad_attr_27]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_27 (
@@ -10338,9 +10325,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_attr
   // R[mio_pad_attr_28]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_28 (
@@ -10354,9 +10341,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_attr
   // R[mio_pad_attr_29]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_29 (
@@ -10370,9 +10357,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_attr
   // R[mio_pad_attr_30]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_30 (
@@ -10386,9 +10373,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_attr
   // R[mio_pad_attr_31]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_31 (
@@ -10402,9 +10389,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_pad_attr
   // R[mio_pad_attr_32]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_32 (
@@ -10418,9 +10405,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_pad_attr
   // R[mio_pad_attr_33]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_33 (
@@ -10434,9 +10421,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_pad_attr
   // R[mio_pad_attr_34]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_34 (
@@ -10450,9 +10437,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_pad_attr
   // R[mio_pad_attr_35]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_35 (
@@ -10466,9 +10453,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_pad_attr
   // R[mio_pad_attr_36]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_36 (
@@ -10482,9 +10469,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_pad_attr
   // R[mio_pad_attr_37]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_37 (
@@ -10498,9 +10485,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_pad_attr
   // R[mio_pad_attr_38]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_38 (
@@ -10514,9 +10501,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_pad_attr
   // R[mio_pad_attr_39]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_39 (
@@ -10530,9 +10517,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_pad_attr
   // R[mio_pad_attr_40]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_40 (
@@ -10546,9 +10533,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_pad_attr
   // R[mio_pad_attr_41]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_41 (
@@ -10562,9 +10549,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_pad_attr
   // R[mio_pad_attr_42]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_42 (
@@ -10578,9 +10565,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_pad_attr
   // R[mio_pad_attr_43]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_43 (
@@ -10594,9 +10581,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_pad_attr
   // R[mio_pad_attr_44]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_44 (
@@ -10610,9 +10597,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_pad_attr
   // R[mio_pad_attr_45]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_45 (
@@ -10626,9 +10613,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_attr_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_pad_attr
   // R[mio_pad_attr_46]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_46 (
@@ -10643,10 +10630,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10671,9 +10656,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10698,9 +10683,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10725,9 +10710,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10752,9 +10737,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10779,9 +10764,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10806,9 +10791,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10833,9 +10818,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10860,9 +10845,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10887,9 +10872,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10914,9 +10899,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10941,9 +10926,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10968,9 +10953,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -10995,9 +10980,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11022,9 +11007,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11049,9 +11034,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11076,9 +11061,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11103,9 +11088,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11130,9 +11115,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11157,9 +11142,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11184,9 +11169,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11211,9 +11196,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11238,9 +11223,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11265,9 +11250,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg dio_pad_attr_regwen
   // R[dio_pad_attr_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11293,10 +11278,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_attr
   // R[dio_pad_attr_0]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_0 (
@@ -11310,9 +11293,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_attr
   // R[dio_pad_attr_1]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_1 (
@@ -11326,9 +11309,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_attr
   // R[dio_pad_attr_2]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_2 (
@@ -11342,9 +11325,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_attr
   // R[dio_pad_attr_3]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_3 (
@@ -11358,9 +11341,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_attr
   // R[dio_pad_attr_4]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_4 (
@@ -11374,9 +11357,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_attr
   // R[dio_pad_attr_5]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_5 (
@@ -11390,9 +11373,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_attr
   // R[dio_pad_attr_6]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_6 (
@@ -11406,9 +11389,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_attr
   // R[dio_pad_attr_7]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_7 (
@@ -11422,9 +11405,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_attr
   // R[dio_pad_attr_8]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_8 (
@@ -11438,9 +11421,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_attr
   // R[dio_pad_attr_9]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_9 (
@@ -11454,9 +11437,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_attr
   // R[dio_pad_attr_10]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_10 (
@@ -11470,9 +11453,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_attr
   // R[dio_pad_attr_11]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_11 (
@@ -11486,9 +11469,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_attr
   // R[dio_pad_attr_12]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_12 (
@@ -11502,9 +11485,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_attr
   // R[dio_pad_attr_13]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_13 (
@@ -11518,9 +11501,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_attr
   // R[dio_pad_attr_14]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_14 (
@@ -11534,9 +11517,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_attr
   // R[dio_pad_attr_15]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_15 (
@@ -11550,9 +11533,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_15_qs)
   );
 
+
   // Subregister 16 of Multireg dio_pad_attr
   // R[dio_pad_attr_16]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_16 (
@@ -11566,9 +11549,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_16_qs)
   );
 
+
   // Subregister 17 of Multireg dio_pad_attr
   // R[dio_pad_attr_17]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_17 (
@@ -11582,9 +11565,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_17_qs)
   );
 
+
   // Subregister 18 of Multireg dio_pad_attr
   // R[dio_pad_attr_18]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_18 (
@@ -11598,9 +11581,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_18_qs)
   );
 
+
   // Subregister 19 of Multireg dio_pad_attr
   // R[dio_pad_attr_19]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_19 (
@@ -11614,9 +11597,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_19_qs)
   );
 
+
   // Subregister 20 of Multireg dio_pad_attr
   // R[dio_pad_attr_20]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_20 (
@@ -11630,9 +11613,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_20_qs)
   );
 
+
   // Subregister 21 of Multireg dio_pad_attr
   // R[dio_pad_attr_21]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_21 (
@@ -11646,9 +11629,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_21_qs)
   );
 
+
   // Subregister 22 of Multireg dio_pad_attr
   // R[dio_pad_attr_22]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_22 (
@@ -11662,9 +11645,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_attr_22_qs)
   );
 
+
   // Subregister 23 of Multireg dio_pad_attr
   // R[dio_pad_attr_23]: V(True)
-
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_23 (
@@ -11679,11 +11662,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_sleep_status
   // R[mio_pad_sleep_status_0]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11708,8 +11689,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11734,8 +11714,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_1_qs)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11760,8 +11739,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_2_qs)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11786,8 +11764,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_3_qs)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11812,8 +11789,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_4_qs)
   );
 
-
-  // F[en_5]: 5:5
+  //   F[en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11838,8 +11814,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_5_qs)
   );
 
-
-  // F[en_6]: 6:6
+  //   F[en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11864,8 +11839,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_6_qs)
   );
 
-
-  // F[en_7]: 7:7
+  //   F[en_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11890,8 +11864,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_7_qs)
   );
 
-
-  // F[en_8]: 8:8
+  //   F[en_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11916,8 +11889,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_8_qs)
   );
 
-
-  // F[en_9]: 9:9
+  //   F[en_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11942,8 +11914,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_9_qs)
   );
 
-
-  // F[en_10]: 10:10
+  //   F[en_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11968,8 +11939,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_10_qs)
   );
 
-
-  // F[en_11]: 11:11
+  //   F[en_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -11994,8 +11964,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_11_qs)
   );
 
-
-  // F[en_12]: 12:12
+  //   F[en_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12020,8 +11989,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_12_qs)
   );
 
-
-  // F[en_13]: 13:13
+  //   F[en_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12046,8 +12014,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_13_qs)
   );
 
-
-  // F[en_14]: 14:14
+  //   F[en_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12072,8 +12039,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_14_qs)
   );
 
-
-  // F[en_15]: 15:15
+  //   F[en_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12098,8 +12064,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_15_qs)
   );
 
-
-  // F[en_16]: 16:16
+  //   F[en_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12124,8 +12089,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_16_qs)
   );
 
-
-  // F[en_17]: 17:17
+  //   F[en_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12150,8 +12114,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_17_qs)
   );
 
-
-  // F[en_18]: 18:18
+  //   F[en_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12176,8 +12139,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_18_qs)
   );
 
-
-  // F[en_19]: 19:19
+  //   F[en_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12202,8 +12164,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_19_qs)
   );
 
-
-  // F[en_20]: 20:20
+  //   F[en_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12228,8 +12189,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_20_qs)
   );
 
-
-  // F[en_21]: 21:21
+  //   F[en_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12254,8 +12214,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_21_qs)
   );
 
-
-  // F[en_22]: 22:22
+  //   F[en_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12280,8 +12239,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_22_qs)
   );
 
-
-  // F[en_23]: 23:23
+  //   F[en_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12306,8 +12264,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_23_qs)
   );
 
-
-  // F[en_24]: 24:24
+  //   F[en_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12332,8 +12289,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_24_qs)
   );
 
-
-  // F[en_25]: 25:25
+  //   F[en_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12358,8 +12314,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_25_qs)
   );
 
-
-  // F[en_26]: 26:26
+  //   F[en_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12384,8 +12339,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_26_qs)
   );
 
-
-  // F[en_27]: 27:27
+  //   F[en_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12410,8 +12364,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_27_qs)
   );
 
-
-  // F[en_28]: 28:28
+  //   F[en_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12436,8 +12389,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_28_qs)
   );
 
-
-  // F[en_29]: 29:29
+  //   F[en_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12462,8 +12414,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_29_qs)
   );
 
-
-  // F[en_30]: 30:30
+  //   F[en_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12488,8 +12439,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_0_en_30_qs)
   );
 
-
-  // F[en_31]: 31:31
+  //   F[en_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12515,10 +12465,9 @@ module pinmux_reg_top (
   );
 
 
-  // Subregister 32 of Multireg mio_pad_sleep_status
+  // Subregister 1 of Multireg mio_pad_sleep_status
   // R[mio_pad_sleep_status_1]: V(False)
-
-  // F[en_32]: 0:0
+  //   F[en_32]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12543,8 +12492,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_32_qs)
   );
 
-
-  // F[en_33]: 1:1
+  //   F[en_33]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12569,8 +12517,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_33_qs)
   );
 
-
-  // F[en_34]: 2:2
+  //   F[en_34]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12595,8 +12542,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_34_qs)
   );
 
-
-  // F[en_35]: 3:3
+  //   F[en_35]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12621,8 +12567,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_35_qs)
   );
 
-
-  // F[en_36]: 4:4
+  //   F[en_36]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12647,8 +12592,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_36_qs)
   );
 
-
-  // F[en_37]: 5:5
+  //   F[en_37]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12673,8 +12617,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_37_qs)
   );
 
-
-  // F[en_38]: 6:6
+  //   F[en_38]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12699,8 +12642,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_38_qs)
   );
 
-
-  // F[en_39]: 7:7
+  //   F[en_39]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12725,8 +12667,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_39_qs)
   );
 
-
-  // F[en_40]: 8:8
+  //   F[en_40]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12751,8 +12692,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_40_qs)
   );
 
-
-  // F[en_41]: 9:9
+  //   F[en_41]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12777,8 +12717,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_41_qs)
   );
 
-
-  // F[en_42]: 10:10
+  //   F[en_42]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12803,8 +12742,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_42_qs)
   );
 
-
-  // F[en_43]: 11:11
+  //   F[en_43]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12829,8 +12767,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_43_qs)
   );
 
-
-  // F[en_44]: 12:12
+  //   F[en_44]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12855,8 +12792,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_44_qs)
   );
 
-
-  // F[en_45]: 13:13
+  //   F[en_45]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12881,8 +12817,7 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_status_1_en_45_qs)
   );
 
-
-  // F[en_46]: 14:14
+  //   F[en_46]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12908,11 +12843,8 @@ module pinmux_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12937,9 +12869,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12964,9 +12896,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -12991,9 +12923,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13018,9 +12950,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13045,9 +12977,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13072,9 +13004,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13099,9 +13031,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13126,9 +13058,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13153,9 +13085,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13180,9 +13112,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13207,9 +13139,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13234,9 +13166,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13261,9 +13193,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13288,9 +13220,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13315,9 +13247,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13342,9 +13274,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13369,9 +13301,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13396,9 +13328,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13423,9 +13355,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13450,9 +13382,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13477,9 +13409,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13504,9 +13436,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13531,9 +13463,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13558,9 +13490,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13585,9 +13517,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13612,9 +13544,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13639,9 +13571,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13666,9 +13598,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13693,9 +13625,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13720,9 +13652,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13747,9 +13679,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13774,9 +13706,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13801,9 +13733,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13828,9 +13760,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13855,9 +13787,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13882,9 +13814,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13909,9 +13841,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13936,9 +13868,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13963,9 +13895,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -13990,9 +13922,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14017,9 +13949,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14044,9 +13976,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14071,9 +14003,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14098,9 +14030,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14125,9 +14057,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14152,9 +14084,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_regwen_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_pad_sleep_regwen
   // R[mio_pad_sleep_regwen_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -14180,10 +14112,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14208,9 +14138,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14235,9 +14165,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14262,9 +14192,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14289,9 +14219,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14316,9 +14246,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14343,9 +14273,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14370,9 +14300,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14397,9 +14327,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14424,9 +14354,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14451,9 +14381,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14478,9 +14408,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14505,9 +14435,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14532,9 +14462,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14559,9 +14489,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14586,9 +14516,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14613,9 +14543,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14640,9 +14570,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14667,9 +14597,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14694,9 +14624,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14721,9 +14651,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14748,9 +14678,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14775,9 +14705,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14802,9 +14732,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14829,9 +14759,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_24]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14856,9 +14786,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_25]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14883,9 +14813,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_26]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14910,9 +14840,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_27]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14937,9 +14867,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_28]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14964,9 +14894,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_29]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14991,9 +14921,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_30]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15018,9 +14948,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_31]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15045,9 +14975,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_32]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15072,9 +15002,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_33]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15099,9 +15029,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_34]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15126,9 +15056,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_35]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15153,9 +15083,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_36]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15180,9 +15110,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_37]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15207,9 +15137,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_38]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15234,9 +15164,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_39]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15261,9 +15191,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_40]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15288,9 +15218,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_41]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15315,9 +15245,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_42]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15342,9 +15272,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_43]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15369,9 +15299,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_44]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15396,9 +15326,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_45]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15423,9 +15353,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_en_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_pad_sleep_en
   // R[mio_pad_sleep_en_46]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15451,10 +15381,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15479,9 +15407,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_0_qs)
   );
 
+
   // Subregister 1 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_1]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15506,9 +15434,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_1_qs)
   );
 
+
   // Subregister 2 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_2]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15533,9 +15461,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_2_qs)
   );
 
+
   // Subregister 3 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_3]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15560,9 +15488,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_3_qs)
   );
 
+
   // Subregister 4 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_4]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15587,9 +15515,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_4_qs)
   );
 
+
   // Subregister 5 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_5]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15614,9 +15542,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_5_qs)
   );
 
+
   // Subregister 6 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_6]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15641,9 +15569,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_6_qs)
   );
 
+
   // Subregister 7 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_7]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15668,9 +15596,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_7_qs)
   );
 
+
   // Subregister 8 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_8]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15695,9 +15623,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_8_qs)
   );
 
+
   // Subregister 9 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_9]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15722,9 +15650,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_9_qs)
   );
 
+
   // Subregister 10 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_10]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15749,9 +15677,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_10_qs)
   );
 
+
   // Subregister 11 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_11]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15776,9 +15704,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_11_qs)
   );
 
+
   // Subregister 12 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_12]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15803,9 +15731,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_12_qs)
   );
 
+
   // Subregister 13 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_13]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15830,9 +15758,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_13_qs)
   );
 
+
   // Subregister 14 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_14]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15857,9 +15785,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_14_qs)
   );
 
+
   // Subregister 15 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_15]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15884,9 +15812,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_15_qs)
   );
 
+
   // Subregister 16 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_16]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15911,9 +15839,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_16_qs)
   );
 
+
   // Subregister 17 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_17]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15938,9 +15866,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_17_qs)
   );
 
+
   // Subregister 18 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_18]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15965,9 +15893,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_18_qs)
   );
 
+
   // Subregister 19 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_19]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15992,9 +15920,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_19_qs)
   );
 
+
   // Subregister 20 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_20]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16019,9 +15947,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_20_qs)
   );
 
+
   // Subregister 21 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_21]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16046,9 +15974,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_21_qs)
   );
 
+
   // Subregister 22 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_22]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16073,9 +16001,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_22_qs)
   );
 
+
   // Subregister 23 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_23]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16100,9 +16028,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_23_qs)
   );
 
+
   // Subregister 24 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_24]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16127,9 +16055,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_24_qs)
   );
 
+
   // Subregister 25 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_25]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16154,9 +16082,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_25_qs)
   );
 
+
   // Subregister 26 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_26]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16181,9 +16109,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_26_qs)
   );
 
+
   // Subregister 27 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_27]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16208,9 +16136,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_27_qs)
   );
 
+
   // Subregister 28 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_28]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16235,9 +16163,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_28_qs)
   );
 
+
   // Subregister 29 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_29]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16262,9 +16190,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_29_qs)
   );
 
+
   // Subregister 30 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_30]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16289,9 +16217,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_30_qs)
   );
 
+
   // Subregister 31 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_31]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16316,9 +16244,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_31_qs)
   );
 
+
   // Subregister 32 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_32]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16343,9 +16271,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_32_qs)
   );
 
+
   // Subregister 33 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_33]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16370,9 +16298,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_33_qs)
   );
 
+
   // Subregister 34 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_34]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16397,9 +16325,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_34_qs)
   );
 
+
   // Subregister 35 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_35]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16424,9 +16352,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_35_qs)
   );
 
+
   // Subregister 36 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_36]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16451,9 +16379,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_36_qs)
   );
 
+
   // Subregister 37 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_37]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16478,9 +16406,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_37_qs)
   );
 
+
   // Subregister 38 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_38]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16505,9 +16433,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_38_qs)
   );
 
+
   // Subregister 39 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_39]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16532,9 +16460,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_39_qs)
   );
 
+
   // Subregister 40 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_40]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16559,9 +16487,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_40_qs)
   );
 
+
   // Subregister 41 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_41]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16586,9 +16514,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_41_qs)
   );
 
+
   // Subregister 42 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_42]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16613,9 +16541,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_42_qs)
   );
 
+
   // Subregister 43 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_43]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16640,9 +16568,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_43_qs)
   );
 
+
   // Subregister 44 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_44]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16667,9 +16595,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_44_qs)
   );
 
+
   // Subregister 45 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_45]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16694,9 +16622,9 @@ module pinmux_reg_top (
     .qs     (mio_pad_sleep_mode_45_qs)
   );
 
+
   // Subregister 46 of Multireg mio_pad_sleep_mode
   // R[mio_pad_sleep_mode_46]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16722,11 +16650,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_sleep_status
   // R[dio_pad_sleep_status]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16751,8 +16677,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16777,8 +16702,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_1_qs)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16803,8 +16727,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_2_qs)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16829,8 +16752,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_3_qs)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16855,8 +16777,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_4_qs)
   );
 
-
-  // F[en_5]: 5:5
+  //   F[en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16881,8 +16802,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_5_qs)
   );
 
-
-  // F[en_6]: 6:6
+  //   F[en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16907,8 +16827,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_6_qs)
   );
 
-
-  // F[en_7]: 7:7
+  //   F[en_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16933,8 +16852,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_7_qs)
   );
 
-
-  // F[en_8]: 8:8
+  //   F[en_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16959,8 +16877,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_8_qs)
   );
 
-
-  // F[en_9]: 9:9
+  //   F[en_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -16985,8 +16902,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_9_qs)
   );
 
-
-  // F[en_10]: 10:10
+  //   F[en_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17011,8 +16927,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_10_qs)
   );
 
-
-  // F[en_11]: 11:11
+  //   F[en_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17037,8 +16952,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_11_qs)
   );
 
-
-  // F[en_12]: 12:12
+  //   F[en_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17063,8 +16977,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_12_qs)
   );
 
-
-  // F[en_13]: 13:13
+  //   F[en_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17089,8 +17002,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_13_qs)
   );
 
-
-  // F[en_14]: 14:14
+  //   F[en_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17115,8 +17027,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_14_qs)
   );
 
-
-  // F[en_15]: 15:15
+  //   F[en_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17141,8 +17052,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_15_qs)
   );
 
-
-  // F[en_16]: 16:16
+  //   F[en_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17167,8 +17077,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_16_qs)
   );
 
-
-  // F[en_17]: 17:17
+  //   F[en_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17193,8 +17102,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_17_qs)
   );
 
-
-  // F[en_18]: 18:18
+  //   F[en_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17219,8 +17127,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_18_qs)
   );
 
-
-  // F[en_19]: 19:19
+  //   F[en_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17245,8 +17152,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_19_qs)
   );
 
-
-  // F[en_20]: 20:20
+  //   F[en_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17271,8 +17177,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_20_qs)
   );
 
-
-  // F[en_21]: 21:21
+  //   F[en_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17297,8 +17202,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_21_qs)
   );
 
-
-  // F[en_22]: 22:22
+  //   F[en_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17323,8 +17227,7 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_status_en_22_qs)
   );
 
-
-  // F[en_23]: 23:23
+  //   F[en_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17350,11 +17253,8 @@ module pinmux_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17379,9 +17279,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17406,9 +17306,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17433,9 +17333,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17460,9 +17360,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17487,9 +17387,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17514,9 +17414,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17541,9 +17441,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17568,9 +17468,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17595,9 +17495,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17622,9 +17522,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17649,9 +17549,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17676,9 +17576,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17703,9 +17603,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17730,9 +17630,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17757,9 +17657,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17784,9 +17684,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_15_qs)
   );
 
+
   // Subregister 16 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17811,9 +17711,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_16_qs)
   );
 
+
   // Subregister 17 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17838,9 +17738,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_17_qs)
   );
 
+
   // Subregister 18 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17865,9 +17765,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_18_qs)
   );
 
+
   // Subregister 19 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17892,9 +17792,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_19_qs)
   );
 
+
   // Subregister 20 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17919,9 +17819,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_20_qs)
   );
 
+
   // Subregister 21 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17946,9 +17846,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_21_qs)
   );
 
+
   // Subregister 22 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -17973,9 +17873,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_regwen_22_qs)
   );
 
+
   // Subregister 23 of Multireg dio_pad_sleep_regwen
   // R[dio_pad_sleep_regwen_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -18001,10 +17901,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18029,9 +17927,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18056,9 +17954,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18083,9 +17981,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18110,9 +18008,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18137,9 +18035,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18164,9 +18062,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18191,9 +18089,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18218,9 +18116,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_8]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18245,9 +18143,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_9]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18272,9 +18170,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_10]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18299,9 +18197,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_11]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18326,9 +18224,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_12]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18353,9 +18251,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_13]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18380,9 +18278,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_14]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18407,9 +18305,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_15]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18434,9 +18332,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_15_qs)
   );
 
+
   // Subregister 16 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_16]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18461,9 +18359,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_16_qs)
   );
 
+
   // Subregister 17 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_17]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18488,9 +18386,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_17_qs)
   );
 
+
   // Subregister 18 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_18]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18515,9 +18413,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_18_qs)
   );
 
+
   // Subregister 19 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_19]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18542,9 +18440,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_19_qs)
   );
 
+
   // Subregister 20 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_20]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18569,9 +18467,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_20_qs)
   );
 
+
   // Subregister 21 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_21]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18596,9 +18494,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_21_qs)
   );
 
+
   // Subregister 22 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_22]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18623,9 +18521,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_en_22_qs)
   );
 
+
   // Subregister 23 of Multireg dio_pad_sleep_en
   // R[dio_pad_sleep_en_23]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18651,10 +18549,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18679,9 +18575,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_0_qs)
   );
 
+
   // Subregister 1 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_1]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18706,9 +18602,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_1_qs)
   );
 
+
   // Subregister 2 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_2]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18733,9 +18629,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_2_qs)
   );
 
+
   // Subregister 3 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_3]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18760,9 +18656,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_3_qs)
   );
 
+
   // Subregister 4 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_4]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18787,9 +18683,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_4_qs)
   );
 
+
   // Subregister 5 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_5]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18814,9 +18710,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_5_qs)
   );
 
+
   // Subregister 6 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_6]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18841,9 +18737,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_6_qs)
   );
 
+
   // Subregister 7 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_7]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18868,9 +18764,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_7_qs)
   );
 
+
   // Subregister 8 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_8]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18895,9 +18791,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_8_qs)
   );
 
+
   // Subregister 9 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_9]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18922,9 +18818,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_9_qs)
   );
 
+
   // Subregister 10 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_10]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18949,9 +18845,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_10_qs)
   );
 
+
   // Subregister 11 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_11]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18976,9 +18872,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_11_qs)
   );
 
+
   // Subregister 12 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_12]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19003,9 +18899,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_12_qs)
   );
 
+
   // Subregister 13 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_13]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19030,9 +18926,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_13_qs)
   );
 
+
   // Subregister 14 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_14]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19057,9 +18953,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_14_qs)
   );
 
+
   // Subregister 15 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_15]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19084,9 +18980,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_15_qs)
   );
 
+
   // Subregister 16 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_16]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19111,9 +19007,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_16_qs)
   );
 
+
   // Subregister 17 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_17]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19138,9 +19034,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_17_qs)
   );
 
+
   // Subregister 18 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_18]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19165,9 +19061,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_18_qs)
   );
 
+
   // Subregister 19 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_19]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19192,9 +19088,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_19_qs)
   );
 
+
   // Subregister 20 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_20]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19219,9 +19115,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_20_qs)
   );
 
+
   // Subregister 21 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_21]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19246,9 +19142,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_21_qs)
   );
 
+
   // Subregister 22 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_22]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19273,9 +19169,9 @@ module pinmux_reg_top (
     .qs     (dio_pad_sleep_mode_22_qs)
   );
 
+
   // Subregister 23 of Multireg dio_pad_sleep_mode
   // R[dio_pad_sleep_mode_23]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19301,10 +19197,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19329,9 +19223,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_0_qs)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19356,9 +19250,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_1_qs)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19383,9 +19277,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_2_qs)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19410,9 +19304,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_3_qs)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19437,9 +19331,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_4_qs)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19464,9 +19358,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_5_qs)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19491,9 +19385,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_regwen_6_qs)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_regwen
   // R[wkup_detector_regwen_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -19519,10 +19413,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector_en
   // R[wkup_detector_en_0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19547,9 +19439,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_0_qs_int)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_en
   // R[wkup_detector_en_1]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19574,9 +19466,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_1_qs_int)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_en
   // R[wkup_detector_en_2]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19601,9 +19493,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_2_qs_int)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_en
   // R[wkup_detector_en_3]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19628,9 +19520,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_3_qs_int)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_en
   // R[wkup_detector_en_4]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19655,9 +19547,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_4_qs_int)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_en
   // R[wkup_detector_en_5]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19682,9 +19574,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_5_qs_int)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_en
   // R[wkup_detector_en_6]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19709,9 +19601,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_en_6_qs_int)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_en
   // R[wkup_detector_en_7]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19737,11 +19629,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector
   // R[wkup_detector_0]: V(False)
-
-  // F[mode_0]: 2:0
+  //   F[mode_0]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19766,8 +19656,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_0_mode_0_qs_int)
   );
 
-
-  // F[filter_0]: 3:3
+  //   F[filter_0]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19792,8 +19681,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_0_filter_0_qs_int)
   );
 
-
-  // F[miodio_0]: 4:4
+  //   F[miodio_0]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19821,8 +19709,7 @@ module pinmux_reg_top (
 
   // Subregister 1 of Multireg wkup_detector
   // R[wkup_detector_1]: V(False)
-
-  // F[mode_1]: 2:0
+  //   F[mode_1]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19847,8 +19734,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_1_mode_1_qs_int)
   );
 
-
-  // F[filter_1]: 3:3
+  //   F[filter_1]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19873,8 +19759,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_1_filter_1_qs_int)
   );
 
-
-  // F[miodio_1]: 4:4
+  //   F[miodio_1]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19902,8 +19787,7 @@ module pinmux_reg_top (
 
   // Subregister 2 of Multireg wkup_detector
   // R[wkup_detector_2]: V(False)
-
-  // F[mode_2]: 2:0
+  //   F[mode_2]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19928,8 +19812,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_2_mode_2_qs_int)
   );
 
-
-  // F[filter_2]: 3:3
+  //   F[filter_2]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19954,8 +19837,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_2_filter_2_qs_int)
   );
 
-
-  // F[miodio_2]: 4:4
+  //   F[miodio_2]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19983,8 +19865,7 @@ module pinmux_reg_top (
 
   // Subregister 3 of Multireg wkup_detector
   // R[wkup_detector_3]: V(False)
-
-  // F[mode_3]: 2:0
+  //   F[mode_3]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20009,8 +19890,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_3_mode_3_qs_int)
   );
 
-
-  // F[filter_3]: 3:3
+  //   F[filter_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20035,8 +19915,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_3_filter_3_qs_int)
   );
 
-
-  // F[miodio_3]: 4:4
+  //   F[miodio_3]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20064,8 +19943,7 @@ module pinmux_reg_top (
 
   // Subregister 4 of Multireg wkup_detector
   // R[wkup_detector_4]: V(False)
-
-  // F[mode_4]: 2:0
+  //   F[mode_4]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20090,8 +19968,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_4_mode_4_qs_int)
   );
 
-
-  // F[filter_4]: 3:3
+  //   F[filter_4]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20116,8 +19993,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_4_filter_4_qs_int)
   );
 
-
-  // F[miodio_4]: 4:4
+  //   F[miodio_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20145,8 +20021,7 @@ module pinmux_reg_top (
 
   // Subregister 5 of Multireg wkup_detector
   // R[wkup_detector_5]: V(False)
-
-  // F[mode_5]: 2:0
+  //   F[mode_5]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20171,8 +20046,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_5_mode_5_qs_int)
   );
 
-
-  // F[filter_5]: 3:3
+  //   F[filter_5]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20197,8 +20071,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_5_filter_5_qs_int)
   );
 
-
-  // F[miodio_5]: 4:4
+  //   F[miodio_5]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20226,8 +20099,7 @@ module pinmux_reg_top (
 
   // Subregister 6 of Multireg wkup_detector
   // R[wkup_detector_6]: V(False)
-
-  // F[mode_6]: 2:0
+  //   F[mode_6]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20252,8 +20124,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_6_mode_6_qs_int)
   );
 
-
-  // F[filter_6]: 3:3
+  //   F[filter_6]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20278,8 +20149,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_6_filter_6_qs_int)
   );
 
-
-  // F[miodio_6]: 4:4
+  //   F[miodio_6]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20307,8 +20177,7 @@ module pinmux_reg_top (
 
   // Subregister 7 of Multireg wkup_detector
   // R[wkup_detector_7]: V(False)
-
-  // F[mode_7]: 2:0
+  //   F[mode_7]: 2:0
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20333,8 +20202,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_7_mode_7_qs_int)
   );
 
-
-  // F[filter_7]: 3:3
+  //   F[filter_7]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20359,8 +20227,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_7_filter_7_qs_int)
   );
 
-
-  // F[miodio_7]: 4:4
+  //   F[miodio_7]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20386,11 +20253,8 @@ module pinmux_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_0]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20415,9 +20279,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_0_qs_int)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_1]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20442,9 +20306,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_1_qs_int)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_2]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20469,9 +20333,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_2_qs_int)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_3]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20496,9 +20360,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_3_qs_int)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_4]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20523,9 +20387,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_4_qs_int)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_5]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20550,9 +20414,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_5_qs_int)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_6]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20577,9 +20441,9 @@ module pinmux_reg_top (
     .qs     (aon_wkup_detector_cnt_th_6_qs_int)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_cnt_th
   // R[wkup_detector_cnt_th_7]: V(False)
-
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20605,10 +20469,8 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_0]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20633,9 +20495,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_0_qs)
   );
 
+
   // Subregister 1 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_1]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20660,9 +20522,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_1_qs)
   );
 
+
   // Subregister 2 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_2]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20687,9 +20549,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_2_qs)
   );
 
+
   // Subregister 3 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_3]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20714,9 +20576,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_3_qs)
   );
 
+
   // Subregister 4 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_4]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20741,9 +20603,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_4_qs)
   );
 
+
   // Subregister 5 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_5]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20768,9 +20630,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_5_qs)
   );
 
+
   // Subregister 6 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_6]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20795,9 +20657,9 @@ module pinmux_reg_top (
     .qs     (wkup_detector_padsel_6_qs)
   );
 
+
   // Subregister 7 of Multireg wkup_detector_padsel
   // R[wkup_detector_padsel_7]: V(False)
-
   prim_subreg #(
     .DW      (6),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20823,11 +20685,9 @@ module pinmux_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wkup_cause
   // R[wkup_cause]: V(False)
-
-  // F[cause_0]: 0:0
+  //   F[cause_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -20852,8 +20712,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_0_qs_int)
   );
 
-
-  // F[cause_1]: 1:1
+  //   F[cause_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -20878,8 +20737,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_1_qs_int)
   );
 
-
-  // F[cause_2]: 2:2
+  //   F[cause_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -20904,8 +20762,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_2_qs_int)
   );
 
-
-  // F[cause_3]: 3:3
+  //   F[cause_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -20930,8 +20787,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_3_qs_int)
   );
 
-
-  // F[cause_4]: 4:4
+  //   F[cause_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -20956,8 +20812,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_4_qs_int)
   );
 
-
-  // F[cause_5]: 5:5
+  //   F[cause_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -20982,8 +20837,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_5_qs_int)
   );
 
-
-  // F[cause_6]: 6:6
+  //   F[cause_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -21008,8 +20862,7 @@ module pinmux_reg_top (
     .qs     (aon_wkup_cause_cause_6_qs_int)
   );
 
-
-  // F[cause_7]: 7:7
+  //   F[cause_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -21033,8 +20886,6 @@ module pinmux_reg_top (
     // to register interface (read)
     .qs     (aon_wkup_cause_cause_7_qs_int)
   );
-
-
 
 
 

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -180,7 +180,6 @@ module pwrmgr_reg_top (
 
   // Register instances
   // R[intr_state]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -207,7 +206,6 @@ module pwrmgr_reg_top (
 
 
   // R[intr_enable]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -234,7 +232,6 @@ module pwrmgr_reg_top (
 
 
   // R[intr_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -250,7 +247,6 @@ module pwrmgr_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -266,7 +262,6 @@ module pwrmgr_reg_top (
 
 
   // R[ctrl_cfg_regwen]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_cfg_regwen (
@@ -282,7 +277,6 @@ module pwrmgr_reg_top (
 
 
   // R[control]: V(False)
-
   //   F[low_power_hint]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -307,7 +301,6 @@ module pwrmgr_reg_top (
     // to register interface (read)
     .qs     (control_low_power_hint_qs)
   );
-
 
   //   F[core_clk_en]: 4:4
   prim_subreg #(
@@ -334,7 +327,6 @@ module pwrmgr_reg_top (
     .qs     (control_core_clk_en_qs)
   );
 
-
   //   F[io_clk_en]: 5:5
   prim_subreg #(
     .DW      (1),
@@ -359,7 +351,6 @@ module pwrmgr_reg_top (
     // to register interface (read)
     .qs     (control_io_clk_en_qs)
   );
-
 
   //   F[usb_clk_en_lp]: 6:6
   prim_subreg #(
@@ -386,7 +377,6 @@ module pwrmgr_reg_top (
     .qs     (control_usb_clk_en_lp_qs)
   );
 
-
   //   F[usb_clk_en_active]: 7:7
   prim_subreg #(
     .DW      (1),
@@ -411,7 +401,6 @@ module pwrmgr_reg_top (
     // to register interface (read)
     .qs     (control_usb_clk_en_active_qs)
   );
-
 
   //   F[main_pd_n]: 8:8
   prim_subreg #(
@@ -440,7 +429,6 @@ module pwrmgr_reg_top (
 
 
   // R[cfg_cdc_sync]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -467,7 +455,6 @@ module pwrmgr_reg_top (
 
 
   // R[wakeup_en_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -493,11 +480,9 @@ module pwrmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg wakeup_en
   // R[wakeup_en]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -522,8 +507,7 @@ module pwrmgr_reg_top (
     .qs     (wakeup_en_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -548,8 +532,7 @@ module pwrmgr_reg_top (
     .qs     (wakeup_en_en_1_qs)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -574,8 +557,7 @@ module pwrmgr_reg_top (
     .qs     (wakeup_en_en_2_qs)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -600,8 +582,7 @@ module pwrmgr_reg_top (
     .qs     (wakeup_en_en_3_qs)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -627,12 +608,9 @@ module pwrmgr_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg wake_status
   // R[wake_status]: V(False)
-
-  // F[val_0]: 0:0
+  //   F[val_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -657,8 +635,7 @@ module pwrmgr_reg_top (
     .qs     (wake_status_val_0_qs)
   );
 
-
-  // F[val_1]: 1:1
+  //   F[val_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -683,8 +660,7 @@ module pwrmgr_reg_top (
     .qs     (wake_status_val_1_qs)
   );
 
-
-  // F[val_2]: 2:2
+  //   F[val_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -709,8 +685,7 @@ module pwrmgr_reg_top (
     .qs     (wake_status_val_2_qs)
   );
 
-
-  // F[val_3]: 3:3
+  //   F[val_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -735,8 +710,7 @@ module pwrmgr_reg_top (
     .qs     (wake_status_val_3_qs)
   );
 
-
-  // F[val_4]: 4:4
+  //   F[val_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -762,9 +736,7 @@ module pwrmgr_reg_top (
   );
 
 
-
   // R[reset_en_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -790,11 +762,9 @@ module pwrmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg reset_en
   // R[reset_en]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -819,8 +789,7 @@ module pwrmgr_reg_top (
     .qs     (reset_en_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -846,12 +815,9 @@ module pwrmgr_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg reset_status
   // R[reset_status]: V(False)
-
-  // F[val_0]: 0:0
+  //   F[val_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -876,8 +842,7 @@ module pwrmgr_reg_top (
     .qs     (reset_status_val_0_qs)
   );
 
-
-  // F[val_1]: 1:1
+  //   F[val_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -903,9 +868,7 @@ module pwrmgr_reg_top (
   );
 
 
-
   // R[escalate_reset_status]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -932,7 +895,6 @@ module pwrmgr_reg_top (
 
 
   // R[wake_info_capture_dis]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -959,7 +921,6 @@ module pwrmgr_reg_top (
 
 
   // R[wake_info]: V(True)
-
   //   F[reasons]: 4:0
   prim_subreg_ext #(
     .DW    (5)
@@ -973,7 +934,6 @@ module pwrmgr_reg_top (
     .q      (reg2hw.wake_info.reasons.q),
     .qs     (wake_info_reasons_qs)
   );
-
 
   //   F[fall_through]: 5:5
   prim_subreg_ext #(
@@ -989,7 +949,6 @@ module pwrmgr_reg_top (
     .qs     (wake_info_fall_through_qs)
   );
 
-
   //   F[abort]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -1003,7 +962,6 @@ module pwrmgr_reg_top (
     .q      (reg2hw.wake_info.abort.q),
     .qs     (wake_info_abort_qs)
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -189,7 +189,6 @@ module rstmgr_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -205,7 +204,6 @@ module rstmgr_reg_top (
 
 
   // R[reset_info]: V(False)
-
   //   F[por]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -230,7 +228,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (reset_info_por_qs)
   );
-
 
   //   F[low_power_exit]: 1:1
   prim_subreg #(
@@ -257,7 +254,6 @@ module rstmgr_reg_top (
     .qs     (reset_info_low_power_exit_qs)
   );
 
-
   //   F[ndm_reset]: 2:2
   prim_subreg #(
     .DW      (1),
@@ -282,7 +278,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (reset_info_ndm_reset_qs)
   );
-
 
   //   F[hw_req]: 5:3
   prim_subreg #(
@@ -311,7 +306,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -338,7 +332,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_info_ctrl]: V(False)
-
   //   F[en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -363,7 +356,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (alert_info_ctrl_en_qs)
   );
-
 
   //   F[index]: 7:4
   prim_subreg #(
@@ -392,7 +384,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_info_attr]: V(True)
-
   prim_subreg_ext #(
     .DW    (4)
   ) u_alert_info_attr (
@@ -408,7 +399,6 @@ module rstmgr_reg_top (
 
 
   // R[alert_info]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_alert_info (
@@ -424,7 +414,6 @@ module rstmgr_reg_top (
 
 
   // R[cpu_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -451,7 +440,6 @@ module rstmgr_reg_top (
 
 
   // R[cpu_info_ctrl]: V(False)
-
   //   F[en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -476,7 +464,6 @@ module rstmgr_reg_top (
     // to register interface (read)
     .qs     (cpu_info_ctrl_en_qs)
   );
-
 
   //   F[index]: 7:4
   prim_subreg #(
@@ -505,7 +492,6 @@ module rstmgr_reg_top (
 
 
   // R[cpu_info_attr]: V(True)
-
   prim_subreg_ext #(
     .DW    (4)
   ) u_cpu_info_attr (
@@ -521,7 +507,6 @@ module rstmgr_reg_top (
 
 
   // R[cpu_info]: V(True)
-
   prim_subreg_ext #(
     .DW    (32)
   ) u_cpu_info (
@@ -536,11 +521,9 @@ module rstmgr_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg sw_rst_regen
   // R[sw_rst_regen]: V(False)
-
-  // F[en_0]: 0:0
+  //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -565,8 +548,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_0_qs)
   );
 
-
-  // F[en_1]: 1:1
+  //   F[en_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -591,8 +573,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_1_qs)
   );
 
-
-  // F[en_2]: 2:2
+  //   F[en_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -617,8 +598,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_2_qs)
   );
 
-
-  // F[en_3]: 3:3
+  //   F[en_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -643,8 +623,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_3_qs)
   );
 
-
-  // F[en_4]: 4:4
+  //   F[en_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -669,8 +648,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_4_qs)
   );
 
-
-  // F[en_5]: 5:5
+  //   F[en_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -695,8 +673,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_5_qs)
   );
 
-
-  // F[en_6]: 6:6
+  //   F[en_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -721,8 +698,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_6_qs)
   );
 
-
-  // F[en_7]: 7:7
+  //   F[en_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -747,8 +723,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_7_qs)
   );
 
-
-  // F[en_8]: 8:8
+  //   F[en_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -773,8 +748,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regen_en_8_qs)
   );
 
-
-  // F[en_9]: 9:9
+  //   F[en_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -800,12 +774,9 @@ module rstmgr_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg sw_rst_ctrl_n
   // R[sw_rst_ctrl_n]: V(True)
-
-  // F[val_0]: 0:0
+  //   F[val_0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_0 (
@@ -819,8 +790,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_0_qs)
   );
 
-
-  // F[val_1]: 1:1
+  //   F[val_1]: 1:1
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_1 (
@@ -834,8 +804,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_1_qs)
   );
 
-
-  // F[val_2]: 2:2
+  //   F[val_2]: 2:2
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_2 (
@@ -849,8 +818,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_2_qs)
   );
 
-
-  // F[val_3]: 3:3
+  //   F[val_3]: 3:3
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_3 (
@@ -864,8 +832,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_3_qs)
   );
 
-
-  // F[val_4]: 4:4
+  //   F[val_4]: 4:4
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_4 (
@@ -879,8 +846,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_4_qs)
   );
 
-
-  // F[val_5]: 5:5
+  //   F[val_5]: 5:5
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_5 (
@@ -894,8 +860,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_5_qs)
   );
 
-
-  // F[val_6]: 6:6
+  //   F[val_6]: 6:6
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_6 (
@@ -909,8 +874,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_6_qs)
   );
 
-
-  // F[val_7]: 7:7
+  //   F[val_7]: 7:7
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_7 (
@@ -924,8 +888,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_7_qs)
   );
 
-
-  // F[val_8]: 8:8
+  //   F[val_8]: 8:8
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_8 (
@@ -939,8 +902,7 @@ module rstmgr_reg_top (
     .qs     (sw_rst_ctrl_n_val_8_qs)
   );
 
-
-  // F[val_9]: 9:9
+  //   F[val_9]: 9:9
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_rst_ctrl_n_val_9 (
@@ -953,8 +915,6 @@ module rstmgr_reg_top (
     .q      (reg2hw.sw_rst_ctrl_n[9].q),
     .qs     (sw_rst_ctrl_n_val_9_qs)
   );
-
-
 
 
 

--- a/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip/rv_plic/rtl/autogen/rv_plic_reg_top.sv
@@ -1574,11 +1574,9 @@ module rv_plic_reg_top (
   logic alert_test_wd;
 
   // Register instances
-
   // Subregister 0 of Multireg ip
   // R[ip_0]: V(False)
-
-  // F[p_0]: 0:0
+  //   F[p_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1603,8 +1601,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_0_qs)
   );
 
-
-  // F[p_1]: 1:1
+  //   F[p_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1629,8 +1626,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_1_qs)
   );
 
-
-  // F[p_2]: 2:2
+  //   F[p_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1655,8 +1651,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_2_qs)
   );
 
-
-  // F[p_3]: 3:3
+  //   F[p_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1681,8 +1676,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_3_qs)
   );
 
-
-  // F[p_4]: 4:4
+  //   F[p_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1707,8 +1701,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_4_qs)
   );
 
-
-  // F[p_5]: 5:5
+  //   F[p_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1733,8 +1726,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_5_qs)
   );
 
-
-  // F[p_6]: 6:6
+  //   F[p_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1759,8 +1751,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_6_qs)
   );
 
-
-  // F[p_7]: 7:7
+  //   F[p_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1785,8 +1776,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_7_qs)
   );
 
-
-  // F[p_8]: 8:8
+  //   F[p_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1811,8 +1801,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_8_qs)
   );
 
-
-  // F[p_9]: 9:9
+  //   F[p_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1837,8 +1826,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_9_qs)
   );
 
-
-  // F[p_10]: 10:10
+  //   F[p_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1863,8 +1851,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_10_qs)
   );
 
-
-  // F[p_11]: 11:11
+  //   F[p_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1889,8 +1876,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_11_qs)
   );
 
-
-  // F[p_12]: 12:12
+  //   F[p_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1915,8 +1901,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_12_qs)
   );
 
-
-  // F[p_13]: 13:13
+  //   F[p_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1941,8 +1926,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_13_qs)
   );
 
-
-  // F[p_14]: 14:14
+  //   F[p_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1967,8 +1951,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_14_qs)
   );
 
-
-  // F[p_15]: 15:15
+  //   F[p_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -1993,8 +1976,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_15_qs)
   );
 
-
-  // F[p_16]: 16:16
+  //   F[p_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2019,8 +2001,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_16_qs)
   );
 
-
-  // F[p_17]: 17:17
+  //   F[p_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2045,8 +2026,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_17_qs)
   );
 
-
-  // F[p_18]: 18:18
+  //   F[p_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2071,8 +2051,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_18_qs)
   );
 
-
-  // F[p_19]: 19:19
+  //   F[p_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2097,8 +2076,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_19_qs)
   );
 
-
-  // F[p_20]: 20:20
+  //   F[p_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2123,8 +2101,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_20_qs)
   );
 
-
-  // F[p_21]: 21:21
+  //   F[p_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2149,8 +2126,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_21_qs)
   );
 
-
-  // F[p_22]: 22:22
+  //   F[p_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2175,8 +2151,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_22_qs)
   );
 
-
-  // F[p_23]: 23:23
+  //   F[p_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2201,8 +2176,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_23_qs)
   );
 
-
-  // F[p_24]: 24:24
+  //   F[p_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2227,8 +2201,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_24_qs)
   );
 
-
-  // F[p_25]: 25:25
+  //   F[p_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2253,8 +2226,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_25_qs)
   );
 
-
-  // F[p_26]: 26:26
+  //   F[p_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2279,8 +2251,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_26_qs)
   );
 
-
-  // F[p_27]: 27:27
+  //   F[p_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2305,8 +2276,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_27_qs)
   );
 
-
-  // F[p_28]: 28:28
+  //   F[p_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2331,8 +2301,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_28_qs)
   );
 
-
-  // F[p_29]: 29:29
+  //   F[p_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2357,8 +2326,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_29_qs)
   );
 
-
-  // F[p_30]: 30:30
+  //   F[p_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2383,8 +2351,7 @@ module rv_plic_reg_top (
     .qs     (ip_0_p_30_qs)
   );
 
-
-  // F[p_31]: 31:31
+  //   F[p_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2410,10 +2377,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 32 of Multireg ip
+  // Subregister 1 of Multireg ip
   // R[ip_1]: V(False)
-
-  // F[p_32]: 0:0
+  //   F[p_32]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2438,8 +2404,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_32_qs)
   );
 
-
-  // F[p_33]: 1:1
+  //   F[p_33]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2464,8 +2429,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_33_qs)
   );
 
-
-  // F[p_34]: 2:2
+  //   F[p_34]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2490,8 +2454,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_34_qs)
   );
 
-
-  // F[p_35]: 3:3
+  //   F[p_35]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2516,8 +2479,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_35_qs)
   );
 
-
-  // F[p_36]: 4:4
+  //   F[p_36]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2542,8 +2504,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_36_qs)
   );
 
-
-  // F[p_37]: 5:5
+  //   F[p_37]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2568,8 +2529,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_37_qs)
   );
 
-
-  // F[p_38]: 6:6
+  //   F[p_38]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2594,8 +2554,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_38_qs)
   );
 
-
-  // F[p_39]: 7:7
+  //   F[p_39]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2620,8 +2579,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_39_qs)
   );
 
-
-  // F[p_40]: 8:8
+  //   F[p_40]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2646,8 +2604,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_40_qs)
   );
 
-
-  // F[p_41]: 9:9
+  //   F[p_41]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2672,8 +2629,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_41_qs)
   );
 
-
-  // F[p_42]: 10:10
+  //   F[p_42]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2698,8 +2654,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_42_qs)
   );
 
-
-  // F[p_43]: 11:11
+  //   F[p_43]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2724,8 +2679,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_43_qs)
   );
 
-
-  // F[p_44]: 12:12
+  //   F[p_44]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2750,8 +2704,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_44_qs)
   );
 
-
-  // F[p_45]: 13:13
+  //   F[p_45]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2776,8 +2729,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_45_qs)
   );
 
-
-  // F[p_46]: 14:14
+  //   F[p_46]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2802,8 +2754,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_46_qs)
   );
 
-
-  // F[p_47]: 15:15
+  //   F[p_47]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2828,8 +2779,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_47_qs)
   );
 
-
-  // F[p_48]: 16:16
+  //   F[p_48]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2854,8 +2804,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_48_qs)
   );
 
-
-  // F[p_49]: 17:17
+  //   F[p_49]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2880,8 +2829,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_49_qs)
   );
 
-
-  // F[p_50]: 18:18
+  //   F[p_50]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2906,8 +2854,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_50_qs)
   );
 
-
-  // F[p_51]: 19:19
+  //   F[p_51]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2932,8 +2879,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_51_qs)
   );
 
-
-  // F[p_52]: 20:20
+  //   F[p_52]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2958,8 +2904,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_52_qs)
   );
 
-
-  // F[p_53]: 21:21
+  //   F[p_53]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2984,8 +2929,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_53_qs)
   );
 
-
-  // F[p_54]: 22:22
+  //   F[p_54]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3010,8 +2954,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_54_qs)
   );
 
-
-  // F[p_55]: 23:23
+  //   F[p_55]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3036,8 +2979,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_55_qs)
   );
 
-
-  // F[p_56]: 24:24
+  //   F[p_56]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3062,8 +3004,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_56_qs)
   );
 
-
-  // F[p_57]: 25:25
+  //   F[p_57]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3088,8 +3029,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_57_qs)
   );
 
-
-  // F[p_58]: 26:26
+  //   F[p_58]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3114,8 +3054,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_58_qs)
   );
 
-
-  // F[p_59]: 27:27
+  //   F[p_59]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3140,8 +3079,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_59_qs)
   );
 
-
-  // F[p_60]: 28:28
+  //   F[p_60]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3166,8 +3104,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_60_qs)
   );
 
-
-  // F[p_61]: 29:29
+  //   F[p_61]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3192,8 +3129,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_61_qs)
   );
 
-
-  // F[p_62]: 30:30
+  //   F[p_62]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3218,8 +3154,7 @@ module rv_plic_reg_top (
     .qs     (ip_1_p_62_qs)
   );
 
-
-  // F[p_63]: 31:31
+  //   F[p_63]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3245,10 +3180,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 64 of Multireg ip
+  // Subregister 2 of Multireg ip
   // R[ip_2]: V(False)
-
-  // F[p_64]: 0:0
+  //   F[p_64]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3273,8 +3207,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_64_qs)
   );
 
-
-  // F[p_65]: 1:1
+  //   F[p_65]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3299,8 +3232,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_65_qs)
   );
 
-
-  // F[p_66]: 2:2
+  //   F[p_66]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3325,8 +3257,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_66_qs)
   );
 
-
-  // F[p_67]: 3:3
+  //   F[p_67]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3351,8 +3282,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_67_qs)
   );
 
-
-  // F[p_68]: 4:4
+  //   F[p_68]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3377,8 +3307,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_68_qs)
   );
 
-
-  // F[p_69]: 5:5
+  //   F[p_69]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3403,8 +3332,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_69_qs)
   );
 
-
-  // F[p_70]: 6:6
+  //   F[p_70]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3429,8 +3357,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_70_qs)
   );
 
-
-  // F[p_71]: 7:7
+  //   F[p_71]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3455,8 +3382,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_71_qs)
   );
 
-
-  // F[p_72]: 8:8
+  //   F[p_72]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3481,8 +3407,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_72_qs)
   );
 
-
-  // F[p_73]: 9:9
+  //   F[p_73]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3507,8 +3432,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_73_qs)
   );
 
-
-  // F[p_74]: 10:10
+  //   F[p_74]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3533,8 +3457,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_74_qs)
   );
 
-
-  // F[p_75]: 11:11
+  //   F[p_75]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3559,8 +3482,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_75_qs)
   );
 
-
-  // F[p_76]: 12:12
+  //   F[p_76]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3585,8 +3507,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_76_qs)
   );
 
-
-  // F[p_77]: 13:13
+  //   F[p_77]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3611,8 +3532,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_77_qs)
   );
 
-
-  // F[p_78]: 14:14
+  //   F[p_78]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3637,8 +3557,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_78_qs)
   );
 
-
-  // F[p_79]: 15:15
+  //   F[p_79]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3663,8 +3582,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_79_qs)
   );
 
-
-  // F[p_80]: 16:16
+  //   F[p_80]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3689,8 +3607,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_80_qs)
   );
 
-
-  // F[p_81]: 17:17
+  //   F[p_81]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3715,8 +3632,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_81_qs)
   );
 
-
-  // F[p_82]: 18:18
+  //   F[p_82]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3741,8 +3657,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_82_qs)
   );
 
-
-  // F[p_83]: 19:19
+  //   F[p_83]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3767,8 +3682,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_83_qs)
   );
 
-
-  // F[p_84]: 20:20
+  //   F[p_84]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3793,8 +3707,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_84_qs)
   );
 
-
-  // F[p_85]: 21:21
+  //   F[p_85]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3819,8 +3732,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_85_qs)
   );
 
-
-  // F[p_86]: 22:22
+  //   F[p_86]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3845,8 +3757,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_86_qs)
   );
 
-
-  // F[p_87]: 23:23
+  //   F[p_87]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3871,8 +3782,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_87_qs)
   );
 
-
-  // F[p_88]: 24:24
+  //   F[p_88]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3897,8 +3807,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_88_qs)
   );
 
-
-  // F[p_89]: 25:25
+  //   F[p_89]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3923,8 +3832,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_89_qs)
   );
 
-
-  // F[p_90]: 26:26
+  //   F[p_90]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3949,8 +3857,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_90_qs)
   );
 
-
-  // F[p_91]: 27:27
+  //   F[p_91]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -3975,8 +3882,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_91_qs)
   );
 
-
-  // F[p_92]: 28:28
+  //   F[p_92]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4001,8 +3907,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_92_qs)
   );
 
-
-  // F[p_93]: 29:29
+  //   F[p_93]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4027,8 +3932,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_93_qs)
   );
 
-
-  // F[p_94]: 30:30
+  //   F[p_94]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4053,8 +3957,7 @@ module rv_plic_reg_top (
     .qs     (ip_2_p_94_qs)
   );
 
-
-  // F[p_95]: 31:31
+  //   F[p_95]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4080,10 +3983,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 96 of Multireg ip
+  // Subregister 3 of Multireg ip
   // R[ip_3]: V(False)
-
-  // F[p_96]: 0:0
+  //   F[p_96]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4108,8 +4010,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_96_qs)
   );
 
-
-  // F[p_97]: 1:1
+  //   F[p_97]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4134,8 +4035,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_97_qs)
   );
 
-
-  // F[p_98]: 2:2
+  //   F[p_98]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4160,8 +4060,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_98_qs)
   );
 
-
-  // F[p_99]: 3:3
+  //   F[p_99]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4186,8 +4085,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_99_qs)
   );
 
-
-  // F[p_100]: 4:4
+  //   F[p_100]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4212,8 +4110,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_100_qs)
   );
 
-
-  // F[p_101]: 5:5
+  //   F[p_101]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4238,8 +4135,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_101_qs)
   );
 
-
-  // F[p_102]: 6:6
+  //   F[p_102]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4264,8 +4160,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_102_qs)
   );
 
-
-  // F[p_103]: 7:7
+  //   F[p_103]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4290,8 +4185,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_103_qs)
   );
 
-
-  // F[p_104]: 8:8
+  //   F[p_104]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4316,8 +4210,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_104_qs)
   );
 
-
-  // F[p_105]: 9:9
+  //   F[p_105]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4342,8 +4235,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_105_qs)
   );
 
-
-  // F[p_106]: 10:10
+  //   F[p_106]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4368,8 +4260,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_106_qs)
   );
 
-
-  // F[p_107]: 11:11
+  //   F[p_107]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4394,8 +4285,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_107_qs)
   );
 
-
-  // F[p_108]: 12:12
+  //   F[p_108]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4420,8 +4310,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_108_qs)
   );
 
-
-  // F[p_109]: 13:13
+  //   F[p_109]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4446,8 +4335,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_109_qs)
   );
 
-
-  // F[p_110]: 14:14
+  //   F[p_110]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4472,8 +4360,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_110_qs)
   );
 
-
-  // F[p_111]: 15:15
+  //   F[p_111]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4498,8 +4385,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_111_qs)
   );
 
-
-  // F[p_112]: 16:16
+  //   F[p_112]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4524,8 +4410,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_112_qs)
   );
 
-
-  // F[p_113]: 17:17
+  //   F[p_113]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4550,8 +4435,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_113_qs)
   );
 
-
-  // F[p_114]: 18:18
+  //   F[p_114]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4576,8 +4460,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_114_qs)
   );
 
-
-  // F[p_115]: 19:19
+  //   F[p_115]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4602,8 +4485,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_115_qs)
   );
 
-
-  // F[p_116]: 20:20
+  //   F[p_116]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4628,8 +4510,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_116_qs)
   );
 
-
-  // F[p_117]: 21:21
+  //   F[p_117]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4654,8 +4535,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_117_qs)
   );
 
-
-  // F[p_118]: 22:22
+  //   F[p_118]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4680,8 +4560,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_118_qs)
   );
 
-
-  // F[p_119]: 23:23
+  //   F[p_119]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4706,8 +4585,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_119_qs)
   );
 
-
-  // F[p_120]: 24:24
+  //   F[p_120]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4732,8 +4610,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_120_qs)
   );
 
-
-  // F[p_121]: 25:25
+  //   F[p_121]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4758,8 +4635,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_121_qs)
   );
 
-
-  // F[p_122]: 26:26
+  //   F[p_122]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4784,8 +4660,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_122_qs)
   );
 
-
-  // F[p_123]: 27:27
+  //   F[p_123]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4810,8 +4685,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_123_qs)
   );
 
-
-  // F[p_124]: 28:28
+  //   F[p_124]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4836,8 +4710,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_124_qs)
   );
 
-
-  // F[p_125]: 29:29
+  //   F[p_125]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4862,8 +4735,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_125_qs)
   );
 
-
-  // F[p_126]: 30:30
+  //   F[p_126]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4888,8 +4760,7 @@ module rv_plic_reg_top (
     .qs     (ip_3_p_126_qs)
   );
 
-
-  // F[p_127]: 31:31
+  //   F[p_127]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4915,10 +4786,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 128 of Multireg ip
+  // Subregister 4 of Multireg ip
   // R[ip_4]: V(False)
-
-  // F[p_128]: 0:0
+  //   F[p_128]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4943,8 +4813,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_128_qs)
   );
 
-
-  // F[p_129]: 1:1
+  //   F[p_129]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4969,8 +4838,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_129_qs)
   );
 
-
-  // F[p_130]: 2:2
+  //   F[p_130]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -4995,8 +4863,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_130_qs)
   );
 
-
-  // F[p_131]: 3:3
+  //   F[p_131]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5021,8 +4888,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_131_qs)
   );
 
-
-  // F[p_132]: 4:4
+  //   F[p_132]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5047,8 +4913,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_132_qs)
   );
 
-
-  // F[p_133]: 5:5
+  //   F[p_133]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5073,8 +4938,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_133_qs)
   );
 
-
-  // F[p_134]: 6:6
+  //   F[p_134]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5099,8 +4963,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_134_qs)
   );
 
-
-  // F[p_135]: 7:7
+  //   F[p_135]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5125,8 +4988,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_135_qs)
   );
 
-
-  // F[p_136]: 8:8
+  //   F[p_136]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5151,8 +5013,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_136_qs)
   );
 
-
-  // F[p_137]: 9:9
+  //   F[p_137]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5177,8 +5038,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_137_qs)
   );
 
-
-  // F[p_138]: 10:10
+  //   F[p_138]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5203,8 +5063,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_138_qs)
   );
 
-
-  // F[p_139]: 11:11
+  //   F[p_139]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5229,8 +5088,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_139_qs)
   );
 
-
-  // F[p_140]: 12:12
+  //   F[p_140]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5255,8 +5113,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_140_qs)
   );
 
-
-  // F[p_141]: 13:13
+  //   F[p_141]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5281,8 +5138,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_141_qs)
   );
 
-
-  // F[p_142]: 14:14
+  //   F[p_142]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5307,8 +5163,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_142_qs)
   );
 
-
-  // F[p_143]: 15:15
+  //   F[p_143]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5333,8 +5188,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_143_qs)
   );
 
-
-  // F[p_144]: 16:16
+  //   F[p_144]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5359,8 +5213,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_144_qs)
   );
 
-
-  // F[p_145]: 17:17
+  //   F[p_145]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5385,8 +5238,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_145_qs)
   );
 
-
-  // F[p_146]: 18:18
+  //   F[p_146]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5411,8 +5263,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_146_qs)
   );
 
-
-  // F[p_147]: 19:19
+  //   F[p_147]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5437,8 +5288,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_147_qs)
   );
 
-
-  // F[p_148]: 20:20
+  //   F[p_148]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5463,8 +5313,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_148_qs)
   );
 
-
-  // F[p_149]: 21:21
+  //   F[p_149]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5489,8 +5338,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_149_qs)
   );
 
-
-  // F[p_150]: 22:22
+  //   F[p_150]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5515,8 +5363,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_150_qs)
   );
 
-
-  // F[p_151]: 23:23
+  //   F[p_151]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5541,8 +5388,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_151_qs)
   );
 
-
-  // F[p_152]: 24:24
+  //   F[p_152]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5567,8 +5413,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_152_qs)
   );
 
-
-  // F[p_153]: 25:25
+  //   F[p_153]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5593,8 +5438,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_153_qs)
   );
 
-
-  // F[p_154]: 26:26
+  //   F[p_154]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5619,8 +5463,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_154_qs)
   );
 
-
-  // F[p_155]: 27:27
+  //   F[p_155]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5645,8 +5488,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_155_qs)
   );
 
-
-  // F[p_156]: 28:28
+  //   F[p_156]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5671,8 +5513,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_156_qs)
   );
 
-
-  // F[p_157]: 29:29
+  //   F[p_157]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5697,8 +5538,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_157_qs)
   );
 
-
-  // F[p_158]: 30:30
+  //   F[p_158]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5723,8 +5563,7 @@ module rv_plic_reg_top (
     .qs     (ip_4_p_158_qs)
   );
 
-
-  // F[p_159]: 31:31
+  //   F[p_159]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5750,10 +5589,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 160 of Multireg ip
+  // Subregister 5 of Multireg ip
   // R[ip_5]: V(False)
-
-  // F[p_160]: 0:0
+  //   F[p_160]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5778,8 +5616,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_160_qs)
   );
 
-
-  // F[p_161]: 1:1
+  //   F[p_161]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5804,8 +5641,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_161_qs)
   );
 
-
-  // F[p_162]: 2:2
+  //   F[p_162]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5830,8 +5666,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_162_qs)
   );
 
-
-  // F[p_163]: 3:3
+  //   F[p_163]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5856,8 +5691,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_163_qs)
   );
 
-
-  // F[p_164]: 4:4
+  //   F[p_164]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5882,8 +5716,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_164_qs)
   );
 
-
-  // F[p_165]: 5:5
+  //   F[p_165]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5908,8 +5741,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_165_qs)
   );
 
-
-  // F[p_166]: 6:6
+  //   F[p_166]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5934,8 +5766,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_166_qs)
   );
 
-
-  // F[p_167]: 7:7
+  //   F[p_167]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5960,8 +5791,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_167_qs)
   );
 
-
-  // F[p_168]: 8:8
+  //   F[p_168]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -5986,8 +5816,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_168_qs)
   );
 
-
-  // F[p_169]: 9:9
+  //   F[p_169]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6012,8 +5841,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_169_qs)
   );
 
-
-  // F[p_170]: 10:10
+  //   F[p_170]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6038,8 +5866,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_170_qs)
   );
 
-
-  // F[p_171]: 11:11
+  //   F[p_171]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6064,8 +5891,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_171_qs)
   );
 
-
-  // F[p_172]: 12:12
+  //   F[p_172]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6090,8 +5916,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_172_qs)
   );
 
-
-  // F[p_173]: 13:13
+  //   F[p_173]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6116,8 +5941,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_173_qs)
   );
 
-
-  // F[p_174]: 14:14
+  //   F[p_174]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6142,8 +5966,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_174_qs)
   );
 
-
-  // F[p_175]: 15:15
+  //   F[p_175]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6168,8 +5991,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_175_qs)
   );
 
-
-  // F[p_176]: 16:16
+  //   F[p_176]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6194,8 +6016,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_176_qs)
   );
 
-
-  // F[p_177]: 17:17
+  //   F[p_177]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6220,8 +6041,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_177_qs)
   );
 
-
-  // F[p_178]: 18:18
+  //   F[p_178]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6246,8 +6066,7 @@ module rv_plic_reg_top (
     .qs     (ip_5_p_178_qs)
   );
 
-
-  // F[p_179]: 19:19
+  //   F[p_179]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -6273,12 +6092,9 @@ module rv_plic_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg le
   // R[le_0]: V(False)
-
-  // F[le_0]: 0:0
+  //   F[le_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6303,8 +6119,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_0_qs)
   );
 
-
-  // F[le_1]: 1:1
+  //   F[le_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6329,8 +6144,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_1_qs)
   );
 
-
-  // F[le_2]: 2:2
+  //   F[le_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6355,8 +6169,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_2_qs)
   );
 
-
-  // F[le_3]: 3:3
+  //   F[le_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6381,8 +6194,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_3_qs)
   );
 
-
-  // F[le_4]: 4:4
+  //   F[le_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6407,8 +6219,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_4_qs)
   );
 
-
-  // F[le_5]: 5:5
+  //   F[le_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6433,8 +6244,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_5_qs)
   );
 
-
-  // F[le_6]: 6:6
+  //   F[le_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6459,8 +6269,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_6_qs)
   );
 
-
-  // F[le_7]: 7:7
+  //   F[le_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6485,8 +6294,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_7_qs)
   );
 
-
-  // F[le_8]: 8:8
+  //   F[le_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6511,8 +6319,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_8_qs)
   );
 
-
-  // F[le_9]: 9:9
+  //   F[le_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6537,8 +6344,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_9_qs)
   );
 
-
-  // F[le_10]: 10:10
+  //   F[le_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6563,8 +6369,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_10_qs)
   );
 
-
-  // F[le_11]: 11:11
+  //   F[le_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6589,8 +6394,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_11_qs)
   );
 
-
-  // F[le_12]: 12:12
+  //   F[le_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6615,8 +6419,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_12_qs)
   );
 
-
-  // F[le_13]: 13:13
+  //   F[le_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6641,8 +6444,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_13_qs)
   );
 
-
-  // F[le_14]: 14:14
+  //   F[le_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6667,8 +6469,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_14_qs)
   );
 
-
-  // F[le_15]: 15:15
+  //   F[le_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6693,8 +6494,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_15_qs)
   );
 
-
-  // F[le_16]: 16:16
+  //   F[le_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6719,8 +6519,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_16_qs)
   );
 
-
-  // F[le_17]: 17:17
+  //   F[le_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6745,8 +6544,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_17_qs)
   );
 
-
-  // F[le_18]: 18:18
+  //   F[le_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6771,8 +6569,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_18_qs)
   );
 
-
-  // F[le_19]: 19:19
+  //   F[le_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6797,8 +6594,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_19_qs)
   );
 
-
-  // F[le_20]: 20:20
+  //   F[le_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6823,8 +6619,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_20_qs)
   );
 
-
-  // F[le_21]: 21:21
+  //   F[le_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6849,8 +6644,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_21_qs)
   );
 
-
-  // F[le_22]: 22:22
+  //   F[le_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6875,8 +6669,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_22_qs)
   );
 
-
-  // F[le_23]: 23:23
+  //   F[le_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6901,8 +6694,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_23_qs)
   );
 
-
-  // F[le_24]: 24:24
+  //   F[le_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6927,8 +6719,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_24_qs)
   );
 
-
-  // F[le_25]: 25:25
+  //   F[le_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6953,8 +6744,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_25_qs)
   );
 
-
-  // F[le_26]: 26:26
+  //   F[le_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -6979,8 +6769,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_26_qs)
   );
 
-
-  // F[le_27]: 27:27
+  //   F[le_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7005,8 +6794,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_27_qs)
   );
 
-
-  // F[le_28]: 28:28
+  //   F[le_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7031,8 +6819,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_28_qs)
   );
 
-
-  // F[le_29]: 29:29
+  //   F[le_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7057,8 +6844,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_29_qs)
   );
 
-
-  // F[le_30]: 30:30
+  //   F[le_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7083,8 +6869,7 @@ module rv_plic_reg_top (
     .qs     (le_0_le_30_qs)
   );
 
-
-  // F[le_31]: 31:31
+  //   F[le_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7110,10 +6895,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 32 of Multireg le
+  // Subregister 1 of Multireg le
   // R[le_1]: V(False)
-
-  // F[le_32]: 0:0
+  //   F[le_32]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7138,8 +6922,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_32_qs)
   );
 
-
-  // F[le_33]: 1:1
+  //   F[le_33]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7164,8 +6947,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_33_qs)
   );
 
-
-  // F[le_34]: 2:2
+  //   F[le_34]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7190,8 +6972,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_34_qs)
   );
 
-
-  // F[le_35]: 3:3
+  //   F[le_35]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7216,8 +6997,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_35_qs)
   );
 
-
-  // F[le_36]: 4:4
+  //   F[le_36]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7242,8 +7022,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_36_qs)
   );
 
-
-  // F[le_37]: 5:5
+  //   F[le_37]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7268,8 +7047,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_37_qs)
   );
 
-
-  // F[le_38]: 6:6
+  //   F[le_38]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7294,8 +7072,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_38_qs)
   );
 
-
-  // F[le_39]: 7:7
+  //   F[le_39]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7320,8 +7097,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_39_qs)
   );
 
-
-  // F[le_40]: 8:8
+  //   F[le_40]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7346,8 +7122,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_40_qs)
   );
 
-
-  // F[le_41]: 9:9
+  //   F[le_41]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7372,8 +7147,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_41_qs)
   );
 
-
-  // F[le_42]: 10:10
+  //   F[le_42]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7398,8 +7172,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_42_qs)
   );
 
-
-  // F[le_43]: 11:11
+  //   F[le_43]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7424,8 +7197,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_43_qs)
   );
 
-
-  // F[le_44]: 12:12
+  //   F[le_44]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7450,8 +7222,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_44_qs)
   );
 
-
-  // F[le_45]: 13:13
+  //   F[le_45]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7476,8 +7247,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_45_qs)
   );
 
-
-  // F[le_46]: 14:14
+  //   F[le_46]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7502,8 +7272,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_46_qs)
   );
 
-
-  // F[le_47]: 15:15
+  //   F[le_47]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7528,8 +7297,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_47_qs)
   );
 
-
-  // F[le_48]: 16:16
+  //   F[le_48]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7554,8 +7322,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_48_qs)
   );
 
-
-  // F[le_49]: 17:17
+  //   F[le_49]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7580,8 +7347,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_49_qs)
   );
 
-
-  // F[le_50]: 18:18
+  //   F[le_50]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7606,8 +7372,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_50_qs)
   );
 
-
-  // F[le_51]: 19:19
+  //   F[le_51]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7632,8 +7397,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_51_qs)
   );
 
-
-  // F[le_52]: 20:20
+  //   F[le_52]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7658,8 +7422,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_52_qs)
   );
 
-
-  // F[le_53]: 21:21
+  //   F[le_53]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7684,8 +7447,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_53_qs)
   );
 
-
-  // F[le_54]: 22:22
+  //   F[le_54]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7710,8 +7472,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_54_qs)
   );
 
-
-  // F[le_55]: 23:23
+  //   F[le_55]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7736,8 +7497,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_55_qs)
   );
 
-
-  // F[le_56]: 24:24
+  //   F[le_56]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7762,8 +7522,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_56_qs)
   );
 
-
-  // F[le_57]: 25:25
+  //   F[le_57]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7788,8 +7547,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_57_qs)
   );
 
-
-  // F[le_58]: 26:26
+  //   F[le_58]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7814,8 +7572,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_58_qs)
   );
 
-
-  // F[le_59]: 27:27
+  //   F[le_59]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7840,8 +7597,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_59_qs)
   );
 
-
-  // F[le_60]: 28:28
+  //   F[le_60]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7866,8 +7622,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_60_qs)
   );
 
-
-  // F[le_61]: 29:29
+  //   F[le_61]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7892,8 +7647,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_61_qs)
   );
 
-
-  // F[le_62]: 30:30
+  //   F[le_62]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7918,8 +7672,7 @@ module rv_plic_reg_top (
     .qs     (le_1_le_62_qs)
   );
 
-
-  // F[le_63]: 31:31
+  //   F[le_63]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7945,10 +7698,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 64 of Multireg le
+  // Subregister 2 of Multireg le
   // R[le_2]: V(False)
-
-  // F[le_64]: 0:0
+  //   F[le_64]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7973,8 +7725,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_64_qs)
   );
 
-
-  // F[le_65]: 1:1
+  //   F[le_65]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -7999,8 +7750,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_65_qs)
   );
 
-
-  // F[le_66]: 2:2
+  //   F[le_66]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8025,8 +7775,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_66_qs)
   );
 
-
-  // F[le_67]: 3:3
+  //   F[le_67]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8051,8 +7800,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_67_qs)
   );
 
-
-  // F[le_68]: 4:4
+  //   F[le_68]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8077,8 +7825,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_68_qs)
   );
 
-
-  // F[le_69]: 5:5
+  //   F[le_69]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8103,8 +7850,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_69_qs)
   );
 
-
-  // F[le_70]: 6:6
+  //   F[le_70]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8129,8 +7875,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_70_qs)
   );
 
-
-  // F[le_71]: 7:7
+  //   F[le_71]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8155,8 +7900,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_71_qs)
   );
 
-
-  // F[le_72]: 8:8
+  //   F[le_72]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8181,8 +7925,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_72_qs)
   );
 
-
-  // F[le_73]: 9:9
+  //   F[le_73]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8207,8 +7950,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_73_qs)
   );
 
-
-  // F[le_74]: 10:10
+  //   F[le_74]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8233,8 +7975,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_74_qs)
   );
 
-
-  // F[le_75]: 11:11
+  //   F[le_75]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8259,8 +8000,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_75_qs)
   );
 
-
-  // F[le_76]: 12:12
+  //   F[le_76]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8285,8 +8025,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_76_qs)
   );
 
-
-  // F[le_77]: 13:13
+  //   F[le_77]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8311,8 +8050,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_77_qs)
   );
 
-
-  // F[le_78]: 14:14
+  //   F[le_78]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8337,8 +8075,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_78_qs)
   );
 
-
-  // F[le_79]: 15:15
+  //   F[le_79]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8363,8 +8100,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_79_qs)
   );
 
-
-  // F[le_80]: 16:16
+  //   F[le_80]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8389,8 +8125,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_80_qs)
   );
 
-
-  // F[le_81]: 17:17
+  //   F[le_81]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8415,8 +8150,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_81_qs)
   );
 
-
-  // F[le_82]: 18:18
+  //   F[le_82]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8441,8 +8175,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_82_qs)
   );
 
-
-  // F[le_83]: 19:19
+  //   F[le_83]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8467,8 +8200,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_83_qs)
   );
 
-
-  // F[le_84]: 20:20
+  //   F[le_84]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8493,8 +8225,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_84_qs)
   );
 
-
-  // F[le_85]: 21:21
+  //   F[le_85]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8519,8 +8250,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_85_qs)
   );
 
-
-  // F[le_86]: 22:22
+  //   F[le_86]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8545,8 +8275,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_86_qs)
   );
 
-
-  // F[le_87]: 23:23
+  //   F[le_87]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8571,8 +8300,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_87_qs)
   );
 
-
-  // F[le_88]: 24:24
+  //   F[le_88]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8597,8 +8325,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_88_qs)
   );
 
-
-  // F[le_89]: 25:25
+  //   F[le_89]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8623,8 +8350,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_89_qs)
   );
 
-
-  // F[le_90]: 26:26
+  //   F[le_90]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8649,8 +8375,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_90_qs)
   );
 
-
-  // F[le_91]: 27:27
+  //   F[le_91]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8675,8 +8400,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_91_qs)
   );
 
-
-  // F[le_92]: 28:28
+  //   F[le_92]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8701,8 +8425,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_92_qs)
   );
 
-
-  // F[le_93]: 29:29
+  //   F[le_93]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8727,8 +8450,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_93_qs)
   );
 
-
-  // F[le_94]: 30:30
+  //   F[le_94]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8753,8 +8475,7 @@ module rv_plic_reg_top (
     .qs     (le_2_le_94_qs)
   );
 
-
-  // F[le_95]: 31:31
+  //   F[le_95]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8780,10 +8501,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 96 of Multireg le
+  // Subregister 3 of Multireg le
   // R[le_3]: V(False)
-
-  // F[le_96]: 0:0
+  //   F[le_96]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8808,8 +8528,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_96_qs)
   );
 
-
-  // F[le_97]: 1:1
+  //   F[le_97]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8834,8 +8553,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_97_qs)
   );
 
-
-  // F[le_98]: 2:2
+  //   F[le_98]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8860,8 +8578,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_98_qs)
   );
 
-
-  // F[le_99]: 3:3
+  //   F[le_99]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8886,8 +8603,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_99_qs)
   );
 
-
-  // F[le_100]: 4:4
+  //   F[le_100]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8912,8 +8628,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_100_qs)
   );
 
-
-  // F[le_101]: 5:5
+  //   F[le_101]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8938,8 +8653,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_101_qs)
   );
 
-
-  // F[le_102]: 6:6
+  //   F[le_102]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8964,8 +8678,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_102_qs)
   );
 
-
-  // F[le_103]: 7:7
+  //   F[le_103]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -8990,8 +8703,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_103_qs)
   );
 
-
-  // F[le_104]: 8:8
+  //   F[le_104]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9016,8 +8728,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_104_qs)
   );
 
-
-  // F[le_105]: 9:9
+  //   F[le_105]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9042,8 +8753,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_105_qs)
   );
 
-
-  // F[le_106]: 10:10
+  //   F[le_106]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9068,8 +8778,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_106_qs)
   );
 
-
-  // F[le_107]: 11:11
+  //   F[le_107]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9094,8 +8803,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_107_qs)
   );
 
-
-  // F[le_108]: 12:12
+  //   F[le_108]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9120,8 +8828,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_108_qs)
   );
 
-
-  // F[le_109]: 13:13
+  //   F[le_109]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9146,8 +8853,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_109_qs)
   );
 
-
-  // F[le_110]: 14:14
+  //   F[le_110]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9172,8 +8878,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_110_qs)
   );
 
-
-  // F[le_111]: 15:15
+  //   F[le_111]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9198,8 +8903,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_111_qs)
   );
 
-
-  // F[le_112]: 16:16
+  //   F[le_112]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9224,8 +8928,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_112_qs)
   );
 
-
-  // F[le_113]: 17:17
+  //   F[le_113]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9250,8 +8953,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_113_qs)
   );
 
-
-  // F[le_114]: 18:18
+  //   F[le_114]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9276,8 +8978,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_114_qs)
   );
 
-
-  // F[le_115]: 19:19
+  //   F[le_115]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9302,8 +9003,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_115_qs)
   );
 
-
-  // F[le_116]: 20:20
+  //   F[le_116]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9328,8 +9028,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_116_qs)
   );
 
-
-  // F[le_117]: 21:21
+  //   F[le_117]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9354,8 +9053,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_117_qs)
   );
 
-
-  // F[le_118]: 22:22
+  //   F[le_118]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9380,8 +9078,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_118_qs)
   );
 
-
-  // F[le_119]: 23:23
+  //   F[le_119]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9406,8 +9103,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_119_qs)
   );
 
-
-  // F[le_120]: 24:24
+  //   F[le_120]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9432,8 +9128,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_120_qs)
   );
 
-
-  // F[le_121]: 25:25
+  //   F[le_121]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9458,8 +9153,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_121_qs)
   );
 
-
-  // F[le_122]: 26:26
+  //   F[le_122]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9484,8 +9178,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_122_qs)
   );
 
-
-  // F[le_123]: 27:27
+  //   F[le_123]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9510,8 +9203,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_123_qs)
   );
 
-
-  // F[le_124]: 28:28
+  //   F[le_124]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9536,8 +9228,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_124_qs)
   );
 
-
-  // F[le_125]: 29:29
+  //   F[le_125]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9562,8 +9253,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_125_qs)
   );
 
-
-  // F[le_126]: 30:30
+  //   F[le_126]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9588,8 +9278,7 @@ module rv_plic_reg_top (
     .qs     (le_3_le_126_qs)
   );
 
-
-  // F[le_127]: 31:31
+  //   F[le_127]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9615,10 +9304,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 128 of Multireg le
+  // Subregister 4 of Multireg le
   // R[le_4]: V(False)
-
-  // F[le_128]: 0:0
+  //   F[le_128]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9643,8 +9331,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_128_qs)
   );
 
-
-  // F[le_129]: 1:1
+  //   F[le_129]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9669,8 +9356,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_129_qs)
   );
 
-
-  // F[le_130]: 2:2
+  //   F[le_130]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9695,8 +9381,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_130_qs)
   );
 
-
-  // F[le_131]: 3:3
+  //   F[le_131]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9721,8 +9406,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_131_qs)
   );
 
-
-  // F[le_132]: 4:4
+  //   F[le_132]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9747,8 +9431,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_132_qs)
   );
 
-
-  // F[le_133]: 5:5
+  //   F[le_133]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9773,8 +9456,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_133_qs)
   );
 
-
-  // F[le_134]: 6:6
+  //   F[le_134]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9799,8 +9481,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_134_qs)
   );
 
-
-  // F[le_135]: 7:7
+  //   F[le_135]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9825,8 +9506,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_135_qs)
   );
 
-
-  // F[le_136]: 8:8
+  //   F[le_136]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9851,8 +9531,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_136_qs)
   );
 
-
-  // F[le_137]: 9:9
+  //   F[le_137]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9877,8 +9556,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_137_qs)
   );
 
-
-  // F[le_138]: 10:10
+  //   F[le_138]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9903,8 +9581,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_138_qs)
   );
 
-
-  // F[le_139]: 11:11
+  //   F[le_139]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9929,8 +9606,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_139_qs)
   );
 
-
-  // F[le_140]: 12:12
+  //   F[le_140]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9955,8 +9631,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_140_qs)
   );
 
-
-  // F[le_141]: 13:13
+  //   F[le_141]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -9981,8 +9656,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_141_qs)
   );
 
-
-  // F[le_142]: 14:14
+  //   F[le_142]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10007,8 +9681,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_142_qs)
   );
 
-
-  // F[le_143]: 15:15
+  //   F[le_143]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10033,8 +9706,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_143_qs)
   );
 
-
-  // F[le_144]: 16:16
+  //   F[le_144]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10059,8 +9731,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_144_qs)
   );
 
-
-  // F[le_145]: 17:17
+  //   F[le_145]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10085,8 +9756,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_145_qs)
   );
 
-
-  // F[le_146]: 18:18
+  //   F[le_146]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10111,8 +9781,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_146_qs)
   );
 
-
-  // F[le_147]: 19:19
+  //   F[le_147]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10137,8 +9806,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_147_qs)
   );
 
-
-  // F[le_148]: 20:20
+  //   F[le_148]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10163,8 +9831,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_148_qs)
   );
 
-
-  // F[le_149]: 21:21
+  //   F[le_149]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10189,8 +9856,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_149_qs)
   );
 
-
-  // F[le_150]: 22:22
+  //   F[le_150]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10215,8 +9881,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_150_qs)
   );
 
-
-  // F[le_151]: 23:23
+  //   F[le_151]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10241,8 +9906,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_151_qs)
   );
 
-
-  // F[le_152]: 24:24
+  //   F[le_152]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10267,8 +9931,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_152_qs)
   );
 
-
-  // F[le_153]: 25:25
+  //   F[le_153]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10293,8 +9956,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_153_qs)
   );
 
-
-  // F[le_154]: 26:26
+  //   F[le_154]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10319,8 +9981,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_154_qs)
   );
 
-
-  // F[le_155]: 27:27
+  //   F[le_155]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10345,8 +10006,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_155_qs)
   );
 
-
-  // F[le_156]: 28:28
+  //   F[le_156]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10371,8 +10031,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_156_qs)
   );
 
-
-  // F[le_157]: 29:29
+  //   F[le_157]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10397,8 +10056,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_157_qs)
   );
 
-
-  // F[le_158]: 30:30
+  //   F[le_158]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10423,8 +10081,7 @@ module rv_plic_reg_top (
     .qs     (le_4_le_158_qs)
   );
 
-
-  // F[le_159]: 31:31
+  //   F[le_159]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10450,10 +10107,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 160 of Multireg le
+  // Subregister 5 of Multireg le
   // R[le_5]: V(False)
-
-  // F[le_160]: 0:0
+  //   F[le_160]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10478,8 +10134,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_160_qs)
   );
 
-
-  // F[le_161]: 1:1
+  //   F[le_161]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10504,8 +10159,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_161_qs)
   );
 
-
-  // F[le_162]: 2:2
+  //   F[le_162]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10530,8 +10184,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_162_qs)
   );
 
-
-  // F[le_163]: 3:3
+  //   F[le_163]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10556,8 +10209,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_163_qs)
   );
 
-
-  // F[le_164]: 4:4
+  //   F[le_164]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10582,8 +10234,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_164_qs)
   );
 
-
-  // F[le_165]: 5:5
+  //   F[le_165]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10608,8 +10259,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_165_qs)
   );
 
-
-  // F[le_166]: 6:6
+  //   F[le_166]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10634,8 +10284,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_166_qs)
   );
 
-
-  // F[le_167]: 7:7
+  //   F[le_167]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10660,8 +10309,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_167_qs)
   );
 
-
-  // F[le_168]: 8:8
+  //   F[le_168]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10686,8 +10334,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_168_qs)
   );
 
-
-  // F[le_169]: 9:9
+  //   F[le_169]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10712,8 +10359,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_169_qs)
   );
 
-
-  // F[le_170]: 10:10
+  //   F[le_170]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10738,8 +10384,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_170_qs)
   );
 
-
-  // F[le_171]: 11:11
+  //   F[le_171]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10764,8 +10409,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_171_qs)
   );
 
-
-  // F[le_172]: 12:12
+  //   F[le_172]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10790,8 +10434,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_172_qs)
   );
 
-
-  // F[le_173]: 13:13
+  //   F[le_173]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10816,8 +10459,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_173_qs)
   );
 
-
-  // F[le_174]: 14:14
+  //   F[le_174]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10842,8 +10484,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_174_qs)
   );
 
-
-  // F[le_175]: 15:15
+  //   F[le_175]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10868,8 +10509,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_175_qs)
   );
 
-
-  // F[le_176]: 16:16
+  //   F[le_176]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10894,8 +10534,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_176_qs)
   );
 
-
-  // F[le_177]: 17:17
+  //   F[le_177]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10920,8 +10559,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_177_qs)
   );
 
-
-  // F[le_178]: 18:18
+  //   F[le_178]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10946,8 +10584,7 @@ module rv_plic_reg_top (
     .qs     (le_5_le_178_qs)
   );
 
-
-  // F[le_179]: 19:19
+  //   F[le_179]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10973,9 +10610,7 @@ module rv_plic_reg_top (
   );
 
 
-
   // R[prio0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11002,7 +10637,6 @@ module rv_plic_reg_top (
 
 
   // R[prio1]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11029,7 +10663,6 @@ module rv_plic_reg_top (
 
 
   // R[prio2]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11056,7 +10689,6 @@ module rv_plic_reg_top (
 
 
   // R[prio3]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11083,7 +10715,6 @@ module rv_plic_reg_top (
 
 
   // R[prio4]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11110,7 +10741,6 @@ module rv_plic_reg_top (
 
 
   // R[prio5]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11137,7 +10767,6 @@ module rv_plic_reg_top (
 
 
   // R[prio6]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11164,7 +10793,6 @@ module rv_plic_reg_top (
 
 
   // R[prio7]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11191,7 +10819,6 @@ module rv_plic_reg_top (
 
 
   // R[prio8]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11218,7 +10845,6 @@ module rv_plic_reg_top (
 
 
   // R[prio9]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11245,7 +10871,6 @@ module rv_plic_reg_top (
 
 
   // R[prio10]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11272,7 +10897,6 @@ module rv_plic_reg_top (
 
 
   // R[prio11]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11299,7 +10923,6 @@ module rv_plic_reg_top (
 
 
   // R[prio12]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11326,7 +10949,6 @@ module rv_plic_reg_top (
 
 
   // R[prio13]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11353,7 +10975,6 @@ module rv_plic_reg_top (
 
 
   // R[prio14]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11380,7 +11001,6 @@ module rv_plic_reg_top (
 
 
   // R[prio15]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11407,7 +11027,6 @@ module rv_plic_reg_top (
 
 
   // R[prio16]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11434,7 +11053,6 @@ module rv_plic_reg_top (
 
 
   // R[prio17]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11461,7 +11079,6 @@ module rv_plic_reg_top (
 
 
   // R[prio18]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11488,7 +11105,6 @@ module rv_plic_reg_top (
 
 
   // R[prio19]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11515,7 +11131,6 @@ module rv_plic_reg_top (
 
 
   // R[prio20]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11542,7 +11157,6 @@ module rv_plic_reg_top (
 
 
   // R[prio21]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11569,7 +11183,6 @@ module rv_plic_reg_top (
 
 
   // R[prio22]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11596,7 +11209,6 @@ module rv_plic_reg_top (
 
 
   // R[prio23]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11623,7 +11235,6 @@ module rv_plic_reg_top (
 
 
   // R[prio24]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11650,7 +11261,6 @@ module rv_plic_reg_top (
 
 
   // R[prio25]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11677,7 +11287,6 @@ module rv_plic_reg_top (
 
 
   // R[prio26]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11704,7 +11313,6 @@ module rv_plic_reg_top (
 
 
   // R[prio27]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11731,7 +11339,6 @@ module rv_plic_reg_top (
 
 
   // R[prio28]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11758,7 +11365,6 @@ module rv_plic_reg_top (
 
 
   // R[prio29]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11785,7 +11391,6 @@ module rv_plic_reg_top (
 
 
   // R[prio30]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11812,7 +11417,6 @@ module rv_plic_reg_top (
 
 
   // R[prio31]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11839,7 +11443,6 @@ module rv_plic_reg_top (
 
 
   // R[prio32]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11866,7 +11469,6 @@ module rv_plic_reg_top (
 
 
   // R[prio33]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11893,7 +11495,6 @@ module rv_plic_reg_top (
 
 
   // R[prio34]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11920,7 +11521,6 @@ module rv_plic_reg_top (
 
 
   // R[prio35]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11947,7 +11547,6 @@ module rv_plic_reg_top (
 
 
   // R[prio36]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11974,7 +11573,6 @@ module rv_plic_reg_top (
 
 
   // R[prio37]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12001,7 +11599,6 @@ module rv_plic_reg_top (
 
 
   // R[prio38]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12028,7 +11625,6 @@ module rv_plic_reg_top (
 
 
   // R[prio39]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12055,7 +11651,6 @@ module rv_plic_reg_top (
 
 
   // R[prio40]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12082,7 +11677,6 @@ module rv_plic_reg_top (
 
 
   // R[prio41]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12109,7 +11703,6 @@ module rv_plic_reg_top (
 
 
   // R[prio42]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12136,7 +11729,6 @@ module rv_plic_reg_top (
 
 
   // R[prio43]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12163,7 +11755,6 @@ module rv_plic_reg_top (
 
 
   // R[prio44]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12190,7 +11781,6 @@ module rv_plic_reg_top (
 
 
   // R[prio45]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12217,7 +11807,6 @@ module rv_plic_reg_top (
 
 
   // R[prio46]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12244,7 +11833,6 @@ module rv_plic_reg_top (
 
 
   // R[prio47]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12271,7 +11859,6 @@ module rv_plic_reg_top (
 
 
   // R[prio48]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12298,7 +11885,6 @@ module rv_plic_reg_top (
 
 
   // R[prio49]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12325,7 +11911,6 @@ module rv_plic_reg_top (
 
 
   // R[prio50]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12352,7 +11937,6 @@ module rv_plic_reg_top (
 
 
   // R[prio51]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12379,7 +11963,6 @@ module rv_plic_reg_top (
 
 
   // R[prio52]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12406,7 +11989,6 @@ module rv_plic_reg_top (
 
 
   // R[prio53]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12433,7 +12015,6 @@ module rv_plic_reg_top (
 
 
   // R[prio54]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12460,7 +12041,6 @@ module rv_plic_reg_top (
 
 
   // R[prio55]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12487,7 +12067,6 @@ module rv_plic_reg_top (
 
 
   // R[prio56]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12514,7 +12093,6 @@ module rv_plic_reg_top (
 
 
   // R[prio57]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12541,7 +12119,6 @@ module rv_plic_reg_top (
 
 
   // R[prio58]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12568,7 +12145,6 @@ module rv_plic_reg_top (
 
 
   // R[prio59]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12595,7 +12171,6 @@ module rv_plic_reg_top (
 
 
   // R[prio60]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12622,7 +12197,6 @@ module rv_plic_reg_top (
 
 
   // R[prio61]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12649,7 +12223,6 @@ module rv_plic_reg_top (
 
 
   // R[prio62]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12676,7 +12249,6 @@ module rv_plic_reg_top (
 
 
   // R[prio63]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12703,7 +12275,6 @@ module rv_plic_reg_top (
 
 
   // R[prio64]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12730,7 +12301,6 @@ module rv_plic_reg_top (
 
 
   // R[prio65]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12757,7 +12327,6 @@ module rv_plic_reg_top (
 
 
   // R[prio66]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12784,7 +12353,6 @@ module rv_plic_reg_top (
 
 
   // R[prio67]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12811,7 +12379,6 @@ module rv_plic_reg_top (
 
 
   // R[prio68]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12838,7 +12405,6 @@ module rv_plic_reg_top (
 
 
   // R[prio69]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12865,7 +12431,6 @@ module rv_plic_reg_top (
 
 
   // R[prio70]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12892,7 +12457,6 @@ module rv_plic_reg_top (
 
 
   // R[prio71]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12919,7 +12483,6 @@ module rv_plic_reg_top (
 
 
   // R[prio72]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12946,7 +12509,6 @@ module rv_plic_reg_top (
 
 
   // R[prio73]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12973,7 +12535,6 @@ module rv_plic_reg_top (
 
 
   // R[prio74]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13000,7 +12561,6 @@ module rv_plic_reg_top (
 
 
   // R[prio75]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13027,7 +12587,6 @@ module rv_plic_reg_top (
 
 
   // R[prio76]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13054,7 +12613,6 @@ module rv_plic_reg_top (
 
 
   // R[prio77]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13081,7 +12639,6 @@ module rv_plic_reg_top (
 
 
   // R[prio78]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13108,7 +12665,6 @@ module rv_plic_reg_top (
 
 
   // R[prio79]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13135,7 +12691,6 @@ module rv_plic_reg_top (
 
 
   // R[prio80]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13162,7 +12717,6 @@ module rv_plic_reg_top (
 
 
   // R[prio81]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13189,7 +12743,6 @@ module rv_plic_reg_top (
 
 
   // R[prio82]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13216,7 +12769,6 @@ module rv_plic_reg_top (
 
 
   // R[prio83]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13243,7 +12795,6 @@ module rv_plic_reg_top (
 
 
   // R[prio84]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13270,7 +12821,6 @@ module rv_plic_reg_top (
 
 
   // R[prio85]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13297,7 +12847,6 @@ module rv_plic_reg_top (
 
 
   // R[prio86]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13324,7 +12873,6 @@ module rv_plic_reg_top (
 
 
   // R[prio87]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13351,7 +12899,6 @@ module rv_plic_reg_top (
 
 
   // R[prio88]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13378,7 +12925,6 @@ module rv_plic_reg_top (
 
 
   // R[prio89]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13405,7 +12951,6 @@ module rv_plic_reg_top (
 
 
   // R[prio90]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13432,7 +12977,6 @@ module rv_plic_reg_top (
 
 
   // R[prio91]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13459,7 +13003,6 @@ module rv_plic_reg_top (
 
 
   // R[prio92]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13486,7 +13029,6 @@ module rv_plic_reg_top (
 
 
   // R[prio93]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13513,7 +13055,6 @@ module rv_plic_reg_top (
 
 
   // R[prio94]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13540,7 +13081,6 @@ module rv_plic_reg_top (
 
 
   // R[prio95]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13567,7 +13107,6 @@ module rv_plic_reg_top (
 
 
   // R[prio96]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13594,7 +13133,6 @@ module rv_plic_reg_top (
 
 
   // R[prio97]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13621,7 +13159,6 @@ module rv_plic_reg_top (
 
 
   // R[prio98]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13648,7 +13185,6 @@ module rv_plic_reg_top (
 
 
   // R[prio99]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13675,7 +13211,6 @@ module rv_plic_reg_top (
 
 
   // R[prio100]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13702,7 +13237,6 @@ module rv_plic_reg_top (
 
 
   // R[prio101]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13729,7 +13263,6 @@ module rv_plic_reg_top (
 
 
   // R[prio102]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13756,7 +13289,6 @@ module rv_plic_reg_top (
 
 
   // R[prio103]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13783,7 +13315,6 @@ module rv_plic_reg_top (
 
 
   // R[prio104]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13810,7 +13341,6 @@ module rv_plic_reg_top (
 
 
   // R[prio105]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13837,7 +13367,6 @@ module rv_plic_reg_top (
 
 
   // R[prio106]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13864,7 +13393,6 @@ module rv_plic_reg_top (
 
 
   // R[prio107]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13891,7 +13419,6 @@ module rv_plic_reg_top (
 
 
   // R[prio108]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13918,7 +13445,6 @@ module rv_plic_reg_top (
 
 
   // R[prio109]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13945,7 +13471,6 @@ module rv_plic_reg_top (
 
 
   // R[prio110]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13972,7 +13497,6 @@ module rv_plic_reg_top (
 
 
   // R[prio111]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -13999,7 +13523,6 @@ module rv_plic_reg_top (
 
 
   // R[prio112]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14026,7 +13549,6 @@ module rv_plic_reg_top (
 
 
   // R[prio113]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14053,7 +13575,6 @@ module rv_plic_reg_top (
 
 
   // R[prio114]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14080,7 +13601,6 @@ module rv_plic_reg_top (
 
 
   // R[prio115]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14107,7 +13627,6 @@ module rv_plic_reg_top (
 
 
   // R[prio116]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14134,7 +13653,6 @@ module rv_plic_reg_top (
 
 
   // R[prio117]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14161,7 +13679,6 @@ module rv_plic_reg_top (
 
 
   // R[prio118]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14188,7 +13705,6 @@ module rv_plic_reg_top (
 
 
   // R[prio119]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14215,7 +13731,6 @@ module rv_plic_reg_top (
 
 
   // R[prio120]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14242,7 +13757,6 @@ module rv_plic_reg_top (
 
 
   // R[prio121]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14269,7 +13783,6 @@ module rv_plic_reg_top (
 
 
   // R[prio122]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14296,7 +13809,6 @@ module rv_plic_reg_top (
 
 
   // R[prio123]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14323,7 +13835,6 @@ module rv_plic_reg_top (
 
 
   // R[prio124]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14350,7 +13861,6 @@ module rv_plic_reg_top (
 
 
   // R[prio125]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14377,7 +13887,6 @@ module rv_plic_reg_top (
 
 
   // R[prio126]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14404,7 +13913,6 @@ module rv_plic_reg_top (
 
 
   // R[prio127]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14431,7 +13939,6 @@ module rv_plic_reg_top (
 
 
   // R[prio128]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14458,7 +13965,6 @@ module rv_plic_reg_top (
 
 
   // R[prio129]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14485,7 +13991,6 @@ module rv_plic_reg_top (
 
 
   // R[prio130]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14512,7 +14017,6 @@ module rv_plic_reg_top (
 
 
   // R[prio131]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14539,7 +14043,6 @@ module rv_plic_reg_top (
 
 
   // R[prio132]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14566,7 +14069,6 @@ module rv_plic_reg_top (
 
 
   // R[prio133]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14593,7 +14095,6 @@ module rv_plic_reg_top (
 
 
   // R[prio134]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14620,7 +14121,6 @@ module rv_plic_reg_top (
 
 
   // R[prio135]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14647,7 +14147,6 @@ module rv_plic_reg_top (
 
 
   // R[prio136]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14674,7 +14173,6 @@ module rv_plic_reg_top (
 
 
   // R[prio137]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14701,7 +14199,6 @@ module rv_plic_reg_top (
 
 
   // R[prio138]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14728,7 +14225,6 @@ module rv_plic_reg_top (
 
 
   // R[prio139]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14755,7 +14251,6 @@ module rv_plic_reg_top (
 
 
   // R[prio140]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14782,7 +14277,6 @@ module rv_plic_reg_top (
 
 
   // R[prio141]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14809,7 +14303,6 @@ module rv_plic_reg_top (
 
 
   // R[prio142]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14836,7 +14329,6 @@ module rv_plic_reg_top (
 
 
   // R[prio143]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14863,7 +14355,6 @@ module rv_plic_reg_top (
 
 
   // R[prio144]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14890,7 +14381,6 @@ module rv_plic_reg_top (
 
 
   // R[prio145]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14917,7 +14407,6 @@ module rv_plic_reg_top (
 
 
   // R[prio146]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14944,7 +14433,6 @@ module rv_plic_reg_top (
 
 
   // R[prio147]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14971,7 +14459,6 @@ module rv_plic_reg_top (
 
 
   // R[prio148]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -14998,7 +14485,6 @@ module rv_plic_reg_top (
 
 
   // R[prio149]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15025,7 +14511,6 @@ module rv_plic_reg_top (
 
 
   // R[prio150]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15052,7 +14537,6 @@ module rv_plic_reg_top (
 
 
   // R[prio151]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15079,7 +14563,6 @@ module rv_plic_reg_top (
 
 
   // R[prio152]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15106,7 +14589,6 @@ module rv_plic_reg_top (
 
 
   // R[prio153]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15133,7 +14615,6 @@ module rv_plic_reg_top (
 
 
   // R[prio154]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15160,7 +14641,6 @@ module rv_plic_reg_top (
 
 
   // R[prio155]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15187,7 +14667,6 @@ module rv_plic_reg_top (
 
 
   // R[prio156]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15214,7 +14693,6 @@ module rv_plic_reg_top (
 
 
   // R[prio157]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15241,7 +14719,6 @@ module rv_plic_reg_top (
 
 
   // R[prio158]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15268,7 +14745,6 @@ module rv_plic_reg_top (
 
 
   // R[prio159]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15295,7 +14771,6 @@ module rv_plic_reg_top (
 
 
   // R[prio160]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15322,7 +14797,6 @@ module rv_plic_reg_top (
 
 
   // R[prio161]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15349,7 +14823,6 @@ module rv_plic_reg_top (
 
 
   // R[prio162]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15376,7 +14849,6 @@ module rv_plic_reg_top (
 
 
   // R[prio163]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15403,7 +14875,6 @@ module rv_plic_reg_top (
 
 
   // R[prio164]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15430,7 +14901,6 @@ module rv_plic_reg_top (
 
 
   // R[prio165]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15457,7 +14927,6 @@ module rv_plic_reg_top (
 
 
   // R[prio166]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15484,7 +14953,6 @@ module rv_plic_reg_top (
 
 
   // R[prio167]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15511,7 +14979,6 @@ module rv_plic_reg_top (
 
 
   // R[prio168]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15538,7 +15005,6 @@ module rv_plic_reg_top (
 
 
   // R[prio169]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15565,7 +15031,6 @@ module rv_plic_reg_top (
 
 
   // R[prio170]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15592,7 +15057,6 @@ module rv_plic_reg_top (
 
 
   // R[prio171]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15619,7 +15083,6 @@ module rv_plic_reg_top (
 
 
   // R[prio172]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15646,7 +15109,6 @@ module rv_plic_reg_top (
 
 
   // R[prio173]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15673,7 +15135,6 @@ module rv_plic_reg_top (
 
 
   // R[prio174]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15700,7 +15161,6 @@ module rv_plic_reg_top (
 
 
   // R[prio175]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15727,7 +15187,6 @@ module rv_plic_reg_top (
 
 
   // R[prio176]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15754,7 +15213,6 @@ module rv_plic_reg_top (
 
 
   // R[prio177]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15781,7 +15239,6 @@ module rv_plic_reg_top (
 
 
   // R[prio178]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15808,7 +15265,6 @@ module rv_plic_reg_top (
 
 
   // R[prio179]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15834,11 +15290,9 @@ module rv_plic_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ie0
   // R[ie0_0]: V(False)
-
-  // F[e_0]: 0:0
+  //   F[e_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15863,8 +15317,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_0_qs)
   );
 
-
-  // F[e_1]: 1:1
+  //   F[e_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15889,8 +15342,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_1_qs)
   );
 
-
-  // F[e_2]: 2:2
+  //   F[e_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15915,8 +15367,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_2_qs)
   );
 
-
-  // F[e_3]: 3:3
+  //   F[e_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15941,8 +15392,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_3_qs)
   );
 
-
-  // F[e_4]: 4:4
+  //   F[e_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15967,8 +15417,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_4_qs)
   );
 
-
-  // F[e_5]: 5:5
+  //   F[e_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -15993,8 +15442,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_5_qs)
   );
 
-
-  // F[e_6]: 6:6
+  //   F[e_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16019,8 +15467,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_6_qs)
   );
 
-
-  // F[e_7]: 7:7
+  //   F[e_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16045,8 +15492,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_7_qs)
   );
 
-
-  // F[e_8]: 8:8
+  //   F[e_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16071,8 +15517,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_8_qs)
   );
 
-
-  // F[e_9]: 9:9
+  //   F[e_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16097,8 +15542,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_9_qs)
   );
 
-
-  // F[e_10]: 10:10
+  //   F[e_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16123,8 +15567,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_10_qs)
   );
 
-
-  // F[e_11]: 11:11
+  //   F[e_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16149,8 +15592,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_11_qs)
   );
 
-
-  // F[e_12]: 12:12
+  //   F[e_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16175,8 +15617,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_12_qs)
   );
 
-
-  // F[e_13]: 13:13
+  //   F[e_13]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16201,8 +15642,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_13_qs)
   );
 
-
-  // F[e_14]: 14:14
+  //   F[e_14]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16227,8 +15667,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_14_qs)
   );
 
-
-  // F[e_15]: 15:15
+  //   F[e_15]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16253,8 +15692,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_15_qs)
   );
 
-
-  // F[e_16]: 16:16
+  //   F[e_16]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16279,8 +15717,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_16_qs)
   );
 
-
-  // F[e_17]: 17:17
+  //   F[e_17]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16305,8 +15742,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_17_qs)
   );
 
-
-  // F[e_18]: 18:18
+  //   F[e_18]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16331,8 +15767,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_18_qs)
   );
 
-
-  // F[e_19]: 19:19
+  //   F[e_19]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16357,8 +15792,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_19_qs)
   );
 
-
-  // F[e_20]: 20:20
+  //   F[e_20]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16383,8 +15817,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_20_qs)
   );
 
-
-  // F[e_21]: 21:21
+  //   F[e_21]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16409,8 +15842,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_21_qs)
   );
 
-
-  // F[e_22]: 22:22
+  //   F[e_22]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16435,8 +15867,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_22_qs)
   );
 
-
-  // F[e_23]: 23:23
+  //   F[e_23]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16461,8 +15892,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_23_qs)
   );
 
-
-  // F[e_24]: 24:24
+  //   F[e_24]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16487,8 +15917,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_24_qs)
   );
 
-
-  // F[e_25]: 25:25
+  //   F[e_25]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16513,8 +15942,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_25_qs)
   );
 
-
-  // F[e_26]: 26:26
+  //   F[e_26]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16539,8 +15967,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_26_qs)
   );
 
-
-  // F[e_27]: 27:27
+  //   F[e_27]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16565,8 +15992,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_27_qs)
   );
 
-
-  // F[e_28]: 28:28
+  //   F[e_28]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16591,8 +16017,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_28_qs)
   );
 
-
-  // F[e_29]: 29:29
+  //   F[e_29]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16617,8 +16042,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_29_qs)
   );
 
-
-  // F[e_30]: 30:30
+  //   F[e_30]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16643,8 +16067,7 @@ module rv_plic_reg_top (
     .qs     (ie0_0_e_30_qs)
   );
 
-
-  // F[e_31]: 31:31
+  //   F[e_31]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16670,10 +16093,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 32 of Multireg ie0
+  // Subregister 1 of Multireg ie0
   // R[ie0_1]: V(False)
-
-  // F[e_32]: 0:0
+  //   F[e_32]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16698,8 +16120,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_32_qs)
   );
 
-
-  // F[e_33]: 1:1
+  //   F[e_33]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16724,8 +16145,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_33_qs)
   );
 
-
-  // F[e_34]: 2:2
+  //   F[e_34]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16750,8 +16170,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_34_qs)
   );
 
-
-  // F[e_35]: 3:3
+  //   F[e_35]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16776,8 +16195,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_35_qs)
   );
 
-
-  // F[e_36]: 4:4
+  //   F[e_36]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16802,8 +16220,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_36_qs)
   );
 
-
-  // F[e_37]: 5:5
+  //   F[e_37]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16828,8 +16245,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_37_qs)
   );
 
-
-  // F[e_38]: 6:6
+  //   F[e_38]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16854,8 +16270,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_38_qs)
   );
 
-
-  // F[e_39]: 7:7
+  //   F[e_39]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16880,8 +16295,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_39_qs)
   );
 
-
-  // F[e_40]: 8:8
+  //   F[e_40]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16906,8 +16320,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_40_qs)
   );
 
-
-  // F[e_41]: 9:9
+  //   F[e_41]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16932,8 +16345,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_41_qs)
   );
 
-
-  // F[e_42]: 10:10
+  //   F[e_42]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16958,8 +16370,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_42_qs)
   );
 
-
-  // F[e_43]: 11:11
+  //   F[e_43]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -16984,8 +16395,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_43_qs)
   );
 
-
-  // F[e_44]: 12:12
+  //   F[e_44]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17010,8 +16420,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_44_qs)
   );
 
-
-  // F[e_45]: 13:13
+  //   F[e_45]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17036,8 +16445,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_45_qs)
   );
 
-
-  // F[e_46]: 14:14
+  //   F[e_46]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17062,8 +16470,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_46_qs)
   );
 
-
-  // F[e_47]: 15:15
+  //   F[e_47]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17088,8 +16495,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_47_qs)
   );
 
-
-  // F[e_48]: 16:16
+  //   F[e_48]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17114,8 +16520,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_48_qs)
   );
 
-
-  // F[e_49]: 17:17
+  //   F[e_49]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17140,8 +16545,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_49_qs)
   );
 
-
-  // F[e_50]: 18:18
+  //   F[e_50]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17166,8 +16570,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_50_qs)
   );
 
-
-  // F[e_51]: 19:19
+  //   F[e_51]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17192,8 +16595,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_51_qs)
   );
 
-
-  // F[e_52]: 20:20
+  //   F[e_52]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17218,8 +16620,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_52_qs)
   );
 
-
-  // F[e_53]: 21:21
+  //   F[e_53]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17244,8 +16645,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_53_qs)
   );
 
-
-  // F[e_54]: 22:22
+  //   F[e_54]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17270,8 +16670,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_54_qs)
   );
 
-
-  // F[e_55]: 23:23
+  //   F[e_55]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17296,8 +16695,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_55_qs)
   );
 
-
-  // F[e_56]: 24:24
+  //   F[e_56]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17322,8 +16720,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_56_qs)
   );
 
-
-  // F[e_57]: 25:25
+  //   F[e_57]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17348,8 +16745,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_57_qs)
   );
 
-
-  // F[e_58]: 26:26
+  //   F[e_58]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17374,8 +16770,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_58_qs)
   );
 
-
-  // F[e_59]: 27:27
+  //   F[e_59]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17400,8 +16795,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_59_qs)
   );
 
-
-  // F[e_60]: 28:28
+  //   F[e_60]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17426,8 +16820,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_60_qs)
   );
 
-
-  // F[e_61]: 29:29
+  //   F[e_61]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17452,8 +16845,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_61_qs)
   );
 
-
-  // F[e_62]: 30:30
+  //   F[e_62]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17478,8 +16870,7 @@ module rv_plic_reg_top (
     .qs     (ie0_1_e_62_qs)
   );
 
-
-  // F[e_63]: 31:31
+  //   F[e_63]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17505,10 +16896,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 64 of Multireg ie0
+  // Subregister 2 of Multireg ie0
   // R[ie0_2]: V(False)
-
-  // F[e_64]: 0:0
+  //   F[e_64]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17533,8 +16923,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_64_qs)
   );
 
-
-  // F[e_65]: 1:1
+  //   F[e_65]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17559,8 +16948,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_65_qs)
   );
 
-
-  // F[e_66]: 2:2
+  //   F[e_66]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17585,8 +16973,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_66_qs)
   );
 
-
-  // F[e_67]: 3:3
+  //   F[e_67]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17611,8 +16998,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_67_qs)
   );
 
-
-  // F[e_68]: 4:4
+  //   F[e_68]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17637,8 +17023,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_68_qs)
   );
 
-
-  // F[e_69]: 5:5
+  //   F[e_69]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17663,8 +17048,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_69_qs)
   );
 
-
-  // F[e_70]: 6:6
+  //   F[e_70]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17689,8 +17073,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_70_qs)
   );
 
-
-  // F[e_71]: 7:7
+  //   F[e_71]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17715,8 +17098,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_71_qs)
   );
 
-
-  // F[e_72]: 8:8
+  //   F[e_72]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17741,8 +17123,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_72_qs)
   );
 
-
-  // F[e_73]: 9:9
+  //   F[e_73]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17767,8 +17148,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_73_qs)
   );
 
-
-  // F[e_74]: 10:10
+  //   F[e_74]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17793,8 +17173,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_74_qs)
   );
 
-
-  // F[e_75]: 11:11
+  //   F[e_75]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17819,8 +17198,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_75_qs)
   );
 
-
-  // F[e_76]: 12:12
+  //   F[e_76]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17845,8 +17223,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_76_qs)
   );
 
-
-  // F[e_77]: 13:13
+  //   F[e_77]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17871,8 +17248,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_77_qs)
   );
 
-
-  // F[e_78]: 14:14
+  //   F[e_78]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17897,8 +17273,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_78_qs)
   );
 
-
-  // F[e_79]: 15:15
+  //   F[e_79]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17923,8 +17298,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_79_qs)
   );
 
-
-  // F[e_80]: 16:16
+  //   F[e_80]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17949,8 +17323,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_80_qs)
   );
 
-
-  // F[e_81]: 17:17
+  //   F[e_81]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -17975,8 +17348,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_81_qs)
   );
 
-
-  // F[e_82]: 18:18
+  //   F[e_82]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18001,8 +17373,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_82_qs)
   );
 
-
-  // F[e_83]: 19:19
+  //   F[e_83]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18027,8 +17398,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_83_qs)
   );
 
-
-  // F[e_84]: 20:20
+  //   F[e_84]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18053,8 +17423,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_84_qs)
   );
 
-
-  // F[e_85]: 21:21
+  //   F[e_85]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18079,8 +17448,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_85_qs)
   );
 
-
-  // F[e_86]: 22:22
+  //   F[e_86]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18105,8 +17473,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_86_qs)
   );
 
-
-  // F[e_87]: 23:23
+  //   F[e_87]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18131,8 +17498,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_87_qs)
   );
 
-
-  // F[e_88]: 24:24
+  //   F[e_88]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18157,8 +17523,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_88_qs)
   );
 
-
-  // F[e_89]: 25:25
+  //   F[e_89]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18183,8 +17548,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_89_qs)
   );
 
-
-  // F[e_90]: 26:26
+  //   F[e_90]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18209,8 +17573,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_90_qs)
   );
 
-
-  // F[e_91]: 27:27
+  //   F[e_91]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18235,8 +17598,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_91_qs)
   );
 
-
-  // F[e_92]: 28:28
+  //   F[e_92]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18261,8 +17623,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_92_qs)
   );
 
-
-  // F[e_93]: 29:29
+  //   F[e_93]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18287,8 +17648,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_93_qs)
   );
 
-
-  // F[e_94]: 30:30
+  //   F[e_94]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18313,8 +17673,7 @@ module rv_plic_reg_top (
     .qs     (ie0_2_e_94_qs)
   );
 
-
-  // F[e_95]: 31:31
+  //   F[e_95]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18340,10 +17699,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 96 of Multireg ie0
+  // Subregister 3 of Multireg ie0
   // R[ie0_3]: V(False)
-
-  // F[e_96]: 0:0
+  //   F[e_96]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18368,8 +17726,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_96_qs)
   );
 
-
-  // F[e_97]: 1:1
+  //   F[e_97]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18394,8 +17751,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_97_qs)
   );
 
-
-  // F[e_98]: 2:2
+  //   F[e_98]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18420,8 +17776,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_98_qs)
   );
 
-
-  // F[e_99]: 3:3
+  //   F[e_99]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18446,8 +17801,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_99_qs)
   );
 
-
-  // F[e_100]: 4:4
+  //   F[e_100]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18472,8 +17826,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_100_qs)
   );
 
-
-  // F[e_101]: 5:5
+  //   F[e_101]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18498,8 +17851,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_101_qs)
   );
 
-
-  // F[e_102]: 6:6
+  //   F[e_102]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18524,8 +17876,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_102_qs)
   );
 
-
-  // F[e_103]: 7:7
+  //   F[e_103]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18550,8 +17901,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_103_qs)
   );
 
-
-  // F[e_104]: 8:8
+  //   F[e_104]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18576,8 +17926,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_104_qs)
   );
 
-
-  // F[e_105]: 9:9
+  //   F[e_105]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18602,8 +17951,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_105_qs)
   );
 
-
-  // F[e_106]: 10:10
+  //   F[e_106]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18628,8 +17976,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_106_qs)
   );
 
-
-  // F[e_107]: 11:11
+  //   F[e_107]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18654,8 +18001,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_107_qs)
   );
 
-
-  // F[e_108]: 12:12
+  //   F[e_108]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18680,8 +18026,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_108_qs)
   );
 
-
-  // F[e_109]: 13:13
+  //   F[e_109]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18706,8 +18051,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_109_qs)
   );
 
-
-  // F[e_110]: 14:14
+  //   F[e_110]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18732,8 +18076,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_110_qs)
   );
 
-
-  // F[e_111]: 15:15
+  //   F[e_111]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18758,8 +18101,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_111_qs)
   );
 
-
-  // F[e_112]: 16:16
+  //   F[e_112]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18784,8 +18126,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_112_qs)
   );
 
-
-  // F[e_113]: 17:17
+  //   F[e_113]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18810,8 +18151,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_113_qs)
   );
 
-
-  // F[e_114]: 18:18
+  //   F[e_114]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18836,8 +18176,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_114_qs)
   );
 
-
-  // F[e_115]: 19:19
+  //   F[e_115]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18862,8 +18201,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_115_qs)
   );
 
-
-  // F[e_116]: 20:20
+  //   F[e_116]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18888,8 +18226,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_116_qs)
   );
 
-
-  // F[e_117]: 21:21
+  //   F[e_117]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18914,8 +18251,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_117_qs)
   );
 
-
-  // F[e_118]: 22:22
+  //   F[e_118]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18940,8 +18276,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_118_qs)
   );
 
-
-  // F[e_119]: 23:23
+  //   F[e_119]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18966,8 +18301,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_119_qs)
   );
 
-
-  // F[e_120]: 24:24
+  //   F[e_120]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -18992,8 +18326,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_120_qs)
   );
 
-
-  // F[e_121]: 25:25
+  //   F[e_121]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19018,8 +18351,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_121_qs)
   );
 
-
-  // F[e_122]: 26:26
+  //   F[e_122]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19044,8 +18376,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_122_qs)
   );
 
-
-  // F[e_123]: 27:27
+  //   F[e_123]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19070,8 +18401,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_123_qs)
   );
 
-
-  // F[e_124]: 28:28
+  //   F[e_124]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19096,8 +18426,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_124_qs)
   );
 
-
-  // F[e_125]: 29:29
+  //   F[e_125]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19122,8 +18451,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_125_qs)
   );
 
-
-  // F[e_126]: 30:30
+  //   F[e_126]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19148,8 +18476,7 @@ module rv_plic_reg_top (
     .qs     (ie0_3_e_126_qs)
   );
 
-
-  // F[e_127]: 31:31
+  //   F[e_127]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19175,10 +18502,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 128 of Multireg ie0
+  // Subregister 4 of Multireg ie0
   // R[ie0_4]: V(False)
-
-  // F[e_128]: 0:0
+  //   F[e_128]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19203,8 +18529,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_128_qs)
   );
 
-
-  // F[e_129]: 1:1
+  //   F[e_129]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19229,8 +18554,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_129_qs)
   );
 
-
-  // F[e_130]: 2:2
+  //   F[e_130]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19255,8 +18579,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_130_qs)
   );
 
-
-  // F[e_131]: 3:3
+  //   F[e_131]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19281,8 +18604,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_131_qs)
   );
 
-
-  // F[e_132]: 4:4
+  //   F[e_132]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19307,8 +18629,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_132_qs)
   );
 
-
-  // F[e_133]: 5:5
+  //   F[e_133]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19333,8 +18654,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_133_qs)
   );
 
-
-  // F[e_134]: 6:6
+  //   F[e_134]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19359,8 +18679,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_134_qs)
   );
 
-
-  // F[e_135]: 7:7
+  //   F[e_135]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19385,8 +18704,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_135_qs)
   );
 
-
-  // F[e_136]: 8:8
+  //   F[e_136]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19411,8 +18729,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_136_qs)
   );
 
-
-  // F[e_137]: 9:9
+  //   F[e_137]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19437,8 +18754,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_137_qs)
   );
 
-
-  // F[e_138]: 10:10
+  //   F[e_138]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19463,8 +18779,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_138_qs)
   );
 
-
-  // F[e_139]: 11:11
+  //   F[e_139]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19489,8 +18804,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_139_qs)
   );
 
-
-  // F[e_140]: 12:12
+  //   F[e_140]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19515,8 +18829,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_140_qs)
   );
 
-
-  // F[e_141]: 13:13
+  //   F[e_141]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19541,8 +18854,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_141_qs)
   );
 
-
-  // F[e_142]: 14:14
+  //   F[e_142]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19567,8 +18879,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_142_qs)
   );
 
-
-  // F[e_143]: 15:15
+  //   F[e_143]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19593,8 +18904,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_143_qs)
   );
 
-
-  // F[e_144]: 16:16
+  //   F[e_144]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19619,8 +18929,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_144_qs)
   );
 
-
-  // F[e_145]: 17:17
+  //   F[e_145]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19645,8 +18954,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_145_qs)
   );
 
-
-  // F[e_146]: 18:18
+  //   F[e_146]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19671,8 +18979,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_146_qs)
   );
 
-
-  // F[e_147]: 19:19
+  //   F[e_147]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19697,8 +19004,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_147_qs)
   );
 
-
-  // F[e_148]: 20:20
+  //   F[e_148]: 20:20
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19723,8 +19029,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_148_qs)
   );
 
-
-  // F[e_149]: 21:21
+  //   F[e_149]: 21:21
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19749,8 +19054,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_149_qs)
   );
 
-
-  // F[e_150]: 22:22
+  //   F[e_150]: 22:22
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19775,8 +19079,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_150_qs)
   );
 
-
-  // F[e_151]: 23:23
+  //   F[e_151]: 23:23
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19801,8 +19104,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_151_qs)
   );
 
-
-  // F[e_152]: 24:24
+  //   F[e_152]: 24:24
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19827,8 +19129,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_152_qs)
   );
 
-
-  // F[e_153]: 25:25
+  //   F[e_153]: 25:25
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19853,8 +19154,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_153_qs)
   );
 
-
-  // F[e_154]: 26:26
+  //   F[e_154]: 26:26
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19879,8 +19179,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_154_qs)
   );
 
-
-  // F[e_155]: 27:27
+  //   F[e_155]: 27:27
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19905,8 +19204,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_155_qs)
   );
 
-
-  // F[e_156]: 28:28
+  //   F[e_156]: 28:28
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19931,8 +19229,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_156_qs)
   );
 
-
-  // F[e_157]: 29:29
+  //   F[e_157]: 29:29
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19957,8 +19254,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_157_qs)
   );
 
-
-  // F[e_158]: 30:30
+  //   F[e_158]: 30:30
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -19983,8 +19279,7 @@ module rv_plic_reg_top (
     .qs     (ie0_4_e_158_qs)
   );
 
-
-  // F[e_159]: 31:31
+  //   F[e_159]: 31:31
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20010,10 +19305,9 @@ module rv_plic_reg_top (
   );
 
 
-  // Subregister 160 of Multireg ie0
+  // Subregister 5 of Multireg ie0
   // R[ie0_5]: V(False)
-
-  // F[e_160]: 0:0
+  //   F[e_160]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20038,8 +19332,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_160_qs)
   );
 
-
-  // F[e_161]: 1:1
+  //   F[e_161]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20064,8 +19357,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_161_qs)
   );
 
-
-  // F[e_162]: 2:2
+  //   F[e_162]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20090,8 +19382,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_162_qs)
   );
 
-
-  // F[e_163]: 3:3
+  //   F[e_163]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20116,8 +19407,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_163_qs)
   );
 
-
-  // F[e_164]: 4:4
+  //   F[e_164]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20142,8 +19432,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_164_qs)
   );
 
-
-  // F[e_165]: 5:5
+  //   F[e_165]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20168,8 +19457,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_165_qs)
   );
 
-
-  // F[e_166]: 6:6
+  //   F[e_166]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20194,8 +19482,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_166_qs)
   );
 
-
-  // F[e_167]: 7:7
+  //   F[e_167]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20220,8 +19507,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_167_qs)
   );
 
-
-  // F[e_168]: 8:8
+  //   F[e_168]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20246,8 +19532,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_168_qs)
   );
 
-
-  // F[e_169]: 9:9
+  //   F[e_169]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20272,8 +19557,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_169_qs)
   );
 
-
-  // F[e_170]: 10:10
+  //   F[e_170]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20298,8 +19582,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_170_qs)
   );
 
-
-  // F[e_171]: 11:11
+  //   F[e_171]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20324,8 +19607,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_171_qs)
   );
 
-
-  // F[e_172]: 12:12
+  //   F[e_172]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20350,8 +19632,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_172_qs)
   );
 
-
-  // F[e_173]: 13:13
+  //   F[e_173]: 13:13
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20376,8 +19657,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_173_qs)
   );
 
-
-  // F[e_174]: 14:14
+  //   F[e_174]: 14:14
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20402,8 +19682,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_174_qs)
   );
 
-
-  // F[e_175]: 15:15
+  //   F[e_175]: 15:15
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20428,8 +19707,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_175_qs)
   );
 
-
-  // F[e_176]: 16:16
+  //   F[e_176]: 16:16
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20454,8 +19732,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_176_qs)
   );
 
-
-  // F[e_177]: 17:17
+  //   F[e_177]: 17:17
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20480,8 +19757,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_177_qs)
   );
 
-
-  // F[e_178]: 18:18
+  //   F[e_178]: 18:18
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20506,8 +19782,7 @@ module rv_plic_reg_top (
     .qs     (ie0_5_e_178_qs)
   );
 
-
-  // F[e_179]: 19:19
+  //   F[e_179]: 19:19
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20533,9 +19808,7 @@ module rv_plic_reg_top (
   );
 
 
-
   // R[threshold0]: V(False)
-
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20562,7 +19835,6 @@ module rv_plic_reg_top (
 
 
   // R[cc0]: V(True)
-
   prim_subreg_ext #(
     .DW    (8)
   ) u_cc0 (
@@ -20578,7 +19850,6 @@ module rv_plic_reg_top (
 
 
   // R[msip0]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -20605,7 +19876,6 @@ module rv_plic_reg_top (
 
 
   // R[alert_test]: V(True)
-
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -20618,7 +19888,6 @@ module rv_plic_reg_top (
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
-
 
 
 

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -211,7 +211,6 @@ module sensor_ctrl_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
-
   //   F[recov_as]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -225,7 +224,6 @@ module sensor_ctrl_reg_top (
     .q      (reg2hw.alert_test.recov_as.q),
     .qs     ()
   );
-
 
   //   F[recov_cg]: 1:1
   prim_subreg_ext #(
@@ -241,7 +239,6 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_gd]: 2:2
   prim_subreg_ext #(
     .DW    (1)
@@ -255,7 +252,6 @@ module sensor_ctrl_reg_top (
     .q      (reg2hw.alert_test.recov_gd.q),
     .qs     ()
   );
-
 
   //   F[recov_ts_hi]: 3:3
   prim_subreg_ext #(
@@ -271,7 +267,6 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_ts_lo]: 4:4
   prim_subreg_ext #(
     .DW    (1)
@@ -285,7 +280,6 @@ module sensor_ctrl_reg_top (
     .q      (reg2hw.alert_test.recov_ts_lo.q),
     .qs     ()
   );
-
 
   //   F[recov_fla]: 5:5
   prim_subreg_ext #(
@@ -301,7 +295,6 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_otp]: 6:6
   prim_subreg_ext #(
     .DW    (1)
@@ -315,7 +308,6 @@ module sensor_ctrl_reg_top (
     .q      (reg2hw.alert_test.recov_otp.q),
     .qs     ()
   );
-
 
   //   F[recov_ot0]: 7:7
   prim_subreg_ext #(
@@ -331,7 +323,6 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_ot1]: 8:8
   prim_subreg_ext #(
     .DW    (1)
@@ -345,7 +336,6 @@ module sensor_ctrl_reg_top (
     .q      (reg2hw.alert_test.recov_ot1.q),
     .qs     ()
   );
-
 
   //   F[recov_ot2]: 9:9
   prim_subreg_ext #(
@@ -361,7 +351,6 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_ot3]: 10:10
   prim_subreg_ext #(
     .DW    (1)
@@ -376,7 +365,6 @@ module sensor_ctrl_reg_top (
     .qs     ()
   );
 
-
   //   F[recov_ot4]: 11:11
   prim_subreg_ext #(
     .DW    (1)
@@ -390,7 +378,6 @@ module sensor_ctrl_reg_top (
     .q      (reg2hw.alert_test.recov_ot4.q),
     .qs     ()
   );
-
 
   //   F[recov_ot5]: 12:12
   prim_subreg_ext #(
@@ -408,7 +395,6 @@ module sensor_ctrl_reg_top (
 
 
   // R[cfg_regwen]: V(False)
-
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
@@ -434,11 +420,9 @@ module sensor_ctrl_reg_top (
   );
 
 
-
   // Subregister 0 of Multireg ack_mode
   // R[ack_mode]: V(False)
-
-  // F[val_0]: 1:0
+  //   F[val_0]: 1:0
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -463,8 +447,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_0_qs)
   );
 
-
-  // F[val_1]: 3:2
+  //   F[val_1]: 3:2
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -489,8 +472,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_1_qs)
   );
 
-
-  // F[val_2]: 5:4
+  //   F[val_2]: 5:4
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -515,8 +497,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_2_qs)
   );
 
-
-  // F[val_3]: 7:6
+  //   F[val_3]: 7:6
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -541,8 +522,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_3_qs)
   );
 
-
-  // F[val_4]: 9:8
+  //   F[val_4]: 9:8
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -567,8 +547,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_4_qs)
   );
 
-
-  // F[val_5]: 11:10
+  //   F[val_5]: 11:10
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -593,8 +572,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_5_qs)
   );
 
-
-  // F[val_6]: 13:12
+  //   F[val_6]: 13:12
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -619,8 +597,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_6_qs)
   );
 
-
-  // F[val_7]: 15:14
+  //   F[val_7]: 15:14
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -645,8 +622,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_7_qs)
   );
 
-
-  // F[val_8]: 17:16
+  //   F[val_8]: 17:16
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -671,8 +647,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_8_qs)
   );
 
-
-  // F[val_9]: 19:18
+  //   F[val_9]: 19:18
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -697,8 +672,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_9_qs)
   );
 
-
-  // F[val_10]: 21:20
+  //   F[val_10]: 21:20
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -723,8 +697,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_10_qs)
   );
 
-
-  // F[val_11]: 23:22
+  //   F[val_11]: 23:22
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -749,8 +722,7 @@ module sensor_ctrl_reg_top (
     .qs     (ack_mode_val_11_qs)
   );
 
-
-  // F[val_12]: 25:24
+  //   F[val_12]: 25:24
   prim_subreg #(
     .DW      (2),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -776,12 +748,9 @@ module sensor_ctrl_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg alert_trig
   // R[alert_trig]: V(False)
-
-  // F[val_0]: 0:0
+  //   F[val_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -806,8 +775,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_0_qs)
   );
 
-
-  // F[val_1]: 1:1
+  //   F[val_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -832,8 +800,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_1_qs)
   );
 
-
-  // F[val_2]: 2:2
+  //   F[val_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -858,8 +825,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_2_qs)
   );
 
-
-  // F[val_3]: 3:3
+  //   F[val_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -884,8 +850,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_3_qs)
   );
 
-
-  // F[val_4]: 4:4
+  //   F[val_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -910,8 +875,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_4_qs)
   );
 
-
-  // F[val_5]: 5:5
+  //   F[val_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -936,8 +900,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_5_qs)
   );
 
-
-  // F[val_6]: 6:6
+  //   F[val_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -962,8 +925,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_6_qs)
   );
 
-
-  // F[val_7]: 7:7
+  //   F[val_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -988,8 +950,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_7_qs)
   );
 
-
-  // F[val_8]: 8:8
+  //   F[val_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1014,8 +975,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_8_qs)
   );
 
-
-  // F[val_9]: 9:9
+  //   F[val_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1040,8 +1000,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_9_qs)
   );
 
-
-  // F[val_10]: 10:10
+  //   F[val_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1066,8 +1025,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_10_qs)
   );
 
-
-  // F[val_11]: 11:11
+  //   F[val_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1092,8 +1050,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_trig_val_11_qs)
   );
 
-
-  // F[val_12]: 12:12
+  //   F[val_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1119,12 +1076,9 @@ module sensor_ctrl_reg_top (
   );
 
 
-
-
   // Subregister 0 of Multireg alert_state
   // R[alert_state]: V(False)
-
-  // F[val_0]: 0:0
+  //   F[val_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1149,8 +1103,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_0_qs)
   );
 
-
-  // F[val_1]: 1:1
+  //   F[val_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1175,8 +1128,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_1_qs)
   );
 
-
-  // F[val_2]: 2:2
+  //   F[val_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1201,8 +1153,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_2_qs)
   );
 
-
-  // F[val_3]: 3:3
+  //   F[val_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1227,8 +1178,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_3_qs)
   );
 
-
-  // F[val_4]: 4:4
+  //   F[val_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1253,8 +1203,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_4_qs)
   );
 
-
-  // F[val_5]: 5:5
+  //   F[val_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1279,8 +1228,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_5_qs)
   );
 
-
-  // F[val_6]: 6:6
+  //   F[val_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1305,8 +1253,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_6_qs)
   );
 
-
-  // F[val_7]: 7:7
+  //   F[val_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1331,8 +1278,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_7_qs)
   );
 
-
-  // F[val_8]: 8:8
+  //   F[val_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1357,8 +1303,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_8_qs)
   );
 
-
-  // F[val_9]: 9:9
+  //   F[val_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1383,8 +1328,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_9_qs)
   );
 
-
-  // F[val_10]: 10:10
+  //   F[val_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1409,8 +1353,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_10_qs)
   );
 
-
-  // F[val_11]: 11:11
+  //   F[val_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1435,8 +1378,7 @@ module sensor_ctrl_reg_top (
     .qs     (alert_state_val_11_qs)
   );
 
-
-  // F[val_12]: 12:12
+  //   F[val_12]: 12:12
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
@@ -1462,9 +1404,7 @@ module sensor_ctrl_reg_top (
   );
 
 
-
   // R[status]: V(False)
-
   //   F[ast_init_done]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1490,7 +1430,6 @@ module sensor_ctrl_reg_top (
     .qs     (status_ast_init_done_qs)
   );
 
-
   //   F[io_pok]: 2:1
   prim_subreg #(
     .DW      (2),
@@ -1515,7 +1454,6 @@ module sensor_ctrl_reg_top (
     // to register interface (read)
     .qs     (status_io_pok_qs)
   );
-
 
 
 


### PR DESCRIPTION
Now, we iterate over elements of `rb.all_regs` then any subregisters (if
the element happened to be a `MultiRegister`) and then any fields.
Hopefully, the result is a little easier to follow. The various
special cases in how we generate signal names mean that this code is
still a little complicated, but the idea is that a reader should be
able to scan to the right place a bit quicker.

The end results are equivalent, but with slightly better controlled
whitespace. To see what's going on, run:

    git diff -w --ignore-blank-lines

which will show no differences except that we fix the subregister
indices in comments in `spi_device_reg_top.sv`.
