### PR TITLE
[otbn,dv] Avoid generating a loop inside a warped loop

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -167,6 +167,12 @@ class LoopStack:
     def maybe_full(self) -> bool:
         return self.max_depth() == LoopStack.stack_depth
 
+    def force_full(self) -> None:
+        '''Make the loop stack look like it's completely full'''
+        self._stack = []
+        self._min_stuck = LoopStack.stack_depth
+        self._max_stuck = LoopStack.stack_depth
+
 
 class Model:
     '''An abstract model of the processor and memories


### PR DESCRIPTION
The problem is that if we decide to generate a loop with a massive
count, we'll end up with a code sequence something like:

       not  x3, x0
       loop x3, 3
    start_of_body:
       ...
       ...
       ...

       ecall

and we generate a magic ELF symbol that says "when you execute the
instruction at start_of_body for the Nth time, jump the counter of the
innermost loop to just before 2^32".

That's fine, but there's a problem if we happen to generate a loop in
the loop body:

       not  x3, x0
       loop x3, 3
    start_of_body:
       loopi 10, 3
       ...
       ...

       ecall

Now, the "innermost loop" is the LOOPI instruction, not the mega-loop
on the outside, and we warp the wrong loop.

Since we don't actually care about "massive loop counts on a loop
other than the innermost one", let's just make sure this never
happens.

