### PR TITLE
[spi_device] TPM over SPI

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -12,8 +12,9 @@
     { protocol: "tlul", direction: "device" }
   ],
   available_input_list: [
-    { name: "sck", desc: "SPI Clock" },
-    { name: "csb", desc: "Chip Enable#" },
+    { name: "sck",     desc: "SPI Clock" },
+    { name: "csb",     desc: "Chip Select#" },
+    { name: "tpm_csb", desc: "TPM Chip Select#"}
   ],
   available_output_list: [
   ],

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -30,6 +30,7 @@
     { name: "rxerr",       desc: "SDI in FwMode has error" },
     { name: "rxoverflow",  desc: "RX Async FIFO overflow" },
     { name: "txunderflow", desc: "TX Async FIFO underflow" },
+    { name: "tpm_cmdaddr_notempty", desc: "TPM Command/Address buffer available" }
   ],
   alert_list: [
     { name: "fatal_fault",
@@ -53,6 +54,12 @@
       default: "24"
       local:   "true"
     }
+    { name:    "NumLocality"
+      desc:    "The number of locality TPM module supports."
+      type:    "int unsigned"
+      default: "5"
+      local:   "true"
+    } // p: NumLocality
   ],
   inter_signal_list: [
     { struct:  "ram_2p_cfg",
@@ -663,6 +670,256 @@
         ]
       }
     }
+    //===============================================================
+    // TPM registers
+    { skipto: "0x800"}
+    { name: "TPM_CAP"
+      desc: '''TPM HWIP Capability register.
+
+        This register shows the features the current TPM HWIP supports.
+        '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      fields: [
+        { bits: "7:0"
+          name: "rev"
+          desc: "Revision of the TPM submodule"
+        } // f: rev
+        { bits: "8"
+          name: "locality"
+          desc: '''If 1, the TPM submodule supports 5 Locality.
+            If 0, only one Locality is provided
+            '''
+        } // f: locality
+        { bits: "18:16"
+          name: "max_xfer_size"
+          desc: '''The maximum transfer size in bytes the TPM submodule supports.
+            The value is the exponent of the 2.
+
+            - 3'b 010: Support up to 4B
+            - 3'b 011: Support up to 8B
+            - 3'b 101: Support up to 32B
+            - 3'b 110: Support up to 64B
+
+            All other values are reserved.
+
+            The SW may advertises as supporting more than `max_xfer_size` to the South Brige.
+            If the SW reports the transfer size more than the value described in this field,
+            the SW must read the data from the write FIFO before the FIFO becomes full in order not to make FIFO overflow.
+            '''
+        } // f: max_xfer_size
+      ]
+    } // R: TPM_CAP
+    { name: "TPM_CFG"
+      desc: '''TPM Configuration register.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "0"
+          name: "en"
+          desc: "If 1, TPM submodule accepts the transactions over SPI"
+        } // f: en
+        { bits: "1"
+          name: "hw_reg_dis"
+          desc: '''If 0, TPM submodule directly returns the return-by-HW registers for the read requests.
+
+            If 1, TPM submodule uploads the TPM command regardless of the address, and the SW may return the value through the read FIFO.
+            '''
+        } // f: hw_reg_dis
+        { bits: "2"
+          name: "invalid_ool"
+          desc: '''If 1, TPM submodule returns the invalid data (0xFF) for the out of the max Locality request.
+            If it is a write request, it discards the request.
+
+            If 0, TPM submodule uploads the TPM command and address. The SW may write 0xFF to the read FIFO.
+
+            Note: The TPM submodule uploads the TPM commands that do not fall into the FIFO registers (0xD4_XXXX) regardless of `invalid_ool` bit.
+            '''
+        } // f: invalid_ool
+      ]
+    } // R: TPM_CFG
+    { name: "TPM_STATUS"
+      desc: '''TPM submodule state register.
+
+        The TPM_STATUS CSR provides the current TPM status, mostly the buffer and FIFO status.
+        '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      fields: [
+        { bits: "0"
+          name: "cmdaddr_notempty"
+          desc: "If 1, the TPM_CMD_ADDR has a valid data. This status is reported via the interrupt also."
+        } // f: cmdaddr_notempty
+        { bits: "1"
+          name: "rdfifo_notempty"
+          desc: "If 1, the TPM_READ_FIFO still has pending data."
+        } // f: rdfifo_notempty
+        { bits: "6:4"
+          name: "rdfifo_depth"
+          desc: "This field represents the current read FIFO depth"
+        } // f: rdfifo_depth
+        { bits: "10:8"
+          name: "wrfifo_depth"
+          desc: "This field represents the current write FIFO depth."
+        } // f: wrfifo_depth
+      ]
+    } // R: TPM_STATUS
+    { multireg: {
+      cname: "TPM"
+      name: "TPM_ACCESS"
+      desc: '''TPM_ACCESS_x register.
+        '''
+      count: "NumLocality"
+      compact: true
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "7:0"
+          name: "access"
+          desc: "TPM_ACCESS"
+        }
+      ]
+    }} // mr: TPM_ACCESS
+    { name: "TPM_STS"
+      desc: '''TPM_STS_x register.
+
+        The register is mirrored to all Localities.
+        The value is returned to the host system only when the activeLocality
+        in the TPM_ACCESS_x is matched to the current received Locality.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "31:0"
+          name: "sts"
+          desc: "TPM_STS_x"
+        }
+      ]
+    } // R: TPM_STS
+    { name: "TPM_INTF_CAPABILITY"
+      desc: "TPM_INTF_CAPABILITY"
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "31:0"
+          name: "intf_capability"
+          desc: "TPM_INTF_CAPABILITY"
+        }
+      ]
+    } // R: TPM_INTF_CAPABILITY
+    { name: "TPM_INT_ENABLE"
+      desc: "TPM_INT_ENABLE"
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "31:0"
+          name: "int_enable"
+          desc: "TPM_INT_ENABLE"
+        }
+      ]
+    } // R: TPM_INT_ENABLE
+    { name: "TPM_INT_VECTOR"
+      desc: "TPM_INT_VECTOR"
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "7:0"
+          name: "int_vector"
+          desc: "TPM_INT_VECTOR"
+        }
+      ]
+    } // R: TPM_INT_VECTOR
+    { name: "TPM_INT_STATUS"
+      desc: "TPM_INT_STATUS"
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "31:0"
+          name: "int_status"
+          desc: "TPM_INT_STATUS"
+        }
+      ]
+    } // R: TPM_INT_STATUS
+    { name: "TPM_DID_VID"
+      desc: "TPM_DID/ TPM_VID register"
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "15:0"
+          name: "vid"
+          desc: "TPM_VID"
+        } // f: vid
+        { bits: "31:16"
+          name: "did"
+          desc: "TPM_DID"
+        } // f: did
+      ]
+    } // R: TPM_DID_VID
+    { name: "TPM_RID"
+      desc: "TPM_RID"
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "7:0"
+          name: "rid"
+          desc: "TPM_RID"
+        }
+      ]
+    } // R: TPM_RID
+    { name: "TPM_CMD_ADDR"
+      desc: '''TPM Command and Address buffer
+
+        The SW may get the received TPM command and address by readin gthis CSR.
+        '''
+      swaccess: "ro"
+      hwaccess: "hrw"
+      hwext: "true"
+      hwre:  "true"
+      hwqe:  "true"
+      fields: [
+        { bits: "23:0"
+          name: "addr"
+          desc: "received address"
+        } // f: addr
+        { bits: "31:24"
+          name: "cmd"
+          desc: "received command"
+        } // f: cmd
+      ]
+    } // R: TPM_CMD_ADDR
+    { name: "TPM_READ_FIFO"
+      desc: '''TPM Read command return data FIFO.
+
+        The write port of the read command FIFO.
+        '''
+      swaccess: "wo"
+      hwaccess: "hro"
+      hwqe: "true"
+      hwext: "true"
+      fields: [
+        { bits: "7:0"
+          name: "value"
+          desc: "write port of the read FIFO"
+        }
+      ]
+    } // R: TPM_READ_FIFO
+    { name: "TPM_WRITE_FIFO"
+      desc: '''TPM Write command received data FIFO.
+        '''
+      swaccess: "ro"
+      hwaccess: "hrw"
+      hwext: "true"
+      hwqe: "true"
+      hwre: "true"
+      fields: [
+        { bits: "7:0"
+          name: "value"
+          desc: "Read only port of the write FIFO"
+        }
+      ]
+    } // R: TPM_WRITE_FIFO
+    //---------------------------------------------------------------
     { skipto: "0x1000" }
     { window: {
         name: "buffer",

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -107,6 +107,9 @@ waive -rules RESET_MUX    -location {spi_device.sv} \
 waive -rules RESET_MUX -location {spi_device.sv} \
       -regexp {'sram_rst_n.*' is driven by a multiplexer here} \
       -comment "Scan reset mux, but need to have asynchronous reset"
+waive -rules RESET_DRIVER -location {spi_tpm.sv} \
+      -regexp {'rst_n' is driven} \
+      -comment "Async reset generated from TPM_CS#"
 
 # clock inverter and muxes
 waive -rules CLOCK_MUX -location {spi_device.sv} -regexp {Clock 'sck_n' is driven by a multiplexer here, used as a clock 'clk_(out|src)_i'} \

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -30,17 +30,20 @@ module spi_device
   output logic [3:0] cio_sd_en_o,
   input        [3:0] cio_sd_i,
 
+  input              cio_tpm_csb_i,
+
   // Passthrough interface
   output spi_device_pkg::passthrough_req_t passthrough_o,
   input  spi_device_pkg::passthrough_rsp_t passthrough_i,
 
   // Interrupts
-  output logic intr_rxf_o,         // RX FIFO Full
-  output logic intr_rxlvl_o,       // RX FIFO above level
-  output logic intr_txlvl_o,       // TX FIFO below level
-  output logic intr_rxerr_o,       // RX Frame error
-  output logic intr_rxoverflow_o,  // RX Async FIFO Overflow
-  output logic intr_txunderflow_o, // TX Async FIFO Underflow
+  output logic intr_rxf_o,                  // RX FIFO Full
+  output logic intr_rxlvl_o,                // RX FIFO above level
+  output logic intr_txlvl_o,                // TX FIFO below level
+  output logic intr_rxerr_o,                // RX Frame error
+  output logic intr_rxoverflow_o,           // RX Async FIFO Overflow
+  output logic intr_txunderflow_o,          // TX Async FIFO Underflow
+  output logic intr_tpm_cmdaddr_notempty_o, // TPM Command/Address buffer
 
   // Memory configuration
   input prim_ram_2p_pkg::ram_2p_cfg_t ram_cfg_i,
@@ -243,6 +246,48 @@ module spi_device
   // Jedec ID
   logic [23:0] jedec_id;
 
+  // TPM ===============================================================
+  localparam int unsigned TpmCmdAddrDepth = 2;
+  localparam int unsigned TpmFifoDepth    = 4; // 4B
+  localparam int unsigned TpmFifoPtrW     = $clog2(TpmFifoDepth+1);
+
+  // pulse signal to set once from tpm_status_cmdaddr_notempty
+  logic intr_tpm_cmdaddr_notempty;
+
+  // Interface
+  logic tpm_mosi, tpm_miso, tpm_miso_en;
+  assign tpm_mosi = cio_sd_i[0];
+
+  // Return-by-HW registers
+  logic [8*spi_device_reg_pkg::NumLocality-1:0] tpm_access;
+  logic [31:0]                                  tpm_int_enable;
+  logic [7:0]                                   tpm_int_vector;
+  logic [31:0]                                  tpm_int_status;
+  logic [31:0]                                  tpm_intf_capability;
+  logic [31:0]                                  tpm_status;
+  logic [31:0]                                  tpm_did_vid;
+  logic [7:0]                                   tpm_rid;
+
+  // Buffer and FIFO signals
+  logic        tpm_cmdaddr_rvalid, tpm_cmdaddr_rready;
+  logic [31:0] tpm_cmdaddr_rdata;
+  logic        tpm_wrfifo_rvalid, tpm_wrfifo_rready;
+  logic [7:0]  tpm_wrfifo_rdata;
+  logic        tpm_rdfifo_wvalid, tpm_rdfifo_wready;
+  logic [7:0]  tpm_rdfifo_wdata;
+
+  tpm_cap_t tpm_cap;
+
+  // TPM CFG
+  logic cfg_tpm_en, cfg_tpm_hw_reg_dis, cfg_tpm_invalid_ool;
+
+  // TPM_STATUS
+  logic tpm_status_cmdaddr_notempty, tpm_status_rdfifo_notempty;
+  logic [TpmFifoPtrW-1:0] tpm_status_rdfifo_depth;
+  logic [TpmFifoPtrW-1:0] tpm_status_wrfifo_depth;
+
+  // TPM ---------------------------------------------------------------
+
   //////////////////////////////////////////////////////////////////////
   // Connect phase (between control signals above and register module //
   //////////////////////////////////////////////////////////////////////
@@ -390,6 +435,8 @@ module spi_device
   assign intr_rxerr_o       = reg2hw.intr_enable.rxerr.q       & reg2hw.intr_state.rxerr.q;
   assign intr_rxoverflow_o  = reg2hw.intr_enable.rxoverflow.q  & reg2hw.intr_state.rxoverflow.q;
   assign intr_txunderflow_o = reg2hw.intr_enable.txunderflow.q & reg2hw.intr_state.txunderflow.q;
+  assign intr_tpm_cmdaddr_notempty_o = reg2hw.intr_enable.tpm_cmdaddr_notempty.q
+                                     & reg2hw.intr_state.tpm_cmdaddr_notempty.q;
 
   assign hw2reg.intr_state.rxf.d    = 1'b1;
   assign hw2reg.intr_state.rxf.de   = intr_sram_rxf_full |
@@ -409,6 +456,11 @@ module spi_device
   assign hw2reg.intr_state.txunderflow.d  = 1'b1;
   assign hw2reg.intr_state.txunderflow.de = intr_fwm_txunderflow |
       (reg2hw.intr_test.txunderflow.qe & reg2hw.intr_test.txunderflow.q);
+
+  assign hw2reg.intr_state.tpm_cmdaddr_notempty.d  = 1'b 1;
+  assign hw2reg.intr_state.tpm_cmdaddr_notempty.de = intr_tpm_cmdaddr_notempty
+   | ( reg2hw.intr_test.tpm_cmdaddr_notempty.qe
+     & reg2hw.intr_test.tpm_cmdaddr_notempty.q);
 
   // SPI Flash commands registers
   // TODO: Add 2FF sync? or just waive?
@@ -765,27 +817,34 @@ module spi_device
     cio_sd_o    = internal_sd;
     cio_sd_en_o = internal_sd_en;
 
-    unique case (spi_mode)
-      FwMode, FlashMode: begin
-        cio_sd_o    = internal_sd;
-        cio_sd_en_o = internal_sd_en;
-      end
-
-      PassThrough: begin
-        if (passthrough_assumed_by_internal) begin
+    if (cfg_tpm_en && !cio_tpm_csb_i) begin : miso_tpm
+      // TPM transaction is on-going. MOSI, MISO is being used by TPM
+      cio_sd_o[0]    = tpm_miso;
+      cio_sd_en_o[0] = tpm_miso_en;
+    end else begin : spi_out_flash_passthrough
+      // SPI Generic, Flash, Passthrough modes
+      unique case (spi_mode)
+        FwMode, FlashMode: begin
           cio_sd_o    = internal_sd;
           cio_sd_en_o = internal_sd_en;
-        end else begin
-          cio_sd_o    = passthrough_sd;
-          cio_sd_en_o = passthrough_sd_en;
         end
-      end
 
-      default: begin
-        cio_sd_o    = internal_sd;
-        cio_sd_en_o = internal_sd_en;
-      end
-    endcase
+        PassThrough: begin
+          if (passthrough_assumed_by_internal) begin
+            cio_sd_o    = internal_sd;
+            cio_sd_en_o = internal_sd_en;
+          end else begin
+            cio_sd_o    = passthrough_sd;
+            cio_sd_en_o = passthrough_sd_en;
+          end
+        end
+
+        default: begin
+          cio_sd_o    = internal_sd;
+          cio_sd_en_o = internal_sd_en;
+        end
+      endcase
+    end
   end
   assign passthrough_assumed_by_internal = mailbox_assumed
     // TOGO: Uncomment below when those submodules are implemented.
@@ -1184,6 +1243,115 @@ module spi_device
 
     .event_cmd_filtered_o ()
   );
+
+  //////////////////
+  // TPM over SPI //
+  //////////////////
+  // Interrupt: Creating a pulse signal
+  prim_edge_detector #(
+    .Width (1),
+    .EnSync (1'b 0)
+  ) u_cmdaddr_notempty_edge (
+    .clk_i,
+    .rst_ni,
+    .d_i               (tpm_status_cmdaddr_notempty),
+    .q_sync_o          (),
+    .q_posedge_pulse_o (intr_tpm_cmdaddr_notempty),
+    .q_negedge_pulse_o ()
+  );
+
+  // Instance of spi_tpm
+  spi_tpm #(
+    // CmdAddrFifoDepth
+    .WrFifoDepth (TpmFifoDepth),
+    .RdFifoDepth (TpmFifoDepth),
+    .EnLocality  (1)
+  ) u_spi_tpm (
+    .clk_in_i  (clk_spi_in_buf ),
+    .clk_out_i (clk_spi_out_buf),
+
+    .sys_clk_i  (clk_i),
+    .sys_rst_ni (rst_ni),
+
+    .scan_rst_ni,
+    .scanmode_i  (scanmode[TpmRstSel]),
+
+    .csb_i     (cio_tpm_csb_i),
+    .mosi_i    (tpm_mosi     ),
+    .miso_o    (tpm_miso     ),
+    .miso_en_o (tpm_miso_en  ),
+
+    .tpm_cap_o (tpm_cap),
+
+    .cfg_tpm_en_i          (cfg_tpm_en         ),
+    .cfg_tpm_hw_reg_dis_i  (cfg_tpm_hw_reg_dis ),
+    .cfg_tpm_invalid_ool_i (cfg_tpm_invalid_ool),
+
+    .sys_access_reg_i          (tpm_access         ),
+    .sys_int_enable_reg_i      (tpm_int_enable     ),
+    .sys_int_vector_reg_i      (tpm_int_vector     ),
+    .sys_int_status_reg_i      (tpm_int_status     ),
+    .sys_intf_capability_reg_i (tpm_intf_capability),
+    .sys_status_reg_i          (tpm_status         ),
+    .sys_id_reg_i              (tpm_did_vid        ),
+    .sys_rid_reg_i             (tpm_rid            ),
+
+    .sys_cmdaddr_rvalid_o (tpm_cmdaddr_rvalid),
+    .sys_cmdaddr_rdata_o  (tpm_cmdaddr_rdata ),
+    .sys_cmdaddr_rready_i (tpm_cmdaddr_rready),
+
+    .sys_wrfifo_rvalid_o (tpm_wrfifo_rvalid),
+    .sys_wrfifo_rdata_o  (tpm_wrfifo_rdata ),
+    .sys_wrfifo_rready_i (tpm_wrfifo_rready),
+
+    .sys_rdfifo_wvalid_i (tpm_rdfifo_wvalid),
+    .sys_rdfifo_wdata_i  (tpm_rdfifo_wdata ),
+    .sys_rdfifo_wready_o (tpm_rdfifo_wready),
+
+    .sys_cmdaddr_notempty_o (tpm_status_cmdaddr_notempty),
+    .sys_rdfifo_notempty_o  (tpm_status_rdfifo_notempty ),
+    .sys_rdfifo_depth_o     (tpm_status_rdfifo_depth    ),
+    .sys_wrfifo_depth_o     (tpm_status_wrfifo_depth    )
+  );
+
+  // Register connection
+  //  TPM_CAP:
+  assign hw2reg.tpm_cap = '{
+    rev:           '{ de: 1'b 1, d: tpm_cap.rev           },
+    locality:      '{ de: 1'b 1, d: tpm_cap.locality      },
+    max_xfer_size: '{ de: 1'b 1, d: tpm_cap.max_xfer_size }
+  };
+
+  //  CFG:
+  assign cfg_tpm_en          = reg2hw.tpm_cfg.en.q;
+  assign cfg_tpm_hw_reg_dis  = reg2hw.tpm_cfg.hw_reg_dis.q;
+  assign cfg_tpm_invalid_ool = reg2hw.tpm_cfg.invalid_ool.q;
+
+  //  STATUS:
+  assign hw2reg.tpm_status = '{
+    cmdaddr_notempty: '{ de: 1'b 1, d: tpm_status_cmdaddr_notempty },
+    rdfifo_notempty:  '{ de: 1'b 1, d: tpm_status_rdfifo_notempty  },
+    rdfifo_depth:     '{ de: 1'b 1, d: tpm_status_rdfifo_depth     },
+    wrfifo_depth:     '{ de: 1'b 1, d: tpm_status_wrfifo_depth     }
+  };
+
+  //  Return-by-HW registers:
+  //    TPM_ACCESS_x, TPM_STS_x, TPM_INT_ENABLE, TPM_INT_VECTOR,
+  //    TPM_INT_STATUS, TPM_INTF_CAPABILITY, TPM_DID_VID, TPM_RID
+  for (genvar i = 0 ; i < NumLocality ; i++) begin : g_tpm_access
+    assign tpm_access[8*i+:8] = reg2hw.tpm_access[i].q;
+  end : g_tpm_access
+
+  assign tpm_int_enable      = reg2hw.tpm_int_enable.q;
+  assign tpm_int_vector      = reg2hw.tpm_int_vector.q;
+  assign tpm_int_status      = reg2hw.tpm_int_status.q;
+  assign tpm_intf_capability = reg2hw.tpm_intf_capability.q;
+  assign tpm_status          = reg2hw.tpm_sts.q;
+  assign tpm_did_vid         = { reg2hw.tpm_did_vid.did.q ,
+                                 reg2hw.tpm_did_vid.vid.q };
+  assign tpm_rid             = reg2hw.tpm_rid.q;
+
+  // END: TPM over SPI --------------------------------------------------------
 
   ////////////////////
   // Common modules //

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -409,7 +409,7 @@ package spi_device_pkg;
   parameter int unsigned BitCntW   = $clog2(BitLength + 1);
 
   // spi device scanmode usage
