### PR TITLE
[otbn,dv] Generate maximal loops

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -141,7 +141,7 @@ We expect to:
 - Complete a loop with the maximal number of iterations.
   Obviously, this isn't a reasonable thing to do for real in a test (there's a 32-bit iteration counter!).
   The testbench will have to force a signal to skip past some iterations.
-  Tracked as `MaxIterLoop_C`.
+  Tracked as `MaximalLoop_C`.
 - Run through a "badly nested" loop, where the body contains the final instruction from an outer loop (checking that we don't wrongly skip back).
   Tracked as `BadNestingEnd_C` and `BadNestingMiddle_C`.
 - Jump into a loop body from outside.

--- a/hw/ip/otbn/dv/memutil/otbn_memutil.cc
+++ b/hw/ip/otbn/dv/memutil/otbn_memutil.cc
@@ -83,7 +83,7 @@ void OtbnMemUtil::OnSymbol(const std::string &name, uint32_t value) {
   // FROM and TO are decimal loop counts and the value of the symbol is the
   // address where it should apply. Trailing junk is allowed (to ensure
   // uniqueness).
-  std::regex lw_re("_loop_warp_([0-9])+_([0-9])+.*");
+  std::regex lw_re("_loop_warp_([0-9]+)_([0-9]+).*");
   std::smatch lw_match;
   if (std::regex_match(name, lw_match, lw_re)) {
     assert(lw_match.size() == 3);

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
@@ -197,7 +197,7 @@ class BadDeepLoop(SnippetGen):
         else:
             body_snippet = Snippet.merge_list([body_snippet, real_body_snippet])
 
-        return (LoopSnippet(hd_pc, hd_insn, body_snippet), model)
+        return (LoopSnippet(hd_pc, hd_insn, body_snippet, None), model)
 
     def gen(self,
             cont: GenCont,

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_giant_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_giant_loop.py
@@ -79,18 +79,22 @@ class BadGiantLoop(Loop):
         assert enc_bodysize is not None
 
         # Now pick the number of iterations (not that the number actually
-        # matters)
+        # matters). Note that we ignore any warp specified: since we'll never
+        # actually complete a loop iteration, there's not much point specifying
+        # any loop warping.
         iters = self.pick_iterations(iters_op_type, bodysize, model)
         if iters is None:
             return None
 
-        iters_opval, num_iters = iters
+        iters_opval, num_iters, warp = iters
         hd_addr = model.pc
         hd_insn = ProgInsn(insn, [iters_opval, enc_bodysize], None)
 
         end_addr = model.pc + 4 * bodysize
 
-        body_model = self._setup_body(hd_insn, end_addr, model, program)
+        body_model, body_loop_stack = self._setup_body(hd_insn, end_addr,
+                                                       model, program, False)
+        assert body_loop_stack is None
 
         # At this point, all the "loop related work" is done: we've entered the
         # loop body (from which we can never leave). Now call the continuation
@@ -101,5 +105,5 @@ class BadGiantLoop(Loop):
         # is not None.
         assert body_snippet is not None
 
-        loop_snippet = LoopSnippet(hd_addr, hd_insn, body_snippet)
+        loop_snippet = LoopSnippet(hd_addr, hd_insn, body_snippet, None)
         return (loop_snippet, True, end_model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_zero_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_zero_loop.py
@@ -58,12 +58,10 @@ class BadZeroLoop(Loop):
         if pieces is None:
             return None
 
-        good_shape, good_hd_insn, body_snippet, model = pieces
+        bodysize, good_hd_insn, body_snippet, model, warp = pieces
 
         # If we successfully generated a loop, generate a new head instruction
         # with the same body size but with zero iterations.
-        _, _, bodysize = good_shape
-
         insn = self.pick_loop_insn()
         op0_type = insn.operands[0].op_type
         op1_type = insn.operands[1].op_type
@@ -76,7 +74,7 @@ class BadZeroLoop(Loop):
         assert enc_bodysize is not None
         bad_hd_insn = ProgInsn(insn, [iter_opval, enc_bodysize], None)
 
-        snippet = LoopSnippet(model_before.pc, bad_hd_insn, body_snippet)
+        snippet = LoopSnippet(model_before.pc, bad_hd_insn, body_snippet, None)
         snippet.insert_into_program(program)
 
         # Return with the initial model (because the head instruction is bad,

--- a/hw/ip/otbn/dv/rig/rig/gens/loop_dup_end.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop_dup_end.py
@@ -52,9 +52,8 @@ class LoopDupEndInner(Loop):
         iters = self.pick_iterations(op0_type, bodysize, model)
         if iters is None:
             return None
-        iter_opval, num_iters = iters
 
-        return (iter_opval, num_iters, bodysize)
+        return (bodysize, iters)
 
 
 class LoopDupEnd(Loop):

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -167,6 +167,12 @@ class LoopStack:
     def maybe_full(self) -> bool:
         return self.max_depth() == LoopStack.stack_depth
 
+    def force_full(self) -> None:
+        '''Make the loop stack look like it's completely full'''
+        self._stack = []
+        self._min_stuck = LoopStack.stack_depth
+        self._max_stuck = LoopStack.stack_depth
+
 
 class Model:
     '''An abstract model of the processor and memories

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -199,6 +199,8 @@ int main(int argc, char **argv) {
     }
   }
 
+  verilator_top.reset();
+
   return 0;
 }
 


### PR DESCRIPTION
This hits the `MaximalLoop_C` coverage point.

The interesting commit is the last one (which tells the RIG to start generating loops with a count of 0xffffffff). The previous commits are bugfixes and tidy-ups to make it work.

Fixes #7273 (this is the last remaining thing that we hadn't hit. Yippee!)