### PR TITLE
[pwm, rtl] PWM register locking with REGWEN signal

### DIFF
--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -31,11 +31,10 @@
     }
   ],
   registers: [
-    { name: "REGEN",
+    { name: "REGWEN",
       desc: "Register write enable for all control registers",
-      swaccess: "rw1c",
-      hwaccess: "hro",
-      async: "clk_core_i",
+      swaccess: "rw0c",
+      hwaccess: "none",
       fields: [
         { bits: "0",
           desc: ''' When true, all writable registers can be modified.
@@ -52,6 +51,7 @@
       swaccess: "rw",
       async: "clk_core_i",
       hwqe: "true",
+      regwen: "REGWEN",
       fields: [
         { bits: "31",
           name: "CNTR_EN",
@@ -88,6 +88,7 @@
         compact: "1",
         async: "clk_core_i",
         hwqe: "true",
+        regwen: "REGWEN",
         fields: [
           { bits: "0",
             name: "EN",
@@ -106,6 +107,7 @@
         compact: "1",
         async: "clk_core_i",
         hwqe: "true",
+        regwen: "REGWEN",
         fields: [
           { bits: "0",
             name: "INVERT",
@@ -123,6 +125,7 @@
         cname: "pwm_params",
         async: "clk_core_i",
         hwqe: "true",
+        regwen: "REGWEN",
         fields: [
           { bits: "31",
             name: "BLINK_EN",
@@ -161,6 +164,7 @@
         cname: "duty_cycle",
         async: "clk_core_i",
         hwqe: "true",
+        regwen: "REGWEN",
         fields: [
           { bits: "31:16",
             name: "B",
@@ -192,6 +196,7 @@
         cname: "blink_param",
         async: "clk_core_i",
         hwqe: "true",
+        regwen: "REGWEN",
         fields: [
           { bits: "15:0",
             name: "X",

--- a/hw/ip/pwm/rtl/pwm.sv
+++ b/hw/ip/pwm/rtl/pwm.sv
@@ -27,12 +27,8 @@ module pwm
   output logic [NOutputs-1:0] cio_pwm_en_o
 );
 
-  // TODO: Deal with Regen in this block, on TLUL clock domain
-  logic                     unused_regen;
   pwm_reg_pkg::pwm_reg2hw_t reg2hw;
   logic [NumAlerts-1:0] alert_test, alerts;
-
-  assign unused_regen = reg2hw.regen.q;
 
   pwm_reg_top u_reg (
     .clk_i,

--- a/hw/ip/pwm/rtl/pwm_core.sv
+++ b/hw/ip/pwm/rtl/pwm_core.sv
@@ -62,11 +62,6 @@ module pwm_core #(
   logic                  phase_ctr_en;
   logic                  cycle_end;
 
-  logic                  unused_regen;
-
-  // TODO: implement register locking
-  assign unused_regen = reg2hw.regen.q;
-
   assign cntr_en = reg2hw.cfg.cntr_en.q;
   assign dc_resn = reg2hw.cfg.dc_resn.q;
   assign clk_div = reg2hw.cfg.clk_div.q;

--- a/hw/ip/pwm/rtl/pwm_reg_pkg.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_pkg.sv
@@ -23,10 +23,6 @@ package pwm_reg_pkg;
   } pwm_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    logic        q;
-  } pwm_reg2hw_regen_reg_t;
-
-  typedef struct packed {
     struct packed {
       logic [26:0] q;
       logic        qe;
@@ -90,8 +86,7 @@ package pwm_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    pwm_reg2hw_alert_test_reg_t alert_test; // [595:594]
-    pwm_reg2hw_regen_reg_t regen; // [593:593]
+    pwm_reg2hw_alert_test_reg_t alert_test; // [594:593]
     pwm_reg2hw_cfg_reg_t cfg; // [592:558]
     pwm_reg2hw_pwm_en_mreg_t [5:0] pwm_en; // [557:546]
     pwm_reg2hw_invert_mreg_t [5:0] invert; // [545:534]
@@ -102,7 +97,7 @@ package pwm_reg_pkg;
 
   // Register offsets
   parameter logic [BlockAw-1:0] PWM_ALERT_TEST_OFFSET = 7'h 0;
-  parameter logic [BlockAw-1:0] PWM_REGEN_OFFSET = 7'h 4;
+  parameter logic [BlockAw-1:0] PWM_REGWEN_OFFSET = 7'h 4;
   parameter logic [BlockAw-1:0] PWM_CFG_OFFSET = 7'h 8;
   parameter logic [BlockAw-1:0] PWM_PWM_EN_OFFSET = 7'h c;
   parameter logic [BlockAw-1:0] PWM_INVERT_OFFSET = 7'h 10;
@@ -132,7 +127,7 @@ package pwm_reg_pkg;
   // Register index
   typedef enum int {
     PWM_ALERT_TEST,
-    PWM_REGEN,
+    PWM_REGWEN,
     PWM_CFG,
     PWM_PWM_EN,
     PWM_INVERT,
@@ -159,7 +154,7 @@ package pwm_reg_pkg;
   // Register width information to check illegal writes
   parameter logic [3:0] PWM_PERMIT [23] = '{
     4'b 0001, // index[ 0] PWM_ALERT_TEST
-    4'b 0001, // index[ 1] PWM_REGEN
+    4'b 0001, // index[ 1] PWM_REGWEN
     4'b 1111, // index[ 2] PWM_CFG
     4'b 0001, // index[ 3] PWM_PWM_EN
     4'b 0001, // index[ 4] PWM_INVERT


### PR DESCRIPTION
  - Update the REGEN register name to REGWEN
  - Change the swaccess and hwaccess fields for REGWEN
  - Add a regwen field for each control registers
  - Remove the TODO comments

Signed-off-by: Muqing Liu <muqing.liu@wdc.com>