### PR TITLE
[rv_ibex] Specify access to randomness from EDN

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -551,7 +551,7 @@
           regwen: "DBUS_REGWEN",
           regwen_multi: true,
           desc: '''
-                  See !!IBUS_ADDR_MATCHING for detailed description.
+                  See !!IBUS_ADDR_MATCHING_0 for detailed description.
                   ''',
                   count: "NumRegions",
           compact: false,
@@ -575,7 +575,7 @@
           regwen: "DBUS_REGWEN",
           regwen_multi: true,
           desc: '''
-                  See !!IBUS_REMAP_ADDR for a detailed description.
+                  See !!IBUS_REMAP_ADDR_0 for a detailed description.
                   ''',
                   count: "NumRegions",
           compact: false,

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -671,6 +671,44 @@
           },
         ]
       },
+
+      { name: "RND_DATA",
+        desc: "Random data from EDN",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        fields: [
+          { bits: "31:0",
+            name: "DATA",
+            resval: "0x0",
+            desc:  '''
+              Random bits taken from the EDN. !!RND_STATUS.RND_DATA_VALID
+              indicates if this data is valid. When valid, reading from this
+              register invalidates the data and requests new data from the EDN.
+              The register becomes valid again when the EDN provides new data.
+              When invalid the register value will read as 0x0 with an EDN
+              request for new data pending. Upon reset the data will be invalid
+              with a new EDN request pending.
+            '''
+          },
+        ]
+      },
+
+      { name: "RND_STATUS",
+        desc: "Status of random data in !!RND_DATA",
+        swaccess: "ro",
+        hwaccess: "hwo",
+        hwext: "true",
+        fields: [
+          { bits: "0",
+            resval: "0",
+            name: "RND_DATA_VALID",
+            desc: '''
+              When set, the data in !!RND_DATA is valid. When clear an EDN
+              request for new data for !!RND_DATA is pending.
+            '''
+          },
+        ]
+      },
     ],
   },
 }

--- a/hw/ip/rv_core_ibex/doc/_index.md
+++ b/hw/ip/rv_core_ibex/doc/_index.md
@@ -50,7 +50,13 @@ There are separate translations controls for instruction and data.
 Each control contains two programmable regions (2 for instruction and 2 for data).
 If a transaction matches multiple regions, the lowest indexed region has priority.
 
-For details on how to program the related registers, please see {{< regref "IBUS_ADDR_MATCHING0" >}} and {{< regref "IBUS_REMAP_ADDR0" >}}
+For details on how to program the related registers, please see {{< regref "IBUS_ADDR_MATCHING_0" >}} and {{< regref "IBUS_REMAP_ADDR_0" >}}.
+
+## Register Table
+
+A number of memory-mapped registers are available to control Ibex-related functionality that's specific to OpenTitan.
+
+{{< incGenFromIpDesc "../data/rv_core_ibex.hjson" "registers" >}}
 
 ## Hardware Interfaces
 

--- a/hw/ip/rv_core_ibex/doc/_index.md
+++ b/hw/ip/rv_core_ibex/doc/_index.md
@@ -52,6 +52,24 @@ If a transaction matches multiple regions, the lowest indexed region has priorit
 
 For details on how to program the related registers, please see {{< regref "IBUS_ADDR_MATCHING_0" >}} and {{< regref "IBUS_REMAP_ADDR_0" >}}.
 
+## Random Number Generation
+
+The wrapper has a connection to the [Entropy Distribution Network (EDN)]({{< relref "hw/ip/edn/doc" >}}) with a register based interface.
+The {{< regref "RND_DATA" >}} register provides 32-bits directly from the EDN.
+{{< regref "RND_STATUS.RND_DATA_VALID" >}} indicates if the data in {{< regref "RND_DATA" >}} is valid or not.
+A polling style interface is used to get new random data.
+Any read to {{< regref "RND_DATA" >}} when it is valid invalidates the data and triggers an EDN request for new data.
+Software should poll {{< regref "RND_STATUS.RND_DATA_VALID" >}} until it is valid and then read from {{< regref "RND_DATA" >}} to get the new random data.
+Either the data is valid or a request for new data is pending.
+It is not possible to have a state where there is no valid data without new data being requested.
+
+Upon reset {{< regref "RND_DATA" >}} is invalid.
+A request is made to the EDN immediately out of reset, this will not be answered until the EDN is enabled.
+Software should take care not to enable the EDN until the entropy complex configuration is as desired.
+When the entropy complex configuration is changed reading {{< regref "RND_DATA" >}} when it is valid will suffice to flush any old random data to trigger a new request under the new configuration.
+If a EDN request is pending when the entropy complex configuration is changed ({{< regref "RND_STATUS.RND_DATA_VALID" >}} is clear), it is advisable to wait until it is complete and then flush out the data to ensure the fresh value was produced under the new configuration.
+
+
 ## Register Table
 
 A number of memory-mapped registers are available to control Ibex-related functionality that's specific to OpenTitan.

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -582,4 +582,13 @@ module rv_core_ibex
     );
   end
 
