### PR TITLE
[CODEOWNERS] Auto-assign reviewer teams for sw/ instead of individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,10 @@ formal/             @cindychip
 # lint/             # TBD
 
 # SW related
-/sw/                @mcy @moidx @sriyerg
+sw/**/*.c           @ot-c-cpp-reviewers
+sw/**/*.cc          @ot-c-cpp-reviewers
+sw/**/*.h           @ot-c-cpp-reviewers
+sw/**/*.rs          @ot-rust-reviewers
 
 # Common docs
 /doc/               @asb


### PR DESCRIPTION
We have created ot-c-cpp-reviewers and ot-rust-reviewers teams in order
to trial using GitHub's Code Review Assignment support
<https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-assignment-for-your-team>.

This change will auto-assign the appropriate team based on the files
modified within sw/.