### PR TITLE
[clkmgr] Exclude threshold values from random csr read/write

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -310,14 +310,20 @@
           bits: "${max_msb}:4",
           name: "MAX_THRESH",
           desc: "Max threshold for ${src} measurement",
-          resval: "${ratio + 10}"
+          resval: "${ratio + 10}",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         {
           bits: "${min_msb}:${max_msb+1}",
           name: "MIN_THRESH",
           desc: "Min threshold for ${src} measurement",
-          resval: "1"
+          resval: "${ratio - 10}",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
       ]
     },

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -410,14 +410,20 @@
           bits: "13:4",
           name: "MAX_THRESH",
           desc: "Max threshold for io measurement",
-          resval: "490"
+          resval: "490",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         {
           bits: "23:14",
           name: "MIN_THRESH",
           desc: "Min threshold for io measurement",
-          resval: "1"
+          resval: "470",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
       ]
     },
@@ -443,14 +449,20 @@
           bits: "12:4",
           name: "MAX_THRESH",
           desc: "Max threshold for io_div2 measurement",
-          resval: "250"
+          resval: "250",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         {
           bits: "21:13",
           name: "MIN_THRESH",
           desc: "Min threshold for io_div2 measurement",
-          resval: "1"
+          resval: "230",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
       ]
     },
@@ -476,14 +488,20 @@
           bits: "11:4",
           name: "MAX_THRESH",
           desc: "Max threshold for io_div4 measurement",
-          resval: "130"
+          resval: "130",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         {
           bits: "19:12",
           name: "MIN_THRESH",
           desc: "Min threshold for io_div4 measurement",
-          resval: "1"
+          resval: "110",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
       ]
     },
@@ -509,14 +527,20 @@
           bits: "13:4",
           name: "MAX_THRESH",
           desc: "Max threshold for main measurement",
-          resval: "510"
+          resval: "510",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         {
           bits: "23:14",
           name: "MIN_THRESH",
           desc: "Min threshold for main measurement",
-          resval: "1"
+          resval: "490",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
       ]
     },
@@ -542,14 +566,20 @@
           bits: "12:4",
           name: "MAX_THRESH",
           desc: "Max threshold for usb measurement",
-          resval: "250"
+          resval: "250",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         {
           bits: "21:13",
           name: "MIN_THRESH",
           desc: "Min threshold for usb measurement",
-          resval: "1"
+          resval: "230",
+          // random updates to this field if measurements are turned on can
+          // cause the results to fail
+          tags: ["excl:CsrNonInitTests:CsrExclWrite"]
         },
       ]
     },

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -742,7 +742,7 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1)
+    .RESVAL  (10'h1d6)
   ) u_io_measure_ctrl_min_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -819,7 +819,7 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h1)
+    .RESVAL  (9'he6)
   ) u_io_div2_measure_ctrl_min_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -896,7 +896,7 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h1)
+    .RESVAL  (8'h6e)
   ) u_io_div4_measure_ctrl_min_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -973,7 +973,7 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (10'h1)
+    .RESVAL  (10'h1ea)
   ) u_main_measure_ctrl_min_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1050,7 +1050,7 @@ module clkmgr_reg_top (
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (9'h1)
+    .RESVAL  (9'he6)
   ) u_usb_measure_ctrl_min_thresh (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),


### PR DESCRIPTION
- This ensures we do not get random measurement failrues
  during test even if they are turned on.

Signed-off-by: Timothy Chen <timothytim@google.com>