### PR TITLE
[rstmgr] Convert multireg use of regen to regwen_multi

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -261,15 +261,16 @@
 
     { multireg: {
         cname: "RSTMGR_SW_RST",
-        name:  "SW_RST_REGEN",
+        name:  "SW_RST_REGWEN",
         desc:  '''
           Register write enable for software controllable resets.
-          When a particular bit value is 0, the corresponding value in !!SW_RST_CTRL_N can no longer be changed.
-          When a particular bit value is 1, the corresponding value in !!SW_RST_CTRL_N can be changed.
+          When a particular bit value is 0, the corresponding value in !!SW_RST_CTRL_N0 can no longer be changed.
+          When a particular bit value is 1, the corresponding value in !!SW_RST_CTRL_N0 can be changed.
         ''',
         count: "NumSwResets",
         swaccess: "rw0c",
-        hwaccess: "hro",
+        hwaccess: "none",
+        compact: false,
         fields: [
           {
             bits: "0",
@@ -286,6 +287,9 @@
     { multireg: {
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_CTRL_N",
+        regwen: "SW_RST_REGWEN",
+        compact: false,
+        regwen_multi: true,
         desc:  '''
           Software controllable resets.
           When a particular bit value is 0, the corresponding module is held in reset.
@@ -293,9 +297,7 @@
         ''',
         count: "NumSwResets",
         swaccess: "rw",
-        hwaccess: "hrw",
-        hwext: "true",
-        hwqe: "true",
+        hwaccess: "hro",
         fields: [
           {
             bits: "0",

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -370,6 +370,10 @@ module rstmgr
   logic dump_capture;
   assign dump_capture =  rst_hw_req | rst_ndm | rst_low_power;
 
+  // halt dump capture once we hit particular conditions
+  logic dump_capture_halt;
+  assign dump_capture_halt = rst_hw_req;
+
   rstmgr_crash_info #(
     .CrashDumpWidth($bits(alert_pkg::alert_crashdump_t))
   ) u_alert_info (
@@ -397,9 +401,9 @@ module rstmgr
   // once dump is captured, no more information is captured until
   // re-eanbled by software.
   assign hw2reg.alert_info_ctrl.en.d  = 1'b0;
-  assign hw2reg.alert_info_ctrl.en.de = dump_capture;
+  assign hw2reg.alert_info_ctrl.en.de = dump_capture_halt;
   assign hw2reg.cpu_info_ctrl.en.d  = 1'b0;
-  assign hw2reg.cpu_info_ctrl.en.de = dump_capture;
+  assign hw2reg.cpu_info_ctrl.en.de = dump_capture_halt;
 
   ////////////////////////////////////////////////////
   // Exported resets                                //

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -222,30 +222,6 @@ module rstmgr
   assign pwr_o.rst_lc_src_n = rst_lc_src_n;
   assign pwr_o.rst_sys_src_n = rst_sys_src_n;
 
-
-  ////////////////////////////////////////////////////
-  // Software reset controls external reg           //
-  ////////////////////////////////////////////////////
-  logic [NumSwResets-1:0] sw_rst_ctrl_n;
-
-  for (genvar i=0; i < NumSwResets; i++) begin : gen_sw_rst_ext_regs
-    prim_subreg #(
-      .DW(1),
-      .SwAccess(prim_subreg_pkg::SwAccessRW),
-      .RESVAL(1)
-    ) u_rst_sw_ctrl_reg (
-      .clk_i,
-      .rst_ni,
-      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regen[i]),
-      .wd(reg2hw.sw_rst_ctrl_n[i].q),
-      .de('0),
-      .d('0),
-      .qe(),
-      .q(sw_rst_ctrl_n[i]),
-      .qs(hw2reg.sw_rst_ctrl_n[i].d)
-    );
-  end
-
   ////////////////////////////////////////////////////
   // leaf reset in the system                       //
   // These should all be generated                  //
@@ -284,7 +260,7 @@ module rstmgr
     .clk_i(clk_${rst.clock.name}_i),
     .rst_ni(rst_${rst.parent}_n[Domain${domain}Sel]),
         % if rst.sw:
-    .d_i(sw_rst_ctrl_n[${rst.name.upper()}]),
+    .d_i(reg2hw.sw_rst_ctrl_n[${rst.name.upper()}]),
         % else:
     .d_i(1'b1),
         % endif

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -36,7 +36,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     send_reset(pwrmgr_pkg::LowPwrEntry, rstreqs);
     csr_rd_check(.ptr(ral.reset_info), .compare_value(32'h2),
                  .err_msg("Expected reset info to indicate low power"));
-    check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b0);
+    check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
 
     // Clear reset_info register.
     csr_wr(.ptr(ral.reset_info), .value('1));
@@ -64,7 +64,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     send_ndm_reset();
     csr_rd_check(.ptr(ral.reset_info), .compare_value(32'h4),
                  .err_msg("Expected reset_info to indicate ndm reset"));
-    check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b0);
+    check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
 
     // Clear reset_info register.
     csr_wr(.ptr(ral.reset_info), .value('1));

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -339,15 +339,16 @@
 
     { multireg: {
         cname: "RSTMGR_SW_RST",
-        name:  "SW_RST_REGEN",
+        name:  "SW_RST_REGWEN",
         desc:  '''
           Register write enable for software controllable resets.
-          When a particular bit value is 0, the corresponding value in !!SW_RST_CTRL_N can no longer be changed.
-          When a particular bit value is 1, the corresponding value in !!SW_RST_CTRL_N can be changed.
+          When a particular bit value is 0, the corresponding value in !!SW_RST_CTRL_N0 can no longer be changed.
+          When a particular bit value is 1, the corresponding value in !!SW_RST_CTRL_N0 can be changed.
         ''',
         count: "NumSwResets",
         swaccess: "rw0c",
-        hwaccess: "hro",
+        hwaccess: "none",
+        compact: false,
         fields: [
           {
             bits: "0",
@@ -364,6 +365,9 @@
     { multireg: {
         cname: "RSTMGR_SW_RST",
         name:  "SW_RST_CTRL_N",
+        regwen: "SW_RST_REGWEN",
+        compact: false,
+        regwen_multi: true,
         desc:  '''
           Software controllable resets.
           When a particular bit value is 0, the corresponding module is held in reset.
@@ -371,9 +375,7 @@
         ''',
         count: "NumSwResets",
         swaccess: "rw",
-        hwaccess: "hrw",
-        hwext: "true",
-        hwqe: "true",
+        hwaccess: "hro",
         fields: [
           {
             bits: "0",

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -1004,6 +1004,10 @@ module rstmgr
   logic dump_capture;
   assign dump_capture =  rst_hw_req | rst_ndm | rst_low_power;
 
+  // halt dump capture once we hit particular conditions
+  logic dump_capture_halt;
+  assign dump_capture_halt = rst_hw_req;
+
   rstmgr_crash_info #(
     .CrashDumpWidth($bits(alert_pkg::alert_crashdump_t))
   ) u_alert_info (
@@ -1031,9 +1035,9 @@ module rstmgr
   // once dump is captured, no more information is captured until
   // re-eanbled by software.
   assign hw2reg.alert_info_ctrl.en.d  = 1'b0;
-  assign hw2reg.alert_info_ctrl.en.de = dump_capture;
+  assign hw2reg.alert_info_ctrl.en.de = dump_capture_halt;
   assign hw2reg.cpu_info_ctrl.en.d  = 1'b0;
-  assign hw2reg.cpu_info_ctrl.en.de = dump_capture;
+  assign hw2reg.cpu_info_ctrl.en.de = dump_capture_halt;
 
   ////////////////////////////////////////////////////
   // Exported resets                                //

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -228,30 +228,6 @@ module rstmgr
   assign pwr_o.rst_lc_src_n = rst_lc_src_n;
   assign pwr_o.rst_sys_src_n = rst_sys_src_n;
 
-
-  ////////////////////////////////////////////////////
-  // Software reset controls external reg           //
-  ////////////////////////////////////////////////////
-  logic [NumSwResets-1:0] sw_rst_ctrl_n;
-
-  for (genvar i=0; i < NumSwResets; i++) begin : gen_sw_rst_ext_regs
-    prim_subreg #(
-      .DW(1),
-      .SwAccess(prim_subreg_pkg::SwAccessRW),
-      .RESVAL(1)
-    ) u_rst_sw_ctrl_reg (
-      .clk_i,
-      .rst_ni,
-      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regen[i]),
-      .wd(reg2hw.sw_rst_ctrl_n[i].q),
-      .de('0),
-      .d('0),
-      .qe(),
-      .q(sw_rst_ctrl_n[i]),
-      .qs(hw2reg.sw_rst_ctrl_n[i].d)
-    );
-  end
-
   ////////////////////////////////////////////////////
   // leaf reset in the system                       //
   // These should all be generated                  //
@@ -695,7 +671,7 @@ module rstmgr
   ) u_0_spi_device (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[SPI_DEVICE]),
+    .d_i(reg2hw.sw_rst_ctrl_n[SPI_DEVICE]),
     .q_o(rst_spi_device_n[Domain0Sel])
   );
 
@@ -721,7 +697,7 @@ module rstmgr
   ) u_0_spi_host0 (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[SPI_HOST0]),
+    .d_i(reg2hw.sw_rst_ctrl_n[SPI_HOST0]),
     .q_o(rst_spi_host0_n[Domain0Sel])
   );
 
@@ -747,7 +723,7 @@ module rstmgr
   ) u_0_spi_host0_core (
     .clk_i(clk_io_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[SPI_HOST0_CORE]),
+    .d_i(reg2hw.sw_rst_ctrl_n[SPI_HOST0_CORE]),
     .q_o(rst_spi_host0_core_n[Domain0Sel])
   );
 
@@ -773,7 +749,7 @@ module rstmgr
   ) u_0_spi_host1 (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[SPI_HOST1]),
+    .d_i(reg2hw.sw_rst_ctrl_n[SPI_HOST1]),
     .q_o(rst_spi_host1_n[Domain0Sel])
   );
 
@@ -799,7 +775,7 @@ module rstmgr
   ) u_0_spi_host1_core (
     .clk_i(clk_io_div2_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[SPI_HOST1_CORE]),
+    .d_i(reg2hw.sw_rst_ctrl_n[SPI_HOST1_CORE]),
     .q_o(rst_spi_host1_core_n[Domain0Sel])
   );
 
@@ -825,7 +801,7 @@ module rstmgr
   ) u_0_usb (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[USB]),
+    .d_i(reg2hw.sw_rst_ctrl_n[USB]),
     .q_o(rst_usb_n[Domain0Sel])
   );
 
@@ -851,7 +827,7 @@ module rstmgr
   ) u_0_usbif (
     .clk_i(clk_usb_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[USBIF]),
+    .d_i(reg2hw.sw_rst_ctrl_n[USBIF]),
     .q_o(rst_usbif_n[Domain0Sel])
   );
 
@@ -877,7 +853,7 @@ module rstmgr
   ) u_0_i2c0 (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[I2C0]),
+    .d_i(reg2hw.sw_rst_ctrl_n[I2C0]),
     .q_o(rst_i2c0_n[Domain0Sel])
   );
 
@@ -903,7 +879,7 @@ module rstmgr
   ) u_0_i2c1 (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[I2C1]),
+    .d_i(reg2hw.sw_rst_ctrl_n[I2C1]),
     .q_o(rst_i2c1_n[Domain0Sel])
   );
 
@@ -929,7 +905,7 @@ module rstmgr
   ) u_0_i2c2 (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_sys_src_n[Domain0Sel]),
-    .d_i(sw_rst_ctrl_n[I2C2]),
+    .d_i(reg2hw.sw_rst_ctrl_n[I2C2]),
     .q_o(rst_i2c2_n[Domain0Sel])
   );
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -14,7 +14,7 @@ package rstmgr_reg_pkg;
   parameter int NumAlerts = 1;
 
   // Address widths within the block
-  parameter int BlockAw = 6;
+  parameter int BlockAw = 7;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -51,11 +51,6 @@ package rstmgr_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } rstmgr_reg2hw_sw_rst_regen_mreg_t;
-
-  typedef struct packed {
-    logic        q;
-    logic        qe;
   } rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t;
 
   typedef struct packed {
@@ -103,45 +98,57 @@ package rstmgr_reg_pkg;
     logic [31:0] d;
   } rstmgr_hw2reg_cpu_info_reg_t;
 
-  typedef struct packed {
-    logic        d;
-  } rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t;
-
   // Register -> HW type
   typedef struct packed {
-    rstmgr_reg2hw_alert_test_reg_t alert_test; // [45:44]
-    rstmgr_reg2hw_reset_info_reg_t reset_info; // [43:40]
-    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [39:35]
-    rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [34:30]
-    rstmgr_reg2hw_sw_rst_regen_mreg_t [9:0] sw_rst_regen; // [29:20]
-    rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [19:0]
+    rstmgr_reg2hw_alert_test_reg_t alert_test; // [25:24]
+    rstmgr_reg2hw_reset_info_reg_t reset_info; // [23:20]
+    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [19:15]
+    rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [14:10]
+    rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [9:0]
   } rstmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [94:86]
-    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [85:84]
-    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [83:80]
-    rstmgr_hw2reg_alert_info_reg_t alert_info; // [79:48]
-    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [47:46]
-    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [45:42]
-    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [41:10]
-    rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [9:0]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [84:76]
+    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [75:74]
+    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [73:70]
+    rstmgr_hw2reg_alert_info_reg_t alert_info; // [69:38]
+    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [37:36]
+    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [35:32]
+    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [31:0]
   } rstmgr_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_TEST_OFFSET = 6'h 0;
-  parameter logic [BlockAw-1:0] RSTMGR_RESET_INFO_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_REGWEN_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_REGWEN_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_CTRL_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_ATTR_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGEN_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_TEST_OFFSET = 7'h 0;
+  parameter logic [BlockAw-1:0] RSTMGR_RESET_INFO_OFFSET = 7'h 4;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_REGWEN_OFFSET = 7'h 8;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 7'h c;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 7'h 10;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_OFFSET = 7'h 14;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_REGWEN_OFFSET = 7'h 18;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_CTRL_OFFSET = 7'h 1c;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_ATTR_OFFSET = 7'h 20;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_0_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_1_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_2_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_3_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_4_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_5_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_6_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_7_OFFSET = 7'h 44;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_8_OFFSET = 7'h 48;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_9_OFFSET = 7'h 4c;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_0_OFFSET = 7'h 50;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_1_OFFSET = 7'h 54;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_2_OFFSET = 7'h 58;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_3_OFFSET = 7'h 5c;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_4_OFFSET = 7'h 60;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_5_OFFSET = 7'h 64;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_6_OFFSET = 7'h 68;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_7_OFFSET = 7'h 6c;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_8_OFFSET = 7'h 70;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_9_OFFSET = 7'h 74;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] RSTMGR_ALERT_TEST_RESVAL = 1'h 0;
@@ -154,17 +161,6 @@ package rstmgr_reg_pkg;
   parameter logic [3:0] RSTMGR_CPU_INFO_ATTR_CNT_AVAIL_RESVAL = 4'h 0;
   parameter logic [31:0] RSTMGR_CPU_INFO_RESVAL = 32'h 0;
   parameter logic [31:0] RSTMGR_CPU_INFO_VALUE_RESVAL = 32'h 0;
-  parameter logic [9:0] RSTMGR_SW_RST_CTRL_N_RESVAL = 10'h 3ff;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_0_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_1_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_2_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_3_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_4_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_5_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_6_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_7_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_8_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_9_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -178,12 +174,30 @@ package rstmgr_reg_pkg;
     RSTMGR_CPU_INFO_CTRL,
     RSTMGR_CPU_INFO_ATTR,
     RSTMGR_CPU_INFO,
-    RSTMGR_SW_RST_REGEN,
-    RSTMGR_SW_RST_CTRL_N
+    RSTMGR_SW_RST_REGWEN_0,
+    RSTMGR_SW_RST_REGWEN_1,
+    RSTMGR_SW_RST_REGWEN_2,
+    RSTMGR_SW_RST_REGWEN_3,
+    RSTMGR_SW_RST_REGWEN_4,
+    RSTMGR_SW_RST_REGWEN_5,
+    RSTMGR_SW_RST_REGWEN_6,
+    RSTMGR_SW_RST_REGWEN_7,
+    RSTMGR_SW_RST_REGWEN_8,
+    RSTMGR_SW_RST_REGWEN_9,
+    RSTMGR_SW_RST_CTRL_N_0,
+    RSTMGR_SW_RST_CTRL_N_1,
+    RSTMGR_SW_RST_CTRL_N_2,
+    RSTMGR_SW_RST_CTRL_N_3,
+    RSTMGR_SW_RST_CTRL_N_4,
+    RSTMGR_SW_RST_CTRL_N_5,
+    RSTMGR_SW_RST_CTRL_N_6,
+    RSTMGR_SW_RST_CTRL_N_7,
+    RSTMGR_SW_RST_CTRL_N_8,
+    RSTMGR_SW_RST_CTRL_N_9
   } rstmgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RSTMGR_PERMIT [12] = '{
+  parameter logic [3:0] RSTMGR_PERMIT [30] = '{
     4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
     4'b 0001, // index[ 1] RSTMGR_RESET_INFO
     4'b 0001, // index[ 2] RSTMGR_ALERT_REGWEN
@@ -194,8 +208,26 @@ package rstmgr_reg_pkg;
     4'b 0001, // index[ 7] RSTMGR_CPU_INFO_CTRL
     4'b 0001, // index[ 8] RSTMGR_CPU_INFO_ATTR
     4'b 1111, // index[ 9] RSTMGR_CPU_INFO
-    4'b 0011, // index[10] RSTMGR_SW_RST_REGEN
-    4'b 0011  // index[11] RSTMGR_SW_RST_CTRL_N
+    4'b 0001, // index[10] RSTMGR_SW_RST_REGWEN_0
+    4'b 0001, // index[11] RSTMGR_SW_RST_REGWEN_1
+    4'b 0001, // index[12] RSTMGR_SW_RST_REGWEN_2
+    4'b 0001, // index[13] RSTMGR_SW_RST_REGWEN_3
+    4'b 0001, // index[14] RSTMGR_SW_RST_REGWEN_4
+    4'b 0001, // index[15] RSTMGR_SW_RST_REGWEN_5
+    4'b 0001, // index[16] RSTMGR_SW_RST_REGWEN_6
+    4'b 0001, // index[17] RSTMGR_SW_RST_REGWEN_7
+    4'b 0001, // index[18] RSTMGR_SW_RST_REGWEN_8
+    4'b 0001, // index[19] RSTMGR_SW_RST_REGWEN_9
+    4'b 0001, // index[20] RSTMGR_SW_RST_CTRL_N_0
+    4'b 0001, // index[21] RSTMGR_SW_RST_CTRL_N_1
+    4'b 0001, // index[22] RSTMGR_SW_RST_CTRL_N_2
+    4'b 0001, // index[23] RSTMGR_SW_RST_CTRL_N_3
+    4'b 0001, // index[24] RSTMGR_SW_RST_CTRL_N_4
+    4'b 0001, // index[25] RSTMGR_SW_RST_CTRL_N_5
+    4'b 0001, // index[26] RSTMGR_SW_RST_CTRL_N_6
+    4'b 0001, // index[27] RSTMGR_SW_RST_CTRL_N_7
+    4'b 0001, // index[28] RSTMGR_SW_RST_CTRL_N_8
+    4'b 0001  // index[29] RSTMGR_SW_RST_CTRL_N_9
   };
 
 endpackage

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -24,7 +24,7 @@ module rstmgr_reg_top (
 
   import rstmgr_reg_pkg::* ;
 
-  localparam int AW = 6;
+  localparam int AW = 7;
   localparam int DW = 32;
   localparam int DBW = DW/8;                    // Byte Width
 
@@ -143,49 +143,66 @@ module rstmgr_reg_top (
   logic [3:0] cpu_info_attr_qs;
   logic cpu_info_re;
   logic [31:0] cpu_info_qs;
-  logic sw_rst_regen_we;
-  logic sw_rst_regen_en_0_qs;
-  logic sw_rst_regen_en_0_wd;
-  logic sw_rst_regen_en_1_qs;
-  logic sw_rst_regen_en_1_wd;
-  logic sw_rst_regen_en_2_qs;
-  logic sw_rst_regen_en_2_wd;
-  logic sw_rst_regen_en_3_qs;
-  logic sw_rst_regen_en_3_wd;
-  logic sw_rst_regen_en_4_qs;
-  logic sw_rst_regen_en_4_wd;
-  logic sw_rst_regen_en_5_qs;
-  logic sw_rst_regen_en_5_wd;
-  logic sw_rst_regen_en_6_qs;
-  logic sw_rst_regen_en_6_wd;
-  logic sw_rst_regen_en_7_qs;
-  logic sw_rst_regen_en_7_wd;
-  logic sw_rst_regen_en_8_qs;
-  logic sw_rst_regen_en_8_wd;
-  logic sw_rst_regen_en_9_qs;
-  logic sw_rst_regen_en_9_wd;
-  logic sw_rst_ctrl_n_re;
-  logic sw_rst_ctrl_n_we;
-  logic sw_rst_ctrl_n_val_0_qs;
-  logic sw_rst_ctrl_n_val_0_wd;
-  logic sw_rst_ctrl_n_val_1_qs;
-  logic sw_rst_ctrl_n_val_1_wd;
-  logic sw_rst_ctrl_n_val_2_qs;
-  logic sw_rst_ctrl_n_val_2_wd;
-  logic sw_rst_ctrl_n_val_3_qs;
-  logic sw_rst_ctrl_n_val_3_wd;
-  logic sw_rst_ctrl_n_val_4_qs;
-  logic sw_rst_ctrl_n_val_4_wd;
-  logic sw_rst_ctrl_n_val_5_qs;
-  logic sw_rst_ctrl_n_val_5_wd;
-  logic sw_rst_ctrl_n_val_6_qs;
-  logic sw_rst_ctrl_n_val_6_wd;
-  logic sw_rst_ctrl_n_val_7_qs;
-  logic sw_rst_ctrl_n_val_7_wd;
-  logic sw_rst_ctrl_n_val_8_qs;
-  logic sw_rst_ctrl_n_val_8_wd;
-  logic sw_rst_ctrl_n_val_9_qs;
-  logic sw_rst_ctrl_n_val_9_wd;
+  logic sw_rst_regwen_0_we;
+  logic sw_rst_regwen_0_qs;
+  logic sw_rst_regwen_0_wd;
+  logic sw_rst_regwen_1_we;
+  logic sw_rst_regwen_1_qs;
+  logic sw_rst_regwen_1_wd;
+  logic sw_rst_regwen_2_we;
+  logic sw_rst_regwen_2_qs;
+  logic sw_rst_regwen_2_wd;
+  logic sw_rst_regwen_3_we;
+  logic sw_rst_regwen_3_qs;
+  logic sw_rst_regwen_3_wd;
+  logic sw_rst_regwen_4_we;
+  logic sw_rst_regwen_4_qs;
+  logic sw_rst_regwen_4_wd;
+  logic sw_rst_regwen_5_we;
+  logic sw_rst_regwen_5_qs;
+  logic sw_rst_regwen_5_wd;
+  logic sw_rst_regwen_6_we;
+  logic sw_rst_regwen_6_qs;
+  logic sw_rst_regwen_6_wd;
+  logic sw_rst_regwen_7_we;
+  logic sw_rst_regwen_7_qs;
+  logic sw_rst_regwen_7_wd;
+  logic sw_rst_regwen_8_we;
+  logic sw_rst_regwen_8_qs;
+  logic sw_rst_regwen_8_wd;
+  logic sw_rst_regwen_9_we;
+  logic sw_rst_regwen_9_qs;
+  logic sw_rst_regwen_9_wd;
+  logic sw_rst_ctrl_n_0_we;
+  logic sw_rst_ctrl_n_0_qs;
+  logic sw_rst_ctrl_n_0_wd;
+  logic sw_rst_ctrl_n_1_we;
+  logic sw_rst_ctrl_n_1_qs;
+  logic sw_rst_ctrl_n_1_wd;
+  logic sw_rst_ctrl_n_2_we;
+  logic sw_rst_ctrl_n_2_qs;
+  logic sw_rst_ctrl_n_2_wd;
+  logic sw_rst_ctrl_n_3_we;
+  logic sw_rst_ctrl_n_3_qs;
+  logic sw_rst_ctrl_n_3_wd;
+  logic sw_rst_ctrl_n_4_we;
+  logic sw_rst_ctrl_n_4_qs;
+  logic sw_rst_ctrl_n_4_wd;
+  logic sw_rst_ctrl_n_5_we;
+  logic sw_rst_ctrl_n_5_qs;
+  logic sw_rst_ctrl_n_5_wd;
+  logic sw_rst_ctrl_n_6_we;
+  logic sw_rst_ctrl_n_6_qs;
+  logic sw_rst_ctrl_n_6_wd;
+  logic sw_rst_ctrl_n_7_we;
+  logic sw_rst_ctrl_n_7_qs;
+  logic sw_rst_ctrl_n_7_wd;
+  logic sw_rst_ctrl_n_8_we;
+  logic sw_rst_ctrl_n_8_qs;
+  logic sw_rst_ctrl_n_8_wd;
+  logic sw_rst_ctrl_n_9_we;
+  logic sw_rst_ctrl_n_9_qs;
+  logic sw_rst_ctrl_n_9_wd;
 
   // Register instances
   // R[alert_test]: V(True)
@@ -521,20 +538,19 @@ module rstmgr_reg_top (
   );
 
 
-  // Subregister 0 of Multireg sw_rst_regen
-  // R[sw_rst_regen]: V(False)
-  //   F[en_0]: 0:0
+  // Subregister 0 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_0]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_0 (
+  ) u_sw_rst_regwen_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_0_wd),
+    .we     (sw_rst_regwen_0_we),
+    .wd     (sw_rst_regwen_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -542,24 +558,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[0].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_0_qs)
+    .qs     (sw_rst_regwen_0_qs)
   );
 
