### PR TITLE
[otbn,dv] Fix ISS assertion for loop warp handling

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/loop.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/loop.py
@@ -176,5 +176,5 @@ class LoopStack:
             return
 
         assert cur_iter_count <= new_iter_count
-        assert new_iter_count + 1 < top.loop_count
+        assert new_iter_count + 1 <= top.loop_count
         top.restarts_left = top.loop_count - new_iter_count - 1


### PR DESCRIPTION
I added this in commit 5d027c9 as a handy way to trigger errors
quickly if the new count specified in the loop warp was bogus (causing
`top.restarts_left` to go negative). Unfortunately, I included an
off-by-one error. :-(
