### PR TITLE
[prim_esc_receiver] Assert escalation in case of sigint error 

### DIFF
--- a/hw/ip/alert_handler/doc/_index.md
+++ b/hw/ip/alert_handler/doc/_index.md
@@ -714,6 +714,7 @@ Further, any differential signal mismatch on both the `esc_tx_i.esc_p/n` and `es
 Mismatches on `esc_rx_i.resp_p/n` can be directly detected at the sender.
 Mismatches on the `esc_tx_i.esc_p/n` line will be signaled back to the sender by setting both the positive and negative response wires to the same value - and that value is being toggled each cycle.
 This implicitly triggers a signal integrity alert on the sender side.
+In addition to that, a signal integrity error on the `esc_tx_i.esc_p/n` lines will lead to assertion of the `esc_req_o` output, since it cannot be guaranteed that the back signalling mechanism always works when the sender / receiver pair is being tampered with.
 
 This back-signaling mechanism can be leveraged to fast-track escalation and use
 another countermeasure in case it is detected that a particular escalation
@@ -733,7 +734,7 @@ Some signal integrity failure cases are illustrated in the wave diagram below:
     { name: 'esc_rx_i.resp_n', wave: '1....|.01010',  node: '.......d' },
     { name: 'esc_tx_i.esc_p',  wave: '0....|1.....',  node: '......c..' },
     { name: 'esc_tx_i.esc_n',  wave: '1....|......' },
-    { name: 'esc_req_o',       wave: '0....|......'},
+    { name: 'esc_req_o',       wave: '0....|1.....'},
   ],
   edge: [
    'a~>b',

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -511,9 +511,9 @@ module lc_ctrl
   ) u_prim_esc_receiver0 (
     .clk_i,
     .rst_ni,
-    .esc_en_o (esc_scrap_state0),
-    .esc_rx_o (esc_scrap_state0_rx_o),
-    .esc_tx_i (esc_scrap_state0_tx_i)
+    .esc_req_o (esc_scrap_state0),
+    .esc_rx_o  (esc_scrap_state0_rx_o),
+    .esc_tx_i  (esc_scrap_state0_tx_i)
   );
 
   // This escalation action moves the life cycle
@@ -525,9 +525,9 @@ module lc_ctrl
   ) u_prim_esc_receiver1 (
     .clk_i,
     .rst_ni,
-    .esc_en_o (esc_scrap_state1),
-    .esc_rx_o (esc_scrap_state1_rx_o),
-    .esc_tx_i (esc_scrap_state1_tx_i)
+    .esc_req_o (esc_scrap_state1),
+    .esc_rx_o  (esc_scrap_state1_rx_o),
+    .esc_tx_i  (esc_scrap_state1_tx_i)
   );
 
   ////////////////////////////

--- a/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
+++ b/hw/ip/prim/dv/prim_esc/tb/prim_esc_tb.sv
@@ -98,8 +98,8 @@ module prim_esc_tb;
     esc_req = 1;
     // Drive random length of esc_req and check `esc_req_out` and `integ_fail` outputs.
     main_clk.wait_clks($urandom_range(1, 20));
-    if (integ_fail == 1) test_error("Esc_req unexpected signal integrity error!");
-    if (esc_req_out == 0)     test_error("Esc_req did not set esc_req!");
+    if (integ_fail == 1)  test_error("Esc_req unexpected signal integrity error!");
+    if (esc_req_out == 0) test_error("Esc_req did not set esc_req!");
     esc_req = 0;
 
     $display("Escalation request sequence finished!");
@@ -113,7 +113,7 @@ module prim_esc_tb;
     release esc_tx.esc_n;
     // Wait #1ps to avoid a race condition on clock edge.
     #1ps;
-    if (esc_req_out == 1) test_error("Signal integrity error should not set esc_req!");
+    if (esc_req_out == 0) test_error("Signal integrity error should set esc_req!");
     esc_req = 0;
 
     $display("Escalation esc_p/n integrity sequence finished!");

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_bind_fpv.sv
@@ -17,7 +17,7 @@ module prim_esc_rxtx_bind_fpv;
     .ping_req_i  ,
     .ping_ok_o   ,
     .integ_fail_o,
-    .esc_en_o
+    .esc_req_o
   );
 
 endmodule : prim_esc_rxtx_bind_fpv

--- a/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_esc_rxtx_fpv.sv
@@ -20,7 +20,7 @@ module prim_esc_rxtx_fpv
   input        ping_req_i,
   output logic ping_ok_o,
   output logic integ_fail_o,
-  output logic esc_en_o
+  output logic esc_req_o
 );
 
   esc_rx_t esc_rx_in, esc_rx_out;
@@ -49,7 +49,7 @@ module prim_esc_rxtx_fpv
   ) u_prim_esc_receiver (
     .clk_i    ,
     .rst_ni   ,
-    .esc_en_o ,
+    .esc_req_o ,
     .esc_rx_o     ( esc_rx_out ),
     .esc_tx_i     ( esc_tx_in  )
   );

--- a/hw/ip/prim/fpv/vip/prim_esc_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_esc_rxtx_assert_fpv.sv
@@ -20,7 +20,7 @@ module prim_esc_rxtx_assert_fpv (
   input        ping_req_i,
   input        ping_ok_o,
   input        integ_fail_o,
-  input        esc_en_o
+  input        esc_req_o
 );
 
   logic error_present;
@@ -103,7 +103,7 @@ module prim_esc_rxtx_assert_fpv (
   `ASSERT(EscCheck_A,
       ##1 esc_req_i
       |->
-      ##[0:1] esc_en_o,
+      ##[0:1] esc_req_o,
       clk_i,
       !rst_ni ||
       error_present)