-  //   F[en_1]: 1:1
+
+  // Subregister 1 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_1]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_1 (
+  ) u_sw_rst_regwen_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_1_wd),
+    .we     (sw_rst_regwen_1_we),
+    .wd     (sw_rst_regwen_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -567,24 +585,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[1].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_1_qs)
+    .qs     (sw_rst_regwen_1_qs)
   );
 
-  //   F[en_2]: 2:2
+
+  // Subregister 2 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_2]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_2 (
+  ) u_sw_rst_regwen_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_2_wd),
+    .we     (sw_rst_regwen_2_we),
+    .wd     (sw_rst_regwen_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -592,24 +612,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[2].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_2_qs)
+    .qs     (sw_rst_regwen_2_qs)
   );
 
-  //   F[en_3]: 3:3
+
+  // Subregister 3 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_3]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_3 (
+  ) u_sw_rst_regwen_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_3_wd),
+    .we     (sw_rst_regwen_3_we),
+    .wd     (sw_rst_regwen_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -617,24 +639,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[3].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_3_qs)
+    .qs     (sw_rst_regwen_3_qs)
   );
 
-  //   F[en_4]: 4:4
+
+  // Subregister 4 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_4]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_4 (
+  ) u_sw_rst_regwen_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_4_wd),
+    .we     (sw_rst_regwen_4_we),
+    .wd     (sw_rst_regwen_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -642,24 +666,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[4].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_4_qs)
+    .qs     (sw_rst_regwen_4_qs)
   );
 
