### PR TITLE
[opentitantool] Add ChipWhisperer CW310 backend

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -31,6 +31,7 @@ libftdi1-dev
 # A requirement of the prebuilt clang toolchain.
 libncurses5
 libssl-dev
+libudev-dev
 libusb-1.0-0
 lsb-release
 make

--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -21,6 +21,8 @@ safe-ftdi = { git = "https://github.com/cr1901/safe-ftdi" }
 num_enum = "0.5.2"
 byteorder = "1.4.3"
 structopt = "0.3"
+rusb = "0.8.1"
+serialport = "4.0.1"
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -12,6 +12,10 @@ pub enum SpiError {
     InvalidWordSize(u32),
     #[error("Invalid speed: {0}")]
     InvalidSpeed(u32),
+    #[error("Invalid data length: {0}")]
+    InvalidDataLength(usize),
+    #[error("Mismatched data length: {0} != {1}")]
+    MismatchedDataLength(usize, usize),
 }
 
 /// Represents the SPI transfer mode.

--- a/sw/host/opentitanlib/src/transport/cw310/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/gpio.rs
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::io::gpio::{Gpio, GpioError, PinDirection, StrapConfig};
+use crate::transport::cw310::usb::Backend;
+use crate::transport::cw310::CW310;
+
+pub struct CW310Gpio {
+    device: Rc<RefCell<Backend>>,
+}
+
+impl CW310Gpio {
+    pub fn open(backend: Rc<RefCell<Backend>>) -> Result<Self> {
+        Ok(CW310Gpio { device: backend })
+    }
+}
+
+impl Gpio for CW310Gpio {
+    fn read(&self, id: &str) -> Result<bool> {
+        let usb = self.device.borrow();
+        let pin = usb.pin_get_state(id)?;
+        Ok(pin != 0)
+    }
+
+    fn write(&self, id: &str, value: bool) -> Result<()> {
+        let usb = self.device.borrow();
+        usb.pin_set_state(id, value)?;
+        Ok(())
+    }
+
+    fn set_direction(&self, id: &str, direction: PinDirection) -> Result<()> {
+        let usb = self.device.borrow();
+        usb.pin_set_output(id, direction == PinDirection::Output)?;
+        Ok(())
+    }
+
+    fn drive_reset(&self, reset: bool) -> Result<()> {
+        self.write(CW310::PIN_SRST, !reset)
+    }
+
+    fn set_strap_pins(&self, strap: StrapConfig) -> Result<()> {
+        match strap {
+            StrapConfig::None => self.write(CW310::PIN_BOOTSTRAP, false),
+            StrapConfig::RomBootstrap => self.write(CW310::PIN_BOOTSTRAP, true),
+            _ => Err(GpioError::InvalidStrapConfig(strap).into()),
+        }
+    }
+}

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -1,0 +1,108 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Result};
+use std::cell::RefCell;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::io::gpio::Gpio;
+use crate::io::spi::Target;
+use crate::io::uart::Uart;
+use crate::transport::{Capabilities, Capability, Transport, TransportError};
+
+pub mod gpio;
+pub mod spi;
+pub mod uart;
+pub mod usb;
+
+#[derive(Default)]
+struct Inner {
+    spi: Option<Rc<dyn Target>>,
+    gpio: Option<Rc<dyn Gpio>>,
+    uart: HashMap<u32, Rc<dyn Uart>>,
+}
+
+pub struct CW310 {
+    device: Rc<RefCell<usb::Backend>>,
+    inner: RefCell<Inner>,
+}
+
+impl CW310 {
+    // Pins needed for reset & bootstrap on the CW310 board.
+    const PIN_SRST: &'static str = "USB_A18";
+    const PIN_BOOTSTRAP: &'static str = "USB_A16";
+    // Pins needed for SPI on the CW310 board.
+    const PIN_CLK: &'static str = "USB_SPI_SCK";
+    const PIN_SDI: &'static str = "USB_SPI_COPI";
+    const PIN_SDO: &'static str = "USB_SPI_CIPO";
+    const PIN_CS: &'static str = "USB_SPI_CS";
+    const PIN_JTAG: &'static str = "USB_A19";
+
+    pub fn new(
+        usb_vid: Option<u16>,
+        usb_pid: Option<u16>,
+        usb_serial: Option<String>,
+    ) -> Result<Self> {
+        let board = CW310 {
+            device: Rc::new(RefCell::new(usb::Backend::new(
+                usb_vid, usb_pid, usb_serial,
+            )?)),
+            inner: RefCell::default(),
+        };
+        board.init_direction()?;
+        Ok(board)
+    }
+
+    // Initialize the IO direction of some basic pins on the board.
+    fn init_direction(&self) -> Result<()> {
+        let device = self.device.borrow();
+        device.pin_set_output(Self::PIN_SRST, true)?;
+        device.pin_set_output(Self::PIN_JTAG, true)?;
+        device.pin_set_output(Self::PIN_BOOTSTRAP, true)?;
+        Ok(())
+    }
+}
+
+impl Transport for CW310 {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::SPI | Capability::GPIO | Capability::UART)
+    }
+
+    fn uart(&self, instance: u32) -> Result<Rc<dyn Uart>> {
+        let mut inner = self.inner.borrow_mut();
+        let uart = match inner.uart.entry(instance) {
+            Entry::Vacant(v) => {
+                let u = v.insert(Rc::new(uart::CW310Uart::open(
+                    Rc::clone(&self.device),
+                    instance,
+                )?));
+                Rc::clone(u)
+            }
+            Entry::Occupied(o) => Rc::clone(o.get()),
+        };
+        Ok(uart)
+    }
+
+    fn gpio(&self) -> Result<Rc<dyn Gpio>> {
+        let mut inner = self.inner.borrow_mut();
+        if inner.gpio.is_none() {
+            inner.gpio = Some(Rc::new(gpio::CW310Gpio::open(Rc::clone(&self.device))?));
+        }
+        Ok(Rc::clone(inner.gpio.as_ref().unwrap()))
+    }
+
+    fn spi(&self, instance: u32) -> Result<Rc<dyn Target>> {
+        ensure!(
+            instance == 0,
+            TransportError::InvalidInstance("spi", instance)
+        );
+        let mut inner = self.inner.borrow_mut();
+        if inner.spi.is_none() {
+            inner.spi = Some(Rc::new(spi::CW310Spi::open(Rc::clone(&self.device))?));
+        }
+        Ok(Rc::clone(inner.spi.as_ref().unwrap()))
+    }
+}

