### PR TITLE
[dv/top_level] Change sw_symbol_backdoor_overwrite input type

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -157,7 +157,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
   // TODO: bootstrap mode not supported.
   // TODO: Need to deal with scrambling.
   virtual function void sw_symbol_backdoor_overwrite(input string symbol,
-                                                     inout byte data[],
+                                                     inout bit [7:0] data[],
                                                      input chip_mem_e mem = FlashBank0Data,
                                                      input sw_type_e sw_type = SwTypeTest);
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -32,8 +32,8 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   // get a 768-bit XORed token output.
   // The first 128 bits of the decoded token should match the OTP's secret9 paritition's
   // descrambled exit token value.
-  virtual function bit[ExitTokenWidthBit-1:0] get_otp_exit_token(
-      bit[7:0] token_in[ExitTokenWidthByte]);
+  virtual function bit [ExitTokenWidthBit-1:0] get_otp_exit_token(
+      bit [7:0] token_in[ExitTokenWidthByte]);
 
     bit [7:0]                      dpi_digest[kmac_pkg::AppDigestW/8];
     bit [kmac_pkg::AppDigestW-1:0] digest_bits;
@@ -46,16 +46,13 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   endfunction
 
   virtual task body();
-    byte lc_exit_token_byte [ExitTokenWidthByte];
     super.body();
 
     // Select LC jtag.
     cfg.tap_straps_vif.drive(SelectLCJtagTap);
 
     // Override the C test kLcExitToken with random data.
-    // TODO: try to remove this conversion variable, and use `bit[7:0]` array type as input.
-    foreach (lc_exit_token[i]) lc_exit_token_byte[i] = lc_exit_token[i];
-    sw_symbol_backdoor_overwrite("kLcExitToken", lc_exit_token_byte);
+    sw_symbol_backdoor_overwrite("kLcExitToken", lc_exit_token);
 
     // Wait for SW to finish set up LC_CTRL.
     cfg.clk_rst_vif.wait_clks(21000);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_spi_tx_rx_vseq.sv
@@ -11,13 +11,13 @@ class chip_sw_spi_tx_rx_vseq extends chip_sw_base_vseq;
   localparam uint SPI_DEVICE_RX_SRAM_SIZE = 1024;
 
   // A set of bytes to be send from SPI_HOST to SPI_DEVICE RX FIFO.
-  rand byte spi_device_rx_data[];
+  rand bit [7:0] spi_device_rx_data[];
   constraint spi_device_rx_data_c {
     spi_device_rx_data.size() == SPI_DEVICE_DATA_SIZE;
   }
 
   // A set of bytes expected to be received on SPI_HOST from SPI_DEVICE TX FIFO.
-  rand byte exp_spi_device_tx_data[];
+  rand bit [7:0] exp_spi_device_tx_data[];
   constraint exp_spi_device_tx_data_c {
     exp_spi_device_tx_data.size() == SPI_DEVICE_DATA_SIZE;
   }
@@ -57,7 +57,7 @@ class chip_sw_spi_tx_rx_vseq extends chip_sw_base_vseq;
     send_spi_host_rx_data(spi_device_tx_data, SPI_DEVICE_DATA_SIZE);
   endtask
 
-  virtual task send_spi_host_rx_data(ref bit[7:0] device_data[$],input int size);
+  virtual task send_spi_host_rx_data(ref bit [7:0] device_data[$],input int size);
     spi_host_seq m_spi_host_seq;
     `uvm_create_on(m_spi_host_seq, p_sequencer.spi_sequencer_h)
     if (size == SPI_DEVICE_DATA_SIZE) begin

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -11,18 +11,18 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
   localparam uint UART_RX_FIFO_SIZE = 32;
 
   // A set of bytes expected to be received on TX.
-  rand byte exp_uart_tx_data[];
+  rand bit [7:0] exp_uart_tx_data[];
   constraint exp_uart_tx_data_c {
     exp_uart_tx_data.size() == UART_DATASET_SIZE;
   }
 
   // A set of bytes to be send back over RX.
-  rand byte uart_rx_data[];
+  rand bit [7:0] uart_rx_data[];
   constraint uart_rx_data_c {
     uart_rx_data.size() == UART_DATASET_SIZE;
   }
 
-  byte uart_idx = 0;
+  bit [7:0] uart_idx = 0;
 
   task pre_start();
     void'($value$plusargs("uart_idx=%0d", uart_idx));
@@ -32,7 +32,7 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
 
   virtual task cpu_init();
     // sw_symbol_backdoor_overwrite takes an array as the input
-    byte uart_idx_data[] = {uart_idx};
+    bit [7:0] uart_idx_data[] = {uart_idx};
 
     super.cpu_init();
     sw_symbol_backdoor_overwrite("kUartTxData", exp_uart_tx_data);


### PR DESCRIPTION
Change this function `sw_symbol_backdoor_overwrite` input type from
`byte` to `bit[7:0]` array so we can directly use this array in DPI
function.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>