### PR TITLE
[rtl/rstmgr] Add assertion for rst_filter_n

### DIFF
--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -67,6 +67,11 @@ module rstmgr_por #(
     .clk_o(rst_clean_n)
   );
 
+  // It turns out we can use rst_filter_n[FilterStages-1] instead of &rst_filter_n because any drop
+  // in rst_ni clears all rst_filter_n bits. This assertion checks that property.
+  `ASSERT(FilterInvariant_A, rst_filter_n[FilterStages-1] == &rst_filter_n,
+          clk_i, rst_ni !== 'x)
+
   assign rst_stable = &rst_filter_n;
   assign cnt_en = rst_stable & !rst_no;
 


### PR DESCRIPTION
Add an assertion for &rst_filter_n == rst_filter_n[FilterStages-1].
This suggests setting rst_stable can avoid a 32 bit and.

Signed-off-by: Guillermo Maturana <maturana@google.com>