--- a/sw/host/opentitanlib/src/transport/cw310/spi.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/spi.rs
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use log;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
+use crate::transport::cw310::usb::Backend;
+use crate::transport::cw310::CW310;
+
+pub struct CW310Spi {
+    device: Rc<RefCell<Backend>>,
+}
+
+impl CW310Spi {
+    pub fn open(device: Rc<RefCell<Backend>>) -> Result<Self> {
+        {
+            let usb = device.borrow();
+            usb.spi1_setpins(
+                // For some reason, SDI/SDO are reversed in the python implementation
+                // and this seems to be required to make the transport work.
+                CW310::PIN_SDI,
+                CW310::PIN_SDO,
+                CW310::PIN_CLK,
+                CW310::PIN_CS,
+            )?;
+            usb.spi1_enable(true)?;
+
+            // Set the JTAG pin to false to use SPI mode.
+            usb.pin_set_state(CW310::PIN_JTAG, false)?;
+        }
+
+        Ok(CW310Spi { device })
+    }
+
+    // Perform a SPI transaction.
+    fn spi_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
+        let usb = self.device.borrow();
+        for transfer in transaction.iter_mut() {
+            match transfer {
+                Transfer::Read(buf) => usb.spi1_read(buf)?,
+                Transfer::Write(buf) => usb.spi1_write(buf)?,
+                Transfer::Both(wbuf, rbuf) => usb.spi1_both(wbuf, rbuf)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Target for CW310Spi {
+    fn get_transfer_mode(&self) -> Result<TransferMode> {
+        Ok(TransferMode::Mode0)
+    }
+    fn set_transfer_mode(&self, mode: TransferMode) -> Result<()> {
+        log::warn!(
+            "set_transfer_mode to {:?}, but only Mode0 is supported on this device",
+            mode
+        );
+        Ok(())
+    }
+
+    fn get_bits_per_word(&self) -> Result<u32> {
+        Ok(8)
+    }
+    fn set_bits_per_word(&self, bits_per_word: u32) -> Result<()> {
+        match bits_per_word {
+            8 => Ok(()),
+            _ => Err(SpiError::InvalidWordSize(bits_per_word).into()),
+        }
+    }
+
+    fn get_max_speed(&self) -> Result<u32> {
+        // FIXME: what is the speed of the SAM3U SPI interface on the CW310 board?
+        Ok(6_000_000)
+    }
+    fn set_max_speed(&self, frequency: u32) -> Result<()> {
+        log::warn!(
+            "set_max_speed to {:?}, but this device doesn't support changing speeds.",
+            frequency
+        );
+        Ok(())
+    }
+
+    fn get_max_transfer_count(&self) -> usize {
+        // Arbitrary value: number of `Transfers` that can be in a single transaction.
+        42
+    }
+
+    fn max_chunk_size(&self) -> usize {
+        65536
+    }
+
+    fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {
+        // Assert CS# (drive low).
+        self.device.borrow().spi1_set_cs_pin(false)?;
+        // Translate SPI Read/Write Transactions into CW310 spi operations.
+        let result = self.spi_transaction(transaction);
+        // Release CS# (allow to float high).
+        self.device.borrow().spi1_set_cs_pin(true)?;
+        result
+    }
+}

--- a/sw/host/opentitanlib/src/transport/cw310/uart.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/uart.rs
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transport::TransportError;
+use anyhow::Result;
+use serialport::{SerialPort, SerialPortType};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use crate::io::uart::Uart;
+use crate::transport::cw310::usb::Backend;
+
+pub struct CW310Uart {
+    port: RefCell<Box<dyn SerialPort>>,
+}
+
+impl CW310Uart {
+    pub fn open(backend: Rc<RefCell<Backend>>, instance: u32) -> Result<Self> {
+        let usb = backend.borrow();
+        let serial_number = usb.get_serial_number();
+
+        let mut ports = serialport::available_ports()?;
+        ports.retain(|port| {
+            if let SerialPortType::UsbPort(info) = &port.port_type {
+                if info.serial_number.as_deref() == Some(serial_number) {
+                    return true;
+                }
+            }
+            false
+        });
+        // The CW board seems to have the last port connected as OpenTitan UART 0.
+        // Reverse the sort order so the last port will be instance 0.
+        ports.sort_by(|a, b| b.port_name.cmp(&a.port_name));
+
+        let port = ports
+            .get(instance as usize)
+            .ok_or(TransportError::InvalidInstance("uart", instance))?;
+        Ok(CW310Uart {
+            port: RefCell::new(serialport::new(&port.port_name, 115200).open()?),
+        })
+    }
+}
+
+impl Uart for CW310Uart {
+    /// Returns the UART baudrate.  May return zero for virtual UARTs.
+    fn get_baudrate(&self) -> u32 {
+        self.port.borrow().baud_rate().unwrap()
+    }
+
+    /// Sets the UART baudrate.  May do nothing for virtual UARTs.
+    fn set_baudrate(&self, baudrate: u32) -> Result<()> {
+        self.port.borrow_mut().set_baud_rate(baudrate)?;
+        Ok(())
+    }
+
+    /// Reads UART receive data into `buf`, returning the number of bytes read.
+    /// This function _may_ block.
+    fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        Ok(self.port.borrow_mut().read(buf)?)
+    }
+
+    /// Reads UART receive data into `buf`, returning the number of bytes read.
+    /// The `timeout` may be used to specify a duration to wait for data.
+    fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
+        let mut port = self.port.borrow_mut();
+        port.set_timeout(timeout)?;
+        let len = port.read(buf)?;
+        port.set_timeout(Duration::MAX)?;
+        Ok(len)
+    }
+
+    /// Writes data from `buf` to the UART.
+    fn write(&self, buf: &[u8]) -> Result<usize> {
+        Ok(self.port.borrow_mut().write(buf)?)
+    }
+}

--- a/sw/host/opentitanlib/src/transport/cw310/usb.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/usb.rs
@@ -1,0 +1,550 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Result};
+use lazy_static::lazy_static;
+use rusb;
+use std::collections::HashMap;
+use std::time::Duration;
+use thiserror::Error;
+
+use crate::collection;
+use crate::io::gpio::GpioError;
+use crate::io::spi::SpiError;
+use crate::util::parse_int::ParseInt;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Could not find device {0}")]
+    NotFound(String),
+}
+
+/// The `UsbBackend` provides low-level USB access to the CW310 board.
+pub struct UsbBackend {
+    handle: rusb::DeviceHandle<rusb::GlobalContext>,
+    serial_number: String,
+    timeout: Duration,
+}
+
+impl UsbBackend {
+    pub const VID_NEWAE: u16 = 0x2b3e;
+    pub const PID_CW310: u16 = 0xc310;
+
+    /// Scan the USB bus for CW310 devices.
+    pub fn scan(
+        usb_vid: Option<u16>,
+        usb_pid: Option<u16>,
+        usb_serial: Option<String>,
+    ) -> Result<Vec<(rusb::Device<rusb::GlobalContext>, String)>> {
+        let usb_vid = usb_vid.unwrap_or(UsbBackend::VID_NEWAE);
+        let usb_pid = usb_pid.unwrap_or(UsbBackend::PID_CW310);
+        let mut devices = Vec::new();
+        for device in rusb::devices()?.iter() {
+            let descriptor = match device.device_descriptor() {
+                Ok(desc) => desc,
+                _ => {
+                    log::error!(
+                        "Could not read device descriptor for device at bus={} address={}",
+                        device.bus_number(),
+                        device.address()
+                    );
+                    continue;
+                }
+            };
+            if descriptor.vendor_id() != usb_vid {
+                continue;
+            }
+            if descriptor.product_id() != usb_pid {
+                continue;
+            }
+            let handle = match device.open() {
+                Ok(handle) => handle,
+                _ => {
+                    log::error!(
+                        "Could not open device at bus={} address={}",
+                        device.bus_number(),
+                        device.address()
+                    );
+                    continue;
+                }
+            };
+            let serial_number = match handle.read_serial_number_string_ascii(&descriptor) {
+                Ok(sn) => sn,
+                _ => {
+                    log::error!(
+                        "Could not read serial number from device at bus={} address={}",
+                        device.bus_number(),
+                        device.address()
+                    );
+                    continue;
+                }
+            };
+            if let Some(sn) = &usb_serial {
+                if &serial_number != sn {
+                    continue;
+                }
+            }
+            devices.push((device, serial_number));
+        }
+        Ok(devices)
+    }
+
+    /// Create a new UsbBackend.
+    pub fn new(
+        usb_vid: Option<u16>,
+        usb_pid: Option<u16>,
+        usb_serial: Option<String>,
+    ) -> Result<Self> {
+        let mut devices = UsbBackend::scan(usb_vid, usb_pid, usb_serial)?;
+        ensure!(!devices.is_empty(), Error::NotFound("CW310".to_string()));
+
+        let (device, serial_number) = devices.remove(0);
+        Ok(UsbBackend {
+            handle: device.open()?,
+            serial_number,
+            timeout: Duration::from_millis(200),
+        })
+    }
+
+    /// Gets the usb serial number of the device.
+    pub fn get_serial_number(&self) -> &str {
+        self.serial_number.as_str()
+    }
+
+    /// Send a control write transaction to the CW310 board.
+    pub fn send_ctrl(&self, cmd: u8, value: u16, data: &[u8]) -> Result<usize> {
+        log::debug!("WRITE_CTRL: bmRequestType: {:02x}, bRequest: {:02x}, wValue: {:04x}, wIndex: {:04x}, data: {:?}",
+                0x41, cmd, value, 0, data);
+        let len = self
+            .handle
+            .write_control(0x41, cmd, value, 0, data, self.timeout)?;
+        Ok(len)
+    }
+
+    /// Send a control read transaction to the CW310 board.
+    pub fn read_ctrl(&self, cmd: u8, value: u16, data: &mut [u8]) -> Result<usize> {
+        let len = self
+            .handle
+            .read_control(0xC1, cmd, value, 0, data, self.timeout)?;
+        log::debug!("READ_CTRL: bmRequestType: {:02x}, bRequest: {:02x}, wValue: {:04x}, wIndex: {:04x}, data: {:?}",
+                0xC1, cmd, value, 0, data);
+        Ok(len)
+    }
+}
+
+/// The `Backend` struct provides high-level access to the CW310 board.
+pub struct Backend {
+    usb: UsbBackend,
+}
+
+impl Backend {
+    /// Commands for the CW310 board.
+    pub const CMD_FW_VERSION: u8 = 0x17;
+    pub const CMD_CDC_SETTINGS_EN: u8 = 0x31;
+    pub const CMD_READMEM_BULK: u8 = 0x10;
+    pub const CMD_WRITEMEM_BULK: u8 = 0x11;
+    pub const CMD_READMEM_CTRL: u8 = 0x12;
+    pub const CMD_WRITEMEM_CTRL: u8 = 0x13;
+    pub const CMD_MEMSTREAM: u8 = 0x14;
+    pub const CMD_WRITEMEM_CTRL_SAM3U: u8 = 0x15;
+    pub const CMD_SMC_READ_SPEED: u8 = 0x27;
+    pub const CMD_FW_BUILD_DATE: u8 = 0x40;
+
+    /// `CMD_FPGAIO_UTIL` is used to configure gpio pins on the SAM3U chip
+    /// which are connected to the FPGA.
+    pub const CMD_FPGAIO_UTIL: u8 = 0x34;
+    /// Requests to the `FPGAIO_UTIL` command.
+    pub const REQ_IO_CONFIG: u16 = 0xA0;
+    pub const REQ_IO_RELEASE: u16 = 0xA1;
+    pub const REQ_IO_OUTPUT: u16 = 0xA2;
+    /// Configuration requests are used in the data packet sent with `REQ_IO_CONFIG`.
+    pub const CONFIG_PIN_INPUT: u8 = 0x01;
+    pub const CONFIG_PIN_OUTPUT: u8 = 0x02;
+    pub const CONFIG_PIN_SPI1_SDO: u8 = 0x10;
+    pub const CONFIG_PIN_SPI1_SDI: u8 = 0x11;
+    pub const CONFIG_PIN_SPI1_SCK: u8 = 0x12;
+    pub const CONFIG_PIN_SPI1_CS: u8 = 0x13;
+
+    /// `CMD_FPGASPI1_XFER` is used to configure and drive SPI transactions
+    /// between the SAM3U chip and the FPGA.
+    pub const CMD_FPGASPI1_XFER: u8 = 0x35;
+    pub const REQ_ENABLE_SPI: u16 = 0xA0;
+    pub const REQ_DISABLE_SPI: u16 = 0xA1;
+    pub const REQ_CS_LOW: u16 = 0xA2;
+    pub const REQ_CS_HIGH: u16 = 0xA3;
+    pub const REQ_SEND_DATA: u16 = 0xA4;
+
+    const LAST_PIN_NUMBER: u8 = 106;
+
+    /// Create a new connection to a CW310 board.
+    pub fn new(
+        usb_vid: Option<u16>,
+        usb_pid: Option<u16>,
+        usb_serial: Option<String>,
+    ) -> Result<Self> {
+        Ok(Backend {
+            usb: UsbBackend::new(usb_vid, usb_pid, usb_serial)?,
+        })
+    }
+
+    /// Gets the usb serial number of the device.
+    pub fn get_serial_number(&self) -> &str {
+        self.usb.get_serial_number()
+    }
+
+    /// Get the firmware build date as a string.
+    pub fn get_firmware_build_date(&self) -> Result<String> {
+        let mut buf = [0u8; 100];
+        let len = self
+            .usb
+            .read_ctrl(Backend::CMD_FW_BUILD_DATE, 0, &mut buf)?;
+        Ok(String::from_utf8_lossy(&buf[0..len]).to_string())
+    }
+
+    /// Get the firmware version.
+    pub fn get_firmware_version(&self) -> Result<[u8; 3]> {
+        let mut buf = [0u8; 3];
+        self.usb.read_ctrl(Backend::CMD_FW_VERSION, 0, &mut buf)?;
+        Ok(buf)
+    }
+
+    /// Set GPIO `pinname` to either output or input mode.
+    pub fn pin_set_output(&self, pinname: &str, output: bool) -> Result<()> {
+        let pinnum = Backend::pin_name_to_number(pinname)?;
+        self.usb.send_ctrl(
+            Backend::CMD_FPGAIO_UTIL,
+            Backend::REQ_IO_CONFIG,
+            &[
+                pinnum,
+                if output {
+                    Backend::CONFIG_PIN_OUTPUT
+                } else {
+                    Backend::CONFIG_PIN_INPUT
+                },
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get the state of GPIO `pinname`.
+    pub fn pin_get_state(&self, pinname: &str) -> Result<u8> {
+        let pinnum = Backend::pin_name_to_number(pinname)? as u16;
+        let mut buf = [0u8; 1];
+        self.usb
+            .read_ctrl(Backend::CMD_FPGAIO_UTIL, pinnum, &mut buf)?;
+        Ok(buf[0])
+    }
+
+    /// Set the state of GPIO `pinname`.
+    pub fn pin_set_state(&self, pinname: &str, value: bool) -> Result<()> {
+        let pinnum = Backend::pin_name_to_number(pinname)?;
+        self.usb.send_ctrl(
+            Backend::CMD_FPGAIO_UTIL,
+            Backend::REQ_IO_OUTPUT,
+            &[pinnum, value as u8],
+        )?;
+        Ok(())
+    }
+
+    /// Configure the SAM3U to perform SPI using the named pins.
+    pub fn spi1_setpins(&self, sdo: &str, sdi: &str, sck: &str, cs: &str) -> Result<()> {
+        let sdo = Backend::pin_name_to_number(sdo)?;
+        let sdi = Backend::pin_name_to_number(sdi)?;
+        let sck = Backend::pin_name_to_number(sck)?;
+        let cs = Backend::pin_name_to_number(cs)?;
+
+        self.usb.send_ctrl(
+            Backend::CMD_FPGAIO_UTIL,
+            Backend::REQ_IO_CONFIG,
+            &[sdo, Backend::CONFIG_PIN_SPI1_SDO],
+        )?;
+        self.usb.send_ctrl(
+            Backend::CMD_FPGAIO_UTIL,
+            Backend::REQ_IO_CONFIG,
+            &[sdi, Backend::CONFIG_PIN_SPI1_SDI],
+        )?;
+        self.usb.send_ctrl(
+            Backend::CMD_FPGAIO_UTIL,
+            Backend::REQ_IO_CONFIG,
+            &[sck, Backend::CONFIG_PIN_SPI1_SCK],
+        )?;
+        self.usb.send_ctrl(
+            Backend::CMD_FPGAIO_UTIL,
+            Backend::REQ_IO_CONFIG,
+            &[cs, Backend::CONFIG_PIN_SPI1_CS],
+        )?;
+        Ok(())
+    }
+
+    /// Enable the spi interface on the SAM3U chip.
+    pub fn spi1_enable(&self, enable: bool) -> Result<()> {
+        self.usb.send_ctrl(
+            Backend::CMD_FPGASPI1_XFER,
+            if enable {
+                Backend::REQ_ENABLE_SPI
+            } else {
+                Backend::REQ_DISABLE_SPI
+            },
+            &[],
+        )?;
+        Ok(())
+    }
+
+    /// Set the value of the SPI chip-select pin.
+    pub fn spi1_set_cs_pin(&self, status: bool) -> Result<()> {
+        self.usb.send_ctrl(
+            Backend::CMD_FPGASPI1_XFER,
+            if status {
+                Backend::REQ_CS_HIGH
+            } else {
+                Backend::REQ_CS_LOW
+            },
+            &[],
+        )?;
+        Ok(())
+    }
+
+    /// Perform an up to 64-byte transfer on the SPI interface.
+    /// This is a low-level function and does not affect the CS pin.
+    pub fn spi1_tx_rx(&self, txdata: &[u8], rxdata: &mut [u8]) -> Result<()> {
+        ensure!(
+            txdata.len() <= 64,
+            SpiError::InvalidDataLength(txdata.len())
+        );
+        ensure!(
+            rxdata.len() <= 64,
+            SpiError::InvalidDataLength(rxdata.len())
+        );
+        ensure!(
+            txdata.len() == rxdata.len(),
+            SpiError::MismatchedDataLength(txdata.len(), rxdata.len())
+        );
+        self.usb
+            .send_ctrl(Backend::CMD_FPGASPI1_XFER, Backend::REQ_SEND_DATA, txdata)?;
+        self.usb.read_ctrl(Backend::CMD_FPGASPI1_XFER, 0, rxdata)?;
+        Ok(())
+    }
+
+    /// Read a `buffer` slice from the SPI interface.
+    /// This is a low-level function and does not affect the CS pin.
+    pub fn spi1_read(&self, buffer: &mut [u8]) -> Result<()> {
+        let wbuf = [0u8; 64];
+        for chunk in buffer.chunks_mut(64) {
+            self.spi1_tx_rx(&wbuf[..chunk.len()], chunk)?;
+        }
+        Ok(())
+    }
+
+    /// Write a `buffer` slice to the SPI interface.
+    /// This is a low-level function and does not affect the CS pin.
+    pub fn spi1_write(&self, buffer: &[u8]) -> Result<()> {
+        let mut rbuf = [0u8; 64];
+        for chunk in buffer.chunks(64) {
+            self.spi1_tx_rx(chunk, &mut rbuf[..chunk.len()])?;
+        }
+        Ok(())
+    }
+
+    /// Perform a write & read transaction to the SPI interface.
+    /// This is a low-level function and does not affect the CS pin.
+    pub fn spi1_both(&self, txbuf: &[u8], rxbuf: &mut [u8]) -> Result<()> {
+        ensure!(
+            txbuf.len() == rxbuf.len(),
+            SpiError::MismatchedDataLength(txbuf.len(), rxbuf.len())
+        );
+        for (wchunk, rchunk) in txbuf.chunks(64).zip(rxbuf.chunks_mut(64)) {
+            self.spi1_tx_rx(wchunk, rchunk)?;
+        }
+        Ok(())
+    }
+
+    /// Given a CW310 pin name, return its pin number.
+    pub fn pin_name_to_number(pinname: &str) -> Result<u8> {
+        // If the pinname is an integer, use it; otherwise try to see if it
+        // is a symbolic name of a pin.
+        if let Ok(pinnum) = u8::from_str(pinname) {
+            ensure!(
+                pinnum <= Backend::LAST_PIN_NUMBER,
+                GpioError::InvalidPinNumber(pinnum)
+            );
+            return Ok(pinnum);
+        }
+        let pinname = pinname.to_uppercase();
+        let pn = pinname.as_str();
+
+        if SCHEMATIC_PIN_NAMES.contains_key(pn) {
+            Ok(SAM3X_PIN_NAMES[SCHEMATIC_PIN_NAMES[pn]])
+        } else if SAM3X_PIN_NAMES.contains_key(pn) {
+            Ok(SAM3X_PIN_NAMES[pn])
+        } else {
+            Err(GpioError::InvalidPinName(pinname).into())
+        }
+    }
+}
+
+lazy_static! {
+    // Mapping of SAM3 pin names to pin numbers.
+    static ref SAM3X_PIN_NAMES: HashMap<&'static str, u8> = collection! {
+        "PA0" =>  0,
+        "PA1" =>  1,
+        "PA2" =>  2,
+        "PA3" =>  3,
+        "PA4" =>  4,
+        "PA5" =>  5,
+        "PA6" =>  6,
+        "PA7" =>  7,
+        "PA8" =>  8,
+        "PA9" =>  9,
+        "PA10" => 10,
+        "PA11" => 11,
+        "PA12" => 12,
+        "PA13" => 13,
+        "PA14" => 14,
+        "PA15" => 15,
+        "PA16" => 16,
+        "PA17" => 17,
+        "PA18" => 18,
+        "PA19" => 19,
+        "PA20" => 20,
+        "PA21" => 21,
+        "PA22" => 22,
+        "PA23" => 23,
+        "PA24" => 24,
+        "PA25" => 25,
+        "PA26" => 26,
+        "PA27" => 27,
+        "PA28" => 28,
+        "PA29" => 29,
+        "PB0" =>  32,
+        "PB1" =>  33,
+        "PB2" =>  34,
+        "PB3" =>  35,
+        "PB4" =>  36,
+        "PB5" =>  37,
+        "PB6" =>  38,
+        "PB7" =>  39,
+        "PB8" =>  40,
+        "PB9" =>  41,
+        "PB10" => 42,
+        "PB11" => 43,
+        "PB12" => 44,
+        "PB13" => 45,
+        "PB14" => 46,
+        "PB15" => 47,
+        "PB16" => 48,
+        "PB17" => 49,
+        "PB18" => 50,
+        "PB19" => 51,
+        "PB20" => 52,
+        "PB21" => 53,
+        "PB22" => 54,
+        "PB23" => 55,
+        "PB24" => 56,
+        "PB25" => 57,
+        "PB26" => 58,
+        "PB27" => 59,
+        "PB28" => 60,
+        "PB29" => 61,
+        "PB30" => 62,
+        "PB31" => 63,
+        "PC0" =>  64,
+        "PC1" =>  65,
+        "PC2" =>  66,
+        "PC3" =>  67,
+        "PC4" =>  68,
+        "PC5" =>  69,
+        "PC6" =>  70,
+        "PC7" =>  71,
+        "PC8" =>  72,
+        "PC9" =>  73,
+        "PC10" => 74,
+        "PC11" => 75,
+        "PC12" => 76,
+        "PC13" => 77,
+        "PC14" => 78,
+        "PC15" => 79,
+        "PC16" => 80,
+        "PC17" => 81,
+        "PC18" => 82,
+        "PC19" => 83,
+        "PC20" => 84,
+        "PC21" => 85,
+        "PC22" => 86,
+        "PC23" => 87,
+        "PC24" => 88,
+        "PC25" => 89,
+        "PC26" => 90,
+        "PC27" => 91,
+        "PC28" => 92,
+        "PC29" => 93,
+        "PC30" => 94,
+        "PD0" =>  96,
+        "PD1" =>  97,
+        "PD2" =>  98,
+        "PD3" =>  99,
+        "PD4" =>  100,
+        "PD5" =>  101,
+        "PD6" =>  102,
+        "PD7" =>  103,
+        "PD8" =>  104,
+        "PD9" =>  105,
+        "PD10" => 106
+    };
+    // Mapping of schematic pin names to SAM3 pin names.
+    static ref SCHEMATIC_PIN_NAMES: HashMap<&'static str, &'static str> = collection! {
+        "USBSPARE0" => "PC10",
+        "USBSPARE1" => "PC11",
+        "USBSPARE2" => "PC12",
+        "USBSPARE3" => "PC13",
+        "USBRD" => "PA29",
+        "USBWR" => "PC18",
+        "USBCE" => "PA6",
+        "USBALE" => "PC17",
+        "USBCK0" => "PB22",
+        "USBCK1" => "PA24",
+        "USB_A0" => "PC21",
+        "USB_A1" => "PC22",
+        "USB_A2" => "PC23",
+        "USB_A3" => "PC24",
+        "USB_A4" => "PC25",
+        "USB_A5" => "PC26",
+        "USB_A6" => "PC27",
+        "USB_A7" => "PC28",
+        "USB_A8" => "PC29",
+        "USB_A9" => "PC30",
+        "USB_A10" => "PD0",
+        "USB_A11" => "PD1",
+        "USB_A12" => "PD2",
+        "USB_A13" => "PD3",
+        "USB_A14" => "PD4",
+        "USB_A15" => "PD5",
+        "USB_A16" => "PD6",
+        "USB_A17" => "PD7",
+        "USB_A18" => "PD8",
+        "USB_A19" => "PD9",
+        "USB_D0" => "PC2",
+        "USB_D1" => "PC3",
+        "USB_D2" => "PC4",
+        "USB_D3" => "PC5",
+        "USB_D4" => "PC6",
+        "USB_D5" => "PC7",
+        "USB_D6" => "PC8",
+        "USB_D7" => "PC9",
+        "SWSTATE" => "PB26",
+        "PWRON" => "PB27",
+        "LEDSURGE" => "PB14",
+        "SAM_FPGA_CFG_CS" => "PB16",
+        "CFG_INITB" => "PB18",
+        "CFG_DONE" => "PB17",
+        "CFB_PROGRAMB" => "PB19",
+        "SAM_FPGA_COPI" => "PB20",
+        "SAM_FPGA_CIPO" => "PB21",
+        "SAM_FPGA_CCLK" => "PB24",
+        "USB_CLK1" => "PA24",
+        "USB_SPI_CIPO" => "PA25",
+        "USB_SPI_COPI" => "PA26",
+        "USB_SPI_SCK" => "PA27",
+        "USB_SPI_CS" => "PA28"
+    };
+}

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -11,6 +11,7 @@ use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
+pub mod cw310;
 pub mod ultradebug;
 pub mod verilator;
 

--- a/sw/host/opentitantool/src/backend/cw310.rs
+++ b/sw/host/opentitantool/src/backend/cw310.rs
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::transport::cw310::CW310;
+use opentitanlib::transport::Transport;
+
+use crate::backend::BackendOpts;
+
+pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
+    Ok(Box::new(CW310::new(
+        args.usb_vid,
+        args.usb_vid,
+        args.usb_serial.clone(),
+    )?))
+}

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use opentitanlib::transport::{EmptyTransport, Transport};
 use opentitanlib::util::parse_int::ParseInt;
 
+pub mod cw310;
 pub mod ultradebug;
 pub mod verilator;
 
@@ -42,6 +43,7 @@ pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
         "" => Ok(Box::new(EmptyTransport)),
         "verilator" => verilator::create(&args.verilator_opts),
         "ultradebug" => ultradebug::create(args),
+        "cw310" => cw310::create(args),
         _ => Err(Error::UnknownInterface(args.interface.clone()).into()),
     }
 }


### PR DESCRIPTION
1. Implement a CW310 backend.
1a. Implement the NewAE low-level usb protocol.
1b. Add a SPI target.
1c. Add a GPIO target.
1d. Add a UART target.  Requires libudev-sys in `apt-requirements.txt`.
2. Add the backend to opentitantool.

Signed-off-by: Chris Frantz <cfrantz@google.com>