### PR TITLE
[dv/alert_handler] fix entropy regression failure

### DIFF
--- a/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env_pkg.sv
@@ -33,7 +33,7 @@ package alert_handler_env_pkg;
   // extra cycle to the calculated cnt, or even combine two signals into one.
   parameter uint IGNORE_CNT_CHECK_NS       = 100_000_000;
   // set the max ping timeout cycle to constrain the simulation run time
-  parameter uint MAX_PING_TIMEOUT_CYCLE    = 100;
+  parameter uint MAX_PING_TIMEOUT_CYCLE    = 300;
 
   parameter uint NUM_CRASHDUMP             = NUM_ALERT_CLASSES * (alert_handler_reg_pkg::AccuCntDw
                                              + alert_handler_reg_pkg::EscCntDw + 3) +

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_entropy_vseq.sv
@@ -11,7 +11,7 @@ class alert_handler_entropy_vseq extends alert_handler_smoke_vseq;
 
   // large number of num_trans to make sure covers all alerts and escalation pings
   constraint num_trans_c {
-    num_trans inside {[4_000:10_000]};
+    num_trans inside {[400:1000]};
   }
 
   // increase the possibility to enable more alerts, because alert_handler only sends ping on

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -54,9 +54,12 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
     max_phase_cyc inside {[0:1_000]};
   }
 
-  // set min to 32 cycles (default value) to avoid alert ping timeout due to random delay
+  // Set min to 120 cycles to avoid alert ping timeout due to random delay.
+  // The max delay after ping request is 10 cycles plus 2 cycles async delay.
+  // Also the alert_sender and alert_handlers are in different clock domains, with a max 10 times
+  // difference in clock frequency.
   constraint ping_timeout_cyc_c {
-    ping_timeout_cyc inside {[32:MAX_PING_TIMEOUT_CYCLE]};
+    ping_timeout_cyc inside {[120:MAX_PING_TIMEOUT_CYCLE]};
   }
 
   constraint enable_classa_only_c {


### PR DESCRIPTION
This PR fixes regression failure in entropy sequence.
The failure is due to ping reponses unexpectedly timeout. The reason is
due to async alert_sender could have a max of 10 time longer clock
period, thus the original timeout cycle is not configured correctly.

This PR also reduces the entropy num_trans, because with EDN, the frequency to send a ping is higher.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>