### PR TITLE
[rstmgr] Make naming consistent for sw_ctrl_regwen

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -261,7 +261,7 @@
 
     { multireg: {
         cname: "RSTMGR_SW_RST",
-        name:  "SW_RST_REGEN",
+        name:  "SW_RST_REGWEN",
         desc:  '''
           Register write enable for software controllable resets.
           When a particular bit value is 0, the corresponding value in !!SW_RST_CTRL_N can no longer be changed.

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -236,7 +236,7 @@ module rstmgr
     ) u_rst_sw_ctrl_reg (
       .clk_i,
       .rst_ni,
-      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regen[i]),
+      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regwen[i]),
       .wd(reg2hw.sw_rst_ctrl_n[i].q),
       .de('0),
       .d('0),

--- a/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -123,10 +123,10 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
         // Read only.
         do_read_check = 1'b0;
       end
-      "sw_rst_regen": begin
+      "sw_rst_regwen": begin
       end
       "sw_rst_ctrl_n": begin
-        // TODO Check with bitwise enables from sw_rst_regen.
+        // TODO Check with bitwise enables from sw_rst_regwen.
         do_read_check = 1'b0;
       end
       default: begin

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -12,12 +12,12 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
   rand ibex_pkg::crash_dump_t cpu_dump;
   rand alert_pkg::alert_crashdump_t alert_dump;
   rand logic [pwrmgr_pkg::TotalResetWidth-1:0] rstreqs;
-  rand logic [NumSwResets-1:0] sw_rst_regen;
+  rand logic [NumSwResets-1:0] sw_rst_regwen;
   rand logic [NumSwResets-1:0] sw_rst_ctrl_n;
 
   constraint rstreqs_non_zero_c {rstreqs != '0;}
-  constraint sw_rst_regen_non_trivial_c {sw_rst_regen != '0 && sw_rst_regen != '1;}
-  constraint sw_rst_some_reset_n {sw_rst_regen & ~sw_rst_ctrl_n != '0;}
+  constraint sw_rst_regwen_non_trivial_c {sw_rst_regwen != '0 && sw_rst_regwen != '1;}
+  constraint sw_rst_some_reset_n {sw_rst_regwen & ~sw_rst_ctrl_n != '0;}
 
   task body();
     // The rstmgr is ready for CSR accesses.
@@ -79,22 +79,22 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
       set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
       csr_rd_check(.ptr(ral.sw_rst_ctrl_n[0]), .compare_value(sw_rst_all_ones),
                    .err_msg("expected no reset on"));
-      csr_wr(.ptr(ral.sw_rst_regen[0]), .value(sw_rst_regen));
-      `uvm_info(`gfn, $sformatf("sw_rst_regen set to 0x%0h", sw_rst_regen), UVM_LOW)
-      csr_rd_check(.ptr(ral.sw_rst_regen[0]), .compare_value(sw_rst_regen),
-                   .err_msg("Expected sw_rst_regen to reflect rw0c"));
+      csr_wr(.ptr(ral.sw_rst_regwen[0]), .value(sw_rst_regwen));
+      `uvm_info(`gfn, $sformatf("sw_rst_regwen set to 0x%0h", sw_rst_regwen), UVM_LOW)
+      csr_rd_check(.ptr(ral.sw_rst_regwen[0]), .compare_value(sw_rst_regwen),
+                   .err_msg("Expected sw_rst_regwen to reflect rw0c"));
 
-      // Check sw_rst_regen can not be set to all ones again because it is rw0c.
-      csr_wr(.ptr(ral.sw_rst_regen[0]), .value('1));
-      csr_rd_check(.ptr(ral.sw_rst_regen[0]), .compare_value(sw_rst_regen),
-                   .err_msg("Expected sw_rst_regen block raising individual bits because rw0c"));
+      // Check sw_rst_regwen can not be set to all ones again because it is rw0c.
+      csr_wr(.ptr(ral.sw_rst_regwen[0]), .value('1));
+      csr_rd_check(.ptr(ral.sw_rst_regwen[0]), .compare_value(sw_rst_regwen),
+                   .err_msg("Expected sw_rst_regwen block raising individual bits because rw0c"));
 
-      // Check that the regen disabled bits block corresponding updated to ctrl_n.
-      csr_wr(.ptr(ral.sw_rst_ctrl_n[0]), .value(sw_rst_regen));
+      // Check that the regwen disabled bits block corresponding updated to ctrl_n.
+      csr_wr(.ptr(ral.sw_rst_ctrl_n[0]), .value(sw_rst_regwen));
       csr_rd_check(.ptr(ral.sw_rst_ctrl_n[0]), .compare_value(sw_rst_all_ones),
                    .err_msg("Expected sw_rst_ctrl_n not to change"));
 
-      check_sw_rst_ctrl_n(sw_rst_ctrl_n, sw_rst_regen, 1);
+      check_sw_rst_ctrl_n(sw_rst_ctrl_n, sw_rst_regwen, 1);
     end
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
   endtask : body

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
@@ -7,7 +7,7 @@
 // transitions that cause rising upper resets but non-rising leafs.
 //
 // Then it clears specific `sw_rst_regen` bits and attempts to cause resets to determine
-// the bits with `sw_rst_regen` cleared cannot cause a reset.
+// the bits with `sw_rst_regwen` cleared cannot cause a reset.
 class rstmgr_sw_rst_vseq extends rstmgr_base_vseq;
   `uvm_object_utils(rstmgr_sw_rst_vseq)
 
@@ -17,25 +17,25 @@ class rstmgr_sw_rst_vseq extends rstmgr_base_vseq;
 
   task body();
     bit [NumSwResets-1:0] exp_ctrl_n;
-    bit [NumSwResets-1:0] sw_rst_regen = '1;
+    bit [NumSwResets-1:0] sw_rst_regwen = '1;
     set_alert_and_cpu_info_for_capture(.alert_dump('1), .cpu_dump('1));
     for (int i = 0; i < num_trans; ++i) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
-      check_sw_rst_ctrl_n(sw_rst_ctrl_n, sw_rst_regen, i % 2);
+      check_sw_rst_ctrl_n(sw_rst_ctrl_n, sw_rst_regwen, i % 2);
     end
     // In preparation for the per-bit enable test, set sw_rst_ctrl_n to all 1.
     csr_wr(.ptr(ral.sw_rst_ctrl_n[0]), .value('1));
     for (int i = 0; i < NumSwResets; ++i) begin
-      bit [NumSwResets-1:0] val_regen;
-      bit [NumSwResets-1:0] exp_regen;
-      val_regen = ~(1 << i);
-      `uvm_info(`gfn, $sformatf("updating sw_rst_regen with %b", val_regen), UVM_LOW)
-      csr_wr(.ptr(ral.sw_rst_regen[0]), .value(val_regen));
-      exp_regen = (~0) << (i + 1);
-      `uvm_info(`gfn, $sformatf("compare sw_rst_regen against %b", exp_regen), UVM_LOW)
-      csr_rd_check(.ptr(ral.sw_rst_regen[0]), .compare_value(exp_regen),
-                   .err_msg($sformatf("The expected value is %b", exp_regen)));
-      check_sw_rst_ctrl_n(.sw_rst_ctrl_n('0), .sw_rst_regen(exp_regen), .erase_ctrl_n(1'b1));
+      bit [NumSwResets-1:0] val_regwen;
+      bit [NumSwResets-1:0] exp_regwen;
+      val_regwen = ~(1 << i);
+      `uvm_info(`gfn, $sformatf("updating sw_rst_regwen with %b", val_regwen), UVM_LOW)
+      csr_wr(.ptr(ral.sw_rst_regwen[0]), .value(val_regwen));
+      exp_regwen = (~0) << (i + 1);
+      `uvm_info(`gfn, $sformatf("compare sw_rst_regwen against %b", exp_regwen), UVM_LOW)
+      csr_rd_check(.ptr(ral.sw_rst_regwen[0]), .compare_value(exp_regwen),
+                   .err_msg($sformatf("The expected value is %b", exp_regwen)));
+      check_sw_rst_ctrl_n(.sw_rst_ctrl_n('0), .sw_rst_regen(exp_regwen), .erase_ctrl_n(1'b1));
     end
     check_alert_and_cpu_info_after_reset(.alert_dump('0), .cpu_dump('0), .enable(1'b1));
   endtask

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -339,7 +339,7 @@
 
     { multireg: {
         cname: "RSTMGR_SW_RST",
-        name:  "SW_RST_REGEN",
+        name:  "SW_RST_REGWEN",
         desc:  '''
           Register write enable for software controllable resets.
           When a particular bit value is 0, the corresponding value in !!SW_RST_CTRL_N can no longer be changed.

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -242,7 +242,7 @@ module rstmgr
     ) u_rst_sw_ctrl_reg (
       .clk_i,
       .rst_ni,
-      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regen[i]),
+      .we(reg2hw.sw_rst_ctrl_n[i].qe & reg2hw.sw_rst_regwen[i]),
       .wd(reg2hw.sw_rst_ctrl_n[i].q),
       .de('0),
       .d('0),

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -51,7 +51,7 @@ package rstmgr_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } rstmgr_reg2hw_sw_rst_regen_mreg_t;
+  } rstmgr_reg2hw_sw_rst_regwen_mreg_t;
 
   typedef struct packed {
     logic        q;
@@ -113,7 +113,7 @@ package rstmgr_reg_pkg;
     rstmgr_reg2hw_reset_info_reg_t reset_info; // [43:40]
     rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [39:35]
     rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [34:30]
-    rstmgr_reg2hw_sw_rst_regen_mreg_t [9:0] sw_rst_regen; // [29:20]
+    rstmgr_reg2hw_sw_rst_regwen_mreg_t [9:0] sw_rst_regwen; // [29:20]
     rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [19:0]
   } rstmgr_reg2hw_t;
 
@@ -140,7 +140,7 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_CTRL_OFFSET = 6'h 1c;
   parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_ATTR_OFFSET = 6'h 20;
   parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGEN_OFFSET = 6'h 28;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_OFFSET = 6'h 28;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 2c;
 
   // Reset values for hwext registers and their fields
@@ -178,7 +178,7 @@ package rstmgr_reg_pkg;
     RSTMGR_CPU_INFO_CTRL,
     RSTMGR_CPU_INFO_ATTR,
     RSTMGR_CPU_INFO,
-    RSTMGR_SW_RST_REGEN,
+    RSTMGR_SW_RST_REGWEN,
     RSTMGR_SW_RST_CTRL_N
   } rstmgr_id_e;
 
