### PR TITLE
[util] Build error fix for later versions of GCC (make_new_dif.py)

### DIFF
--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -14,7 +14,7 @@ using testing::Test;
 class IrqGetStateTest : public UartTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {
-  dif_uart_irq_state_snapshot_t irq_snapshot;
+  dif_uart_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_EQ(dif_uart_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
 
@@ -24,7 +24,7 @@ TEST_F(IrqGetStateTest, NullArgs) {
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
-  dif_uart_irq_state_snapshot_t irq_snapshot;
+  dif_uart_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(UART_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
@@ -33,7 +33,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 }
 
 TEST_F(IrqGetStateTest, SuccessNoneRaised) {
-  dif_uart_irq_state_snapshot_t irq_snapshot;
+  dif_uart_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(UART_INTR_STATE_REG_OFFSET, 0);
   EXPECT_EQ(dif_uart_irq_get_state(&uart_, &irq_snapshot), kDifOk);
@@ -211,7 +211,7 @@ TEST_F(IrqForceTest, Success) {
 class IrqDisableAllTest : public UartTest {};
 
 TEST_F(IrqDisableAllTest, NullArgs) {
-  dif_uart_irq_enable_snapshot_t irq_snapshot;
+  dif_uart_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_EQ(dif_uart_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
 
@@ -224,7 +224,7 @@ TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
-  dif_uart_irq_enable_snapshot_t irq_snapshot;
+  dif_uart_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
@@ -233,7 +233,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
-  dif_uart_irq_enable_snapshot_t irq_snapshot;
+  dif_uart_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
@@ -245,7 +245,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
 class IrqRestoreAllTest : public UartTest {};
 
 TEST_F(IrqRestoreAllTest, NullArgs) {
-  dif_uart_irq_enable_snapshot_t irq_snapshot;
+  dif_uart_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_EQ(dif_uart_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
 

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -27,7 +27,7 @@ using testing::Test;
 class IrqGetStateTest : public ${ip.name_camel}Test {};
 
 TEST_F(IrqGetStateTest, NullArgs) {
-  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
       nullptr, 
@@ -46,7 +46,7 @@ TEST_F(IrqGetStateTest, NullArgs) {
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
-  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 
     std::numeric_limits<uint32_t>::max());
@@ -58,7 +58,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 }
 
 TEST_F(IrqGetStateTest, SuccessNoneRaised) {
-  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 0);
   EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
@@ -309,7 +309,7 @@ TEST_F(IrqForceTest, Success) {
 class IrqDisableAllTest : public ${ip.name_camel}Test {};
 
 TEST_F(IrqDisableAllTest, NullArgs) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
       nullptr, 
@@ -331,7 +331,7 @@ TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
@@ -343,7 +343,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
@@ -358,7 +358,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
 class IrqRestoreAllTest : public ${ip.name_camel}Test {};
 
 TEST_F(IrqRestoreAllTest, NullArgs) {
-  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot;
+  dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
       nullptr, 


### PR DESCRIPTION
Build error with gcc version of:
`gcc version 11.1.0 (GCC)`

Although not a huge issue, as the reference platform of OT is Ubuntu
18.04, which has an older version of GCC, it is still relevant to fix
it for future versions.

This is also helpful for the people using rolling distros as
archlinux, etc...