### PR TITLE
[otbn, doc] Specify new all errors fatal mode

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -197,6 +197,25 @@
         }
       ],
     }
+    { name: "CTRL",
+      desc: "control register",
+      hwext: "true",
+      swaccess: "rw",
+      hwaccess: "hrw",
+      hwqe:  "true",
+      fields: [
+        { bits: "0",
+          name: "software_errs_fatal",
+          resval: 0,
+          desc: '''
+            When set software errors produce fatal errors, rather than
+            recoverable errors. This field can only be changed when OTBN is in
+            the IDLE state (see !!STATUS). Any writes to this field when OTBN
+            isn't in the IDLE state are ignored.
+          '''
+        }
+      ],
+    }
     { name: "STATUS",
       desc: "Status",
       swaccess: "ro",
@@ -326,6 +345,11 @@
           resval: 0,
           desc: "A `LIFECYCLE_ESCALATION` error was observed."
         }
+        { bits: "22",
+          name: "fatal_software"
+          resval: 0,
+          desc: "A `FATAL_SOFTWARE` error was observed."
+        }
       ]
     } // register : err_bits
     { name: "FATAL_ALERT_CAUSE",
@@ -369,6 +393,11 @@
           name: "lifecycle_escalation"
           resval: 0,
           desc: "A `LIFECYCLE_ESCALATION` error was observed."
+        }
+        { bits: "6",
+          name: "fatal_software"
+          resval: 0,
+          desc: "A `FATAL_SOFTWARE` error was observed."
         }
       ]
     } // register : fatal_alert_cause

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -588,7 +588,8 @@ Whenever an error is detected, OTBN reacts locally, and informs the OpenTitan sy
 OTBN generally does not try to recover from errors itself, and provides no error handling support to code that runs on it.
 
 OTBN gives host software the option to recover from some errors by restarting the operation.