@@ -143,10 +143,10 @@ module prim_esc_rxtx_assert_fpv (
   `ASSERT(AutoEscalation0_A,
       ping_req_i &&
       ping_ok_o &&
-      !esc_en_o ##1
+      !esc_req_o ##1
       !ping_req_i [*0 : 2**prim_esc_rxtx_fpv.u_prim_esc_receiver.TimeoutCntDw - 4]
       |->
-      !esc_en_o,
+      !esc_req_o,
       clk_i,
       !rst_ni ||
       error_d ||
@@ -157,10 +157,10 @@ module prim_esc_rxtx_assert_fpv (
   `ASSERT(AutoEscalation1_A,
       ping_req_i &&
       ping_ok_o &&
-      !esc_en_o ##1
+      !esc_req_o ##1
       !ping_req_i [* 2**prim_esc_rxtx_fpv.u_prim_esc_receiver.TimeoutCntDw - 3 : $]
       |->
-      esc_en_o,
+      esc_req_o,
       clk_i,
       !rst_ni ||
       error_d ||

--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -49,7 +49,7 @@ module prim_esc_receiver
   input           clk_i,
   input           rst_ni,
   // escalation enable
-  output logic    esc_en_o,
+  output logic    esc_req_o,
   // escalation / ping response
   output esc_rx_t esc_rx_o,
   // escalation output diff pair
@@ -90,7 +90,7 @@ module prim_esc_receiver
   // Ping Monitor Counter / Auto Escalation //
   ////////////////////////////////////////////
 
-  logic ping_en, esc_en;
+  logic ping_en, esc_req;
   logic [1:0][TimeoutCntDw-1:0] cnt_q;
 
   for (genvar k = 0; k < 2; k++) begin : gen_timeout_cnt
@@ -117,9 +117,9 @@ module prim_esc_receiver
   // - requested via the escalation sender/receiver path,
   // - the ping monitor timeout is reached,
   // - the two ping monitor counters are in an inconsistent state.
-  assign esc_en_o = esc_en      ||
-                    (&cnt_q[0]) ||
-                    (cnt_q[0] != cnt_q[1]);
+  assign esc_req_o = esc_req     ||
+                     (&cnt_q[0]) ||
+                     (cnt_q[0] != cnt_q[1]);
 
   /////////////////
   // RX/TX Logic //
@@ -149,7 +149,7 @@ module prim_esc_receiver
     state_d  = state_q;
     resp_pd  = 1'b0;
     resp_nd  = 1'b1;
-    esc_en   = 1'b0;
+    esc_req  = 1'b0;
     ping_en  = 1'b0;
 
     unique case (state_q)
@@ -167,7 +167,7 @@ module prim_esc_receiver
         state_d = PingResp;
         if (esc_level) begin
           state_d  = EscResp;
-          esc_en   = 1'b1;
+          esc_req  = 1'b1;
         end
       end
       // finish ping response. in case esc_level is again asserted,
@@ -179,7 +179,7 @@ module prim_esc_receiver
         ping_en = 1'b1;
         if (esc_level) begin
           state_d  = EscResp;
-          esc_en   = 1'b1;
+          esc_req  = 1'b1;
         end
       end
       // we have got an escalation enable pulse,
@@ -190,7 +190,7 @@ module prim_esc_receiver
           state_d  = EscResp;
           resp_pd  = ~resp_pq;
           resp_nd  = resp_pq;
-          esc_en   = 1'b1;
+          esc_req  = 1'b1;
         end
       end
       // we have a signal integrity issue at one of
@@ -235,7 +235,7 @@ module prim_esc_receiver
   ////////////////
 
   // check whether all outputs have a good known state after reset
-  `ASSERT_KNOWN(EscEnKnownO_A, esc_en_o)
+  `ASSERT_KNOWN(EscEnKnownO_A, esc_req_o)
   `ASSERT_KNOWN(RespPKnownO_A, esc_rx_o)
 
   `ASSERT(SigIntCheck0_A, esc_tx_i.esc_p == esc_tx_i.esc_n |=>
@@ -254,10 +254,10 @@ module prim_esc_receiver
       |=> esc_rx_o.resp_p != $past(esc_rx_o.resp_p))
   // detect escalation pulse
   `ASSERT(EscEnCheck_A, esc_tx_i.esc_p && (esc_tx_i.esc_p ^ esc_tx_i.esc_n) && state_q != SigInt
-      |=> esc_tx_i.esc_p && (esc_tx_i.esc_p ^ esc_tx_i.esc_n) |-> esc_en_o)
+      |=> esc_tx_i.esc_p && (esc_tx_i.esc_p ^ esc_tx_i.esc_n) |-> esc_req_o)
   // make sure the counter does not wrap around
   `ASSERT(EscCntWrap_A, &cnt_q[0] |=> cnt_q[0] != 0)
   // if the counter expires, escalation should be asserted
-  `ASSERT(EscCntEsc_A, &cnt_q[0] |-> esc_en_o)
+  `ASSERT(EscCntEsc_A, &cnt_q[0] |-> esc_req_o)
 
 endmodule : prim_esc_receiver

--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -200,6 +200,7 @@ module prim_esc_receiver
       // toggling them.
       SigInt: begin
         state_d = Idle;
+        esc_req = 1'b1;
         if (sigint_detected) begin
           state_d = SigInt;
           resp_pd = ~resp_pq;
@@ -239,14 +240,16 @@ module prim_esc_receiver
   `ASSERT_KNOWN(RespPKnownO_A, esc_rx_o)
 
   `ASSERT(SigIntCheck0_A, esc_tx_i.esc_p == esc_tx_i.esc_n |=>
-      esc_rx_o.resp_p == esc_rx_o.resp_n, clk_i, !rst_ni)
+      esc_rx_o.resp_p == esc_rx_o.resp_n)
   `ASSERT(SigIntCheck1_A, esc_tx_i.esc_p == esc_tx_i.esc_n |=> state_q == SigInt)
+  // auto-escalate in case of signal integrity issue
+  `ASSERT(SigIntCheck2_A, esc_tx_i.esc_p == esc_tx_i.esc_n |=> esc_req_o)
   // correct diff encoding
   `ASSERT(DiffEncCheck_A, esc_tx_i.esc_p ^ esc_tx_i.esc_n |=>
       esc_rx_o.resp_p ^ esc_rx_o.resp_n)
-  // disable in case of ping integrity issue
-  `ASSERT(PingRespCheck_A, $rose(esc_tx_i.esc_p) |=> $fell(esc_tx_i.esc_p) |->
-      $rose(esc_rx_o.resp_p) |=> $fell(esc_rx_o.resp_p),
+  // disable in case of signal integrity issue
+  `ASSERT(PingRespCheck_A, state_q == Idle ##1 $rose(esc_tx_i.esc_p) ##1 $fell(esc_tx_i.esc_p) |->
+      $rose(esc_rx_o.resp_p) ##1 $fell(esc_rx_o.resp_p),
       clk_i, !rst_ni || (esc_tx_i.esc_p == esc_tx_i.esc_n))
   // escalation response needs to continuously toggle
   `ASSERT(EscRespCheck_A, esc_tx_i.esc_p && $past(esc_tx_i.esc_p) &&
@@ -254,7 +257,7 @@ module prim_esc_receiver
       |=> esc_rx_o.resp_p != $past(esc_rx_o.resp_p))
   // detect escalation pulse
   `ASSERT(EscEnCheck_A, esc_tx_i.esc_p && (esc_tx_i.esc_p ^ esc_tx_i.esc_n) && state_q != SigInt
-      |=> esc_tx_i.esc_p && (esc_tx_i.esc_p ^ esc_tx_i.esc_n) |-> esc_req_o)
+      ##1 esc_tx_i.esc_p && (esc_tx_i.esc_p ^ esc_tx_i.esc_n) |-> esc_req_o)
   // make sure the counter does not wrap around
   `ASSERT(EscCntWrap_A, &cnt_q[0] |=> cnt_q[0] != 0)
   // if the counter expires, escalation should be asserted

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -85,7 +85,7 @@ module pwrmgr
   ) u_esc_rx (
     .clk_i,
     .rst_ni,
-    .esc_en_o(esc_rst_req),
+    .esc_req_o(esc_rst_req),
     .esc_rx_o(esc_rst_rx_o),
     .esc_tx_i(esc_rst_tx_i)
   );

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -193,9 +193,9 @@ module rv_core_ibex
     .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
     .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
   ) u_prim_esc_receiver (
-    .clk_i    ( clk_esc_i  ),
-    .rst_ni   ( rst_esc_ni ),
-    .esc_en_o ( esc_irq_nm ),
+    .clk_i     ( clk_esc_i  ),
+    .rst_ni    ( rst_esc_ni ),
+    .esc_req_o ( esc_irq_nm ),
     .esc_rx_o,
     .esc_tx_i
   );


### PR DESCRIPTION
This addresses #7489 and #7748.

In particular, the escalation receivers now automatically assert the escalation request if they detect an integrity error on their input diff pair.