-  typedef enum logic [2:0] {
+  typedef enum logic [3:0] {
     ClkInvSel,
     CsbRstMuxSel,
     TxRstMuxSel,
@@ -417,6 +417,7 @@ package spi_device_pkg;
     ClkMuxSel,
     ClkSramSel,
     RstSramSel,
+    TpmRstSel,
     ScanModeUseLast
   } scan_mode_e;
 

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -420,4 +420,12 @@ package spi_device_pkg;
     ScanModeUseLast
   } scan_mode_e;
 
+  // TPM ======================================================================
+  typedef struct packed {
+    logic [7:0] rev;
+    logic       locality;
+    logic [2:0] max_xfer_size;
+  } tpm_cap_t;
+  // TPM ----------------------------------------------------------------------
+
 endpackage : spi_device_pkg

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -9,6 +9,7 @@ package spi_device_reg_pkg;
   // Param list
   parameter int unsigned SramDepth = 1024;
   parameter int unsigned NumCmdInfo = 24;
+  parameter int unsigned NumLocality = 5;
   parameter int NumAlerts = 1;
 
   // Address widths within the block
@@ -37,6 +38,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic        q;
     } txunderflow;
+    struct packed {
+      logic        q;
+    } tpm_cmdaddr_notempty;
   } spi_device_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -58,6 +62,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic        q;
     } txunderflow;
+    struct packed {
+      logic        q;
+    } tpm_cmdaddr_notempty;
   } spi_device_reg2hw_intr_enable_reg_t;
 
   typedef struct packed {
@@ -85,6 +92,10 @@ package spi_device_reg_pkg;
       logic        q;
       logic        qe;
     } txunderflow;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } tpm_cmdaddr_notempty;
   } spi_device_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -254,6 +265,79 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } hw_reg_dis;
+    struct packed {
+      logic        q;
+    } invalid_ool;
+  } spi_device_reg2hw_tpm_cfg_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+  } spi_device_reg2hw_tpm_access_mreg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_tpm_sts_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_tpm_intf_capability_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_tpm_int_enable_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+  } spi_device_reg2hw_tpm_int_vector_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_tpm_int_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [15:0] q;
+    } vid;
+    struct packed {
+      logic [15:0] q;
+    } did;
+  } spi_device_reg2hw_tpm_did_vid_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+  } spi_device_reg2hw_tpm_rid_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [23:0] q;
+      logic        qe;
+      logic        re;
+    } addr;
+    struct packed {
+      logic [7:0]  q;
+      logic        qe;
+      logic        re;
+    } cmd;
+  } spi_device_reg2hw_tpm_cmd_addr_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+    logic        qe;
+  } spi_device_reg2hw_tpm_read_fifo_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  q;
+    logic        qe;
+    logic        re;
+  } spi_device_reg2hw_tpm_write_fifo_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        d;
       logic        de;
     } rxf;
