### PR TITLE
[dv/alert_handler] Fix tl_integ_err_vseq

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -69,7 +69,10 @@ package alert_handler_env_pkg;
     LocalAlertPingFail,
     LocalEscPingFail,
     LocalAlertIntFail,
-    LocalEscIntFail
+    LocalEscIntFail,
+    LocalBusIntgFail,
+    LocalShadowRegUpdateErr,
+    LocalShadowRegStorageErr
   } local_alert_type_e;
 
   // forward declare classes to allow typedefs below

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -23,4 +23,10 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  // Override the task to check corresponding CSR status is updated correctly.
+  virtual task check_tl_intg_error_response();
+    bit exp_val = `gmv(ral.loc_alert_en_shadowed[LocalBusIntgFail]);
+    csr_rd_check(.ptr(ral.loc_alert_cause[LocalBusIntgFail]), .compare_value(exp_val));
+  endtask
+
 endclass


### PR DESCRIPTION
This PR fixes the failure in tl_integ_err auto generated sequence
because alert_handler does not have any alert coming out.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>