### PR TITLE
[dv] Add clkmgr to CI and nightly

### DIFF
--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -20,8 +20,7 @@
              "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
              "{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
-             // TODO (#8191), cause a CI failure. Remove it temporarily
-             // "{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson",
+             "{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",
              "{proj_root}/hw/ip/edn/dv/edn_sim_cfg.hjson",
              "{proj_root}/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson",


### PR DESCRIPTION
Don't use VCS 2020.12-SP2-1 to run clkmgr as there is a tool bug and it will hang

Use VCS 2020.12-SP2 (which is the one used in CI and nightly) or 
VCS 2020.12-SP2-2 instead

Refer to #8191
Signed-off-by: Weicai Yang <weicai@google.com>