### PR TITLE
[dv] Fix shadow reg

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -148,7 +148,10 @@ class dv_base_reg extends uvm_reg;
 
   // A helper function for shadow register or field read to clear the `shadow_wr_staged` flag.
   virtual function void clear_shadow_wr_staged();
-    if (is_shadowed) shadow_wr_staged = 0;
+    if (is_shadowed) begin
+      if (shadow_wr_staged) `uvm_info(`gfn, "clear shadow_wr_staged", UVM_MEDIUM)
+      shadow_wr_staged = 0;
+    end
   endfunction
 
   function bit get_is_shadowed();
@@ -224,7 +227,7 @@ class dv_base_reg extends uvm_reg;
 
   // shadow register read will clear its phase tracker
   virtual task post_read(uvm_reg_item rw);
-    clear_shadow_wr_staged();
+    if (rw.status == UVM_IS_OK) clear_shadow_wr_staged();
   endtask
 
   virtual function void set_is_ext_reg(bit is_ext);

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -128,8 +128,10 @@ class dv_base_reg_field extends uvm_reg_field;
 
   // shadow register field read will clear its phase tracker
   virtual task post_read(uvm_reg_item rw);
-    dv_base_reg parent_csr = get_dv_base_reg_parent();
-    parent_csr.clear_shadow_wr_staged();
+    if (rw.status == UVM_IS_OK) begin
+      dv_base_reg parent_csr = get_dv_base_reg_parent();
+      parent_csr.clear_shadow_wr_staged();
+    end
   endtask
 
   // override RAL's reset function to support enable registers


### PR DESCRIPTION
In CSR tests, TLUL access may be aborted and dropped
Only clear shadow_wr_staged when read is done successfully

Signed-off-by: Weicai Yang <weicai@google.com>