### PR TITLE
[dvsim] Add passing count by milestone in reports

### DIFF
--- a/util/dvsim/Testplan.py
+++ b/util/dvsim/Testplan.py
@@ -287,8 +287,9 @@ class Testplan():
         self.progress = {}
         for key in Testpoint.milestones:
             self.progress[key] = {
-                "written": 0,
                 "total": 0,
+                "written": 0,
+                "passing": 0,
                 "progress": 0.0,
             }
 
@@ -440,6 +441,8 @@ class Testplan():
                 # Compute the testplan progress.
                 self.progress[ms]["total"] += 1
                 if tr.total != 0:
+                    if tr.passing == tr.total:
+                        self.progress[ms]["passing"] += 1
                     self.progress[ms]["written"] += 1
 
                 # Compute the milestone total & the grand total.
@@ -500,7 +503,7 @@ class Testplan():
                 self.progress.pop(ms)
                 continue
 
-            stat["progress"] = self._get_percentage(stat["written"],
+            stat["progress"] = self._get_percentage(stat["passing"],
                                                     stat["total"])
 
         self.test_results_mapped = True
@@ -527,8 +530,9 @@ class Testplan():
                 written += 1
 
         self.progress["Covergroups"] = {
-            "written": written,
             "total": total,
+            "written": written,
+            "passing": written,
             "progress": self._get_percentage(written, total),
         }
 


### PR DESCRIPTION
This change adds passing count to the testplan progress table in the
generated report. The progress (%tage) is now computed as pass
percentage instead of written percentage. So if the test is written but
one or more seeds are failing, it will not be counted towards the
progress.

The table now looks like this (addition of 'passing' column):

### Testplan Progress
|  Items  |  Total  |  Written  |  Passing  |  Progress  |
|:-------:|:-------:|:---------:|:---------:|:----------:|
|   V1    |    6    |     6     |     6     |  100.00 %  |
|   V2    |   19    |    19     |    19     |  100.00 %  |
|   V3    |    1    |     1     |     1     |  100.00 %  |


Signed-off-by: Srikrishna Iyer <sriyer@google.com>