### PR TITLE
[dif] autogen UART IRQ DIFs and integrate intro src tree

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -1,11 +1,11 @@
 diff --git a/sw/device/boot_rom/rom_crt.S b/sw/device/boot_rom/rom_crt.S
-index 8c61ec4d7..1c8e29d86 100644
+index acff1a477..1c8e29d86 100644
 --- a/sw/device/boot_rom/rom_crt.S
 +++ b/sw/device/boot_rom/rom_crt.S
-@@ -84,19 +84,6 @@ _reset_start:
+@@ -81,19 +81,6 @@ _reset_start:
  _start:
    .globl _start
-
+ 
 -  // Enable entropy complex - this is not the full enable
 -  li   a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
 -  li   t0, 0xa0a
@@ -58,7 +58,7 @@ index 901eba868..b19979b89 100644
 @@ -203,18 +203,13 @@ int main(void) {
    sca_init(kScaTriggerSourceAes, kScaPeripheralAes);
    sca_get_uart(&uart1);
-
+ 
 -  LOG_INFO("Running AES serial");
 -
 -  LOG_INFO("Initializing simple serial interface to capture board.");
@@ -66,45 +66,43 @@ index 901eba868..b19979b89 100644
    simple_serial_register_handler('k', aes_serial_set_key);
    simple_serial_register_handler('p', aes_serial_single_encrypt);
    simple_serial_register_handler('b', aes_serial_batch_encrypt);
-
+ 
 -  LOG_INFO("Initializing AES unit.");
    init_aes();
-
+ 
 -  LOG_INFO("Starting simple serial packet handling.");
    while (true) {
      simple_serial_process_packet();
    }
 diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
-index 9210f4529..81fd2a223 100644
+index 3fb4ff13d..e310076c3 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
 @@ -56,7 +56,6 @@ enum {
    kRvTimerHart = kTopEarlgreyPlicTargetIbex0,
  };
-
+ 
 -static dif_uart_t uart0;
  static dif_uart_t uart1;
  static dif_gpio_t gpio;
  static dif_rv_timer_t timer;
-@@ -78,16 +77,9 @@ static void sca_init_uart(void) {
-       (dif_uart_params_t){
-           .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-       },
--      &uart0));
+@@ -75,13 +74,9 @@ static void sca_init_uart(void) {
+   };
+ 
+   IGNORE_RESULT(dif_uart_init(
+-      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
 -  IGNORE_RESULT(dif_uart_configure(&uart0, uart_config));
 -  base_uart_stdout(&uart0);
 -
 -  IGNORE_RESULT(dif_uart_init(
--      (dif_uart_params_t){
--          .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR),
--      },
-       &uart1));
+-      mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR), &uart1));
++      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart1));
    IGNORE_RESULT(dif_uart_configure(&uart1, uart_config));
 +  base_uart_stdout(&uart1);
  }
-
+ 
  /**
-@@ -155,32 +147,11 @@ void handler_irq_timer(void) {
+@@ -149,32 +144,11 @@ void handler_irq_timer(void) {
   * @param disable Set of peripherals to disable.
   */
  void sca_disable_peripherals(sca_peripherals_t disable) {
@@ -137,8 +135,8 @@ index 9210f4529..81fd2a223 100644
 +      .last_hintable_clock = CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT};
    dif_clkmgr_t clkmgr;
    IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr));
-
-@@ -194,19 +165,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
+ 
+@@ -188,19 +162,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
          &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
          kDifClkmgrToggleDisabled));
    }
@@ -168,12 +166,12 @@ index 5b995c27f..0ce27b2f1 100644
  #include "sw/device/lib/testing/check.h"
 -#include "sw/device/lib/testing/entropy_testutils.h"
  #include "sw/device/lib/testing/test_framework/test_main.h"
-
+ 
  #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 @@ -67,9 +66,6 @@ bool test_main(void) {
-
+ 
    LOG_INFO("Running AES test");
-
+ 
 -  // First of all, we need to get the entropy complex up and running.
 -  entropy_testutils_boot_mode_init();
 -