@@ -194,7 +194,7 @@ package rstmgr_reg_pkg;
     4'b 0001, // index[ 7] RSTMGR_CPU_INFO_CTRL
     4'b 0001, // index[ 8] RSTMGR_CPU_INFO_ATTR
     4'b 1111, // index[ 9] RSTMGR_CPU_INFO
-    4'b 0011, // index[10] RSTMGR_SW_RST_REGEN
+    4'b 0011, // index[10] RSTMGR_SW_RST_REGWEN
     4'b 0011  // index[11] RSTMGR_SW_RST_CTRL_N
   };
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -143,27 +143,27 @@ module rstmgr_reg_top (
   logic [3:0] cpu_info_attr_qs;
   logic cpu_info_re;
   logic [31:0] cpu_info_qs;
-  logic sw_rst_regen_we;
-  logic sw_rst_regen_en_0_qs;
-  logic sw_rst_regen_en_0_wd;
-  logic sw_rst_regen_en_1_qs;
-  logic sw_rst_regen_en_1_wd;
-  logic sw_rst_regen_en_2_qs;
-  logic sw_rst_regen_en_2_wd;
-  logic sw_rst_regen_en_3_qs;
-  logic sw_rst_regen_en_3_wd;
-  logic sw_rst_regen_en_4_qs;
-  logic sw_rst_regen_en_4_wd;
-  logic sw_rst_regen_en_5_qs;
-  logic sw_rst_regen_en_5_wd;
-  logic sw_rst_regen_en_6_qs;
-  logic sw_rst_regen_en_6_wd;
-  logic sw_rst_regen_en_7_qs;
-  logic sw_rst_regen_en_7_wd;
-  logic sw_rst_regen_en_8_qs;
-  logic sw_rst_regen_en_8_wd;
-  logic sw_rst_regen_en_9_qs;
-  logic sw_rst_regen_en_9_wd;
+  logic sw_rst_regwen_we;
+  logic sw_rst_regwen_en_0_qs;
+  logic sw_rst_regwen_en_0_wd;
+  logic sw_rst_regwen_en_1_qs;
+  logic sw_rst_regwen_en_1_wd;
+  logic sw_rst_regwen_en_2_qs;
+  logic sw_rst_regwen_en_2_wd;
+  logic sw_rst_regwen_en_3_qs;
+  logic sw_rst_regwen_en_3_wd;
+  logic sw_rst_regwen_en_4_qs;
+  logic sw_rst_regwen_en_4_wd;
+  logic sw_rst_regwen_en_5_qs;
+  logic sw_rst_regwen_en_5_wd;
+  logic sw_rst_regwen_en_6_qs;
+  logic sw_rst_regwen_en_6_wd;
+  logic sw_rst_regwen_en_7_qs;
+  logic sw_rst_regwen_en_7_wd;
+  logic sw_rst_regwen_en_8_qs;
+  logic sw_rst_regwen_en_8_wd;
+  logic sw_rst_regwen_en_9_qs;
+  logic sw_rst_regwen_en_9_wd;
   logic sw_rst_ctrl_n_re;
   logic sw_rst_ctrl_n_we;
   logic sw_rst_ctrl_n_val_0_qs;
@@ -521,20 +521,20 @@ module rstmgr_reg_top (
   );
 
 
-  // Subregister 0 of Multireg sw_rst_regen
-  // R[sw_rst_regen]: V(False)
+  // Subregister 0 of Multireg sw_rst_regwen
+  // R[sw_rst_regwen]: V(False)
   //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_0 (
+  ) u_sw_rst_regwen_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_0_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -542,10 +542,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[0].q),
+    .q      (reg2hw.sw_rst_regwen[0].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_0_qs)
+    .qs     (sw_rst_regwen_en_0_qs)
   );
 
   //   F[en_1]: 1:1
