### PR TITLE
[otbn,dv] Add a handy wrapper to run lots of Verilated tests

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -74,6 +74,18 @@ full .fst wave trace pass the `-t` flag. To get an instruction level trace pass
 the `--otbn-trace-file=trace.log` argument. The instruction trace format is
 documented in `hw/ip/otbn/dv/tracer`.
 
+To run several auto-generated binaries against the Verilated RTL, use
+the script at `dv/verilator/run-some.py`. For example,
+
+```sh
+hw/ip/otbn/dv/verilator/run-some.py --size=1500 --count=50 X
+```
+
+will generate and run 50 binaries, each of which will execute up to
+1500 instructions when run. The generated binaries, a Verilated model
+and the output from running them can all be found in the directory
+called `X`.
+
 ### Run the smoke test
 
 A smoke test which exercises some functionality of OTBN can be found, together

--- a/hw/ip/otbn/dv/uvm/gen-binaries.py
+++ b/hw/ip/otbn/dv/uvm/gen-binaries.py
@@ -117,7 +117,7 @@ def main() -> int:
                               'defaults to the OBJ_DIR environment variable '
                               'if set, or build-out at the top of the '
                               'repository if not.'))
-    parser.add_argument('--seed', type=read_positive, default=0)
+    parser.add_argument('--seed', type=read_positive, default=1)
     parser.add_argument('--size', type=read_positive, default=100)
     parser.add_argument('--verbose', '-v', action='store_true')
     parser.add_argument('--no-smoke', action='store_true',
@@ -125,6 +125,9 @@ def main() -> int:
                               'generating exactly one binary)'))
     parser.add_argument('--jobs', '-j', type=read_jobs, nargs='?',
                         const='unlimited', help='Number of parallel jobs.')
+    parser.add_argument('--gen-only', action='store_true',
+                        help="Generate the ninja file but don't run it")
+    parser.add_argument('--ninja-suffix', type=str)
     parser.add_argument('destdir',
                         help='Destination directory')
 
@@ -143,9 +146,16 @@ def main() -> int:
 
     os.makedirs(args.destdir, exist_ok=True)
 
-    with open(os.path.join(args.destdir, 'build.ninja'), 'w') as ninja_handle:
+    ninja_fname = 'build.ninja'
+    if args.ninja_suffix is not None:
+        ninja_fname += '.' + args.ninja_suffix
+
+    with open(os.path.join(args.destdir, ninja_fname), 'w') as ninja_handle:
         write_ninja(ninja_handle, not args.no_smoke, rig_count,
                     args.seed, args.size, toolchain, otbn_dir)
+
+    if args.gen_only:
+        return 0
 
     # Handle the -j argument like Make does, defaulting to 1 thread. This
     # behaves a bit more reasonably than ninja's default (# cores) if we're

--- a/hw/ip/otbn/dv/verilator/run-some.py
+++ b/hw/ip/otbn/dv/verilator/run-some.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''A handy wrapper that uses gen-binaries.sh and a Verilated binary
+
+Use this with a command line like
+
+    run-some.py --size=1500 --count=10 XXX
+
+which will generate 10 OTBN binaries, each with up to 1500 instructions in
+their respective traces. It will also build a Verilated model of OTBN (using
+otbn_top_sim) and run the model on each binary.
+
+'''
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from typing import TextIO
+
+_SCRIPT_DIR = os.path.dirname(__file__)
+
+
+def find_gen_binaries() -> str:
+    '''Find the path to gen-binaries.py'''
+    path = os.path.join(_SCRIPT_DIR, '../uvm/gen-binaries.py')
+    if not os.path.exists(path):
+        raise RuntimeError(f'No such file: {path}')
+    return os.path.normpath(path)
+
+
+def get_projdir() -> str:
+    '''Return the path to the top of the project'''
+    path = os.path.join(_SCRIPT_DIR, '../../../../..')
+    assert os.path.exists(os.path.join(path, '.git'))
+    return os.path.normpath(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--count', type=int, default=10,
+                        help='Number of binaries to generate and run')
+    parser.add_argument('--seed', type=int, default=1)
+    parser.add_argument('--size', type=int, default=100)
+    parser.add_argument('--no-smoke', action='store_true',
+                        help=('Do not generate the smoke test (useful if '
+                              'generating exactly one binary)'))
+    parser.add_argument('destdir', help='Destination directory')
+
+    args = parser.parse_args()
+
+    # Run gen-binaries.py in --gen-only mode, which will produce a
+    # build.ninja.gen describing how to generate the binaries.
+    gb_flags = ['--gen-only',
+                '--ninja-suffix=gen',
+                '--count={}'.format(args.count),
+                '--seed={}'.format(args.seed),
+                '--size={}'.format(args.size)]
+    if args.no_smoke:
+        gb_flags.append('--no-smoke')
+
+    gb_cmd = [find_gen_binaries()] + gb_flags + [args.destdir]
+    if subprocess.run(gb_cmd, check=False).returncode:
+        print('Failed to run generate-binaries (command: {})'
+              .format(' '.join([shlex.quote(arg) for arg in gb_cmd])),
+              file=sys.stderr)
+        return 1
+
+    # Next, we make our own build.ninja, which says how to compile and run the
+    # verilated testbench
+    with open(os.path.join(args.destdir, 'build.ninja'), 'w') as ninja_handle:
+        write_ninja(ninja_handle, args.destdir,
+                    args.no_smoke, args.seed, args.count)
+
+    # Finally, use ninja to run everything, continuing on error (so that you
+    # can run 100 seeds and see what proportion fails).
+    ninja_cmd = ['ninja', '-C', args.destdir, '-k0', 'run']
+    return subprocess.run(ninja_cmd, check=False).returncode
+
+
+def write_ninja(handle: TextIO,
+                destdir: str,
+                no_smoke: bool,
+                seed: int,
+                count: int) -> None:
+    handle.write('include build.ninja.gen\n\n')
+
+    # Find the project directory, as viewed from destdir
+    projdir_from_here = get_projdir()
+    projdir_from_destdir = os.path.relpath(projdir_from_here, destdir)
+
+    # The rule to build the Verilated system
+    handle.write('rule fusesoc\n'
+                 f'  command = fusesoc --cores-root={projdir_from_destdir} '
+                 'run --target=sim --setup --build lowrisc:ip:otbn_top_sim '
+                 '>fusesoc.log 2>&1\n\n')
+    handle.write('tb = build/lowrisc_ip_otbn_top_sim_0.1/sim-verilator/Votbn_top_sim\n\n')
+    handle.write('build $tb: fusesoc\n\n')
+
+    # Collect up all the generated files
+    basenames = [] if no_smoke else ['smoke']
+    for off in range(count if no_smoke else count - 1):
+        basenames.append(str(seed + off))
+
+    # Rules to run them
+    handle.write('rule run\n'
+                 '  command = $tb --load-elf $in >$out\n\n')
+    for name in basenames:
+        handle.write(f'build {name}.out: run {name}.elf | $tb\n')
+    handle.write('\n')
+
+    # A phony rule to run everything
+    handle.write('build run: phony {}\n\n'
+                 .format(' '.join([f'{name}.out' for name in basenames])))
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This is a "pre-dv-only" thing, but it's a darn sight faster than
running VCS. Example usage:

    hw/ip/otbn/dv/verilator/run-some.py --size=1500 --count=10 XXX
