### PR TITLE
[otbn] Raise a fatal alert for incoming LC escalations

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -18,6 +18,7 @@ class Status(IntEnum):
     BUSY_EXECUTE = 0x01
     BUSY_SEC_WIPE_DMEM = 0x02
     BUSY_SEC_WIPE_IMEM = 0x03
+    LOCKED = 0xFF
 
 
 class ErrBits(IntEnum):

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -664,10 +664,12 @@ module otbn
                                   reg2hw.alert_test.recov.qe;
 
   logic [NumAlerts-1:0] alerts;
-  assign alerts[AlertFatal] = illegal_bus_access_d |
+  assign alerts[AlertFatal] = imem_rerror          |
+                              dmem_rerror          |
                               bus_intg_violation   |
-                              imem_rerror          |
-                              dmem_rerror;
+                              illegal_bus_access_d |
+                              lifecycle_escalation;
+
   assign alerts[AlertRecov] = 1'b0; // TODO: Implement
 
   for (genvar i = 0; i < NumAlerts; i++) begin: gen_alert_tx

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -543,11 +543,6 @@ module otbn
   assign dmem_rerror_bus  = !dmem_access_core ? {dmem_rerror, 1'b0} : 2'b00;
   assign dmem_rerror_core = dmem_rerror;
 
-  // The top bits of DMEM rdata aren't currently used (they will eventually be used for integrity
-  // checks within the core)
-  logic unused_dmem_top_rdata;
-  assign unused_dmem_top_rdata = &{1'b0, dmem_rdata[ExtWLEN-1:WLEN]};
-
   // Registers =================================================================
 
   logic reg_bus_intg_violation;


### PR DESCRIPTION
We specify that an incoming lifecycle escalation is handled in the
same way as any other fatal error, which raises a fatal alert. We didn't
do that in RTL yet so far.

Also include two other small (unrelated) fixes.