### PR TITLE
[dv/tool] Include toggle coverage for prim_alert_sender in cover_reg_top

### DIFF
--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -8,7 +8,10 @@
 +moduletree *_reg_top
 +node tb.dut tl_*
 
-// Remove everything else from toggle coverage.
+// Remove everything else from toggle coverage except:
+// - `prim_alert_sender`: the `alert_test` task under `cip_base_vseq` drives `alert_test_i` and
+// verifies `alert_rx/tx` handshake in each IP.
 begin tgl
   -tree tb
+  +module prim_alert_sender
 end

--- a/hw/dv/tools/xcelium/cover_reg_top.ccf
+++ b/hw/dv/tools/xcelium/cover_reg_top.ccf
@@ -9,6 +9,10 @@ include_ccf ${dv_root}/tools/xcelium/common.ccf
 deselect_coverage -betfs -module ${DUT_TOP}...
 select_coverage -befs -module *_reg_top...
 
+// Include toggle coverage on `prim_alert_sender` because the `alert_test` task under
+// `cip_base_vseq` drives `alert_test_i` and verifies `alert_rx/tx` handshake in each IP.
+select_coverage -toggle -module prim_alert_sender
+
 // TODO: The intent below is to only enable coverage on the DUT's TL interfaces (tests using this
 // ccf file are meant to fully exercise the TL interfaces, but they do not verify the rest of the
 // functionality of the block). We enable coverage on all DUT ports but exclude ports that do not


### PR DESCRIPTION
Recent coverage review found signal `alert_test_i` is uncovered in
toggle coverage. This signal is exclusively verify under automated
`alert_test` sequence. The `alert_test` sequence is under
`cover_reg_top` build mode, so we enable the toggle coverage collection
for `prim_alert_sender` in VCS and Xcelium.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>