@@ -181,10 +179,10 @@ index 5b995c27f..0ce27b2f1 100644
    dif_aes_params_t params = {
        .base_addr = mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index b52efb47d..c8ba0060b 100644
+index 7abdc2045..829968cb9 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
-@@ -243,7 +243,6 @@ aes_smoketest_lib = declare_dependency(
+@@ -207,7 +207,6 @@ aes_smoketest_lib = declare_dependency(
        sw_lib_dif_aes,
        sw_lib_mmio,
        sw_lib_runtime_log,

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
@@ -114,18 +114,14 @@ static dif_uart_t uart;
         Test for some common mistakes.
 */
 void portable_init(core_portable *p, int *argc, char *argv[]) {
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart) == kDifUartOk,
-      "failed to init UART");
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart) == kDifOk,
+        "failed to init UART");
   CHECK(dif_uart_configure(&uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "failed to configure UART");

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -40,18 +40,14 @@ void _boot_start(void) {
   while (flash_get_init_status())
     ;
 
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart0) == kDifUartOk,
-      "failed to init UART");
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart0) == kDifOk,
+        "failed to init UART");
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "failed to configure UART");

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -78,14 +78,14 @@ void demo_spi_to_log_echo(const dif_spi_device_t *spi) {
 void demo_uart_to_uart_and_gpio_echo(dif_uart_t *uart, dif_gpio_t *gpio) {
   while (true) {
     size_t chars_available;
-    if (dif_uart_rx_bytes_available(uart, &chars_available) != kDifUartOk ||
+    if (dif_uart_rx_bytes_available(uart, &chars_available) != kDifOk ||
         chars_available == 0) {
       break;
     }
 
     uint8_t rcv_char;
-    CHECK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL) == kDifUartOk);
-    CHECK(dif_uart_byte_send_polled(uart, rcv_char) == kDifUartOk);
+    CHECK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL) == kDifOk);
+    CHECK(dif_uart_byte_send_polled(uart, rcv_char) == kDifOk);
     CHECK(dif_gpio_write_all(gpio, rcv_char << 8) == kDifGpioOk);
   }
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -34,9 +34,12 @@ static uint8_t config_descriptors[] = {
     USB_CFG_DSCR_HEAD(
         USB_CFG_DSCR_LEN + 2 * (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN),
         2),
-    VEND_INTERFACE_DSCR(0, 2, 0x50, 1), USB_BULK_EP_DSCR(0, 1, 32, 0),
-    USB_BULK_EP_DSCR(1, 1, 32, 4), VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
-    USB_BULK_EP_DSCR(0, 2, 32, 0), USB_BULK_EP_DSCR(1, 2, 32, 4),
+    VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 1, 32, 0),
+    USB_BULK_EP_DSCR(1, 1, 32, 4),
+    VEND_INTERFACE_DSCR(1, 2, 0x50, 1),
+    USB_BULK_EP_DSCR(0, 2, 32, 0),
+    USB_BULK_EP_DSCR(1, 2, 32, 4),
 };
 
 /**
@@ -75,12 +78,12 @@ static dif_uart_t uart;
  */
 static void usb_receipt_callback_0(uint8_t c) {
   c = make_printable(c, '?');
-  CHECK(dif_uart_byte_send_polled(&uart, c) == kDifUartOk);
+  CHECK(dif_uart_byte_send_polled(&uart, c) == kDifOk);
   ++usb_chars_recved_total;
 }
 static void usb_receipt_callback_1(uint8_t c) {
   c = make_printable(c + 1, '?');
-  CHECK(dif_uart_byte_send_polled(&uart, c) == kDifUartOk);
+  CHECK(dif_uart_byte_send_polled(&uart, c) == kDifOk);
   ++usb_chars_recved_total;
 }
 
