### PR TITLE
[dv/shadow_reg] Fix alert shadow_reg regression error

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -18,7 +18,7 @@ virtual function bit [BUS_DW-1:0] get_shadow_reg_diff_val(dv_base_reg      csr,
     int index;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(index, reg_mask[index] == 1;)
     get_shadow_reg_diff_val = origin_val;
-    get_shadow_reg_diff_val [index] = ~get_shadow_reg_diff_val[index];
+    get_shadow_reg_diff_val[index] = ~get_shadow_reg_diff_val[index];
   end
 endfunction
 
@@ -78,8 +78,8 @@ endtask
 virtual task write_and_check_update_error(dv_base_reg shadowed_csr);
   uvm_reg_data_t wdata, err_wdata;
   string         alert_name = shadowed_csr.get_update_err_alert_name();
-  err_wdata = get_shadow_reg_diff_val(shadowed_csr, wdata);
   `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
+  err_wdata = get_shadow_reg_diff_val(shadowed_csr, wdata);
 
   csr_wr(.ptr(shadowed_csr), .value(wdata), .en_shadow_wr(0), .predict(1));
 
@@ -87,6 +87,8 @@ virtual task write_and_check_update_error(dv_base_reg shadowed_csr);
   // If the shadow register is external register, writing two different value might not actually
   // trigger update error. So we trigger dv_base_reg function to double check.
   predict_shadow_reg_status(.predict_update_err(shadowed_csr.get_shadow_update_err()));
+  `uvm_info(`gfn, $sformatf("write %0s with first value %0h second value %0h",
+            shadowed_csr.get_name(), wdata, err_wdata), UVM_HIGH);
 
   read_check_shadow_reg_status("Write_and_check_update_error task");
   csr_rd_check(.ptr(shadowed_csr), .compare_vs_ral(1));

--- a/hw/ip/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip/alert_handler/data/alert_handler_testplan.hjson
@@ -6,6 +6,7 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/enable_reg_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   testpoints: [


### PR DESCRIPTION
1. Fix regression error because we randomize `err_data` before
randomizing `wdata`.
2. Add testplan for shadow_reg errors in alert_handler
3. Add a small uvm debug message for shadow reg

Signed-off-by: Cindy Chen <chencindy@opentitan.org>