-  //   F[en_5]: 5:5
+
+  // Subregister 5 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_5]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_5 (
+  ) u_sw_rst_regwen_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_5_wd),
+    .we     (sw_rst_regwen_5_we),
+    .wd     (sw_rst_regwen_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -667,24 +693,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[5].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_5_qs)
+    .qs     (sw_rst_regwen_5_qs)
   );
 
-  //   F[en_6]: 6:6
+
+  // Subregister 6 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_6]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_6 (
+  ) u_sw_rst_regwen_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_6_wd),
+    .we     (sw_rst_regwen_6_we),
+    .wd     (sw_rst_regwen_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -692,24 +720,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[6].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_6_qs)
+    .qs     (sw_rst_regwen_6_qs)
   );
 
-  //   F[en_7]: 7:7
+
+  // Subregister 7 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_7]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_7 (
+  ) u_sw_rst_regwen_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_7_wd),
+    .we     (sw_rst_regwen_7_we),
+    .wd     (sw_rst_regwen_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -717,24 +747,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[7].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_7_qs)
+    .qs     (sw_rst_regwen_7_qs)
   );
 
-  //   F[en_8]: 8:8
+
+  // Subregister 8 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_8]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_8 (
+  ) u_sw_rst_regwen_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_8_wd),
+    .we     (sw_rst_regwen_8_we),
+    .wd     (sw_rst_regwen_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -742,24 +774,26 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[8].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_8_qs)
+    .qs     (sw_rst_regwen_8_qs)
   );
 