@@ -277,6 +361,10 @@ package spi_device_reg_pkg;
       logic        d;
       logic        de;
     } txunderflow;
+    struct packed {
+      logic        d;
+      logic        de;
+    } tpm_cmdaddr_notempty;
   } spi_device_hw2reg_intr_state_reg_t;
 
   typedef struct packed {
@@ -367,42 +455,105 @@ package spi_device_reg_pkg;
     logic [31:0] d;
   } spi_device_hw2reg_upload_addrfifo_reg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } rev;
+    struct packed {
+      logic        d;
+      logic        de;
+    } locality;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } max_xfer_size;
+  } spi_device_hw2reg_tpm_cap_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmdaddr_notempty;
+    struct packed {
+      logic        d;
+      logic        de;
+    } rdfifo_notempty;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } rdfifo_depth;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } wrfifo_depth;
+  } spi_device_hw2reg_tpm_status_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [23:0] d;
+    } addr;
+    struct packed {
+      logic [7:0]  d;
+    } cmd;
+  } spi_device_hw2reg_tpm_cmd_addr_reg_t;
+
+  typedef struct packed {
+    logic [7:0]  d;
+  } spi_device_hw2reg_tpm_write_fifo_reg_t;
+
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1146:1141]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1140:1135]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1134:1123]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1122:1121]
-    spi_device_reg2hw_control_reg_t control; // [1120:1115]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1114:1102]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1101:1070]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1069:1054]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1053:1038]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1037:1006]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1005:974]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [973:948]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [947:924]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [923:914]
-    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [913:905]
-    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [904:872]
-    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [871:616]
-    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [615:584]
-    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [583:552]
-    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [551:0]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1424:1418]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1417:1411]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1410:1397]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1396:1395]
+    spi_device_reg2hw_control_reg_t control; // [1394:1389]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1388:1376]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1375:1344]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1343:1328]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1327:1312]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1311:1280]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1279:1248]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1247:1222]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1221:1198]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1197:1188]
+    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1187:1179]
+    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1178:1146]
+    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1145:890]
+    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [889:858]
+    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [857:826]
+    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [825:274]
+    spi_device_reg2hw_tpm_cfg_reg_t tpm_cfg; // [273:271]
+    spi_device_reg2hw_tpm_access_mreg_t [4:0] tpm_access; // [270:231]
+    spi_device_reg2hw_tpm_sts_reg_t tpm_sts; // [230:199]
+    spi_device_reg2hw_tpm_intf_capability_reg_t tpm_intf_capability; // [198:167]
+    spi_device_reg2hw_tpm_int_enable_reg_t tpm_int_enable; // [166:135]
+    spi_device_reg2hw_tpm_int_vector_reg_t tpm_int_vector; // [134:127]
+    spi_device_reg2hw_tpm_int_status_reg_t tpm_int_status; // [126:95]
+    spi_device_reg2hw_tpm_did_vid_reg_t tpm_did_vid; // [94:63]
+    spi_device_reg2hw_tpm_rid_reg_t tpm_rid; // [62:55]
+    spi_device_reg2hw_tpm_cmd_addr_reg_t tpm_cmd_addr; // [54:19]
+    spi_device_reg2hw_tpm_read_fifo_reg_t tpm_read_fifo; // [18:10]
+    spi_device_reg2hw_tpm_write_fifo_reg_t tpm_write_fifo; // [9:0]
   } spi_device_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [189:178]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [177:162]
-    spi_device_hw2reg_status_reg_t status; // [161:156]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [155:139]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [138:122]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [121:90]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [89:66]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [65:40]
-    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [39:32]
-    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [31:0]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [258:245]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [244:229]
+    spi_device_hw2reg_status_reg_t status; // [228:223]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [222:206]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [205:189]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [188:157]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [156:133]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [132:107]
+    spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [106:99]
+    spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [98:67]
+    spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [66:52]
+    spi_device_hw2reg_tpm_status_reg_t tpm_status; // [51:40]
+    spi_device_hw2reg_tpm_cmd_addr_reg_t tpm_cmd_addr; // [39:8]
+    spi_device_hw2reg_tpm_write_fifo_reg_t tpm_write_fifo; // [7:0]
   } spi_device_hw2reg_t;
 
   // Register offsets
@@ -460,15 +611,31 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h cc;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h d0;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_ACCESS_0_OFFSET = 13'h 80c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_ACCESS_1_OFFSET = 13'h 810;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STS_OFFSET = 13'h 814;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET = 13'h 818;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_INT_ENABLE_OFFSET = 13'h 81c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_INT_VECTOR_OFFSET = 13'h 820;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_INT_STATUS_OFFSET = 13'h 824;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_DID_VID_OFFSET = 13'h 828;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_RID_OFFSET = 13'h 82c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CMD_ADDR_OFFSET = 13'h 830;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_READ_FIFO_OFFSET = 13'h 834;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_WRITE_FIFO_OFFSET = 13'h 838;
 
   // Reset values for hwext registers and their fields
-  parameter logic [5:0] SPI_DEVICE_INTR_TEST_RESVAL = 6'h 0;
+  parameter logic [6:0] SPI_DEVICE_INTR_TEST_RESVAL = 7'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_RXF_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_RXLVL_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_TXLVL_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_RXERR_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_RXOVERFLOW_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_INTR_TEST_TXUNDERFLOW_RESVAL = 1'h 0;
+  parameter logic [0:0] SPI_DEVICE_INTR_TEST_TPM_CMDADDR_NOTEMPTY_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_ALERT_TEST_RESVAL = 1'h 0;
   parameter logic [0:0] SPI_DEVICE_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
   parameter logic [23:0] SPI_DEVICE_ASYNC_FIFO_LEVEL_RESVAL = 24'h 0;
@@ -481,6 +648,9 @@ package spi_device_reg_pkg;
   parameter logic [23:0] SPI_DEVICE_FLASH_STATUS_RESVAL = 24'h 0;
   parameter logic [7:0] SPI_DEVICE_UPLOAD_CMDFIFO_RESVAL = 8'h 0;
   parameter logic [31:0] SPI_DEVICE_UPLOAD_ADDRFIFO_RESVAL = 32'h 0;
+  parameter logic [31:0] SPI_DEVICE_TPM_CMD_ADDR_RESVAL = 32'h 0;
+  parameter logic [7:0] SPI_DEVICE_TPM_READ_FIFO_RESVAL = 8'h 0;
+  parameter logic [7:0] SPI_DEVICE_TPM_WRITE_FIFO_RESVAL = 8'h 0;
 
   // Window parameters
   parameter logic [BlockAw-1:0] SPI_DEVICE_BUFFER_OFFSET = 13'h 1000;
@@ -541,11 +711,26 @@ package spi_device_reg_pkg;
     SPI_DEVICE_CMD_INFO_20,
     SPI_DEVICE_CMD_INFO_21,
     SPI_DEVICE_CMD_INFO_22,
-    SPI_DEVICE_CMD_INFO_23
+    SPI_DEVICE_CMD_INFO_23,
+    SPI_DEVICE_TPM_CAP,
+    SPI_DEVICE_TPM_CFG,
+    SPI_DEVICE_TPM_STATUS,
+    SPI_DEVICE_TPM_ACCESS_0,
+    SPI_DEVICE_TPM_ACCESS_1,
+    SPI_DEVICE_TPM_STS,
+    SPI_DEVICE_TPM_INTF_CAPABILITY,
+    SPI_DEVICE_TPM_INT_ENABLE,
+    SPI_DEVICE_TPM_INT_VECTOR,
+    SPI_DEVICE_TPM_INT_STATUS,
+    SPI_DEVICE_TPM_DID_VID,
+    SPI_DEVICE_TPM_RID,
+    SPI_DEVICE_TPM_CMD_ADDR,
+    SPI_DEVICE_TPM_READ_FIFO,
+    SPI_DEVICE_TPM_WRITE_FIFO
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [54] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [69] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -599,7 +784,22 @@ package spi_device_reg_pkg;
     4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_20
     4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_21
     4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_22
-    4'b 1111  // index[53] SPI_DEVICE_CMD_INFO_23
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_23
+    4'b 0111, // index[54] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[55] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[56] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[57] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[58] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[59] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[60] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[61] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[62] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[63] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[64] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[65] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[66] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[67] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[68] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -169,6 +169,8 @@ module spi_device_reg_top (
   logic intr_state_rxoverflow_wd;
   logic intr_state_txunderflow_qs;
   logic intr_state_txunderflow_wd;
+  logic intr_state_tpm_cmdaddr_notempty_qs;
+  logic intr_state_tpm_cmdaddr_notempty_wd;
   logic intr_enable_we;
   logic intr_enable_rxf_qs;
   logic intr_enable_rxf_wd;
@@ -182,6 +184,8 @@ module spi_device_reg_top (
   logic intr_enable_rxoverflow_wd;
   logic intr_enable_txunderflow_qs;
   logic intr_enable_txunderflow_wd;
+  logic intr_enable_tpm_cmdaddr_notempty_qs;
+  logic intr_enable_tpm_cmdaddr_notempty_wd;
   logic intr_test_we;
   logic intr_test_rxf_wd;
   logic intr_test_rxlvl_wd;
@@ -189,6 +193,7 @@ module spi_device_reg_top (
   logic intr_test_rxerr_wd;
   logic intr_test_rxoverflow_wd;
   logic intr_test_txunderflow_wd;
+  logic intr_test_tpm_cmdaddr_notempty_wd;
   logic alert_test_we;
   logic alert_test_wd;
   logic control_we;
@@ -1351,6 +1356,62 @@ module spi_device_reg_top (
   logic cmd_info_23_upload_23_wd;
   logic cmd_info_23_busy_23_qs;
   logic cmd_info_23_busy_23_wd;
+  logic [7:0] tpm_cap_rev_qs;
+  logic tpm_cap_locality_qs;
+  logic [2:0] tpm_cap_max_xfer_size_qs;
+  logic tpm_cfg_we;
+  logic tpm_cfg_en_qs;
+  logic tpm_cfg_en_wd;
+  logic tpm_cfg_hw_reg_dis_qs;
+  logic tpm_cfg_hw_reg_dis_wd;
+  logic tpm_cfg_invalid_ool_qs;
+  logic tpm_cfg_invalid_ool_wd;
+  logic tpm_status_cmdaddr_notempty_qs;
+  logic tpm_status_rdfifo_notempty_qs;
+  logic [2:0] tpm_status_rdfifo_depth_qs;
+  logic [2:0] tpm_status_wrfifo_depth_qs;
+  logic tpm_access_0_we;
+  logic [7:0] tpm_access_0_access_0_qs;
+  logic [7:0] tpm_access_0_access_0_wd;
+  logic [7:0] tpm_access_0_access_1_qs;
+  logic [7:0] tpm_access_0_access_1_wd;
+  logic [7:0] tpm_access_0_access_2_qs;
+  logic [7:0] tpm_access_0_access_2_wd;
+  logic [7:0] tpm_access_0_access_3_qs;
+  logic [7:0] tpm_access_0_access_3_wd;
+  logic tpm_access_1_we;
+  logic [7:0] tpm_access_1_qs;
+  logic [7:0] tpm_access_1_wd;
+  logic tpm_sts_we;
+  logic [31:0] tpm_sts_qs;
+  logic [31:0] tpm_sts_wd;
+  logic tpm_intf_capability_we;
+  logic [31:0] tpm_intf_capability_qs;
+  logic [31:0] tpm_intf_capability_wd;
+  logic tpm_int_enable_we;
+  logic [31:0] tpm_int_enable_qs;
+  logic [31:0] tpm_int_enable_wd;
+  logic tpm_int_vector_we;
+  logic [7:0] tpm_int_vector_qs;
+  logic [7:0] tpm_int_vector_wd;
+  logic tpm_int_status_we;
+  logic [31:0] tpm_int_status_qs;
+  logic [31:0] tpm_int_status_wd;
+  logic tpm_did_vid_we;
+  logic [15:0] tpm_did_vid_vid_qs;
+  logic [15:0] tpm_did_vid_vid_wd;
+  logic [15:0] tpm_did_vid_did_qs;
+  logic [15:0] tpm_did_vid_did_wd;
+  logic tpm_rid_we;
+  logic [7:0] tpm_rid_qs;
+  logic [7:0] tpm_rid_wd;
+  logic tpm_cmd_addr_re;
+  logic [23:0] tpm_cmd_addr_addr_qs;
+  logic [7:0] tpm_cmd_addr_cmd_qs;
+  logic tpm_read_fifo_we;
+  logic [7:0] tpm_read_fifo_wd;
+  logic tpm_write_fifo_re;
+  logic [7:0] tpm_write_fifo_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1508,6 +1569,32 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (intr_state_txunderflow_qs)
+  );
+
+
+  //   F[tpm_cmdaddr_notempty]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_intr_state_tpm_cmdaddr_notempty (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intr_state_we),
+    .wd     (intr_state_tpm_cmdaddr_notempty_wd),
+
+    // from internal hardware
+    .de     (hw2reg.intr_state.tpm_cmdaddr_notempty.de),
+    .d      (hw2reg.intr_state.tpm_cmdaddr_notempty.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_state.tpm_cmdaddr_notempty.q),
+
+    // to register interface (read)
+    .qs     (intr_state_tpm_cmdaddr_notempty_qs)
   );
 
 
@@ -1669,6 +1756,32 @@ module spi_device_reg_top (
   );
 
 
+  //   F[tpm_cmdaddr_notempty]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_intr_enable_tpm_cmdaddr_notempty (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intr_enable_we),
+    .wd     (intr_enable_tpm_cmdaddr_notempty_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intr_enable.tpm_cmdaddr_notempty.q),
+
+    // to register interface (read)
+    .qs     (intr_enable_tpm_cmdaddr_notempty_qs)
+  );
+
+
   // R[intr_test]: V(True)
 
   //   F[rxf]: 0:0
