### PR TITLE
[sca, kmac] Optimize KMAC SCA captures

### DIFF
--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -478,7 +478,7 @@ module kmac
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       idle_o <= 1'b 1;
-    end else if ((sha3_fsm == sha3_pkg::StIdle) && msgfifo_empty) begin
+    end else if ((sha3_fsm == sha3_pkg::StIdle) && (msgfifo_empty || SecIdleAcceptSwMsg)) begin
       idle_o <= 1'b 1;
     end else begin
       idle_o <= 1'b 0;


### PR DESCRIPTION
This PR contains two commits:
- If the FPGA SCA mode in KMAC is enabled, KMAC is made to keep signaling `idle` even though the message FIFO can contain data already. This is required to not trigger the capture while Ibex is writing to the message FIFO.
- Optimize sha3_serial SCA application to make use of the FPGA SCA mode in KMAC for lower noise, fewer samples, less processing, and signal back digest to host via UART for verifying KMAC operation during capture.

To give an idea of the impact on these changes, this is what a KMAC power trace looked before:
![Screen Shot 2021-08-14 at 00 09 51](https://user-images.githubusercontent.com/57949550/129433587-3fa27e00-89b3-4465-bb9b-b9d98a74a177.png)

Now, all the action is happening within the first 2000 samples and there is much less noise. Towards the end of the trace is when Ibex gets out of sleep (just to give you an idea of how much noise this creates).
![bokeh_plot](https://user-images.githubusercontent.com/20307557/133779443-60f9a037-5af4-46e3-a66e-692ab58bb1a0.png)
 