-  //   F[en_9]: 9:9
+
+  // Subregister 9 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen_9]: V(False)
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_9 (
+  ) u_sw_rst_regwen_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_9_wd),
+    .we     (sw_rst_regwen_9_we),
+    .wd     (sw_rst_regwen_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -767,158 +801,285 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[9].q),
+    .q      (),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_9_qs)
+    .qs     (sw_rst_regwen_9_qs)
   );
 
 
   // Subregister 0 of Multireg sw_rst_ctrl_n
-  // R[sw_rst_ctrl_n]: V(True)
-  //   F[val_0]: 0:0
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_0 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_0_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[0].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[0].qe),
+  // R[sw_rst_ctrl_n_0]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_0_we & sw_rst_regwen_0_qs),
+    .wd     (sw_rst_ctrl_n_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[0].q),
-    .qs     (sw_rst_ctrl_n_val_0_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_0_qs)
   );
 
-  //   F[val_1]: 1:1
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_1 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_1_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[1].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[1].qe),
+
+  // Subregister 1 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_1]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_1_we & sw_rst_regwen_1_qs),
+    .wd     (sw_rst_ctrl_n_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[1].q),
-    .qs     (sw_rst_ctrl_n_val_1_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_1_qs)
   );
 
-  //   F[val_2]: 2:2
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_2 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_2_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[2].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[2].qe),
+
+  // Subregister 2 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_2]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_2_we & sw_rst_regwen_2_qs),
+    .wd     (sw_rst_ctrl_n_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[2].q),
-    .qs     (sw_rst_ctrl_n_val_2_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_2_qs)
   );
 
