### PR TITLE
[dv/alert_handler] Clean up alert_handler tb

### DIFF
--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -11,15 +11,14 @@
       class``i``_phase2_cyc_shadowed.value inside {[0: max_phase_cyc]};); \
   `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_phase3_cyc_shadowed,      \
       class``i``_phase3_cyc_shadowed.value inside {[0: max_phase_cyc]};); \
-  csr_update(ral.class``i``_phase0_cyc_shadowed, .en_shadow_wr(1'b1));    \
-  csr_update(ral.class``i``_phase1_cyc_shadowed, .en_shadow_wr(1'b1));    \
-  csr_update(ral.class``i``_phase2_cyc_shadowed, .en_shadow_wr(1'b1));    \
-  csr_update(ral.class``i``_phase3_cyc_shadowed, .en_shadow_wr(1'b1));
+  csr_update(ral.class``i``_phase0_cyc_shadowed);                         \
+  csr_update(ral.class``i``_phase1_cyc_shadowed);                         \
+  csr_update(ral.class``i``_phase2_cyc_shadowed);                         \
+  csr_update(ral.class``i``_phase3_cyc_shadowed);
 
 `define RAND_WRITE_CLASS_CTRL(i, lock_bit) \
   `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.class``i``_ctrl_shadowed, lock.value == lock_bit;)  \
-  csr_wr(.ptr(ral.class``i``_ctrl_shadowed), .value(ral.class``i``_ctrl_shadowed.get()), \
-         .en_shadow_wr(1'b1));
+  csr_wr(.ptr(ral.class``i``_ctrl_shadowed), .value(ral.class``i``_ctrl_shadowed.get()));
 
 class alert_handler_base_vseq extends cip_base_vseq #(
     .CFG_T               (alert_handler_env_cfg),
@@ -82,7 +81,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   // If not set, this task has 50% of chance to write value 1 to ping_timer_en register.
   virtual task lock_config(bit do_lock_config);
     if (do_lock_config || $urandom_range(0, 1)) begin
-      csr_wr(.ptr(ral.ping_timer_en_shadowed), .value(do_lock_config), .en_shadow_wr(1'b1));
+      csr_wr(.ptr(ral.ping_timer_en_shadowed), .value(do_lock_config));
     end
   endtask
 
@@ -160,15 +159,15 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     csr_rd(.ptr(ral.classc_accum_cnt), .value(csr_val));
     csr_rd(.ptr(ral.classd_accum_cnt), .value(csr_val));
 
-    csr_rd(.ptr(ral.classa_esc_cnt), .value(csr_val));
-    csr_rd(.ptr(ral.classb_esc_cnt), .value(csr_val));
-    csr_rd(.ptr(ral.classc_esc_cnt), .value(csr_val));
-    csr_rd(.ptr(ral.classd_esc_cnt), .value(csr_val));
-
     csr_rd(.ptr(ral.classa_state), .value(csr_val));
     csr_rd(.ptr(ral.classb_state), .value(csr_val));
     csr_rd(.ptr(ral.classc_state), .value(csr_val));
     csr_rd(.ptr(ral.classd_state), .value(csr_val));
+
+    csr_rd(.ptr(ral.classa_esc_cnt), .value(csr_val));
+    csr_rd(.ptr(ral.classb_esc_cnt), .value(csr_val));
+    csr_rd(.ptr(ral.classc_esc_cnt), .value(csr_val));
+    csr_rd(.ptr(ral.classd_esc_cnt), .value(csr_val));
   endtask
 
   virtual task wait_alert_handshake_done();
@@ -236,21 +235,21 @@ class alert_handler_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task wr_intr_timeout_cycle(bit[TL_DW-1:0] intr_timeout_cyc[NUM_ALERT_CLASSES]);
-    csr_wr(.ptr(ral.classa_timeout_cyc_shadowed), .value(intr_timeout_cyc[0]), .en_shadow_wr(1'b1));
-    csr_wr(.ptr(ral.classb_timeout_cyc_shadowed), .value(intr_timeout_cyc[1]), .en_shadow_wr(1'b1));
-    csr_wr(.ptr(ral.classc_timeout_cyc_shadowed), .value(intr_timeout_cyc[2]), .en_shadow_wr(1'b1));
-    csr_wr(.ptr(ral.classd_timeout_cyc_shadowed), .value(intr_timeout_cyc[3]), .en_shadow_wr(1'b1));
+    csr_wr(.ptr(ral.classa_timeout_cyc_shadowed), .value(intr_timeout_cyc[0]));
+    csr_wr(.ptr(ral.classb_timeout_cyc_shadowed), .value(intr_timeout_cyc[1]));
+    csr_wr(.ptr(ral.classc_timeout_cyc_shadowed), .value(intr_timeout_cyc[2]));
+    csr_wr(.ptr(ral.classd_timeout_cyc_shadowed), .value(intr_timeout_cyc[3]));
   endtask
 
   virtual task wr_class_accum_threshold(bit[TL_DW-1:0] accum_thresh[NUM_ALERT_CLASSES]);
-    csr_wr(.ptr(ral.classa_accum_thresh_shadowed), .value(accum_thresh[0]), .en_shadow_wr(1'b1));
-    csr_wr(.ptr(ral.classb_accum_thresh_shadowed), .value(accum_thresh[1]), .en_shadow_wr(1'b1));
-    csr_wr(.ptr(ral.classc_accum_thresh_shadowed), .value(accum_thresh[2]), .en_shadow_wr(1'b1));
-    csr_wr(.ptr(ral.classd_accum_thresh_shadowed), .value(accum_thresh[3]), .en_shadow_wr(1'b1));
+    csr_wr(.ptr(ral.classa_accum_thresh_shadowed), .value(accum_thresh[0]));
+    csr_wr(.ptr(ral.classb_accum_thresh_shadowed), .value(accum_thresh[1]));
+    csr_wr(.ptr(ral.classc_accum_thresh_shadowed), .value(accum_thresh[2]));
+    csr_wr(.ptr(ral.classd_accum_thresh_shadowed), .value(accum_thresh[3]));
   endtask
 
   virtual task wr_ping_timeout_cycle(bit[TL_DW-1:0] timeout_val);
-    csr_wr(.ptr(ral.ping_timeout_cyc_shadowed), .value(timeout_val), .en_shadow_wr(1'b1));
+    csr_wr(.ptr(ral.ping_timeout_cyc_shadowed), .value(timeout_val));
     if (!config_locked) begin
       if (timeout_val == 0) timeout_val = 1;
       foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout_cycle = timeout_val;

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -168,15 +168,12 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
       // wait escalation done, and random interrupt with clear_esc
       wait_alert_handshake_done();
-      fork
-        begin
-          wait_esc_handshake_done();
-        end
-        begin
-          cfg.clk_rst_vif.wait_clks($urandom_range(0, max_wait_phases_cyc));
-          if ($urandom_range(0, 1) && (esc_int_err == 0)) clear_esc();
-        end
-      join
+      if ($urandom_range(0, 1) && (esc_int_err == 0)) begin
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, max_wait_phases_cyc));
+        clear_esc();
+      end
+      wait_esc_handshake_done();
+
       read_alert_cause();
       read_esc_status();
       if (do_clr_esc) clear_esc();


### PR DESCRIPTION
1). Remove all shadow_wr_en because it is default to On in csr_wr
2). Remove the fork join to simplify the sequence logic

Signed-off-by: Cindy Chen <chencindy@opentitan.org>