### PR TITLE
[otbn,util] Fix run-some.py when destdir doesn't lie in project

### DIFF
--- a/hw/ip/otbn/dv/verilator/run-some.py
+++ b/hw/ip/otbn/dv/verilator/run-some.py
@@ -107,8 +107,9 @@ def write_ninja(handle: TextIO,
         basenames.append(str(seed + off))
 
     # Rules to run them
-    handle.write('rule run\n'
-                 '  command = $tb --load-elf $in >$out\n\n')
+    handle.write(f'rule run\n'
+                 f'  command = REPO_TOP={projdir_from_destdir} '
+                 f'$tb --load-elf $in >$out\n\n')
     for name in basenames:
         handle.write(f'build {name}.out: run {name}.elf | $tb\n')
     handle.write('\n')


### PR DESCRIPTION
The "run the testbench" command runs inside destdir. It needs to know
where to find the ISS, which it would normally do by searching up for
a `.git` from the current directory. Setting the `REPO_TOP` environment
variable overrides this behaviour and tells it where to look.
