### PR TITLE
[dv/alert_handler] Support shadow register sequence

### DIFF
--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
@@ -27,6 +27,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -20,6 +20,8 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     has_edn = 1;
     super.initialize(csr_base_addr);
+    shadow_update_err_status_fields[ral.loc_alert_cause[LocalShadowRegUpdateErr].la] = 1;
+    shadow_storage_err_status_fields[ral.loc_alert_cause[LocalShadowRegStorageErr].la] = 1;
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -29,4 +29,22 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
     csr_rd_check(.ptr(ral.loc_alert_cause[LocalBusIntgFail]), .compare_value(exp_val));
   endtask
 
+  virtual function void predict_shadow_reg_status(bit predict_update_err  = 0,
+                                                  bit predict_storage_err = 0);
+    if (predict_update_err) begin
+      foreach (cfg.shadow_update_err_status_fields[status_field]) begin
+        if (`gmv(ral.loc_alert_en_shadowed[LocalShadowRegUpdateErr])) begin
+          void'(status_field.predict(cfg.shadow_update_err_status_fields[status_field]));
+        end
+      end
+    end
+    if (predict_storage_err) begin
+      foreach (cfg.shadow_storage_err_status_fields[status_field]) begin
+        if (`gmv(ral.loc_alert_en_shadowed[LocalShadowRegStorageErr])) begin
+          void'(status_field.predict(cfg.shadow_storage_err_status_fields[status_field]));
+        end
+      end
+    end
+  endfunction
+
 endclass


### PR DESCRIPTION
This PR supports alert_handler shadow reg sequence. The alert_handler
does not have any outgoing alerts, so the checking is slightly different
from common sequence.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>