### PR TITLE
[otbn] Alter ISS behaviour for invalid BN.SID instructions

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -922,12 +922,17 @@ class BNLID(OTBNInsn):
         addr = (grs1_val + self.offset) & ((1 << 32) - 1)
         grd_val = state.gprs.get_reg(self.grd).read_unsigned()
 
+        saw_err = False
+
         if grd_val > 31:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            saw_err = True
 
         if not state.dmem.is_valid_256b_addr(addr):
             state.stop_at_end_of_cycle(ErrBits.BAD_DATA_ADDR)
+            saw_err = True
+
+        if saw_err:
             return
 
         wrd = grd_val & 0x1f
@@ -972,12 +977,17 @@ class BNSID(OTBNInsn):
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
             return
 
+        saw_err = False
+
         if grs2_val > 31:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
-            return
+            saw_err = True
 
         if not state.dmem.is_valid_256b_addr(addr):
             state.stop_at_end_of_cycle(ErrBits.BAD_DATA_ADDR)
+            saw_err = True
+
+        if saw_err:
             return
 
         wrs = grs2_val & 0x1f


### PR DESCRIPTION
For a sequence like the following:

    li      x10, 100
    bn.sid  x10, 10720(x0)

there are two reasons that the BN.SID instruction should raise an
error. Firstly, `x10` is `100`, which isn't a valid WDR index. Secondly,
the store address is `10720`, which is above the top of memory. The
error bits for these two errors are `ILLEGAL_INSN` and `BAD_DATA_ADDR`,
respectively.

The RTL signals both errors, which seems reasonable but doesn't match
what the ISS was doing. Change the ISS to match.

Note that there are lots of examples of "multiple errors" in a cycle
that need checking. This is just urgent because we've suddenly started
generating streams with the RIG that happen to trigger this case quite
frequently.

This ties in with https://github.com/lowRISC/opentitan/issues/7809 (although I intend to work through things in a rather more principled order once I've fixed the failing tests we've got at the moment).