### PR TITLE
[prim_esc_receiver] Fix response toggling corner case

### DIFF
--- a/hw/ip/prim/rtl/prim_esc_receiver.sv
+++ b/hw/ip/prim/rtl/prim_esc_receiver.sv
@@ -157,14 +157,16 @@ module prim_esc_receiver
       Idle: begin
         if (esc_level) begin
           state_d = Check;
-          resp_pd = 1'b1;
-          resp_nd = 1'b0;
+          resp_pd = ~resp_pq;
+          resp_nd = resp_pq;
         end
       end
       // we decide here whether this is only a ping request or
       // whether this is an escalation enable
       Check: begin
         state_d = PingResp;
+        resp_pd = ~resp_pq;
+        resp_nd = resp_pq;
         if (esc_level) begin
           state_d  = EscResp;
           esc_req  = 1'b1;
@@ -174,8 +176,8 @@ module prim_esc_receiver
       // we got an escalation signal (pings cannot occur back to back)
       PingResp: begin
         state_d = Idle;
-        resp_pd = 1'b1;
-        resp_nd = 1'b0;
+        resp_pd = ~resp_pq;
+        resp_nd = resp_pq;
         ping_en = 1'b1;
         if (esc_level) begin
           state_d  = EscResp;


### PR DESCRIPTION
This should prevent spurious integrity alerts when a ping request is interrupted by an escalation request.

In particular, instead of hard coding the value of the response diff pair in the FSM, we just keep on toggling the previous values whenever we are in a response state (no matter whether we are responding to a ping or escalation response).

The only time we reset the diff-pair state to an initial value is in the idle state when no request is detected.

Fix #8139

Signed-off-by: Michael Schaffner <msf@google.com>