### PR TITLE
[top] Integrate ast into chip_earlgrey_verilator

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -44,6 +44,9 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
+  AST_BYPASS_CLK:
+    datatype: bool
+    paramtype: vlogdefine
 
 targets:
   default: &default_target
@@ -59,6 +62,7 @@ targets:
     default_tool: verilator
     parameters:
       - SYNTHESIS=true
+      - AST_BYPASS_CLK=true
     tools:
       verilator:
         mode: lint-only
@@ -73,6 +77,7 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
+      - AST_CLK_BYPASS=true
     toplevel: chip_earlgrey_asic
 
   formal:

--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -11,15 +11,25 @@ filesets:
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:ibex:ibex_tracer
       - lowrisc:prim:clock_div
+      - lowrisc:systems:ast
+      - lowrisc:systems:scan_role_pkg
 
     files:
       - rtl/chip_earlgrey_verilator.sv: { file_type: systemVerilogSource }
+
+parameters:
+  AST_BYPASS_CLK:
+    datatype: bool
+    paramtype: vlogdefine
 
 targets:
   default: &default_target
     filesets:
       - files_sim_verilator
+    parameters:
+      - AST_BYPASS_CLK=true
     toplevel: chip_earlgrey_verilator
+
 
   lint:
     <<: *default_target

--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -114,4 +114,3 @@ targets:
       vcs:
         vcs_options: [-timescale=1ns/1ps -l vcs.log]
     toplevel: ast
-

--- a/hw/top_earlgrey/ip/ast/rtl/rglts_pdm_3p3v.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/rglts_pdm_3p3v.sv
@@ -47,7 +47,8 @@ initial begin
   init_start = 1'b0;
 end
 
-always_ff @( init_start, posedge vcc_pok_h_i, negedge vcc_pok_h_i ) begin
+always_ff @( posedge init_start, negedge init_start,
+             posedge vcc_pok_h_i, negedge vcc_pok_h_i ) begin
   if ( init_start ) begin
     mr_vcc_dly <= 1'b0;
   end else if ( !init_start && vcc_pok_h_i ) begin
@@ -57,7 +58,9 @@ always_ff @( init_start, posedge vcc_pok_h_i, negedge vcc_pok_h_i ) begin
   end
 end
 
