### PR TITLE
[top_englishbreakfast] Remove lifecycle controller

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -42,6 +42,7 @@ package lc_ctrl_pkg;
 
   parameter int RmaSeedWidth = 32;
   typedef logic [RmaSeedWidth-1:0] lc_flash_rma_seed_t;
+  parameter lc_flash_rma_seed_t LC_FLASH_RMA_SEED_DEFAULT = '0;
 
   parameter int LcKeymgrDivWidth = 128;
   typedef logic [LcKeymgrDivWidth-1:0] lc_keymgr_div_t;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -784,6 +784,7 @@ module top_earlgrey #(
 
   assign rv_core_ibex_boot_addr = ADDR_SPACE_ROM_CTRL__ROM;
 
+
   // Struct breakout module tool-inserted DFT TAP signals
   pinmux_jtag_breakout u_dft_tap_breakout (
     .req_i    (pinmux_aon_dft_jtag_req),

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -223,13 +223,6 @@
       reset_connections: {rst_ni: "sys_io_div4", rst_aon_ni: "sys_aon", rst_usb_48mhz_ni: "usb"},
       base_addr: "0x40110000",
     },
-    { name: "lc_ctrl",
-      type: "lc_ctrl",
-      clock_srcs: {clk_i: "io_div4", clk_kmac_i: "io_div4"},
-      clock_group: "timers",
-      reset_connections: {rst_ni: "lc_io_div4", rst_kmac_ni: "lc_io_div4"},
-      base_addr: "0x40140000",
-    },
     { name: "pwrmgr_aon",
       type: "pwrmgr",
       clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
@@ -518,13 +511,9 @@
   //  e.g flash_ctrl0.flash: [flash_phy0.flash_ctrl]
   inter_module: {
     'connect': {
-      'flash_ctrl.rma_req'      : ['lc_ctrl.lc_flash_rma_req'],
-      'flash_ctrl.rma_ack'      : ['lc_ctrl.lc_flash_rma_ack'],
-      'flash_ctrl.rma_seed'     : ['lc_ctrl.lc_flash_rma_seed'],
       'pwrmgr_aon.pwr_flash'    : ['flash_ctrl.pwrmgr'],
       'pwrmgr_aon.pwr_rst'      : ['rstmgr_aon.pwr'],
       'pwrmgr_aon.pwr_clk'      : ['clkmgr_aon.pwr'],
-      'pwrmgr_aon.pwr_lc'       : ['lc_ctrl.pwr_lc'],
       'pwrmgr_aon.strap'        : ['pinmux_aon.strap_en'],
       'pwrmgr_aon.low_power'    : ['pinmux_aon.sleep_en',
                                    'aon_timer_aon.sleep_mode'],
@@ -543,34 +532,7 @@
       'clkmgr_aon.idle'         : [],
 
       // Pinmux JTAG signals
-      'pinmux_aon.lc_jtag' : ['lc_ctrl.jtag'],
       'pinmux_aon.rv_jtag' : ['rv_dm.jtag'],
-
-      // LC function control signal broadcast
-      'lc_ctrl.lc_dft_en'          : ['pinmux_aon.lc_dft_en',
-                                      'clkmgr_aon.lc_dft_en'
-                                     ],
-      'lc_ctrl.lc_nvm_debug_en'    : ['flash_ctrl.lc_nvm_debug_en'],
-      'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
-                                      'sram_ctrl_ret_aon.lc_hw_debug_en',
-                                      'pinmux_aon.lc_hw_debug_en',
-                                      'rv_dm.lc_hw_debug_en'],
-      'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en'],
-      'lc_ctrl.lc_keymgr_en'       : [],
-      'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',
-                                      'sram_ctrl_main.lc_escalate_en',
-                                      'sram_ctrl_ret_aon.lc_escalate_en',
-                                      'aon_timer_aon.lc_escalate_en',
-                                      'flash_ctrl.lc_escalate_en'],
-      'lc_ctrl.lc_clk_byp_req'     : ['clkmgr_aon.lc_clk_byp_req'],
-      'lc_ctrl.lc_clk_byp_ack'     : ['clkmgr_aon.lc_clk_byp_ack'],
-
-      // LC access control signal broadcast
-      'lc_ctrl.lc_creator_seed_sw_rw_en'   : ['flash_ctrl.lc_creator_seed_sw_rw_en'],
-      'lc_ctrl.lc_owner_seed_sw_rw_en'     : ['flash_ctrl.lc_owner_seed_sw_rw_en'],
-      'lc_ctrl.lc_iso_part_sw_rd_en'       : ['flash_ctrl.lc_iso_part_sw_rd_en'],
-      'lc_ctrl.lc_iso_part_sw_wr_en'       : ['flash_ctrl.lc_iso_part_sw_wr_en'],
-      'lc_ctrl.lc_seed_hw_rd_en'           : ['flash_ctrl.lc_seed_hw_rd_en'],
 
       // rv_plic connections
       'rv_plic.msip' : ['rv_core_ibex.irq_software'],
