### PR TITLE
[ci] Wrap chip-level verilator builds in a CI script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -265,22 +265,7 @@ jobs:
       verilator --version
       verible-verilog-lint --version
     displayName: Display environment
-  - bash: |
-      . util/build_consts.sh
-      mkdir -p "$OBJ_DIR/hw"
-      mkdir -p "$BIN_DIR/hw/top_earlgrey"
-
-      # Compile the simulation without threading; the runners provided by
-      # Azure provide two virtual CPUs, which seems to equal one physical
-      # CPU (at most); the use of threading slows down the simulation.
-      fusesoc --cores-root=. \
-        run --flag=fileset_top --target=sim --setup --build \
-        --build-root="$OBJ_DIR/hw" \
-        lowrisc:dv:chip_verilator_sim \
-        --verilator_options="--threads 4"
-
-      cp "$OBJ_DIR/hw/sim-verilator/Vchip_sim_tb" \
-        "$BIN_DIR/hw/top_earlgrey/Vchip_earlgrey_verilator"
+  - bash: ci/scripts/build-chip-verilator.sh earlgrey
     displayName: Build simulation with Verilator
   - template: ci/upload-artifacts-template.yml
     parameters:
@@ -301,22 +286,7 @@ jobs:
       verilator --version
       verible-verilog-lint --version
     displayName: Display environment
-  - bash: |
-      . util/build_consts.sh
-      mkdir -p "$OBJ_DIR/hw"
-      mkdir -p "$BIN_DIR/hw/top_englishbreakfast"
-
-      # Compile the simulation without threading; the runners provided by
-      # Azure provide two virtual CPUs, which seems to equal one physical
-      # CPU (at most); the use of threading slows down the simulation.
-      fusesoc --cores-root=. \
-        run --flag=fileset_topgen --target=sim --setup --build \
-        --build-root="$OBJ_DIR/hw" \
-        lowrisc:systems:chip_englishbreakfast_verilator \
-        --verilator_options="--no-threads"
-
-      cp "$OBJ_DIR/hw/sim-verilator/Vchip_englishbreakfast_verilator" \
-        "$BIN_DIR/hw/top_englishbreakfast"
+  - bash: ci/scripts/build-chip-verilator.sh englishbreakfast
     displayName: Build simulation with Verilator
   - template: ci/upload-artifacts-template.yml
     parameters:

--- a/ci/scripts/build-chip-verilator.sh
+++ b/ci/scripts/build-chip-verilator.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Build a chip-level verilator simulation
+#
+# Expects three arguments: the toplevel to build, the fusesoc core and
+# the intermediate Verilated binary name
+
+set -e
+
+if [ $# != 1 ]; then
+    echo >&2 "Usage: build-chip-verilator.sh <toplevel>"
+    exit 1
+fi
+tl="$1"
+
+case "$tl" in
+    earlgrey)
+        fileset=fileset_top
+        fusesoc_core=lowrisc:dv:chip_verilator_sim
+        vname=Vchip_sim_tb
+        ;;
+    englishbreakfast)
+        fileset=fileset_topgen
+        fusesoc_core=lowrisc:systems:chip_englishbreakfast_verilator
+        vname=Vchip_englishbreakfast_verilator
+        ;;
+    *)
+        echo >&2 "Unknown toplevel: $tl"
+        exit 1
+esac
+
+# Move to project root
+cd $(git rev-parse --show-toplevel)
+
+. util/build_consts.sh
+
+set -x
+
+mkdir -p "$OBJ_DIR/hw"
+mkdir -p "$BIN_DIR/hw/top_${tl}"
+
+fusesoc --cores-root=. \
+  run --flag=$fileset --target=sim --setup --build \
+  --build-root="$OBJ_DIR/hw" \
+  $fusesoc_core \
+  --verilator_options="--threads 4"
+
+cp "$OBJ_DIR/hw/sim-verilator/${vname}" \
+   "$BIN_DIR/hw/top_${tl}/Vchip_${tl}_verilator"


### PR DESCRIPTION
This just makes things a little easier to reproduce locally.
