### PR TITLE
[otbn,dv] Fix two separate loop warp bugs

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -331,6 +331,10 @@ void ISSWrapper::add_loop_warp(uint32_t addr, uint32_t from_cnt,
   run_command(oss.str(), nullptr);
 }
 
+void ISSWrapper::clear_loop_warps() {
+  run_command("clear_loop_warps\n", nullptr);
+}
+
 void ISSWrapper::dump_d(const std::string &path) const {
   std::ostringstream oss;
   oss << "dump_d " << path << "\n";

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -33,6 +33,9 @@ struct ISSWrapper {
   // Add a loop warp instruction to the simulation
   void add_loop_warp(uint32_t addr, uint32_t from_cnt, uint32_t to_cnt);
 
+  // Clear any loop warp instructions from the simulation
+  void clear_loop_warps();
+
   // Dump the contents of DMEM to a file
   void dump_d(const std::string &path) const;
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -195,6 +195,13 @@ int OtbnModel::take_loop_warps(const OtbnMemUtil &memutil) {
   if (!iss)
     return -1;
 
+  try {
+    iss->clear_loop_warps();
+  } catch (std::runtime_error &err) {
+    std::cerr << "Error when clearing loop warps: " << err.what() << "\n";
+    return -1;
+  }
+
   for (auto &pr : memutil.GetLoopWarps()) {
     auto &key = pr.first;
     uint32_t addr = key.first;

--- a/hw/ip/otbn/dv/otbnsim/sim/loop.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/loop.py
@@ -176,4 +176,5 @@ class LoopStack:
             return
 
         assert cur_iter_count <= new_iter_count
+        assert new_iter_count + 1 < top.loop_count
         top.restarts_left = top.loop_count - new_iter_count - 1

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -29,6 +29,8 @@ prefixed with "0x" if they are hexadecimal.
                          at address <addr> and will jump from iteration <from>
                          to iteration <to>.
 
+    clear_loop_warps     Clear any loop warp rules
+
     load_d <path>        Replace the current contents of DMEM with <path>
                          (read as an array of 32-bit little-endian words)
 
@@ -155,6 +157,15 @@ def on_add_loop_warp(sim: OTBNSim, args: List[str]) -> None:
     sim.add_loop_warp(addr, from_cnt, to_cnt)
 
 
+def on_clear_loop_warps(sim: OTBNSim, args: List[str]) -> None:
+    '''Run until ecall or error'''
+    if len(args):
+        raise ValueError('clear_loop_warps expects zero arguments. Got {}.'
+                         .format(args))
+
+    sim.loop_warps = {}
+
+
 def on_load_d(sim: OTBNSim, args: List[str]) -> None:
     '''Load contents of data memory from file at path given by only argument'''
     if len(args) != 1:
@@ -238,6 +249,7 @@ _HANDLERS = {
     'run': on_run,
     'load_elf': on_load_elf,
     'add_loop_warp': on_add_loop_warp,
+    'clear_loop_warps': on_clear_loop_warps,
     'load_d': on_load_d,
     'load_i': on_load_i,
     'dump_d': on_dump_d,

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -137,8 +137,13 @@ class Loop(SnippetGen):
             warp = None
             iters = actual_iters
         else:
-            lo = random.randint(0, max_iters)
+            # We will start '1 + lo' iterations before the warp (and finish
+            # 'lo' of them). We'll then finish 'max_iters - lo' iterations
+            # after the warp. Both '1 + lo' and 'max_iters - lo' must be
+            # positive.
+            lo = random.randint(0, max_iters - 1)
             hi = actual_iters - (max_iters - lo)
+            assert 0 <= lo <= hi < actual_iters
             warp = (lo, hi)
             iters = max_iters
 


### PR DESCRIPTION
The first commit fixes a bug at generation time, where we might decide to jump past the last iteration of the loop (causing the ISS to shout!). The second commit improves error reporting for the bug fixed by the third commit, where we weren't clearing up properly after ourselves between binaries in the `otbn_multi` test.

These bugs both appear when running `util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_multi --fixed-seed 408306723` with commit 46bc19431 (seen in nightly testing).