### PR TITLE
[keymgr/dv] Fix keymgr_tl_intg_err

### DIFF
--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -705,6 +705,8 @@
               resval: "0"
             },
         ],
+        tags: [// HW-update reg
+               "excl:CsrNonInitTests:CsrExclCheck"]
       },
     },
 
@@ -729,6 +731,8 @@
               resval: "0"
             },
         ],
+        tags: [// HW-update reg
+               "excl:CsrNonInitTests:CsrExclCheck"]
       },
     },
 

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -19,11 +19,9 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
     tl_intg_alert_name = "fatal_fault_err";
     has_edn = 1;
     super.initialize(csr_base_addr);
-    //tl_intg_alert_fields[ral.err_code.invalid_states] = 1;
     tl_intg_alert_fields[ral.fault_status.regfile_intg] = 1;
     shadow_update_err_status_fields[ral.err_code.invalid_shadow_update] = 1;
     shadow_storage_err_status_fields[ral.fault_status.shadow] = 1;
-    //shadow_storage_err_status_fields[ral.err_code.invalid_states] = 1;
 
     m_keymgr_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_keymgr_kmac_agent_cfg");
     m_keymgr_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;


### PR DESCRIPTION
1. don't check sw_share in CSR tests as it's hw-update
2. add checking working_state after regfile_intg and shadow storage error

Signed-off-by: Weicai Yang <weicai@google.com>