### PR TITLE
[util] Fix `make_new_dif.py` runtime failure for no IRQ IP

### DIFF
--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -107,8 +107,9 @@ class Ip:
         assert (self.hjson_data and
                 "ERROR: must load IP HJSON before loarding IRQs")
         irqs = []
-        for irq in self.hjson_data["interrupt_list"]:
-            irqs.append(Irq(irq))
+        if "interrupt_list" in self.hjson_data:
+            for irq in self.hjson_data["interrupt_list"]:
+                irqs.append(Irq(irq))
         return irqs
 
 
@@ -157,7 +158,7 @@ def main():
         print("DIF header successfully written to {}.".format(
             str(header_out_file)))
 
-    if "autogen" in args.only:
+    if "autogen" in args.only and len(ip.irqs):
         # Render all templates
         for filetype in ["inc", "c", "unittest"]:
             assert (ip.irqs and "ERROR: this IP generates no interrupts.")


### PR DESCRIPTION
When an IP doesn't have interrupts, the script fails trying to access
a dictionary key that is not present. Example:
```
util/make_new_dif.py --ip sram_ctrl --peripheral "SRAM Controller"
Traceback (most recent call last):
  File "/home/svt/development/repos/opentitan/util/make_new_dif.py", line 218, in <module>
    main()
  File "/home/svt/development/repos/opentitan/util/make_new_dif.py", line 136, in main
    ip = Ip(args.ip, args.peripheral)
  File "/home/svt/development/repos/opentitan/util/make_new_dif.py", line 104, in __init__
    self.irqs = self._load_irqs()
  File "/home/svt/development/repos/opentitan/util/make_new_dif.py", line 110, in _load_irqs
    for irq in self.hjson_data["interrupt_list"]:
KeyError: 'interrupt_list'
```

It doesn't even reach the later assert:
`assert (ip.irqs and "ERROR: this IP generates no interrupts.")`

But it probably should only hit assert as the result of a genuine bug,
and not when a valid module without IRQs is requested.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>