-  //   F[val_3]: 3:3
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_3 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_3_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[3].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[3].qe),
+
+  // Subregister 3 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_3]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_3_we & sw_rst_regwen_3_qs),
+    .wd     (sw_rst_ctrl_n_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[3].q),
-    .qs     (sw_rst_ctrl_n_val_3_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_3_qs)
   );
 
-  //   F[val_4]: 4:4
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_4 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_4_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[4].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[4].qe),
+
+  // Subregister 4 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_4]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_4_we & sw_rst_regwen_4_qs),
+    .wd     (sw_rst_ctrl_n_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[4].q),
-    .qs     (sw_rst_ctrl_n_val_4_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_4_qs)
   );
 
-  //   F[val_5]: 5:5
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_5 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_5_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[5].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[5].qe),
+
+  // Subregister 5 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_5]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_5_we & sw_rst_regwen_5_qs),
+    .wd     (sw_rst_ctrl_n_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[5].q),
-    .qs     (sw_rst_ctrl_n_val_5_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_5_qs)
   );
 
-  //   F[val_6]: 6:6
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_6 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_6_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[6].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[6].qe),
+
+  // Subregister 6 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_6]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_6_we & sw_rst_regwen_6_qs),
+    .wd     (sw_rst_ctrl_n_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[6].q),
-    .qs     (sw_rst_ctrl_n_val_6_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_6_qs)
   );
 