-always_ff @( init_start, vcc_pok_h_i,
+
+always_ff @( posedge init_start, negedge init_start,
+             posedge vcc_pok_h_i, negedge vcc_pok_h_i,
              posedge main_pd_h_ni, negedge main_pd_h_ni ) begin
   if ( init_start ) begin
     mr_pd_dly <= 1'b1;
@@ -77,6 +80,7 @@ vcaon_pgd u_vcaon_pok (
 );
 
 assign vcaon_pok_h_o = vcaon_pok_h && vcc_pok_h_i;
+
 
 `else  // of SYNTHESIS
 // SYNTHESUS/VERILATOR/LINTER/FPGA

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -15,6 +15,7 @@ module chip_earlgrey_verilator (
   // communication with UART
   input cio_uart_rx_p2d_i,
   output logic cio_uart_tx_d2p_o,
+  output logic cio_uart_tx_en_d2p_o,
 
   // communication with SPI
   input cio_spi_device_sck_p2d_i,
@@ -100,29 +101,25 @@ module chip_earlgrey_verilator (
   assign cio_uart_tx_d2p_o    = mio_out[33];
   assign cio_uart_tx_en_d2p_o = mio_oe[33];
 
-  // dummy ast connections
+
+  ////////////////////////////////
+  // AST - Custom for Verilator //
+  ////////////////////////////////
+  ast_pkg::ast_pwst_t ast_pwst;
+  ast_pkg::ast_pwst_t ast_pwst_h;
+
+  // pwrmgr interface
   pwrmgr_pkg::pwr_ast_req_t base_ast_pwr;
   pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
-  ast_pkg::ast_alert_req_t ast_base_alerts;
-  ast_pkg::ast_status_t ast_base_status;
 
-  assign ast_base_pwr.slow_clk_val = 1'b1;
-  assign ast_base_pwr.core_clk_val = base_ast_pwr.core_clk_en;
-  assign ast_base_pwr.io_clk_val   = base_ast_pwr.io_clk_en;
-  assign ast_base_pwr.usb_clk_val  = base_ast_pwr.usb_clk_en;
-  assign ast_base_pwr.main_pok     = base_ast_pwr.main_pd_n;
+  ast_pkg::ast_clks_t ast_base_clks;
 
-  ast_pkg::ast_dif_t silent_alert = '{
-                                       p: 1'b0,
-                                       n: 1'b1
-                                     };
+  // external clock comes in at a fixed position
+  logic ext_clk;
+  assign ext_clk = '0;
 
-  assign ast_base_alerts.alerts = {ast_pkg::NumAlerts{silent_alert}};
-  assign ast_base_status.io_pok = {ast_pkg::NumIoRails{1'b1}};
-
-  // the rst_ni pin only goes to AST
-  // the rest of the logic generates reset based on the 'pok' signal.
-  // for verilator purposes, make these two the same.
+  logic [ast_pkg::Pad2AstInWidth-1:0] pad2ast;
+  assign pad2ast = '0;
 
   logic clk_aon;
   // reset is not used below becuase verilator uses only sync resets
@@ -140,6 +137,217 @@ module chip_earlgrey_verilator (
     .test_en_i('0),
     .clk_o(clk_aon)
   );
+
+  ast_pkg::clks_osc_byp_t clks_osc_byp;
+  assign clks_osc_byp = '{
+    usb: clk_i,
+    sys: clk_i,
+    io:  clk_i,
+    aon: clk_aon
+  };
+
+  ///////////////////////////////////////
+  // AST - Common with other platforms //
+  ///////////////////////////////////////
+
+  // TLUL interface
+  tlul_pkg::tl_h2d_t base_ast_bus;
+  tlul_pkg::tl_d2h_t ast_base_bus;
+
+  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
+
+  // synchronization clocks / rests
+  clkmgr_pkg::clkmgr_out_t clkmgr_aon_clocks;
+  rstmgr_pkg::rstmgr_out_t rstmgr_aon_resets;
+
+  // monitored clock
+  logic sck_monitor;
+
+  // otp power sequence
+  otp_ctrl_pkg::otp_ast_req_t otp_ctrl_otp_ast_pwr_seq;
+  otp_ctrl_pkg::otp_ast_rsp_t otp_ctrl_otp_ast_pwr_seq_h;
+
+  logic usb_ref_pulse;
+  logic usb_ref_val;
+
+  // adc
+  ast_pkg::adc_ast_req_t adc_req;
+  ast_pkg::adc_ast_rsp_t adc_rsp;
+
+  // entropy source interface
+  // The entropy source pacakge definition should eventually be moved to es
+  entropy_src_pkg::entropy_src_rng_req_t es_rng_req;
+  entropy_src_pkg::entropy_src_rng_rsp_t es_rng_rsp;
+  logic es_rng_fips;
+
+  // entropy distribution network
+  edn_pkg::edn_req_t ast_edn_edn_req;
+  edn_pkg::edn_rsp_t ast_edn_edn_rsp;
+
+  // alerts interface
+  ast_pkg::ast_alert_rsp_t ast_alert_rsp;
+  ast_pkg::ast_alert_req_t ast_alert_req;
+
+  // Flash connections
+  lc_ctrl_pkg::lc_tx_t flash_bist_enable;
+  logic flash_power_down_h;
+  logic flash_power_ready_h;
+
+  // Life cycle clock bypass req/ack
+  lc_ctrl_pkg::lc_tx_t ast_clk_byp_req;
+  lc_ctrl_pkg::lc_tx_t ast_clk_byp_ack;
+
+  // DFT connections
+  logic scan_en;
+  lc_ctrl_pkg::lc_tx_t dft_en;
+  pinmux_pkg::dft_strap_test_req_t dft_strap_test;
+
+  // Debug connections
+  logic [ast_pkg::Ast2PadOutWidth-1:0] ast2pinmux;
+
+  // Jitter enable
+  logic jen;
+
+  // reset domain connections
+  import rstmgr_pkg::PowerDomains;
+  import rstmgr_pkg::DomainAonSel;
+  import rstmgr_pkg::Domain0Sel;
+
+  // AST does not use all clocks / resets forwarded to it
+  logic unused_slow_clk_en;
+  assign unused_slow_clk_en = base_ast_pwr.slow_clk_en;
+
+  logic unused_pwr_clamp;
+  assign unused_pwr_clamp = base_ast_pwr.pwr_clamp;
+
+  ast_pkg::ast_dif_t flash_alert;
+  ast_pkg::ast_dif_t otp_alert;
+  logic ast_init_done;
+
+
+  ast #(
+    .EntropyStreams(ast_pkg::EntropyStreams),
+    .AdcChannels(ast_pkg::AdcChannels),
+    .AdcDataWidth(ast_pkg::AdcDataWidth),
+    .UsbCalibWidth(ast_pkg::UsbCalibWidth),
+    .Ast2PadOutWidth(ast_pkg::Ast2PadOutWidth),
+    .Pad2AstInWidth(ast_pkg::Pad2AstInWidth)
+  ) u_ast (
+    // different between verilator and other platforms
+    .clk_ast_ext_i         ( clk_i ),
+    .por_ni                ( rst_ni ),
+    // USB IO Pull-up Calibration Setting
+    .usb_io_pu_cal_o       (  ),
+    // adc
+    .adc_a0_ai             ( '0 ),
+    .adc_a1_ai             ( '0 ),
+    // Direct short to PAD
+    .pad2ast_t0_ai         ( '0 ),
+    .pad2ast_t1_ai         ( '0 ),
+    .ast2pad_t0_ao         (  ),
+    .ast2pad_t1_ao         (  ),
+    // Memory configuration connections
+    .dpram_rmf_o           (  ),
+    .dpram_rml_o           (  ),
+    .spram_rm_o            (  ),
+    .sprgf_rm_o            (  ),
+    .sprom_rm_o            (  ),
+    // clocks' oschillator bypass for FPGA
+    .clk_osc_byp_i         ( clks_osc_byp ),
+
+
+    // clocks and resets supplied for detection
+    .sns_clks_i      ( clkmgr_aon_clocks    ),
+    .sns_rsts_i      ( rstmgr_aon_resets    ),
+    .sns_spi_ext_clk_i ( sck_monitor          ),
+    // tlul
+    .tl_i                  ( base_ast_bus ),
+    .tl_o                  ( ast_base_bus ),
+    // init done indication
+    .ast_init_done_o       ( ast_init_done ),
+    // buffered clocks & resets
+    .clk_ast_tlul_i (clkmgr_aon_clocks.clk_io_div4_secure),
+    .clk_ast_adc_i (clkmgr_aon_clocks.clk_aon_secure),
+    .clk_ast_alert_i (clkmgr_aon_clocks.clk_io_div4_secure),
+    .clk_ast_es_i (clkmgr_aon_clocks.clk_main_secure),
+    .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
+    .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
+    .rst_ast_tlul_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_es_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_rng_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_usb_ni (rstmgr_aon_resets.rst_usbif_n[rstmgr_pkg::Domain0Sel]),
+
+    // pok test for FPGA
+    .vcc_supp_i            ( 1'b1 ),
+    .vcaon_supp_i          ( 1'b1 ),
+    .vcmain_supp_i         ( 1'b1 ),
+    .vioa_supp_i           ( 1'b1 ),
+    .viob_supp_i           ( 1'b1 ),
+    // pok
+    .ast_pwst_o            ( ast_pwst ),
+    .ast_pwst_h_o          ( ast_pwst_h ),
+    // main regulator
+    .main_env_iso_en_i     ( base_ast_pwr.pwr_clamp_env ),
+    .main_pd_ni            ( base_ast_pwr.main_pd_n ),
+    // pdm control (flash)/otp
+    .flash_power_down_h_o  ( flash_power_down_h ),
+    .flash_power_ready_h_o ( flash_power_ready_h ),
+    .otp_power_seq_i       ( otp_ctrl_otp_ast_pwr_seq ),
+    .otp_power_seq_h_o     ( otp_ctrl_otp_ast_pwr_seq_h ),
+    // system source clock
+    .clk_src_sys_en_i      ( base_ast_pwr.core_clk_en ),
+    // need to add function in clkmgr
+    .clk_src_sys_jen_i     ( jen ),
+    .clk_src_sys_o         ( ast_base_clks.clk_sys  ),
+    .clk_src_sys_val_o     ( ast_base_pwr.core_clk_val ),
+    // aon source clock
+    .clk_src_aon_o         ( ast_base_clks.clk_aon ),
+    .clk_src_aon_val_o     ( ast_base_pwr.slow_clk_val ),
+    // io source clock
+    .clk_src_io_en_i       ( base_ast_pwr.io_clk_en ),
+    .clk_src_io_o          ( ast_base_clks.clk_io ),
+    .clk_src_io_val_o      ( ast_base_pwr.io_clk_val ),
+    // usb source clock
+    .usb_ref_pulse_i       ( usb_ref_pulse ),
+    .usb_ref_val_i         ( usb_ref_val ),
+    .clk_src_usb_en_i      ( base_ast_pwr.usb_clk_en ),
+    .clk_src_usb_o         ( ast_base_clks.clk_usb ),
+    .clk_src_usb_val_o     ( ast_base_pwr.usb_clk_val ),
+    // adc
+    .adc_pd_i              ( adc_req.pd ),
+    .adc_chnsel_i          ( adc_req.channel_sel ),
+    .adc_d_o               ( adc_rsp.data ),
+    .adc_d_val_o           ( adc_rsp.data_valid ),
+    // rng
+    .rng_en_i              ( es_rng_req.rng_enable ),
+    .rng_fips_i            ( es_rng_fips ),
+    .rng_val_o             ( es_rng_rsp.rng_valid ),
+    .rng_b_o               ( es_rng_rsp.rng_b ),
+    // entropy
+    .entropy_rsp_i         ( ast_edn_edn_rsp ),
+    .entropy_req_o         ( ast_edn_edn_req ),
+    // alerts
+    .fla_alert_src_i       ( flash_alert    ),
+    .otp_alert_src_i       ( otp_alert      ),
+    .alert_rsp_i           ( ast_alert_rsp  ),
+    .alert_req_o           ( ast_alert_req  ),
+    // dft
+    .dft_strap_test_i      ( dft_strap_test   ),
+    .lc_dft_en_i           ( dft_en           ),
+    // pinmux related
+    .padmux2ast_i          ( pad2ast    ),
+    .ast2padmux_o          ( ast2pinmux ),
+    .lc_clk_byp_req_i      ( ast_clk_byp_req   ),
+    .lc_clk_byp_ack_o      ( ast_clk_byp_ack   ),
+    .flash_bist_en_o       ( flash_bist_enable ),
+    // scan
+    .dft_scan_md_o         ( scanmode ),
+    .scan_shift_en_o       ( scan_en ),
+    .scan_reset_no         ( scan_rst_n )
+  );
+
 
   // TODO: generate these indices from the target-specific
   // pinout configuration. But first, this verilator top needs
@@ -170,41 +378,63 @@ module chip_earlgrey_verilator (
   };
 
   lc_ctrl_pkg::lc_tx_t lc_clk_bypass;
+
+
   // Top-level design
+
+  logic [rstmgr_pkg::PowerDomains-1:0] por_n;
+  assign por_n = {ast_pwst.main_pok, ast_pwst.aon_pok};
+
   top_earlgrey #(
     .SramCtrlRetAonInstrExec(0),
     .SramCtrlMainInstrExec(1),
     .PinmuxAonTargetCfg(PinmuxTargetCfg)
   ) top_earlgrey (
-    .por_n_i                      ( {rst_ni, rst_ni} ),
+    // update por / reset connections, this is not quite right here
+    .por_n_i                      (por_n             ),
     .clk_main_i                   (clk_i             ),
     .clk_io_i                     (clk_i             ),
     .clk_usb_i                    (clk_i             ),
     .clk_aon_i                    (clk_aon           ),
-    .clks_ast_o                   (                  ),
-    .rsts_ast_o                   (                  ),
+    // change the above
+    .clks_ast_o                   (clkmgr_aon_clocks ),
+    .clk_main_jitter_en_o         ( jen              ),
+    .rsts_ast_o                   ( rstmgr_aon_resets),
+    .sck_monitor_o                ( sck_monitor      ),
     .pwrmgr_ast_req_o             ( base_ast_pwr     ),
     .pwrmgr_ast_rsp_i             ( ast_base_pwr     ),
-    .sensor_ctrl_ast_alert_req_i  ( ast_base_alerts  ),
-    .sensor_ctrl_ast_alert_rsp_o  (                  ),
-    .sensor_ctrl_ast_status_i     ( ast_base_status  ),
-    .usbdev_usb_ref_val_o         (                  ),
-    .usbdev_usb_ref_pulse_o       (                  ),
-    .ast_tl_req_o                 (                  ),
-    .ast_tl_rsp_i                 ( '0               ),
-    .ast_edn_req_i                ( '0               ),
-    .ast_edn_rsp_o                (                  ),
-    .otp_ctrl_otp_ast_pwr_seq_o   (                  ),
-    .otp_ctrl_otp_ast_pwr_seq_h_i ( '0               ),
-    .flash_bist_enable_i          ( lc_ctrl_pkg::Off ),
-    .flash_power_down_h_i         ( 1'b0             ),
-    .flash_power_ready_h_i        ( 1'b1             ),
-    // Need to model this logic at some point, otherwise entropy
-    // on verilator will hang
-    .es_rng_req_o                 (                  ),
-    .es_rng_rsp_i                 ( '0               ),
-    .ast_clk_byp_req_o            ( lc_clk_bypass    ),
-    .ast_clk_byp_ack_i            ( lc_clk_bypass    ),
+    .sensor_ctrl_ast_alert_req_i  ( ast_alert_req    ),
+    .sensor_ctrl_ast_alert_rsp_o  ( ast_alert_rsp    ),
+    .sensor_ctrl_ast_status_i     ( ast_pwst.io_pok  ),
+    .usbdev_usb_ref_val_o         ( usb_ref_pulse    ),
+    .usbdev_usb_ref_pulse_o       ( usb_ref_val      ),
+    .ast_tl_req_o                 ( base_ast_bus     ),
+    .ast_tl_rsp_i                 ( ast_base_bus     ),
+    .adc_req_o                    ( adc_req          ),
+    .adc_rsp_i                    ( adc_rsp          ),
+    .ast_edn_req_i                ( ast_edn_edn_req  ),
+    .ast_edn_rsp_o                ( ast_edn_edn_rsp  ),
+    .otp_ctrl_otp_ast_pwr_seq_o   ( otp_ctrl_otp_ast_pwr_seq   ),
+    .otp_ctrl_otp_ast_pwr_seq_h_i ( otp_ctrl_otp_ast_pwr_seq_h ),
+    .otp_alert_o                  ( otp_alert                  ),
+    .flash_bist_enable_i          ( flash_bist_enable          ),
+    .flash_power_down_h_i         ( flash_power_down_h         ),
+    .flash_power_ready_h_i        ( flash_power_ready_h        ),
+    .flash_alert_o                ( flash_alert                ),
+    .es_rng_req_o                 ( es_rng_req                 ),
+    .es_rng_rsp_i                 ( es_rng_rsp                 ),
+    .es_rng_fips_o                ( es_rng_fips                ),
+    .ast_clk_byp_req_o            ( ast_clk_byp_req            ),
+    .ast_clk_byp_ack_i            ( ast_clk_byp_ack            ),
+    .ast2pinmux_i                 ( ast2pinmux                 ),
+    .ast_init_done_i              ( ast_init_done              ),
+
+    // Flash test mode voltages
+    .flash_test_mode_a_io         ( ),
+    .flash_test_voltage_h_io      ( ),
+
+    // OTP external voltage
+    .otp_ext_voltage_h_io         ( ),
 
     // Multiplexed I/O
     .mio_in_i                     (mio_in),
@@ -221,14 +451,18 @@ module chip_earlgrey_verilator (
     .dio_attr_o                   ( ),
 
     // Memory attributes
+    // This is different between verilator and the rest of the platforms right now
     .ram_1p_cfg_i                 ('0),
     .ram_2p_cfg_i                 ('0),
     .rom_cfg_i                    ('0),
 
     // DFT signals
-    .scan_rst_ni                  (1'b1),
-    .scan_en_i                    (1'b0),
-    .scanmode_i                   (lc_ctrl_pkg::Off)
+    .ast_lc_dft_en_o              ( dft_en                     ),
+    .dft_strap_test_o             ( dft_strap_test             ),
+    .dft_hold_tap_sel_i           ( '0                         ),
+    .scan_rst_ni                  ( scan_rst_n                 ),
+    .scan_en_i                    ( scan_en                    ),
+    .scanmode_i                   ( scanmode                   )
   );
 
 endmodule : chip_earlgrey_verilator


### PR DESCRIPTION
- This is a preparatory step for #7349 and eventual common chip level template
- SYNTHESIS is replaced with AST_BYPASS_CLK inside the oscillator modules
  because verilator sims are not actually "synthesis". There are other parameters in the system that depend on the SYNTHESIS flag not being set.
- Verilator also does not accept mixed style always statements, so make some minor tweaks to adjust for that.
- Lastly, verilator does not support "timed delays" (it only works on clock edges), so the initial blocks with delays have no impact.  It seems we can get away with this for now based on results, but it is something to keep an eye on. 

Signed-off-by: Timothy Chen <timothytim@google.com>