### PR TITLE
[flash_ctrl/dv] Add callback sequence hook and mechanism

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -24,6 +24,7 @@ filesets:
       - flash_ctrl_scoreboard.sv: {is_include_file: true}
       - flash_ctrl_env.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_vseq_list.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_callback_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_base_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_common_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_rand_ops_base_vseq.sv: {is_include_file: true}

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -18,6 +18,21 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
+  
+  // Vseq to do some initial post-reset actions. Can be overriden by extending envs.
+  flash_ctrl_callback_vseq callback_vseq;
+
+  virtual task pre_start();
+    `uvm_create_on(callback_vseq, p_sequencer);
+    super.pre_start();
+  endtask
+
+  // After finishing basic dut_init do some additional required actions with callback_vseq
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    callback_vseq.dut_init_callback();
+  endtask : dut_init
+
   virtual task dut_shutdown();
     // check for pending flash_ctrl operations and wait for them to complete
     // TODO

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_callback_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_callback_vseq.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence hook to attach to flash_ctrl_base_vseq.
+class flash_ctrl_callback_vseq extends cip_base_vseq #(
+    .RAL_T               (flash_ctrl_core_reg_block),
+    .CFG_T               (flash_ctrl_env_cfg),
+    .COV_T               (flash_ctrl_env_cov),
+    .VIRTUAL_SEQUENCER_T (flash_ctrl_virtual_sequencer)
+  );
+  `uvm_object_utils(flash_ctrl_callback_vseq)
+  `uvm_object_new
+
+  virtual task dut_init_callback();
+    // Do nothing but can be overridden in closed source environment.
+  endtask
+
+endclass : flash_ctrl_callback_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "flash_ctrl_callback_vseq.sv"
 `include "flash_ctrl_base_vseq.sv"
 `include "flash_ctrl_common_vseq.sv"
 `include "flash_ctrl_rand_ops_base_vseq.sv"


### PR DESCRIPTION
Hi,
Adding callback vseq exactly the same as in the OTP.
In the flash it's needed for some flash_shim registers configuration that should be done after reset.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>