### PR TITLE
[reggen] Ensure that registers are "either RC or not"

### DIFF
--- a/hw/ip/trial1/data/trial1.hjson
+++ b/hw/ip/trial1/data/trial1.hjson
@@ -290,7 +290,7 @@
           bits: "27:24",
           name: "field6",
           desc: "field description"
-          swaccess: "rc",
+          swaccess: "rw",
           hwaccess: "hrw",
           resval: "0x7",
         }

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -158,7 +158,6 @@ module trial1_reg_top (
   logic [31:0] rctype0_wd;
   logic wotype0_we;
   logic [31:0] wotype0_wd;
-  logic mixtype0_re;
   logic mixtype0_we;
   logic [3:0] mixtype0_field0_qs;
   logic [3:0] mixtype0_field0_wd;
@@ -889,14 +888,14 @@ module trial1_reg_top (
   //   F[field6]: 27:24
   prim_subreg #(
     .DW      (4),
-    .SwAccess(prim_subreg_pkg::SwAccessRC),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h7)
   ) u_mixtype0_field6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (mixtype0_re),
+    .we     (mixtype0_we),
     .wd     (mixtype0_field6_wd),
 
     // from internal hardware
@@ -1145,7 +1144,6 @@ module trial1_reg_top (
   assign wotype0_we = addr_hit[13] & reg_we & !reg_error;
 
   assign wotype0_wd = reg_wdata[31:0];
-  assign mixtype0_re = addr_hit[14] & reg_re & !reg_error;
   assign mixtype0_we = addr_hit[14] & reg_we & !reg_error;
 
   assign mixtype0_field0_wd = reg_wdata[3:0];
@@ -1156,7 +1154,7 @@ module trial1_reg_top (
 
   assign mixtype0_field5_wd = reg_wdata[23:20];
 
-  assign mixtype0_field6_wd = '1;
+  assign mixtype0_field6_wd = reg_wdata[27:24];
 
   assign mixtype0_field7_wd = reg_wdata[31:28];
   assign rwtype5_we = addr_hit[15] & reg_we & !reg_error;


### PR DESCRIPTION
This was true across the design, except in the trial1 example, where
the "MIXTYPE" register had registers that were a mixture of types.

The point of this is to ensure that all the fields of a register are
updated together. This will allow us to hoist things like the QE
signal up to the register level, de-duplicating things. But that's
only possible if all fields get updated together.
