### PR TITLE
[dv] Fix coverage report error

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -167,7 +167,12 @@
                      "-dir {cov_merge_db_dir}",
                      "-line nocasedef",
                      "-format both",
-                     "-elfile {vcs_cov_excl_files}",
+                     '''{eval_cmd} opts=`echo {vcs_cov_excl_files}`; \
+                     if [ "$opts" != "" ]; then \
+                       opts="-elfile $opts"; \
+                       echo $opts;
+                     fi
+                     ''',
                      "-report {cov_report_dir}"]
   cov_report_txt:   "{cov_report_dir}/dashboard.txt"
   cov_report_page:  "dashboard.html"


### PR DESCRIPTION
It's due to the update in #8137 and now not all the IP has elfile
This fix is to avoid using `-elfile` when no elfile is in the list

Signed-off-by: Weicai Yang <weicai@google.com>