### PR TITLE
[otbn] Add testplan entry for lifecycle escalations

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -87,5 +87,13 @@
       milestone: V2
       tests: []
     }
+    {
+      name: lc_escalation
+      desc: '''
+            Trigger the life cycle escalation input.
+            '''
+      milestone: V2
+      tests: []
+    }
   ]
 }

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -587,7 +587,7 @@ Errors which could be caused by a programmer's mistake are typically considered 
 The description of the {{< regref "ERR_BITS" >}} register lists all possible error causes; those prefixed with `fatal_` are fatal errors.
 
 Recoverable errors terminate the currently active OTBN operation and return control to the host CPU.
-Fatal errors render OTBN unusable until it is reset.
+Fatal errors lock OTBN until it is reset.
 
 ### Recoverable Errors {#design-details-recoverable-errors}
 

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -859,7 +859,9 @@ Depending on the application additional steps might be necessary, such as deleti
 
 ## Driver {#driver}
 
-A higher-level driver for the OTBN block is available at `sw/device/lib/runtime/otbn.h` ([API documentation](/sw/apis/otbn_8h.html)).
+A higher-level driver for the OTBN block is available at `sw/device/lib/runtime/otbn.h` ([API documentation](/sw/apis/lib_2runtime_2otbn_8h.html)).
+
+Another driver for OTBN is part of the silicon creator code at `sw/device/silicon_creator/lib/drivers/otbn.h`.
 
 ## Register Table
 

--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -373,7 +373,7 @@ The instruction-specific covergroup is `insn_log_binop_cg` (shared with other lo
 This instruction uses the `I` encoding schema, with covergroup `enc_i_cg`.
 The instruction-specific covergroup is `insn_xw_cg` (shared with `SW`).
 
-- Load from a valid address, where `<grs1>` is above the top of memory and a negative `<offset>` brings the load address in range. 
+- Load from a valid address, where `<grs1>` is above the top of memory and a negative `<offset>` brings the load address in range.
   Tracked as `oob_base_neg_off_cross`.
 - Load from a valid address, where `<grs1>` is negative and a positive `<offset>` brings the load address in range.
   Tracked as `neg_base_pos_off_cross`.


### PR DESCRIPTION
The life cycle escalation input wasn't covered by the test plan yet, add a dedicated test for it (since it is a dedicated input to the module).

This PR also includes two minor improvements to the OTBN spec which are not strictly related, but small enough to include here.