### PR TITLE
[fpv] Fix compile error in pwrmgr

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -171,6 +171,12 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/rv_plic/{sub_flow}/{tool}"
                cov: true
+               overrides: [
+                 {
+                   name:  design_level
+                   value: "top"
+                 }
+               ]
              }
              {
                name: rv_plic_generic_fpv
@@ -314,6 +320,12 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pwrmgr/{sub_flow}/{tool}"
                cov: false
+               overrides: [
+                 {
+                   name:  design_level
+                   value: "top"
+                 }
+               ]
              }
              {
                name: rom_ctrl


### PR DESCRIPTION
This PR fixes pwrmgr compile error by selecting top design level.
Also apply the same fix for rv_plic top-level model.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>