### PR TITLE
[dif/lc_ctrl] autogen lc_ctrl IRQ DIFs and integrate intro src tree

### DIFF
--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+
+#include "lc_ctrl_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This file is auto-generated.
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_H_
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_INC_
-#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_INC_
+// This file is auto-generated.
 
 /**
  * @file
@@ -39,4 +39,4 @@ typedef struct dif_lc_ctrl {
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_INC_
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.inc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.inc
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_INC_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_INC_
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/lc_ctrl/doc/">LC_CTRL</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to lc_ctrl.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_lc_ctrl {
+  /**
+   * The base address for the lc_ctrl hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_lc_ctrl_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_LC_CTRL_AUTOGEN_INC_

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_lc_ctrl_unittest.h"
+
+namespace dif_lc_ctrl_unittest {
+namespace {}  // namespace
+}  // namespace dif_lc_ctrl_unittest

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.h
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This file is auto-generated.
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_H_
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_INC_
-#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_INC_
+// This file is auto-generated.
 
 /**
  * @file
@@ -189,4 +189,4 @@ dif_result_t dif_uart_irq_restore_all(
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_INC_
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_UART_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.inc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.inc
@@ -30,7 +30,7 @@ extern "C" {
  */
 typedef struct dif_uart {
   /**
-   * The base address for the UART hardware registers.
+   * The base address for the uart hardware registers.
    */
   mmio_region_t base_addr;
 } dif_uart_t;

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -9,7 +9,6 @@
 namespace dif_uart_unittest {
 namespace {
 using testing::Eq;
-using testing::Test;
 
 class IrqGetStateTest : public UartTest {};
 

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -10,7 +10,6 @@ sw_lib_dif_autogen_uart = declare_dependency(
       hw_ip_uart_reg_h,
       'dif_uart_autogen.c',
     ],
-    include_directories: include_directories('../'),
     dependencies: [
       sw_lib_mmio,
     ],
@@ -25,7 +24,6 @@ sw_lib_dif_autogen_lc_ctrl = declare_dependency(
       hw_ip_lc_ctrl_reg_h,
       'dif_lc_ctrl_autogen.c',
     ],
-    include_directories: include_directories('../'),
     dependencies: [
       sw_lib_mmio,
     ],

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -16,3 +16,18 @@ sw_lib_dif_autogen_uart = declare_dependency(
     ],
   )
 )
+
+# Autogen Lifecycle Controller DIF library
+sw_lib_dif_autogen_lc_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_lc_ctrl',
+    sources: [
+      hw_ip_lc_ctrl_reg_h,
+      'dif_lc_ctrl_autogen.c',
+    ],
+    include_directories: include_directories('../'),
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -23,24 +23,22 @@ enum {
   kLcCtrlMutexRelease = 0,
 };
 