@@ -553,13 +553,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_1 (
+  ) u_sw_rst_regwen_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_1_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -567,10 +567,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[1].q),
+    .q      (reg2hw.sw_rst_regwen[1].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_1_qs)
+    .qs     (sw_rst_regwen_en_1_qs)
   );
 
   //   F[en_2]: 2:2
@@ -578,13 +578,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_2 (
+  ) u_sw_rst_regwen_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_2_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -592,10 +592,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[2].q),
+    .q      (reg2hw.sw_rst_regwen[2].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_2_qs)
+    .qs     (sw_rst_regwen_en_2_qs)
   );
 
   //   F[en_3]: 3:3
@@ -603,13 +603,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_3 (
+  ) u_sw_rst_regwen_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_3_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -617,10 +617,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[3].q),
+    .q      (reg2hw.sw_rst_regwen[3].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_3_qs)
+    .qs     (sw_rst_regwen_en_3_qs)
   );
 
   //   F[en_4]: 4:4
@@ -628,13 +628,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_4 (
+  ) u_sw_rst_regwen_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_4_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -642,10 +642,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[4].q),
+    .q      (reg2hw.sw_rst_regwen[4].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_4_qs)
+    .qs     (sw_rst_regwen_en_4_qs)
   );
 
   //   F[en_5]: 5:5
