### PR TITLE
[dif/aes] autogen aes IRQ DIFs and integrate into src tree

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -52,10 +52,10 @@ index 8861f54ba..8442bb896 100644
 -  mmio_region_write32(reg32, reg_offset, reg_value & mask);
  }
 diff --git a/sw/device/sca/aes_serial.c b/sw/device/sca/aes_serial.c
-index 901eba868..b19979b89 100644
+index a2087eb4f..d8d347e1e 100644
 --- a/sw/device/sca/aes_serial.c
 +++ b/sw/device/sca/aes_serial.c
-@@ -203,18 +203,13 @@ int main(void) {
+@@ -201,18 +201,13 @@ int main(void) {
    sca_init(kScaTriggerSourceAes, kScaPeripheralAes);
    sca_get_uart(&uart1);
  
@@ -75,7 +75,7 @@ index 901eba868..b19979b89 100644
      simple_serial_process_packet();
    }
 diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
-index 3fb4ff13d..e310076c3 100644
+index 093d215b1..dd231b2cc 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
 @@ -56,7 +56,6 @@ enum {
@@ -157,7 +157,7 @@ index 3fb4ff13d..e310076c3 100644
      IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
          &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
 diff --git a/sw/device/tests/aes_smoketest.c b/sw/device/tests/aes_smoketest.c
-index 5b995c27f..0ce27b2f1 100644
+index dff8bd9b6..396123ef7 100644
 --- a/sw/device/tests/aes_smoketest.c
 +++ b/sw/device/tests/aes_smoketest.c
 @@ -7,7 +7,6 @@
@@ -168,7 +168,7 @@ index 5b995c27f..0ce27b2f1 100644
  #include "sw/device/lib/testing/test_framework/test_main.h"
  
  #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-@@ -67,9 +66,6 @@ bool test_main(void) {
+@@ -66,9 +65,6 @@ bool test_main(void) {
  
    LOG_INFO("Running AES test");
  
@@ -176,8 +176,8 @@ index 5b995c27f..0ce27b2f1 100644
 -  entropy_testutils_boot_mode_init();
 -
    // Initialise AES.
-   dif_aes_params_t params = {
-       .base_addr = mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
+   CHECK(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes) ==
+         kDifOk);
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
 index 7abdc2045..829968cb9 100644
 --- a/sw/device/tests/meson.build

--- a/sw/device/lib/dif/autogen/dif_aes_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_aes.h"
+
+#include "aes_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_aes_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.h
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_AES_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_AES_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/aes/doc/">AES</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to aes.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_aes {
+  /**
+   * The base address for the aes hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_aes_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_AES_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_aes.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "aes_regs.h"  // Generated.
+
+namespace dif_aes_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class AesTest : public Test, public MmioTest {
+ protected:
+  dif_aes_t aes_ = {.base_addr = dev().region()};
+};
+
+}  // namespace
+}  // namespace dif_aes_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,6 +2,20 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Autogen AES DIF library
+sw_lib_dif_autogen_aes = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_aes',
+    sources: [
+      hw_ip_aes_reg_h,
+      'dif_aes_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen UART DIF library
 sw_lib_dif_autogen_uart = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -10,6 +10,9 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sw/device/lib/dif/autogen/dif_aes_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -170,68 +173,16 @@ typedef enum dif_aes_alert {
 } dif_aes_alert_t;
 
 /**
- * Hardware instantiation parameters for AES.
- *
- * This struct describes information about the underlying hardware that is
- * not determined until the hardware design is used as part of a top-level
- * design.
- */
-typedef struct dif_aes_params {
-  /**
-   * The base address for the AES hardware registers.
-   */
-  mmio_region_t base_addr;
-} dif_aes_params_t;
-
-/**
- * A handle to AES.
- *
- * This type should be treated as opaque by users.
- */
-typedef struct dif_aes {
-  dif_aes_params_t params;
-} dif_aes_t;
-
-/**
- * The result of a AES operation.
- */
-typedef enum dif_aes_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifAesOk = 0,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifAesError = 1,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifAesBadArg = 2,
-  /**
-   * Device is busy, and cannot perform the requested operation.
-   */
-  kDifAesBusy,
-  /**
-   * The AES unit has no valid output.
-   */
-  kDifAesOutputInvalid,
-} dif_aes_result_t;
-
-/**
  * Creates a new handle for AES.
  *
  * This function does not actuate the hardware.
  *
- * @param params Hardware instantiation parameters.
+ * @param base_addr Hardware instantiation base address.
  * @param[out] aes Out param for the initialised handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_init(dif_aes_params_t params, dif_aes_t *aes);
+dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes);
 
 /**
  * Resets an instance of AES.
@@ -242,7 +193,7 @@ dif_aes_result_t dif_aes_init(dif_aes_params_t params, dif_aes_t *aes);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_reset(const dif_aes_t *aes);
+dif_result_t dif_aes_reset(const dif_aes_t *aes);
 
 /**
  * Begins an AES transaction in ECB mode.
@@ -264,9 +215,9 @@ dif_aes_result_t dif_aes_reset(const dif_aes_t *aes);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_start_ecb(const dif_aes_t *aes,
-                                   const dif_aes_transaction_t *transaction,
-                                   dif_aes_key_share_t key);
+dif_result_t dif_aes_start_ecb(const dif_aes_t *aes,
+                               const dif_aes_transaction_t *transaction,
+                               dif_aes_key_share_t key);
 
 /**
  * Begins an AES transaction in CBC mode.
@@ -291,9 +242,9 @@ dif_aes_result_t dif_aes_start_ecb(const dif_aes_t *aes,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_start_cbc(const dif_aes_t *aes,
-                                   const dif_aes_transaction_t *transaction,
-                                   dif_aes_key_share_t key, dif_aes_iv_t iv);
+dif_result_t dif_aes_start_cbc(const dif_aes_t *aes,
+                               const dif_aes_transaction_t *transaction,
+                               dif_aes_key_share_t key, dif_aes_iv_t iv);
 
 /**
  * Begins an AES transaction in CTR mode.
@@ -316,9 +267,9 @@ dif_aes_result_t dif_aes_start_cbc(const dif_aes_t *aes,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_start_ctr(const dif_aes_t *aes,
-                                   const dif_aes_transaction_t *transaction,
-                                   dif_aes_key_share_t key, dif_aes_iv_t iv);
+dif_result_t dif_aes_start_ctr(const dif_aes_t *aes,
+                               const dif_aes_transaction_t *transaction,
+                               dif_aes_key_share_t key, dif_aes_iv_t iv);
 
 /**
  * Ends an AES transaction.
@@ -333,7 +284,7 @@ dif_aes_result_t dif_aes_start_ctr(const dif_aes_t *aes,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_end(const dif_aes_t *aes);
+dif_result_t dif_aes_end(const dif_aes_t *aes);
 
 /**
  * Loads AES Input Data.
@@ -349,8 +300,7 @@ dif_aes_result_t dif_aes_end(const dif_aes_t *aes);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_load_data(const dif_aes_t *aes,
-                                   const dif_aes_data_t data);
+dif_result_t dif_aes_load_data(const dif_aes_t *aes, const dif_aes_data_t data);
 
 /**
  * Reads AES Output Data.
@@ -364,8 +314,7 @@ dif_aes_result_t dif_aes_load_data(const dif_aes_t *aes,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_read_output(const dif_aes_t *aes,
-                                     dif_aes_data_t *data);
+dif_result_t dif_aes_read_output(const dif_aes_t *aes, dif_aes_data_t *data);
 
 /**
  * AES Trigger flags.
@@ -400,8 +349,7 @@ typedef enum dif_aes_trigger {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_trigger(const dif_aes_t *aes,
-                                 dif_aes_trigger_t trigger);
+dif_result_t dif_aes_trigger(const dif_aes_t *aes, dif_aes_trigger_t trigger);
 
 /**
  * AES Status flags.
@@ -453,8 +401,8 @@ typedef enum dif_aes_status {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
-                                    bool *set);
+dif_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
+                                bool *set);
 
 /**
  * Forces a particular alert, causing it to be serviced as if hardware had
@@ -465,8 +413,7 @@ dif_aes_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_aes_result_t dif_aes_alert_force(const dif_aes_t *aes,
-                                     dif_aes_alert_t alert);
+dif_result_t dif_aes_alert_force(const dif_aes_t *aes, dif_aes_alert_t alert);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -647,16 +647,21 @@ sw_lib_dif_aes = declare_dependency(
       hw_ip_aes_reg_h,
       'dif_aes.c',
     ],
-    dependencies: [sw_lib_mmio],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_autogen_aes,
+    ],
   )
 )
 
 test('dif_aes_unittest', executable(
     'dif_aes_unittest',
     sources: [
-      hw_ip_aes_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_aes.c',
       'dif_aes_unittest.cc',
+      'autogen/dif_aes_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_aes.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_aes_autogen.c',
+      hw_ip_aes_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -62,14 +62,14 @@ static void aes_serial_set_key(const uint8_t *key, size_t key_len) {
   dif_aes_key_share_t key_shares;
   memcpy(key_shares.share0, key, sizeof(key_shares.share0));
   memset(key_shares.share1, 0, sizeof(key_shares.share1));
-  SS_CHECK(dif_aes_start_ecb(&aes, &transaction, key_shares) == kDifAesOk);
+  SS_CHECK(dif_aes_start_ecb(&aes, &transaction, key_shares) == kDifOk);
 }
 
 /**
  * Callback wrapper for AES manual trigger function.
  */
 static void aes_manual_trigger(void) {
-  SS_CHECK(dif_aes_trigger(&aes, kDifAesTriggerStart) == kDifAesOk);
+  SS_CHECK(dif_aes_trigger(&aes, kDifAesTriggerStart) == kDifOk);
 }
 
 /**
@@ -87,12 +87,12 @@ static void aes_serial_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
   bool ready = false;
   do {
     SS_CHECK(dif_aes_get_status(&aes, kDifAesStatusInputReady, &ready) ==
-             kDifAesOk);
+             kDifOk);
   } while (!ready);
   dif_aes_data_t data;
   SS_CHECK(plaintext_len <= sizeof(data.data));
   memcpy(data.data, plaintext, plaintext_len);
-  SS_CHECK(dif_aes_load_data(&aes, data) == kDifAesOk);
+  SS_CHECK(dif_aes_load_data(&aes, data) == kDifOk);
 
   // Start AES operation (this triggers the capture) and go to sleep.
   // Using the SecAesStartTriggerDelay hardware parameter, the AES unit is
@@ -122,11 +122,11 @@ static void aes_serial_single_encrypt(const uint8_t *plaintext,
   bool ready = false;
   do {
     SS_CHECK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready) ==
-             kDifAesOk);
+             kDifOk);
   } while (!ready);
 
   dif_aes_data_t ciphertext;
-  SS_CHECK(dif_aes_read_output(&aes, &ciphertext) == kDifAesOk);
+  SS_CHECK(dif_aes_read_output(&aes, &ciphertext) == kDifOk);
   simple_serial_send_packet('r', (uint8_t *)ciphertext.data,
                             sizeof(ciphertext.data));
 }
@@ -171,11 +171,11 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
   bool ready = false;
   do {
     SS_CHECK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready) ==
-             kDifAesOk);
+             kDifOk);
   } while (!ready);
 
   dif_aes_data_t ciphertext;
-  SS_CHECK(dif_aes_read_output(&aes, &ciphertext) == kDifAesOk);
+  SS_CHECK(dif_aes_read_output(&aes, &ciphertext) == kDifOk);
   simple_serial_send_packet('r', (uint8_t *)ciphertext.data,
                             sizeof(ciphertext.data));
 }
@@ -184,11 +184,9 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
  * Initializes the AES peripheral.
  */
 static void init_aes(void) {
-  dif_aes_params_t params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
-  };
-  SS_CHECK(dif_aes_init(params, &aes) == kDifAesOk);
-  SS_CHECK(dif_aes_reset(&aes) == kDifAesOk);
+  SS_CHECK(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
+                        &aes) == kDifOk);
+  SS_CHECK(dif_aes_reset(&aes) == kDifOk);
 }
 
 /**

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -49,15 +49,14 @@ const test_config_t kTestConfig;
 
 static bool aes_input_ready(const dif_aes_t *aes) {
   bool status;
-  CHECK(dif_aes_get_status(aes, kDifAesStatusInputReady, &status) == kDifAesOk);
+  CHECK(dif_aes_get_status(aes, kDifAesStatusInputReady, &status) == kDifOk);
 
   return status;
 }
 
 static bool aes_output_valid(const dif_aes_t *aes) {
   bool status;
-  CHECK(dif_aes_get_status(aes, kDifAesStatusOutputValid, &status) ==
-        kDifAesOk);
+  CHECK(dif_aes_get_status(aes, kDifAesStatusOutputValid, &status) == kDifOk);
 
   return status;
 }
@@ -71,11 +70,9 @@ bool test_main(void) {
   entropy_testutils_boot_mode_init();
 
   // Initialise AES.
-  dif_aes_params_t params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
-  };
-  CHECK(dif_aes_init(params, &aes) == kDifAesOk);
-  CHECK(dif_aes_reset(&aes) == kDifAesOk);
+  CHECK(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes) ==
+        kDifOk);
+  CHECK(dif_aes_reset(&aes) == kDifOk);
 
   // Mask the key. Note that this should not be done manually. Software is
   // expected to get the key in two shares right from the beginning.
@@ -95,7 +92,7 @@ bool test_main(void) {
       .mode = kDifAesModeEncrypt,
       .operation = kDifAesOperationAuto,
   };
-  CHECK(dif_aes_start_ecb(&aes, &transaction, key) == kDifAesOk);
+  CHECK(dif_aes_start_ecb(&aes, &transaction, key) == kDifOk);
 
   // "Convert" plain data byte arrays to `dif_aes_data_t`.
   dif_aes_data_t in_data_plain;
@@ -104,16 +101,16 @@ bool test_main(void) {
   // Load the plain text to trigger the encryption operation.
   while (!aes_input_ready(&aes)) {
   }
-  CHECK(dif_aes_load_data(&aes, in_data_plain) == kDifAesOk);
+  CHECK(dif_aes_load_data(&aes, in_data_plain) == kDifOk);
 
   // Read out the produced cipher text.
   dif_aes_data_t out_data_cipher;
   while (!aes_output_valid(&aes)) {
   }
-  CHECK(dif_aes_read_output(&aes, &out_data_cipher) == kDifAesOk);
+  CHECK(dif_aes_read_output(&aes, &out_data_cipher) == kDifOk);
 
   // Finish the ECB encryption transaction.
-  CHECK(dif_aes_end(&aes) == kDifAesOk);
+  CHECK(dif_aes_end(&aes) == kDifOk);
 
   // Check the produced cipher text against the reference.
   uint32_t cipher_text_gold_words[TEXT_LENGTH_IN_WORDS];
@@ -126,22 +123,22 @@ bool test_main(void) {
 
   // Setup ECB decryption transaction.
   transaction.mode = kDifAesModeDecrypt;
-  CHECK(dif_aes_start_ecb(&aes, &transaction, key) == kDifAesOk);
+  CHECK(dif_aes_start_ecb(&aes, &transaction, key) == kDifOk);
 
   // Load the previously produced cipher text to start the decryption operation.
   while (!aes_input_ready(&aes)) {
   }
-  CHECK(dif_aes_load_data(&aes, out_data_cipher) == kDifAesOk);
+  CHECK(dif_aes_load_data(&aes, out_data_cipher) == kDifOk);
 
   // Read out the produced plain text.
 
   dif_aes_data_t out_data_plain;
   while (!aes_output_valid(&aes)) {
   }
-  CHECK(dif_aes_read_output(&aes, &out_data_plain) == kDifAesOk);
+  CHECK(dif_aes_read_output(&aes, &out_data_plain) == kDifOk);
 
   // Finish the ECB encryption transaction.
-  CHECK(dif_aes_end(&aes) == kDifAesOk);
+  CHECK(dif_aes_end(&aes) == kDifOk);
 
   // Check the produced plain text against the reference.
   uint32_t plain_text_gold_words[TEXT_LENGTH_IN_WORDS];


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "aes".