### PR TITLE
[clkgmr] Disable gating of software controllable clocks on FPGA

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -322,6 +322,7 @@
   );
 
   prim_clock_gating #(
+    .NoFpgaGate(1'b1),
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_${k}_cg (
     .clk_i(clk_${v.src.name}_root),

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -462,6 +462,7 @@
   );
 
   prim_clock_gating #(
+    .NoFpgaGate(1'b1),
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_div4_peri_cg (
     .clk_i(clk_io_div4_root),
@@ -491,6 +492,7 @@
   );
 
   prim_clock_gating #(
+    .NoFpgaGate(1'b1),
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_div2_peri_cg (
     .clk_i(clk_io_div2_root),
@@ -520,6 +522,7 @@
   );
 
   prim_clock_gating #(
+    .NoFpgaGate(1'b1),
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_io_peri_cg (
     .clk_i(clk_io_root),
@@ -549,6 +552,7 @@
   );
 
   prim_clock_gating #(
+    .NoFpgaGate(1'b1),
     .FpgaBufGlobal(1'b1) // This clock spans across multiple clock regions.
   ) u_clk_usb_peri_cg (
     .clk_i(clk_usb_root),


### PR DESCRIPTION
It seems that the use of additional BUFGCEs leads to congestion issues which leads to unpredictable FPGA implementation times and an increase in CI failures. This commit disables the gating of these clocks. We can re-enable it once we have a better understanding of the underlying issues.

Note that this PR leaves the hintable clocks gateable. Those use BUFHCEs which should be uncritical. If this doesn't solve the routing issues temporarily, I we can also disable the gating of hintable clocks. Let's see.