### PR TITLE
[CI] Temporarily remove clkmgr to avoid the CI failure

### DIFF
--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -20,7 +20,8 @@
              "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
-             "{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson",
+             // TODO (#8191), cause a CI failure. Remove it temporarily
+             // "{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_sim_cfg.hjson",
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson",


### PR DESCRIPTION
Filed issue #8191 as well
Signed-off-by: Weicai Yang <weicai@google.com>