### PR TITLE
[keymgr/dv] Add operations before LC enables keymgr

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -35,11 +35,18 @@ class keymgr_base_vseq extends cip_base_vseq #(
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init();
+
+    op_before_enable_keymgr();
+
     cfg.keymgr_vif.init();
 
     delay_after_reset_before_access_csr();
 
     if (do_keymgr_init) keymgr_init();
+  endtask
+
+  // callback task before LC enables keymgr
+  virtual task op_before_enable_keymgr();
   endtask
 
   virtual task delay_after_reset_before_access_csr();
@@ -178,6 +185,12 @@ class keymgr_base_vseq extends cip_base_vseq #(
     csr_rd(.ptr(ral.err_code), .value(rd_val));
     if (rd_val != 0) begin
       csr_wr(.ptr(ral.err_code), .value(rd_val));
+    end
+
+    // read and clear interrupt
+    csr_rd(.ptr(ral.intr_state), .value(rd_val));
+    if (rd_val != 0) begin
+      csr_wr(.ptr(ral.intr_state), .value(rd_val));
     end
   endtask : wait_op_done
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
@@ -7,6 +7,12 @@ class keymgr_lc_disable_vseq extends keymgr_random_vseq;
   `uvm_object_utils(keymgr_lc_disable_vseq)
   `uvm_object_new
 
+  virtual task op_before_enable_keymgr();
+    `uvm_info(`gfn, "Dummy operations before LC enables keymgr", UVM_MEDIUM)
+    keymgr_operations();
+    `uvm_info(`gfn, "Dummy operations are done", UVM_MEDIUM)
+  endtask
+
   virtual task body();
     bit regular_vseq_done;
 


### PR DESCRIPTION
After review testplan, add 2 small things
1. Add operations before LC enables keymgr
2. Read/clear inerrupt after operation

Signed-off-by: Weicai Yang <weicai@google.com>