### PR TITLE
[prim] Change prim_reg_cdc assertions

### DIFF
--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -139,9 +139,9 @@ module prim_reg_cdc #(
 
   `ifdef SIMULATION
     logic async_flag;
-    always_ff @(posedge src_req or posedge dst_req or
+    always_ff @(posedge clk_dst_i or
       negedge rst_src_ni or negedge rst_dst_ni) begin
-      if (!rst_src_ni && !rst_dst_ni) begin
+      if (!rst_src_ni | !rst_dst_ni) begin
         async_flag <= '0;
       end else if (src_req) begin
         async_flag <= 1'b1;


### PR DESCRIPTION
Do not use the src_req directly as event glitches can cause unexpected behavior.

Signed-off-by: Timothy Chen <timothytim@google.com>