### PR TITLE
[util] Make regwen_multi / compact consistent

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -292,7 +292,6 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   desc:     '''Enable register for alerts.
                   ''',
                   count:    "NAlerts",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -319,7 +318,6 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   desc:     '''Class assignment of alerts.
                   ''',
                   count:    "NAlerts",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -391,7 +389,6 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   and "shadow reg storage error" (6).
                   ''',
                   count:    "N_LOC_ALERT",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -420,7 +417,6 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
                   and "shadow reg storage error" (6).
                   ''',
                   count:    "N_LOC_ALERT",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -306,7 +306,6 @@
                   desc:     '''Enable register for alerts.
                   ''',
                   count:    "NAlerts",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -333,7 +332,6 @@
                   desc:     '''Class assignment of alerts.
                   ''',
                   count:    "NAlerts",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -405,7 +403,6 @@
                   and "shadow reg storage error" (6).
                   ''',
                   count:    "N_LOC_ALERT",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -434,7 +431,6 @@
                   and "shadow reg storage error" (6).
                   ''',
                   count:    "N_LOC_ALERT",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -88,13 +88,18 @@ class MultiRegister(RegBase):
                                        'regwen_multi field of multireg {}'
                                        .format(self.reg.name))
 
-        default_compact = True if len(self.reg.fields) == 1 else False
+        default_compact = True if len(self.reg.fields) == 1 and not self.regwen_multi else False
         self.compact = check_bool(rd.get('compact', default_compact),
                                   'compact field of multireg {}'
                                   .format(self.reg.name))
         if self.compact and len(self.reg.fields) > 1:
             raise ValueError('Multireg {} sets the compact flag '
                              'but has multiple fields.'
+                             .format(self.reg.name))
+
+        if self.regwen_multi and self.compact:
+            raise ValueError('Multireg {} sets the compact flag '
+                             'but has regwen_multi set.'
                              .format(self.reg.name))
 
         count_str = check_str(rd['count'],


### PR DESCRIPTION
- Do not require the user to have to set both
- Also add an error check if regwen_multi and compact are both true

Signed-off-by: Timothy Chen <timothytim@google.com>