### PR TITLE
[keymgr/dv] Fix sw_binding gated by LC

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -272,7 +272,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
 
   // when reset occurs or keymgr_en = Off, disable checks in seq and check in scb only
   virtual function bit get_check_en();
-    return cfg.keymgr_vif.keymgr_en == lc_ctrl_pkg::On && !cfg.under_reset;
+    return cfg.keymgr_vif.get_keymgr_en() && !cfg.under_reset;
   endfunction
 
   task post_start();

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_lc_disable_vseq.sv
@@ -8,8 +8,10 @@ class keymgr_lc_disable_vseq extends keymgr_random_vseq;
   `uvm_object_new
 
   virtual task op_before_enable_keymgr();
+    if (cfg.keymgr_vif.keymgr_en == lc_ctrl_pkg::On) return;
+
     `uvm_info(`gfn, "Dummy operations before LC enables keymgr", UVM_MEDIUM)
-    keymgr_operations();
+    keymgr_operations(.advance_state(0));
     `uvm_info(`gfn, "Dummy operations are done", UVM_MEDIUM)
   endtask
 


### PR DESCRIPTION
A small fix to gate sw_binding if keymgr_en is off

Add more fixes:
Also fixed to check the condition (keymgr_en) before issuing dummy operation.
And fix the condition of predicting err_code and alert after LC disable

Signed-off-by: Weicai Yang <weicai@google.com>