-  //   F[val_7]: 7:7
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_7 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_7_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[7].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[7].qe),
+
+  // Subregister 7 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_7]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_7_we & sw_rst_regwen_7_qs),
+    .wd     (sw_rst_ctrl_n_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[7].q),
-    .qs     (sw_rst_ctrl_n_val_7_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_7_qs)
   );
 
-  //   F[val_8]: 8:8
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_8 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_8_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[8].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[8].qe),
+
+  // Subregister 8 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_8]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_8_we & sw_rst_regwen_8_qs),
+    .wd     (sw_rst_ctrl_n_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[8].q),
-    .qs     (sw_rst_ctrl_n_val_8_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_8_qs)
   );
 
-  //   F[val_9]: 9:9
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_9 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_9_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[9].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[9].qe),
+
+  // Subregister 9 of Multireg sw_rst_ctrl_n
+  // R[sw_rst_ctrl_n_9]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h1)
+  ) u_sw_rst_ctrl_n_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (sw_rst_ctrl_n_9_we & sw_rst_regwen_9_qs),
+    .wd     (sw_rst_ctrl_n_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
     .q      (reg2hw.sw_rst_ctrl_n[9].q),
-    .qs     (sw_rst_ctrl_n_val_9_qs)
+
+    // to register interface (read)
+    .qs     (sw_rst_ctrl_n_9_qs)
   );
 
 
 