-dif_lc_ctrl_result_t dif_lc_ctrl_init(dif_lc_ctrl_params_t params,
-                                      dif_lc_ctrl_t *lc) {
+dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc) {
   if (lc == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
-  lc->params = params;
-  return kDifLcCtrlOk;
+  lc->base_addr = base_addr;
+  return kDifOk;
 }
 
-dif_lc_ctrl_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
-                                           dif_lc_ctrl_state_t *state) {
+dif_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
+                                   dif_lc_ctrl_state_t *state) {
   if (lc == NULL || state == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t reg =
-      mmio_region_read32(lc->params.base_addr, LC_CTRL_LC_STATE_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(lc->base_addr, LC_CTRL_LC_STATE_REG_OFFSET);
   switch (bitfield_field32_read(reg, LC_CTRL_LC_STATE_STATE_FIELD)) {
     case LC_CTRL_LC_STATE_STATE_VALUE_RAW:
       *state = kDifLcCtrlStateRaw;
@@ -117,10 +115,10 @@ dif_lc_ctrl_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
       break;
 
     default:
-      return kDifLcCtrlError;
+      return kDifError;
   }
 
-  return kDifLcCtrlOk;
+  return kDifOk;
 }
 
 dif_lc_ctrl_attempts_result_t dif_lc_ctrl_get_attempts(const dif_lc_ctrl_t *lc,
@@ -129,8 +127,8 @@ dif_lc_ctrl_attempts_result_t dif_lc_ctrl_get_attempts(const dif_lc_ctrl_t *lc,
     return kDifLcCtrlAttemptsBadArg;
   }
 
-  uint32_t reg = mmio_region_read32(lc->params.base_addr,
-                                    LC_CTRL_LC_TRANSITION_CNT_REG_OFFSET);
+  uint32_t reg =
+      mmio_region_read32(lc->base_addr, LC_CTRL_LC_TRANSITION_CNT_REG_OFFSET);
   uint8_t value =
       bitfield_field32_read(reg, LC_CTRL_LC_TRANSITION_CNT_CNT_FIELD);
   if (value == LC_CTRL_LC_TRANSITION_CNT_CNT_MASK) {
@@ -141,14 +139,13 @@ dif_lc_ctrl_attempts_result_t dif_lc_ctrl_get_attempts(const dif_lc_ctrl_t *lc,
   return kDifLcCtrlAttemptsOk;
 }
 
-dif_lc_ctrl_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
-                                            dif_lc_ctrl_status_t *status) {
+dif_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
+                                    dif_lc_ctrl_status_t *status) {
   if (lc == NULL || status == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t reg =
-      mmio_region_read32(lc->params.base_addr, LC_CTRL_STATUS_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(lc->base_addr, LC_CTRL_STATUS_REG_OFFSET);
 
   dif_lc_ctrl_status_t status_word = 0;
 
@@ -203,17 +200,17 @@ dif_lc_ctrl_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
   }
 
   *status = status_word;
-  return kDifLcCtrlOk;
+  return kDifOk;
 }
 
-dif_lc_ctrl_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
-                                              dif_lc_ctrl_id_state_t *state) {
+dif_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
+                                      dif_lc_ctrl_id_state_t *state) {
   if (lc == NULL || state == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
   uint32_t reg =
-      mmio_region_read32(lc->params.base_addr, LC_CTRL_LC_ID_STATE_REG_OFFSET);
+      mmio_region_read32(lc->base_addr, LC_CTRL_LC_ID_STATE_REG_OFFSET);
   switch (bitfield_field32_read(reg, LC_CTRL_LC_ID_STATE_STATE_FIELD)) {
     case LC_CTRL_LC_ID_STATE_STATE_VALUE_BLANK:
       *state = kDifLcCtrlIdStateBlank;
@@ -225,28 +222,28 @@ dif_lc_ctrl_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
       *state = kDifLcCtrlIdStateInvalid;
       break;
     default:
-      return kDifLcCtrlError;
+      return kDifError;
   }
 
-  return kDifLcCtrlOk;
+  return kDifOk;
 }
 
-dif_lc_ctrl_result_t dif_lc_ctrl_get_device_id(
-    const dif_lc_ctrl_t *lc, dif_lc_ctrl_device_id_t *device_id) {
+dif_result_t dif_lc_ctrl_get_device_id(const dif_lc_ctrl_t *lc,
+                                       dif_lc_ctrl_device_id_t *device_id) {
   if (lc == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
-  mmio_region_memcpy_from_mmio32(
-      lc->params.base_addr, LC_CTRL_DEVICE_ID_0_REG_OFFSET, device_id->data,
-      ARRAYSIZE(device_id->data) * sizeof(uint32_t));
-  return kDifLcCtrlOk;
+  mmio_region_memcpy_from_mmio32(lc->base_addr, LC_CTRL_DEVICE_ID_0_REG_OFFSET,
+                                 device_id->data,
+                                 ARRAYSIZE(device_id->data) * sizeof(uint32_t));
+  return kDifOk;
 }
 
-dif_lc_ctrl_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
-                                             dif_lc_ctrl_alert_t alert) {
+dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
+                                     dif_lc_ctrl_alert_t alert) {
   if (lc == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
   bitfield_bit32_index_t alert_idx;
@@ -261,13 +258,13 @@ dif_lc_ctrl_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
       alert_idx = LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT;
       break;
     default:
-      return kDifLcCtrlBadArg;
+      return kDifBadArg;
   }
 
   uint32_t reg = bitfield_bit32_write(0, alert_idx, true);
-  mmio_region_write32(lc->params.base_addr, LC_CTRL_ALERT_TEST_REG_OFFSET, reg);
+  mmio_region_write32(lc->base_addr, LC_CTRL_ALERT_TEST_REG_OFFSET, reg);
 
-  return kDifLcCtrlOk;
+  return kDifOk;
 }
 
 dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_try_acquire(
@@ -276,11 +273,10 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_try_acquire(
     return kDifLcCtrlMutexBadArg;
   }
 
-  mmio_region_write32(lc->params.base_addr,
-                      LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET,
+  mmio_region_write32(lc->base_addr, LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET,
                       kLcCtrlMutexAcquire);
-  uint32_t reg = mmio_region_read32(lc->params.base_addr,
-                                    LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET);
+  uint32_t reg =
+      mmio_region_read32(lc->base_addr, LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET);
   // If the register is zero, that means we failed to take the mutex for
   // whatever reason.
   if (reg == kLcCtrlMutexRelease) {
@@ -295,15 +291,14 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_release(const dif_lc_ctrl_t *lc) {
     return kDifLcCtrlMutexBadArg;
   }
 
-  uint32_t reg = mmio_region_read32(lc->params.base_addr,
-                                    LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET);
+  uint32_t reg =
+      mmio_region_read32(lc->base_addr, LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET);
   if (reg == kLcCtrlMutexRelease) {
     // We're not holding the mutex, which is a programmer error.
     return kDifLcCtrlMutexError;
   }
 
-  mmio_region_write32(lc->params.base_addr,
-                      LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET,
+  mmio_region_write32(lc->base_addr, LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET,
                       kLcCtrlMutexRelease);
   return kDifLcCtrlMutexOk;
 }
@@ -406,18 +401,18 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_transition(
         ctrl_reg, LC_CTRL_TRANSITION_CTRL_EXT_CLOCK_EN_BIT, false);
   }
 
-  uint32_t busy = mmio_region_read32(lc->params.base_addr,
-                                     LC_CTRL_TRANSITION_REGWEN_REG_OFFSET);
+  uint32_t busy =
+      mmio_region_read32(lc->base_addr, LC_CTRL_TRANSITION_REGWEN_REG_OFFSET);
   if (busy == 0) {
     return kDifLcCtrlMutexAlreadyTaken;
   }
 
   // Set the target for the transition.
-  mmio_region_write32(lc->params.base_addr,
-                      LC_CTRL_TRANSITION_TARGET_REG_OFFSET, target);
+  mmio_region_write32(lc->base_addr, LC_CTRL_TRANSITION_TARGET_REG_OFFSET,
+                      target);
 
   // Program the clock selection.
-  mmio_region_write32(lc->params.base_addr, LC_CTRL_TRANSITION_CTRL_REG_OFFSET,
+  mmio_region_write32(lc->base_addr, LC_CTRL_TRANSITION_CTRL_REG_OFFSET,
                       ctrl_reg);
 
   // Fill in a token, if necessary.
@@ -425,14 +420,13 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_transition(
     for (int i = 0; i < sizeof(token->data); i += sizeof(uint32_t)) {
       uint32_t word;
       memcpy(&word, &token->data[i], sizeof(uint32_t));
-      mmio_region_write32(lc->params.base_addr,
+      mmio_region_write32(lc->base_addr,
                           LC_CTRL_TRANSITION_TOKEN_0_REG_OFFSET + i, word);
     }
   }
 
   // With both parameters set up, schedule the transition.
-  mmio_region_write32(lc->params.base_addr, LC_CTRL_TRANSITION_CMD_REG_OFFSET,
-                      1);
+  mmio_region_write32(lc->base_addr, LC_CTRL_TRANSITION_CMD_REG_OFFSET, 1);
   return kDifLcCtrlMutexOk;
 }
 
@@ -442,26 +436,26 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_set_otp_vendor_test_reg(
     return kDifLcCtrlMutexBadArg;
   }
 
-  uint32_t busy = mmio_region_read32(lc->params.base_addr,
-                                     LC_CTRL_TRANSITION_REGWEN_REG_OFFSET);
+  uint32_t busy =
+      mmio_region_read32(lc->base_addr, LC_CTRL_TRANSITION_REGWEN_REG_OFFSET);
   if (busy == 0) {
     return kDifLcCtrlMutexAlreadyTaken;
   }
 
-  mmio_region_write32(lc->params.base_addr,
-                      LC_CTRL_OTP_VENDOR_TEST_CTRL_REG_OFFSET, settings);
+  mmio_region_write32(lc->base_addr, LC_CTRL_OTP_VENDOR_TEST_CTRL_REG_OFFSET,
+                      settings);
 
   return kDifLcCtrlMutexOk;
 }
 
-dif_lc_ctrl_result_t dif_lc_ctrl_get_otp_vendor_test_reg(
-    const dif_lc_ctrl_t *lc, uint32_t *settings) {
+dif_result_t dif_lc_ctrl_get_otp_vendor_test_reg(const dif_lc_ctrl_t *lc,
+                                                 uint32_t *settings) {
   if (lc == NULL || settings == NULL) {
-    return kDifLcCtrlBadArg;
+    return kDifBadArg;
   }
 
-  *settings = mmio_region_read32(lc->params.base_addr,
+  *settings = mmio_region_read32(lc->base_addr,
                                  LC_CTRL_OTP_VENDOR_TEST_CTRL_REG_OFFSET);
 
-  return kDifLcCtrlOk;
+  return kDifOk;
 }

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -14,8 +14,9 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+
+#include "sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.inc"
 
 #ifdef __cplusplus
 extern "C" {
@@ -297,68 +298,24 @@ typedef struct dif_lc_ctrl_device_id {
 } dif_lc_ctrl_device_id_t;
 
 /**
- * Hardware instantiation parameters for a lifecycle controller.
- *
- * This struct describes information about the underlying hardware that is
- * not determined until the hardware design is used as part of a top-level
- * design.
- */
-typedef struct dif_lc_ctrl_params {
-  /**
-   * The base address for the lifecycle controller hardware registers.
-   */
-  mmio_region_t base_addr;
-} dif_lc_ctrl_params_t;
-
-/**
- * A handle to a lifecycle controller.
- *
- * This type should be treated as opaque by users.
- */
-typedef struct dif_lc_ctrl {
-  dif_lc_ctrl_params_t params;
-} dif_lc_ctrl_t;
-
-/**
- * The result of a lifecycle controller operation.
- */
-typedef enum dif_lc_ctrl_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifLcCtrlOk = 0,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifLcCtrlError = 1,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifLcCtrlBadArg = 2,
-} dif_lc_ctrl_result_t;
-
-/**
  * The result of a lifecycle attempt counter operation.
  */
 typedef enum dif_lc_ctrl_attempts_result {
   /**
    * Indicates that the operation succeeded.
    */
-  kDifLcCtrlAttemptsOk = kDifLcCtrlOk,
+  kDifLcCtrlAttemptsOk = kDifOk,
   /**
    * Indicates some unspecified failure.
    */
-  kDifLcCtrlAttemptsError = kDifLcCtrlError,
+  kDifLcCtrlAttemptsError = kDifError,
   /**
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
    * When this value is returned, no hardware operations occurred.
    */
-  kDifLcCtrlAttemptsBadArg = kDifLcCtrlBadArg,
+  kDifLcCtrlAttemptsBadArg = kDifBadArg,
   /**
    * Indicates that too many lifecycle transitions have occurred, such that the
    * hardware can no longer keep a count.
@@ -373,18 +330,18 @@ typedef enum dif_lc_ctrl_mutex_result {
   /**
    * Indicates that the operation succeeded.
    */
-  kDifLcCtrlMutexOk = kDifLcCtrlOk,
+  kDifLcCtrlMutexOk = kDifOk,
   /**
    * Indicates some unspecified failure.
    */
-  kDifLcCtrlMutexError = kDifLcCtrlError,
+  kDifLcCtrlMutexError = kDifError,
   /**
    * Indicates that some parameter passed into a function failed a
    * precondition.
    *
    * When this value is returned, no hardware operations occurred.
    */
-  kDifLcCtrlMutexBadArg = kDifLcCtrlBadArg,
+  kDifLcCtrlMutexBadArg = kDifBadArg,
 
   /**
    * Indicates that a mutex-guarded operation failed because someone (other
@@ -416,13 +373,12 @@ typedef enum dif_lc_ctrl_alert {
  *
  * This function does not actuate the hardware.
  *
- * @param params Hardware instantiation parameters.
+ * @param base_addr Base address of the UART peripheral.
  * @param[out] lc Out param for the initialized handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_init(dif_lc_ctrl_params_t params,
-                                      dif_lc_ctrl_t *lc);
+dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc);
 
 /**
  * Returns the current state of the lifecycle controller.
@@ -432,8 +388,8 @@ dif_lc_ctrl_result_t dif_lc_ctrl_init(dif_lc_ctrl_params_t params,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
-                                           dif_lc_ctrl_state_t *state);
+dif_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
+                                   dif_lc_ctrl_state_t *state);
 
 /**
  * Returns the number of lifecycle transitions that this device has attempted,
@@ -455,8 +411,8 @@ dif_lc_ctrl_attempts_result_t dif_lc_ctrl_get_attempts(const dif_lc_ctrl_t *lc,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
-                                            dif_lc_ctrl_status_t *status);
+dif_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
+                                    dif_lc_ctrl_status_t *status);
 
 /**
  * Returns the current personalization state of the lifecycle controller.
@@ -466,8 +422,8 @@ dif_lc_ctrl_result_t dif_lc_ctrl_get_status(const dif_lc_ctrl_t *lc,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
-                                              dif_lc_ctrl_id_state_t *state);
+dif_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
+                                      dif_lc_ctrl_id_state_t *state);
 
 /**
  * Returns the current device id reading from lifecycle controller's device id
@@ -478,8 +434,8 @@ dif_lc_ctrl_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_get_device_id(
-    const dif_lc_ctrl_t *lc, dif_lc_ctrl_device_id_t *device_id);
+dif_result_t dif_lc_ctrl_get_device_id(const dif_lc_ctrl_t *lc,
+                                       dif_lc_ctrl_device_id_t *device_id);
 
 /**
  * Forces a particular alert, causing it to be escalated as if the hardware had
@@ -490,8 +446,8 @@ dif_lc_ctrl_result_t dif_lc_ctrl_get_device_id(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
-                                             dif_lc_ctrl_alert_t alert);
+dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
+                                     dif_lc_ctrl_alert_t alert);
 
 /**
  * Attempts to acquire the lifecycle controller's HW mutex.
@@ -555,8 +511,8 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_set_otp_vendor_test_reg(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_result_t dif_lc_ctrl_get_otp_vendor_test_reg(
-    const dif_lc_ctrl_t *lc, uint32_t *settings);
+dif_result_t dif_lc_ctrl_get_otp_vendor_test_reg(const dif_lc_ctrl_t *lc,
+                                                 uint32_t *settings);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -14,9 +14,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
 
-#include "sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.inc"
+#include "sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.h
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.h
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_LC_CTRL_UNITTEST_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_LC_CTRL_UNITTEST_H_
+
+#include <cstring>
+#include <limits>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+
+#include "lc_ctrl_regs.h"  // Generated.
+
+namespace dif_lc_ctrl_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class LcCtrlTest : public Test, public MmioTest {
+ protected:
+  dif_lc_ctrl_t lc_ = {.base_addr = dev().region()};
+};
+
+}  // namespace
+}  // namespace dif_lc_ctrl_unittest
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_LC_CTRL_UNITTEST_H_

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -14,7 +14,7 @@
 
 #include "sw/device/lib/base/mmio.h"
 
-#include "sw/device/lib/dif/autogen/dif_uart_autogen.inc"
+#include "sw/device/lib/dif/autogen/dif_uart_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -548,6 +548,7 @@ sw_lib_dif_lc_ctrl = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_lc_ctrl,
     ],
   )
 )
@@ -555,9 +556,11 @@ sw_lib_dif_lc_ctrl = declare_dependency(
 test('dif_lc_ctrl_unittest', executable(
     'dif_lc_ctrl_unittest',
     sources: [
-      hw_ip_lc_ctrl_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_lc_ctrl.c',
       'dif_lc_ctrl_unittest.cc',
+      'autogen/dif_lc_ctrl_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_lc_ctrl.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c',
+      hw_ip_lc_ctrl_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
@@ -73,8 +73,7 @@ bool test_main(void) {
                         &otp) == kDifOtpCtrlOk);
 
   mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
-  CHECK(dif_lc_ctrl_init((dif_lc_ctrl_params_t){.base_addr = lc_reg}, &lc) ==
-        kDifLcCtrlOk);
+  CHECK(dif_lc_ctrl_init(lc_reg, &lc) == kDifOk);
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,
@@ -85,7 +84,7 @@ bool test_main(void) {
 
   // Read out Device ID from LC_CTRL's `device_id` registers.
   dif_lc_ctrl_device_id_t lc_device_id;
-  CHECK(dif_lc_ctrl_get_device_id(&lc, &lc_device_id) == kDifLcCtrlOk,
+  CHECK(dif_lc_ctrl_get_device_id(&lc, &lc_device_id) == kDifOk,
         "LC_CTRL failed to read device_id registers");
 
   // Read out Device ID from OTP DAI read, and compare the value with LC_CTRL's

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
@@ -55,12 +55,11 @@ bool test_main(void) {
   LOG_INFO("Start LC_CTRL transition test.");
 
   mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
-  CHECK(dif_lc_ctrl_init((dif_lc_ctrl_params_t){.base_addr = lc_reg}, &lc) ==
-        kDifLcCtrlOk);
+  CHECK(dif_lc_ctrl_init(lc_reg, &lc) == kDifOk);
 
   LOG_INFO("Read and check LC state.");
   dif_lc_ctrl_state_t curr_state;
-  CHECK(dif_lc_ctrl_get_state(&lc, &curr_state) == kDifLcCtrlOk);
+  CHECK(dif_lc_ctrl_get_state(&lc, &curr_state) == kDifOk);
 
   // The OTP preload image hardcode lc_count as 8.
   const uint8_t LcStateTransitionCount = 8;

--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -192,7 +192,7 @@ def main():
 
         if "autogen" in args.only:
             # Render all templates
-            for filetype in [".inc", ".c", "_unittest.cc"]:
+            for filetype in [".h", ".c", "_unittest.cc"]:
                 # Build input/output file names.
                 template_file = (
                     REPO_TOP / f"util/make_new_dif/dif_autogen{filetype}.tpl")

--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -115,8 +115,9 @@ class Ip:
         assert (self.hjson_data and
                 "ERROR: must load IP HJSON before loarding IRQs")
         irqs = []
-        for irq in self.hjson_data["interrupt_list"]:
-            irqs.append(Irq(irq))
+        if "interrupt_list" in self.hjson_data:
+            for irq in self.hjson_data["interrupt_list"]:
+                irqs.append(Irq(irq))
         return irqs
 
 
@@ -191,21 +192,12 @@ def main():
 
         if "autogen" in args.only:
             # Render all templates
-            for filetype in ["inc", "c", "unittest"]:
-                assert (ip.irqs and "ERROR: this IP generates no interrupts.")
+            for filetype in [".inc", ".c", "_unittest.cc"]:
                 # Build input/output file names.
-                if filetype == "unittest":
-                    template_file = (
-                        REPO_TOP /
-                        f"util/make_new_dif/dif_autogen_{filetype}.cc.tpl")
-                    out_file = (autogen_dif_dir /
-                                f"dif_{ip.name_snake}_autogen_unittest.cc")
-                else:
-                    template_file = (
-                        REPO_TOP /
-                        f"util/make_new_dif/dif_autogen.{filetype}.tpl")
-                    out_file = (autogen_dif_dir /
-                                f"dif_{ip.name_snake}_autogen.{filetype}")
+                template_file = (
+                    REPO_TOP / f"util/make_new_dif/dif_autogen{filetype}.tpl")
+                out_file = (autogen_dif_dir /
+                            f"dif_{ip.name_snake}_autogen{filetype}")
 
                 # Read in template.
                 template = Template(template_file.read_text())

--- a/util/make_new_dif/dif_autogen.c.tpl
+++ b/util/make_new_dif/dif_autogen.c.tpl
@@ -31,180 +31,184 @@
 
 #include "${ip.name_snake}_regs.h"  // Generated.
 
-/**
- * Get the corresponding interrupt register bit offset. INTR_STATE,
- * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
- * routine can be reused.
- */
-static bool ${ip.name_snake}_get_irq_bit_index(
-  dif_${ip.name_snake}_irq_t irq,
-  bitfield_bit32_index_t *index_out) {
+% if len(irqs) > 0:
 
-  switch (irq) {
-% for irq in irqs:
-    case kDif${ip.name_camel}Irq${irq.name_camel}:
-      *index_out = ${ip.name_upper}_INTR_STATE_${irq.name_upper}_BIT;
-      break;
-% endfor
-    default:
-      return false;
+  /**
+   * Get the corresponding interrupt register bit offset. INTR_STATE,
+   * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+   * routine can be reused.
+   */
+  static bool ${ip.name_snake}_get_irq_bit_index(
+    dif_${ip.name_snake}_irq_t irq,
+    bitfield_bit32_index_t *index_out) {
+
+    switch (irq) {
+  % for irq in irqs:
+      case kDif${ip.name_camel}Irq${irq.name_camel}:
+        *index_out = ${ip.name_upper}_INTR_STATE_${irq.name_upper}_BIT;
+        break;
+  % endfor
+      default:
+        return false;
+    }
+
+    return true;
   }
 
-  return true;
-}
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_get_state(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_state_snapshot_t *snapshot) {
 
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_get_state(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_state_snapshot_t *snapshot) {
+    if (${ip.name_snake} == NULL || snapshot == NULL) {
+      return kDifBadArg;
+    }
 
-  if (${ip.name_snake} == NULL || snapshot == NULL) {
-    return kDifBadArg;
+    *snapshot = ${mmio_region_read32("STATE")}
+
+    return kDifOk;
   }
 
-  *snapshot = ${mmio_region_read32("STATE")}
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_is_pending(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    bool *is_pending) {
 
-  return kDifOk;
-}
+    if (${ip.name_snake} == NULL || is_pending == NULL) {
+      return kDifBadArg;
+    }
 
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_is_pending(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq,
-  bool *is_pending) {
+    bitfield_bit32_index_t index;
+    if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
+      return kDifBadArg;
+    }
 
-  if (${ip.name_snake} == NULL || is_pending == NULL) {
-    return kDifBadArg;
+    uint32_t intr_state_reg = ${mmio_region_read32("STATE")}
+    *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+    return kDifOk;
   }
 
-  bitfield_bit32_index_t index;
-  if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
-    return kDifBadArg;
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_acknowledge(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq) {
+
+    if (${ip.name_snake} == NULL) {
+      return kDifBadArg;
+    }
+
+    bitfield_bit32_index_t index;
+    if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
+      return kDifBadArg;
+    }
+
+    // Writing to the register clears the corresponding bits (Write-one clear).
+    uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+    ${mmio_region_write32("STATE", "intr_state_reg")}
+
+    return kDifOk;
   }
 
-  uint32_t intr_state_reg = ${mmio_region_read32("STATE")}
-  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_get_enabled(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    dif_toggle_t *state) {
+    
+    if (${ip.name_snake} == NULL || state == NULL) {
+      return kDifBadArg;
+    }
 
-  return kDifOk;
-}
+    bitfield_bit32_index_t index;
+    if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
+      return kDifBadArg;
+    }
 
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_acknowledge(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq) {
+    uint32_t intr_enable_reg = ${mmio_region_read32("ENABLE")}
+    bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+    *state = is_enabled ? 
+      kDifToggleEnabled : kDifToggleDisabled;
 
-  if (${ip.name_snake} == NULL) {
-    return kDifBadArg;
+    return kDifOk;
   }
 
-  bitfield_bit32_index_t index;
-  if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
-    return kDifBadArg;
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_set_enabled(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    dif_toggle_t state) {
+
+    if (${ip.name_snake} == NULL) {
+      return kDifBadArg;
+    }
+
+    bitfield_bit32_index_t index;
+    if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
+      return kDifBadArg;
+    }
+
+    uint32_t intr_enable_reg = ${mmio_region_read32("ENABLE")}
+    bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+    intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+    ${mmio_region_write32("ENABLE", "intr_enable_reg")}
+
+    return kDifOk;
   }
 
-  // Writing to the register clears the corresponding bits (Write-one clear).
-  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
-  ${mmio_region_write32("STATE", "intr_state_reg")}
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_force(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq) {
 
-  return kDifOk;
-}
+    if (${ip.name_snake} == NULL) {
+      return kDifBadArg;
+    }
 
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_get_enabled(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq,
-  dif_toggle_t *state) {
-  
-  if (${ip.name_snake} == NULL || state == NULL) {
-    return kDifBadArg;
+    bitfield_bit32_index_t index;
+    if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
+      return kDifBadArg;
+    }
+
+    uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+    ${mmio_region_write32("TEST", "intr_test_reg")}
+
+    return kDifOk;
   }
 
-  bitfield_bit32_index_t index;
-  if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
-    return kDifBadArg;
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_disable_all(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot) {
+
+    if (${ip.name_snake} == NULL) {
+      return kDifBadArg;
+    }
+
+    // Pass the current interrupt state to the caller, if requested.
+    if (snapshot != NULL) {
+      *snapshot = ${mmio_region_read32("ENABLE")}
+    }
+
+    // Disable all interrupts.
+    ${mmio_region_write32("ENABLE", "0u")}
+
+    return kDifOk;
   }
 
-  uint32_t intr_enable_reg = ${mmio_region_read32("ENABLE")}
-  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
-  *state = is_enabled ? 
-    kDifToggleEnabled : kDifToggleDisabled;
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_restore_all(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    const dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot) {
 
-  return kDifOk;
-}
+    if (${ip.name_snake} == NULL || snapshot == NULL) {
+      return kDifBadArg;
+    }
 
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_set_enabled(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq,
-  dif_toggle_t state) {
+    ${mmio_region_write32("ENABLE", "*snapshot")}
 
-  if (${ip.name_snake} == NULL) {
-    return kDifBadArg;
+    return kDifOk;
   }
 
-  bitfield_bit32_index_t index;
-  if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
-    return kDifBadArg;
-  }
-
-  uint32_t intr_enable_reg = ${mmio_region_read32("ENABLE")}
-  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
-  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
-  ${mmio_region_write32("ENABLE", "intr_enable_reg")}
-
-  return kDifOk;
-}
-
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_force(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq) {
-
-  if (${ip.name_snake} == NULL) {
-    return kDifBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  if (!${ip.name_snake}_get_irq_bit_index(irq, &index)) {
-    return kDifBadArg;
-  }
-
-  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
-  ${mmio_region_write32("TEST", "intr_test_reg")}
-
-  return kDifOk;
-}
-
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_disable_all(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot) {
-
-  if (${ip.name_snake} == NULL) {
-    return kDifBadArg;
-  }
-
-  // Pass the current interrupt state to the caller, if requested.
-  if (snapshot != NULL) {
-    *snapshot = ${mmio_region_read32("ENABLE")}
-  }
-
-  // Disable all interrupts.
-  ${mmio_region_write32("ENABLE", "0u")}
-
-  return kDifOk;
-}
-
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_restore_all(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  const dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot) {
-
-  if (${ip.name_snake} == NULL || snapshot == NULL) {
-    return kDifBadArg;
-  }
-
-  ${mmio_region_write32("ENABLE", "*snapshot")}
-
-  return kDifOk;
-}
+% endif

--- a/util/make_new_dif/dif_autogen.h.tpl
+++ b/util/make_new_dif/dif_autogen.h.tpl
@@ -18,10 +18,10 @@
     2. list[irq]: See util/make_new_dif.py for the definition of the `irq` obj.
 </%doc>
 
-// This file is auto-generated.
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_${ip.name_upper}_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_${ip.name_upper}_AUTOGEN_H_
 
-#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_${ip.name_upper}_AUTOGEN_INC_
-#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_${ip.name_upper}_AUTOGEN_INC_
+// This file is auto-generated.
 
 /**
  * @file
@@ -194,4 +194,4 @@ typedef struct dif_${ip.name_snake} {
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_${ip.name_upper}_AUTOGEN_INC_
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_${ip.name_upper}_AUTOGEN_H_

--- a/util/make_new_dif/dif_autogen.inc.tpl
+++ b/util/make_new_dif/dif_autogen.inc.tpl
@@ -51,140 +51,144 @@ typedef struct dif_${ip.name_snake} {
   mmio_region_t base_addr;
 } dif_${ip.name_snake}_t;
 
-/**
- * A ${ip.name_snake} interrupt request type.
- */
-typedef enum dif_${ip.name_snake}_irq {
-% for irq in irqs:
+% if len(irqs) > 0:
+
   /**
-   * ${irq.description}
+   * A ${ip.name_snake} interrupt request type.
    */
-  kDif${ip.name_camel}Irq${irq.name_camel} = ${loop.index},
-% endfor
-} dif_${ip.name_snake}_irq_t;
+  typedef enum dif_${ip.name_snake}_irq {
+  % for irq in irqs:
+    /**
+     * ${irq.description}
+     */
+    kDif${ip.name_camel}Irq${irq.name_camel} = ${loop.index},
+  % endfor
+  } dif_${ip.name_snake}_irq_t;
 
-/**
- * A snapshot of the state of the interrupts for this IP.
- *
- * This is an opaque type, to be used with the `dif_${ip.name_snake}_irq_get_state()`
- * function.
- */
-typedef uint32_t dif_${ip.name_snake}_irq_state_snapshot_t;
+  /**
+   * A snapshot of the state of the interrupts for this IP.
+   *
+   * This is an opaque type, to be used with the `dif_${ip.name_snake}_irq_get_state()`
+   * function.
+   */
+  typedef uint32_t dif_${ip.name_snake}_irq_state_snapshot_t;
 
-/**
- * A snapshot of the enablement state of the interrupts for this IP.
- *
- * This is an opaque type, to be used with the
- * `dif_${ip.name_snake}_irq_disable_all()` and `dif_${ip.name_snake}_irq_restore_all()`
- * functions.
- */
-typedef uint32_t dif_${ip.name_snake}_irq_enable_snapshot_t;
+  /**
+   * A snapshot of the enablement state of the interrupts for this IP.
+   *
+   * This is an opaque type, to be used with the
+   * `dif_${ip.name_snake}_irq_disable_all()` and `dif_${ip.name_snake}_irq_restore_all()`
+   * functions.
+   */
+  typedef uint32_t dif_${ip.name_snake}_irq_enable_snapshot_t;
 
-/**
- * Returns whether a particular interrupt is currently pending.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_get_state(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_state_snapshot_t *snapshot);
+  /**
+   * Returns whether a particular interrupt is currently pending.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @param[out] is_pending Out-param for whether the interrupt is pending.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_get_state(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_state_snapshot_t *snapshot);
 
-/**
- * Returns whether a particular interrupt is currently pending.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_is_pending(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq,
-  bool *is_pending);
+  /**
+   * Returns whether a particular interrupt is currently pending.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @param[out] is_pending Out-param for whether the interrupt is pending.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_is_pending(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    bool *is_pending);
 
-/**
- * Acknowledges a particular interrupt, indicating to the hardware that it has
- * been successfully serviced.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param irq An interrupt request.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_acknowledge(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq);
+  /**
+   * Acknowledges a particular interrupt, indicating to the hardware that it has
+   * been successfully serviced.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_acknowledge(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq);
 
-/**
- * Checks whether a particular interrupt is currently enabled or disabled.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param irq An interrupt request.
- * @param[out] state Out-param toggle state of the interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_get_enabled(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq,
-  dif_toggle_t *state);
+  /**
+   * Checks whether a particular interrupt is currently enabled or disabled.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @param[out] state Out-param toggle state of the interrupt.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_get_enabled(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    dif_toggle_t *state);
 
-/**
- * Sets whether a particular interrupt is currently enabled or disabled.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param irq An interrupt request.
- * @param state The new toggle state for the interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_set_enabled(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq,
-  dif_toggle_t state);
+  /**
+   * Sets whether a particular interrupt is currently enabled or disabled.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @param state The new toggle state for the interrupt.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_set_enabled(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq,
+    dif_toggle_t state);
 
-/**
- * Forces a particular interrupt, causing it to be serviced as if hardware had
- * asserted it.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param irq An interrupt request.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_force(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_t irq);
+  /**
+   * Forces a particular interrupt, causing it to be serviced as if hardware had
+   * asserted it.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param irq An interrupt request.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_force(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_t irq);
 
-/**
- * Disables all interrupts, optionally snapshotting all enable states for later
- * restoration.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_disable_all(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot);
+  /**
+   * Disables all interrupts, optionally snapshotting all enable states for later
+   * restoration.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_disable_all(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot);
 
-/**
- * Restores interrupts from the given (enable) snapshot.
- *
- * @param ${ip.name_snake} A ${ip.name_snake} handle.
- * @param snapshot A snapshot to restore from.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_irq_restore_all(
-  const dif_${ip.name_snake}_t *${ip.name_snake},
-  const dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot);
+  /**
+   * Restores interrupts from the given (enable) snapshot.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param snapshot A snapshot to restore from.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_irq_restore_all(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    const dif_${ip.name_snake}_irq_enable_snapshot_t *snapshot);
+
+% endif
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/util/make_new_dif/dif_autogen.inc.tpl
+++ b/util/make_new_dif/dif_autogen.inc.tpl
@@ -46,7 +46,7 @@ extern "C" {
  */
 typedef struct dif_${ip.name_snake} { 
   /**
-   * The base address for the ${ip.name_upper} hardware registers.
+   * The base address for the ${ip.name_snake} hardware registers.
    */
   mmio_region_t base_addr;
 } dif_${ip.name_snake}_t;

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -21,382 +21,384 @@
 
 namespace dif_${ip.name_snake}_unittest {
 namespace {
-using testing::Eq;
-using testing::Test;
-
-class IrqGetStateTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqGetStateTest, NullArgs) {
-  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
-      nullptr, 
-      &irq_snapshot),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
-      &${ip.name_snake}_, 
-      nullptr),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
-      nullptr, 
-      nullptr),
-    kDifBadArg);
-}
-
-TEST_F(IrqGetStateTest, SuccessAllRaised) {
-  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
-
-  EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 
-    std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
-      &${ip.name_snake}_, 
-      &irq_snapshot),
-    kDifOk);
-  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
-}
-
-TEST_F(IrqGetStateTest, SuccessNoneRaised) {
-  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
-
-  EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
-      &${ip.name_snake}_, 
-      &irq_snapshot),
-    kDifOk);
-  EXPECT_EQ(irq_snapshot, 0);
-}
-
-class IrqIsPendingTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqIsPendingTest, NullArgs) {
-  bool is_pending;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
-      nullptr, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      &is_pending),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
-      &${ip.name_snake}_, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      nullptr),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
-      nullptr,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      nullptr),
-    kDifBadArg);
-}
-
-TEST_F(IrqIsPendingTest, BadIrq) {
-  bool is_pending;
-  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
-      &${ip.name_snake}_, 
-      (dif_${ip.name_snake}_irq_t)32,
-      &is_pending),
-    kDifBadArg);
-}
-
-TEST_F(IrqIsPendingTest, Success) {
-  bool irq_state;
-
-  // Get the first IRQ state.
-  irq_state = false;
-  EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      &irq_state),
-    kDifOk);
-  EXPECT_TRUE(irq_state);
-
-  // Get the last IRQ state.
-  irq_state = true;
-  EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, false}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[-1].name_camel},
-      &irq_state),
-    kDifOk);
-  EXPECT_FALSE(irq_state);
-}
-
-class IrqAcknowledgeTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
-      nullptr, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel}),
-    kDifBadArg);
-}
-
-TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
-      nullptr, 
-      (dif_${ip.name_snake}_irq_t)32),
-    kDifBadArg);
-}
-
-TEST_F(IrqAcknowledgeTest, Success) {
-  // Clear the first IRQ state.
-  EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                 {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel}),
-    kDifOk);
-
-  // Clear the last IRQ state.
-  EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                 {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
-    kDifOk);
-}
-
-class IrqGetEnabledTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqGetEnabledTest, NullArgs) {
-  dif_toggle_t irq_state;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
-      nullptr, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      &irq_state),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
-      &${ip.name_snake}_, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      nullptr),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
-      nullptr, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      nullptr),
-    kDifBadArg);
-}
-
-TEST_F(IrqGetEnabledTest, BadIrq) {
-  dif_toggle_t irq_state;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
-      &${ip.name_snake}_, 
-      (dif_${ip.name_snake}_irq_t)32,
-      &irq_state),
-    kDifBadArg);
-}
-
-TEST_F(IrqGetEnabledTest, Success) {
-  dif_toggle_t irq_state;
-
-  // First IRQ is enabled.
-  irq_state = kDifToggleDisabled;
-  EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      &irq_state),
-    kDifOk);
-  EXPECT_EQ(irq_state, kDifToggleEnabled);
-
-  // Last IRQ is disabled.
-  irq_state = kDifToggleEnabled;
-  EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      &irq_state),
-    kDifOk);
-  EXPECT_EQ(irq_state, kDifToggleDisabled);
-}
-
-class IrqSetEnabledTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqSetEnabledTest, NullArgs) {
-  dif_toggle_t irq_state = kDifToggleEnabled;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
-      nullptr, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      irq_state),
-    kDifBadArg);
-}
-
-TEST_F(IrqSetEnabledTest, BadIrq) {
-  dif_toggle_t irq_state = kDifToggleEnabled;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
-      &${ip.name_snake}_, 
-      (dif_${ip.name_snake}_irq_t)32,
-      irq_state),
-    kDifBadArg);
-}
-
-TEST_F(IrqSetEnabledTest, Success) {
-  dif_toggle_t irq_state;
-
-  // Enable first IRQ.
-  irq_state = kDifToggleEnabled;
-  EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT,
-                  0x1,
-                  true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel},
-      irq_state),
-    kDifOk);
-
-  // Disable last IRQ.
-  irq_state = kDifToggleDisabled;
-  EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, 
-                  0x1, 
-                  false}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[-1].name_camel},
-      irq_state),
-    kDifOk);
-}
-
-class IrqForceTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_${ip.name_snake}_irq_force(
-      nullptr, 
-      kDif${ip.name_camel}Irq${irqs[0].name_camel}),
-    kDifBadArg);
-}
-
-TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_${ip.name_snake}_irq_force(
-      nullptr, 
-      (dif_${ip.name_snake}_irq_t)32),
-    kDifBadArg);
-}
-
-TEST_F(IrqForceTest, Success) {
-  // Force first IRQ.
-  EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
-                 {{${ip.name_upper}_INTR_TEST_${irqs[0].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_force(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[0].name_camel}),
-    kDifOk);
-
-  // Force last IRQ.
-  EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
-                 {{${ip.name_upper}_INTR_TEST_${irqs[-1].name_upper}_BIT, true}});
-  EXPECT_EQ(dif_${ip.name_snake}_irq_force(
-      &${ip.name_snake}_,
-      kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
-    kDifOk);
-}
-
-class IrqDisableAllTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqDisableAllTest, NullArgs) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
-      nullptr, 
-      &irq_snapshot),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
-      nullptr, 
-      nullptr),
-    kDifBadArg);
-}
-
-TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
-  EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
-      &${ip.name_snake}_, 
-      nullptr),
-    kDifOk);
-}
-
-TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
-
-  EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
-      &${ip.name_snake}_, 
-      &irq_snapshot),
-    kDifOk);
-  EXPECT_EQ(irq_snapshot, 0);
-}
-
-TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
-
-  EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                std::numeric_limits<uint32_t>::max());
-  EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
-      &${ip.name_snake}_, 
-      &irq_snapshot),
-    kDifOk);
-  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
-}
-
-class IrqRestoreAllTest : public ${ip.name_camel}Test {};
-
-TEST_F(IrqRestoreAllTest, NullArgs) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
-      nullptr, 
-      &irq_snapshot),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
-      &${ip.name_snake}_, 
-      nullptr),
-    kDifBadArg);
-
-  EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
-      nullptr, 
-      nullptr),
-    kDifBadArg);
-}
-
-TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 
-    std::numeric_limits<uint32_t>::max();
-
-  EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 
-    std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
-      &${ip.name_snake}_, 
-      &irq_snapshot),
-    kDifOk);
-}
-
-TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
-
-  EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
-      &${ip.name_snake}_, 
-      &irq_snapshot),
-    kDifOk);
-}
+% if len(irqs) > 0:
+  using testing::Eq;
+
+  class IrqGetStateTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqGetStateTest, NullArgs) {
+    dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+        nullptr, 
+        &irq_snapshot),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+        &${ip.name_snake}_, 
+        nullptr),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+        nullptr, 
+        nullptr),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqGetStateTest, SuccessAllRaised) {
+    dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
+
+    EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 
+      std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+        &${ip.name_snake}_, 
+        &irq_snapshot),
+      kDifOk);
+    EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+  }
+
+  TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+    dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
+
+    EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 0);
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+        &${ip.name_snake}_, 
+        &irq_snapshot),
+      kDifOk);
+    EXPECT_EQ(irq_snapshot, 0);
+  }
+
+  class IrqIsPendingTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqIsPendingTest, NullArgs) {
+    bool is_pending;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+        nullptr, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        &is_pending),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+        &${ip.name_snake}_, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        nullptr),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+        nullptr,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        nullptr),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqIsPendingTest, BadIrq) {
+    bool is_pending;
+    // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+        &${ip.name_snake}_, 
+        (dif_${ip.name_snake}_irq_t)32,
+        &is_pending),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqIsPendingTest, Success) {
+    bool irq_state;
+
+    // Get the first IRQ state.
+    irq_state = false;
+    EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
+                  {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        &irq_state),
+      kDifOk);
+    EXPECT_TRUE(irq_state);
+
+    // Get the last IRQ state.
+    irq_state = true;
+    EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
+                  {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, false}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[-1].name_camel},
+        &irq_state),
+      kDifOk);
+    EXPECT_FALSE(irq_state);
+  }
+
+  class IrqAcknowledgeTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqAcknowledgeTest, NullArgs) {
+    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+        nullptr, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqAcknowledgeTest, BadIrq) {
+    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+        nullptr, 
+        (dif_${ip.name_snake}_irq_t)32),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqAcknowledgeTest, Success) {
+    // Clear the first IRQ state.
+    EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
+                   {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      kDifOk);
+
+    // Clear the last IRQ state.
+    EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
+                   {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
+      kDifOk);
+  }
+
+  class IrqGetEnabledTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqGetEnabledTest, NullArgs) {
+    dif_toggle_t irq_state;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+        nullptr, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        &irq_state),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+        &${ip.name_snake}_, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        nullptr),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+        nullptr, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        nullptr),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqGetEnabledTest, BadIrq) {
+    dif_toggle_t irq_state;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+        &${ip.name_snake}_, 
+        (dif_${ip.name_snake}_irq_t)32,
+        &irq_state),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqGetEnabledTest, Success) {
+    dif_toggle_t irq_state;
+
+    // First IRQ is enabled.
+    irq_state = kDifToggleDisabled;
+    EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
+                  {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        &irq_state),
+      kDifOk);
+    EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+    // Last IRQ is disabled.
+    irq_state = kDifToggleEnabled;
+    EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
+                  {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        &irq_state),
+      kDifOk);
+    EXPECT_EQ(irq_state, kDifToggleDisabled);
+  }
+
+  class IrqSetEnabledTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqSetEnabledTest, NullArgs) {
+    dif_toggle_t irq_state = kDifToggleEnabled;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+        nullptr, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        irq_state),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqSetEnabledTest, BadIrq) {
+    dif_toggle_t irq_state = kDifToggleEnabled;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+        &${ip.name_snake}_, 
+        (dif_${ip.name_snake}_irq_t)32,
+        irq_state),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqSetEnabledTest, Success) {
+    dif_toggle_t irq_state;
+
+    // Enable first IRQ.
+    irq_state = kDifToggleEnabled;
+    EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
+                  {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT,
+                    0x1,
+                    true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+        irq_state),
+      kDifOk);
+
+    // Disable last IRQ.
+    irq_state = kDifToggleDisabled;
+    EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
+                  {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, 
+                    0x1, 
+                    false}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[-1].name_camel},
+        irq_state),
+      kDifOk);
+  }
+
+  class IrqForceTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqForceTest, NullArgs) {
+    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+        nullptr, 
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqForceTest, BadIrq) {
+    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+        nullptr, 
+        (dif_${ip.name_snake}_irq_t)32),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqForceTest, Success) {
+    // Force first IRQ.
+    EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
+                   {{${ip.name_upper}_INTR_TEST_${irqs[0].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      kDifOk);
+
+    // Force last IRQ.
+    EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
+                   {{${ip.name_upper}_INTR_TEST_${irqs[-1].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
+      kDifOk);
+  }
+
+  class IrqDisableAllTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqDisableAllTest, NullArgs) {
+    dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+        nullptr, 
+        &irq_snapshot),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+        nullptr, 
+        nullptr),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+    EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+        &${ip.name_snake}_, 
+        nullptr),
+      kDifOk);
+  }
+
+  TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+    dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
+
+    EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+        &${ip.name_snake}_, 
+        &irq_snapshot),
+      kDifOk);
+    EXPECT_EQ(irq_snapshot, 0);
+  }
+
+  TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+    dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
+
+    EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
+                  std::numeric_limits<uint32_t>::max());
+    EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+        &${ip.name_snake}_, 
+        &irq_snapshot),
+      kDifOk);
+    EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+  }
+
+  class IrqRestoreAllTest : public ${ip.name_camel}Test {};
+
+  TEST_F(IrqRestoreAllTest, NullArgs) {
+    dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+        nullptr, 
+        &irq_snapshot),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+        &${ip.name_snake}_, 
+        nullptr),
+      kDifBadArg);
+
+    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+        nullptr, 
+        nullptr),
+      kDifBadArg);
+  }
+
+  TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+    dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 
+      std::numeric_limits<uint32_t>::max();
+
+    EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 
+      std::numeric_limits<uint32_t>::max());
+    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+        &${ip.name_snake}_, 
+        &irq_snapshot),
+      kDifOk);
+  }
+
+  TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+    dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
+
+    EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
+    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+        &${ip.name_snake}_, 
+        &irq_snapshot),
+      kDifOk);
+  }
+
+% endif
 
 }  // namespace
 }  // namespace dif_${ip.name_snake}_unittest

--- a/util/make_new_dif/dif_template.h.tpl
+++ b/util/make_new_dif/dif_template.h.tpl
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 
-#include "sw/device/lib/dif/autogen/dif_${ip.name_snake}_autogen.inc"
+#include "sw/device/lib/dif/autogen/dif_${ip.name_snake}_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "lc_ctrl".

Note: this PR depends on #8280, and therefore contains a duplicate commit that will be removed when all dependencies are merged.