### PR TITLE
[spi_device] Mailbox Address CSR

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -214,6 +214,16 @@
             the SPI line 0 following the SPI command as the address field.
             '''
         }
+        { bits: "24"
+          name: "mailbox_en"
+          desc: '''Mailbox enable.
+
+            If 1, in the flash and passthrough mode, the IP checks the incoming
+            address and return from the internal Mailbox buffer if the address
+            falls into the MAILBOX range
+            (MAILBOX_ADDR:MAILBOX_ADDR+MAILBOX_SIZE)}.
+            '''
+        } // f: mailbox_en
       ]
     },
     { name: "FIFO_LEVEL",
@@ -475,6 +485,21 @@
         } // f: threshold
       ]
     } // R: READ_THRESHOLD
+    { name: "MAILBOX_ADDR"
+      desc: '''Mailbox Base address register.
+
+        The mailbox size is fixed. In this version of IP, the size is 1kB.
+        Lower 10 bits of the Mailbox address is tied to 0.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "31:0"
+          name: "addr"
+          desc: "Mailbox Address. Lower 10 bits are ignored"
+        } // f: addr
+      ]
+    } // R: MAILBOX_ADDR
     { name: "UPLOAD_STATUS"
       desc: '''Upload module status register.
         '''

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -222,6 +222,9 @@ module spi_device
   // Mailbox in Passthrough needs to take SPI if readcmd hits mailbox address
   logic mailbox_assumed, passthrough_assumed_by_internal;
 
+  logic cfg_mailbox_en;
+  logic [31:0] mailbox_addr;
+
   // Threshold value of a buffer in bytes
   logic [BufferAw:0] readbuf_threshold;
 
@@ -539,6 +542,12 @@ module spi_device
   assign jedec_id = {reg2hw.jedec_id.mf.q, reg2hw.jedec_id.id.q};
 
   assign readbuf_threshold = reg2hw.read_threshold.q[BufferAw:0];
+
+  localparam int unsigned MailboxAw = $clog2(SramMailboxDepth*SramDw/8);
+  assign cfg_mailbox_en = reg2hw.cfg.mailbox_en.q;
+  assign mailbox_addr   = { reg2hw.mailbox_addr.q[31:MailboxAw],
+                            {MailboxAw{1'b0}}
+                          };
 
   // Passthrough config: value shall be stable while SPI transaction is active
   //assign cmd_filter = reg2hw.cmd_filter.q;
@@ -1078,8 +1087,8 @@ module spi_device
 
     .addr_4b_en_i (cfg_addr_4b_en),
 
-    .mailbox_en_i      (1'b 0),
-    .mailbox_addr_i    ('0), // 32
+    .mailbox_en_i      (cfg_mailbox_en ),
+    .mailbox_addr_i    (mailbox_addr   ),
     .mailbox_assumed_o (mailbox_assumed),
 
     .readbuf_address_o (readbuf_addr_sck),

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -140,6 +140,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic        q;
     } addr_4b_en;
+    struct packed {
+      logic        q;
+    } mailbox_en;
   } spi_device_reg2hw_cfg_reg_t;
 
   typedef struct packed {
@@ -204,6 +207,10 @@ package spi_device_reg_pkg;
   typedef struct packed {
     logic [9:0] q;
   } spi_device_reg2hw_read_threshold_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_mailbox_addr_reg_t;
 
   typedef struct packed {
     logic [7:0]  q;
@@ -510,20 +517,21 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1426:1420]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1419:1413]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1412:1399]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1398:1397]
-    spi_device_reg2hw_control_reg_t control; // [1396:1391]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1390:1378]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1377:1346]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1345:1330]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1329:1314]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1313:1282]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1281:1250]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1249:1224]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1223:1200]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1199:1190]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1459:1453]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1452:1446]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1445:1432]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1431:1430]
+    spi_device_reg2hw_control_reg_t control; // [1429:1424]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1423:1410]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1409:1378]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1377:1362]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1361:1346]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1345:1314]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1313:1282]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1281:1256]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1255:1232]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1231:1222]
+    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1221:1190]
     spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1189:1181]
     spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1180:1148]
     spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1147:892]
