### PR TITLE
[dv,verilator] Round up SV_MEM_WIDTH_BYTES to a multiple of 4

### DIFF
--- a/hw/dv/verilator/cpp/mem_area.h
+++ b/hw/dv/verilator/cpp/mem_area.h
@@ -12,7 +12,11 @@
 // This is the maximum width of a memory that's supported by the code in
 // prim_util_memload.svh
 #define SV_MEM_WIDTH_BITS 312
-#define SV_MEM_WIDTH_BYTES ((SV_MEM_WIDTH_BITS + 7) / 8)
+
+// This is the number of bytes to reserve for buffers used to pass data between
+// C++ and SystemVerilog using prim_util_memload.svh. Since this goes over DPI
+// using the svBitVecVal type, we have to round up to the next 32-bit word.
+#define SV_MEM_WIDTH_BYTES (4 * ((SV_MEM_WIDTH_BITS + 31) / 32))
 
 /**
  * A "memory area", representing a memory in the simulated design.


### PR DESCRIPTION
See section H.7.7 of IEEE 1800-2017 for the chapter and verse, but the
basic point is that we pass arguments of type `bit[A:B]` as an array
of `svBitVecVal`, which is a `uint32_t` in disguise.

(Spotted when trying to diagnose an unrelated problem in OTBN and recompiling things with asan)