### PR TITLE
[dv/top_level] Randomize lc exit_token value

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -10,15 +10,17 @@ filesets:
       - lowrisc:opentitan:bus_params_pkg
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:ip:spi_device
-      - lowrisc:dv:ralgen
-      - lowrisc:dv:str_utils
+      - lowrisc:ip:kmac_pkg
       - lowrisc:dv:cip_lib
-      - lowrisc:dv:uart_agent
+      - lowrisc:dv:digestpp_dpi
       - lowrisc:dv:jtag_riscv_agent
-      - lowrisc:dv:spi_agent
       - lowrisc:dv:mem_bkdr_util
+      - lowrisc:dv:ralgen
+      - lowrisc:dv:spi_agent
+      - lowrisc:dv:str_utils
       - lowrisc:dv:sw_test_status
       - lowrisc:dv:sw_logger_if
+      - lowrisc:dv:uart_agent
     files:
       - chip_env_pkg.sv
       - chip_env_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -3,27 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package chip_env_pkg;
+
   // dep packages
   import uvm_pkg::*;
   import top_pkg::*;
-  import flash_ctrl_pkg::*;
-  import otp_ctrl_pkg::*;
-  import sram_ctrl_pkg::*;
-  import dv_utils_pkg::*;
-  import dv_base_reg_pkg::*;
+
+  import bus_params_pkg::*;
+  import chip_ral_pkg::*;
+  import cip_base_pkg::*;
   import csr_utils_pkg::*;
+  import digestpp_dpi_pkg::*;
+  import dv_base_reg_pkg::*;
+  import dv_lib_pkg::*;
+  import dv_utils_pkg::*;
+  import flash_ctrl_pkg::*;
+  import jtag_riscv_agent_pkg::*;
+  import kmac_pkg::*;
+  import mem_bkdr_util_pkg::*;
+  import otp_ctrl_pkg::*;
+  import spi_agent_pkg::*;
+  import sram_ctrl_pkg::*;
+  import str_utils_pkg::*;
+  import sw_test_status_pkg::*;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;
-  import jtag_riscv_agent_pkg::*;
-  import spi_agent_pkg::*;
-  import dv_lib_pkg::*;
-  import cip_base_pkg::*;
-  import chip_ral_pkg::*;
-  import sw_test_status_pkg::*;
   import xbar_env_pkg::*;
-  import bus_params_pkg::*;
-  import str_utils_pkg::*;
-  import mem_bkdr_util_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
@@ -21,9 +21,8 @@ static dif_lc_ctrl_t lc;
 
 const test_config_t kTestConfig;
 
-// TODO: Issue more resets and andomize this array in each reset.
 // LC exit token value for LC state transition.
-static const uint8_t lc_exit_token[LC_TOKEN_SIZE] = {
+static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 };
@@ -75,7 +74,9 @@ bool test_main(void) {
     dif_lc_ctrl_token_t token;
     dif_lc_ctrl_settings_t settings;
     settings.clock_select = kDifLcCtrlInternalClockEn;
-    memcpy(token.data, lc_exit_token, sizeof(lc_exit_token));
+    for (int i = 0; i < LC_TOKEN_SIZE; i++) {
+      token.data[i] = kLcExitToken[i];
+    }
     CHECK(dif_lc_ctrl_mutex_try_acquire(&lc) == kDifLcCtrlMutexOk);
     CHECK(dif_lc_ctrl_transition(&lc, kDifLcCtrlStateDev, &token, &settings) ==
               kDifLcCtrlMutexOk,


### PR DESCRIPTION
This PR supports randomize lc exit_token in SV and C test.
To support this:
1). Add a random array in SV and pass it to C test.
2). Add cshake128 dpi function to decode the exit_token value.
This PR finishes a TODO in issue #7665

Signed-off-by: Cindy Chen <chencindy@opentitan.org>