### PR TITLE
[keymgr/dv] Add testing HW valid=0

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
@@ -94,6 +94,11 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
     }
   endgroup
 
+  covergroup invalid_hw_input_cg with function sample(
+      keymgr_invalid_hw_input_type_e invalid_hw_input);
+    invalid_hw_input_cp: coverpoint invalid_hw_input;
+  endgroup
+
   covergroup fault_status_cg with function sample(keymgr_pkg::keymgr_fault_pos_e fault);
     fault_cp: coverpoint fault {
       // these are done in a direct test
@@ -145,6 +150,7 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
     lc_disable_cg = new();
     sideload_clear_cg = new();
     err_code_cg = new();
+    invalid_hw_input_cg = new();
     fault_status_cg = new();
     reseed_interval_cg = new();
     key_version_compare_cg = new();

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -37,6 +37,17 @@ package keymgr_env_pkg;
     Attestation
   } keymgr_cdi_type_e;
 
+  typedef enum {
+    OtpRootKeyInvalid,
+    OtpRootKeyValidLow,
+    LcStateInvalid,
+    OtpDevIdInvalid,
+    RomDigestInvalid,
+    RomDigestValidLow,
+    FlashCreatorSeedInvalid,
+    FlashOwnerSeedInvalid
+  } keymgr_invalid_hw_input_type_e;
+
   string msg_id = "keymgr_env_pkg";
   // functions
   // state is incremental, if it's not in defined enum, consider as StDisabled

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -166,8 +166,12 @@ interface keymgr_if(input clk, input rst_n);
                                              local_otp_device_id inside {0, '1};, , msg_id)
         end
         1: begin
+           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_key,
+                                              !local_otp_key.valid;, , msg_id)
+         end
+        1: begin
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_otp_key,
-                                             local_otp_key.valid == 1; // TODO this is tie to 1
+                                             local_otp_key.valid;
                                              local_otp_key.key_share0 inside {0, '1} ||
                                              local_otp_key.key_share1 inside {0, '1};, , msg_id)
         end
@@ -178,7 +182,12 @@ interface keymgr_if(input clk, input rst_n);
         end
         1: begin
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_rom_digest,
-                                             local_rom_digest inside {0, '1};, , msg_id)
+                                             !local_rom_digest.valid;, , msg_id)
+        end
+        1: begin
+          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(local_rom_digest,
+                                             local_rom_digest.valid == 1;
+                                             local_rom_digest.data inside {0, '1};, , msg_id)
         end
       endcase
     end


### PR DESCRIPTION
1. Add testing HW valid=0
2. Add covergroup for hw invalid inputs
3. Fix InvalidIn error condition

Signed-off-by: Weicai Yang <weicai@google.com>