@@ -653,13 +653,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_5 (
+  ) u_sw_rst_regwen_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_5_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -667,10 +667,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[5].q),
+    .q      (reg2hw.sw_rst_regwen[5].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_5_qs)
+    .qs     (sw_rst_regwen_en_5_qs)
   );
 
   //   F[en_6]: 6:6
@@ -678,13 +678,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_6 (
+  ) u_sw_rst_regwen_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_6_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -692,10 +692,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[6].q),
+    .q      (reg2hw.sw_rst_regwen[6].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_6_qs)
+    .qs     (sw_rst_regwen_en_6_qs)
   );
 
   //   F[en_7]: 7:7
@@ -703,13 +703,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_7 (
+  ) u_sw_rst_regwen_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_7_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -717,10 +717,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[7].q),
+    .q      (reg2hw.sw_rst_regwen[7].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_7_qs)
+    .qs     (sw_rst_regwen_en_7_qs)
   );
 
   //   F[en_8]: 8:8
@@ -728,13 +728,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_8 (
+  ) u_sw_rst_regwen_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_8_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -742,10 +742,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[8].q),
+    .q      (reg2hw.sw_rst_regwen[8].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_8_qs)
+    .qs     (sw_rst_regwen_en_8_qs)
   );
 
   //   F[en_9]: 9:9
