### PR TITLE
[dv/csr] Update write exclusion wdata value

### DIFF
--- a/hw/dv/sv/csr_utils/csr_seq_lib.sv
+++ b/hw/dv/sv/csr_utils/csr_seq_lib.sv
@@ -200,7 +200,7 @@ class csr_write_seq extends csr_base_seq;
                                 test_csrs[i].get_full_name()), UVM_MEDIUM)
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
-      wdata &= get_mask_excl_fields(test_csrs[i], CsrExclWrite, CsrHwResetTest);
+      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrHwResetTest);
 
       `downcast(dv_csr, test_csrs[i])
       if (en_rand_backdoor_write && !dv_csr.get_is_ext_reg()) begin
@@ -245,7 +245,7 @@ class csr_rw_seq extends csr_base_seq;
                                 test_csrs[i].get_full_name()), UVM_MEDIUM)
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
-      wdata &= get_mask_excl_fields(test_csrs[i], CsrExclWrite, CsrRwTest);
+      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrRwTest);
 
       // if external checker is not enabled and writes are made non-blocking, then we need to
       // pre-predict so that the mirrored value will be updated. if we dont, then csr_rd_check task
@@ -422,7 +422,7 @@ class csr_aliasing_seq extends csr_base_seq;
                                 test_csrs[i].get_full_name()), UVM_MEDIUM)
 
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
-      wdata &= get_mask_excl_fields(test_csrs[i], CsrExclWrite, CsrAliasingTest);
+      wdata = get_csr_wdata_with_write_excl(test_csrs[i], wdata, CsrAliasingTest);
       csr_wr(.ptr(test_csrs[i]), .value(wdata), .blocking(0), .predict(!external_checker));
 
       all_csrs.shuffle();


### PR DESCRIPTION
This PR fixes issue #8234. In current code, if a field is excluded from
CSR write, we mask out the excluded fields to 0. This is under the
assumption that all fields' reset value is 0, which is not always the
case.
So this PR adds a function to find the mirrored value of the excluded
field from write, and update the wdata value accordingly.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>