### PR TITLE
[dv/alert] remove ping corner case in alert handler

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip/alert_handler/data/alert_handler_testplan.hjson
@@ -16,7 +16,8 @@
               phases after one alert has been triggered
             - Check interrupt pins, alert cause CSR values, escalation pings, and crashdump_o
               output values
-            - Support both synchronous and asynchronous settings'''
+            - Support both synchronous and asynchronous settings
+            '''
       milestone: V1
       tests: ["alert_handler_smoke"]
     }
@@ -24,7 +25,8 @@
       name: esc_accum
       desc: '''
             Based on the smoke test, this test will focus on testing the escalation accumulation
-            feature. So all the escalations in the test will be triggered by alert accumulation.'''
+            feature. So all the escalations in the test will be triggered by alert accumulation.
+            '''
       milestone: V2
       tests: ["alert_handler_esc_alert_accum"]
     }
@@ -32,7 +34,8 @@
       name: esc_timeout
       desc: '''
            Based on the smoke test, this test will focus on testing the escalation timeout
-           feature. So all the escalations in the test will be triggered by interrupt timeout.'''
+           feature. So all the escalations in the test will be triggered by interrupt timeout.
+           '''
       milestone: V2
       tests: ["alert_handler_esc_intr_timeout"]
     }
@@ -40,7 +43,8 @@
       name: entropy
       desc: '''
             Based on the smoke test, this test enables ping testing, and check if the ping feature
-            correctly pings all devices within certain period of time'''
+            correctly pings all devices within certain period of time.
+            '''
       milestone: V2
       tests: ["alert_handler_entropy"]
     }
@@ -48,49 +52,30 @@
       name: sig_int_fail
       desc: '''
             This test will randomly inject differential pair failures on alert tx/rx pairs and the
-            escalator tx/rx pairs. Then check if integrity failure alert is triggered and escalated'''
+            escalator tx/rx pairs. Then check if integrity failure alert is triggered and
+            escalated.
+            '''
       milestone: V2
       tests: ["alert_handler_sig_int_fail"]
-    }
-    {
-      name: ping_corner_cases
-      desc: '''
-            Based on the entropy test, this test will randomly inject ping timeout errors and ping
-            signal integrity errors on alert tx/rx or escalator tx/rx pairs.
-            Once a ping request is detected, the sequence will randomly execute one of the three
-            tasks:
-            - Interrupt the ping by a reset
-            - Inject alerts without any delay. This task attempts to hit the corner case where
-              esc ping is interrupted by real esc signal
-            - Let the ping response finish without any interruption. This taks attempts to hit the
-              ping timeout and ping signal integrity fail corner case
-            Then the sequence will read and check all the alert and esc status registers. Then
-            clear the interrupts.
-            Because alert_handler module's ping interval default value is relative long for
-            simulation, this test shortens this interval in order to hit all the corner cases in
-            a reasonable amount of run time. This test also disables ping related functional
-            coverage to ensure the original LFSR design is able to reach all the alerts and
-            escalators'''
-      milestone: V2
-      tests: ["alert_handler_ping_corner_cases"]
     }
     {
       name: clk_skew
       desc: '''
             This test will randomly inject clock skew within the differential pairs. Then check no
-            alert is raised'''
+            alert is raised.
+            '''
       milestone: V2
       tests: ["alert_handler_smoke"]
     }
     {
       name: random_alerts
-      desc: "Input random alerts and randomly write phase cycles"
+      desc: "Input random alerts and randomly write phase cycles."
       milestone: V2
       tests: ["alert_handler_random_alerts"]
     }
     {
       name: random_classes
-      desc: "Based on random_alerts test, this test will also randomly enable interrupt classes"
+      desc: "Based on random_alerts test, this test will also randomly enable interrupt classes."
       milestone: V2
       tests: ["alert_handler_random_classes"]
     }
@@ -99,7 +84,8 @@
       desc: '''
             Combine above sequences in one test to run sequentially with the following exclusions:
             - CSR sequences: scoreboard disabled
-            - Ping_corner_cases sequence: included reset in the sequence'''
+            - Ping_corner_cases sequence: included reset in the sequence
+            '''
       milestone: V2
       tests: ["alert_handler_stress_all"]
     }

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
@@ -81,17 +81,6 @@
       run_opts: ["+test_timeout_ns=10_000_000_000"]
     }
 
-    // zero_delays: avoid check_interrupts and ping response fail happened in the same cycle,
-    //   ensure alert triggers as soon as ping is detected
-    // reduece_ping_timer_wait_cycles: shorten the simulation time, also serves as a switch to turn
-    //   off certain checks and coverages
-    {
-      name: alert_handler_ping_corner_cases
-      uvm_test_seq: alert_handler_ping_corner_cases_vseq
-      run_opts: ["+reduce_ping_timer_wait_cycles=1", "+test_timeout_ns=1_000_000_000",
-                 "+zero_delays=1"]
-    }
-
     {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -90,9 +90,6 @@ module tb;
   );
 
   initial begin
-    static bit reduce_ping_timer_wait_cycles = 0;
-    void'($value$plusargs("reduce_ping_timer_wait_cycles=%0b", reduce_ping_timer_wait_cycles));
-    if (reduce_ping_timer_wait_cycles) force dut.u_ping_timer.wait_cyc_mask_i = 24'h3FFFF;
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);


### PR DESCRIPTION
This PR removes ping corner case in alert_handler testbench because they
are covered in prim_alert or prim_esc, and the related coverage are
excluded.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>