### PR TITLE
[top] typo fix in chip_earlgrey_asic core file

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -77,7 +77,7 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
-      - AST_CLK_BYPASS=true
+      - AST_BYPASS_CLK=true
     toplevel: chip_earlgrey_asic
 
   formal:


### PR DESCRIPTION
Signed-off-by: Arnon Sharlin <arnon.sharlin@opentitan.org>
Seems like a typo that broke the foundry release script