### PR TITLE
[sw/silicon_creator] Configure alerts by default in shutdown_init

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -43,6 +43,7 @@ enum module_ {
   kModuleBootstrap =    MODULE_CODE('B', 'S'),
   kModuleLog =          MODULE_CODE('L', 'G'),
   kModuleBootData =     MODULE_CODE('B', 'D'),
+  kModuleShutdown =     MODULE_CODE('S', 'D'),
   // clang-format on
 };
 
@@ -119,6 +120,7 @@ enum module_ {
   X(kErrorLogBadFormatSpecifier,      ERROR_(1, kModuleLog, kInternal)), \
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
   X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \
+  X(kErrorShutdownBadLcState,         ERROR_(1, kModuleShutdown, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -70,6 +70,17 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
   // Are we in a lifecycle state which needs alert configuration?
   uint32_t lc_shift;
   switch (lc_state) {
+    case kLcStateTestUnlocked0:
+    case kLcStateTestUnlocked1:
+    case kLcStateTestUnlocked2:
+    case kLcStateTestUnlocked3:
+    case kLcStateTestUnlocked4:
+    case kLcStateTestUnlocked5:
+    case kLcStateTestUnlocked6:
+    case kLcStateTestUnlocked7:
+      // Don't configure alerts during manufacturing as OTP may not have been
+      // programmed yet.
+      return kErrorOk;
     case kLcStateProd:
       lc_shift = 0;
       break;
@@ -83,8 +94,11 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       lc_shift = 24;
       break;
     default:
-      // No alert init for any other lifecycle states.
-      return kErrorOk;
+      // Invalid lifecycle state.
+      shutdown_finalize(kErrorShutdownBadLcState);
+
+      // Reachable if using a mock implementation of `shutdown_finalize`.
+      return kErrorShutdownBadLcState;
   }
 
   // Get the enable and escalation settings for all four alert classes.
@@ -216,7 +230,6 @@ shutdown_redact_policy_inline(void) {
                       LC_CTRL_LC_STATE_REG_OFFSET),
       LC_CTRL_LC_STATE_STATE_FIELD);
   switch (lc_state) {
-    case kLcStateRaw:
     case kLcStateTestUnlocked0:
     case kLcStateTestUnlocked1:
     case kLcStateTestUnlocked2:

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -15,6 +15,22 @@ extern "C" {
 #endif
 
 /**
+ * Evaluate an expression and call `shutdown_finalize` if the result is an
+ * error.
+ *
+ * The error will be passed as an argument to `shutdown_finalize`.
+ *
+ * @param expr_ An expression which results in an rom_error_t.
+ */
+#define SHUTDOWN_IF_ERROR(expr_) \
+  do {                           \
+    rom_error_t error = (expr_); \
+    if (error != kErrorOk) {     \
+      shutdown_finalize(error);  \
+    }                            \
+  } while (false)
+
+/**
  * Initializes the Mask ROM shutdown infrastructure.
  *
  * Reads the shutdown policy from OTP, and initializes the alert handler.

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -609,5 +609,12 @@ TEST_F(ShutdownTest, FlashKill) {
   unmocked_shutdown_flash_kill();
 }
 
+TEST_F(ShutdownTest, ShutdownIfErrorOk) { SHUTDOWN_IF_ERROR(kErrorOk); }
+
+TEST_F(ShutdownTest, ShutdownIfErrorUnknown) {
+  ExpectFinalize(kErrorUnknown);
+  SHUTDOWN_IF_ERROR(kErrorUnknown);
+}
+
 }  // namespace
 }  // namespace shutdown_unittest

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -345,6 +345,18 @@ class ShutdownTest : public mask_rom_test::MaskRomTest {
         }));
   }
 
+  // Expect a call to `shutdown_finalize`.
+  void ExpectFinalize(rom_error_t error) {
+    // In the RV32 environment, finalize should never return.
+    // In the X86_64 unittest environment, verify that all of the various
+    // kill functions were called.
+    EXPECT_CALL(shutdown_, shutdown_report_error(error));
+    EXPECT_CALL(shutdown_, shutdown_software_escalate());
+    EXPECT_CALL(shutdown_, shutdown_keymgr_kill());
+    EXPECT_CALL(shutdown_, shutdown_flash_kill());
+    EXPECT_CALL(shutdown_, shutdown_hang());
+  }
+
   OtpConfiguration otp_config_ = kOtpConfig;
   // Use NiceMock because we aren't interested in the specifics of OTP reads,
   // but we want to mock out calls to otp_read32.
@@ -491,12 +503,10 @@ TEST_F(ShutdownTest, InitializeRma) {
 TEST_F(ShutdownTest, RedactPolicyManufacturing) {
   // Devices in manufacturing or RMA states should not redact errors regardless
   // of the redaction level set by OTP.
-  constexpr auto kManufacturingStates = std::array<lifecycle_state_t, 10>{
-      kLcStateRaw,           kLcStateTestUnlocked0,
-      kLcStateTestUnlocked1, kLcStateTestUnlocked2,
-      kLcStateTestUnlocked3, kLcStateTestUnlocked4,
-      kLcStateTestUnlocked5, kLcStateTestUnlocked6,
-      kLcStateTestUnlocked7, kLcStateRma};
+  constexpr auto kManufacturingStates = std::array<lifecycle_state_t, 9>{
+      kLcStateTestUnlocked0, kLcStateTestUnlocked1, kLcStateTestUnlocked2,
+      kLcStateTestUnlocked3, kLcStateTestUnlocked4, kLcStateTestUnlocked5,
+      kLcStateTestUnlocked6, kLcStateTestUnlocked7, kLcStateRma};
   for (const auto state : kManufacturingStates) {
     EXPECT_ABS_READ32(
         TOP_EARLGREY_LC_CTRL_BASE_ADDR + LC_CTRL_LC_STATE_REG_OFFSET,
@@ -537,6 +547,40 @@ TEST_F(ShutdownTest, RedactPolicyInvalid) {
   }
 }
 
+TEST_F(ShutdownTest, InitializeManufacturing) {
+  // OTP reads and alert setup should be skipped in the RAW and TEST_UNLOCKED
+  // lifecycle states.
+  constexpr std::array<lifecycle_state_t, 8> kManufacturingStates = {
+      kLcStateTestUnlocked0, kLcStateTestUnlocked1, kLcStateTestUnlocked2,
+      kLcStateTestUnlocked3, kLcStateTestUnlocked4, kLcStateTestUnlocked5,
+      kLcStateTestUnlocked6, kLcStateTestUnlocked7,
+  };
+  for (auto state : kManufacturingStates) {
+    EXPECT_EQ(shutdown_init(state), kErrorOk);
+  }
+}
+
+TEST_F(ShutdownTest, InitializeInvalid) {
+  // Invalid states (such as the INVALID lifecycle state itself) should be
+  // treated as PROD.
+  constexpr std::array<lifecycle_state_t, 12> kInvalidStates = {
+      kLcStateRaw,         kLcStateTestLocked0,
+      kLcStateTestLocked1, kLcStateTestLocked2,
+      kLcStateTestLocked3, kLcStateTestLocked4,
+      kLcStateTestLocked5, kLcStateTestLocked6,
+      kLcStateScrap,       kLcStatePostTransition,
+      kLcStateEscalate,    kLcStateInvalid,
+  };
+  for (auto state : kInvalidStates) {
+    SetupOtpReads();
+    ExpectFinalize(kErrorShutdownBadLcState);
+
+    // Note: the unmocked implementation of `shutdown_finalize` will never
+    // return and therefore `shutdown_init` will not return.
+    EXPECT_EQ(shutdown_init(state), kErrorShutdownBadLcState);
+  }
+}
+
 TEST(ShutdownModule, RedactErrors) {
   EXPECT_EQ(shutdown_redact(kErrorOk, kShutdownErrorRedactNone), 0);
   EXPECT_EQ(shutdown_redact(kErrorOk, kShutdownErrorRedactError), 0);
@@ -555,15 +599,7 @@ TEST(ShutdownModule, RedactErrors) {
 
 TEST_F(ShutdownTest, ShutdownFinalize) {
   SetupOtpReads();
-  EXPECT_CALL(shutdown_, shutdown_report_error(kErrorUnknown));
-  EXPECT_CALL(shutdown_, shutdown_software_escalate());
-  EXPECT_CALL(shutdown_, shutdown_keymgr_kill());
-  EXPECT_CALL(shutdown_, shutdown_flash_kill());
-  EXPECT_CALL(shutdown_, shutdown_hang());
-
-  // In the RV32 environment, finalize should never return.
-  // In the X86_64 unittest environment, verify that all of the various
-  // kill functions were called.
+  ExpectFinalize(kErrorUnknown);
   shutdown_finalize(kErrorUnknown);
 }
 


### PR DESCRIPTION
If the device is in an unrecognized/unhandled lifecycle state then
configure the alert handler as if the device were in PROD rather
than skipping alert configuration.

Only skip alert configuration during manufacture.

Updates #7148.