### PR TITLE
[keymgr/dv] Fix keymgr_cmd_invalid

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -133,7 +133,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
 
     case (op)
       keymgr_pkg::OpAdvance: begin
-        bit is_err = get_hw_invalid_input() || get_fault_err();
+        bit is_err = get_hw_invalid_input();
         `uvm_info(`gfn, $sformatf("What is is_err: %d", is_err), UVM_MEDIUM)
 
         case (current_state)
@@ -141,13 +141,11 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
             compare_adv_creator_data(.cdi_type(current_cdi),
                                      .exp_match(!is_err),
                                      .byte_data_q(item.byte_data_q));
-            if (is_err) compare_invalid_data(item.byte_data_q);
           end
           keymgr_pkg::StCreatorRootKey: begin
             compare_adv_owner_int_data(.cdi_type(current_cdi),
                                        .exp_match(!is_err),
                                        .byte_data_q(item.byte_data_q));
-            if (is_err) compare_invalid_data(item.byte_data_q);
           end
           keymgr_pkg::StOwnerIntKey: begin
             compare_adv_owner_data(.cdi_type(current_cdi),

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
@@ -15,6 +15,8 @@ class keymgr_cmd_invalid_vseq extends keymgr_lc_disable_vseq;
     // forcing internal design may cause uninitialized reg to be used, disable these checking
     $assertoff(0, "tb.keymgr_kmac_intf");
     $assertoff(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+    $assertoff(0, "tb.dut.u_ctrl.DataEn_A");
+    $assertoff(0, "tb.dut.u_ctrl.DataEnDis_A");
     cfg.keymgr_vif.force_cmd_err();
 
     // if it's in StDisabled, do an OP to ensure fault error occurs
@@ -29,7 +31,7 @@ class keymgr_cmd_invalid_vseq extends keymgr_lc_disable_vseq;
     check_fatal_alert_nonblocking("fatal_fault_err");
 
     cfg.clk_rst_vif.wait_clks($urandom_range(1, 500));
-    csr_rd_check(.ptr(ral.working_state), .compare_value(keymgr_pkg::StDisabled));
+    csr_rd_check(.ptr(ral.working_state), .compare_value(keymgr_pkg::StInvalid));
   endtask : trigger_error
 
   // disable checker in seq, only check in scb
@@ -44,5 +46,7 @@ class keymgr_cmd_invalid_vseq extends keymgr_lc_disable_vseq;
     cfg.en_scb = 1;
     $asserton(0, "tb.keymgr_kmac_intf");
     $asserton(0, "tb.dut.tlul_assert_device.gen_device.dDataKnown_A");
+    $asserton(0, "tb.dut.u_ctrl.DataEn_A");
+    $asserton(0, "tb.dut.u_ctrl.DataEnDis_A");
   endtask
 endclass : keymgr_cmd_invalid_vseq


### PR DESCRIPTION
Disable some assertions for keymgr_cmd_invalid as we force internal FSM
to illegal values
Minor fix for advance with errors

Signed-off-by: Weicai Yang <weicai@google.com>