-All software errors are treated as recoverable and are handled as described in the section [Reaction to Recoverable Errors](#design-details-recoverable-errors).
+All software errors are treated as recoverable, unless {{< regref "CTRL.software_errs_fatal" >}} is set, and are handled as described in the section [Reaction to Recoverable Errors](#design-details-recoverable-errors).
+When {{< regref "CTRL.software_errs_fatal" >}} is set, software errors become fatal errors.
 
 Fatal errors are treated as described in the section [Reaction to Fatal Errors](#design-details-fatal-errors).
 
@@ -701,6 +702,11 @@ This way, no alert is generated without setting an error code somewhere.
       <td><code>LIFECYCLE_ESCALATION<code></td>
       <td>fatal</td>
       <td>A life cycle escalation request was received.</td>
+    </tr>
+    <tr>
+      <td><code>FATAL_SOFTWARE<code></td>
+      <td>fatal</td>
+      <td>A software error was seen and {{< regref "CTRL.software_errs_fatal" >}} was set.</td>
     </tr>
   </tbody>
 </table>

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -33,3 +33,4 @@ class ErrBits(IntEnum):
     BUS_INTG_VIOLATION = 1 << 19
     ILLEGAL_BUS_ACCESS = 1 << 20
     LIFECYCLE_ESCALATION = 1 << 21
+    FATAL_SOFTWARE = 1 << 22

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -599,6 +599,8 @@ module otbn
 
   `ASSERT(OtbnStatesOneHot, $onehot0({busy_execute_q, locked}))
 
+  assign hw2reg.ctrl.d = 1'b0;
+
   // ERR_BITS register
   // The error bits for an OTBN operation get stored on the cycle that done is
   // asserted. Software is expected to read them out before starting the next operation.
@@ -635,6 +637,9 @@ module otbn
   assign hw2reg.err_bits.lifecycle_escalation.de = done;
   assign hw2reg.err_bits.lifecycle_escalation.d = err_bits.lifecycle_escalation;
 
+  assign hw2reg.err_bits.fatal_software.de = done;
+  assign hw2reg.err_bits.fatal_software.d = 1'b0;
+
   // FATAL_ALERT_CAUSE register. The .de and .d values are equal for each bit, so that it can only
   // be set, not cleared.
   assign hw2reg.fatal_alert_cause.imem_intg_violation.de = imem_rerror;
@@ -650,6 +655,8 @@ module otbn
   assign hw2reg.fatal_alert_cause.illegal_bus_access.d  = illegal_bus_access_d;
   assign hw2reg.fatal_alert_cause.lifecycle_escalation.de = lifecycle_escalation;
   assign hw2reg.fatal_alert_cause.lifecycle_escalation.d  = lifecycle_escalation;
+  assign hw2reg.fatal_alert_cause.fatal_software.de = 0;
+  assign hw2reg.fatal_alert_cause.fatal_software.d  = 0;
 
   // INSN_CNT register
   logic [31:0] insn_cnt;

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -353,6 +353,8 @@ module otbn_controller
   // or illegal WSR/CSR referenced).
   assign illegal_insn_static = insn_illegal_i | ispr_err;
 
+  // TODO: Implement fatal error on software error mode
+  assign err_bits_o.fatal_software       = 1'b0;
   assign err_bits_o.lifecycle_escalation = lifecycle_escalation_i;
   assign err_bits_o.illegal_bus_access   = illegal_bus_access_i;
   assign err_bits_o.bus_intg_violation   = bus_intg_violation_i;
@@ -366,7 +368,8 @@ module otbn_controller
   assign err_bits_o.bad_insn_addr        = imem_addr_err;
 
   assign err = |err_bits_o;
-  assign fatal_err = |{err_bits_o.lifecycle_escalation,
+  assign fatal_err = |{err_bits_o.fatal_software,
+                       err_bits_o.lifecycle_escalation,
                        err_bits_o.illegal_bus_access,
                        err_bits_o.bus_intg_violation,
                        err_bits_o.reg_intg_violation,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -70,6 +70,7 @@ package otbn_pkg;
   //
   // Note: These errors are duplicated in other places. If updating them here, update those too.
   typedef struct packed {
+    logic fatal_software;
     logic lifecycle_escalation;
     logic illegal_bus_access;
     logic bus_intg_violation;

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -41,6 +41,9 @@ static_assert(kDifOtbnErrBitsIllegalBusAccess ==
 static_assert(kDifOtbnErrBitsLifecycleEscalation ==
                   (1 << OTBN_ERR_BITS_LIFECYCLE_ESCALATION_BIT),
               "Layout of error bits changed.");
+static_assert(kDifOtbnErrBitsFatalSoftware ==
+                  (1 << OTBN_ERR_BITS_FATAL_SOFTWARE_BIT),
+              "Layout of error bits changed.");
 
 /**
  * Data width of big number subset, in bytes.

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -116,6 +116,8 @@ typedef enum dif_otbn_err_bits {
   kDifOtbnErrBitsIllegalBusAccess = (1 << 20),
   /** A LIFECYCLE_ESCALATION error was observed. */
   kDifOtbnErrBitsLifecycleEscalation = (1 << 21),
+  /** A FATAL_SOFTWARE error was observed. */
+  kDifOtbnErrBitsFatalSoftware = (1 << 22),
 } dif_otbn_err_bits_t;
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -36,6 +36,8 @@ ASSERT_ERR_BIT_MATCH(kOtbnErrBitsIllegalBusAccess,
                      OTBN_ERR_BITS_ILLEGAL_BUS_ACCESS_BIT);
 ASSERT_ERR_BIT_MATCH(kOtbnErrBitsLifecycleEscalation,
                      OTBN_ERR_BITS_LIFECYCLE_ESCALATION_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalSoftware,
+                     OTBN_ERR_BITS_FATAL_SOFTWARE_BIT);
 
 const size_t kOtbnDMemSizeBytes = OTBN_DMEM_SIZE_BYTES;
 const size_t kOtbnIMemSizeBytes = OTBN_IMEM_SIZE_BYTES;

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -91,6 +91,8 @@ typedef enum otbn_err_bits {
   kOtbnErrBitsIllegalBusAccess = (1 << 20),
   /** A LIFECYCLE_ESCALATION error was observed. */
   kOtbnErrBitsLifecycleEscalation = (1 << 21),
+  /** A FATAL_SOFTWARE error was observed. */
+  kOtbnErrBitsFatalSoftware = (1 << 22),
 } otbn_err_bits_t;
 
 /**


### PR DESCRIPTION
A new `CTRL` register is introduced. When the `all_errs_fatal` bit is
set here then any error OTBN sees is promoted to a fatal error. This bit
can only be changed when OTBN is idle.

Fixes #8044

Signed-off-by: Greg Chadwick <gac@lowrisc.org>