### PR TITLE
[opentitantool] Support HyperDebug transport, configuration files, H1D3 flash chip

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -22,6 +22,7 @@ num_enum = "0.5.2"
 byteorder = "1.4.3"
 structopt = "0.3"
 tempfile = "3.1.0"
+serialport = "4.0.1"
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"

--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -21,6 +21,7 @@ safe-ftdi = { git = "https://github.com/cr1901/safe-ftdi" }
 num_enum = "0.5.2"
 byteorder = "1.4.3"
 structopt = "0.3"
+tempfile = "3.1.0"
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"

--- a/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
+++ b/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
@@ -74,7 +74,7 @@ fn dispatch_enum(name: &Ident, e: &DataEnum) -> TokenStream {
                 fn run(
                     &self,
                     context: &dyn std::any::Any,
-                    backend: &mut dyn opentitanlib::transport::Transport
+                    env: &opentitanlib::app::TargetEnvironment,
                 ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
                     match self {
                         #(#arms),*
@@ -102,6 +102,6 @@ fn dispatch_variant(name: &Ident, variant: &Variant) -> TokenStream {
     }
     quote! {
         #name::#ident(ref __field) =>
-            opentitanlib::app::command::CommandDispatch::run(__field, context, backend)
+            opentitanlib::app::command::CommandDispatch::run(__field, context, env)
     }
 }

--- a/sw/host/opentitanlib/src/app/command.rs
+++ b/sw/host/opentitanlib/src/app/command.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transport::Transport;
+use crate::app::TargetEnvironment;
 use anyhow::Result;
 use erased_serde::Serialize;
 pub use opentitantool_derive::*;
@@ -20,6 +20,6 @@ pub trait CommandDispatch {
     fn run(
         &self,
         context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>>;
 }

--- a/sw/host/opentitanlib/src/app/conf.rs
+++ b/sw/host/opentitanlib/src/app/conf.rs
@@ -1,0 +1,88 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone, Debug)]
+pub enum PinMode {
+    Input,
+    PushPull,
+    OpenDrain,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PinConfiguration {
+    pub name: String,
+    pub mode: PinMode,
+    pub initial_level: bool,
+    pub pullup: bool,
+    pub alias_of: String, // Name of a pin defined by the transport
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub enum UartParity {
+    None,
+    Even,
+    Odd,
+    Mark,
+    Space,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub enum UartStopBits {
+    Stop1,
+    Stop1_5,
+    Stop2,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct UartConfiguration {
+    pub name: String,
+    pub baudrate: u32,
+    pub parity: UartParity,
+    pub stopbits: UartStopBits,
+    pub alias_of: String, // Name of a uart defined by the transport
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct SpiConfiguration {
+    pub name: String,
+    pub alias_of: String, // Name of a spi port defined by the transport
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum FlashAddressMode {
+    Mode3b,
+    Mode4b,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+// Defines the way to reach and program flash storage
+pub enum FlashDriver {
+    SpiEeprom {
+        size: u32,
+        erase_block_size: u32,
+        erase_opcode: u8,
+        program_block_size: u32,
+        address_mode: FlashAddressMode,
+        spi_bus: String, // Name of a bus defined by the transport
+        // Possibly add more fields to declare SPI mode/speed
+    },
+    SpiExternalDriver {
+        command: String,
+        spi_bus: String, // Name of a bus defined by the transport
+        // Possibly add more fields to declare SPI mode/speed
+    }
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct FlashConfiguration {
+    pub name: String,
+    pub reset_pin: String,
+    pub bootloader_pin: String, // Could be absent (empty)
+    pub driver: FlashDriver,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct ConfigurationFile {
+    pub pins: Vec<PinConfiguration>,
+    pub uarts: Vec<UartConfiguration>,
+    pub flash: Vec<FlashConfiguration>,
+}

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -4,3 +4,61 @@
 
 //! Useful modules for OpenTitanTool application development.
 pub mod command;
+pub mod conf;
+
+use anyhow::Result;
+use std::collections::HashMap;
+use thiserror::Error;
+
+// This is the structure to be passed to each Command implementation,
+// replacing the "bare" Transport argument.  The fields other than
+// transport will have been computed from a number ConfigurationFiles.
+pub struct TargetEnvironment {
+    pub transport: std::cell::RefCell<Box<dyn crate::transport::Transport>>,
+    pub pin_map: HashMap<String, u32>,
+    pub _uart_map: HashMap<String, u32>,
+    pub _spi_map: HashMap<String, u32>,
+    pub flash_map: HashMap<String, conf::FlashConfiguration>,
+}
+
+impl TargetEnvironment {
+    pub fn new(transport: Box<dyn crate::transport::Transport>) -> Self {
+        let mut result = Self {
+            transport: std::cell::RefCell::new(transport),
+            pin_map: HashMap::new(),
+            _uart_map: HashMap::new(),
+            _spi_map: HashMap::new(),
+            flash_map: HashMap::new(),
+        };
+        // TODO(jbk): Load symbolic names of pins as advertised by the
+        // transport itself into pin_map and other members, for now
+        // these hard-coded values are appropriate for UltraDebug.
+        result.pin_map.insert("5".to_string(), 5);
+        result.pin_map.insert("6".to_string(), 6);
+        result.pin_map.insert("UD_RESET_B".to_string(), 5);
+        result.pin_map.insert("UD_BOOTSTRAP".to_string(), 6);
+        result
+    }
+
+    pub fn add_configuration_file(&mut self, file: conf::ConfigurationFile) -> Result<()> {
+        // Merge content of configuration file into pin_map and other
+        // members.
+        for pin_conf in file.pins {
+            let pin = *self.pin_map.get(&pin_conf.alias_of)
+                .ok_or(Error::InvalidPin(pin_conf.alias_of.clone()))?;
+            self.pin_map.insert(pin_conf.name, pin);
+            // TODO(jbk): Apply input / open drain / push pull
+            // configuration to the pin.
+        }
+        for flash_conf in file.flash {
+            self.flash_map.insert(flash_conf.name.clone(), flash_conf.clone());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid pin name: {0}")]
+    InvalidPin(String),
+}

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+
+use crate::io::gpio::{Gpio, PinDirection, StrapConfig};
+use crate::transport::hyperdebug::Hyperdebug;
+
+pub struct HyperdebugGpio {
+    console_tty: Box<std::path::Path>,
+    _gpio_names: Vec<String>, // TODO(jbk): Should probably be reference, rather than copy
+}
+
+impl HyperdebugGpio {
+    pub fn open(hyperdebug: &Hyperdebug) -> Result<Self> {
+        let result = HyperdebugGpio {
+            console_tty: hyperdebug.console_tty.clone(),
+            _gpio_names: hyperdebug.gpio_names.clone(),
+        };
+        Ok(result)
+    }
+}
+
+impl Gpio for HyperdebugGpio {
+    /// Reads the value of the the GPIO pin `id`.
+    fn read(&self, _id: &str) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Sets the value of the GPIO pin `id` to `value`.
+    fn write(&self, id: &str, value: bool) -> Result<()> {
+        Hyperdebug::execute_command(
+            &self.console_tty,
+            &format!("gpioset {} {}", id, if value { 1 } else { 0 }),
+            |_| {})
+    }
+
+    /// Sets the `direction` of GPIO `id` as input or output.
+    fn set_direction(&self, _id: &str, _direction: PinDirection) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Drive the reset pin. The `reset` parameter represents whether or not the caller
+    /// wants to drive the chip into reset, _not_ the logic-level of the reset pin.
+    fn drive_reset(&self, _reset: bool) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Set the requested strap value to the strapping pins.  Note: not all backends
+    /// support all settings.  An unsupported StrapConfig will result in an
+    /// `InvalidStrapConfig` error.
+    fn set_strap_pins(&self, _strap: StrapConfig) -> Result<()> {
+        unimplemented!()
+    }
+}

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -1,0 +1,270 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+use std::cell::RefCell;
+use std::fs;
+use std::rc::Rc;
+
+use thiserror::Error;
+
+use crate::io::gpio::Gpio;
+use crate::io::spi::Target;
+use crate::io::uart::Uart;
+use crate::transport::{Capabilities, Capability, Transport};
+
+pub mod gpio;
+pub mod uart;
+
+pub struct Hyperdebug {
+    pub path: std::path::PathBuf,
+    gpio_names: Vec<String>,
+    console_tty: Box<std::path::Path>,
+    uart_ttys: [Box<std::path::Path>; 3],
+    inner: RefCell<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    gpio: Option<Rc<dyn Gpio>>,
+    _spis: [Option<Rc<dyn Target>>; 1],
+    uarts: [Option<Rc<dyn Uart>>; 3],
+}
+
+impl Hyperdebug {
+    pub const VID_GOOGLE: u16 = 0x18d1;
+    pub const PID_HYPERDEBUG: u16 = 0x520e;
+
+    /// Create a new `Hyperdebug` struct, optionally specifying the USB vid/pid/serial number.
+    pub fn open(usb_vid: Option<u16>, usb_pid: Option<u16>, _usb_serial: &Option<String>)
+                -> Result<Self> {
+        let mut result: Option<Self> = Option::None;
+        for entry in fs::read_dir("/sys/bus/usb/devices")? {
+            let dir_entry = entry?;
+            let inspect_usb_device = || -> Result<Self> {
+                let vendor = u16::from_str_radix(&Self::read_string(
+                    dir_entry.path().join("idVendor"))?, 16)?;
+                let product = u16::from_str_radix(&Self::read_string(
+                    dir_entry.path().join("idProduct"))?, 16)?;
+                if vendor == usb_vid.unwrap_or(Self::VID_GOOGLE)
+                    && product == usb_pid.unwrap_or(Self::PID_HYPERDEBUG) {
+                        Hyperdebug::do_open(dir_entry.path())
+                    } else {
+                        Err(Error::NoMatch.into())
+                    }
+            };
+
+            if let Ok(candidate) = inspect_usb_device() {
+                match result {
+                    None => {
+                        result = Some(candidate);
+                    }
+                    Some(_) => {
+                        return Err(Error::MultipleDevices.into());
+                    }
+                }
+            }
+        }
+        match result {
+            Some(candidate) => {
+                print!("Connecting to HyperDebug device {:?}\n", candidate.path);
+                Ok(candidate)
+            }
+            _ => Err(Error::NoDevice.into())
+        }
+    }
+
+    fn do_open(path: std::path::PathBuf) -> Result<Self> {
+        let mut console_tty: Option<std::path::PathBuf> = Option::None;
+        let mut uart1_tty: Option<std::path::PathBuf> = Option::None;
+        let mut uart2_tty: Option<std::path::PathBuf> = Option::None;
+        let mut uart4_tty: Option<std::path::PathBuf> = Option::None;
+        for entry in fs::read_dir(&path)? {
+            let dir_entry = entry?;
+            if dir_entry.file_type()?.is_dir() {
+                match dir_entry.file_name().into_string() {
+                    Ok(filename) => {
+                        if filename.ends_with(":1.0") {
+                            console_tty = Self::find_tty(&dir_entry.path())?
+                        } else if filename.ends_with(":1.2") {
+                            uart1_tty = Self::find_tty(&dir_entry.path())?
+                        } else if filename.ends_with(":1.3") {
+                            uart2_tty = Self::find_tty(&dir_entry.path())?
+                        } else if filename.ends_with(":1.4") {
+                            uart4_tty = Self::find_tty(&dir_entry.path())?
+                        }
+                    }
+                    _ => ()
+                }
+            }
+        }
+        let console_tty = console_tty.ok_or(Error::NoDevice)?.into_boxed_path();
+        let mut gpio_names: Vec<String> = Vec::new();
+        Self::execute_command(&console_tty, &format!("gpioget"), |line| {
+            gpio_names.push(line[5..].to_string());
+        })?;
+        let result = Hyperdebug {
+            path,
+            gpio_names,
+            console_tty,
+            uart_ttys: [
+                uart1_tty.ok_or(Error::NoDevice)?.into_boxed_path(),
+                uart2_tty.ok_or(Error::NoDevice)?.into_boxed_path(),
+                uart4_tty.ok_or(Error::NoDevice)?.into_boxed_path()
+            ],
+            inner: Default::default()
+        };
+        Ok(result)
+    }
+
+    fn find_tty(path: &std::path::PathBuf) -> Result<Option<std::path::PathBuf>> {
+        for entry in fs::read_dir(path)? {
+            let dir_entry = entry?;
+            match dir_entry.file_name().into_string() {
+                Ok(filename) => {
+                    if filename.starts_with("tty") {
+                        return Ok(Option::Some(std::path::PathBuf::from("/dev")
+                                               .join(dir_entry.file_name())));
+                    }
+                }
+                _ => ()
+            }
+        }
+        Ok(Option::None)
+    }
+
+    fn read_string(path: std::path::PathBuf) -> Result<String> {
+        let file = fs::File::open(path)?;
+        let mut line = String::new();
+        let len = std::io::BufRead::read_line(&mut std::io::BufReader::new(file), &mut line)?;
+        line.remove(len - 1);
+        Ok(line)
+    }
+
+    pub fn execute_command(
+        console_tty: &std::path::Path,
+        cmd: &String,
+        mut callback:
+        impl FnMut(&String)) -> Result<()> {
+        use std::io::Read;
+        use std::io::Write;
+        let mut port = serialport::new(console_tty.to_str().ok_or(Error::UnicodePathError)?, 115_200)
+            .timeout(std::time::Duration::from_millis(100))
+            .open().expect("Failed to open port");
+
+        // Ideally, we would invoke Linux flock() on the serial
+        // device, to detect minicom or another instance of
+        // opentitantool having the same serial port open.  Incoming
+        // serial data could go silenly missing, in such cases.
+        let mut buf: [u8; 128] = [0; 128];
+        loop {
+            match port.read(&mut buf[0..128]) {
+                Ok(rc) => {
+                    print!("Discarded {} characters: {:?}\n", rc, &std::str::from_utf8(&buf[0..rc]));
+                }
+                Err(error) => {
+                    match error.kind() {
+                        std::io::ErrorKind::TimedOut => {
+                            break;
+                        }
+                        _ => {
+                            print!("Error reading: {:?}\n", error);
+                            return Err(error.into())
+                        }
+                    }
+                }
+            }
+        }
+        port.write(format!("\u{2}{}\n", cmd).as_bytes())?;
+        //std::thread::sleep(std::time::Duration::from_millis(100));
+        let mut seen_echo = false;
+        let mut len: usize = 0;
+        loop {
+            match port.read(&mut buf[len..128]) {
+                Ok(rc) => {
+                    len += rc;
+                    'outer: loop {
+                        for i in 0..len {
+                            if buf[i] == 10 {
+                                // Newline
+                                let mut end = i;
+                                if end > 0 && buf[end - 1] == 13 {
+                                    end -= 1;
+                                }
+                                let line = std::str::from_utf8(&buf[0..end])?;
+                                if seen_echo {
+                                    callback(&line.to_string());
+                                } else {
+                                    let minmatch = std::cmp::min(6, cmd.len());
+                                    if line.len() >= minmatch && line[line.len() - minmatch..]
+                                        == cmd[cmd.len() - minmatch..] {
+                                        seen_echo = true;
+                                    }
+                                }
+                                buf.rotate_left(i + 1);
+                                len -= i + 1;
+                                continue 'outer;
+                            }
+                        }
+                        break
+                    }
+                }
+                Err(error) => {
+                    match error.kind() {
+                        std::io::ErrorKind::TimedOut => {
+                            if std::str::from_utf8(&buf[0..len])? == "> " {
+                                return Ok(())
+                            } else {
+                                print!("Timeout with {} bytes left\n", len);
+                                return Ok(())
+                            }
+                        }
+                        _ => {
+                            print!("Error reading: {:?}\n", error);
+                            return Err(error.into())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("USB device did not match")]
+    NoMatch,
+    #[error("Found no HyperDebug USB device")]
+    NoDevice,
+    #[error("Found multiple HyperDebug USB devices, use --serial")]
+    MultipleDevices,
+    #[error("Error communicating with HyperDebug")]
+    CommunicationError,
+    #[error("Encountered non-unicode path")]
+    UnicodePathError,
+}
+
+impl Transport for Hyperdebug {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::UART | Capability::GPIO | Capability::SPI)
+    }
+
+    fn uart(&self, instance: u32) -> Result<Rc<dyn Uart>> {
+        let mut inner = self.inner.borrow_mut();
+        if inner.uarts[instance as usize].is_none() {
+            inner.uarts[instance as usize] = Some(Rc::new(uart::HyperdebugUart::open(&self, instance)?));
+        }
+        Ok(Rc::clone(inner.uarts[instance as usize].as_ref().unwrap()))
+    }
+
+    
+    fn gpio(&self) -> Result<Rc<dyn Gpio>> {
+        let mut inner = self.inner.borrow_mut();
+        if inner.gpio.is_none() {
+            inner.gpio = Some(Rc::new(gpio::HyperdebugGpio::open(&self)?));
+        }
+        Ok(Rc::clone(inner.gpio.as_ref().unwrap()))
+    }
+}

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+use std::cell::RefCell;
+use std::time::Duration;
+use std::io::Read;
+use std::io::Write;
+
+use crate::io::uart::Uart;
+use crate::transport::hyperdebug::Error;
+use crate::transport::hyperdebug::Hyperdebug;
+
+pub struct HyperdebugUart {
+    port: RefCell<Box<dyn serialport::SerialPort>>,
+}
+
+impl HyperdebugUart {
+    pub fn open(hyperdebug: &Hyperdebug, instance: u32) -> Result<Self> {
+        let port =
+            serialport::new(hyperdebug.uart_ttys[instance as usize].to_str().ok_or(Error::UnicodePathError)?,
+                            115_200)
+            .timeout(Duration::from_millis(100))
+            .open().expect("Failed to open port");
+        let result = HyperdebugUart {
+            port: RefCell::new(port),
+        };
+        Ok(result)
+    }
+}
+
+impl Uart for HyperdebugUart {
+
+    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        self.port.borrow_mut().set_timeout(Duration::MAX)?;
+        Ok(self.port.borrow_mut().read(buf)?)
+    }
+
+    fn write(&self, buf: &[u8]) -> Result<usize> {
+        Ok(self.port.borrow_mut().write(buf)?)
+    }
+
+    fn get_baudrate(&self) -> u32 {
+        match self.port.borrow().baud_rate() {
+            Ok(baud_rate) => baud_rate,
+            _ => panic!("SerialPort::baud_rate() returned Err")
+        }
+    }
+
+    fn set_baudrate(&self, baudrate: u32) -> Result<()> {
+        Ok(self.port.borrow_mut().set_baud_rate(baudrate)?)
+    }
+
+    fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        self.port.borrow_mut().set_timeout(timeout)?;
+        Ok(self.port.borrow_mut().read(buf)?)
+    }
+}

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -11,6 +11,7 @@ use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
+pub mod hyperdebug;
 pub mod ultradebug;
 pub mod verilator;
 

--- a/sw/host/opentitantool/h1dx_devboard_ultradebug.json
+++ b/sw/host/opentitantool/h1dx_devboard_ultradebug.json
@@ -1,0 +1,40 @@
+{
+  "pins": [
+    {
+      "name": "RESET",
+      "mode": "OpenDrain",
+      "initial_level": true,
+      "pullup": true,
+      "alias_of": "UD_RESET_B"
+    },
+    {
+      "name": "BOOTSTRAP",
+      "mode": "PushPull",
+      "initial_level": false,
+      "pullup": false,
+      "alias_of": "UD_BOOTSTRAP"
+    }
+  ],
+  "uarts": [
+    {
+      "name": "console",
+      "baudrate": 115200,
+      "parity": "None",
+      "stopbits": "Stop1",
+      "alias_of": "UART1"
+    }
+  ],
+  "flash": [
+    {
+      "name": "H1Dx_flash",
+      "reset_pin": "RESET",
+      "bootloader_pin": "BOOTSTRAP",
+      "driver": {
+	"SpiExternalDriver": {
+	  "command": "/home/jbk/src/ti50/ports/cr50-utils/software/tools/SPI/spiflash --dauntless --verbose --parent --input=$IMAGEFILE",
+	  "spi_bus": "SPI1"
+	}
+      }
+    }
+  ]
+}

--- a/sw/host/opentitantool/src/backend/hyperdebug.rs
+++ b/sw/host/opentitantool/src/backend/hyperdebug.rs
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::transport::hyperdebug::Hyperdebug;
+use opentitanlib::transport::Transport;
+
+use crate::backend::BackendOpts;
+
+pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
+    Ok(Box::new(Hyperdebug::open(
+        args.usb_vid,
+        args.usb_vid,
+        &args.usb_serial,
+    )?))
+}

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -11,6 +11,7 @@ use opentitanlib::app::TargetEnvironment;
 use opentitanlib::util::parse_int::ParseInt;
 
 pub mod ultradebug;
+pub mod hyperdebug;
 pub mod verilator;
 
 #[derive(Debug, StructOpt)]
@@ -46,6 +47,7 @@ pub fn create(args: &BackendOpts) -> Result<TargetEnvironment> {
         "" => Ok(Box::new(EmptyTransport) as Box<dyn Transport>),
         "verilator" => verilator::create(&args.verilator_opts),
         "ultradebug" => ultradebug::create(args),
+        "hyperdebug" => hyperdebug::create(args),
         _ => Err(Error::UnknownInterface(args.interface.clone()).into()),
     }?;
     let mut env = TargetEnvironment::new(transport);

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -15,10 +15,12 @@ use std::os::unix::io::AsRawFd;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
+use opentitanlib::app::TargetEnvironment;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::io::uart::Uart;
-use opentitanlib::transport::{Capability, Transport};
+use opentitanlib::transport::Capability;
 use opentitanlib::util::file;
+
 
 #[derive(Debug, StructOpt)]
 pub struct Console {
@@ -45,8 +47,10 @@ impl CommandDispatch for Console {
     fn run(
         &self,
         _context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
+
         // We need the UART for the console command to operate.
         transport.capabilities().request(Capability::UART).ok()?;
         let mut stdout = std::io::stdout();

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -7,9 +7,10 @@ use erased_serde::Serialize;
 use std::any::Any;
 use structopt::StructOpt;
 
+use opentitanlib::app::TargetEnvironment;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::io::gpio::PinDirection;
-use opentitanlib::transport::{Capability, Transport};
+use opentitanlib::transport::{Capability};
 
 #[derive(Debug, StructOpt)]
 /// Reads a GPIO pin.
@@ -28,8 +29,9 @@ impl CommandDispatch for GpioRead {
     fn run(
         &self,
         _context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::GPIO).ok()?;
         let gpio = transport.gpio()?;
         let value = gpio.read(&self.pin)?;
@@ -57,8 +59,9 @@ impl CommandDispatch for GpioWrite {
     fn run(
         &self,
         _context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::GPIO).ok()?;
         let gpio = transport.gpio()?;
 
@@ -85,8 +88,9 @@ impl CommandDispatch for GpioSetDirection {
     fn run(
         &self,
         _context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::GPIO).ok()?;
         let gpio = transport.gpio()?;
         gpio.set_direction(&self.pin, self.direction)?;

--- a/sw/host/opentitantool/src/command/hello.rs
+++ b/sw/host/opentitantool/src/command/hello.rs
@@ -12,8 +12,8 @@ use erased_serde::Serialize;
 use std::any::Any;
 use structopt::StructOpt;
 
+use opentitanlib::app::TargetEnvironment;
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::transport::Transport;
 
 #[derive(Debug, StructOpt)]
 /// The `hello world` command accepts an command option of `--cruel`.
@@ -32,7 +32,7 @@ impl CommandDispatch for HelloWorld {
     fn run(
         &self,
         _context: &dyn Any,
-        _transport: &mut dyn Transport,
+        _env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
         // Is the world cruel or not?
         let msg = if self.cruel {
@@ -56,7 +56,7 @@ impl CommandDispatch for HelloPeople {
     fn run(
         &self,
         _context: &dyn Any,
-        _transport: &mut dyn Transport,
+        _env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
         // The `hello people` command produces no result.
         Ok(None)
@@ -87,7 +87,7 @@ impl CommandDispatch for GoodbyeCommand {
     fn run(
         &self,
         _context: &dyn Any,
-        _transport: &mut dyn Transport,
+        _env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
         Ok(Some(Box::new(GoodbyeMessage {
             message: "Goodbye!".to_owned(),

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -12,10 +12,11 @@ use std::path::PathBuf;
 use std::time::Instant;
 use structopt::StructOpt;
 
+use opentitanlib::app::TargetEnvironment;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::io::spi::Transfer;
 use opentitanlib::spiflash::SpiFlash;
-use opentitanlib::transport::{Capability, Transport};
+use opentitanlib::transport::Capability;
 
 /// Read and parse an SFDP table.
 #[derive(Debug, StructOpt)]
@@ -73,8 +74,9 @@ impl CommandDispatch for SpiSfdp {
     fn run(
         &self,
         context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = transport.spi(context.bus)?;
@@ -115,8 +117,9 @@ impl CommandDispatch for SpiReadId {
     fn run(
         &self,
         context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = transport.spi(context.bus)?;
@@ -164,8 +167,9 @@ impl CommandDispatch for SpiRead {
     fn run(
         &self,
         context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = transport.spi(context.bus)?;
@@ -214,8 +218,9 @@ impl CommandDispatch for SpiErase {
     fn run(
         &self,
         context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = transport.spi(context.bus)?;
@@ -256,8 +261,9 @@ impl CommandDispatch for SpiProgram {
     fn run(
         &self,
         context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
+        let transport = env.transport.borrow_mut();
         transport.capabilities().request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = transport.spi(context.bus)?;
@@ -302,10 +308,10 @@ impl CommandDispatch for SpiCommand {
     fn run(
         &self,
         _context: &dyn Any,
-        transport: &mut dyn Transport,
+        env: &TargetEnvironment,
     ) -> Result<Option<Box<dyn Serialize>>> {
         // None of the SPI commands care about the prior context, but they do
         // care about the `bus` parameter in the current node.
-        self.command.run(self, transport)
+        self.command.run(self, env)
     }
 }

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -42,9 +42,9 @@ fn main() -> Result<()> {
         .filter(None, opts.logging)
         .init();
 
-    let mut interface = backend::create(&opts.backend_opts)?;
+    let env = backend::create(&opts.backend_opts)?;
 
-    if let Some(value) = opts.command.run(&opts, &mut *interface)? {
+    if let Some(value) = opts.command.run(&opts, &env)? {
         println!("{}", serde_json::to_string_pretty(&value)?);
     }
     Ok(())


### PR DESCRIPTION
Add support for recognizing HyperDebug USB device, with some GPIO and UART support (not complete, need Transport trait to be enhanced to support multiple UART ports.)
Propagate configuration file contents along with Transport to each Command implementation.
Add support for flash chips using other protocols besides the one implemented in struct SpiFlash.

These features are the first steps on the path to Chrome OS using OpenTitan tool in the automated test lab.