### PR TITLE
[prim, keymgr] Migrate keymgr_cnt to prim_count

### DIFF
--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -10,6 +10,7 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:all
+      - lowrisc:prim:count
       - lowrisc:prim:lfsr
       - lowrisc:prim:lc_sync
       - lowrisc:prim:msb_extend
@@ -24,7 +25,6 @@ filesets:
       - rtl/keymgr_sideload_key.sv
       - rtl/keymgr_ctrl.sv
       - rtl/keymgr_cfg_en.sv
-      - rtl/keymgr_cnt.sv
       - rtl/keymgr_kmac_if.sv
       - rtl/keymgr_input_checks.sv
       - rtl/keymgr_reseed_ctrl.sv

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -335,9 +335,9 @@ module keymgr_ctrl import keymgr_pkg::*; #(
     endcase // unique case (update_sel)
   end
 
-  keymgr_cnt #(
+  prim_count #(
     .Width(CntWidth),
-    .CntStyle(DupCnt)
+    .CntStyle(prim_count_pkg::DupCnt)
   ) u_cnt (
     .clk_i,
     .rst_ni,

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -131,7 +131,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   assign start = adv_en_i | id_en_i | gen_en_i;
 
   logic cnt_err;
-  keymgr_cnt #(
+  prim_count #(
     .Width(CntWidth),
     .OutSelDnCnt(1'b1)
   ) u_cnt (

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -100,12 +100,6 @@ package keymgr_pkg;
     Otbn
   } keymgr_key_dest_e;
 
-  // Enumeration for hardened count style
-  typedef enum logic {
-    CrossCnt, // up count and down count
-    DupCnt    // duplicate counters
-  } keymgr_cnt_style_e;
-
   // Enumeration for key select
   typedef enum logic {
     HwKey = 0,

--- a/hw/ip/prim/prim_count.core
+++ b/hw/ip/prim/prim_count.core
@@ -1,0 +1,38 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:count"
+description: ""
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:prim:count_pkg:0.1
+    files:
+      - rtl/prim_count.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/prim_count_pkg.core
+++ b/hw/ip/prim/prim_count_pkg.core
@@ -1,0 +1,37 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:count_pkg:0.1"
+description: "Hardened counter package"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_count_pkg.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim/rtl/prim_count_pkg.sv
+++ b/hw/ip/prim/rtl/prim_count_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Package for primitive hardened counter module
+//
+
+package prim_count_pkg;
+
+  // Enumeration for hardened count style
+  typedef enum logic {
+    CrossCnt, // up count and down count
+    DupCnt    // duplicate counters
+  } prim_count_style_e;
+
+  // Enumeration for differential valid
+  typedef enum logic [1:0] {
+    CmpInvalid = 2'b01,
+    CmpValid   = 2'b10
+  } cmp_valid_e;
+
+endpackage //


### PR DESCRIPTION
- Make the prim_count module available for others to use.
- Note the prim_count module is very tailored to how keymgr
  and flash_ctrl will use it.  So other enhancements will
  probably need to be made for other purposes.
