### PR TITLE
[dv/alert_handler] Fix tl_intg_err regression failure

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -529,9 +529,9 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   endtask
 
   // override csr_vseq to control adapter to abort transaction
-  virtual task run_csr_vseq(string          csr_test_type = "",
-                            int             num_test_csrs = 0,
-                            bit             do_rand_wr_and_reset = 1);
+  virtual task run_csr_vseq(string csr_test_type = "",
+                            int    num_test_csrs = 0,
+                            bit    do_rand_wr_and_reset = 1);
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(csr_access_abort_pct)
     foreach (cfg.m_tl_agent_cfgs[i]) begin


### PR DESCRIPTION
This PR fixes the regression failure for tl_intg_err where this sequence
triggers local alerts and escalation. Then the csr_rw sequence has
mismatch due to the escalation.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>