+  //////////////
+  // RND Data //
+  //////////////
+
+  // Not yet implemented, tie-off all signals for now
+  assign hw2reg.rnd_data.de = 1'b0;
+  assign hw2reg.rnd_data.d  = '0;
+
+  assign hw2reg.rnd_status.d = 1'b0;
 endmodule

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -113,6 +113,15 @@ package rv_core_ibex_reg_pkg;
     } recov_core_err;
   } rv_core_ibex_hw2reg_err_status_reg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } rv_core_ibex_hw2reg_rnd_data_reg_t;
+
+  typedef struct packed {
+    logic        d;
+  } rv_core_ibex_hw2reg_rnd_status_reg_t;
+
   // Register -> HW type for cfg interface
   typedef struct packed {
     rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [275:268]
@@ -129,8 +138,10 @@ package rv_core_ibex_reg_pkg;
 
   // HW -> register type for cfg interface
   typedef struct packed {
-    rv_core_ibex_hw2reg_nmi_state_reg_t nmi_state; // [11:8]
-    rv_core_ibex_hw2reg_err_status_reg_t err_status; // [7:0]
+    rv_core_ibex_hw2reg_nmi_state_reg_t nmi_state; // [45:42]
+    rv_core_ibex_hw2reg_err_status_reg_t err_status; // [41:34]
+    rv_core_ibex_hw2reg_rnd_data_reg_t rnd_data; // [33:1]
+    rv_core_ibex_hw2reg_rnd_status_reg_t rnd_status; // [0:0]
   } rv_core_ibex_cfg_hw2reg_t;
 
   // Register offsets for cfg interface
@@ -158,6 +169,8 @@ package rv_core_ibex_reg_pkg;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_ENABLE_OFFSET = 7'h 54;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_STATE_OFFSET = 7'h 58;
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 7'h 5c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_DATA_OFFSET = 7'h 60;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_STATUS_OFFSET = 7'h 64;
 
   // Reset values for hwext registers and their fields for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
@@ -165,6 +178,8 @@ package rv_core_ibex_reg_pkg;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_HW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_CORE_IBEX_RND_STATUS_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_RESVAL = 1'h 0;
 
   // Register index for cfg interface
   typedef enum int {
@@ -191,11 +206,13 @@ package rv_core_ibex_reg_pkg;
     RV_CORE_IBEX_DBUS_REMAP_ADDR_1,
     RV_CORE_IBEX_NMI_ENABLE,
     RV_CORE_IBEX_NMI_STATE,
-    RV_CORE_IBEX_ERR_STATUS
+    RV_CORE_IBEX_ERR_STATUS,
+    RV_CORE_IBEX_RND_DATA,
+    RV_CORE_IBEX_RND_STATUS
   } rv_core_ibex_cfg_id_e;
 
   // Register width information to check illegal writes for cfg interface
-  parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [24] = '{
+  parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [26] = '{
     4'b 0001, // index[ 0] RV_CORE_IBEX_ALERT_TEST
     4'b 0001, // index[ 1] RV_CORE_IBEX_SW_ALERT_REGWEN_0
     4'b 0001, // index[ 2] RV_CORE_IBEX_SW_ALERT_REGWEN_1
@@ -219,7 +236,9 @@ package rv_core_ibex_reg_pkg;
     4'b 1111, // index[20] RV_CORE_IBEX_DBUS_REMAP_ADDR_1
     4'b 0001, // index[21] RV_CORE_IBEX_NMI_ENABLE
     4'b 0001, // index[22] RV_CORE_IBEX_NMI_STATE
-    4'b 0011  // index[23] RV_CORE_IBEX_ERR_STATUS
+    4'b 0011, // index[23] RV_CORE_IBEX_ERR_STATUS
+    4'b 1111, // index[24] RV_CORE_IBEX_RND_DATA
+    4'b 0001  // index[25] RV_CORE_IBEX_RND_STATUS
   };
 
 endpackage


### PR DESCRIPTION
There's two commits here, one specifies the new randomness functionality the other fixes up a couple of prior rv_core_ibex doc issues.