### PR TITLE
Adding first Bazel dif unit test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt='-std=c++14'

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "bitfield",
+    linkstatic = True,
+    srcs = [
+        "bitfield.c",
+        "bitfield.h",
+        ],
+    )
+
+cc_library(
+    name = "mem",
+    linkstatic = True,
+    srcs = [
+        "memory.c",
+        "memory.h",
+        ],
+    copts = [
+        "-fno-builtin",
+        ],
+    )
+
+
+cc_library(
+    name = "mmio",
+    linkstatic = True,
+    srcs = [
+        "mmio.c",
+        "mmio.h",
+        ],
+    deps = [
+        ":bitfield",
+        ":mem",
+        ],
+    )
+
+cc_library(
+    name = "hardened",
+    linkstatic = True,
+    srcs = [
+        "hardened.c",
+        "hardened.h",
+        "stdasm.h",
+        ],
+    )

--- a/sw/device/lib/base/testing/BUILD
+++ b/sw/device/lib/base/testing/BUILD
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"]) 
+
+cc_library(
+    name = "mock_mmio",
+    linkstatic = True,
+    srcs = [
+        "mock_mmio.cc",
+        "mock_mmio.h",
+        "mock_mmio_test_utils.h",
+        ],
+    deps = [
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/base:bitfield",
+        "@googletest//:gtest",
+        ],
+    copts = ["-DMOCK_MMIO"],
+    )
+
+cc_test(
+  name = "mock_mmio_test",
+  srcs = [
+      "mock_mmio_test.cc",
+      ],
+  deps = [
+      "@googletest//:gtest_main",
+      ":mock_mmio",
+      ],
+      copts = [
+          "-DMOCK_MMIO",
+          ],
+    )

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -1,0 +1,34 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+cc_library(
+  name = "clkmgr",
+  srcs = [
+      ":dif_clkmgr.c",
+      ":dif_clkmgr.h",
+      ":dif_warn_unused_result.h",
+      ],
+  deps = [
+      "//sw/device/lib/base:mmio",
+      "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+      ],
+  )
+
+cc_test(
+  name = "clkmgr_unittest",
+  srcs = [
+      ":dif_clkmgr_unittest.cc",
+      ],
+  deps = [
+      ":clkmgr",
+      "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+      "@googletest//:gtest_main",
+      "//sw/device/lib/base:mmio",
+      "//sw/device/lib/base/testing:mock_mmio",
+      ],
+  copts = [
+      "-DMOCK_MMIO",
+      ],
+  )
+


### PR DESCRIPTION
This required a number of supporting changes:
*  Configure bazel to use C++14
*  Add BUILD file for clkmgr dif unit test dependencies
*  Add the clkmgr dif unit test for bazel, can be run with
```bazel test //sw/device/lib/dif:clkmgr_unittest```

Signed-off-by: Drew Macrae <drewmacrae@google.com>