### PR TITLE
[otbn,dv] Fix a follow-up bug in the bad_load_store generator

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
@@ -208,7 +208,7 @@ class BadLoadStore(SnippetGen):
 
             if val + min_offset <= -4:
                 tgt_lo = val + min_offset
-                tgt_hi = -1
+                tgt_hi = min(val + max_offset, -1)
             else:
                 tgt_lo = max(model.dmem_size, val + min_offset)
                 tgt_hi = val + max_offset


### PR DESCRIPTION
Commit af368fc eliminated some sources of unrepresentable values, but
I missed one here. If `val` is (when interpreted as a 32-bit signed
integer) more negative than `-max_offset-4` then `-4` won't actually be
representable.

This commit fixes things by clamping to `val + max_offset`.

In practice, this problem didn't happen all that often because, while
we generate things like `0xffffffff` very easily, getting things like
`0xcb6b5000` (the value that triggered the bug) is rather less likely.
