### PR TITLE
[otbn,dv] Implementation of 32b RND in OTBN DV

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -229,17 +229,6 @@ static bool read_ext_reg(const std::string &reg_name,
   return true;
 }
 
-static std::string wlen_val_to_hex_str(uint32_t val[8]) {
-  std::ostringstream oss;
-
-  oss << std::hex << "0x";
-  for (int i = 7; i >= 0; --i) {
-    oss << std::setfill('0') << std::setw(8) << val[i];
-  }
-
-  return oss.str();
-}
-
 ISSWrapper::ISSWrapper() : tmpdir(new TmpDir()) {
   std::string model_path(find_otbn_model());
 
@@ -368,9 +357,13 @@ void ISSWrapper::start() {
   mirrored_.status = 1;
 }
 
-void ISSWrapper::edn_rnd_data(uint32_t edn_rnd_data[8]) {
+void ISSWrapper::edn_rnd_cdc_done() {
+  run_command("edn_rnd_cdc_done\n", nullptr);
+}
+
+void ISSWrapper::edn_step(uint32_t edn_rnd_data) {
   std::ostringstream oss;
-  oss << "edn_rnd_data " << wlen_val_to_hex_str(edn_rnd_data) << "\n";
+  oss << "edn_step " << std::hex << "0x" << edn_rnd_data << "\n";
   run_command(oss.str(), nullptr);
 }
 

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -58,8 +58,12 @@ struct ISSWrapper {
   void start();
 
   // Provide data for RND. ISS will stall when RND is read and RND data isn't
-  // available
-  void edn_rnd_data(uint32_t edn_rnd_data[8]);
+  // available. RND data is available only when 8 32b packages are sent and
+  // also RTL signals CDC is done.
+  void edn_step(uint32_t edn_rnd_data);
+
+  // Signals 256b EDN random number is valid in the RTL.
+  void edn_rnd_cdc_done();
 
   // Signal URND reseed at beginning of execution is complete
   void edn_urnd_reseed_complete();

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -33,12 +33,16 @@ class OtbnModel {
   // zero. Returns 0 on success; -1 on failure.
   int start();
 
+  // EDN Step sends ISS the RND data when ACK signal is high.
+  void edn_step(svLogicVecVal *edn_rnd_data /* logic [31:0] */);
+
+  // Signals that RTL is finished processing RND data from EDN
+  void edn_rnd_cdc_done();
+
   // Step once in the model. Returns 1 if the model has finished, 0 if not and
   // -1 on failure. If gen_trace is true, pass trace entries to the trace
   // checker. If the model has finished, writes otbn.ERR_BITS to *err_bits.
-  int step(svLogic edn_rnd_data_valid,
-           svLogicVecVal *edn_rnd_data, /* logic [255:0] */
-           svLogic edn_urnd_data_valid, svBitVecVal *status /* bit [7:0] */,
+  int step(svLogic edn_urnd_data_valid, svBitVecVal *status /* bit [7:0] */,
            svBitVecVal *insn_cnt /* bit [31:0] */,
            svBitVecVal *err_bits /* bit [31:0] */,
            svBitVecVal *stop_pc /* bit [31:0] */);

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -22,6 +22,13 @@ OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope,
 // Delete an OtbnModel
 void otbn_model_destroy(OtbnModel *model);
 
+// Call edn_step function of OtbnModel
+void edn_model_step(OtbnModel *model,
+                    svLogicVecVal *edn_rnd_data /* logic [31:0] */);
+
+// Signal RTL is finished processing RND data to Model
+void edn_model_rnd_cdc_done(OtbnModel *model);
+
 // The main entry point to the OTBN model, exported from here and used in
 // otbn_core_model.sv.
 //
@@ -52,11 +59,9 @@ void otbn_model_destroy(OtbnModel *model);
 // the contents of DMEM from the ISS and inject them into the simulation
 // memory.
 //
-// If start is true, we start the model and then step once (as described
+// If start is true, we start the model and then step once (as
 // above).
 unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
-                         svLogic edn_rnd_data_valid,
-                         svLogicVecVal *edn_rnd_data, /* logic [255:0] */
                          svLogic edn_urnd_data_valid,
                          svBitVecVal *status /* bit [7:0] */,
                          svBitVecVal *insn_cnt /* bit [31:0] */,

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -16,12 +16,16 @@ package otbn_model_pkg;
 
   import "DPI-C" function void otbn_model_destroy(chandle model);
 
+  import "DPI-C" function void edn_model_step(chandle model,
+                                              logic [31:0] edn_rnd_data);
+
+  import "DPI-C" function
+    void edn_model_rnd_cdc_done(chandle model);
+
   import "DPI-C" context function
     int unsigned otbn_model_step(chandle          model,
                                  logic            start,
                                  int unsigned     model_state,
-                                 logic            edn_rnd_data_valid,
-                                 logic [WLEN-1:0] edn_rnd_data,
                                  logic            edn_urnd_data_valid,
                                  inout bit [7:0]  status,
                                  inout bit [31:0] insn_cnt,

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -129,7 +129,7 @@ class RandWSR(WSR):
 
     def request_value(self) -> bool:
         '''Signals intent to read RND, returns True if a value is available'''
-        if self._random_value:
+        if self._random_value is not None:
             return True
 
         self.pending_request = True

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -238,6 +238,7 @@ class Model:
         csrs.touch_addr(0x7c1)      # FG1
         csrs.touch_addr(0x7c8)      # FLAGS
         csrs.touch_range(0x7d0, 8)  # MOD0 - MOD7
+        csrs.touch_addr(0x7d8)      # RND_PREFETCH
         csrs.touch_addr(0xfc0)      # RND
 
         wsrs.touch_addr(0x0)        # MOD

--- a/hw/ip/otbn/dv/verilator/otbn_mock_edn.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_mock_edn.sv
@@ -6,7 +6,9 @@
  * Mock EDN end point that returns a fixed value after a fixed delay used for
  * OTBN simulation purposes.
  */
-module otbn_mock_edn #(
+module otbn_mock_edn
+  import edn_pkg::*;
+#(
   parameter int Width = 256,
   parameter logic [Width-1:0] FixedEdnVal = '0,
   parameter int Delay = 16,
@@ -16,10 +18,17 @@ module otbn_mock_edn #(
   input clk_i,
   input rst_ni,
 
-  input              edn_req_i,
-  output             edn_ack_o,
-  output [Width-1:0] edn_data_o
+  input  edn_req_t edn_req_i,
+  output edn_rsp_t edn_rsp_o,
+
+  output [Width-1:0] edn_data_o,
+  output             edn_ack_o
 );
+
+  assign edn_rsp_o.edn_ack  = edn_req_active && !edn_req_counter[0];
+  assign edn_rsp_o.edn_fips = 1'b0;
+  assign edn_rsp_o.edn_bus  = 32'h9999_9999;
+
   parameter int MaxDelay = Delay - 1;
   logic [DelayWidth-1:0] edn_req_counter;
   logic                  edn_req_active;
@@ -31,14 +40,14 @@ module otbn_mock_edn #(
 
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      edn_req_counter <= 0;
+      edn_req_counter <= '0;
       edn_req_active  <= 0;
     end else begin
       if (edn_req_active) begin
-        edn_req_counter <= edn_req_counter + 4'b1;
+        edn_req_counter <= edn_req_counter + 1;
       end
 
-      if (edn_req_i & ~edn_req_active) begin
+      if (edn_req_i.edn_req & ~edn_req_active) begin
         edn_req_active <= 1;
       end
 


### PR DESCRIPTION
This commit includes processing 32b packages from EDN instead of
probing DUT and setting 256b directly.

Also includes #8239. When #8239 gets merged the commit will be removed from this PR.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>