@@ -753,13 +753,13 @@ module rstmgr_reg_top (
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h1)
-  ) u_sw_rst_regen_en_9 (
+  ) u_sw_rst_regwen_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_rst_regen_we),
-    .wd     (sw_rst_regen_en_9_wd),
+    .we     (sw_rst_regwen_we),
+    .wd     (sw_rst_regwen_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -767,10 +767,10 @@ module rstmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_rst_regen[9].q),
+    .q      (reg2hw.sw_rst_regwen[9].q),
 
     // to register interface (read)
-    .qs     (sw_rst_regen_en_9_qs)
+    .qs     (sw_rst_regwen_en_9_qs)
   );
 
 
@@ -931,7 +931,7 @@ module rstmgr_reg_top (
     addr_hit[ 7] = (reg_addr == RSTMGR_CPU_INFO_CTRL_OFFSET);
     addr_hit[ 8] = (reg_addr == RSTMGR_CPU_INFO_ATTR_OFFSET);
     addr_hit[ 9] = (reg_addr == RSTMGR_CPU_INFO_OFFSET);
-    addr_hit[10] = (reg_addr == RSTMGR_SW_RST_REGEN_OFFSET);
+    addr_hit[10] = (reg_addr == RSTMGR_SW_RST_REGWEN_OFFSET);
     addr_hit[11] = (reg_addr == RSTMGR_SW_RST_CTRL_N_OFFSET);
   end
 
@@ -985,27 +985,27 @@ module rstmgr_reg_top (
   assign cpu_info_ctrl_index_wd = reg_wdata[7:4];
   assign cpu_info_attr_re = addr_hit[8] & reg_re & !reg_error;
   assign cpu_info_re = addr_hit[9] & reg_re & !reg_error;
-  assign sw_rst_regen_we = addr_hit[10] & reg_we & !reg_error;
+  assign sw_rst_regwen_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign sw_rst_regen_en_0_wd = reg_wdata[0];
+  assign sw_rst_regwen_en_0_wd = reg_wdata[0];
 
-  assign sw_rst_regen_en_1_wd = reg_wdata[1];
+  assign sw_rst_regwen_en_1_wd = reg_wdata[1];
 
-  assign sw_rst_regen_en_2_wd = reg_wdata[2];
+  assign sw_rst_regwen_en_2_wd = reg_wdata[2];
 
-  assign sw_rst_regen_en_3_wd = reg_wdata[3];
+  assign sw_rst_regwen_en_3_wd = reg_wdata[3];
 
-  assign sw_rst_regen_en_4_wd = reg_wdata[4];
+  assign sw_rst_regwen_en_4_wd = reg_wdata[4];
 
-  assign sw_rst_regen_en_5_wd = reg_wdata[5];
+  assign sw_rst_regwen_en_5_wd = reg_wdata[5];
 
-  assign sw_rst_regen_en_6_wd = reg_wdata[6];
+  assign sw_rst_regwen_en_6_wd = reg_wdata[6];
 
-  assign sw_rst_regen_en_7_wd = reg_wdata[7];
+  assign sw_rst_regwen_en_7_wd = reg_wdata[7];
 
-  assign sw_rst_regen_en_8_wd = reg_wdata[8];
+  assign sw_rst_regwen_en_8_wd = reg_wdata[8];
 
-  assign sw_rst_regen_en_9_wd = reg_wdata[9];
+  assign sw_rst_regwen_en_9_wd = reg_wdata[9];
   assign sw_rst_ctrl_n_re = addr_hit[11] & reg_re & !reg_error;
   assign sw_rst_ctrl_n_we = addr_hit[11] & reg_we & !reg_error;
 
@@ -1079,16 +1079,16 @@ module rstmgr_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[0] = sw_rst_regen_en_0_qs;
-        reg_rdata_next[1] = sw_rst_regen_en_1_qs;
-        reg_rdata_next[2] = sw_rst_regen_en_2_qs;
-        reg_rdata_next[3] = sw_rst_regen_en_3_qs;
-        reg_rdata_next[4] = sw_rst_regen_en_4_qs;
-        reg_rdata_next[5] = sw_rst_regen_en_5_qs;
-        reg_rdata_next[6] = sw_rst_regen_en_6_qs;
-        reg_rdata_next[7] = sw_rst_regen_en_7_qs;
-        reg_rdata_next[8] = sw_rst_regen_en_8_qs;
-        reg_rdata_next[9] = sw_rst_regen_en_9_qs;
+        reg_rdata_next[0] = sw_rst_regwen_en_0_qs;
+        reg_rdata_next[1] = sw_rst_regwen_en_1_qs;
+        reg_rdata_next[2] = sw_rst_regwen_en_2_qs;
+        reg_rdata_next[3] = sw_rst_regwen_en_3_qs;
+        reg_rdata_next[4] = sw_rst_regwen_en_4_qs;
+        reg_rdata_next[5] = sw_rst_regwen_en_5_qs;
+        reg_rdata_next[6] = sw_rst_regwen_en_6_qs;
+        reg_rdata_next[7] = sw_rst_regwen_en_7_qs;
+        reg_rdata_next[8] = sw_rst_regwen_en_8_qs;
+        reg_rdata_next[9] = sw_rst_regwen_en_9_qs;
       end
 
       addr_hit[11]: begin

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -56,7 +56,7 @@ static_assert(
 static bool rstmgr_software_reset_is_locked(
     mmio_region_t base_addr, dif_rstmgr_peripheral_t peripheral) {
   uint32_t bitfield =
-      mmio_region_read32(base_addr, RSTMGR_SW_RST_REGEN_REG_OFFSET);
+      mmio_region_read32(base_addr, RSTMGR_SW_RST_REGWEN_REG_OFFSET);
 
   // When bit is cleared, the software reset for `peripheral` is disabled.
   return !bitfield_bit32_read(bitfield, peripheral);
@@ -124,7 +124,7 @@ dif_rstmgr_result_t dif_rstmgr_reset_lock(const dif_rstmgr_t *handle,
   // Clear bit to disable the software reset for the peripheral.
   uint32_t bitfield = bitfield_bit32_write(UINT32_MAX, peripheral, false);
 
-  mmio_region_write32(base_addr, RSTMGR_SW_RST_REGEN_REG_OFFSET, bitfield);
+  mmio_region_write32(base_addr, RSTMGR_SW_RST_REGWEN_REG_OFFSET, bitfield);
 
   return kDifRstmgrOk;
 }

--- a/sw/device/lib/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_rstmgr_unittest.cc
@@ -76,7 +76,7 @@ TEST_F(ResetLockTest, Success) {
     // indexed by `bit_index`.
     uint32_t bitfield = bitfield_bit32_write(
         std::numeric_limits<uint32_t>::max(), bit_index, false);
-    EXPECT_WRITE32(RSTMGR_SW_RST_REGEN_REG_OFFSET, bitfield);
+    EXPECT_WRITE32(RSTMGR_SW_RST_REGWEN_REG_OFFSET, bitfield);
 
     EXPECT_EQ(dif_rstmgr_reset_lock(&rstmgr_, bit_index), kDifRstmgrOk);
   }
@@ -108,7 +108,7 @@ TEST_F(ResetIsLockedTest, Success) {
     // by `bit_index`.
     uint32_t bit_locked = bitfield_bit32_write(
         std::numeric_limits<uint32_t>::max(), bit_index, false);
-    EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET, bit_locked);
+    EXPECT_READ32(RSTMGR_SW_RST_REGWEN_REG_OFFSET, bit_locked);
 
     bool is_locked = false;
     EXPECT_EQ(dif_rstmgr_reset_is_locked(&rstmgr_, bit_index, &is_locked),
@@ -116,7 +116,7 @@ TEST_F(ResetIsLockedTest, Success) {
     EXPECT_TRUE(is_locked);
 
     is_locked = true;
-    EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET, {{bit_index, true}});
+    EXPECT_READ32(RSTMGR_SW_RST_REGWEN_REG_OFFSET, {{bit_index, true}});
     EXPECT_EQ(dif_rstmgr_reset_is_locked(&rstmgr_, bit_index, &is_locked),
               kDifRstmgrOk);
     EXPECT_FALSE(is_locked);
@@ -397,7 +397,7 @@ TEST_F(SoftwareResetTest, SoftwareResetIsLocked) {
     // by `bit_index`.
     uint32_t locked = bitfield_bit32_write(std::numeric_limits<uint32_t>::max(),
                                            bit_index, false);
-    EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET, locked);
+    EXPECT_READ32(RSTMGR_SW_RST_REGWEN_REG_OFFSET, locked);
 
     EXPECT_EQ(dif_rstmgr_software_reset(&rstmgr_, bit_index,
                                         kDifRstmgrSoftwareResetHold),
@@ -409,7 +409,7 @@ TEST_F(SoftwareResetTest, SuccessHold) {
   for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // Software reset is not locked for any of the supported peripherals.
-    EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET,
+    EXPECT_READ32(RSTMGR_SW_RST_REGWEN_REG_OFFSET,
                   std::numeric_limits<uint32_t>::max());
 
     // Check that reset can be asserted for every supported peripheral.
@@ -433,7 +433,7 @@ TEST_F(SoftwareResetTest, SuccessRelease) {
   for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // Software reset is not locked for any of the supported peripherals.
-    EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET,
+    EXPECT_READ32(RSTMGR_SW_RST_REGWEN_REG_OFFSET,
                   std::numeric_limits<uint32_t>::max());
 
     // Check that reset can be de-asserted for every supported peripheral.
@@ -450,7 +450,7 @@ TEST_F(SoftwareResetTest, SuccessReset) {
   for (uint32_t bit_index = 0; bit_index < RSTMGR_PARAM_NUM_SW_RESETS;
        ++bit_index) {
     // Software reset is not locked for any of the supported peripherals.
-    EXPECT_READ32(RSTMGR_SW_RST_REGEN_REG_OFFSET,
+    EXPECT_READ32(RSTMGR_SW_RST_REGWEN_REG_OFFSET,
                   std::numeric_limits<uint32_t>::max());
 
     // Check that reset can be asserted for every supported peripheral.


### PR DESCRIPTION
- Even though sw_ctrl_regwen is used externally and not in the
  conventional regwen way, making the naming consitent so that
  its purpose is clear.

Signed-off-by: Timothy Chen <timothytim@google.com>