@@ -580,43 +588,44 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_FLASH_STATUS_OFFSET = 13'h 38;
   parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 3c;
   parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 40;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 44;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 48;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 4c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 50;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 54;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 58;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 5c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 60;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 64;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 68;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 6c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 70;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 74;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 44;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 48;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 4c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 50;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 54;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 58;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 5c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 60;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 64;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 68;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 6c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 70;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 74;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 78;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h d8;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -681,6 +690,7 @@ package spi_device_reg_pkg;
     SPI_DEVICE_FLASH_STATUS,
     SPI_DEVICE_JEDEC_ID,
     SPI_DEVICE_READ_THRESHOLD,
+    SPI_DEVICE_MAILBOX_ADDR,
     SPI_DEVICE_UPLOAD_STATUS,
     SPI_DEVICE_UPLOAD_CMDFIFO,
     SPI_DEVICE_UPLOAD_ADDRFIFO,
@@ -736,13 +746,13 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [69] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [70] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
     4'b 0001, // index[ 3] SPI_DEVICE_ALERT_TEST
     4'b 1111, // index[ 4] SPI_DEVICE_CONTROL
-    4'b 0111, // index[ 5] SPI_DEVICE_CFG
+    4'b 1111, // index[ 5] SPI_DEVICE_CFG
     4'b 1111, // index[ 6] SPI_DEVICE_FIFO_LEVEL
     4'b 0111, // index[ 7] SPI_DEVICE_ASYNC_FIFO_LEVEL
     4'b 0001, // index[ 8] SPI_DEVICE_STATUS
@@ -754,58 +764,59 @@ package spi_device_reg_pkg;
     4'b 0111, // index[14] SPI_DEVICE_FLASH_STATUS
     4'b 0111, // index[15] SPI_DEVICE_JEDEC_ID
     4'b 0011, // index[16] SPI_DEVICE_READ_THRESHOLD
-    4'b 1111, // index[17] SPI_DEVICE_UPLOAD_STATUS
-    4'b 0001, // index[18] SPI_DEVICE_UPLOAD_CMDFIFO
-    4'b 1111, // index[19] SPI_DEVICE_UPLOAD_ADDRFIFO
-    4'b 1111, // index[20] SPI_DEVICE_CMD_FILTER_0
-    4'b 1111, // index[21] SPI_DEVICE_CMD_FILTER_1
-    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_2
-    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_3
-    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_4
-    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_5
-    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_6
-    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_7
-    4'b 1111, // index[28] SPI_DEVICE_ADDR_SWAP_MASK
-    4'b 1111, // index[29] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 1111, // index[30] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[31] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[32] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_23
-    4'b 0111, // index[54] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[55] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[56] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[57] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[58] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[59] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[60] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[61] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[62] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[63] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[64] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[65] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[66] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[67] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[68] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 1111, // index[17] SPI_DEVICE_MAILBOX_ADDR
+    4'b 1111, // index[18] SPI_DEVICE_UPLOAD_STATUS
+    4'b 0001, // index[19] SPI_DEVICE_UPLOAD_CMDFIFO
+    4'b 1111, // index[20] SPI_DEVICE_UPLOAD_ADDRFIFO
+    4'b 1111, // index[21] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[29] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111, // index[30] SPI_DEVICE_ADDR_SWAP_DATA
+    4'b 1111, // index[31] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[32] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_23
+    4'b 0111, // index[55] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[56] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[57] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[58] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[59] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[60] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[61] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[62] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[63] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[64] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[65] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[66] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[67] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[68] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[69] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -220,6 +220,8 @@ module spi_device_reg_top (
   logic [7:0] cfg_timer_v_wd;
   logic cfg_addr_4b_en_qs;
   logic cfg_addr_4b_en_wd;
+  logic cfg_mailbox_en_qs;
+  logic cfg_mailbox_en_wd;
   logic fifo_level_we;
   logic [15:0] fifo_level_rxlvl_qs;
   logic [15:0] fifo_level_rxlvl_wd;
@@ -269,6 +271,9 @@ module spi_device_reg_top (
   logic read_threshold_we;
   logic [9:0] read_threshold_qs;
   logic [9:0] read_threshold_wd;
+  logic mailbox_addr_we;
+  logic [31:0] mailbox_addr_qs;
+  logic [31:0] mailbox_addr_wd;
   logic [4:0] upload_status_cmdfifo_depth_qs;
   logic upload_status_cmdfifo_notempty_qs;
   logic [4:0] upload_status_addrfifo_depth_qs;
@@ -2165,6 +2170,31 @@ module spi_device_reg_top (
     .qs     (cfg_addr_4b_en_qs)
   );
 
+  //   F[mailbox_en]: 24:24
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cfg_mailbox_en (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cfg_we),
+    .wd     (cfg_mailbox_en_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cfg.mailbox_en.q),
+
+    // to register interface (read)
+    .qs     (cfg_mailbox_en_qs)
+  );
+
 
   // R[fifo_level]: V(False)
   //   F[rxlvl]: 15:0