@@ -105,16 +108,12 @@ static const uint32_t kDiffMask = 2;
 static const uint32_t kUPhyMask = 4;
 
 int main(int argc, char **argv) {
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart) == kDifUartOk);
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart) == kDifOk);
   CHECK(dif_uart_configure(&uart, (dif_uart_config_t){
                                       .baudrate = kUartBaudrate,
                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifUartToggleDisabled,
+                                      .parity_enable = kDifToggleDisabled,
                                       .parity = kDifUartParityEven,
                                   }) == kDifUartConfigOk);
   base_uart_stdout(&uart);
@@ -181,14 +180,14 @@ int main(int argc, char **argv) {
 
     while (true) {
       size_t chars_available;
-      if (dif_uart_rx_bytes_available(&uart, &chars_available) != kDifUartOk ||
+      if (dif_uart_rx_bytes_available(&uart, &chars_available) != kDifOk ||
           chars_available == 0) {
         break;
       }
 
       uint8_t rcv_char;
-      CHECK(dif_uart_bytes_receive(&uart, 1, &rcv_char, NULL) == kDifUartOk);
-      CHECK(dif_uart_byte_send_polled(&uart, rcv_char) == kDifUartOk);
+      CHECK(dif_uart_bytes_receive(&uart, 1, &rcv_char, NULL) == kDifOk);
+      CHECK(dif_uart_byte_send_polled(&uart, rcv_char) == kDifOk);
 
       CHECK(dif_gpio_write_all(&gpio, rcv_char << 8) == kDifGpioOk);
 

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -21,16 +21,12 @@ static dif_spi_device_t spi;
 static dif_uart_t uart;
 
 int main(int argc, char **argv) {
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart) == kDifUartOk);
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart) == kDifOk);
   CHECK(dif_uart_configure(&uart, (dif_uart_config_t){
                                       .baudrate = kUartBaudrate,
                                       .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifUartToggleDisabled,
+                                      .parity_enable = kDifToggleDisabled,
                                       .parity = kDifUartParityEven,
                                   }) == kDifUartConfigOk);
   base_uart_stdout(&uart);

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -1,0 +1,193 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_uart.h"
+
+#include "uart_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool uart_get_irq_bit_index(dif_uart_irq_t irq,
+                                   bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifUartIrqTxWatermark:
+      *index_out = UART_INTR_STATE_TX_WATERMARK_BIT;
+      break;
+    case kDifUartIrqRxWatermark:
+      *index_out = UART_INTR_STATE_RX_WATERMARK_BIT;
+      break;
+    case kDifUartIrqTxEmpty:
+      *index_out = UART_INTR_STATE_TX_EMPTY_BIT;
+      break;
+    case kDifUartIrqRxOverflow:
+      *index_out = UART_INTR_STATE_RX_OVERFLOW_BIT;
+      break;
+    case kDifUartIrqRxFrameErr:
+      *index_out = UART_INTR_STATE_RX_FRAME_ERR_BIT;
+      break;
+    case kDifUartIrqRxBreakErr:
+      *index_out = UART_INTR_STATE_RX_BREAK_ERR_BIT;
+      break;
+    case kDifUartIrqRxTimeout:
+      *index_out = UART_INTR_STATE_RX_TIMEOUT_BIT;
+      break;
+    case kDifUartIrqRxParityErr:
+      *index_out = UART_INTR_STATE_RX_PARITY_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_get_state(const dif_uart_t *uart,
+                                    dif_uart_irq_state_snapshot_t *snapshot) {
+  if (uart == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(uart->base_addr, UART_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_is_pending(const dif_uart_t *uart, dif_uart_irq_t irq,
+                                     bool *is_pending) {
+  if (uart == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!uart_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(uart->base_addr, UART_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_acknowledge(const dif_uart_t *uart,
+                                      dif_uart_irq_t irq) {
+  if (uart == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!uart_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(uart->base_addr, UART_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_get_enabled(const dif_uart_t *uart,
+                                      dif_uart_irq_t irq, dif_toggle_t *state) {
+  if (uart == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!uart_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_set_enabled(const dif_uart_t *uart,
+                                      dif_uart_irq_t irq, dif_toggle_t state) {
+  if (uart == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!uart_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_force(const dif_uart_t *uart, dif_uart_irq_t irq) {
+  if (uart == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!uart_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(uart->base_addr, UART_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_disable_all(
+    const dif_uart_t *uart, dif_uart_irq_enable_snapshot_t *snapshot) {
+  if (uart == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_restore_all(
+    const dif_uart_t *uart, const dif_uart_irq_enable_snapshot_t *snapshot) {
+  if (uart == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.inc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.inc
@@ -1,0 +1,192 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_INC_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_INC_
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/uart/doc/">UART</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to UART.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_uart {
+  /**
+   * The base address for the UART hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_uart_t;
+
+/**
+ * A UART interrupt request type.
+ */
+typedef enum dif_uart_irq {
+  /**
+   * Raised if the transmit FIFO is past the high-water mark.
+   */
+  kDifUartIrqTxWatermark = 0,
+  /**
+   * Raised if the receive FIFO is past the high-water mark.
+   */
+  kDifUartIrqRxWatermark = 1,
+  /**
+   * Raised if the transmit FIFO has emptied and no transmit is ongoing.
+   */
+  kDifUartIrqTxEmpty = 2,
+  /**
+   * Raised if the receive FIFO has overflowed.
+   */
+  kDifUartIrqRxOverflow = 3,
+  /**
+   * Raised if a framing error has been detected on receive.
+   */
+  kDifUartIrqRxFrameErr = 4,
+  /**
+   * Raised if break condition has been detected on receive.
+   */
+  kDifUartIrqRxBreakErr = 5,
+  /**
+   * Raised if RX FIFO has characters remaining in the FIFO without being
+   * retrieved for the programmed time period.
+   */
+  kDifUartIrqRxTimeout = 6,
+  /**
+   * Raised if the receiver has detected a parity error.
+   */
+  kDifUartIrqRxParityErr = 7,
+} dif_uart_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_uart_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_uart_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_uart_irq_disable_all()` and `dif_uart_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_uart_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param uart A UART handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_get_state(const dif_uart_t *uart,
+                                    dif_uart_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param uart A UART handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_is_pending(const dif_uart_t *uart, dif_uart_irq_t irq,
+                                     bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param uart A UART handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_acknowledge(const dif_uart_t *uart,
+                                      dif_uart_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param uart A UART handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_get_enabled(const dif_uart_t *uart,
+                                      dif_uart_irq_t irq, dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param uart A UART handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_set_enabled(const dif_uart_t *uart,
+                                      dif_uart_irq_t irq, dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param uart A UART handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_force(const dif_uart_t *uart, dif_uart_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param uart A UART handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_disable_all(const dif_uart_t *uart,
+                                      dif_uart_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param uart A UART handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_irq_restore_all(
+    const dif_uart_t *uart, const dif_uart_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_INC_

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -1,0 +1,274 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_uart_unittest.h"
+
+namespace dif_uart_unittest {
+namespace {
+using testing::Eq;
+using testing::Test;
+
+class IrqGetStateTest : public UartTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_uart_irq_state_snapshot_t irq_snapshot;
+
+  EXPECT_EQ(dif_uart_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_get_state(&uart_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_uart_irq_state_snapshot_t irq_snapshot;
+
+  EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_uart_irq_get_state(&uart_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_uart_irq_state_snapshot_t irq_snapshot;
+
+  EXPECT_READ32(UART_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_uart_irq_get_state(&uart_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public UartTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_uart_irq_is_pending(nullptr, kDifUartIrqTxWatermark, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_is_pending(&uart_, kDifUartIrqTxWatermark, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_is_pending(nullptr, kDifUartIrqTxWatermark, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_uart_irq_is_pending(&uart_, (dif_uart_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
+                {{UART_INTR_STATE_TX_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_uart_irq_is_pending(&uart_, kDifUartIrqTxWatermark, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
+                {{UART_INTR_STATE_RX_PARITY_ERR_BIT, false}});
+  EXPECT_EQ(dif_uart_irq_is_pending(&uart_, kDifUartIrqRxParityErr, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public UartTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_uart_irq_acknowledge(nullptr, kDifUartIrqTxWatermark),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_uart_irq_acknowledge(nullptr, (dif_uart_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
+                 {{UART_INTR_STATE_TX_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_uart_irq_acknowledge(&uart_, kDifUartIrqTxWatermark), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
+                 {{UART_INTR_STATE_RX_PARITY_ERR_BIT, true}});
+  EXPECT_EQ(dif_uart_irq_acknowledge(&uart_, kDifUartIrqRxParityErr), kDifOk);
+}
+
+class IrqGetEnabledTest : public UartTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_uart_irq_get_enabled(nullptr, kDifUartIrqTxWatermark, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_get_enabled(&uart_, kDifUartIrqTxWatermark, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_get_enabled(nullptr, kDifUartIrqTxWatermark, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_uart_irq_get_enabled(&uart_, (dif_uart_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET,
+                {{UART_INTR_ENABLE_TX_WATERMARK_BIT, true}});
+  EXPECT_EQ(
+      dif_uart_irq_get_enabled(&uart_, kDifUartIrqTxWatermark, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET,
+                {{UART_INTR_ENABLE_RX_PARITY_ERR_BIT, true}});
+  EXPECT_EQ(
+      dif_uart_irq_get_enabled(&uart_, kDifUartIrqTxWatermark, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public UartTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(
+      dif_uart_irq_set_enabled(nullptr, kDifUartIrqTxWatermark, irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, (dif_uart_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(UART_INTR_ENABLE_REG_OFFSET,
+                {{UART_INTR_ENABLE_TX_WATERMARK_BIT, 0x1, true}});
+  EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, kDifUartIrqTxWatermark, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(UART_INTR_ENABLE_REG_OFFSET,
+                {{UART_INTR_ENABLE_RX_PARITY_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, kDifUartIrqRxParityErr, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public UartTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_uart_irq_force(nullptr, kDifUartIrqTxWatermark), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_uart_irq_force(nullptr, (dif_uart_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(UART_INTR_TEST_REG_OFFSET,
+                 {{UART_INTR_TEST_TX_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_uart_irq_force(&uart_, kDifUartIrqTxWatermark), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(UART_INTR_TEST_REG_OFFSET,
+                 {{UART_INTR_TEST_RX_PARITY_ERR_BIT, true}});
+  EXPECT_EQ(dif_uart_irq_force(&uart_, kDifUartIrqRxParityErr), kDifOk);
+}
+
+class IrqDisableAllTest : public UartTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_uart_irq_enable_snapshot_t irq_snapshot;
+
+  EXPECT_EQ(dif_uart_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_uart_irq_disable_all(&uart_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_uart_irq_enable_snapshot_t irq_snapshot;
+
+  EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_uart_irq_disable_all(&uart_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_uart_irq_enable_snapshot_t irq_snapshot;
+
+  EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_uart_irq_disable_all(&uart_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public UartTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_uart_irq_enable_snapshot_t irq_snapshot;
+
+  EXPECT_EQ(dif_uart_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_restore_all(&uart_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_uart_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_uart_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_uart_irq_restore_all(&uart_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_uart_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_uart_irq_restore_all(&uart_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_uart_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Autogen UART DIF library
+sw_lib_dif_autogen_uart = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_uart',
+    sources: [
+      hw_ip_uart_reg_h,
+      'dif_uart_autogen.c',
+    ],
+    include_directories: include_directories('../'),
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)

--- a/sw/device/lib/dif/dif_uart_unittest.h
+++ b/sw/device/lib/dif/dif_uart_unittest.h
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_UNITTEST_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_UNITTEST_H_
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_uart.h"
+
+#include "uart_regs.h"  // Generated.
+
+namespace dif_uart_unittest {
+namespace {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Test;
+
+const std::vector<uint8_t> kBytesArray = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a',
+    'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+    'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+};
+
+class UartTest : public Test, public MmioTest {
+ protected:
+  void ExpectDeviceReset() {
+    EXPECT_WRITE32(UART_CTRL_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_FIFO_CTRL_REG_OFFSET,
+                   {
+                       {UART_FIFO_CTRL_RXRST_BIT, true},
+                       {UART_FIFO_CTRL_TXRST_BIT, true},
+                   });
+    EXPECT_WRITE32(UART_OVRD_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_TIMEOUT_CTRL_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_WRITE32(UART_INTR_STATE_REG_OFFSET,
+                   std::numeric_limits<uint32_t>::max());
+  }
+
+  dif_uart_t uart_ = {
+      .base_addr = dev().region(),
+  };
+
+  // NCO is calculated as NCO = 2^20 * fbaud / fpclk, so the following values
+  // should result in NCO of 1. This is the default configuration, which will
+  // be used unless the values are overridden.
+  dif_uart_config_t config_ = {
+      .baudrate = 1,
+      .clk_freq_hz = 1048576,
+      .parity_enable = kDifUartToggleDisabled,
+      .parity = kDifUartParityEven,
+  };
+};
+
+}  // namespace
+}  // namespace dif_uart_unittest
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_UART_UNITTEST_H_

--- a/sw/device/lib/dif/dif_uart_unittest.h
+++ b/sw/device/lib/dif/dif_uart_unittest.h
@@ -50,7 +50,7 @@ class UartTest : public Test, public MmioTest {
   dif_uart_config_t config_ = {
       .baudrate = 1,
       .clk_freq_hz = 1048576,
-      .parity_enable = kDifUartToggleDisabled,
+      .parity_enable = kDifToggleDisabled,
       .parity = kDifUartParityEven,
   };
 };

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+subdir('autogen')
+
 # Clock Manager DIF Library (dif_clkmgr)
 sw_lib_dif_clkmgr = declare_dependency(
   link_with: static_library(
@@ -80,6 +82,7 @@ sw_lib_dif_edn = declare_dependency(
   )
 )
 
+
 # UART DIF library (dif_uart)
 sw_lib_dif_uart = declare_dependency(
   link_with: static_library(
@@ -90,6 +93,7 @@ sw_lib_dif_uart = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_dif_autogen_uart,
     ],
   )
 )
@@ -98,7 +102,9 @@ test('dif_uart_unittest', executable(
     'dif_uart_unittest',
     sources: [
       'dif_uart_unittest.cc',
+      'autogen/dif_uart_autogen_unittest.cc',
       meson.source_root() / 'sw/device/lib/dif/dif_uart.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_uart_autogen.c',
       hw_ip_uart_reg_h,
     ],
     dependencies: [

--- a/sw/device/lib/runtime/print.c
+++ b/sw/device/lib/runtime/print.c
@@ -49,7 +49,8 @@ static size_t base_dev_null(void *data, const char *buf, size_t len) {
   return len;
 }
 static buffer_sink_t base_stdout = {
-    .data = NULL, .sink = &base_dev_null,
+    .data = NULL,
+    .sink = &base_dev_null,
 };
 
 void base_set_stdout(buffer_sink_t out) {
@@ -62,7 +63,7 @@ void base_set_stdout(buffer_sink_t out) {
 static size_t base_dev_uart(void *data, const char *buf, size_t len) {
   const dif_uart_t *uart = (const dif_uart_t *)data;
   for (size_t i = 0; i < len; ++i) {
-    if (dif_uart_byte_send_polled(uart, (uint8_t)buf[i]) != kDifUartOk) {
+    if (dif_uart_byte_send_polled(uart, (uint8_t)buf[i]) != kDifOk) {
       return i;
     }
   }
@@ -111,10 +112,12 @@ size_t base_snprintf(char *buf, size_t len, const char *format, ...) {
   va_start(args, format);
 
   snprintf_captures_t data = {
-      .buf = buf, .bytes_left = len,
+      .buf = buf,
+      .bytes_left = len,
   };
   buffer_sink_t out = {
-      .data = &data, .sink = &snprintf_sink,
+      .data = &data,
+      .sink = &snprintf_sink,
   };
   size_t bytes_left = base_vfprintf(out, format, args);
   va_end(args);

--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -17,9 +17,8 @@ extern "C" {
 
 // NOTE: This is only present so that print.c can link without pulling in
 // dif_uart.c.
-extern "C" dif_uart_result_t dif_uart_byte_send_polled(const dif_uart *,
-                                                       uint8_t) {
-  return kDifUartOk;
+extern "C" dif_result_t dif_uart_byte_send_polled(const dif_uart *, uint8_t) {
+  return kDifOk;
 }
 
 namespace base {

--- a/sw/device/lib/testing/test_framework/test_main.c
+++ b/sw/device/lib/testing/test_framework/test_main.c
@@ -16,18 +16,14 @@
 
 static dif_uart_t uart0;
 static void init_uart(void) {
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart0) == kDifUartOk,
-      "failed to init UART");
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart0) == kDifOk,
+        "failed to init UART");
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "failed to configure UART");

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -20,18 +20,14 @@ extern volatile uint32_t end_signature[];
 static dif_uart_t uart0;
 
 int opentitan_compliance_main(int argc, char **argv) {
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart0) == kDifUartOk,
-      "failed to init UART");
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart0) == kDifOk,
+        "failed to init UART");
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "failed to configure UART");

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -70,23 +70,17 @@ static void sca_init_uart(void) {
   const dif_uart_config_t uart_config = {
       .baudrate = kUartBaudrate,
       .clk_freq_hz = kClockFreqPeripheralHz,
-      .parity_enable = kDifUartToggleDisabled,
+      .parity_enable = kDifToggleDisabled,
       .parity = kDifUartParityEven,
   };
 
   IGNORE_RESULT(dif_uart_init(
-      (dif_uart_params_t){
-          .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-      },
-      &uart0));
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
   IGNORE_RESULT(dif_uart_configure(&uart0, uart_config));
   base_uart_stdout(&uart0);
 
   IGNORE_RESULT(dif_uart_init(
-      (dif_uart_params_t){
-          .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR),
-      },
-      &uart1));
+      mmio_region_from_addr(TOP_EARLGREY_UART1_BASE_ADDR), &uart1));
   IGNORE_RESULT(dif_uart_configure(&uart1, uart_config));
 }
 

--- a/sw/device/silicon_creator/rom_exts/rom_ext.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext.c
@@ -37,13 +37,10 @@ void rom_ext_boot(void) {
     abort();
   }
 
-  dif_uart_result_t init_result = dif_uart_init(
-      (dif_uart_params_t){
-          .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-      },
-      &uart);
+  dif_result_t init_result =
+      dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart);
 
-  if (init_result != kDifUartOk) {
+  if (init_result != kDifOk) {
     abort();
   }
 
@@ -51,7 +48,7 @@ void rom_ext_boot(void) {
       dif_uart_configure(&uart, (dif_uart_config_t){
                                     .baudrate = kUartBaudrate,
                                     .clk_freq_hz = kClockFreqPeripheralHz,
-                                    .parity_enable = kDifUartToggleDisabled,
+                                    .parity_enable = kDifToggleDisabled,
                                     .parity = kDifUartParityEven,
                                 });
 

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -38,18 +38,14 @@ volatile char ensure_bss_exists;
 
 static dif_uart_t uart0;
 static void init_uart(void) {
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart0) == kDifUartOk,
-      "failed to init UART");
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart0) == kDifOk,
+        "failed to init UART");
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "failed to configure UART");

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -58,7 +58,7 @@ static void handle_uart_isr(const dif_rv_plic_irq_id_t interrupt_id) {
       test_status_set(kTestStatusFailed);
   }
 
-  CHECK(dif_uart_irq_acknowledge(&uart0, uart_irq) == kDifUartOk,
+  CHECK(dif_uart_irq_acknowledge(&uart0, uart_irq) == kDifOk,
         "ISR failed to clear IRQ!");
 }
 
@@ -92,16 +92,12 @@ void handler_irq_external(void) {
 }
 
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
-  CHECK(dif_uart_init(
-            (dif_uart_params_t){
-                .base_addr = base_addr,
-            },
-            uart) == kDifUartOk);
+  CHECK(dif_uart_init(base_addr, uart) == kDifOk);
   CHECK(dif_uart_configure(uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "UART config failed!");
@@ -118,10 +114,10 @@ static void plic_initialise(mmio_region_t base_addr, dif_rv_plic_t *plic) {
  */
 static void uart_configure_irqs(dif_uart_t *uart) {
   CHECK(dif_uart_irq_set_enabled(&uart0, kDifUartIrqRxOverflow,
-                                 kDifUartToggleEnabled) == kDifUartOk,
+                                 kDifToggleEnabled) == kDifOk,
         "RX overflow IRQ enable failed!");
   CHECK(dif_uart_irq_set_enabled(&uart0, kDifUartIrqTxEmpty,
-                                 kDifUartToggleEnabled) == kDifUartOk,
+                                 kDifToggleEnabled) == kDifOk,
         "TX empty IRQ enable failed!");
 }
 
@@ -158,7 +154,7 @@ static void plic_configure_irqs(dif_rv_plic_t *plic) {
 static void execute_test(dif_uart_t *uart) {
   // Force UART RX overflow interrupt.
   uart_rx_overflow_handled = false;
-  CHECK(dif_uart_irq_force(uart, kDifUartIrqRxOverflow) == kDifUartOk,
+  CHECK(dif_uart_irq_force(uart, kDifUartIrqRxOverflow) == kDifOk,
         "failed to force RX overflow IRQ!");
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_rx_overflow_handled) {
@@ -168,7 +164,7 @@ static void execute_test(dif_uart_t *uart) {
 
   // Force UART TX empty interrupt.
   uart_tx_empty_handled = false;
-  CHECK(dif_uart_irq_force(uart, kDifUartIrqTxEmpty) == kDifUartOk,
+  CHECK(dif_uart_irq_force(uart, kDifUartIrqTxEmpty) == kDifOk,
         "failed to force TX empty IRQ!");
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_tx_empty_handled) {

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -19,32 +19,28 @@ const test_config_t kTestConfig = {
 
 bool test_main(void) {
   dif_uart_t uart;
-  CHECK(
-      dif_uart_init(
-          (dif_uart_params_t){
-              .base_addr = mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-          },
-          &uart) == kDifUartOk);
+  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
+                      &uart) == kDifOk);
   CHECK(dif_uart_configure(&uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
                                .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifUartToggleDisabled,
+                               .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
                            }) == kDifUartConfigOk,
         "UART config failed!");
 
   CHECK(dif_uart_loopback_set(&uart, kDifUartLoopbackSystem,
-                              kDifUartToggleEnabled) == kDifUartOk);
-  CHECK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll) == kDifUartOk);
+                              kDifToggleEnabled) == kDifOk);
+  CHECK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll) == kDifOk);
 
   // Send all bytes in `kSendData`, and check that they are received via
   // the loopback mechanism.
   for (int i = 0; i < sizeof(kSendData); ++i) {
-    CHECK(dif_uart_byte_send_polled(&uart, kSendData[i]) == kDifUartOk);
+    CHECK(dif_uart_byte_send_polled(&uart, kSendData[i]) == kDifOk);
 
     uint8_t receive_byte;
-    CHECK(dif_uart_byte_receive_polled(&uart, &receive_byte) == kDifUartOk);
+    CHECK(dif_uart_byte_receive_polled(&uart, &receive_byte) == kDifOk);
     CHECK(receive_byte == kSendData[i]);
   }
 


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "uart".

**Note**:  this PR depends on #8143 and therefore contains duplicate commits that will be removed when #8143 is merged.