### PR TITLE
[fpga] Manually place bufh cell to ease congestion

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -634,7 +634,9 @@ module spi_device
     .clk_o  (sram_clk_muxed)
   );
 
-  prim_clock_gating u_sram_clk_cg (
+  prim_clock_gating #(
+    .FpgaBufGlobal(1'b0)
+  ) u_sram_clk_cg (
     .clk_i  (sram_clk_muxed),
     .en_i   (sram_clk_en),
     .test_en_i ((scanmode[ClkSramSel] == lc_ctrl_pkg::On) | mbist_en_i),

--- a/hw/top_earlgrey/data/placement.xdc
+++ b/hw/top_earlgrey/data/placement.xdc
@@ -5,3 +5,10 @@ set_property LOC RAMB36_X4Y18 [get_cells -hierarchical -filter { NAME =~  "*u_ro
 set_property LOC RAMB36_X4Y19 [get_cells -hierarchical -filter { NAME =~  "*u_rom_ctrl*u_rom*rdata_o_reg_1" && PRIMITIVE_TYPE =~ BMEM.*.* }]
 set_property LOC RAMB36_X3Y14 [get_cells -hierarchical -filter { NAME =~  "*u_rom_ctrl*u_rom*rdata_o_reg_2" && PRIMITIVE_TYPE =~ BMEM.*.* }]
 set_property LOC RAMB36_X3Y15 [get_cells -hierarchical -filter { NAME =~  "*u_rom_ctrl*u_rom*rdata_o_reg_3" && PRIMITIVE_TYPE =~ BMEM.*.* }]
+
+# Clock net "top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]" driven by instance "top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/gen_gate.gen_bufhce.u_bufhce" located at site "BUFHCE_X1Y0"
+#startgroup
+create_pblock {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}
+add_cells_to_pblock [get_pblocks  {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]"}]]]
+resize_pblock [get_pblocks {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}] -add {CLOCKREGION_X1Y0:CLOCKREGION_X1Y0}
+#endgroup


### PR DESCRIPTION
Manually place the aes bufh cell to ensure it is not placed
into the same clock region as otbn / kmac / hmac.

For whatever reason, vivado attempts to cram all the blocks
that utilize bufh into the same clocking region (even though
it can easily relocate them).  This causes congestion as there
are over 15000 flip flops betweeen aes / otbn / kmac / hmac.

This PR follows the example shown here:
https://www.xilinx.com/support/answers/66386.html.

Also make the cg in spi_device local, so we don't have the siuation
of global -> local -> global, and instead global -> local -> local.
The former scenario seems to cause hold violations sometimes.

Signed-off-by: Timothy Chen <timothytim@google.com>