### PR TITLE
[dv] Remove common_cov_excl.el from unr.cfg

### DIFF
--- a/hw/dv/tools/vcs/unr.cfg
+++ b/hw/dv/tools/vcs/unr.cfg
@@ -13,9 +13,6 @@
 # Black box some of the modules
 # -blackBoxes -type design *
 
-# Include common el file, so that it doesn't generate reviewed common exclusions
--covEL $dv_root/tools/vcs/common_cov_excl.el
-
 # Name of the generated exclusion file
 -save_exclusion $SCRATCH_PATH/cov_unr/unr_exclude.el
 


### PR DESCRIPTION
The exclusion common_cov_excl.el is moved to common_cov_excl.cfg
UNR will get this info from coverage vdb

Thanks Udi for reporting this issue.
Signed-off-by: Weicai Yang <weicai@google.com>