-  logic [11:0] addr_hit;
+  logic [29:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RSTMGR_ALERT_TEST_OFFSET);
@@ -931,8 +1092,26 @@ module rstmgr_reg_top (
     addr_hit[ 7] = (reg_addr == RSTMGR_CPU_INFO_CTRL_OFFSET);
     addr_hit[ 8] = (reg_addr == RSTMGR_CPU_INFO_ATTR_OFFSET);
     addr_hit[ 9] = (reg_addr == RSTMGR_CPU_INFO_OFFSET);
-    addr_hit[10] = (reg_addr == RSTMGR_SW_RST_REGEN_OFFSET);
-    addr_hit[11] = (reg_addr == RSTMGR_SW_RST_CTRL_N_OFFSET);
+    addr_hit[10] = (reg_addr == RSTMGR_SW_RST_REGWEN_0_OFFSET);
+    addr_hit[11] = (reg_addr == RSTMGR_SW_RST_REGWEN_1_OFFSET);
+    addr_hit[12] = (reg_addr == RSTMGR_SW_RST_REGWEN_2_OFFSET);
+    addr_hit[13] = (reg_addr == RSTMGR_SW_RST_REGWEN_3_OFFSET);
+    addr_hit[14] = (reg_addr == RSTMGR_SW_RST_REGWEN_4_OFFSET);
+    addr_hit[15] = (reg_addr == RSTMGR_SW_RST_REGWEN_5_OFFSET);
+    addr_hit[16] = (reg_addr == RSTMGR_SW_RST_REGWEN_6_OFFSET);
+    addr_hit[17] = (reg_addr == RSTMGR_SW_RST_REGWEN_7_OFFSET);
+    addr_hit[18] = (reg_addr == RSTMGR_SW_RST_REGWEN_8_OFFSET);
+    addr_hit[19] = (reg_addr == RSTMGR_SW_RST_REGWEN_9_OFFSET);
+    addr_hit[20] = (reg_addr == RSTMGR_SW_RST_CTRL_N_0_OFFSET);
+    addr_hit[21] = (reg_addr == RSTMGR_SW_RST_CTRL_N_1_OFFSET);
+    addr_hit[22] = (reg_addr == RSTMGR_SW_RST_CTRL_N_2_OFFSET);
+    addr_hit[23] = (reg_addr == RSTMGR_SW_RST_CTRL_N_3_OFFSET);
+    addr_hit[24] = (reg_addr == RSTMGR_SW_RST_CTRL_N_4_OFFSET);
+    addr_hit[25] = (reg_addr == RSTMGR_SW_RST_CTRL_N_5_OFFSET);
+    addr_hit[26] = (reg_addr == RSTMGR_SW_RST_CTRL_N_6_OFFSET);
+    addr_hit[27] = (reg_addr == RSTMGR_SW_RST_CTRL_N_7_OFFSET);
+    addr_hit[28] = (reg_addr == RSTMGR_SW_RST_CTRL_N_8_OFFSET);
+    addr_hit[29] = (reg_addr == RSTMGR_SW_RST_CTRL_N_9_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -951,7 +1130,25 @@ module rstmgr_reg_top (
                (addr_hit[ 8] & (|(RSTMGR_PERMIT[ 8] & ~reg_be))) |
                (addr_hit[ 9] & (|(RSTMGR_PERMIT[ 9] & ~reg_be))) |
                (addr_hit[10] & (|(RSTMGR_PERMIT[10] & ~reg_be))) |
-               (addr_hit[11] & (|(RSTMGR_PERMIT[11] & ~reg_be)))));
+               (addr_hit[11] & (|(RSTMGR_PERMIT[11] & ~reg_be))) |
+               (addr_hit[12] & (|(RSTMGR_PERMIT[12] & ~reg_be))) |
+               (addr_hit[13] & (|(RSTMGR_PERMIT[13] & ~reg_be))) |
+               (addr_hit[14] & (|(RSTMGR_PERMIT[14] & ~reg_be))) |
+               (addr_hit[15] & (|(RSTMGR_PERMIT[15] & ~reg_be))) |
+               (addr_hit[16] & (|(RSTMGR_PERMIT[16] & ~reg_be))) |
+               (addr_hit[17] & (|(RSTMGR_PERMIT[17] & ~reg_be))) |
+               (addr_hit[18] & (|(RSTMGR_PERMIT[18] & ~reg_be))) |
+               (addr_hit[19] & (|(RSTMGR_PERMIT[19] & ~reg_be))) |
+               (addr_hit[20] & (|(RSTMGR_PERMIT[20] & ~reg_be))) |
+               (addr_hit[21] & (|(RSTMGR_PERMIT[21] & ~reg_be))) |
+               (addr_hit[22] & (|(RSTMGR_PERMIT[22] & ~reg_be))) |
+               (addr_hit[23] & (|(RSTMGR_PERMIT[23] & ~reg_be))) |
+               (addr_hit[24] & (|(RSTMGR_PERMIT[24] & ~reg_be))) |
+               (addr_hit[25] & (|(RSTMGR_PERMIT[25] & ~reg_be))) |
+               (addr_hit[26] & (|(RSTMGR_PERMIT[26] & ~reg_be))) |
+               (addr_hit[27] & (|(RSTMGR_PERMIT[27] & ~reg_be))) |
+               (addr_hit[28] & (|(RSTMGR_PERMIT[28] & ~reg_be))) |
+               (addr_hit[29] & (|(RSTMGR_PERMIT[29] & ~reg_be)))));
   end
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -985,49 +1182,66 @@ module rstmgr_reg_top (
   assign cpu_info_ctrl_index_wd = reg_wdata[7:4];
   assign cpu_info_attr_re = addr_hit[8] & reg_re & !reg_error;
   assign cpu_info_re = addr_hit[9] & reg_re & !reg_error;
-  assign sw_rst_regen_we = addr_hit[10] & reg_we & !reg_error;
+  assign sw_rst_regwen_0_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_0_wd = reg_wdata[0];
+  assign sw_rst_regwen_0_wd = reg_wdata[0];
+  assign sw_rst_regwen_1_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_1_wd = reg_wdata[1];
+  assign sw_rst_regwen_1_wd = reg_wdata[0];
+  assign sw_rst_regwen_2_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_2_wd = reg_wdata[2];
+  assign sw_rst_regwen_2_wd = reg_wdata[0];
+  assign sw_rst_regwen_3_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_3_wd = reg_wdata[3];
+  assign sw_rst_regwen_3_wd = reg_wdata[0];
+  assign sw_rst_regwen_4_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_4_wd = reg_wdata[4];
+  assign sw_rst_regwen_4_wd = reg_wdata[0];
+  assign sw_rst_regwen_5_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_5_wd = reg_wdata[5];
+  assign sw_rst_regwen_5_wd = reg_wdata[0];
+  assign sw_rst_regwen_6_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_6_wd = reg_wdata[6];
+  assign sw_rst_regwen_6_wd = reg_wdata[0];
+  assign sw_rst_regwen_7_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_7_wd = reg_wdata[7];
+  assign sw_rst_regwen_7_wd = reg_wdata[0];
+  assign sw_rst_regwen_8_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_8_wd = reg_wdata[8];
+  assign sw_rst_regwen_8_wd = reg_wdata[0];
+  assign sw_rst_regwen_9_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_9_wd = reg_wdata[9];
-  assign sw_rst_ctrl_n_re = addr_hit[11] & reg_re & !reg_error;
-  assign sw_rst_ctrl_n_we = addr_hit[11] & reg_we & !reg_error;
+  assign sw_rst_regwen_9_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_0_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_0_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_0_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_1_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_1_wd = reg_wdata[1];
+  assign sw_rst_ctrl_n_1_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_2_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_2_wd = reg_wdata[2];
+  assign sw_rst_ctrl_n_2_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_3_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_3_wd = reg_wdata[3];
+  assign sw_rst_ctrl_n_3_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_4_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_4_wd = reg_wdata[4];
+  assign sw_rst_ctrl_n_4_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_5_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_5_wd = reg_wdata[5];
+  assign sw_rst_ctrl_n_5_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_6_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_6_wd = reg_wdata[6];
+  assign sw_rst_ctrl_n_6_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_7_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_7_wd = reg_wdata[7];
+  assign sw_rst_ctrl_n_7_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_8_we = addr_hit[28] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_8_wd = reg_wdata[8];
+  assign sw_rst_ctrl_n_8_wd = reg_wdata[0];
+  assign sw_rst_ctrl_n_9_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign sw_rst_ctrl_n_val_9_wd = reg_wdata[9];
+  assign sw_rst_ctrl_n_9_wd = reg_wdata[0];
 
   // Read data return
   always_comb begin
@@ -1079,29 +1293,83 @@ module rstmgr_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[0] = sw_rst_regen_en_0_qs;
-        reg_rdata_next[1] = sw_rst_regen_en_1_qs;
-        reg_rdata_next[2] = sw_rst_regen_en_2_qs;
-        reg_rdata_next[3] = sw_rst_regen_en_3_qs;
-        reg_rdata_next[4] = sw_rst_regen_en_4_qs;
-        reg_rdata_next[5] = sw_rst_regen_en_5_qs;
-        reg_rdata_next[6] = sw_rst_regen_en_6_qs;
-        reg_rdata_next[7] = sw_rst_regen_en_7_qs;
-        reg_rdata_next[8] = sw_rst_regen_en_8_qs;
-        reg_rdata_next[9] = sw_rst_regen_en_9_qs;
+        reg_rdata_next[0] = sw_rst_regwen_0_qs;
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[0] = sw_rst_ctrl_n_val_0_qs;
-        reg_rdata_next[1] = sw_rst_ctrl_n_val_1_qs;
-        reg_rdata_next[2] = sw_rst_ctrl_n_val_2_qs;
-        reg_rdata_next[3] = sw_rst_ctrl_n_val_3_qs;
-        reg_rdata_next[4] = sw_rst_ctrl_n_val_4_qs;
-        reg_rdata_next[5] = sw_rst_ctrl_n_val_5_qs;
-        reg_rdata_next[6] = sw_rst_ctrl_n_val_6_qs;
-        reg_rdata_next[7] = sw_rst_ctrl_n_val_7_qs;
-        reg_rdata_next[8] = sw_rst_ctrl_n_val_8_qs;
-        reg_rdata_next[9] = sw_rst_ctrl_n_val_9_qs;
+        reg_rdata_next[0] = sw_rst_regwen_1_qs;
+      end
+
+      addr_hit[12]: begin
+        reg_rdata_next[0] = sw_rst_regwen_2_qs;
+      end
+
+      addr_hit[13]: begin
+        reg_rdata_next[0] = sw_rst_regwen_3_qs;
+      end
+
+      addr_hit[14]: begin
+        reg_rdata_next[0] = sw_rst_regwen_4_qs;
+      end
+
+      addr_hit[15]: begin
+        reg_rdata_next[0] = sw_rst_regwen_5_qs;
+      end
+
+      addr_hit[16]: begin
+        reg_rdata_next[0] = sw_rst_regwen_6_qs;
+      end
+
+      addr_hit[17]: begin
+        reg_rdata_next[0] = sw_rst_regwen_7_qs;
+      end
+
+      addr_hit[18]: begin
+        reg_rdata_next[0] = sw_rst_regwen_8_qs;
+      end
+
+      addr_hit[19]: begin
+        reg_rdata_next[0] = sw_rst_regwen_9_qs;
+      end
+
+      addr_hit[20]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_0_qs;
+      end
+
+      addr_hit[21]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_1_qs;
+      end
+
+      addr_hit[22]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_2_qs;
+      end
+
+      addr_hit[23]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_3_qs;
+      end
+
+      addr_hit[24]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_4_qs;
+      end
+
+      addr_hit[25]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_5_qs;
+      end
+
+      addr_hit[26]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_6_qs;
+      end
+
+      addr_hit[27]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_7_qs;
+      end
+
+      addr_hit[28]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_8_qs;
+      end
+
+      addr_hit[29]: begin
+        reg_rdata_next[0] = sw_rst_ctrl_n_9_qs;
       end
 
       default: begin


### PR DESCRIPTION
Fixes #8154 

- rstmgr was using a customized verison of multi reg because
  it was implemented at a time when `regwen_multi` did not exist.
- convert to `regwen_multi` to make the usage more standardized and
  covered by standardized testing.