### PR TITLE
[dif/alert_handler] autogen alert_handler IRQ DIFs and integrate into src tree

### DIFF
--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
@@ -1,0 +1,191 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_alert_handler.h"
+
+#include "alert_handler_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool alert_handler_get_irq_bit_index(dif_alert_handler_irq_t irq,
+                                            bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifAlertHandlerIrqClassa:
+      *index_out = ALERT_HANDLER_INTR_STATE_CLASSA_BIT;
+      break;
+    case kDifAlertHandlerIrqClassb:
+      *index_out = ALERT_HANDLER_INTR_STATE_CLASSB_BIT;
+      break;
+    case kDifAlertHandlerIrqClassc:
+      *index_out = ALERT_HANDLER_INTR_STATE_CLASSC_BIT;
+      break;
+    case kDifAlertHandlerIrqClassd:
+      *index_out = ALERT_HANDLER_INTR_STATE_CLASSD_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_get_state(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_irq_state_snapshot_t *snapshot) {
+  if (alert_handler == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(alert_handler->base_addr,
+                                 ALERT_HANDLER_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_is_pending(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    bool *is_pending) {
+  if (alert_handler == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!alert_handler_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg = mmio_region_read32(
+      alert_handler->base_addr, ALERT_HANDLER_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_acknowledge(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq) {
+  if (alert_handler == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!alert_handler_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(alert_handler->base_addr,
+                      ALERT_HANDLER_INTR_STATE_REG_OFFSET, intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_get_enabled(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    dif_toggle_t *state) {
+  if (alert_handler == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!alert_handler_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      alert_handler->base_addr, ALERT_HANDLER_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_set_enabled(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    dif_toggle_t state) {
+  if (alert_handler == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!alert_handler_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      alert_handler->base_addr, ALERT_HANDLER_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(alert_handler->base_addr,
+                      ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_force(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq) {
+  if (alert_handler == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!alert_handler_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(alert_handler->base_addr,
+                      ALERT_HANDLER_INTR_TEST_REG_OFFSET, intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_disable_all(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_irq_enable_snapshot_t *snapshot) {
+  if (alert_handler == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(alert_handler->base_addr,
+                                   ALERT_HANDLER_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(alert_handler->base_addr,
+                      ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_restore_all(
+    const dif_alert_handler_t *alert_handler,
+    const dif_alert_handler_irq_enable_snapshot_t *snapshot) {
+  if (alert_handler == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(alert_handler->base_addr,
+                      ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
@@ -1,0 +1,187 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ALERT_HANDLER_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ALERT_HANDLER_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/alert_handler/doc/">ALERT_HANDLER</a> Device Interface
+ * Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to alert_handler.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_alert_handler {
+  /**
+   * The base address for the alert_handler hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_alert_handler_t;
+
+/**
+ * A alert_handler interrupt request type.
+ */
+typedef enum dif_alert_handler_irq {
+  /**
+   * Interrupt state bit of Class A. Set by HW in case an alert within this
+   * class triggered. Defaults true, write one to clear.
+   */
+  kDifAlertHandlerIrqClassa = 0,
+  /**
+   * Interrupt state bit of Class B. Set by HW in case an alert within this
+   * class triggered. Defaults true, write one to clear.
+   */
+  kDifAlertHandlerIrqClassb = 1,
+  /**
+   * Interrupt state bit of Class C. Set by HW in case an alert within this
+   * class triggered. Defaults true, write one to clear.
+   */
+  kDifAlertHandlerIrqClassc = 2,
+  /**
+   * Interrupt state bit of Class D. Set by HW in case an alert within this
+   * class triggered. Defaults true, write one to clear.
+   */
+  kDifAlertHandlerIrqClassd = 3,
+} dif_alert_handler_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_alert_handler_irq_get_state()` function.
+ */
+typedef uint32_t dif_alert_handler_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_alert_handler_irq_disable_all()` and
+ * `dif_alert_handler_irq_restore_all()` functions.
+ */
+typedef uint32_t dif_alert_handler_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_get_state(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_is_pending(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_acknowledge(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_get_enabled(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_set_enabled(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq,
+    dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_force(
+    const dif_alert_handler_t *alert_handler, dif_alert_handler_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_disable_all(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param alert_handler A alert_handler handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_irq_restore_all(
+    const dif_alert_handler_t *alert_handler,
+    const dif_alert_handler_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ALERT_HANDLER_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -1,0 +1,324 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_alert_handler.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "alert_handler_regs.h"  // Generated.
+
+namespace dif_alert_handler_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class AlertHandlerTest : public Test, public MmioTest {
+ protected:
+  dif_alert_handler_t alert_handler_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public AlertHandlerTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_alert_handler_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_alert_handler_irq_get_state(nullptr, &irq_snapshot),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_get_state(&alert_handler_, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_alert_handler_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_alert_handler_irq_get_state(&alert_handler_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_alert_handler_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ALERT_HANDLER_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_alert_handler_irq_get_state(&alert_handler_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public AlertHandlerTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_alert_handler_irq_is_pending(nullptr, kDifAlertHandlerIrqClassa,
+                                             &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_is_pending(
+                &alert_handler_, kDifAlertHandlerIrqClassa, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_is_pending(nullptr, kDifAlertHandlerIrqClassa,
+                                             nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_alert_handler_irq_is_pending(
+                &alert_handler_, (dif_alert_handler_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
+                {{ALERT_HANDLER_INTR_STATE_CLASSA_BIT, true}});
+  EXPECT_EQ(dif_alert_handler_irq_is_pending(
+                &alert_handler_, kDifAlertHandlerIrqClassa, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
+                {{ALERT_HANDLER_INTR_STATE_CLASSD_BIT, false}});
+  EXPECT_EQ(dif_alert_handler_irq_is_pending(
+                &alert_handler_, kDifAlertHandlerIrqClassd, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public AlertHandlerTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(
+      dif_alert_handler_irq_acknowledge(nullptr, kDifAlertHandlerIrqClassa),
+      kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(
+      dif_alert_handler_irq_acknowledge(nullptr, (dif_alert_handler_irq_t)32),
+      kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
+                 {{ALERT_HANDLER_INTR_STATE_CLASSA_BIT, true}});
+  EXPECT_EQ(dif_alert_handler_irq_acknowledge(&alert_handler_,
+                                              kDifAlertHandlerIrqClassa),
+            kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_STATE_REG_OFFSET,
+                 {{ALERT_HANDLER_INTR_STATE_CLASSD_BIT, true}});
+  EXPECT_EQ(dif_alert_handler_irq_acknowledge(&alert_handler_,
+                                              kDifAlertHandlerIrqClassd),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public AlertHandlerTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_alert_handler_irq_get_enabled(
+                nullptr, kDifAlertHandlerIrqClassa, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_get_enabled(
+                &alert_handler_, kDifAlertHandlerIrqClassa, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_get_enabled(
+                nullptr, kDifAlertHandlerIrqClassa, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_alert_handler_irq_get_enabled(
+                &alert_handler_, (dif_alert_handler_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
+                {{ALERT_HANDLER_INTR_ENABLE_CLASSA_BIT, true}});
+  EXPECT_EQ(dif_alert_handler_irq_get_enabled(
+                &alert_handler_, kDifAlertHandlerIrqClassa, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
+                {{ALERT_HANDLER_INTR_ENABLE_CLASSD_BIT, true}});
+  EXPECT_EQ(dif_alert_handler_irq_get_enabled(
+                &alert_handler_, kDifAlertHandlerIrqClassa, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public AlertHandlerTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_alert_handler_irq_set_enabled(
+                nullptr, kDifAlertHandlerIrqClassa, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_alert_handler_irq_set_enabled(
+                &alert_handler_, (dif_alert_handler_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
+                {{ALERT_HANDLER_INTR_ENABLE_CLASSA_BIT, 0x1, true}});
+  EXPECT_EQ(dif_alert_handler_irq_set_enabled(
+                &alert_handler_, kDifAlertHandlerIrqClassa, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
+                {{ALERT_HANDLER_INTR_ENABLE_CLASSD_BIT, 0x1, false}});
+  EXPECT_EQ(dif_alert_handler_irq_set_enabled(
+                &alert_handler_, kDifAlertHandlerIrqClassd, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public AlertHandlerTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_alert_handler_irq_force(nullptr, kDifAlertHandlerIrqClassa),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_alert_handler_irq_force(nullptr, (dif_alert_handler_irq_t)32),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_TEST_REG_OFFSET,
+                 {{ALERT_HANDLER_INTR_TEST_CLASSA_BIT, true}});
+  EXPECT_EQ(
+      dif_alert_handler_irq_force(&alert_handler_, kDifAlertHandlerIrqClassa),
+      kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_TEST_REG_OFFSET,
+                 {{ALERT_HANDLER_INTR_TEST_CLASSD_BIT, true}});
+  EXPECT_EQ(
+      dif_alert_handler_irq_force(&alert_handler_, kDifAlertHandlerIrqClassd),
+      kDifOk);
+}
+
+class IrqDisableAllTest : public AlertHandlerTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_alert_handler_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_alert_handler_irq_disable_all(nullptr, &irq_snapshot),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_alert_handler_irq_disable_all(&alert_handler_, nullptr),
+            kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_alert_handler_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_alert_handler_irq_disable_all(&alert_handler_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_alert_handler_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_alert_handler_irq_disable_all(&alert_handler_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public AlertHandlerTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_alert_handler_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_alert_handler_irq_restore_all(nullptr, &irq_snapshot),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_restore_all(&alert_handler_, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_alert_handler_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_alert_handler_irq_restore_all(&alert_handler_, &irq_snapshot),
+            kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_alert_handler_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_alert_handler_irq_restore_all(&alert_handler_, &irq_snapshot),
+            kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_alert_handler_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -16,6 +16,20 @@ sw_lib_dif_autogen_aes = declare_dependency(
   )
 )
 
+# Autogen Alert Handler DIF library
+sw_lib_dif_autogen_alert_handler = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_alert_handler',
+    sources: [
+      hw_ip_alert_handler_reg_h,
+      'dif_alert_handler_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen HMAC DIF library
 sw_lib_dif_autogen_hmac = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -438,6 +438,7 @@ sw_lib_dif_alert_handler = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_alert_handler,
     ],
   )
 )
@@ -446,7 +447,9 @@ test('dif_alert_handler_unittest', executable(
     'dif_alert_handler_unittest',
     sources: [
       'dif_alert_handler_unittest.cc',
+      'autogen/dif_alert_handler_autogen_unittest.cc',
       meson.source_root() / 'sw/device/lib/dif/dif_alert_handler.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_alert_handler_autogen.c',
       hw_ip_alert_handler_reg_h,
     ],
     dependencies: [


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "alert_handler".