### PR TITLE
[sw/silicon_creator] Create `.shutdown` section

### DIFF
--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -257,10 +257,20 @@ SHUTDOWN_FUNC(noreturn, shutdown_hang(void)) {
 #endif
 }
 
+#ifndef OT_OFF_TARGET_TEST
+/**
+ * The shutdown_finalize function goes into the .shutdown section which is
+ * placed by the linker script after all other executable code.
+ */
+__attribute__((section(".shutdown")))
+#endif
 void shutdown_finalize(rom_error_t reason) {
   uint32_t redacted_error = shutdown_redact(
       reason, otp_read32(OTP_CTRL_PARAM_ROM_ERROR_REPORTING_OFFSET));
+
+  // TODO(lowRISC/opentitan#8236): base_printf is in the .text section.
   base_printf("boot_fault: 0x%08x\n", redacted_error);
+
   shutdown_software_escalate();
   shutdown_keymgr_kill();
   shutdown_flash_kill();

--- a/sw/device/silicon_creator/mask_rom/mask_rom.ld
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.ld
@@ -86,6 +86,20 @@ SECTIONS {
     *(.text)
     *(.text.*)
 
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+  } > rom
+
+  /**
+   * Shutdown text section, containing shutdown function(s).
+   *
+   * This must be the last executable section in the ROM.
+   */
+  .shutdown : ALIGN(4) {
+    *(.shutdown)
+    *(.shutdown.*)
+
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _text_end = .;

--- a/sw/device/silicon_creator/rom_exts/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_common.ld
@@ -68,6 +68,19 @@ SECTIONS {
   } > eflash
 
   /**
+   * Shutdown text section, containing shutdown function(s).
+   *
+   * This must be the last executable section in the ROM_EXT flash image.
+   */
+  .shutdown : ALIGN(4) {
+    *(.shutdown)
+    *(.shutdown.*)
+
+    /* Ensure section end is word-aligned. */
+    . = ALIGN(4);
+  } > eflash
+
+  /**
    * Read-only data section, containing all large compile-time constants, like
    * strings.
    */


### PR DESCRIPTION
The `.shutdown` section is placed after all other executable code and just contains the `shutdown_finalize` function.