### PR TITLE
[rom_ctrl] Use FileSiz to determine ELF segment size

### DIFF
--- a/hw/ip/rom_ctrl/util/mem.py
+++ b/hw/ip/rom_ctrl/util/mem.py
@@ -203,14 +203,14 @@ class MemFile:
             seg_type = segment['p_type']
 
             # We're only interested in nonempty PT_LOAD segments
-            if seg_type != 'PT_LOAD' or segment['p_memsz'] == 0:
+            if seg_type != 'PT_LOAD' or segment['p_filesz'] == 0:
                 continue
 
             # seg_lma is the (relative) address of the first byte to be loaded.
             # seg_top is the address of the last byte to be loaded. A one-byte
             # segment will have seg_lma == seg_top.
             seg_lma = segment['p_paddr'] - base_addr
-            seg_top = seg_lma + segment['p_memsz'] - 1
+            seg_top = seg_lma + segment['p_filesz'] - 1
 
             assert seg_lma <= seg_top
 


### PR DESCRIPTION
MemSiz includes memory that is allocated but not loaded. FileSiz
is the actual size of the segment in the ELF file.

For example, the mask ROM ELF file contains a segment with both
.data and .bss packed into it. The FileSiz is 0xc bytes (the size
of .data) while the MemSiz is larger at 0xa8 bytes because it
includes the .bss section that is not loaded from ROM and takes up
no space in the ELF file.