@@ -1757,6 +1870,21 @@ module spi_device_reg_top (
     .qre    (),
     .qe     (reg2hw.intr_test.txunderflow.qe),
     .q      (reg2hw.intr_test.txunderflow.q),
+    .qs     ()
+  );
+
+
+  //   F[tpm_cmdaddr_notempty]: 6:6
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_intr_test_tpm_cmdaddr_notempty (
+    .re     (1'b0),
+    .we     (intr_test_we),
+    .wd     (intr_test_tpm_cmdaddr_notempty_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.intr_test.tpm_cmdaddr_notempty.qe),
+    .q      (reg2hw.intr_test.tpm_cmdaddr_notempty.q),
     .qs     ()
   );
 
@@ -16428,9 +16556,691 @@ module spi_device_reg_top (
 
 
 
+  // R[tpm_cap]: V(False)
+
+  //   F[rev]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (8'h0)
+  ) u_tpm_cap_rev (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_cap.rev.de),
+    .d      (hw2reg.tpm_cap.rev.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_cap_rev_qs)
+  );
 
 
-  logic [53:0] addr_hit;
+  //   F[locality]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_tpm_cap_locality (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_cap.locality.de),
+    .d      (hw2reg.tpm_cap.locality.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_cap_locality_qs)
+  );
+
+
+  //   F[max_xfer_size]: 18:16
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (3'h0)
+  ) u_tpm_cap_max_xfer_size (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_cap.max_xfer_size.de),
+    .d      (hw2reg.tpm_cap.max_xfer_size.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_cap_max_xfer_size_qs)
+  );
+
+
+  // R[tpm_cfg]: V(False)
+
+  //   F[en]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_tpm_cfg_en (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_cfg_we),
+    .wd     (tpm_cfg_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_cfg.en.q),
+
+    // to register interface (read)
+    .qs     (tpm_cfg_en_qs)
+  );
+
+
+  //   F[hw_reg_dis]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_tpm_cfg_hw_reg_dis (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_cfg_we),
+    .wd     (tpm_cfg_hw_reg_dis_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_cfg.hw_reg_dis.q),
+
+    // to register interface (read)
+    .qs     (tpm_cfg_hw_reg_dis_qs)
+  );
+
+
+  //   F[invalid_ool]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_tpm_cfg_invalid_ool (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_cfg_we),
+    .wd     (tpm_cfg_invalid_ool_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_cfg.invalid_ool.q),
+
+    // to register interface (read)
+    .qs     (tpm_cfg_invalid_ool_qs)
+  );
+
+
+  // R[tpm_status]: V(False)
+
+  //   F[cmdaddr_notempty]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_tpm_status_cmdaddr_notempty (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_status.cmdaddr_notempty.de),
+    .d      (hw2reg.tpm_status.cmdaddr_notempty.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_status_cmdaddr_notempty_qs)
+  );
+
+
+  //   F[rdfifo_notempty]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_tpm_status_rdfifo_notempty (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_status.rdfifo_notempty.de),
+    .d      (hw2reg.tpm_status.rdfifo_notempty.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_status_rdfifo_notempty_qs)
+  );
+
+
+  //   F[rdfifo_depth]: 6:4
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (3'h0)
+  ) u_tpm_status_rdfifo_depth (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_status.rdfifo_depth.de),
+    .d      (hw2reg.tpm_status.rdfifo_depth.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_status_rdfifo_depth_qs)
+  );
+
+
+  //   F[wrfifo_depth]: 10:8
+  prim_subreg #(
+    .DW      (3),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (3'h0)
+  ) u_tpm_status_wrfifo_depth (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.tpm_status.wrfifo_depth.de),
+    .d      (hw2reg.tpm_status.wrfifo_depth.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (tpm_status_wrfifo_depth_qs)
+  );
+
+
+
+  // Subregister 0 of Multireg tpm_access
+  // R[tpm_access_0]: V(False)
+
+  // F[access_0]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_access_0_access_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_access_0_we),
+    .wd     (tpm_access_0_access_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_access[0].q),
+
+    // to register interface (read)
+    .qs     (tpm_access_0_access_0_qs)
+  );
+
+
+  // F[access_1]: 15:8
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_access_0_access_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_access_0_we),
+    .wd     (tpm_access_0_access_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_access[1].q),
+
+    // to register interface (read)
+    .qs     (tpm_access_0_access_1_qs)
+  );
+
+
+  // F[access_2]: 23:16
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_access_0_access_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_access_0_we),
+    .wd     (tpm_access_0_access_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_access[2].q),
+
+    // to register interface (read)
+    .qs     (tpm_access_0_access_2_qs)
+  );
+
+
+  // F[access_3]: 31:24
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_access_0_access_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_access_0_we),
+    .wd     (tpm_access_0_access_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_access[3].q),
+
+    // to register interface (read)
+    .qs     (tpm_access_0_access_3_qs)
+  );
+
+
+  // Subregister 4 of Multireg tpm_access
+  // R[tpm_access_1]: V(False)
+
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_access_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_access_1_we),
+    .wd     (tpm_access_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_access[4].q),
+
+    // to register interface (read)
+    .qs     (tpm_access_1_qs)
+  );
+
+
+  // R[tpm_sts]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_tpm_sts (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_sts_we),
+    .wd     (tpm_sts_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_sts.q),
+
+    // to register interface (read)
+    .qs     (tpm_sts_qs)
+  );
+
+
+  // R[tpm_intf_capability]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_tpm_intf_capability (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_intf_capability_we),
+    .wd     (tpm_intf_capability_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_intf_capability.q),
+
+    // to register interface (read)
+    .qs     (tpm_intf_capability_qs)
+  );
+
+
+  // R[tpm_int_enable]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_tpm_int_enable (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_int_enable_we),
+    .wd     (tpm_int_enable_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_int_enable.q),
+
+    // to register interface (read)
+    .qs     (tpm_int_enable_qs)
+  );
+
+
+  // R[tpm_int_vector]: V(False)
+
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_int_vector (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_int_vector_we),
+    .wd     (tpm_int_vector_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_int_vector.q),
+
+    // to register interface (read)
+    .qs     (tpm_int_vector_qs)
+  );
+
+
+  // R[tpm_int_status]: V(False)
+
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_tpm_int_status (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_int_status_we),
+    .wd     (tpm_int_status_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_int_status.q),
+
+    // to register interface (read)
+    .qs     (tpm_int_status_qs)
+  );
+
+
+  // R[tpm_did_vid]: V(False)
+
+  //   F[vid]: 15:0
+  prim_subreg #(
+    .DW      (16),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (16'h0)
+  ) u_tpm_did_vid_vid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_did_vid_we),
+    .wd     (tpm_did_vid_vid_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_did_vid.vid.q),
+
+    // to register interface (read)
+    .qs     (tpm_did_vid_vid_qs)
+  );
+
+
+  //   F[did]: 31:16
+  prim_subreg #(
+    .DW      (16),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (16'h0)
+  ) u_tpm_did_vid_did (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_did_vid_we),
+    .wd     (tpm_did_vid_did_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_did_vid.did.q),
+
+    // to register interface (read)
+    .qs     (tpm_did_vid_did_qs)
+  );
+
+
+  // R[tpm_rid]: V(False)
+
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_tpm_rid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (tpm_rid_we),
+    .wd     (tpm_rid_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.tpm_rid.q),
+
+    // to register interface (read)
+    .qs     (tpm_rid_qs)
+  );
+
+
+  // R[tpm_cmd_addr]: V(True)
+
+  //   F[addr]: 23:0
+  prim_subreg_ext #(
+    .DW    (24)
+  ) u_tpm_cmd_addr_addr (
+    .re     (tpm_cmd_addr_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.tpm_cmd_addr.addr.d),
+    .qre    (reg2hw.tpm_cmd_addr.addr.re),
+    .qe     (reg2hw.tpm_cmd_addr.addr.qe),
+    .q      (reg2hw.tpm_cmd_addr.addr.q),
+    .qs     (tpm_cmd_addr_addr_qs)
+  );
+
+
+  //   F[cmd]: 31:24
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_tpm_cmd_addr_cmd (
+    .re     (tpm_cmd_addr_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.tpm_cmd_addr.cmd.d),
+    .qre    (reg2hw.tpm_cmd_addr.cmd.re),
+    .qe     (reg2hw.tpm_cmd_addr.cmd.qe),
+    .q      (reg2hw.tpm_cmd_addr.cmd.q),
+    .qs     (tpm_cmd_addr_cmd_qs)
+  );
+
+
+  // R[tpm_read_fifo]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_tpm_read_fifo (
+    .re     (1'b0),
+    .we     (tpm_read_fifo_we),
+    .wd     (tpm_read_fifo_wd),
+    .d      ('0),
+    .qre    (),
+    .qe     (reg2hw.tpm_read_fifo.qe),
+    .q      (reg2hw.tpm_read_fifo.q),
+    .qs     ()
+  );
+
+
+  // R[tpm_write_fifo]: V(True)
+
+  prim_subreg_ext #(
+    .DW    (8)
+  ) u_tpm_write_fifo (
+    .re     (tpm_write_fifo_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.tpm_write_fifo.d),
+    .qre    (reg2hw.tpm_write_fifo.re),
+    .qe     (reg2hw.tpm_write_fifo.qe),
+    .q      (reg2hw.tpm_write_fifo.q),
+    .qs     (tpm_write_fifo_qs)
+  );
+
+
+
+
+  logic [68:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -16487,6 +17297,21 @@ module spi_device_reg_top (
     addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
     addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
     addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -16547,7 +17372,22 @@ module spi_device_reg_top (
                (addr_hit[50] & (|(SPI_DEVICE_PERMIT[50] & ~reg_be))) |
                (addr_hit[51] & (|(SPI_DEVICE_PERMIT[51] & ~reg_be))) |
                (addr_hit[52] & (|(SPI_DEVICE_PERMIT[52] & ~reg_be))) |
-               (addr_hit[53] & (|(SPI_DEVICE_PERMIT[53] & ~reg_be)))));
+               (addr_hit[53] & (|(SPI_DEVICE_PERMIT[53] & ~reg_be))) |
+               (addr_hit[54] & (|(SPI_DEVICE_PERMIT[54] & ~reg_be))) |
+               (addr_hit[55] & (|(SPI_DEVICE_PERMIT[55] & ~reg_be))) |
+               (addr_hit[56] & (|(SPI_DEVICE_PERMIT[56] & ~reg_be))) |
+               (addr_hit[57] & (|(SPI_DEVICE_PERMIT[57] & ~reg_be))) |
+               (addr_hit[58] & (|(SPI_DEVICE_PERMIT[58] & ~reg_be))) |
+               (addr_hit[59] & (|(SPI_DEVICE_PERMIT[59] & ~reg_be))) |
+               (addr_hit[60] & (|(SPI_DEVICE_PERMIT[60] & ~reg_be))) |
+               (addr_hit[61] & (|(SPI_DEVICE_PERMIT[61] & ~reg_be))) |
+               (addr_hit[62] & (|(SPI_DEVICE_PERMIT[62] & ~reg_be))) |
+               (addr_hit[63] & (|(SPI_DEVICE_PERMIT[63] & ~reg_be))) |
+               (addr_hit[64] & (|(SPI_DEVICE_PERMIT[64] & ~reg_be))) |
+               (addr_hit[65] & (|(SPI_DEVICE_PERMIT[65] & ~reg_be))) |
+               (addr_hit[66] & (|(SPI_DEVICE_PERMIT[66] & ~reg_be))) |
+               (addr_hit[67] & (|(SPI_DEVICE_PERMIT[67] & ~reg_be))) |
+               (addr_hit[68] & (|(SPI_DEVICE_PERMIT[68] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -16562,6 +17402,8 @@ module spi_device_reg_top (
   assign intr_state_rxoverflow_wd = reg_wdata[4];
 
   assign intr_state_txunderflow_wd = reg_wdata[5];
+
+  assign intr_state_tpm_cmdaddr_notempty_wd = reg_wdata[6];
   assign intr_enable_we = addr_hit[1] & reg_we & !reg_error;
 
   assign intr_enable_rxf_wd = reg_wdata[0];
@@ -16575,6 +17417,8 @@ module spi_device_reg_top (
   assign intr_enable_rxoverflow_wd = reg_wdata[4];
 
   assign intr_enable_txunderflow_wd = reg_wdata[5];
+
+  assign intr_enable_tpm_cmdaddr_notempty_wd = reg_wdata[6];
   assign intr_test_we = addr_hit[2] & reg_we & !reg_error;
 
   assign intr_test_rxf_wd = reg_wdata[0];
@@ -16588,6 +17432,8 @@ module spi_device_reg_top (
   assign intr_test_rxoverflow_wd = reg_wdata[4];
 
   assign intr_test_txunderflow_wd = reg_wdata[5];
+
+  assign intr_test_tpm_cmdaddr_notempty_wd = reg_wdata[6];
   assign alert_test_we = addr_hit[3] & reg_we & !reg_error;
 
   assign alert_test_wd = reg_wdata[0];
@@ -17733,6 +18579,53 @@ module spi_device_reg_top (
   assign cmd_info_23_upload_23_wd = reg_wdata[24];
 
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
+  assign tpm_cfg_we = addr_hit[55] & reg_we & !reg_error;
+
+  assign tpm_cfg_en_wd = reg_wdata[0];
+
+  assign tpm_cfg_hw_reg_dis_wd = reg_wdata[1];
+
+  assign tpm_cfg_invalid_ool_wd = reg_wdata[2];
+  assign tpm_access_0_we = addr_hit[57] & reg_we & !reg_error;
+
+  assign tpm_access_0_access_0_wd = reg_wdata[7:0];
+
+  assign tpm_access_0_access_1_wd = reg_wdata[15:8];
+
+  assign tpm_access_0_access_2_wd = reg_wdata[23:16];
+
+  assign tpm_access_0_access_3_wd = reg_wdata[31:24];
+  assign tpm_access_1_we = addr_hit[58] & reg_we & !reg_error;
+
+  assign tpm_access_1_wd = reg_wdata[7:0];
+  assign tpm_sts_we = addr_hit[59] & reg_we & !reg_error;
+
+  assign tpm_sts_wd = reg_wdata[31:0];
+  assign tpm_intf_capability_we = addr_hit[60] & reg_we & !reg_error;
+
+  assign tpm_intf_capability_wd = reg_wdata[31:0];
+  assign tpm_int_enable_we = addr_hit[61] & reg_we & !reg_error;
+
+  assign tpm_int_enable_wd = reg_wdata[31:0];
+  assign tpm_int_vector_we = addr_hit[62] & reg_we & !reg_error;
+
+  assign tpm_int_vector_wd = reg_wdata[7:0];
+  assign tpm_int_status_we = addr_hit[63] & reg_we & !reg_error;
+
+  assign tpm_int_status_wd = reg_wdata[31:0];
+  assign tpm_did_vid_we = addr_hit[64] & reg_we & !reg_error;
+
+  assign tpm_did_vid_vid_wd = reg_wdata[15:0];
+
+  assign tpm_did_vid_did_wd = reg_wdata[31:16];
+  assign tpm_rid_we = addr_hit[65] & reg_we & !reg_error;
+
+  assign tpm_rid_wd = reg_wdata[7:0];
+  assign tpm_cmd_addr_re = addr_hit[66] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[67] & reg_we & !reg_error;
+
+  assign tpm_read_fifo_wd = reg_wdata[7:0];
+  assign tpm_write_fifo_re = addr_hit[68] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -17745,6 +18638,7 @@ module spi_device_reg_top (
         reg_rdata_next[3] = intr_state_rxerr_qs;
         reg_rdata_next[4] = intr_state_rxoverflow_qs;
         reg_rdata_next[5] = intr_state_txunderflow_qs;
+        reg_rdata_next[6] = intr_state_tpm_cmdaddr_notempty_qs;
       end
 
       addr_hit[1]: begin
@@ -17754,6 +18648,7 @@ module spi_device_reg_top (
         reg_rdata_next[3] = intr_enable_rxerr_qs;
         reg_rdata_next[4] = intr_enable_rxoverflow_qs;
         reg_rdata_next[5] = intr_enable_txunderflow_qs;
+        reg_rdata_next[6] = intr_enable_tpm_cmdaddr_notempty_qs;
       end
 
       addr_hit[2]: begin
@@ -17763,6 +18658,7 @@ module spi_device_reg_top (
         reg_rdata_next[3] = '0;
         reg_rdata_next[4] = '0;
         reg_rdata_next[5] = '0;
+        reg_rdata_next[6] = '0;
       end
 
       addr_hit[3]: begin
@@ -18481,6 +19377,78 @@ module spi_device_reg_top (
         reg_rdata_next[20] = cmd_info_23_payload_dir_23_qs;
         reg_rdata_next[24] = cmd_info_23_upload_23_qs;
         reg_rdata_next[25] = cmd_info_23_busy_23_qs;
+      end
+
+      addr_hit[54]: begin
+        reg_rdata_next[7:0] = tpm_cap_rev_qs;
+        reg_rdata_next[8] = tpm_cap_locality_qs;
+        reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
+      end
+
+      addr_hit[55]: begin
+        reg_rdata_next[0] = tpm_cfg_en_qs;
+        reg_rdata_next[1] = tpm_cfg_hw_reg_dis_qs;
+        reg_rdata_next[2] = tpm_cfg_invalid_ool_qs;
+      end
+
+      addr_hit[56]: begin
+        reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
+        reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
+        reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
+        reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
+      end
+
+      addr_hit[57]: begin
+        reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
+        reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
+        reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
+        reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
+      end
+
+      addr_hit[58]: begin
+        reg_rdata_next[7:0] = tpm_access_1_qs;
+      end
+
+      addr_hit[59]: begin
+        reg_rdata_next[31:0] = tpm_sts_qs;
+      end
+
+      addr_hit[60]: begin
+        reg_rdata_next[31:0] = tpm_intf_capability_qs;
+      end
+
+      addr_hit[61]: begin
+        reg_rdata_next[31:0] = tpm_int_enable_qs;
+      end
+
+      addr_hit[62]: begin
+        reg_rdata_next[7:0] = tpm_int_vector_qs;
+      end
+
+      addr_hit[63]: begin
+        reg_rdata_next[31:0] = tpm_int_status_qs;
+      end
+
+      addr_hit[64]: begin
+        reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
+        reg_rdata_next[31:16] = tpm_did_vid_did_qs;
+      end
+
+      addr_hit[65]: begin
+        reg_rdata_next[7:0] = tpm_rid_qs;
+      end
+
+      addr_hit[66]: begin
+        reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
+        reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
+      end
+
+      addr_hit[67]: begin
+        reg_rdata_next[7:0] = '0;
+      end
+
+      addr_hit[68]: begin
+        reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 
       default: begin

--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -1,0 +1,1064 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Serial Peripheral Interface (SPI) Trusted Platform Module (TPM)
+/*
+*/
+
+module spi_tpm
+  import spi_device_pkg::*;
+#(
+  parameter int unsigned CmdAddrFifoDepth  = 2,
+
+  // Max Write/Read buffer size to support is 64B in TPM spec.
+  // But more than 4B is for future use. So, 4B is recommended.
+  parameter int unsigned WrFifoDepth   = 4,
+  parameter int unsigned RdFifoDepth   = 4,
+
+  // Locality determines the number of TPM_ACCESS registers.
+  // Other HW managed registers are shared across the locality.
+  // If host accesses the HW managed registers that are unsupported locality,
+  // the HW returns 0xFF. The SW is responsible to the other SW managed
+  // registers.
+  parameter bit EnLocality   = 1,
+
+  // derived
+  localparam int unsigned CmdAddrPtrW = $clog2(CmdAddrFifoDepth+1),
+  localparam int unsigned WrFifoPtrW  = $clog2(WrFifoDepth+1),
+  localparam int unsigned RdFifoPtrW  = $clog2(RdFifoDepth+1),
+
+  localparam int unsigned NumLocality = (EnLocality) ? 5 : 1,
+
+  localparam int unsigned AccessRegSize    = 8, // times Locality
+  localparam int unsigned IntEnRegSize     = 32,
+  localparam int unsigned IntVectorRegSize = 8,
+  localparam int unsigned IntStsRegSize    = 32,
+  localparam int unsigned IntfCapRegSize   = 32,
+  localparam int unsigned StatusRegSize    = 32,
+  localparam int unsigned IdRegSize        = 32, // {DID, VID}
+  localparam int unsigned RidRegSize       = 8,
+
+  localparam int unsigned ActiveLocalityBitPos = 5, // Access[5]
+
+  localparam int unsigned CmdAddrSize  = 32, // Cmd 8bit + Addr 24bit
+  localparam int unsigned DataFifoSize = $bits(spi_byte_t),
+
+  // TPM_CAP related constants.
+  //  - Revision: the number visible in TPM_CAP CSR. Need to update the
+  //    revision when the SW interface is revised.
+  localparam logic [7:0] CapTpmRevision = 8'h 00,
+  //  - Max Xfer Size: the supported xfer_size is visible to the SW via
+  //    TPM_CAP CSR
+  localparam logic [2:0] CapMaxXferSize = 3'($clog2(WrFifoDepth))
+) (
+  input clk_in_i,
+  input clk_out_i,
+
+  input sys_clk_i,
+
+  input sys_rst_ni,
+
+  input                      scan_rst_ni,
+  input lc_ctrl_pkg::lc_tx_t scanmode_i, // scanmode[RstTpmSel]
+
+  // SPI interface
+  input        csb_i, // TPM needs separate CS#
+  input        mosi_i,
+  output logic miso_o,
+  output logic miso_en_o,
+
+  // TPM Capability
+  output tpm_cap_t tpm_cap_o,
+
+  // Configurations
+  //  tpm_en to turn on the TPM function
+  input cfg_tpm_en_i,
+
+  //  hw_reg_dis to turn off return-by-HW registers
+  input cfg_tpm_hw_reg_dis_i,
+
+  //  tpm_invalid_ool : TPM function returns invalid (0xFF) when the received
+  //  address is out of the Locality.
+  //  If this bit is turned off, the logic uploads the command and address
+  //  even the address is out of the max Locality.
+  input cfg_tpm_invalid_ool_i,
+
+  // Registers in SYS clock
+  input [NumLocality*AccessRegSize-1:0] sys_access_reg_i,
+  input [IntEnRegSize-1:0]              sys_int_enable_reg_i,
+  input [IntVectorRegSize-1:0]          sys_int_vector_reg_i,
+  input [IntStsRegSize-1:0]             sys_int_status_reg_i,
+  input [IntfCapRegSize-1:0]            sys_intf_capability_reg_i,
+  input [StatusRegSize-1:0]             sys_status_reg_i,
+  input [IdRegSize-1:0]                 sys_id_reg_i,
+  input [RidRegSize-1:0]                sys_rid_reg_i,
+
+  // Buffer and FIFO status
+  output logic                   sys_cmdaddr_rvalid_o,
+  output logic [CmdAddrSize-1:0] sys_cmdaddr_rdata_o,
+  input                          sys_cmdaddr_rready_i,
+
+  output logic                    sys_wrfifo_rvalid_o,
+  output logic [DataFifoSize-1:0] sys_wrfifo_rdata_o,
+  input                           sys_wrfifo_rready_i,
+
+  input                     sys_rdfifo_wvalid_i,
+  input  [DataFifoSize-1:0] sys_rdfifo_wdata_i,
+  output logic              sys_rdfifo_wready_o,
+
+  // TPM_STATUS
+  output logic                  sys_cmdaddr_notempty_o,
+  output logic                  sys_rdfifo_notempty_o,
+  output logic [RdFifoPtrW-1:0] sys_rdfifo_depth_o,
+  output logic [WrFifoPtrW-1:0] sys_wrfifo_depth_o
+);
+
+  // Capability
+  assign tpm_cap_o = '{
+    rev:          CapTpmRevision,
+    locality:     EnLocality,
+    max_fer_size: CapMaxXferSize
+  };
+
+  // Latch SYS registers here
+  localparam TpmRegisterSize = (AccessRegSize * NumLocality) + IntEnRegSize
+                             + IntVectorRegSize + IntStsRegSize + IntfCapRegSize
+                             + StatusRegSize + IdRegSize + RidRegSize;
+
+  localparam logic [7:0]  TpmFifoAddr           = 8'h D4;
+
+  typedef enum logic [3:0] {
+    RegAccess    = 4'h 0,
+    RegIntEn     = 4'h 1,
+    RegIntVect   = 4'h 2,
+    RegIntSts    = 4'h 3,
+    RegIntfCap   = 4'h 4,
+    RegSts       = 4'h 5,
+    RegHashStart = 4'h 6,
+    RegId        = 4'h 7,
+    RegRid       = 4'h 8,
+    HwRegEnd     = 4'h 9
+  } hw_reg_idx_e;
+  localparam int unsigned NumHwReg = int unsigned'(HwRegEnd);
+
+  localparam logic [11:0] TpmReturnByHwAddr [NumHwReg] = '{
+    12'h 000, // 000     Access_x
+    12'h 008, // 00B:008 Interrupt Enable
+    12'h 00C, // 00C     Interrupt Vector
+    12'h 010, // 013:010 Interrupt Status
+    12'h 014, // 017:014 Interface Capability
+    12'h 018, // 01B:018 Status_x
+    12'h 020, // 023:020 Hash Start
+    12'h F00, // F03:F00 DID_VID
+    12'h F04  // F04:F04 RID
+  };
+
+  ///////////////////
+  // Clock & Reset //
+  ///////////////////
+
+  logic rst_n;
+
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_tpm_csb_rst_scan_mux (
+    .clk0_i (sys_rst_ni & ~csb_i),
+    .clk1_i (scan_rst_ni),
+    .sel_i  (scanmode_i == lc_ctrl_pkg::On),
+    .clk_o  (rst_n)
+  );
+
+  // TODO: internal reset (sys_rst_ni & csb_i)
+  // Do we really need the csb reset for TPM?
+
+  ////////////////
+  // Definition //
+  ////////////////
+
+  // Configuration structure
+  typedef struct packed {
+    logic tpm_en;
+    logic hw_reg_dis;
+    logic invalid_ool;
+  } tpm_cfg_t;
+
+  typedef enum logic {
+    Write = 1'b 0,
+    Read  = 1'b 1
+  } cmd_type_e;
+
+  typedef enum logic [3:0] {
+    // In Idle state, the TPM waits the opcode from the host system. When
+    // Opcode (first byte) is received, the TPM configures internal datapath
+    // based on the opcode.  opcode[7]: Read(1)/Write(0) opcode[5:0]: transfer
+    // size in 0-based number (e.g 'd63 == 64B)
+    //
+    // Next state:
+    //  - StAddr: when bitcnt hits 5'h7, the state moves to StAddr state.
+    //  - StErr??: If the xfer_size is bigger than the compile-time parameter,
+    //    reports error.
+    StIdle,
+
+    // Address is 3B register offset. The logic decodes the address and
+    // determines if the register to be returned by HW or by SW.
+    //
+    // HW managed registers:
+    //  - TPM_ACCESS_x
+    //  - TPM_INT_ENABLE
+    //  - TPM_INT_VECTOR
+    //  - TPM_INT_STATUS
+    //  - TPM_INTF_CAPABILITY
+    //  - TPM_STS_x
+    //  - TPM_DID , TPM_VID
+    //
+    // Next state:
+    //  - StWait: If the address is not for a Return-by-HW register, or the
+    //    hw_reg_dis configuration is set, the state machine moves to WAIT
+    //    state to send more WAIT byte to the SB.
+    //  - StStartByte: If the received command is a read command and the
+    //    address is for a Return-by-HW register and the hw_reg_dis config is
+    //    not set, the state machine does not need more WAIT state. The state
+    //    machine directly moves to StStartByte to send `START (0x01)`.
+    //  - StWrite: If the received command is a write command, and the write
+    //    FIFO is empty, the state machine moves to the StWrite state
+    //    directly.  If this condition is met, the state machine sends `START`
+    //    byte at the last byte of the address phase.
+    StAddr,
+
+    // In Wait state, the TPM sends 0x00 to SPI MISO line in order to hold the
+    // host system to send write data or to receive the read data.
+    //
+    // Next state:
+    //  - StStartByte: From Wait state, it always moves to StStartByte when
+    //    FIFOs are ready to be used.
+    StWait,
+
+    // In StartByte state, TPM sends 0x01 to SPI MISO line. When the host
+    // receives the data[0], it assumes the TPM device is ready to receive
+    // data or to send the requested data if the value is 1.
+    //
+    // Next state:
+    //  - StReadFifo: If the received command is a read command (cmd_type ==
+    //    Read), the state machine moves to StRead and sends the output of the
+    //    read FIFO to the parallel-to-serial module.
+    //  - StReadHwReg: If the received address is hw reg, and enabled hw
+    //    return, move to ReadHwReg state to return the HW data.
+    //  - StWrite: If the received command is a write command (cmd_type ==
+    //    Write), the state machine moves to StWrite and stacks the incoming
+    //    data into the write FIFO. It is assumed that the write FIFO has
+    //    enough empty space to store the incoming transfer size.
+    StStartByte,
+
+    // In Read state, the module reads data from the Read FIFO and returns to
+    // the host system. After the transfer size amount of data is sent, it
+    // moves to the End state.
+    //
+    // Next state:
+    //  - ??? : If the SB toggles more than the xfer size?
+    StReadFifo,
+
+    StReadHwReg,
+
+    // In Write state, the module accepts the data from MOSI and stores into
+    // the Write FIFO. After the transfer size amount of data is received, the
+    // TPM stop receiving the data and move to the End state.
+    //
+    // Next state:
+    //  - StEnd: When the module stores the xfer_size amount of the write data
+    //    into the write FIFO, it moves to StEnd state and waits the CS#
+    //    deassertion.
+    StWrite,
+
+    // In End state, TPM waits CSb de-assertion. This is TERMINAL_STATE.
+    StEnd
+  } st_e;
+
+  st_e sck_st_q, sck_st_d;
+
+  // tpm_reg_t struct defines the Return-by-HW registers. These registers must
+  // be processed by the HW to return the data in at most one WAIT cycle.
+  //
+  // The TPM submodule returns WAIT by default at the last byte of the address
+  // phase. Then, when the module receives the addr[2], it knows the SB is
+  // accessing the Return-by-HW registers. It sets the `is_hw_reg` flag.
+  //
+  // When the state machine in this submodule moves from the Address state, if
+  // the flag is set and the `cfg_tpm_hw_reg_dis_i` is cleard, the state
+  // machine directly moves to `START` state as it does not need to wait
+  // longer.
+  typedef struct packed {
+    logic [AccessRegSize*NumLocality-1:0] access;
+    logic [IntEnRegSize-1:0]              int_enable;
+    logic [IntVectorRegSize-1:0]          int_vector;
+    logic [IntStsRegSize-1:0]             int_status;
+    logic [IntfCapRegSize-1:0]            intf_capacity;
+    logic [StatusRegSize-1:0]             status;
+    logic [IdRegSize-1:0]                 id;  // Device ID, Vendor ID
+    logic [RidRegSize-1:0]                rid; // Revision ID
+  } tpm_reg_t;
+
+  ///////////
+  // Signal//
+  ///////////
+
+  // CS# assertion pulse signal in SCK domain
+  logic isck_csb_asserted_pulse, sck_csb_asserted_pulse;
+
+  tpm_cfg_t sys_tpm_cfg;
+  tpm_cfg_t sck_tpm_cfg;
+
+  assign sys_tpm_cfg = '{
+    tpm_en:      cfg_tpm_en_i,
+    hw_reg_dis:  cfg_tpm_hw_reg_dis_i,
+    invalid_ool: cfg_tpm_invalid_ool_i
+  };
+
+  tpm_reg_t sys_tpm_reg;
+  tpm_reg_t isck_tpm_reg;
+
+  logic [NumLocality-1:0] sck_active_locality; // TPM_ACCESS_x[5]
+
+  assign sys_tpm_reg = '{
+    access:        sys_access_reg_i,
+    int_enable:    sys_int_enable_reg_i,
+    int_vector:    sys_int_vector_reg_i,
+    int_status:    sys_int_status_reg_i,
+    intf_capacity: sys_intf_capability_reg_i,
+    status:        sys_status_reg_i,
+    id:            sys_id_reg_i,
+    rid:           sys_rid_reg_i
+  };
+
+  // FIFOs
+  logic                   sck_cmdaddr_wvalid,  sck_cmdaddr_wready;
+  logic [CmdAddrSize-1:0] sck_cmdaddr_wdata_q, sck_cmdaddr_wdata_d;
+  logic [CmdAddrPtrW-1:0] sys_cmdaddr_rdepth,  sck_cmdaddr_wdepth;
+
+  logic cmdaddr_inc;
+
+  // (sys_cmdaddr_rdepth > 0)
+  assign sys_cmdaddr_notempty_o = |sys_cmdaddr_rdepth;
+
+  logic                    sck_wrfifo_wvalid, sck_wrfifo_wready;
+  logic [DataFifoSize-1:0] sck_wrfifo_wdata;
+  logic [WrFifoPtrW-1:0]   sys_wrfifo_rdepth, sck_wrfifo_wdepth;
+
+  assign sys_wrfifo_depth_o = sys_wrfifo_rdepth;
+
+  // Read FIFO uses inverted SCK (clk_out_i)
+  logic                    isck_rdfifo_rvalid, isck_rdfifo_rready;
+  logic [DataFifoSize-1:0] isck_rdfifo_rdata;
+  logic [RdFifoPtrW-1:0]   sys_rdfifo_wdepth, isck_rdfifo_rdepth;
+
+  assign sys_rdfifo_depth_o = sys_rdfifo_wdepth;
+
+  // If cmdaddr_shift_en is 1, the logic stacks the incoming MOSI into cmdaddr
+  // register.
+  logic       cmdaddr_shift_en;
+  logic [4:0] cmdaddr_bitcnt;
+
+  logic [23:0] addr; // used temporary while shifting the cmd address
+
+  // Write Data Latch Enable: Latch and generate a pulse when a byte is stacked.
+  logic       wrdata_shift_en;
+  logic [2:0] wrdata_bitcnt;
+
+  logic [7:0] wrdata_q, wrdata_d;
+
+  // Read FIFO is in inverted SCK domain (clk_out)
+  logic       sck_rddata_shift_en, isck_rddata_shift_en;
+  logic [2:0] rddata_bitcnt;
+
+  // Indicate if the received address is FIFO register. Should start with
+  // D4_xxxx
+  logic is_fifo_reg;
+  logic check_fifo_reg;
+
+  // If the received command falls into the return-by-HW registers, then
+  // `is_hw_reg` is set.
+  logic is_hw_reg;
+  hw_reg_idx_e sck_hw_reg_idx, isck_hw_reg_idx;
+
+  logic [31:0] isck_hw_reg_word;
+  logic [7:0]  isck_hw_reg_byte;
+
+  // Set this signal when the received address bits are enough, which should
+  // be address[23:2] or bigger.
+  logic check_hw_reg;
+
+  // When the address shifted up to addr[12] (cmdaddr_bitcnt == 5'h 13), the
+  // module can decide if the received address is in the Locality or not. If
+  // it is not in the locality, the logic may return the invalid and discard
+  // the request.
+  logic latch_locality;
+
+  // bit[15:12] in the received address is the locality if the address is FIFO
+  // addr.
+  logic [3:0] locality;
+
+
+  // The first bit of the command (Command[7]) indicates the command direction.
+  logic      latch_cmd_type;
+  cmd_type_e cmd_type;
+
+  // xfer_size: Command[5:0] is the command xfer size. currently the logic
+  // supports up to WrFifoDepth.
+  logic       latch_xfer_size;
+  logic [5:0] xfer_size;
+  logic [5:0] xfer_bytes_q, xfer_bytes_d;
+  logic       xfer_size_met;
+
+  // Output MISO
+  typedef enum logic [2:0] {
+    SelWait     = 3'h 0, // 0x00
+    SelStart    = 3'h 1, // 0x01
+    SelInvalid  = 3'h 2, // 0xFF
+    SelHwReg    = 3'h 3, // depends on hw_reg_idx
+    SelRdFifo   = 3'h 4  // from RdFifo
+  } tpm_data_sel_e;
+
+  logic       sck_p2s_valid;
+  logic       sck_p2s_sent; // pulse of bit 7
+
+  logic       isck_p2s_valid;
+  logic [7:0] isck_p2s_data;
+  logic       isck_p2s_sent;
+
+  tpm_data_sel_e sck_data_sel, isck_data_sel;
+
+  logic isck_miso_en;
+  logic isck_miso;
+
+  assign miso_en_o = isck_miso_en;
+  assign miso_o    = isck_miso;
+
+  /////////
+  // CDC //
+  /////////
+
+  // clk_in csb_asserted_pulse
+  prim_edge_detector #(
+    .Width      (1),
+    .ResetValue (1'b 1),
+    .EnSync     (1'b 1)
+  ) u_sck_csb_edge (
+    .clk_i             (clk_in_i),
+    .rst_ni            (rst_n),
+    .d_i               (1'b 0), // rst_n has CSb assertion
+    .q_sync_o          (),
+    .q_posedge_pulse_o (),
+    .q_negedge_pulse_o (sck_csb_asserted_pulse)
+  );
+
+  // Latch configs
+
+  // clk_out csb_asserted pulse
+  prim_edge_detector #(
+    .Width      (1),
+    .ResetValue (1'b 1),
+    .EnSync     (1'b 1)
+  ) u_isck_csb_edge (
+    .clk_i             (clk_out_i),
+    .rst_ni            (rst_n),
+    .d_i               (1'b 0),
+    .q_sync_o          (),
+    .q_posedge_pulse_o (),
+    .q_negedge_pulse_o (isck_csb_asserted_pulse)
+  );
+
+  // Configuration latched into SCK
+  always_ff @(posedge clk_in_i or negedge sys_rst_ni) begin
+    if (!sys_rst_ni) begin
+      sck_tpm_cfg <= '{default: '0};
+    end else if (sck_csb_asserted_pulse) begin
+      sck_tpm_cfg <= sys_tpm_cfg;
+    end
+  end
+
+  // SYS register latched into the SCK (or isck?)
+  always_ff @(posedge clk_in_i or negedge sys_rst_ni) begin
+    if (!sys_rst_ni) begin
+      isck_tpm_reg <= '{default: '0};
+    end else if (isck_csb_asserted_pulse) begin
+      isck_tpm_reg <= sys_tpm_reg;
+    end
+  end
+
+  // Latch activeLocality in SCK to be used in the state machine
+  always_ff @(posedge clk_in_i or negedge sys_rst_ni) begin
+    if (!sys_rst_ni) begin
+      sck_active_locality <= NumLocality'(0);
+    end else if (sck_csb_asserted_pulse) begin
+      for (int unsigned i = 0 ; i < NumLocality ; i++) begin
+        sck_active_locality[i] <=
+          sys_tpm_reg.access[AccessRegSize*i + ActiveLocalityBitPos];
+      end
+    end
+  end
+
+  // data_sel (sck -> isck)
+  always_ff @(posedge clk_out_i or negedge rst_n) begin
+    if (!rst_n) begin
+      isck_data_sel <= SelWait;
+    end else begin
+      isck_data_sel <= sck_data_sel;
+    end
+  end
+
+  //////////////
+  // Datapath //
+  //////////////
+
+  // command, addr latch
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      cmdaddr_bitcnt <= 5'h 0;
+    end else if (cmdaddr_shift_en) begin
+      cmdaddr_bitcnt <= cmdaddr_bitcnt + 5'h 1;
+    end
+  end
+
+  assign sck_cmdaddr_wvalid = cmdaddr_bitcnt == 5'h 1F && !is_hw_reg;
+
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      sck_cmdaddr_wdata_q <= '0;
+    end else if (cmdaddr_shift_en) begin
+      sck_cmdaddr_wdata_q <= sck_cmdaddr_wdata_d;
+    end else if (cmdaddr_inc) begin
+      // When a byte is sent, it increases the index
+      sck_cmdaddr_wdata_q <= sck_cmdaddr_wdata_q + 1'b 1;
+    end
+  end
+
+  assign sck_cmdaddr_wdata_d = {sck_cmdaddr_wdata_q[0+:CmdAddrSize-1], mosi_i};
+
+  // Write Data Latch
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      wrdata_bitcnt <= '0;
+    end else if (wrdata_shift_en) begin
+      wrdata_bitcnt <= wrdata_bitcnt + 3'h 1;
+    end
+  end
+
+  assign sck_wrfifo_wvalid = (wrdata_bitcnt == 3'h 7);
+
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      wrdata_q <= 8'h 0;
+    end else if (wrdata_shift_en) begin
+      wrdata_q <= wrdata_d;
+    end
+  end
+
+  assign wrdata_d = {wrdata_q[6:0], mosi_i};
+
+  assign sck_wrfifo_wdata = wrdata_d;
+
+  // Address: This is a comb logic that shows correct address value when the
+  // address is compared with other logics
+  always_comb begin
+    addr = 24'h 00_0000;
+    unique case (1'b 1)
+      check_fifo_reg: begin
+        // when checking the fifo_reg, only 8bit address is received.
+        // Look at the assertion FifoRegCondition_A,
+        addr = {sck_cmdaddr_wdata_d[7:0], 16'h 0000};
+      end
+
+      latch_locality: begin
+        addr = {sck_cmdaddr_wdata_d[11:0], 12'h 000};
+      end
+
+      check_hw_reg: begin
+        // In Return-by-HW Reg check stage, the lower 2 bits were not arrived.
+        // Look at the assertion HwRegCondition_A
+        addr = {sck_cmdaddr_wdata_d[21:0], 2'b 00};
+      end
+
+      default: addr = 24'h 00_0000;
+    endcase
+  end
+
+  // when the address[16] is received, check if the address is for FIFO.
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      is_fifo_reg <= 1'b 0;
+    end else if (check_fifo_reg && (addr[23:16] == TpmFifoAddr)) begin
+      is_fifo_reg <= 1'b 1;
+    end
+  end
+
+  // Return-by-HW register check
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      is_hw_reg      <= 1'b 0;
+      sck_hw_reg_idx <= RegAccess;
+    end else if (check_hw_reg && is_fifo_reg && locality < 4'(NumLocality)) begin
+      // check_hw_reg asserts when cmdaddr_bitcnt is 29.
+      for (int i = 0 ; i < NumHwReg; i ++) begin
+        if (TpmReturnByHwAddr[i][11:2] == addr[11:2]) begin
+          is_hw_reg      <= 1'b 1;
+          sck_hw_reg_idx <= hw_reg_idx_e'(i);
+        end
+      end // for
+    end // if check_hw_reg
+  end
+
+  // hw_reg_idx (sck -> isck)
+  always_ff @(posedge clk_out_i or negedge rst_n) begin
+    if (!rst_n) isck_hw_reg_idx <= RegAccess;
+    else        isck_hw_reg_idx <= sck_hw_reg_idx;
+  end
+
+  // locality store
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      locality <= '0;
+    end else if (latch_locality && is_fifo_reg) begin
+      locality <= addr[15:12];
+    end
+  end
+
+  // cmd_type
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      cmd_type <= Write;
+    end else if (latch_cmd_type) begin
+      // latch at the very first SCK edge
+      cmd_type <= cmd_type_e'(sck_cmdaddr_wdata_d[0]);
+    end
+  end
+
+  // xfer_size
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      xfer_size <= 6'h 0;
+    end else if (latch_xfer_size) begin
+      xfer_size <= sck_cmdaddr_wdata_d[5:0];
+    end
+  end
+
+  // Xfer size count
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      xfer_bytes_q <= '0;
+    end else if ((sck_p2s_sent && sck_rddata_shift_en) ||
+      (sck_wrfifo_wvalid && wrdata_shift_en)) begin
+      xfer_bytes_q <= xfer_bytes_d;
+    end
+  end
+  assign xfer_bytes_d  = xfer_bytes_q + 6'h 1;
+  assign xfer_size_met = xfer_bytes_d == xfer_size;
+
+  // Output data mux
+  always_comb begin
+    isck_p2s_data = 8'h 00;
+
+    unique case (isck_data_sel)
+      SelWait: begin
+        isck_p2s_data = 8'h 00;
+      end
+
+      SelStart: begin
+        isck_p2s_data = 8'h 01;
+      end
+
+      SelInvalid: begin
+        isck_p2s_data = 8'h FF;
+      end
+
+      SelHwReg: begin
+        isck_p2s_data = isck_hw_reg_byte;
+      end
+
+      SelRdFifo: begin
+        isck_p2s_data = isck_rdfifo_rdata;
+      end
+
+      default: begin
+        isck_p2s_data = 8'h 00;
+      end
+    endcase
+  end
+
+  // HW REG mux
+  prim_slicer #(
+    .InW    (32),
+    .OutW   (8),
+    .IndexW (2)
+  ) u_hw_reg_slice (
+    .sel_i (sck_cmdaddr_wdata_q[1:0]),
+    .data_i (isck_hw_reg_word),
+    .data_o (isck_hw_reg_byte)
+  );
+
+  always_comb begin : hw_reg_mux
+    isck_hw_reg_word = 32'h FFFF_FFFF;
+
+    unique case (isck_hw_reg_idx)
+      RegAccess: begin
+        if (locality < 4'(NumLocality)) begin
+          isck_hw_reg_word = isck_tpm_reg.access[AccessRegSize*locality+:32];
+        end
+      end
+
+      RegIntEn: begin
+        isck_hw_reg_word = isck_tpm_reg.int_enable;
+      end
+
+      RegIntVect: begin
+        isck_hw_reg_word = {24'h FFFFFF, isck_tpm_reg.int_vector};
+      end
+
+      RegIntSts: begin
+        isck_hw_reg_word = isck_tpm_reg.int_status;
+      end
+
+      RegIntfCap: begin
+        isck_hw_reg_word = isck_tpm_reg.intf_capacity;
+      end
+
+      RegSts: begin
+        // Check locality to return FFh or correct value
+        if (locality < 4'(NumLocality) && sck_active_locality[locality]) begin
+          // return data
+          isck_hw_reg_word = isck_tpm_reg.status;
+        end else begin
+          isck_hw_reg_word = 32'h FFFF_FFFF;
+        end
+      end
+
+      RegHashStart: begin
+        isck_hw_reg_word = 32'h 0000_0000;
+      end
+
+      RegId: begin
+        isck_hw_reg_word = isck_tpm_reg.id;
+      end
+
+      RegRid: begin
+        isck_hw_reg_word = {24'h FFFFFF, isck_tpm_reg.rid};
+      end
+
+      default: begin
+        isck_hw_reg_word = 32'h FFFF_FFFF;
+      end
+    endcase
+  end : hw_reg_mux
+
+  // Parallel to Serial (Output)
+
+
+  ///////////////////
+  // State Machine //
+  ///////////////////
+
+  // Inputs
+  //  - CFG: (tpm_en, tpm_hw_reg_dis, tpm_invalid_ool)
+  //  - is_hw_reg
+  //
+  // Outputs
+  //  - latch_cmd_type
+  //  - latch_xfer_size
+  //  - latch_locality
+  //  - check_hw_reg
+  //  - check_fifo_reg
+  //  - cmdaddr_shift_en
+  //  - wrdata_shift_en
+  //  - p2s_valid
+  //  - sck_data_sel
+
+  always_ff @(posedge clk_in_i or negedge rst_n) begin
+    if (!rst_n) begin
+      sck_st_q <= StIdle;
+    end else begin
+      sck_st_q <= sck_st_d;
+    end
+  end
+
+  always_comb begin : next_state
+    sck_st_d = sck_st_q;
+
+    // Default output values
+    latch_cmd_type  = 1'b 0;
+    latch_xfer_size = 1'b 0;
+    latch_locality  = 1'b 0;
+
+    check_hw_reg    = 1'b 0;
+    check_fifo_reg  = 1'b 0;
+
+    cmdaddr_shift_en    = 1'b 0;
+    wrdata_shift_en     = 1'b 0;
+    sck_rddata_shift_en = 1'b 0;
+
+    sck_p2s_valid = 1'b 0;
+    sck_data_sel  = SelWait;
+
+    unique case (sck_st_q)
+      StIdle: begin
+        cmdaddr_shift_en = 1'b 1;
+
+        if (cmdaddr_bitcnt == 5'h 0) begin
+          latch_cmd_type = 1'b 1;
+        end
+
+        if (cmdaddr_bitcnt == 5'h 7) begin
+          if (sck_tpm_cfg.tpm_en) begin
+            sck_st_d = StAddr;
+
+            latch_xfer_size = 1'b 1;
+          end else begin
+            // Stop processing and move to End state.
+            // sck_tpm_cfg.tpm_en cannot be compared right after reset.  Due
+            // to the absent of the SCK, the configuration cannot be
+            // synchronized into SCK domain at the first 3 clock cycle.
+            // So, the enable signal is checked when the state is about to
+            // move to StAddr.
+            sck_st_d = StEnd;
+          end
+        end
+      end
+
+      StAddr: begin
+        // NOTE: The coding style in this state is ugly. How can we improve?
+        cmdaddr_shift_en = 1'b 1;
+
+        if (cmdaddr_bitcnt == 5'h F) begin
+          check_fifo_reg = 1'b 1;
+        end
+
+        if (cmdaddr_bitcnt == 5'h 1D) begin
+          check_hw_reg = 1'b 1;
+        end
+
+        if (cmdaddr_bitcnt >= 5'h 17) begin
+          // TODO: Add output logic here (Send WAIT or START)
+          sck_p2s_valid = 1'b 1;
+          sck_data_sel  = SelWait;
+        end
+
+        // Next state: if is_fifo_reg 1 && !cfg_hw_reg_dis
+        if (cmdaddr_bitcnt == 5'h 1F) begin
+          if ((cmd_type == Read) && !is_fifo_reg) begin
+            sck_st_d = StWait;
+          end else if ((cmd_type == Write) && ~|sck_wrfifo_wdepth) begin
+            // Write command and FIFO is empty. Ready to push
+            // TODO: Change the state machine to send start byte at
+            //       cmdaddr_bitcnt == 5'h 17 if write command and FIFO is
+            //       empty, then the state can go to StWrite directly.
+            sck_st_d = StStartByte;
+          end else if ((cmd_type == Read) && is_hw_reg &&
+            !sck_tpm_cfg.hw_reg_dis) begin
+            // If read command and HW REG, then return by HW
+            // is_hw_reg contains (is_fifo_reg && (locality < NumLocality))
+            sck_st_d = StStartByte;
+          end else if (cmd_type == Read) begin
+            // Other read command sends to Wait, till SW response
+            sck_st_d = StWait;
+          end
+        end
+
+      end
+
+      StWait: begin
+        sck_p2s_valid = 1'b 1;
+        sck_data_sel = SelWait;
+
+        if (sck_p2s_sent) begin
+          // at every LSB of a byte, check the next state condition
+          if ((cmd_type == Read) && |isck_rdfifo_rdepth) begin
+            sck_st_d = StStartByte;
+          end
+        end
+      end
+
+      StStartByte: begin
+        sck_p2s_valid = 1'b 1;
+        sck_data_sel  = SelStart;
+
+        if (sck_p2s_sent) begin
+          // Must move to next state as StartByte is a byte
+          if ((cmd_type == Read) && is_fifo_reg &&
+            is_hw_reg && !sck_tpm_cfg.hw_reg_dis) begin
+            sck_st_d = StReadHwReg;
+          end else if (cmd_type == Read) begin
+            sck_st_d = StReadFifo;
+          end
+        end
+      end
+
+      StReadFifo: begin
+        sck_rddata_shift_en = 1'b 1;
+
+        sck_p2s_valid = 1'b 1;
+        sck_data_sel  = SelRdFifo;
+
+        // TODO: RdFifo rready (sck --> isck)
+
+        // TODO: check xfer_size handling
+        if (sck_p2s_sent && xfer_size_met) begin
+          sck_st_d = StEnd;
+        end
+      end
+
+      StReadHwReg: begin
+        sck_p2s_valid = 1'b 1;
+        sck_data_sel  = SelHwReg;
+
+        // HW Reg slice? using index
+      end
+
+      StWrite: begin
+        wrdata_shift_en = 1'b 1;
+        // Processed by the logic. Does not have to do
+
+        // TODO: check xfer_size handling
+        if (sck_wrfifo_wvalid && xfer_size_met) begin
+          sck_st_d = StEnd;
+        end
+      end
+
+      StEnd: begin // TERMINAL_STATE
+        // TODO: Check if open pull-up cancel the transaction?
+        //       If yes, then drive 0x00 for the read command
+        if (cmd_type == Read) begin
+          sck_p2s_valid = 1'b 1;
+          sck_data_sel  = SelWait; // drive 0x00
+        end
+      end
+
+      default: begin
+        sck_st_d = StIdle;
+      end
+    endcase
+
+  end : next_state
+
+  //////////////
+  // Instance //
+  //////////////
+  prim_fifo_async #(
+    .Width (CmdAddrSize),
+    .Depth (CmdAddrFifoDepth),
+    .OutputZeroIfEmpty (1'b 1)
+  ) u_cmdaddr_buffer (
+    .clk_wr_i  (clk_in_i),
+    .rst_wr_ni (sys_rst_ni),
+    .wvalid_i  (sck_cmdaddr_wvalid),
+    .wready_o  (sck_cmdaddr_wready),
+    .wdata_i   (sck_cmdaddr_wdata_d),
+    .wdepth_o  (sck_cmdaddr_wdepth),
+
+    .clk_rd_i  (sys_clk_i),
+    .rst_rd_ni (sys_rst_ni),
+    .rvalid_o  (sys_cmdaddr_rvalid_o),
+    .rready_i  (sys_cmdaddr_rready_i),
+    .rdata_o   (sys_cmdaddr_rdata_o),
+    .rdepth_o  (sys_cmdaddr_rdepth)
+  );
+
+  prim_fifo_async #(
+    .Width (DataFifoSize),
+    .Depth (WrFifoDepth),
+    .OutputZeroIfEmpty (1'b 1)
+  ) u_wrfifo (
+    .clk_wr_i  (clk_in_i),
+    .rst_wr_ni (sys_rst_ni),
+    .wvalid_i  (sck_wrfifo_wvalid),
+    .wready_o  (sck_wrfifo_wready),
+    .wdata_i   (sck_wrfifo_wdata),
+    .wdepth_o  (sck_wrfifo_wdepth),
+
+    .clk_rd_i  (sys_clk_i),
+    .rst_rd_ni (sys_rst_ni),
+    .rvalid_o  (sys_wrfifo_rvalid_o),
+    .rready_i  (sys_wrfifo_rready_i),
+    .rdata_o   (sys_wrfifo_rdata_o),
+    .rdepth_o  ()
+
+  );
+
+  // The content inside the Read FIFO needs to be flush out when a TPM
+  // transaction is completed (CSb deasserted).  So, everytime CSb is
+  // deasserted --> rst_n asserted. So, reset the read FIFO.
+  prim_fifo_async #(
+    .Width (DataFifoSize),
+    .Depth (RdFifoDepth),
+    .OutputZeroIfEmpty (1'b 1)
+  ) u_rdfifo (
+    .clk_wr_i  (sys_clk_i),
+    .rst_wr_ni (rst_n),     // Need synchronizer?
+    .wvalid_i  (sys_rdfifo_wvalid_i),
+    .wready_o  (sys_rdfifo_wready_o),
+    .wdata_i   (sys_rdfifo_wdata_i),
+    .wdepth_o  (sys_rdfifo_wdepth),
+
+    .clk_rd_i  (clk_out_i),
+    .rst_rd_ni (rst_n),
+    .rvalid_o  (isck_rdfifo_rvalid),
+    .rready_i  (isck_rdfifo_rready),
+    .rdata_o   (isck_rdfifo_rdata),
+    .rdepth_o  (isck_rdfifo_rdepth)
+
+  );
+
+  ///////////////
+  // Assertion //
+  ///////////////
+
+  // Parameters
+  `ASSERT_INIT(CmdPowerof2_A,  CmdFifoDepth  == 2**$clog2(CmdFifoDepth))
+  `ASSERT_INIT(AddrPowerof2_A, AddrFifoDepth == 2**$clog2(AddrFifoDepth))
+  `ASSERT_INIT(RdPowerof2_A,   RdFifoDepth   == 2**$clog2(RdFifoDepth))
+  // Write FIFO: should be in the range of TPM spec supported (4B, 8B, 32B, 64B)
+  // Read FIFO can have more flexible size as SW can push more bytes in
+  // a transaction.
+  `ASSERT_INIT(WrDepthSpec_A, WrFifoDepth inside {4, 8, 32, 64})
+
+  `ASSERT_INIT(DataFifoLessThan64_A, WrFifoDepth <= 64 && RdFifoDepth <= 64)
+
+  `ASSERT_INIT(TpmRegSizeMatch_A, TpmRegisterSize == $bits(tpm_reg_t))
+
+  // CMDADDR buffer should be available, if not, at least error to be propagated
+  `ASSERT(CmdAddrAvailable_A,
+          sck_cmdaddr_wvalid |-> sck_cmdaddr_wready,
+          clk_in_i, !rst_n)
+
+  // When a byte is being pushed to WrFifo, the FIFO should have a space
+  `ASSERT(WrFifoAvailable_A,
+          sck_wrfifo_wvalid |-> sck_wrfifo_wready,
+          clk_in_i, !rst_n)
+
+  // If the command and the address have been shifted, the Locality, command
+  // type should be matched with the shifted register.
+  `ASSERT(CmdAddrInfo_A,
+          $fall(cmdaddr_shift_en) && !csb_i |->
+            (locality == sck_cmdaddr_wdata_q[15:12]) &&
+            (cmd_type == sck_cmdaddr_wdata_q[31]),
+          clk_in_i, !rst_n)
+
+  // The condition of fifo_reg check
+  `ASSERT(FifoRegCondition_A,
+          check_fifo_reg |-> (cmdaddr_bitcnt == 5'h 15),
+          clk_in_i, !rst_n)
+
+  // when check_hw_reg is set, the address should have a word size
+  `ASSERT(HwRegCondition_A,
+          check_hw_reg |-> (cmdaddr_bitcnt == 5'h 1D),
+          clk_in_i, !rst_n)
+
+  // If is_hw_reg set, then it should be FIFO reg and within locality
+  `ASSERT(HwRegCondition2_a,
+          $rose(is_hw_reg) |-> is_fifo_reg && (locality < 4'(NumLocality)),
+          clk_in_i, !rst_n)
+
+  // If module returns data in StAddr, the cmdaddr_bitcount should be the last
+  // byte
+  `ASSERT(CmdAddrBitCntInAddrSt_A,
+          (sck_st_q == StAddr) && sck_p2s_valid |-> (cmdaddr_bitcnt inside [23..31]),
+          clk_in_i, !rst_n)
+
+endmodule : spi_tpm

--- a/hw/ip/spi_device/spi_device.core
+++ b/hw/ip/spi_device/spi_device.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:clock_gating
       - lowrisc:prim:clock_inv
       - lowrisc:prim:ram_2p_adv
+      - lowrisc:prim:edge_detector
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:prim:lc_sync
       - lowrisc:ip:spi_device_pkg
@@ -31,6 +32,7 @@ filesets:
       - rtl/spid_jedec.sv
       - rtl/spid_fifo2sram_adapter.sv
       - rtl/spid_upload.sv
+      - rtl/spi_tpm.sv
       - rtl/spi_s2p.sv
       - rtl/spi_p2s.sv
       - rtl/spi_device.sv


### PR DESCRIPTION
This PR adds the TPM over SPI feature in the SPI_DEVICE HWIP. The TPM submodule implements [the TPM over SPI technical spec](https://docs.google.com/document/d/1tGvgOsJflz_f2frRU39W2XCtIebCTJ8nUoAdbhzFA40/edit) (issue #7848 ).

This PR is currently in drafting. It has most of the data path but not yet fully implemented.