### PR TITLE
[edn/rtl] recoverable alert status bits added

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -77,7 +77,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "REGWEN",
-      fields: [
+      tags: [// Internal HW can modify status register
+                "excl:CsrAllTests:CsrExclWrite"]
+     fields: [
         { bits: "3:0",
           name: "EDN_ENABLE",
           desc: '''
@@ -254,7 +256,41 @@
       desc: "Recoverable alert status register",
       swaccess: "rw0c",
       hwaccess: "hwo",
+          tags: [// Internal HW can modify status register
+                 "excl:CsrAllTests:CsrExclCheck"]
       fields: [
+        { bits: "0",
+          name: "EDN_ENABLE_FIELD_ALERT",
+          desc: '''
+                This bit is set when the EDN_ENABLE field is set to an illegal value,
+                something other than 0x5 or 0xA.
+                Writing a zero to this register resets the status bits.
+                '''
+        }
+        { bits: "1",
+          name: "BOOT_REQ_MODE_FIELD_ALERT",
+          desc: '''
+                This bit is set when the BOOT_REQ_MODE field is set to an illegal value,
+                something other than 0x5 or 0xA.
+                Writing a zero to this register resets the status bits.
+                '''
+        }
+        { bits: "2",
+          name: "AUTO_REQ_MODE_FIELD_ALERT",
+          desc: '''
+                This bit is set when the AUTO_REQ_MODE field is set to an illegal value,
+                something other than 0x5 or 0xA.
+                Writing a zero to this register resets the status bits.
+                '''
+        }
+        { bits: "3",
+          name: "CMD_FIFO_RST_FIELD_ALERT",
+          desc: '''
+                This bit is set when the CMD_FIFO_RST field is set to an illegal value,
+                something other than 0x5 or 0xA.
+                Writing a zero to this register resets the status bits.
+                '''
+        }
         { bits: "12",
           name: "EDN_BUS_CMP_ALERT",
           desc: '''

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -36,8 +36,6 @@ module edn
 
   // Interrupts
   output logic      intr_edn_cmd_req_done_o,
-  // TODO: add intrp
-  // output logic      intr_edn_ebus_check_failed_o,
   output logic      intr_edn_fatal_err_o
 );
 
@@ -89,9 +87,6 @@ module edn
     .fatal_alert_test_o(alert_test[1]),
 
     .intr_edn_cmd_req_done_o,
-  // TODO: add intrp - remove () below
-  //  .intr_edn_ebus_check_failed_o,
-    .intr_edn_ebus_check_failed_o(),
     .intr_edn_fatal_err_o
   );
 
@@ -135,8 +130,6 @@ module edn
 
   // Interrupt Asserts
   `ASSERT_KNOWN(IntrEdnCmdReqDoneKnownO_A, intr_edn_cmd_req_done_o)
-  // TODO: add intrp
-  // `ASSERT_KNOWN(IntrEdnEBusCheckFailedKnownO_A, intr_edn_ebus_check_failed_o)
-  `ASSERT_KNOWN(IntrEdnFifoErrKnownO_A, intr_edn_fatal_err_o)
+
 
 endmodule

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -36,7 +36,6 @@ module edn_core import edn_pkg::*;
 
   // Interrupts
   output logic        intr_edn_cmd_req_done_o,
-  output logic        intr_edn_ebus_check_failed_o,
   output logic        intr_edn_fatal_err_o
 );
 
@@ -53,7 +52,6 @@ module edn_core import edn_pkg::*;
 
   // signals
   logic event_edn_cmd_req_done;
-  logic event_edn_ebus_check_failed;
   logic event_edn_fatal_err;
   logic edn_enable;
   logic edn_enable_pfe;
@@ -149,12 +147,6 @@ module edn_core import edn_pkg::*;
   logic                               edn_bus_cmp_alert;
   logic                               unused_err_code_test_bit;
 
-  // TODO: remove when connected
-  logic                               unused_edn_enable_pfa;
-  logic                               unused_boot_req_mode_pfa;
-  logic                               unused_auto_req_mode_pfa;
-  logic                               unused_cmd_fifo_rst_pfa;
-
   // flops
   logic [31:0]                        cs_cmd_req_q, cs_cmd_req_d;
   logic                               cs_cmd_req_vld_q, cs_cmd_req_vld_d;
@@ -226,24 +218,6 @@ module edn_core import edn_pkg::*;
     .intr_o                 (intr_edn_cmd_req_done_o)
   );
 
-  // TODO: add intrp
-//  prim_intr_hw #(
-//    .Width(1)
-//  ) u_intr_hw_edn_ebus_check_failed (
-//    .clk_i                  (clk_i),
-//    .rst_ni                 (rst_ni),
-//    .event_intr_i           (event_edn_ebus_check_failed),
-//    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.edn_ebus_check_failed.q),
-//    .reg2hw_intr_test_q_i   (reg2hw.intr_test.edn_ebus_check_failed.q),
-//    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.edn_ebus_check_failed.qe),
-//    .reg2hw_intr_state_q_i  (reg2hw.intr_state.edn_ebus_check_failed.q),
-//    .hw2reg_intr_state_de_o (hw2reg.intr_state.edn_ebus_check_failed.de),
-//    .hw2reg_intr_state_d_o  (hw2reg.intr_state.edn_ebus_check_failed.d),
-//    .intr_o                 (intr_edn_ebus_check_failed_o)
-//  );
-
-  // TODO: remove when intrp is added
-  assign intr_edn_ebus_check_failed_o = event_edn_ebus_check_failed;
 
   prim_intr_hw #(
     .Width(1)
@@ -262,9 +236,6 @@ module edn_core import edn_pkg::*;
 
   // interrupt for sw app interface only
   assign event_edn_cmd_req_done = csrng_cmd_ack;
-
-  // entropy bus check failed interrupt
-  assign event_edn_ebus_check_failed = edn_bus_cmp_alert;
 
   // set the interrupt sources
   assign event_edn_fatal_err = edn_enable && (
@@ -345,18 +316,14 @@ module edn_core import edn_pkg::*;
   assign edn_enable_pfe = (edn_enb_e'(reg2hw.ctrl.edn_enable.q) == EDN_FIELD_ON);
   assign edn_enable_pfd = (edn_enb_e'(reg2hw.ctrl.edn_enable.q) == ~EDN_FIELD_ON);
   assign edn_enable_pfa = !(edn_enable_pfe || edn_enable_pfd);
-  // TODO: add below to status reg
-//  assign hw2reg.recov_alert_sts.edn_enable_field_alert.de = edn_enable_pfa;
-//  assign hw2reg.recov_alert_sts.edn_enable_field_alert.d  = edn_enable_pfa;
-  assign unused_edn_enable_pfa = edn_enable_pfa;
+  assign hw2reg.recov_alert_sts.edn_enable_field_alert.de = edn_enable_pfa;
+  assign hw2reg.recov_alert_sts.edn_enable_field_alert.d  = edn_enable_pfa;
 
   assign cmd_fifo_rst_pfe = (edn_enb_e'(reg2hw.ctrl.cmd_fifo_rst.q) == EDN_FIELD_ON);
   assign cmd_fifo_rst_pfd = (edn_enb_e'(reg2hw.ctrl.cmd_fifo_rst.q) == ~EDN_FIELD_ON);
   assign cmd_fifo_rst_pfa = !(cmd_fifo_rst_pfe || cmd_fifo_rst_pfd);
-  // TODO: add below to status reg
-//  assign hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.de = cmd_fifo_rst_pfa;
-//  assign hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.d  = cmd_fifo_rst_pfa;
-  assign unused_cmd_fifo_rst_pfa = cmd_fifo_rst_pfa;
+  assign hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.de = cmd_fifo_rst_pfa;
+  assign hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.d  = cmd_fifo_rst_pfa;
 
   // master module enable
   assign edn_enable = edn_enable_pfe;
@@ -369,10 +336,8 @@ module edn_core import edn_pkg::*;
   assign auto_req_mode_pfe = (edn_enb_e'(reg2hw.ctrl.auto_req_mode.q) == EDN_FIELD_ON);
   assign auto_req_mode_pfd = (edn_enb_e'(reg2hw.ctrl.auto_req_mode.q) == ~EDN_FIELD_ON);
   assign auto_req_mode_pfa = !(auto_req_mode_pfe || auto_req_mode_pfd);
-  // TODO: add below to status reg
-//  assign hw2reg.recov_alert_sts.auto_req_mode_field_alert.de = auto_req_mode_pfa;
-//  assign hw2reg.recov_alert_sts.auto_req_mode_field_alert.d  = auto_req_mode_pfa;
-  assign unused_auto_req_mode_pfa = auto_req_mode_pfa;
+  assign hw2reg.recov_alert_sts.auto_req_mode_field_alert.de = auto_req_mode_pfa;
+  assign hw2reg.recov_alert_sts.auto_req_mode_field_alert.d  = auto_req_mode_pfa;
 
 
   // SW interface connection
@@ -561,10 +526,8 @@ module edn_core import edn_pkg::*;
   assign boot_req_mode_pfe = (edn_enb_e'(reg2hw.ctrl.boot_req_mode.q) == EDN_FIELD_ON);
   assign boot_req_mode_pfd = (edn_enb_e'(reg2hw.ctrl.boot_req_mode.q) == ~EDN_FIELD_ON);
   assign boot_req_mode_pfa = !(boot_req_mode_pfe || boot_req_mode_pfd);
-  // TODO: add below to status reg
-//  assign hw2reg.recov_alert_sts.boot_req_mode_field_alert.de = boot_req_mode_pfa;
-//  assign hw2reg.recov_alert_sts.boot_req_mode_field_alert.d  = boot_req_mode_pfa;
-  assign unused_boot_req_mode_pfa = boot_req_mode_pfa;
+  assign hw2reg.recov_alert_sts.boot_req_mode_field_alert.de = boot_req_mode_pfa;
+  assign hw2reg.recov_alert_sts.boot_req_mode_field_alert.d  = boot_req_mode_pfa;
 
 
   // boot request
@@ -676,8 +639,8 @@ module edn_core import edn_pkg::*;
 
   assign recov_alert_o = edn_bus_cmp_alert;
 
-  assign hw2reg.recov_alert_sts.de = edn_bus_cmp_alert;
-  assign hw2reg.recov_alert_sts.d  = edn_bus_cmp_alert;
+  assign hw2reg.recov_alert_sts.edn_bus_cmp_alert.de = edn_bus_cmp_alert;
+  assign hw2reg.recov_alert_sts.edn_bus_cmp_alert.d  = edn_bus_cmp_alert;
 
   //--------------------------------------------
   // end point interface packers generation

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -130,8 +130,26 @@ package edn_reg_pkg;
   } edn_hw2reg_sw_cmd_sts_reg_t;
 
   typedef struct packed {
-    logic        d;
-    logic        de;
+    struct packed {
+      logic        d;
+      logic        de;
+    } edn_enable_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } boot_req_mode_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } auto_req_mode_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cmd_fifo_rst_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } edn_bus_cmp_alert;
   } edn_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
@@ -181,10 +199,10 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [27:24]
-    edn_hw2reg_sum_sts_reg_t sum_sts; // [23:20]
-    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [19:16]
-    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [15:14]
+    edn_hw2reg_intr_state_reg_t intr_state; // [35:32]
+    edn_hw2reg_sum_sts_reg_t sum_sts; // [31:28]
+    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [27:24]
+    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [23:14]
     edn_hw2reg_err_code_reg_t err_code; // [13:0]
   } edn_hw2reg_t;
 

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -153,8 +153,16 @@ module edn_reg_top (
   logic [31:0] max_num_reqs_between_reseeds_qs;
   logic [31:0] max_num_reqs_between_reseeds_wd;
   logic recov_alert_sts_we;
-  logic recov_alert_sts_qs;
-  logic recov_alert_sts_wd;
+  logic recov_alert_sts_edn_enable_field_alert_qs;
+  logic recov_alert_sts_edn_enable_field_alert_wd;
+  logic recov_alert_sts_boot_req_mode_field_alert_qs;
+  logic recov_alert_sts_boot_req_mode_field_alert_wd;
+  logic recov_alert_sts_auto_req_mode_field_alert_qs;
+  logic recov_alert_sts_auto_req_mode_field_alert_wd;
+  logic recov_alert_sts_cmd_fifo_rst_field_alert_qs;
+  logic recov_alert_sts_cmd_fifo_rst_field_alert_wd;
+  logic recov_alert_sts_edn_bus_cmp_alert_qs;
+  logic recov_alert_sts_edn_bus_cmp_alert_wd;
   logic err_code_sfifo_rescmd_err_qs;
   logic err_code_sfifo_gencmd_err_qs;
   logic err_code_edn_ack_sm_err_qs;
@@ -635,28 +643,129 @@ module edn_reg_top (
 
 
   // R[recov_alert_sts]: V(False)
+  //   F[edn_enable_field_alert]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
-  ) u_recov_alert_sts (
+  ) u_recov_alert_sts_edn_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (recov_alert_sts_we),
-    .wd     (recov_alert_sts_wd),
+    .wd     (recov_alert_sts_edn_enable_field_alert_wd),
 
     // from internal hardware
-    .de     (hw2reg.recov_alert_sts.de),
-    .d      (hw2reg.recov_alert_sts.d),
+    .de     (hw2reg.recov_alert_sts.edn_enable_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.edn_enable_field_alert.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (recov_alert_sts_qs)
+    .qs     (recov_alert_sts_edn_enable_field_alert_qs)
+  );
+
+  //   F[boot_req_mode_field_alert]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_boot_req_mode_field_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_boot_req_mode_field_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.boot_req_mode_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.boot_req_mode_field_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_boot_req_mode_field_alert_qs)
+  );
+
+  //   F[auto_req_mode_field_alert]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_auto_req_mode_field_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_auto_req_mode_field_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.auto_req_mode_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.auto_req_mode_field_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_auto_req_mode_field_alert_qs)
+  );
+
+  //   F[cmd_fifo_rst_field_alert]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_cmd_fifo_rst_field_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_cmd_fifo_rst_field_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_cmd_fifo_rst_field_alert_qs)
+  );
+
+  //   F[edn_bus_cmp_alert]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_edn_bus_cmp_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_edn_bus_cmp_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.edn_bus_cmp_alert.de),
+    .d      (hw2reg.recov_alert_sts.edn_bus_cmp_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_edn_bus_cmp_alert_qs)
   );
 
 
@@ -956,7 +1065,15 @@ module edn_reg_top (
   assign max_num_reqs_between_reseeds_wd = reg_wdata[31:0];
   assign recov_alert_sts_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign recov_alert_sts_wd = reg_wdata[12];
+  assign recov_alert_sts_edn_enable_field_alert_wd = reg_wdata[0];
+
+  assign recov_alert_sts_boot_req_mode_field_alert_wd = reg_wdata[1];
+
+  assign recov_alert_sts_auto_req_mode_field_alert_wd = reg_wdata[2];
+
+  assign recov_alert_sts_cmd_fifo_rst_field_alert_wd = reg_wdata[3];
+
+  assign recov_alert_sts_edn_bus_cmp_alert_wd = reg_wdata[12];
   assign err_code_test_we = addr_hit[14] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
@@ -1023,7 +1140,11 @@ module edn_reg_top (
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[12] = recov_alert_sts_qs;
+        reg_rdata_next[0] = recov_alert_sts_edn_enable_field_alert_qs;
+        reg_rdata_next[1] = recov_alert_sts_boot_req_mode_field_alert_qs;
+        reg_rdata_next[2] = recov_alert_sts_auto_req_mode_field_alert_qs;
+        reg_rdata_next[3] = recov_alert_sts_cmd_fifo_rst_field_alert_qs;
+        reg_rdata_next[12] = recov_alert_sts_edn_bus_cmp_alert_qs;
       end
 
       addr_hit[13]: begin

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -16,7 +16,7 @@ index 8c61ec4d7..1c8e29d86 100644
 -  sw   t0, CSRNG_CTRL_REG_OFFSET(a0)
 -
 -  li   a0, TOP_EARLGREY_EDN0_BASE_ADDR
--  li   t0, 0xaa
+-  li   t0, 0x55aa
 -  sw   t0, EDN_CTRL_REG_OFFSET(a0)
 -
    // Request memory scrambling and init

--- a/sw/device/boot_rom/rom_crt.S
+++ b/sw/device/boot_rom/rom_crt.S
@@ -91,7 +91,7 @@ _start:
   sw   t0, CSRNG_CTRL_REG_OFFSET(a0)
 
   li   a0, TOP_EARLGREY_EDN0_BASE_ADDR
-  li   t0, 0xaa
+  li   t0, 0x55aa
   sw   t0, EDN_CTRL_REG_OFFSET(a0)
 
   // Request memory scrambling and init

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -55,9 +55,9 @@ static void setup_edn(void) {
   // run before a DIF is available,
   // https://github.com/lowRISC/opentitan/issues/6082
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN0_BASE_ADDR),
-                      EDN_CTRL_REG_OFFSET, 0xaa);
+                      EDN_CTRL_REG_OFFSET, 0x55aa);
   mmio_region_write32(mmio_region_from_addr(TOP_EARLGREY_EDN1_BASE_ADDR),
-                      EDN_CTRL_REG_OFFSET, 0xaa);
+                      EDN_CTRL_REG_OFFSET, 0x55aa);
 }
 
 void entropy_testutils_boot_mode_init(void) {

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -144,7 +144,7 @@ _mask_rom_start_boot:
   sw t0, CSRNG_CTRL_REG_OFFSET(a0)
 
   li a0, TOP_EARLGREY_EDN0_BASE_ADDR
-  li t0, (0xa << EDN_CTRL_EDN_ENABLE_OFFSET) | (0xa << EDN_CTRL_BOOT_REQ_MODE_OFFSET)
+  li t0, (0xa << EDN_CTRL_EDN_ENABLE_OFFSET) | (0xa << EDN_CTRL_BOOT_REQ_MODE_OFFSET) | (0x5 << EDN_CTRL_AUTO_REQ_MODE_OFFSET) | (0x5 << EDN_CTRL_CMD_FIFO_RST_OFFSET)
   sw t0, EDN_CTRL_REG_OFFSET(a0)
 
   // Scramble and initialize main memory (main SRAM).


### PR DESCRIPTION
Alert status based on enable field illegal state settings have been added to the recoverable alert status register.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>