### PR TITLE
[alert_handler] doc and testbench updates

### DIFF
--- a/hw/ip/alert_handler/doc/_index.md
+++ b/hw/ip/alert_handler/doc/_index.md
@@ -180,7 +180,7 @@ The `crashdump_o` struct outputs a snapshot of CSRs and alert handler state bits
   typedef struct packed {
     // alerts
     logic    [NAlerts-1:0] alert_cause;     // alert cause bits
-    logic    [3:0]         loc_alert_cause; // local alert cause bits
+    logic    [6:0]         loc_alert_cause; // local alert cause bits
     // class state
     logic    [3:0][15:0]   class_accum_cnt; // current accumulator value
     logic    [3:0][31:0]   class_esc_cnt;   // current escalation counter value

--- a/hw/ip/alert_handler/dv/env/alert_handler_env.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env.sv
@@ -39,8 +39,8 @@ class alert_handler_env extends cip_base_env #(
       cfg.esc_device_cfg[i].en_cov = cfg.en_cov;
     end
     // get vifs
-    if (!uvm_config_db#(entropy_vif)::get(this, "", "entropy_vif", cfg.entropy_vif)) begin
-      `uvm_fatal(get_full_name(), "failed to get entropy_vif from uvm_config_db")
+    if (!uvm_config_db#(crashdump_vif)::get(this, "", "crashdump_vif", cfg.crashdump_vif)) begin
+      `uvm_fatal(get_full_name(), "failed to get crashdump_vif from uvm_config_db")
     end
   endfunction
 

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_cfg.sv
@@ -6,7 +6,7 @@ class alert_handler_env_cfg extends cip_base_env_cfg #(.RAL_T(alert_handler_reg_
 
   // ext component cfgs
   esc_en_vif               esc_en_vif;
-  entropy_vif              entropy_vif;
+  crashdump_vif            crashdump_vif;
   rand alert_esc_agent_cfg alert_host_cfg[];
   rand alert_esc_agent_cfg esc_device_cfg[];
 

--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -27,13 +27,17 @@ package alert_handler_env_pkg;
   parameter uint NUM_ESC_PHASES            = 4;
   parameter uint NUM_ALERT_CLASS_MSB       = $clog2(NUM_ALERT_CLASSES) - 1;
   parameter uint MIN_CYCLE_PER_PHASE       = 2;
-  parameter uint NUM_LOCAL_ALERTS          = 4;
+  parameter uint NUM_LOCAL_ALERTS          = 7;
   parameter bit  [NUM_ALERTS-1:0] ASYNC_ON = alert_handler_reg_pkg::AsyncOn;
   // ignore esc signal cycle count after ping occurs - as ping response might ended up adding one
   // extra cycle to the calculated cnt, or even combine two signals into one.
-  parameter uint IGNORE_CNT_CHECK_NS         = 100_000_000;
+  parameter uint IGNORE_CNT_CHECK_NS       = 100_000_000;
   // set the max ping timeout cycle to constrain the simulation run time
-  parameter uint MAX_PING_TIMEOUT_CYCLE     = 100;
+  parameter uint MAX_PING_TIMEOUT_CYCLE    = 100;
+
+  parameter uint NUM_CRASHDUMP             = NUM_ALERT_CLASSES * (alert_handler_reg_pkg::AccuCntDw
+                                             + alert_handler_reg_pkg::EscCntDw + 3) +
+                                             NUM_ALERTS + NUM_LOCAL_ALERTS;
   // types
   typedef enum {
     EscPhase0,
@@ -77,7 +81,7 @@ package alert_handler_env_pkg;
 
   // forward declare classes to allow typedefs below
   typedef virtual pins_if #(NUM_MAX_ESC_SEV) esc_en_vif;
-  typedef virtual pins_if #(1) entropy_vif;
+  typedef virtual pins_if #(NUM_CRASHDUMP) crashdump_vif;
 
   // functions
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -5,8 +5,6 @@
 class alert_handler_common_vseq extends alert_handler_base_vseq;
   `uvm_object_utils(alert_handler_common_vseq)
 
-  rand bit entropy_bit;
-
   constraint num_trans_c {
     num_trans inside {[1:2]};
   }
@@ -14,8 +12,6 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   `uvm_object_new
 
   virtual task body();
-    // driven entropy to avoid assertion error in ping_timer
-    cfg.entropy_vif.drive(entropy_bit);
     // run alert/esc ping response sequences without error or timeout to prevent triggering local
     // alert failure
     run_alert_ping_rsp_seq_nonblocking(0);

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -26,7 +26,6 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   rand bit do_wr_phases_cyc;
   rand bit do_esc_intr_timeout;
   rand bit do_lock_config;
-  rand bit rand_drive_entropy;
   rand bit [TL_DW-1:0] ping_timeout_cyc;
   rand bit [TL_DW-1:0] max_phase_cyc;
   rand bit [TL_DW-1:0] intr_timeout_cyc [NUM_ALERT_CLASSES];
@@ -136,9 +135,6 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
       if (do_esc_intr_timeout) wr_intr_timeout_cycle(intr_timeout_cyc);
       wr_class_accum_threshold(accum_thresh);
       wr_ping_timeout_cycle(ping_timeout_cyc);
-
-      //drive entropy
-      cfg.entropy_vif.drive(rand_drive_entropy);
 
       // when all configuration registers are set, write lock register
       lock_config(do_lock_config);

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -17,12 +17,12 @@ module tb;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   wire [NUM_MAX_ESC_SEV-1:0]    esc_en;
-  wire entropy;
+  wire [NUM_CRASHDUMP-1:0]      crashdump;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(interrupts);
-  pins_if #(1) entropy_if(entropy);
+  pins_if #(NUM_CRASHDUMP) crashdump_if(crashdump);
   pins_if #(1) devmode_if(devmode);
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
   alert_esc_if esc_device_if [NUM_ESCS](.clk(clk), .rst_n(rst_n));
@@ -80,7 +80,7 @@ module tb;
     .intr_classb_o        ( interrupts[1] ),
     .intr_classc_o        ( interrupts[2] ),
     .intr_classd_o        ( interrupts[3] ),
-    .crashdump_o          (               ),
+    .crashdump_o          ( crashdump     ),
     .edn_o                ( edn_if.req    ),
     .edn_i                ( {edn_if.ack, edn_if.d_data} ),
     .alert_rx_o           ( alert_rx      ),
@@ -94,7 +94,7 @@ module tb;
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
-    uvm_config_db#(entropy_vif)::set(null, "*.env", "entropy_vif", entropy_if);
+    uvm_config_db#(crashdump_vif)::set(null, "*.env", "crashdump_vif", crashdump_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);


### PR DESCRIPTION
Two updates on alert_handler:
1). Small update on doc regarding number of local alerts
2). Remove entropy_en -> it is replaced by edn
      Add pins for crashdump, the scb checking will be implemented in a separate PR because it depends on PR #8173 