### PR TITLE
[otbn] Convert RSA example to a single entry point

### DIFF
--- a/sw/device/tests/otbn/otbn_rsa_test.c
+++ b/sw/device/tests/otbn/otbn_rsa_test.c
@@ -67,8 +67,8 @@ static const bool kTestDecrypt = true;
 static const bool kTestRsaGreater1k = false;
 
 OTBN_DECLARE_APP_SYMBOLS(rsa);
-OTBN_DECLARE_PTR_SYMBOL(rsa, rsa_encrypt);
-OTBN_DECLARE_PTR_SYMBOL(rsa, rsa_decrypt);
+OTBN_DECLARE_PTR_SYMBOL(rsa, start);
+OTBN_DECLARE_PTR_SYMBOL(rsa, mode);
 OTBN_DECLARE_PTR_SYMBOL(rsa, n_limbs);
 OTBN_DECLARE_PTR_SYMBOL(rsa, in);
 OTBN_DECLARE_PTR_SYMBOL(rsa, out);
@@ -76,10 +76,8 @@ OTBN_DECLARE_PTR_SYMBOL(rsa, modulus);
 OTBN_DECLARE_PTR_SYMBOL(rsa, exp);
 
 static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(rsa);
-static const otbn_ptr_t kOtbnFuncRsaRsaEncrypt =
-    OTBN_PTR_T_INIT(rsa, rsa_encrypt);
-static const otbn_ptr_t kOtbnFuncRsaRsaDecrypt =
-    OTBN_PTR_T_INIT(rsa, rsa_decrypt);
+static const otbn_ptr_t kOtbnFuncRsaStart = OTBN_PTR_T_INIT(rsa, start);
+static const otbn_ptr_t kOtbnVarRsaMode = OTBN_PTR_T_INIT(rsa, mode);
 static const otbn_ptr_t kOtbnVarRsaNLimbs = OTBN_PTR_T_INIT(rsa, n_limbs);
 static const otbn_ptr_t kOtbnVarRsaIn = OTBN_PTR_T_INIT(rsa, in);
 static const otbn_ptr_t kOtbnVarRsaOut = OTBN_PTR_T_INIT(rsa, out);
@@ -118,6 +116,9 @@ static void rsa_encrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
   CHECK(n_limbs != 0 && n_limbs <= 16);
 
   // Write input arguments.
+  uint32_t mode = 1;  // mode 1 => encrypt
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(mode), &mode,
+                               kOtbnVarRsaMode) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(n_limbs), &n_limbs,
                                kOtbnVarRsaNLimbs) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, modulus,
@@ -126,7 +127,7 @@ static void rsa_encrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
         kOtbnOk);
 
   // Call OTBN to perform operation, and wait for it to complete.
-  CHECK(otbn_call_function(otbn_ctx, kOtbnFuncRsaRsaEncrypt) == kOtbnOk);
+  CHECK(otbn_call_function(otbn_ctx, kOtbnFuncRsaStart) == kOtbnOk);
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
 
   // Read back results.
@@ -157,6 +158,9 @@ static void rsa_decrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
   CHECK(n_limbs != 0 && n_limbs <= 16);
 
   // Write input arguments.
+  uint32_t mode = 2;  // mode 2 => decrypt
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(mode), &mode,
+                               kOtbnVarRsaMode) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(n_limbs), &n_limbs,
                                kOtbnVarRsaNLimbs) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, modulus,
@@ -167,7 +171,7 @@ static void rsa_decrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
         kOtbnOk);
 
   // Call OTBN to perform operation
-  CHECK(otbn_call_function(otbn_ctx, kOtbnFuncRsaRsaDecrypt) == kOtbnOk);
+  CHECK(otbn_call_function(otbn_ctx, kOtbnFuncRsaStart) == kOtbnOk);
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
 
   // Read back results.

--- a/sw/otbn/code-snippets/rsa.s
+++ b/sw/otbn/code-snippets/rsa.s
@@ -3,8 +3,25 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 .text
+.globl start
+start:
+  /* Read mode, then tail-call either rsa_encrypt or rsa_decrypt */
+  la    x2, mode
+  lw    x2, 0(x2)
 
- .globl rsa_encrypt
+  li    x3, 1
+  beq   x2, x3, rsa_encrypt
+
+  li    x3, 2
+  beq   x2, x3, rsa_decrypt
+
+  /* Mode is neither 1 (= encrypt) nor 2 (= decrypt). Fail. */
+  unimp
+
+
+/**
+ * RSA encryption
+ */
 rsa_encrypt:
   jal      x1, modload
   jal      x1, modexp_65537
@@ -13,7 +30,6 @@ rsa_encrypt:
 /**
  * RSA decryption
  */
-.globl rsa_decrypt
 rsa_decrypt:
   jal      x1, modload
   jal      x1, modexp
@@ -21,14 +37,15 @@ rsa_decrypt:
 
 
 .data
-
 /*
 The structure of the 256b below are mandated by the calling convention of the
 RSA library.
 */
 
-/* reserved */
-.word 0x00000000
+/* Mode (1 = encrypt; 2 = decrypt) */
+.globl mode
+mode:
+  .word 0x00000000
 
 /* N: Key/modulus size in 256b limbs (i.e. for RSA-1024: N = 4) */
 .globl n_limbs


### PR DESCRIPTION
This is part of the work to remove `START_ADDR` functionality: the RSA
test is the only piece of code that we have at the moment using
multiple start addresses.

See #4200 for more context.