### PR TITLE
[dv/top_level] Loop through the SW test multiple times

### DIFF
--- a/hw/ip/prim/rtl/prim_fifo_async.sv
+++ b/hw/ip/prim/rtl/prim_fifo_async.sv
@@ -278,9 +278,9 @@ module prim_fifo_async #(
   end
 
   // TODO: assertions on full, empty
-  `ASSERT(GrayWptr_A, $countones(fifo_wptr_gray_q ^ $past(fifo_wptr_gray_q)) <= 1,
+  `ASSERT(GrayWptr_A, ##1 $countones(fifo_wptr_gray_q ^ $past(fifo_wptr_gray_q)) <= 1,
           clk_wr_i, !rst_wr_ni)
-  `ASSERT(GrayRptr_A, $countones(fifo_rptr_gray_q ^ $past(fifo_rptr_gray_q)) <= 1,
+  `ASSERT(GrayRptr_A, ##1 $countones(fifo_rptr_gray_q ^ $past(fifo_rptr_gray_q)) <= 1,
           clk_rd_i, !rst_rd_ni)
 
 endmodule

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -223,10 +223,12 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
+      // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
       name: chip_sw_lc_ctrl_transition
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
       sw_images: ["sw/device/tests/lc_ctrl_transition_test:1"]
       en_run_modes: ["sw_test_mode"]
+      reseed: 15
     }
     {
       name: chip_sw_pwrmgr_usbdev_wakeup

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -20,6 +20,11 @@ class chip_base_vseq extends cip_base_vseq #(
   // Local queue for holding received UART TX data.
   byte uart_tx_data_q[$];
 
+  // Default only iterate through SW code once.
+  constraint num_trans_c {
+    num_trans == 1;
+  }
+
   `uvm_object_new
 
   task post_start();
@@ -65,6 +70,7 @@ class chip_base_vseq extends cip_base_vseq #(
     // Do DUT init after some additional settings.
     bit do_dut_init_save = do_dut_init;
     do_dut_init = 1'b0;
+    cfg.sw_test_status_vif.set_sw_test_last_iteration(num_trans == 1);
     super.pre_start();
     do_dut_init = do_dut_init_save;
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -13,11 +13,13 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
 
   rand bit [7:0] lc_exit_token[ExitTokenWidthByte];
 
-  virtual task dut_init(string reset_kind = "HARD");
+  constraint num_trans_c {
+    num_trans inside {[2:3]};
+  }
+
+  virtual function void backdoor_override_otp();
     bit [otp_ctrl_reg_pkg::TestUnlockTokenSize-1:0] rand_unlock_token;
     `DV_CHECK_STD_RANDOMIZE_FATAL(rand_unlock_token)
-
-    super.dut_init(reset_kind);
 
     // Override the LC partition to TestUnlocked2.
     cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition(lc_ctrl_state_pkg::LcStTestUnlocked2);
@@ -26,6 +28,11 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
     cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(
         .unlock_token(rand_unlock_token),
         .exit_token(get_otp_exit_token(lc_exit_token)));
+  endfunction
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    backdoor_override_otp();
   endtask
 
   // This function takes the token value from LC_CTRL token CSRs, then runs through cshake128 to
@@ -48,31 +55,48 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   virtual task body();
     super.body();
 
-    // Select LC jtag.
-    cfg.tap_straps_vif.drive(SelectLCJtagTap);
+    for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
+      // sw_symbol_backdoor_overwrite takes an array as the input
+      bit [7:0] trans_i_array[] = {trans_i};
+      sw_symbol_backdoor_overwrite("kTestIterationCount", trans_i_array);
 
-    // Override the C test kLcExitToken with random data.
-    sw_symbol_backdoor_overwrite("kLcExitToken", lc_exit_token);
+      if (trans_i > 0) begin
+        apply_reset();
+        backdoor_override_otp();
+        cfg.sw_test_status_vif.set_sw_test_last_iteration(trans_i == num_trans);
+      end
 
-    // Wait for SW to finish set up LC_CTRL.
-    cfg.clk_rst_vif.wait_clks(21000);
+      // Override the C test kLcExitToken with random data.
+      sw_symbol_backdoor_overwrite("kLcExitToken", lc_exit_token);
 
-    while(1) begin
-      bit [TL_DW-1:0]  status_val;
-      lc_ctrl_status_e dummy;
-      cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
-      jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.status.get_offset(),
-                                          p_sequencer.jtag_sequencer_h,
-                                          status_val);
+      // Wait for SW to finish power on set up.
+      wait (cfg.sw_logger_vif.printed_log == "Start LC_CTRL transition test.");
 
-      // Ensure that none of the other status bits are set.
-      `DV_CHECK_EQ(status_val >> dummy.num(), 0,
-                   $sformatf("Unexpected status error %0h", status_val))
-      if (status_val[LcTransitionSuccessful]) break;
+      // Select LC jtag.
+      cfg.tap_straps_vif.drive(SelectLCJtagTap);
+
+      while(1) begin
+        bit [TL_DW-1:0]  status_val;
+        lc_ctrl_status_e dummy;
+        cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
+        jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.status.get_offset(),
+                                            p_sequencer.jtag_sequencer_h,
+                                            status_val);
+
+        // Ensure that none of the other status bits are set.
+        `DV_CHECK_EQ(status_val >> dummy.num(), 0,
+                     $sformatf("Unexpected status error %0h", status_val))
+        if (status_val[LcTransitionSuccessful]) break;
+      end
+
+      // LC state transition requires a chip reset.
+      apply_reset();
+
+      // Wait for SW test finishes with a pass/fail status.
+      wait (cfg.sw_test_status_vif.sw_test_status inside {SwTestStatusPassed,
+                                                          SwTestStatusFailed});
+      `uvm_info(`gfn, $sformatf("Sequence %0d/%0d finished!", trans_i, num_trans), UVM_LOW)
     end
-
-    // Issue hard reset.
-    apply_reset();
   endtask
 
 endclass


### PR DESCRIPTION
This PR adds a loop to run the SW test a few times.
This is tracked as an action item in issue #7665.
Later PR will randomize the unlock token to reach higher coverage.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>