### PR TITLE
[dv/cover_cfg] Exclude prim_alert/esc pairs

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -8,7 +8,11 @@
 +tree tb.dut
 -module pins_if     // DV construct.
 -module clk_rst_if  // DV construct.
--moduletree prim_alert_sender  // prim_alert_sender is verified in FPV.
+// Prim_alert/esc pairs are verified in FPV and DV testbenches.
+-moduletree prim_alert_sender
+-moduletree prim_alert_receiver
+-moduletree prim_esc_sender
+-moduletree prim_esc_receiver
 -moduletree prim_prince // prim_prince is verified in a separate DV environment.
 -moduletree prim_lfsr // prim_lfsr is verified in FPV.
 
@@ -16,6 +20,9 @@ begin tgl
   -tree tb
   +tree tb.dut 1
   +module prim_alert_sender
+  +module prim_alert_receiver
+  +module prim_esc_sender
+  +module prim_esc_receiver
   +module prim_prince
   +module prim_lfsr
 end


### PR DESCRIPTION
This PR excludes prim_alert/esc pairs from IPs because they are fully
verified in DV and FPV testbenches.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>