@@ -607,6 +569,9 @@
         // hardwired connections
         'rv_core_ibex.hart_id', 'rv_core_ibex.boot_addr',
 
+        // lc_ctrl.lc_cpu_en - always enabled for English Breakfast
+        'rv_core_ibex.lc_cpu_en'
+
         // Xbars
 
         // Pinmux JTAG signals for the tool-inserted DFT TAP
@@ -615,8 +580,6 @@
         // OTP HW_CFG Broadcast signals.
         // TODO(#6713): The actual struct breakout and mapping currently needs to
         // be performed by hand in the toplevel template.
-        'lc_ctrl.otp_device_id',
-        'lc_ctrl.otp_manuf_state',
         'sram_ctrl_main.otp_en_sram_ifetch',
         'sram_ctrl_ret_aon.otp_en_sram_ifetch'
     ],

--- a/hw/top_englishbreakfast/data/xbar_peri.hjson
+++ b/hw/top_englishbreakfast/data/xbar_peri.hjson
@@ -75,12 +75,6 @@
       reset:     "rst_peri_ni",
       pipeline:  "false"
     },
-    { name:      "lc_ctrl",
-      type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
-      pipeline:  "false"
-    },
     { name:      "sram_ctrl_ret_aon.regs",
       type:      "device",
       clock:     "clk_peri_i",
@@ -105,7 +99,6 @@
       "uart0",
       "gpio", "spi_device", "spi_host0", "rv_timer", "usbdev",
       "pwrmgr_aon", "rstmgr_aon", "clkmgr_aon", "pinmux_aon",
-      "lc_ctrl",
       "sram_ctrl_ret_aon.ram", "sram_ctrl_ret_aon.regs", "ast"
     ],
   },

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -298,6 +298,7 @@ def is_shadowed_port(block: IpBlock, port: str) -> bool:
 
     return port == shadowed_port
 
+
 def shadow_name(name: str) -> str:
     """Return the appropriate shadow reset name based on port name
     """
@@ -504,6 +505,16 @@ def is_rom_ctrl(modules):
     '''
     for m in modules:
         if m['type'] == 'rom_ctrl':
+            return True
+
+    return False
+
+
+def is_lc_ctrl(modules):
+    '''Return true if lc_ctrl exists in the design
+    '''
+    for m in modules:
+        if m['type'] == 'lc_ctrl':
             return True
 
     return False

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -273,6 +273,12 @@ module top_${top["name"]} #(
   assign rv_core_ibex_boot_addr = ADDR_SPACE_ROM;
 % endif
 
+  ## Not all top levels have a lifecycle controller.
+  ## For those that do not, always enable ibex.
+% if not lib.is_lc_ctrl(top["module"]):
+  assign rv_core_ibex_lc_cpu_en = lc_ctrl_pkg::On;
+% endif
+
   // Struct breakout module tool-inserted DFT TAP signals
   pinmux_jtag_breakout u_dft_tap_breakout (
     .req_i    (pinmux_aon_dft_jtag_req),


### PR DESCRIPTION
The lifecycle controller is anyway not used on this platform but it consumes quite some FPGA resources. As logic utilization on the small FPGA is currently above 90%, it makes to free some resources. This reduces build time (CI). Plus the freed resources will become handy for some AES changes and experiments I need to do.