### PR TITLE
[sw/testing] verify entropy smoke test result

### DIFF
--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -61,5 +61,5 @@ bool test_main() {
     result |= entropy_data[i] ^ kExpectedEntropyData[i];
   }
 
-  return true;
+  return result == 0;
 }


### PR DESCRIPTION
Clang 13 warns about `result` being set but not used. Check its value, and thus that the obtained entropy data matched the expected one.

Signed-off-by: Luís Marques <luismarques@lowrisc.org>