@@ -2662,6 +2692,32 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (read_threshold_qs)
+  );
+
+
+  // R[mailbox_addr]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_mailbox_addr (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (mailbox_addr_we),
+    .wd     (mailbox_addr_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.mailbox_addr.q),
+
+    // to register interface (read)
+    .qs     (mailbox_addr_qs)
   );
 
 
@@ -16675,7 +16731,7 @@ module spi_device_reg_top (
 
 
 
-  logic [68:0] addr_hit;
+  logic [69:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -16695,58 +16751,59 @@ module spi_device_reg_top (
     addr_hit[14] = (reg_addr == SPI_DEVICE_FLASH_STATUS_OFFSET);
     addr_hit[15] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
     addr_hit[16] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
-    addr_hit[17] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
-    addr_hit[18] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
-    addr_hit[19] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
-    addr_hit[20] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
-    addr_hit[21] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
-    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
-    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
-    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
-    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
-    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
-    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
-    addr_hit[28] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
-    addr_hit[29] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[17] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
+    addr_hit[18] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
+    addr_hit[19] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
+    addr_hit[20] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[29] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[30] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -16822,7 +16879,8 @@ module spi_device_reg_top (
                (addr_hit[65] & (|(SPI_DEVICE_PERMIT[65] & ~reg_be))) |
                (addr_hit[66] & (|(SPI_DEVICE_PERMIT[66] & ~reg_be))) |
                (addr_hit[67] & (|(SPI_DEVICE_PERMIT[67] & ~reg_be))) |
-               (addr_hit[68] & (|(SPI_DEVICE_PERMIT[68] & ~reg_be)))));
+               (addr_hit[68] & (|(SPI_DEVICE_PERMIT[68] & ~reg_be))) |
+               (addr_hit[69] & (|(SPI_DEVICE_PERMIT[69] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -16896,6 +16954,8 @@ module spi_device_reg_top (
   assign cfg_timer_v_wd = reg_wdata[15:8];
 
   assign cfg_addr_4b_en_wd = reg_wdata[16];
+
+  assign cfg_mailbox_en_wd = reg_wdata[24];
   assign fifo_level_we = addr_hit[6] & reg_we & !reg_error;
 
   assign fifo_level_rxlvl_wd = reg_wdata[15:0];
@@ -16934,9 +16994,12 @@ module spi_device_reg_top (
   assign read_threshold_we = addr_hit[16] & reg_we & !reg_error;
 
   assign read_threshold_wd = reg_wdata[9:0];
-  assign upload_cmdfifo_re = addr_hit[18] & reg_re & !reg_error;
-  assign upload_addrfifo_re = addr_hit[19] & reg_re & !reg_error;
-  assign cmd_filter_0_we = addr_hit[20] & reg_we & !reg_error;
+  assign mailbox_addr_we = addr_hit[17] & reg_we & !reg_error;
+
+  assign mailbox_addr_wd = reg_wdata[31:0];
+  assign upload_cmdfifo_re = addr_hit[19] & reg_re & !reg_error;
+  assign upload_addrfifo_re = addr_hit[20] & reg_re & !reg_error;
+  assign cmd_filter_0_we = addr_hit[21] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
@@ -17001,7 +17064,7 @@ module spi_device_reg_top (
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
-  assign cmd_filter_1_we = addr_hit[21] & reg_we & !reg_error;
+  assign cmd_filter_1_we = addr_hit[22] & reg_we & !reg_error;
 
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
@@ -17066,7 +17129,7 @@ module spi_device_reg_top (
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
-  assign cmd_filter_2_we = addr_hit[22] & reg_we & !reg_error;
+  assign cmd_filter_2_we = addr_hit[23] & reg_we & !reg_error;
 
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
@@ -17131,7 +17194,7 @@ module spi_device_reg_top (
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
-  assign cmd_filter_3_we = addr_hit[23] & reg_we & !reg_error;
+  assign cmd_filter_3_we = addr_hit[24] & reg_we & !reg_error;
 
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
@@ -17196,7 +17259,7 @@ module spi_device_reg_top (
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
-  assign cmd_filter_4_we = addr_hit[24] & reg_we & !reg_error;
+  assign cmd_filter_4_we = addr_hit[25] & reg_we & !reg_error;
 
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
@@ -17261,7 +17324,7 @@ module spi_device_reg_top (
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
-  assign cmd_filter_5_we = addr_hit[25] & reg_we & !reg_error;
+  assign cmd_filter_5_we = addr_hit[26] & reg_we & !reg_error;
 
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
@@ -17326,7 +17389,7 @@ module spi_device_reg_top (
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
-  assign cmd_filter_6_we = addr_hit[26] & reg_we & !reg_error;
+  assign cmd_filter_6_we = addr_hit[27] & reg_we & !reg_error;
 
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
@@ -17391,7 +17454,7 @@ module spi_device_reg_top (
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
-  assign cmd_filter_7_we = addr_hit[27] & reg_we & !reg_error;
+  assign cmd_filter_7_we = addr_hit[28] & reg_we & !reg_error;
 
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
@@ -17456,13 +17519,13 @@ module spi_device_reg_top (
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-  assign addr_swap_mask_we = addr_hit[28] & reg_we & !reg_error;
+  assign addr_swap_mask_we = addr_hit[29] & reg_we & !reg_error;
 
   assign addr_swap_mask_wd = reg_wdata[31:0];
-  assign addr_swap_data_we = addr_hit[29] & reg_we & !reg_error;
+  assign addr_swap_data_we = addr_hit[30] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[30] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[31] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -17485,7 +17548,7 @@ module spi_device_reg_top (
   assign cmd_info_0_upload_0_wd = reg_wdata[24];
 
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
-  assign cmd_info_1_we = addr_hit[31] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[32] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -17508,7 +17571,7 @@ module spi_device_reg_top (
   assign cmd_info_1_upload_1_wd = reg_wdata[24];
 
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
-  assign cmd_info_2_we = addr_hit[32] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[33] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -17531,7 +17594,7 @@ module spi_device_reg_top (
   assign cmd_info_2_upload_2_wd = reg_wdata[24];
 
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
-  assign cmd_info_3_we = addr_hit[33] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[34] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -17554,7 +17617,7 @@ module spi_device_reg_top (
   assign cmd_info_3_upload_3_wd = reg_wdata[24];
 
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
-  assign cmd_info_4_we = addr_hit[34] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -17577,7 +17640,7 @@ module spi_device_reg_top (
   assign cmd_info_4_upload_4_wd = reg_wdata[24];
 
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
-  assign cmd_info_5_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -17600,7 +17663,7 @@ module spi_device_reg_top (
   assign cmd_info_5_upload_5_wd = reg_wdata[24];
 
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
-  assign cmd_info_6_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -17623,7 +17686,7 @@ module spi_device_reg_top (
   assign cmd_info_6_upload_6_wd = reg_wdata[24];
 
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
-  assign cmd_info_7_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -17646,7 +17709,7 @@ module spi_device_reg_top (
   assign cmd_info_7_upload_7_wd = reg_wdata[24];
 
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
-  assign cmd_info_8_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -17669,7 +17732,7 @@ module spi_device_reg_top (
   assign cmd_info_8_upload_8_wd = reg_wdata[24];
 
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
-  assign cmd_info_9_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -17692,7 +17755,7 @@ module spi_device_reg_top (
   assign cmd_info_9_upload_9_wd = reg_wdata[24];
 
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
-  assign cmd_info_10_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -17715,7 +17778,7 @@ module spi_device_reg_top (
   assign cmd_info_10_upload_10_wd = reg_wdata[24];
 
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
-  assign cmd_info_11_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -17738,7 +17801,7 @@ module spi_device_reg_top (
   assign cmd_info_11_upload_11_wd = reg_wdata[24];
 
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
-  assign cmd_info_12_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -17761,7 +17824,7 @@ module spi_device_reg_top (
   assign cmd_info_12_upload_12_wd = reg_wdata[24];
 
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
-  assign cmd_info_13_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -17784,7 +17847,7 @@ module spi_device_reg_top (
   assign cmd_info_13_upload_13_wd = reg_wdata[24];
 
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
-  assign cmd_info_14_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -17807,7 +17870,7 @@ module spi_device_reg_top (
   assign cmd_info_14_upload_14_wd = reg_wdata[24];
 
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
-  assign cmd_info_15_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -17830,7 +17893,7 @@ module spi_device_reg_top (
   assign cmd_info_15_upload_15_wd = reg_wdata[24];
 
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
-  assign cmd_info_16_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -17853,7 +17916,7 @@ module spi_device_reg_top (
   assign cmd_info_16_upload_16_wd = reg_wdata[24];
 
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
-  assign cmd_info_17_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -17876,7 +17939,7 @@ module spi_device_reg_top (
   assign cmd_info_17_upload_17_wd = reg_wdata[24];
 
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
-  assign cmd_info_18_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -17899,7 +17962,7 @@ module spi_device_reg_top (
   assign cmd_info_18_upload_18_wd = reg_wdata[24];
 
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
-  assign cmd_info_19_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -17922,7 +17985,7 @@ module spi_device_reg_top (
   assign cmd_info_19_upload_19_wd = reg_wdata[24];
 
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
-  assign cmd_info_20_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -17945,7 +18008,7 @@ module spi_device_reg_top (
   assign cmd_info_20_upload_20_wd = reg_wdata[24];
 
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
-  assign cmd_info_21_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -17968,7 +18031,7 @@ module spi_device_reg_top (
   assign cmd_info_21_upload_21_wd = reg_wdata[24];
 
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
-  assign cmd_info_22_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -17991,7 +18054,7 @@ module spi_device_reg_top (
   assign cmd_info_22_upload_22_wd = reg_wdata[24];
 
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
-  assign cmd_info_23_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -18014,7 +18077,7 @@ module spi_device_reg_top (
   assign cmd_info_23_upload_23_wd = reg_wdata[24];
 
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
-  assign tpm_cfg_we = addr_hit[55] & reg_we & !reg_error;
+  assign tpm_cfg_we = addr_hit[56] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -18025,7 +18088,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[57] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[58] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -18034,37 +18097,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[58] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[59] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[59] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[60] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[60] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[61] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[61] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[62] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[62] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[63] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[63] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[64] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[64] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[66] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[66] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[67] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[67] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[7:0];
-  assign tpm_write_fifo_re = addr_hit[68] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[69] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -18119,6 +18182,7 @@ module spi_device_reg_top (
         reg_rdata_next[3] = cfg_rx_order_qs;
         reg_rdata_next[15:8] = cfg_timer_v_qs;
         reg_rdata_next[16] = cfg_addr_4b_en_qs;
+        reg_rdata_next[24] = cfg_mailbox_en_qs;
       end
 
       addr_hit[6]: begin
@@ -18179,6 +18243,10 @@ module spi_device_reg_top (
       end
 
       addr_hit[17]: begin
+        reg_rdata_next[31:0] = mailbox_addr_qs;
+      end
+
+      addr_hit[18]: begin
         reg_rdata_next[4:0] = upload_status_cmdfifo_depth_qs;
         reg_rdata_next[7] = upload_status_cmdfifo_notempty_qs;
         reg_rdata_next[12:8] = upload_status_addrfifo_depth_qs;
@@ -18186,15 +18254,15 @@ module spi_device_reg_top (
         reg_rdata_next[24:16] = upload_status_payload_depth_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[7:0] = upload_cmdfifo_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[31:0] = upload_addrfifo_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
         reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
         reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
@@ -18229,7 +18297,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
         reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
         reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
@@ -18264,7 +18332,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
         reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
         reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
@@ -18299,7 +18367,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
         reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
         reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
@@ -18334,7 +18402,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
         reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
         reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
@@ -18369,7 +18437,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
         reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
         reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
@@ -18404,7 +18472,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
         reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
         reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
@@ -18439,7 +18507,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
         reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
         reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
@@ -18474,15 +18542,15 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[31:0] = addr_swap_mask_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[8] = cmd_info_0_addr_en_0_qs;
         reg_rdata_next[9] = cmd_info_0_addr_swap_en_0_qs;
@@ -18496,7 +18564,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_0_busy_0_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[8] = cmd_info_1_addr_en_1_qs;
         reg_rdata_next[9] = cmd_info_1_addr_swap_en_1_qs;
@@ -18510,7 +18578,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_1_busy_1_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[8] = cmd_info_2_addr_en_2_qs;
         reg_rdata_next[9] = cmd_info_2_addr_swap_en_2_qs;
@@ -18524,7 +18592,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_2_busy_2_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[8] = cmd_info_3_addr_en_3_qs;
         reg_rdata_next[9] = cmd_info_3_addr_swap_en_3_qs;
@@ -18538,7 +18606,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_3_busy_3_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[8] = cmd_info_4_addr_en_4_qs;
         reg_rdata_next[9] = cmd_info_4_addr_swap_en_4_qs;
@@ -18552,7 +18620,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_4_busy_4_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[8] = cmd_info_5_addr_en_5_qs;
         reg_rdata_next[9] = cmd_info_5_addr_swap_en_5_qs;
@@ -18566,7 +18634,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_5_busy_5_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[8] = cmd_info_6_addr_en_6_qs;
         reg_rdata_next[9] = cmd_info_6_addr_swap_en_6_qs;
@@ -18580,7 +18648,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_6_busy_6_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[8] = cmd_info_7_addr_en_7_qs;
         reg_rdata_next[9] = cmd_info_7_addr_swap_en_7_qs;
@@ -18594,7 +18662,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_7_busy_7_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[8] = cmd_info_8_addr_en_8_qs;
         reg_rdata_next[9] = cmd_info_8_addr_swap_en_8_qs;
@@ -18608,7 +18676,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_8_busy_8_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[8] = cmd_info_9_addr_en_9_qs;
         reg_rdata_next[9] = cmd_info_9_addr_swap_en_9_qs;
@@ -18622,7 +18690,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_9_busy_9_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[8] = cmd_info_10_addr_en_10_qs;
         reg_rdata_next[9] = cmd_info_10_addr_swap_en_10_qs;
@@ -18636,7 +18704,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_10_busy_10_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[8] = cmd_info_11_addr_en_11_qs;
         reg_rdata_next[9] = cmd_info_11_addr_swap_en_11_qs;
@@ -18650,7 +18718,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_11_busy_11_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[8] = cmd_info_12_addr_en_12_qs;
         reg_rdata_next[9] = cmd_info_12_addr_swap_en_12_qs;
@@ -18664,7 +18732,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_12_busy_12_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[8] = cmd_info_13_addr_en_13_qs;
         reg_rdata_next[9] = cmd_info_13_addr_swap_en_13_qs;
@@ -18678,7 +18746,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_13_busy_13_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[8] = cmd_info_14_addr_en_14_qs;
         reg_rdata_next[9] = cmd_info_14_addr_swap_en_14_qs;
@@ -18692,7 +18760,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_14_busy_14_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[8] = cmd_info_15_addr_en_15_qs;
         reg_rdata_next[9] = cmd_info_15_addr_swap_en_15_qs;
@@ -18706,7 +18774,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_15_busy_15_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[8] = cmd_info_16_addr_en_16_qs;
         reg_rdata_next[9] = cmd_info_16_addr_swap_en_16_qs;
@@ -18720,7 +18788,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_16_busy_16_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[8] = cmd_info_17_addr_en_17_qs;
         reg_rdata_next[9] = cmd_info_17_addr_swap_en_17_qs;
@@ -18734,7 +18802,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_17_busy_17_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[8] = cmd_info_18_addr_en_18_qs;
         reg_rdata_next[9] = cmd_info_18_addr_swap_en_18_qs;
@@ -18748,7 +18816,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_18_busy_18_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[8] = cmd_info_19_addr_en_19_qs;
         reg_rdata_next[9] = cmd_info_19_addr_swap_en_19_qs;
@@ -18762,7 +18830,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_19_busy_19_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[8] = cmd_info_20_addr_en_20_qs;
         reg_rdata_next[9] = cmd_info_20_addr_swap_en_20_qs;
@@ -18776,7 +18844,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_20_busy_20_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[8] = cmd_info_21_addr_en_21_qs;
         reg_rdata_next[9] = cmd_info_21_addr_swap_en_21_qs;
@@ -18790,7 +18858,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_21_busy_21_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[8] = cmd_info_22_addr_en_22_qs;
         reg_rdata_next[9] = cmd_info_22_addr_swap_en_22_qs;
@@ -18804,7 +18872,7 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_22_busy_22_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[8] = cmd_info_23_addr_en_23_qs;
         reg_rdata_next[9] = cmd_info_23_addr_swap_en_23_qs;
@@ -18818,13 +18886,13 @@ module spi_device_reg_top (
         reg_rdata_next[25] = cmd_info_23_busy_23_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -18832,63 +18900,63 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
         reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[7:0] = '0;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 


### PR DESCRIPTION
This PR defines the mailbox related CSRs (mailbox_en and mailbox_addr).

By setting the mailbox address, the SPI_DEVICE hijacks the read request and return the data from the internal mailbox buffer rather than the read buffer or from the attached SPI Flash device (in passthrough mode).

