### PR TITLE
opentitanlib/src/transport: Added symbolic pin names

### DIFF
--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{anyhow, Result};
 use bitflags::bitflags;
+use std::collections::HashMap;
 
 use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
@@ -69,12 +70,24 @@ pub trait Transport {
     fn spi(&self) -> Result<Box<dyn Target>> {
         unimplemented!();
     }
+    /// Returns a mapping from symbolic names to spi port index to be used above.
+    fn enumerate_spi(&self) -> HashMap<String, u32> {
+        unimplemented!();
+    }
     /// Returns a [`Uart`] implementation.
     fn uart(&self) -> Result<Box<dyn Uart>> {
         unimplemented!();
     }
+    /// Returns a mapping from symbolic names to uart index to be used above.
+    fn enumerate_uart(&self) -> HashMap<String, u32> {
+        unimplemented!();
+    }
     /// Returns a [`Gpio`] implementation.
     fn gpio(&self) -> Result<Box<dyn Gpio>> {
+        unimplemented!();
+    }
+    /// Returns a mapping from symbolic names to gpio index to be used above.
+    fn enumerate_gpio(&self) -> HashMap<String, u32> {
         unimplemented!();
     }
 }

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -5,6 +5,7 @@
 use anyhow::Result;
 use safe_ftdi as ftdi;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::io::gpio::Gpio;
@@ -30,6 +31,15 @@ impl UltradebugGpio {
         Ok(UltradebugGpio {
             device: ultradebug.mpsse(ftdi::Interface::B)?,
         })
+    }
+
+    pub fn enumerate() -> HashMap<String, u32> {
+        let mut pins = HashMap::new();
+        pins.insert(String::from("UD_SPI_ZB"), Self::PIN_SPI_ZB);
+        pins.insert(String::from("UD_RESET_B"), Self::PIN_RESET_B);
+        pins.insert(String::from("UD_BOOTSTRAP"), Self::PIN_BOOTSTRAP);
+        pins.insert(String::from("UD_TGT_RESET"), Self::PIN_TGT_RESET);
+        pins
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
@@ -6,6 +6,7 @@ use anyhow::{bail, Result};
 
 use safe_ftdi as ftdi;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::io::gpio::Gpio;
@@ -119,6 +120,9 @@ impl Transport for Ultradebug {
 
     fn gpio(&self) -> Result<Box<dyn Gpio>> {
         Ok(Box::new(gpio::UltradebugGpio::open(&self)?))
+    }
+    fn enumerate_gpio(&self) -> HashMap<String, u32> {
+        gpio::UltradebugGpio::enumerate()
     }
 
     fn spi(&self) -> Result<Box<dyn Target>> {


### PR DESCRIPTION
My first attempt at a GitHub pull request, this is the first step towards OpenTitan tool supporting symbolic pin names for future GPIO manipulation commands.

This CL adds new methods to the Transport trait, and show demonstration implementation for UltraDebug.  The uart and spi enumeration functions being added currently have no practical use, as the spi() and uart() methods themselves need to be enhanced to each take an integer argument.

Signed-off-by: <jbk@chromium.org>