### PR TITLE
[rust] Upgrade to rust 1.55.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-1213-g9e5c085
-  RUST_VERSION: 1.52.1
+  RUST_VERSION: 1.55.0
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20210412-1
   # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -38,7 +38,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'rust': {
-        'min_version': '1.52.1',
+        'min_version': '1.55.0',
         'as_needed': True
     },
     'vivado': {

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -10,7 +10,7 @@ ARG VERILATOR_VERSION=4.210
 ARG OPENOCD_VERSION=0.11.0
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20210412-1
-ARG RUST_VERSION=1.52.1
+ARG RUST_VERSION=1.55.0
 
 # Main container image.
 FROM ubuntu:18.04 AS opentitan


### PR DESCRIPTION
1. Rust-1.53.0 has [`IntoIterator` for arrays](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#intoiterator-for-arrays) which is needed for the `collection!` macro.
2. Rust-1.54.0 re-enabled incremental compilation, which was disabled in 1.52.1.
3. Rust-1.55.0 updates `std::io::ErrorKind` variants and supports open ranges in patterns.

Signed-off-by: Chris Frantz <cfrantz@google.com>