### PR TITLE
[flash_ctrl] Flash hardening shadow reg

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -595,13 +595,14 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "MP_REGION_CFG",
+          name: "MP_REGION_CFG_SHADOWED",
           desc: "Memory property configuration for data partition",
           count: "NumRegions",
           swaccess: "rw",
           hwaccess: "hro",
           regwen: "REGION_CFG_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -671,10 +672,11 @@
       },
 
       // Default region properties for data partition
-      { name: "DEFAULT_REGION",
+      { name: "DEFAULT_REGION_SHADOWED",
         desc: "Default region properties",
         swaccess: "rw",
         hwaccess: "hro",
+        shadowed: "true",
         resval: "0",
         fields: [
           { bits: "0",
@@ -757,7 +759,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK0_INFO0_PAGE_CFG",
+          name: "BANK0_INFO0_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank0,
                   Unlike data partition, each page is individually configured.
@@ -767,6 +769,7 @@
           hwaccess: "hro",
           regwen: "BANK0_INFO0_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -854,7 +857,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK0_INFO1_PAGE_CFG",
+          name: "BANK0_INFO1_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank0,
                   Unlike data partition, each page is individually configured.
@@ -864,6 +867,7 @@
           hwaccess: "hro",
           regwen: "BANK0_INFO1_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -951,7 +955,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK0_INFO2_PAGE_CFG",
+          name: "BANK0_INFO2_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank0,
                   Unlike data partition, each page is individually configured.
@@ -961,6 +965,7 @@
           hwaccess: "hro",
           regwen: "BANK0_INFO2_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1048,7 +1053,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK1_INFO0_PAGE_CFG",
+          name: "BANK1_INFO0_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank1,
                   Unlike data partition, each page is individually configured.
@@ -1058,6 +1063,7 @@
           hwaccess: "hro",
           regwen: "BANK1_INFO0_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1145,7 +1151,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK1_INFO1_PAGE_CFG",
+          name: "BANK1_INFO1_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank1,
                   Unlike data partition, each page is individually configured.
@@ -1155,6 +1161,7 @@
           hwaccess: "hro",
           regwen: "BANK1_INFO1_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1242,7 +1249,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK1_INFO2_PAGE_CFG",
+          name: "BANK1_INFO2_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank1,
                   Unlike data partition, each page is individually configured.
@@ -1252,6 +1259,7 @@
           hwaccess: "hro",
           regwen: "BANK1_INFO2_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1335,12 +1343,13 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "MP_BANK_CFG",
+          name: "MP_BANK_CFG_SHADOWED",
           desc: "Memory properties bank configuration",
           count: "RegNumBanks",
           swaccess: "rw",
           hwaccess: "hro",
-          regwen: "BANK_CFG_REGWEN"
+          regwen: "BANK_CFG_REGWEN",
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "ERASE_EN",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -603,6 +603,8 @@
           regwen: "REGION_CFG_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -677,6 +679,8 @@
         swaccess: "rw",
         hwaccess: "hro",
         shadowed: "true",
+        update_err_alert: "recov_err",
+        storage_err_alert: "fatal_err",
         resval: "0",
         fields: [
           { bits: "0",
@@ -770,6 +774,8 @@
           regwen: "BANK0_INFO0_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -868,6 +874,8 @@
           regwen: "BANK0_INFO1_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -966,6 +974,8 @@
           regwen: "BANK0_INFO2_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1064,6 +1074,8 @@
           regwen: "BANK1_INFO0_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1162,6 +1174,8 @@
           regwen: "BANK1_INFO1_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1260,6 +1274,8 @@
           regwen: "BANK1_INFO2_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1350,6 +1366,8 @@
           hwaccess: "hro",
           regwen: "BANK_CFG_REGWEN",
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "ERASE_EN",
@@ -1446,6 +1464,12 @@
               This is a synchronous error.
             '''
           },
+          { bits: "6",
+            name: "update_err",
+            desc: '''
+              A shadow register encountered an update error.
+            '''
+          },
         ]
       },
 
@@ -1514,7 +1538,13 @@
               The life cycle management interface has encountered a fatal error.
               There is an error with the RMA state machine or counts.
               '''
-          }
+          },
+          { bits: "9",
+            name: "storage_err",
+            desc: '''
+              A shadow register encountered a storage fault.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -600,6 +600,8 @@
           regwen: "REGION_CFG_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -674,6 +676,8 @@
         swaccess: "rw",
         hwaccess: "hro",
         shadowed: "true",
+        update_err_alert: "recov_err",
+        storage_err_alert: "fatal_err",
         resval: "0",
         fields: [
           { bits: "0",
@@ -769,6 +773,8 @@
           regwen: "BANK${bank}_INFO${idx}_REGWEN",
           regwen_multi: true,
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -861,6 +867,8 @@
           hwaccess: "hro",
           regwen: "BANK_CFG_REGWEN",
           shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "ERASE_EN",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -592,13 +592,14 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "MP_REGION_CFG",
+          name: "MP_REGION_CFG_SHADOWED",
           desc: "Memory property configuration for data partition",
           count: "NumRegions",
           swaccess: "rw",
           hwaccess: "hro",
           regwen: "REGION_CFG_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -668,10 +669,11 @@
       },
 
       // Default region properties for data partition
-      { name: "DEFAULT_REGION",
+      { name: "DEFAULT_REGION_SHADOWED",
         desc: "Default region properties",
         swaccess: "rw",
         hwaccess: "hro",
+        shadowed: "true",
         resval: "0",
         fields: [
           { bits: "0",
@@ -756,7 +758,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK${bank}_INFO${idx}_PAGE_CFG",
+          name: "BANK${bank}_INFO${idx}_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank${bank},
                   Unlike data partition, each page is individually configured.
@@ -766,6 +768,7 @@
           hwaccess: "hro",
           regwen: "BANK${bank}_INFO${idx}_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -851,12 +854,13 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "MP_BANK_CFG",
+          name: "MP_BANK_CFG_SHADOWED",
           desc: "Memory properties bank configuration",
           count: "RegNumBanks",
           swaccess: "rw",
           hwaccess: "hro",
-          regwen: "BANK_CFG_REGWEN"
+          regwen: "BANK_CFG_REGWEN",
+          shadowed: "true",
           fields: [
               { bits: "0",
                 name: "ERASE_EN",
@@ -953,6 +957,12 @@
               This is a synchronous error.
             '''
           },
+          { bits: "6",
+            name: "update_err",
+            desc: '''
+              A shadow register encountered an update error.
+            '''
+          },
         ]
       },
 
@@ -1021,7 +1031,13 @@
               The life cycle management interface has encountered a fatal error.
               There is an error with the RMA state machine or counts.
               '''
-          }
+          },
+          { bits: "9",
+            name: "storage_err",
+            desc: '''
+              A shadow register encountered a storage fault.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -20,6 +20,7 @@ module flash_ctrl
 ) (
   input        clk_i,
   input        rst_ni,
+  input        rst_shadowed_ni,
 
   input        clk_otp_i,
   input        rst_otp_ni,
@@ -91,9 +92,13 @@ module flash_ctrl
 
   // Register module
   logic intg_err;
+  logic update_err;
+  logic storage_err;
+
   flash_ctrl_core_reg_top u_reg_core (
     .clk_i,
     .rst_ni,
+    .rst_shadowed_ni,
 
     .tl_i(core_tl_i),
     .tl_o(core_tl_o),
@@ -107,6 +112,11 @@ module flash_ctrl
     .intg_err_o (intg_err),
     .devmode_i  (1'b1)
   );
+
+  bank_cfg_t [NumBanks-1:0] bank_cfg;
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_cfg
+    assign bank_cfg[i].q = reg2hw.mp_bank_cfg_shadowed[i].q;
+  end
 
   // FIFO Connections
   logic                 prog_fifo_wvalid;
@@ -680,33 +690,60 @@ module flash_ctrl
   //////////////////////////////////////
   // extra region is the default region
   mp_region_cfg_t [MpRegions:0] region_cfgs;
-  assign region_cfgs[MpRegions-1:0] = reg2hw.mp_region_cfg[MpRegions-1:0];
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_mp_regions
+    assign region_cfgs[i].base.q        = reg2hw.mp_region_cfg_shadowed[i].base.q;
+    assign region_cfgs[i].size.q        = reg2hw.mp_region_cfg_shadowed[i].size.q;
+    assign region_cfgs[i].en.q          = reg2hw.mp_region_cfg_shadowed[i].en.q;
+    assign region_cfgs[i].rd_en.q       = reg2hw.mp_region_cfg_shadowed[i].rd_en.q;
+    assign region_cfgs[i].prog_en.q     = reg2hw.mp_region_cfg_shadowed[i].prog_en.q;
+    assign region_cfgs[i].erase_en.q    = reg2hw.mp_region_cfg_shadowed[i].erase_en.q;
+    assign region_cfgs[i].scramble_en.q = reg2hw.mp_region_cfg_shadowed[i].scramble_en.q;
+    assign region_cfgs[i].ecc_en.q      = reg2hw.mp_region_cfg_shadowed[i].ecc_en.q;
+    assign region_cfgs[i].he_en.q       = reg2hw.mp_region_cfg_shadowed[i].he_en.q;
+  end
 
   //default region
   assign region_cfgs[MpRegions].base.q = '0;
   assign region_cfgs[MpRegions].size.q = NumBanks * PagesPerBank;
   assign region_cfgs[MpRegions].en.q = 1'b1;
-  assign region_cfgs[MpRegions].rd_en.q = reg2hw.default_region.rd_en.q;
-  assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region.prog_en.q;
-  assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
-  assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region.scramble_en.q;
-  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region.ecc_en.q;
-  assign region_cfgs[MpRegions].he_en.q = reg2hw.default_region.he_en.q;
+  assign region_cfgs[MpRegions].rd_en.q = reg2hw.default_region_shadowed.rd_en.q;
+  assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region_shadowed.prog_en.q;
+  assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region_shadowed.erase_en.q;
+  assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region_shadowed.scramble_en.q;
+  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region_shadowed.ecc_en.q;
+  assign region_cfgs[MpRegions].he_en.q = reg2hw.default_region_shadowed.he_en.q;
 
   //////////////////////////////////////
   // Info partition properties configuration
   //////////////////////////////////////
-  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] reg2hw_info_page_cfgs;
+  typedef flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t reg2hw_info_page_cft_t;
+  reg2hw_info_page_cft_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] sw_info_cfgs;
+  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_cfgs;
   info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs;
-  localparam int InfoBits = $bits(info_page_cfg_t) * InfosPerBank;
+  localparam int InfoBits = $bits(reg2hw_info_page_cft_t) * InfosPerBank;
 
   // transform from reg output to structure
   // Not all types have the maximum number of banks, so those are packed to 0
   % for bank in range(cfg.banks):
   %   for idx in range(cfg.info_types):
-  assign reg2hw_info_page_cfgs[${bank}][${idx}] = InfoBits'(reg2hw.bank${bank}_info${idx}_page_cfg);
+  assign sw_info_cfgs[${bank}][${idx}] = InfoBits'(reg2hw.bank${bank}_info${idx}_page_cfg_shadowed);
   %   endfor
   % endfor
+
+  // strip error indications
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_cfg_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_cfg_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_cfg_page
+        assign info_cfgs[i][j][k].en.q = sw_info_cfgs[i][j][k].en.q;
+        assign info_cfgs[i][j][k].rd_en.q = sw_info_cfgs[i][j][k].rd_en.q;
+        assign info_cfgs[i][j][k].prog_en.q = sw_info_cfgs[i][j][k].prog_en.q;
+        assign info_cfgs[i][j][k].erase_en.q = sw_info_cfgs[i][j][k].erase_en.q;
+        assign info_cfgs[i][j][k].scramble_en.q = sw_info_cfgs[i][j][k].scramble_en.q;
+        assign info_cfgs[i][j][k].ecc_en.q = sw_info_cfgs[i][j][k].ecc_en.q;
+        assign info_cfgs[i][j][k].he_en.q = sw_info_cfgs[i][j][k].he_en.q;
+      end
+    end
+  end
 
   // qualify reg2hw settings with creator / owner privileges
   for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
@@ -715,7 +752,7 @@ module flash_ctrl
         .Bank(i),
         .InfoSel(j)
       ) u_info_cfg (
-        .cfgs_i(reg2hw_info_page_cfgs[i][j]),
+        .cfgs_i(info_cfgs[i][j]),
         .creator_seed_priv_i(creator_seed_priv),
         .owner_seed_priv_i(owner_seed_priv),
         .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
@@ -749,7 +786,7 @@ module flash_ctrl
 
     // sw configuration for data partition
     .region_cfgs_i(region_cfgs),
-    .bank_cfgs_i(reg2hw.mp_bank_cfg),
+    .bank_cfgs_i(bank_cfg),
 
     // sw configuration for info partition
     .info_page_cfgs_i(info_page_cfgs),
@@ -866,13 +903,14 @@ module flash_ctrl
   // Alert senders
   //////////////////////////////////////
 
+
   logic [NumAlerts-1:0] alert_srcs;
   logic [NumAlerts-1:0] alert_tests;
 
-  // TODO Add shadow update
   // An excessive number of recoverable errors may also indicate an attack
   logic recov_err;
-  assign recov_err = sw_ctrl_done & |sw_ctrl_err;
+  assign recov_err = (sw_ctrl_done & |sw_ctrl_err) |
+                     update_err;
 
   logic fatal_err;
   assign fatal_err = |reg2hw.fault_status;
@@ -925,6 +963,85 @@ module flash_ctrl
   // Errors and Interrupts
   //////////////////////////////////////
 
+  // shadow errors and faults
+  logic [NumBanks-1:0] bank_update_err, bank_store_err;
+  logic [MpRegions-1:0] data_update_err, data_store_err;
+  logic default_update_err, default_store_err;
+  logic [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_update_err, info_store_err;
+
+  assign update_err = |data_update_err |
+                      |default_update_err |
+                      |info_update_err |
+                      |bank_update_err;
+
+  assign storage_err = |data_store_err |
+                       |default_store_err |
+                       |info_store_err |
+                       |bank_store_err;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_err
+    assign bank_update_err[i] = reg2hw.mp_bank_cfg_shadowed[i].err_update;
+    assign bank_store_err[i] = reg2hw.mp_bank_cfg_shadowed[i].err_storage;
+  end
+
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_data_err
+    assign data_update_err[i] = reg2hw.mp_region_cfg_shadowed[i].base.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].size.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].en.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].rd_en.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].prog_en.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].erase_en.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].scramble_en.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].ecc_en.err_update |
+                                reg2hw.mp_region_cfg_shadowed[i].he_en.err_update;
+
+    assign data_store_err[i] = reg2hw.mp_region_cfg_shadowed[i].base.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].size.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].en.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].rd_en.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].prog_en.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].erase_en.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].scramble_en.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].ecc_en.err_storage |
+                               reg2hw.mp_region_cfg_shadowed[i].he_en.err_storage;
+  end
+
+  assign default_update_err =  reg2hw.default_region_shadowed.rd_en.err_update |
+                               reg2hw.default_region_shadowed.prog_en.err_update |
+                               reg2hw.default_region_shadowed.erase_en.err_update |
+                               reg2hw.default_region_shadowed.scramble_en.err_update |
+                               reg2hw.default_region_shadowed.ecc_en.err_update |
+                               reg2hw.default_region_shadowed.he_en.err_update;
+
+  assign default_store_err =  reg2hw.default_region_shadowed.rd_en.err_storage |
+                              reg2hw.default_region_shadowed.prog_en.err_storage |
+                              reg2hw.default_region_shadowed.erase_en.err_storage |
+                              reg2hw.default_region_shadowed.scramble_en.err_storage |
+                              reg2hw.default_region_shadowed.ecc_en.err_storage |
+                              reg2hw.default_region_shadowed.he_en.err_storage;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_err_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_err_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_err_page
+        assign info_update_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_update |
+                                          sw_info_cfgs[i][j][k].rd_en.err_update |
+                                          sw_info_cfgs[i][j][k].prog_en.err_update |
+                                          sw_info_cfgs[i][j][k].erase_en.err_update |
+                                          sw_info_cfgs[i][j][k].scramble_en.err_update |
+                                          sw_info_cfgs[i][j][k].ecc_en.err_update |
+                                          sw_info_cfgs[i][j][k].he_en.err_update;
+
+        assign info_store_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_storage |
+                                         sw_info_cfgs[i][j][k].rd_en.err_storage |
+                                         sw_info_cfgs[i][j][k].prog_en.err_storage |
+                                         sw_info_cfgs[i][j][k].erase_en.err_storage |
+                                         sw_info_cfgs[i][j][k].scramble_en.err_storage |
+                                         sw_info_cfgs[i][j][k].ecc_en.err_storage |
+                                         sw_info_cfgs[i][j][k].he_en.err_storage;
+      end
+    end
+  end
+
   // all software interface errors are treated as synchronous errors
   assign hw2reg.err_code.oob_err.d        = 1'b1;
   assign hw2reg.err_code.mp_err.d         = 1'b1;
@@ -932,12 +1049,14 @@ module flash_ctrl
   assign hw2reg.err_code.prog_win_err.d   = 1'b1;
   assign hw2reg.err_code.prog_type_err.d  = 1'b1;
   assign hw2reg.err_code.flash_phy_err.d  = 1'b1;
+  assign hw2reg.err_code.update_err.d     = 1'b1;
   assign hw2reg.err_code.oob_err.de       = sw_ctrl_err.oob_err;
   assign hw2reg.err_code.mp_err.de        = sw_ctrl_err.mp_err;
   assign hw2reg.err_code.rd_err.de        = sw_ctrl_err.rd_err;
   assign hw2reg.err_code.prog_win_err.de  = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de = sw_ctrl_err.prog_type_err;
   assign hw2reg.err_code.flash_phy_err.de = sw_ctrl_err.phy_err;
+  assign hw2reg.err_code.update_err.de    = update_err;
   assign hw2reg.err_addr.d                = {reg2hw.addr.q[31:BusAddrW],ctrl_err_addr};
   assign hw2reg.err_addr.de               = sw_ctrl_err.mp_err |
                                             sw_ctrl_err.rd_err |
@@ -953,6 +1072,7 @@ module flash_ctrl
   assign hw2reg.fault_status.reg_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.phy_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.lcmgr_err.d      = 1'b1;
+  assign hw2reg.fault_status.storage_err.d    = 1'b1;
   assign hw2reg.fault_status.oob_err.de       = hw_err.oob_err;
   assign hw2reg.fault_status.mp_err.de        = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de        = hw_err.rd_err;
@@ -962,6 +1082,7 @@ module flash_ctrl
   assign hw2reg.fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.fault_status.lcmgr_err.de     = lcmgr_err;
+  assign hw2reg.fault_status.storage_err.de   = storage_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -114,8 +114,65 @@ package flash_ctrl_pkg;
   } flash_lcmgr_phase_e;
 
   // alias for super long reg_pkg typedef
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t info_page_cfg_t;
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_mreg_t mp_region_cfg_t;
+  typedef struct packed {
+    logic        q;
+  } bank_cfg_t;
+
+  // This is identical to the reg structures but do not have err_updates / storage
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
+      logic        q;
+    } he_en;
+  } info_page_cfg_t;
+
+  // This is identical to the reg structures but do not have err_updates / storage
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
+      logic        q;
+    } he_en;
+    struct packed {
+      logic [8:0]  q;
+    } base;
+    struct packed {
+      logic [9:0] q;
+    } size;
+  } mp_region_cfg_t;
 
   // memory protection specific structs
   typedef struct packed {

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -113,6 +113,16 @@ package flash_ctrl_pkg;
     PhaseInvalid
   } flash_lcmgr_phase_e;
 
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_default_region_shadowed_reg_t;
+
+  typedef flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t sw_bank_cfg_t;
+  typedef flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t sw_region_cfg_t;
+  typedef flash_ctrl_reg2hw_default_region_shadowed_reg_t sw_default_cfg_t;
+  typedef flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t sw_info_cfg_t;
+
   // alias for super long reg_pkg typedef
   typedef struct packed {
     logic        q;

--- a/hw/ip/flash_ctrl/data/flash_ctrl_region_cfg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_region_cfg.sv.tpl
@@ -1,0 +1,252 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash control region configuration processing
+//
+// There are two main purpose of this module:
+// 1. strip the error conditions away from reg packages (see #8282)
+// 2. generate shadow update and storage errors
+
+module flash_ctrl_region_cfg
+  import flash_ctrl_pkg::*;
+  import flash_ctrl_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+  input lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en_i,
+  input sw_bank_cfg_t [NumBanks-1:0] bank_cfg_i,
+  input sw_region_cfg_t [MpRegions-1:0] region_cfg_i,
+  input sw_default_cfg_t default_cfg_i,
+% for bank in range(cfg.banks):
+  % for idx in range(cfg.info_types):
+  input sw_info_cfg_t [NumInfos${idx}-1:0] bank${bank}_info${idx}_cfg_i,
+  % endfor
+% endfor
+
+  output bank_cfg_t [NumBanks-1:0] bank_cfg_o,
+  output mp_region_cfg_t [MpRegions:0] region_cfgs_o,
+  output info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs_o,
+
+  output logic update_err_o,
+  output logic storage_err_o
+);
+
+  //////////////////////////////////////
+  // Life cycle synchronizer
+  //////////////////////////////////////
+
+  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
+
+  // synchronize enables into local domain
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_creator_seed_sw_rw_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_creator_seed_sw_rw_en_i),
+    .lc_en_o(lc_creator_seed_sw_rw_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_owner_seed_sw_rw_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_owner_seed_sw_rw_en_i),
+    .lc_en_o(lc_owner_seed_sw_rw_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_iso_part_sw_rd_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_iso_part_sw_rd_en_i),
+    .lc_en_o(lc_iso_part_sw_rd_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_iso_part_sw_wr_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_iso_part_sw_wr_en_i),
+    .lc_en_o(lc_iso_part_sw_wr_en)
+  );
+
+  //////////////////////////////////////
+  // Bank speicfic configuration
+  //////////////////////////////////////
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_cfg
+    assign bank_cfg_o[i].q = bank_cfg_i[i].q;
+  end
+
+  //////////////////////////////////////
+  // Data partition regions
+  //////////////////////////////////////
+  // extra region is the default region
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_mp_regions
+    assign region_cfgs_o[i].base.q        = region_cfg_i[i].base.q;
+    assign region_cfgs_o[i].size.q        = region_cfg_i[i].size.q;
+    assign region_cfgs_o[i].en.q          = region_cfg_i[i].en.q;
+    assign region_cfgs_o[i].rd_en.q       = region_cfg_i[i].rd_en.q;
+    assign region_cfgs_o[i].prog_en.q     = region_cfg_i[i].prog_en.q;
+    assign region_cfgs_o[i].erase_en.q    = region_cfg_i[i].erase_en.q;
+    assign region_cfgs_o[i].scramble_en.q = region_cfg_i[i].scramble_en.q;
+    assign region_cfgs_o[i].ecc_en.q      = region_cfg_i[i].ecc_en.q;
+    assign region_cfgs_o[i].he_en.q       = region_cfg_i[i].he_en.q;
+  end
+
+  //default region
+  assign region_cfgs_o[MpRegions].base.q        = '0;
+  assign region_cfgs_o[MpRegions].size.q        = NumBanks * PagesPerBank;
+  assign region_cfgs_o[MpRegions].en.q          = 1'b1;
+  assign region_cfgs_o[MpRegions].rd_en.q       = default_cfg_i.rd_en.q;
+  assign region_cfgs_o[MpRegions].prog_en.q     = default_cfg_i.prog_en.q;
+  assign region_cfgs_o[MpRegions].erase_en.q    = default_cfg_i.erase_en.q;
+  assign region_cfgs_o[MpRegions].scramble_en.q = default_cfg_i.scramble_en.q;
+  assign region_cfgs_o[MpRegions].ecc_en.q      = default_cfg_i.ecc_en.q;
+  assign region_cfgs_o[MpRegions].he_en.q       = default_cfg_i.he_en.q;
+
+  //////////////////////////////////////
+  // Info partition properties configuration
+  //////////////////////////////////////
+  sw_info_cfg_t   [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] sw_info_cfgs;
+  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_cfgs;
+  localparam int InfoBits = $bits(sw_info_cfg_t) * InfosPerBank;
+
+  // transform from unique names reg output to structure
+  // Not all types have the maximum number of banks, so those are packed to 0
+  % for bank in range(cfg.banks):
+  %   for idx in range(cfg.info_types):
+  assign sw_info_cfgs[${bank}][${idx}] = InfoBits'(bank${bank}_info${idx}_cfg_i);
+  %   endfor
+  % endfor
+
+  // strip error indications
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_cfg_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_cfg_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_cfg_page
+        assign info_cfgs[i][j][k].en.q = sw_info_cfgs[i][j][k].en.q;
+        assign info_cfgs[i][j][k].rd_en.q = sw_info_cfgs[i][j][k].rd_en.q;
+        assign info_cfgs[i][j][k].prog_en.q = sw_info_cfgs[i][j][k].prog_en.q;
+        assign info_cfgs[i][j][k].erase_en.q = sw_info_cfgs[i][j][k].erase_en.q;
+        assign info_cfgs[i][j][k].scramble_en.q = sw_info_cfgs[i][j][k].scramble_en.q;
+        assign info_cfgs[i][j][k].ecc_en.q = sw_info_cfgs[i][j][k].ecc_en.q;
+        assign info_cfgs[i][j][k].he_en.q = sw_info_cfgs[i][j][k].he_en.q;
+      end
+    end
+  end
+
+  // qualify software settings with creator / owner privileges
+  for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
+      flash_ctrl_info_cfg # (
+        .Bank(i),
+        .InfoSel(j)
+      ) u_info_cfg (
+        .cfgs_i(info_cfgs[i][j]),
+        .creator_seed_priv_i(lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On),
+        .owner_seed_priv_i(lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .cfgs_o(info_page_cfgs_o[i][j])
+      );
+    end
+  end
+
+  //////////////////////////////////////
+  // Update / storage error generation
+  //////////////////////////////////////
+
+  // shadow errors and faults
+  logic [NumBanks-1:0] bank_update_err, bank_store_err;
+  logic [MpRegions-1:0] data_update_err, data_store_err;
+  logic default_update_err, default_store_err;
+  logic [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_update_err, info_store_err;
+
+  assign update_err_o = |data_update_err |
+                        |default_update_err |
+                        |info_update_err |
+                        |bank_update_err;
+
+  assign storage_err_o = |data_store_err |
+                         |default_store_err |
+                         |info_store_err |
+                         |bank_store_err;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_err
+    assign bank_update_err[i] = bank_cfg_i[i].err_update;
+    assign bank_store_err[i] = bank_cfg_i[i].err_storage;
+  end
+
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_data_err
+    assign data_update_err[i] = region_cfg_i[i].base.err_update |
+                                region_cfg_i[i].size.err_update |
+                                region_cfg_i[i].en.err_update |
+                                region_cfg_i[i].rd_en.err_update |
+                                region_cfg_i[i].prog_en.err_update |
+                                region_cfg_i[i].erase_en.err_update |
+                                region_cfg_i[i].scramble_en.err_update |
+                                region_cfg_i[i].ecc_en.err_update |
+                                region_cfg_i[i].he_en.err_update;
+
+    assign data_store_err[i] = region_cfg_i[i].base.err_storage |
+                               region_cfg_i[i].size.err_storage |
+                               region_cfg_i[i].en.err_storage |
+                               region_cfg_i[i].rd_en.err_storage |
+                               region_cfg_i[i].prog_en.err_storage |
+                               region_cfg_i[i].erase_en.err_storage |
+                               region_cfg_i[i].scramble_en.err_storage |
+                               region_cfg_i[i].ecc_en.err_storage |
+                               region_cfg_i[i].he_en.err_storage;
+  end
+
+  assign default_update_err =  default_cfg_i.rd_en.err_update |
+                               default_cfg_i.prog_en.err_update |
+                               default_cfg_i.erase_en.err_update |
+                               default_cfg_i.scramble_en.err_update |
+                               default_cfg_i.ecc_en.err_update |
+                               default_cfg_i.he_en.err_update;
+
+  assign default_store_err =  default_cfg_i.rd_en.err_storage |
+                              default_cfg_i.prog_en.err_storage |
+                              default_cfg_i.erase_en.err_storage |
+                              default_cfg_i.scramble_en.err_storage |
+                              default_cfg_i.ecc_en.err_storage |
+                              default_cfg_i.he_en.err_storage;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_err_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_err_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_err_page
+        assign info_update_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_update |
+                                          sw_info_cfgs[i][j][k].rd_en.err_update |
+                                          sw_info_cfgs[i][j][k].prog_en.err_update |
+                                          sw_info_cfgs[i][j][k].erase_en.err_update |
+                                          sw_info_cfgs[i][j][k].scramble_en.err_update |
+                                          sw_info_cfgs[i][j][k].ecc_en.err_update |
+                                          sw_info_cfgs[i][j][k].he_en.err_update;
+
+        assign info_store_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_storage |
+                                         sw_info_cfgs[i][j][k].rd_en.err_storage |
+                                         sw_info_cfgs[i][j][k].prog_en.err_storage |
+                                         sw_info_cfgs[i][j][k].erase_en.err_storage |
+                                         sw_info_cfgs[i][j][k].scramble_en.err_storage |
+                                         sw_info_cfgs[i][j][k].ecc_en.err_storage |
+                                         sw_info_cfgs[i][j][k].he_en.err_storage;
+      end
+    end
+  end
+
+  //////////////////////////////////////
+  // unused
+  //////////////////////////////////////
+
+endmodule // flash_ctrl_reg_wrap

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -18,7 +18,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
-  
+
   // Vseq to do some initial post-reset actions. Can be overriden by extending envs.
   flash_ctrl_callback_vseq callback_vseq;
 
@@ -66,16 +66,19 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     uvm_reg_data_t data;
     uvm_reg csr;
     data =
-        get_csr_val_with_updated_field(ral.mp_region_cfg[index].en, data, region_cfg.en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg[index].rd_en, data, region_cfg.read_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg[index].prog_en, data,
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].en, data,
+                                       region_cfg.en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].rd_en, data,
+                                       region_cfg.read_en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].prog_en, data,
                                        region_cfg.program_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg[index].erase_en, data,
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].erase_en, data,
                                        region_cfg.erase_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg[index].base, data,
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].base, data,
                                        region_cfg.start_page) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg[index].size, data, region_cfg.num_pages);
-    csr_wr(.ptr(ral.mp_region_cfg[index]), .value(data));
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].size, data,
+                                       region_cfg.num_pages);
+    csr_wr(.ptr(ral.mp_region_cfg_shadowed[index]), .value(data));
   endtask
 
   // Configure the protection for the "default" region (all pages that do not fall into one
@@ -83,10 +86,10 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   virtual task flash_ctrl_default_region_cfg(bit read_en, bit program_en, bit erase_en);
     uvm_reg_data_t data;
 
-    data = get_csr_val_with_updated_field(ral.default_region.rd_en, data, read_en) |
-           get_csr_val_with_updated_field(ral.default_region.prog_en, data, program_en) |
-           get_csr_val_with_updated_field(ral.default_region.erase_en, data, erase_en);
-    csr_wr(.ptr(ral.default_region), .value(data));
+    data = get_csr_val_with_updated_field(ral.default_region_shadowed.rd_en, data, read_en) |
+           get_csr_val_with_updated_field(ral.default_region_shadowed.prog_en, data, program_en) |
+           get_csr_val_with_updated_field(ral.default_region_shadowed.erase_en, data, erase_en);
+    csr_wr(.ptr(ral.default_region_shadowed), .value(data));
   endtask
 
   // Configure the memory protection of some selected page in one of the information partitions in
@@ -95,7 +98,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
                                            flash_bank_mp_info_page_cfg_t page_cfg);
     uvm_reg_data_t data;
     uvm_reg csr;
-    string csr_name = $sformatf("bank%0d_info%0d_page_cfg", bank, info_part);
+    string csr_name = $sformatf("bank%0d_info%0d_page_cfg_shadowed", bank, info_part);
     // If the selected information partition has only 1 page, no suffix needed to the register
     //  name, if there is more than one page, the page index should be added to the register name.
     if (flash_ctrl_pkg::InfoTypeSize[info_part] > 1) begin
@@ -114,7 +117,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Configure bank erasability.
   virtual task flash_ctrl_bank_erase_cfg(bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en);
-    csr_wr(.ptr(ral.mp_bank_cfg[0]), .value(bank_erase_en));
+    csr_wr(.ptr(ral.mp_bank_cfg_shadowed[0]), .value(bank_erase_en));
   endtask
 
   // Configure read and program fifo levels for interrupt.

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -48,6 +48,7 @@ module tb;
   flash_ctrl dut (
     .clk_i      (clk      ),
     .rst_ni     (rst_n    ),
+    .rst_shadowed_ni(rst_n),
     .clk_otp_i  (clk      ),
     .rst_otp_ni (rst_n    ),
 

--- a/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
@@ -11,16 +11,10 @@ waive -rules TERMINAL_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid
 waive -rules MISSING_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid.*} \
       -comment "Behavior is part of default state"
 
-# Remove errors from prim_* modules
-# TBD These should be directly addressed in primgen modules long term
-waive -rules INPUT_NOT_READ -location {prim_flop.sv} -regexp {Input port.*} \
-      -comment "Silience prim related errors"
-
-waive -rules OUTPUT_NOT_DRIVEN -location {prim_flop*.sv} -regexp {.*q_o.*} \
-      -comment "Silience prim related errors"
-
-waive -rules INPUT_NOT_READ -location {prim_flop_2sync.sv} -regexp {Input port.*} \
-      -comment "Silience prim related errors"
+# the rst done signals were an intentional choice to address resets
+# that could potentially release at different times
+waive -rules CONST_FF -location {flash_ctrl_core_reg_top.sv} \
+      -regexp {.*rst_done.*} \
 
 # State is handled as part of "default"
 waive -rules MISSING_STATE -location {flash_phy_core.sv} \

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -20,6 +20,7 @@ module flash_ctrl
 ) (
   input        clk_i,
   input        rst_ni,
+  input        rst_shadowed_ni,
 
   input        clk_otp_i,
   input        rst_otp_ni,
@@ -91,9 +92,13 @@ module flash_ctrl
 
   // Register module
   logic intg_err;
+  logic update_err;
+  logic storage_err;
+
   flash_ctrl_core_reg_top u_reg_core (
     .clk_i,
     .rst_ni,
+    .rst_shadowed_ni,
 
     .tl_i(core_tl_i),
     .tl_o(core_tl_o),
@@ -106,6 +111,33 @@ module flash_ctrl
 
     .intg_err_o (intg_err),
     .devmode_i  (1'b1)
+  );
+
+  bank_cfg_t [NumBanks-1:0] bank_cfgs;
+  mp_region_cfg_t [MpRegions:0] region_cfgs;
+  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs;
+
+  flash_ctrl_region_cfg u_region_cfg (
+    .clk_i,
+    .rst_ni,
+    .lc_creator_seed_sw_rw_en_i,
+    .lc_owner_seed_sw_rw_en_i,
+    .lc_iso_part_sw_wr_en_i,
+    .lc_iso_part_sw_rd_en_i,
+    .bank_cfg_i(reg2hw.mp_bank_cfg_shadowed),
+    .region_cfg_i(reg2hw.mp_region_cfg_shadowed),
+    .default_cfg_i(reg2hw.default_region_shadowed),
+    .bank0_info0_cfg_i(reg2hw.bank0_info0_page_cfg_shadowed),
+    .bank0_info1_cfg_i(reg2hw.bank0_info1_page_cfg_shadowed),
+    .bank0_info2_cfg_i(reg2hw.bank0_info2_page_cfg_shadowed),
+    .bank1_info0_cfg_i(reg2hw.bank1_info0_page_cfg_shadowed),
+    .bank1_info1_cfg_i(reg2hw.bank1_info1_page_cfg_shadowed),
+    .bank1_info2_cfg_i(reg2hw.bank1_info2_page_cfg_shadowed),
+    .bank_cfg_o(bank_cfgs),
+    .region_cfgs_o(region_cfgs),
+    .info_page_cfgs_o(info_page_cfgs),
+    .update_err_o(update_err),
+    .storage_err_o(storage_err)
   );
 
   // FIFO Connections
@@ -183,8 +215,6 @@ module flash_ctrl
   flash_sel_e if_sel;
   logic sw_sel;
   flash_lcmgr_phase_e hw_phase;
-  logic creator_seed_priv;
-  logic owner_seed_priv;
   logic lcmgr_err;
 
   // Flash control arbitration connections to software interface
@@ -227,51 +257,10 @@ module flash_ctrl
   flash_req_t flash_phy_req;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
   lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
   // flash functional disable
   lc_ctrl_pkg::lc_tx_t flash_disable;
-
-  // synchronize enables into local domain
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_creator_seed_sw_rw_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_creator_seed_sw_rw_en_i),
-    .lc_en_o(lc_creator_seed_sw_rw_en)
-  );
-
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_owner_seed_sw_rw_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_owner_seed_sw_rw_en_i),
-    .lc_en_o(lc_owner_seed_sw_rw_en)
-  );
-
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_iso_part_sw_rd_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_iso_part_sw_rd_en_i),
-    .lc_en_o(lc_iso_part_sw_rd_en)
-  );
-
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_iso_part_sw_wr_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_iso_part_sw_wr_en_i),
-    .lc_en_o(lc_iso_part_sw_wr_en)
-  );
 
   prim_lc_sync #(
     .NumCopies(1)
@@ -393,12 +382,6 @@ module flash_ctrl
   assign prog_op       = op_type == FlashOpProgram;
   assign erase_op      = op_type == FlashOpErase;
   assign sw_sel        = if_sel == SwSel;
-
-  // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
-
-  // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -675,66 +658,12 @@ module flash_ctrl
     endcase // unique case (op_type)
   end
 
-  //////////////////////////////////////
-  // Data partition properties configuration
-  //////////////////////////////////////
-  // extra region is the default region
-  mp_region_cfg_t [MpRegions:0] region_cfgs;
-  for (genvar i = 0; i < MpRegions; i++) begin : gen_mp_regions
-    assign region_cfgs[i].base.q        = reg2hw.mp_region_cfg_shadowed[i].base.q;
-    assign region_cfgs[i].size.q        = reg2hw.mp_region_cfg_shadowed[i].size.q;
-    assign region_cfgs[i].en.q          = reg2hw.mp_region_cfg_shadowed[i].en.q;
-    assign region_cfgs[i].rd_en.q       = reg2hw.mp_region_cfg_shadowed[i].rd_en.q;
-    assign region_cfgs[i].prog_en.q     = reg2hw.mp_region_cfg_shadowed[i].prog_en.q;
-    assign region_cfgs[i].erase_en.q    = reg2hw.mp_region_cfg_shadowed[i].erase_en.q;
-    assign region_cfgs[i].scramble_en.q = reg2hw.mp_region_cfg_shadowed[i].scramble_en.q;
-    assign region_cfgs[i].ecc_en.q      = reg2hw.mp_region_cfg_shadowed[i].ecc_en.q;
-    assign region_cfgs[i].he_en.q       = reg2hw.mp_region_cfg_shadowed[i].he_en.q;
-  end
 
-  //default region
-  assign region_cfgs[MpRegions].base.q = '0;
-  assign region_cfgs[MpRegions].size.q = NumBanks * PagesPerBank;
-  assign region_cfgs[MpRegions].en.q = 1'b1;
-  assign region_cfgs[MpRegions].rd_en.q = reg2hw.default_region_shadowed.rd_en.q;
-  assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region_shadowed.prog_en.q;
-  assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region_shadowed.erase_en.q;
-  assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region_shadowed.scramble_en.q;
-  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region_shadowed.ecc_en.q;
-  assign region_cfgs[MpRegions].he_en.q = reg2hw.default_region_shadowed.he_en.q;
 
   //////////////////////////////////////
   // Info partition properties configuration
   //////////////////////////////////////
-  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] reg2hw_info_page_cfgs;
-  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs;
-  localparam int InfoBits = $bits(info_page_cfg_t) * InfosPerBank;
 
-  // transform from reg output to structure
-  // Not all types have the maximum number of banks, so those are packed to 0
-  assign reg2hw_info_page_cfgs[0][0] = InfoBits'(reg2hw.bank0_info0_page_cfg_shadowed);
-  assign reg2hw_info_page_cfgs[0][1] = InfoBits'(reg2hw.bank0_info1_page_cfg_shadowed);
-  assign reg2hw_info_page_cfgs[0][2] = InfoBits'(reg2hw.bank0_info2_page_cfg_shadowed);
-  assign reg2hw_info_page_cfgs[1][0] = InfoBits'(reg2hw.bank1_info0_page_cfg_shadowed);
-  assign reg2hw_info_page_cfgs[1][1] = InfoBits'(reg2hw.bank1_info1_page_cfg_shadowed);
-  assign reg2hw_info_page_cfgs[1][2] = InfoBits'(reg2hw.bank1_info2_page_cfg_shadowed);
-
-  // qualify reg2hw settings with creator / owner privileges
-  for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
-    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
-      flash_ctrl_info_cfg # (
-        .Bank(i),
-        .InfoSel(j)
-      ) u_info_cfg (
-        .cfgs_i(reg2hw_info_page_cfgs[i][j]),
-        .creator_seed_priv_i(creator_seed_priv),
-        .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
-        .cfgs_o(info_page_cfgs[i][j])
-      );
-    end
-  end
 
   //////////////////////////////////////
   // flash memory properties
@@ -760,7 +689,7 @@ module flash_ctrl
 
     // sw configuration for data partition
     .region_cfgs_i(region_cfgs),
-    .bank_cfgs_i(reg2hw.mp_bank_cfg_shadowed),
+    .bank_cfgs_i(bank_cfgs),
 
     // sw configuration for info partition
     .info_page_cfgs_i(info_page_cfgs),
@@ -877,13 +806,14 @@ module flash_ctrl
   // Alert senders
   //////////////////////////////////////
 
+
   logic [NumAlerts-1:0] alert_srcs;
   logic [NumAlerts-1:0] alert_tests;
 
-  // TODO Add shadow update
   // An excessive number of recoverable errors may also indicate an attack
   logic recov_err;
-  assign recov_err = sw_ctrl_done & |sw_ctrl_err;
+  assign recov_err = (sw_ctrl_done & |sw_ctrl_err) |
+                     update_err;
 
   logic fatal_err;
   assign fatal_err = |reg2hw.fault_status;
@@ -936,24 +866,6 @@ module flash_ctrl
   // Errors and Interrupts
   //////////////////////////////////////
 
-  // shadow errors and faults
-  logic [MpRegions-1:0] data_update_err;
-  logic info_update_err;
-  logic update_err;
-  logic storage_err;
-
-  for (genvar i = 0; i < MpRegions; i++) begin : gen_data_update_err
-    assign data_update_err[i] = reg2hw.mp_region_cfg_shadowed[i].base.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].size.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].en.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].rd_en.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].prog_en.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].erase_en.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].scramble_en.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].ecc_en.err_update |
-                                reg2hw.mp_region_cfg_shadowed[i].he_en.err_update;
-  end
-
 
 
   // all software interface errors are treated as synchronous errors
@@ -963,12 +875,14 @@ module flash_ctrl
   assign hw2reg.err_code.prog_win_err.d   = 1'b1;
   assign hw2reg.err_code.prog_type_err.d  = 1'b1;
   assign hw2reg.err_code.flash_phy_err.d  = 1'b1;
+  assign hw2reg.err_code.update_err.d     = 1'b1;
   assign hw2reg.err_code.oob_err.de       = sw_ctrl_err.oob_err;
   assign hw2reg.err_code.mp_err.de        = sw_ctrl_err.mp_err;
   assign hw2reg.err_code.rd_err.de        = sw_ctrl_err.rd_err;
   assign hw2reg.err_code.prog_win_err.de  = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de = sw_ctrl_err.prog_type_err;
   assign hw2reg.err_code.flash_phy_err.de = sw_ctrl_err.phy_err;
+  assign hw2reg.err_code.update_err.de    = update_err;
   assign hw2reg.err_addr.d                = {reg2hw.addr.q[31:BusAddrW],ctrl_err_addr};
   assign hw2reg.err_addr.de               = sw_ctrl_err.mp_err |
                                             sw_ctrl_err.rd_err |
@@ -984,6 +898,7 @@ module flash_ctrl
   assign hw2reg.fault_status.reg_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.phy_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.lcmgr_err.d      = 1'b1;
+  assign hw2reg.fault_status.storage_err.d    = 1'b1;
   assign hw2reg.fault_status.oob_err.de       = hw_err.oob_err;
   assign hw2reg.fault_status.mp_err.de        = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de        = hw_err.rd_err;
@@ -993,6 +908,7 @@ module flash_ctrl
   assign hw2reg.fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.fault_status.lcmgr_err.de     = lcmgr_err;
+  assign hw2reg.fault_status.storage_err.de   = storage_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -9,6 +9,7 @@
 module flash_ctrl_core_reg_top (
   input clk_i,
   input rst_ni,
+  input rst_shadowed_ni,
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
@@ -255,171 +256,180 @@ module flash_ctrl_core_reg_top (
   logic region_cfg_regwen_7_we;
   logic region_cfg_regwen_7_qs;
   logic region_cfg_regwen_7_wd;
-  logic mp_region_cfg_0_we;
-  logic mp_region_cfg_0_en_0_qs;
-  logic mp_region_cfg_0_en_0_wd;
-  logic mp_region_cfg_0_rd_en_0_qs;
-  logic mp_region_cfg_0_rd_en_0_wd;
-  logic mp_region_cfg_0_prog_en_0_qs;
-  logic mp_region_cfg_0_prog_en_0_wd;
-  logic mp_region_cfg_0_erase_en_0_qs;
-  logic mp_region_cfg_0_erase_en_0_wd;
-  logic mp_region_cfg_0_scramble_en_0_qs;
-  logic mp_region_cfg_0_scramble_en_0_wd;
-  logic mp_region_cfg_0_ecc_en_0_qs;
-  logic mp_region_cfg_0_ecc_en_0_wd;
-  logic mp_region_cfg_0_he_en_0_qs;
-  logic mp_region_cfg_0_he_en_0_wd;
-  logic [8:0] mp_region_cfg_0_base_0_qs;
-  logic [8:0] mp_region_cfg_0_base_0_wd;
-  logic [9:0] mp_region_cfg_0_size_0_qs;
-  logic [9:0] mp_region_cfg_0_size_0_wd;
-  logic mp_region_cfg_1_we;
-  logic mp_region_cfg_1_en_1_qs;
-  logic mp_region_cfg_1_en_1_wd;
-  logic mp_region_cfg_1_rd_en_1_qs;
-  logic mp_region_cfg_1_rd_en_1_wd;
-  logic mp_region_cfg_1_prog_en_1_qs;
-  logic mp_region_cfg_1_prog_en_1_wd;
-  logic mp_region_cfg_1_erase_en_1_qs;
-  logic mp_region_cfg_1_erase_en_1_wd;
-  logic mp_region_cfg_1_scramble_en_1_qs;
-  logic mp_region_cfg_1_scramble_en_1_wd;
-  logic mp_region_cfg_1_ecc_en_1_qs;
-  logic mp_region_cfg_1_ecc_en_1_wd;
-  logic mp_region_cfg_1_he_en_1_qs;
-  logic mp_region_cfg_1_he_en_1_wd;
-  logic [8:0] mp_region_cfg_1_base_1_qs;
-  logic [8:0] mp_region_cfg_1_base_1_wd;
-  logic [9:0] mp_region_cfg_1_size_1_qs;
-  logic [9:0] mp_region_cfg_1_size_1_wd;
-  logic mp_region_cfg_2_we;
-  logic mp_region_cfg_2_en_2_qs;
-  logic mp_region_cfg_2_en_2_wd;
-  logic mp_region_cfg_2_rd_en_2_qs;
-  logic mp_region_cfg_2_rd_en_2_wd;
-  logic mp_region_cfg_2_prog_en_2_qs;
-  logic mp_region_cfg_2_prog_en_2_wd;
-  logic mp_region_cfg_2_erase_en_2_qs;
-  logic mp_region_cfg_2_erase_en_2_wd;
-  logic mp_region_cfg_2_scramble_en_2_qs;
-  logic mp_region_cfg_2_scramble_en_2_wd;
-  logic mp_region_cfg_2_ecc_en_2_qs;
-  logic mp_region_cfg_2_ecc_en_2_wd;
-  logic mp_region_cfg_2_he_en_2_qs;
-  logic mp_region_cfg_2_he_en_2_wd;
-  logic [8:0] mp_region_cfg_2_base_2_qs;
-  logic [8:0] mp_region_cfg_2_base_2_wd;
-  logic [9:0] mp_region_cfg_2_size_2_qs;
-  logic [9:0] mp_region_cfg_2_size_2_wd;
-  logic mp_region_cfg_3_we;
-  logic mp_region_cfg_3_en_3_qs;
-  logic mp_region_cfg_3_en_3_wd;
-  logic mp_region_cfg_3_rd_en_3_qs;
-  logic mp_region_cfg_3_rd_en_3_wd;
-  logic mp_region_cfg_3_prog_en_3_qs;
-  logic mp_region_cfg_3_prog_en_3_wd;
-  logic mp_region_cfg_3_erase_en_3_qs;
-  logic mp_region_cfg_3_erase_en_3_wd;
-  logic mp_region_cfg_3_scramble_en_3_qs;
-  logic mp_region_cfg_3_scramble_en_3_wd;
-  logic mp_region_cfg_3_ecc_en_3_qs;
-  logic mp_region_cfg_3_ecc_en_3_wd;
-  logic mp_region_cfg_3_he_en_3_qs;
-  logic mp_region_cfg_3_he_en_3_wd;
-  logic [8:0] mp_region_cfg_3_base_3_qs;
-  logic [8:0] mp_region_cfg_3_base_3_wd;
-  logic [9:0] mp_region_cfg_3_size_3_qs;
-  logic [9:0] mp_region_cfg_3_size_3_wd;
-  logic mp_region_cfg_4_we;
-  logic mp_region_cfg_4_en_4_qs;
-  logic mp_region_cfg_4_en_4_wd;
-  logic mp_region_cfg_4_rd_en_4_qs;
-  logic mp_region_cfg_4_rd_en_4_wd;
-  logic mp_region_cfg_4_prog_en_4_qs;
-  logic mp_region_cfg_4_prog_en_4_wd;
-  logic mp_region_cfg_4_erase_en_4_qs;
-  logic mp_region_cfg_4_erase_en_4_wd;
-  logic mp_region_cfg_4_scramble_en_4_qs;
-  logic mp_region_cfg_4_scramble_en_4_wd;
-  logic mp_region_cfg_4_ecc_en_4_qs;
-  logic mp_region_cfg_4_ecc_en_4_wd;
-  logic mp_region_cfg_4_he_en_4_qs;
-  logic mp_region_cfg_4_he_en_4_wd;
-  logic [8:0] mp_region_cfg_4_base_4_qs;
-  logic [8:0] mp_region_cfg_4_base_4_wd;
-  logic [9:0] mp_region_cfg_4_size_4_qs;
-  logic [9:0] mp_region_cfg_4_size_4_wd;
-  logic mp_region_cfg_5_we;
-  logic mp_region_cfg_5_en_5_qs;
-  logic mp_region_cfg_5_en_5_wd;
-  logic mp_region_cfg_5_rd_en_5_qs;
-  logic mp_region_cfg_5_rd_en_5_wd;
-  logic mp_region_cfg_5_prog_en_5_qs;
-  logic mp_region_cfg_5_prog_en_5_wd;
-  logic mp_region_cfg_5_erase_en_5_qs;
-  logic mp_region_cfg_5_erase_en_5_wd;
-  logic mp_region_cfg_5_scramble_en_5_qs;
-  logic mp_region_cfg_5_scramble_en_5_wd;
-  logic mp_region_cfg_5_ecc_en_5_qs;
-  logic mp_region_cfg_5_ecc_en_5_wd;
-  logic mp_region_cfg_5_he_en_5_qs;
-  logic mp_region_cfg_5_he_en_5_wd;
-  logic [8:0] mp_region_cfg_5_base_5_qs;
-  logic [8:0] mp_region_cfg_5_base_5_wd;
-  logic [9:0] mp_region_cfg_5_size_5_qs;
-  logic [9:0] mp_region_cfg_5_size_5_wd;
-  logic mp_region_cfg_6_we;
-  logic mp_region_cfg_6_en_6_qs;
-  logic mp_region_cfg_6_en_6_wd;
-  logic mp_region_cfg_6_rd_en_6_qs;
-  logic mp_region_cfg_6_rd_en_6_wd;
-  logic mp_region_cfg_6_prog_en_6_qs;
-  logic mp_region_cfg_6_prog_en_6_wd;
-  logic mp_region_cfg_6_erase_en_6_qs;
-  logic mp_region_cfg_6_erase_en_6_wd;
-  logic mp_region_cfg_6_scramble_en_6_qs;
-  logic mp_region_cfg_6_scramble_en_6_wd;
-  logic mp_region_cfg_6_ecc_en_6_qs;
-  logic mp_region_cfg_6_ecc_en_6_wd;
-  logic mp_region_cfg_6_he_en_6_qs;
-  logic mp_region_cfg_6_he_en_6_wd;
-  logic [8:0] mp_region_cfg_6_base_6_qs;
-  logic [8:0] mp_region_cfg_6_base_6_wd;
-  logic [9:0] mp_region_cfg_6_size_6_qs;
-  logic [9:0] mp_region_cfg_6_size_6_wd;
-  logic mp_region_cfg_7_we;
-  logic mp_region_cfg_7_en_7_qs;
-  logic mp_region_cfg_7_en_7_wd;
-  logic mp_region_cfg_7_rd_en_7_qs;
-  logic mp_region_cfg_7_rd_en_7_wd;
-  logic mp_region_cfg_7_prog_en_7_qs;
-  logic mp_region_cfg_7_prog_en_7_wd;
-  logic mp_region_cfg_7_erase_en_7_qs;
-  logic mp_region_cfg_7_erase_en_7_wd;
-  logic mp_region_cfg_7_scramble_en_7_qs;
-  logic mp_region_cfg_7_scramble_en_7_wd;
-  logic mp_region_cfg_7_ecc_en_7_qs;
-  logic mp_region_cfg_7_ecc_en_7_wd;
-  logic mp_region_cfg_7_he_en_7_qs;
-  logic mp_region_cfg_7_he_en_7_wd;
-  logic [8:0] mp_region_cfg_7_base_7_qs;
-  logic [8:0] mp_region_cfg_7_base_7_wd;
-  logic [9:0] mp_region_cfg_7_size_7_qs;
-  logic [9:0] mp_region_cfg_7_size_7_wd;
-  logic default_region_we;
-  logic default_region_rd_en_qs;
-  logic default_region_rd_en_wd;
-  logic default_region_prog_en_qs;
-  logic default_region_prog_en_wd;
-  logic default_region_erase_en_qs;
-  logic default_region_erase_en_wd;
-  logic default_region_scramble_en_qs;
-  logic default_region_scramble_en_wd;
-  logic default_region_ecc_en_qs;
-  logic default_region_ecc_en_wd;
-  logic default_region_he_en_qs;
-  logic default_region_he_en_wd;
+  logic mp_region_cfg_shadowed_0_re;
+  logic mp_region_cfg_shadowed_0_we;
+  logic mp_region_cfg_shadowed_0_en_0_qs;
+  logic mp_region_cfg_shadowed_0_en_0_wd;
+  logic mp_region_cfg_shadowed_0_rd_en_0_qs;
+  logic mp_region_cfg_shadowed_0_rd_en_0_wd;
+  logic mp_region_cfg_shadowed_0_prog_en_0_qs;
+  logic mp_region_cfg_shadowed_0_prog_en_0_wd;
+  logic mp_region_cfg_shadowed_0_erase_en_0_qs;
+  logic mp_region_cfg_shadowed_0_erase_en_0_wd;
+  logic mp_region_cfg_shadowed_0_scramble_en_0_qs;
+  logic mp_region_cfg_shadowed_0_scramble_en_0_wd;
+  logic mp_region_cfg_shadowed_0_ecc_en_0_qs;
+  logic mp_region_cfg_shadowed_0_ecc_en_0_wd;
+  logic mp_region_cfg_shadowed_0_he_en_0_qs;
+  logic mp_region_cfg_shadowed_0_he_en_0_wd;
+  logic [8:0] mp_region_cfg_shadowed_0_base_0_qs;
+  logic [8:0] mp_region_cfg_shadowed_0_base_0_wd;
+  logic [9:0] mp_region_cfg_shadowed_0_size_0_qs;
+  logic [9:0] mp_region_cfg_shadowed_0_size_0_wd;
+  logic mp_region_cfg_shadowed_1_re;
+  logic mp_region_cfg_shadowed_1_we;
+  logic mp_region_cfg_shadowed_1_en_1_qs;
+  logic mp_region_cfg_shadowed_1_en_1_wd;
+  logic mp_region_cfg_shadowed_1_rd_en_1_qs;
+  logic mp_region_cfg_shadowed_1_rd_en_1_wd;
+  logic mp_region_cfg_shadowed_1_prog_en_1_qs;
+  logic mp_region_cfg_shadowed_1_prog_en_1_wd;
+  logic mp_region_cfg_shadowed_1_erase_en_1_qs;
+  logic mp_region_cfg_shadowed_1_erase_en_1_wd;
+  logic mp_region_cfg_shadowed_1_scramble_en_1_qs;
+  logic mp_region_cfg_shadowed_1_scramble_en_1_wd;
+  logic mp_region_cfg_shadowed_1_ecc_en_1_qs;
+  logic mp_region_cfg_shadowed_1_ecc_en_1_wd;
+  logic mp_region_cfg_shadowed_1_he_en_1_qs;
+  logic mp_region_cfg_shadowed_1_he_en_1_wd;
+  logic [8:0] mp_region_cfg_shadowed_1_base_1_qs;
+  logic [8:0] mp_region_cfg_shadowed_1_base_1_wd;
+  logic [9:0] mp_region_cfg_shadowed_1_size_1_qs;
+  logic [9:0] mp_region_cfg_shadowed_1_size_1_wd;
+  logic mp_region_cfg_shadowed_2_re;
+  logic mp_region_cfg_shadowed_2_we;
+  logic mp_region_cfg_shadowed_2_en_2_qs;
+  logic mp_region_cfg_shadowed_2_en_2_wd;
+  logic mp_region_cfg_shadowed_2_rd_en_2_qs;
+  logic mp_region_cfg_shadowed_2_rd_en_2_wd;
+  logic mp_region_cfg_shadowed_2_prog_en_2_qs;
+  logic mp_region_cfg_shadowed_2_prog_en_2_wd;
+  logic mp_region_cfg_shadowed_2_erase_en_2_qs;
+  logic mp_region_cfg_shadowed_2_erase_en_2_wd;
+  logic mp_region_cfg_shadowed_2_scramble_en_2_qs;
+  logic mp_region_cfg_shadowed_2_scramble_en_2_wd;
+  logic mp_region_cfg_shadowed_2_ecc_en_2_qs;
+  logic mp_region_cfg_shadowed_2_ecc_en_2_wd;
+  logic mp_region_cfg_shadowed_2_he_en_2_qs;
+  logic mp_region_cfg_shadowed_2_he_en_2_wd;
+  logic [8:0] mp_region_cfg_shadowed_2_base_2_qs;
+  logic [8:0] mp_region_cfg_shadowed_2_base_2_wd;
+  logic [9:0] mp_region_cfg_shadowed_2_size_2_qs;
+  logic [9:0] mp_region_cfg_shadowed_2_size_2_wd;
+  logic mp_region_cfg_shadowed_3_re;
+  logic mp_region_cfg_shadowed_3_we;
+  logic mp_region_cfg_shadowed_3_en_3_qs;
+  logic mp_region_cfg_shadowed_3_en_3_wd;
+  logic mp_region_cfg_shadowed_3_rd_en_3_qs;
+  logic mp_region_cfg_shadowed_3_rd_en_3_wd;
+  logic mp_region_cfg_shadowed_3_prog_en_3_qs;
+  logic mp_region_cfg_shadowed_3_prog_en_3_wd;
+  logic mp_region_cfg_shadowed_3_erase_en_3_qs;
+  logic mp_region_cfg_shadowed_3_erase_en_3_wd;
+  logic mp_region_cfg_shadowed_3_scramble_en_3_qs;
+  logic mp_region_cfg_shadowed_3_scramble_en_3_wd;
+  logic mp_region_cfg_shadowed_3_ecc_en_3_qs;
+  logic mp_region_cfg_shadowed_3_ecc_en_3_wd;
+  logic mp_region_cfg_shadowed_3_he_en_3_qs;
+  logic mp_region_cfg_shadowed_3_he_en_3_wd;
+  logic [8:0] mp_region_cfg_shadowed_3_base_3_qs;
+  logic [8:0] mp_region_cfg_shadowed_3_base_3_wd;
+  logic [9:0] mp_region_cfg_shadowed_3_size_3_qs;
+  logic [9:0] mp_region_cfg_shadowed_3_size_3_wd;
+  logic mp_region_cfg_shadowed_4_re;
+  logic mp_region_cfg_shadowed_4_we;
+  logic mp_region_cfg_shadowed_4_en_4_qs;
+  logic mp_region_cfg_shadowed_4_en_4_wd;
+  logic mp_region_cfg_shadowed_4_rd_en_4_qs;
+  logic mp_region_cfg_shadowed_4_rd_en_4_wd;
+  logic mp_region_cfg_shadowed_4_prog_en_4_qs;
+  logic mp_region_cfg_shadowed_4_prog_en_4_wd;
+  logic mp_region_cfg_shadowed_4_erase_en_4_qs;
+  logic mp_region_cfg_shadowed_4_erase_en_4_wd;
+  logic mp_region_cfg_shadowed_4_scramble_en_4_qs;
+  logic mp_region_cfg_shadowed_4_scramble_en_4_wd;
+  logic mp_region_cfg_shadowed_4_ecc_en_4_qs;
+  logic mp_region_cfg_shadowed_4_ecc_en_4_wd;
+  logic mp_region_cfg_shadowed_4_he_en_4_qs;
+  logic mp_region_cfg_shadowed_4_he_en_4_wd;
+  logic [8:0] mp_region_cfg_shadowed_4_base_4_qs;
+  logic [8:0] mp_region_cfg_shadowed_4_base_4_wd;
+  logic [9:0] mp_region_cfg_shadowed_4_size_4_qs;
+  logic [9:0] mp_region_cfg_shadowed_4_size_4_wd;
+  logic mp_region_cfg_shadowed_5_re;
+  logic mp_region_cfg_shadowed_5_we;
+  logic mp_region_cfg_shadowed_5_en_5_qs;
+  logic mp_region_cfg_shadowed_5_en_5_wd;
+  logic mp_region_cfg_shadowed_5_rd_en_5_qs;
+  logic mp_region_cfg_shadowed_5_rd_en_5_wd;
+  logic mp_region_cfg_shadowed_5_prog_en_5_qs;
+  logic mp_region_cfg_shadowed_5_prog_en_5_wd;
+  logic mp_region_cfg_shadowed_5_erase_en_5_qs;
+  logic mp_region_cfg_shadowed_5_erase_en_5_wd;
+  logic mp_region_cfg_shadowed_5_scramble_en_5_qs;
+  logic mp_region_cfg_shadowed_5_scramble_en_5_wd;
+  logic mp_region_cfg_shadowed_5_ecc_en_5_qs;
+  logic mp_region_cfg_shadowed_5_ecc_en_5_wd;
+  logic mp_region_cfg_shadowed_5_he_en_5_qs;
+  logic mp_region_cfg_shadowed_5_he_en_5_wd;
+  logic [8:0] mp_region_cfg_shadowed_5_base_5_qs;
+  logic [8:0] mp_region_cfg_shadowed_5_base_5_wd;
+  logic [9:0] mp_region_cfg_shadowed_5_size_5_qs;
+  logic [9:0] mp_region_cfg_shadowed_5_size_5_wd;
+  logic mp_region_cfg_shadowed_6_re;
+  logic mp_region_cfg_shadowed_6_we;
+  logic mp_region_cfg_shadowed_6_en_6_qs;
+  logic mp_region_cfg_shadowed_6_en_6_wd;
+  logic mp_region_cfg_shadowed_6_rd_en_6_qs;
+  logic mp_region_cfg_shadowed_6_rd_en_6_wd;
+  logic mp_region_cfg_shadowed_6_prog_en_6_qs;
+  logic mp_region_cfg_shadowed_6_prog_en_6_wd;
+  logic mp_region_cfg_shadowed_6_erase_en_6_qs;
+  logic mp_region_cfg_shadowed_6_erase_en_6_wd;
+  logic mp_region_cfg_shadowed_6_scramble_en_6_qs;
+  logic mp_region_cfg_shadowed_6_scramble_en_6_wd;
+  logic mp_region_cfg_shadowed_6_ecc_en_6_qs;
+  logic mp_region_cfg_shadowed_6_ecc_en_6_wd;
+  logic mp_region_cfg_shadowed_6_he_en_6_qs;
+  logic mp_region_cfg_shadowed_6_he_en_6_wd;
+  logic [8:0] mp_region_cfg_shadowed_6_base_6_qs;
+  logic [8:0] mp_region_cfg_shadowed_6_base_6_wd;
+  logic [9:0] mp_region_cfg_shadowed_6_size_6_qs;
+  logic [9:0] mp_region_cfg_shadowed_6_size_6_wd;
+  logic mp_region_cfg_shadowed_7_re;
+  logic mp_region_cfg_shadowed_7_we;
+  logic mp_region_cfg_shadowed_7_en_7_qs;
+  logic mp_region_cfg_shadowed_7_en_7_wd;
+  logic mp_region_cfg_shadowed_7_rd_en_7_qs;
+  logic mp_region_cfg_shadowed_7_rd_en_7_wd;
+  logic mp_region_cfg_shadowed_7_prog_en_7_qs;
+  logic mp_region_cfg_shadowed_7_prog_en_7_wd;
+  logic mp_region_cfg_shadowed_7_erase_en_7_qs;
+  logic mp_region_cfg_shadowed_7_erase_en_7_wd;
+  logic mp_region_cfg_shadowed_7_scramble_en_7_qs;
+  logic mp_region_cfg_shadowed_7_scramble_en_7_wd;
+  logic mp_region_cfg_shadowed_7_ecc_en_7_qs;
+  logic mp_region_cfg_shadowed_7_ecc_en_7_wd;
+  logic mp_region_cfg_shadowed_7_he_en_7_qs;
+  logic mp_region_cfg_shadowed_7_he_en_7_wd;
+  logic [8:0] mp_region_cfg_shadowed_7_base_7_qs;
+  logic [8:0] mp_region_cfg_shadowed_7_base_7_wd;
+  logic [9:0] mp_region_cfg_shadowed_7_size_7_qs;
+  logic [9:0] mp_region_cfg_shadowed_7_size_7_wd;
+  logic default_region_shadowed_re;
+  logic default_region_shadowed_we;
+  logic default_region_shadowed_rd_en_qs;
+  logic default_region_shadowed_rd_en_wd;
+  logic default_region_shadowed_prog_en_qs;
+  logic default_region_shadowed_prog_en_wd;
+  logic default_region_shadowed_erase_en_qs;
+  logic default_region_shadowed_erase_en_wd;
+  logic default_region_shadowed_scramble_en_qs;
+  logic default_region_shadowed_scramble_en_wd;
+  logic default_region_shadowed_ecc_en_qs;
+  logic default_region_shadowed_ecc_en_wd;
+  logic default_region_shadowed_he_en_qs;
+  logic default_region_shadowed_he_en_wd;
   logic bank0_info0_regwen_0_we;
   logic bank0_info0_regwen_0_qs;
   logic bank0_info0_regwen_0_wd;
@@ -450,210 +460,223 @@ module flash_ctrl_core_reg_top (
   logic bank0_info0_regwen_9_we;
   logic bank0_info0_regwen_9_qs;
   logic bank0_info0_regwen_9_wd;
-  logic bank0_info0_page_cfg_0_we;
-  logic bank0_info0_page_cfg_0_en_0_qs;
-  logic bank0_info0_page_cfg_0_en_0_wd;
-  logic bank0_info0_page_cfg_0_rd_en_0_qs;
-  logic bank0_info0_page_cfg_0_rd_en_0_wd;
-  logic bank0_info0_page_cfg_0_prog_en_0_qs;
-  logic bank0_info0_page_cfg_0_prog_en_0_wd;
-  logic bank0_info0_page_cfg_0_erase_en_0_qs;
-  logic bank0_info0_page_cfg_0_erase_en_0_wd;
-  logic bank0_info0_page_cfg_0_scramble_en_0_qs;
-  logic bank0_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info0_page_cfg_0_ecc_en_0_qs;
-  logic bank0_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info0_page_cfg_0_he_en_0_qs;
-  logic bank0_info0_page_cfg_0_he_en_0_wd;
-  logic bank0_info0_page_cfg_1_we;
-  logic bank0_info0_page_cfg_1_en_1_qs;
-  logic bank0_info0_page_cfg_1_en_1_wd;
-  logic bank0_info0_page_cfg_1_rd_en_1_qs;
-  logic bank0_info0_page_cfg_1_rd_en_1_wd;
-  logic bank0_info0_page_cfg_1_prog_en_1_qs;
-  logic bank0_info0_page_cfg_1_prog_en_1_wd;
-  logic bank0_info0_page_cfg_1_erase_en_1_qs;
-  logic bank0_info0_page_cfg_1_erase_en_1_wd;
-  logic bank0_info0_page_cfg_1_scramble_en_1_qs;
-  logic bank0_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info0_page_cfg_1_ecc_en_1_qs;
-  logic bank0_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info0_page_cfg_1_he_en_1_qs;
-  logic bank0_info0_page_cfg_1_he_en_1_wd;
-  logic bank0_info0_page_cfg_2_we;
-  logic bank0_info0_page_cfg_2_en_2_qs;
-  logic bank0_info0_page_cfg_2_en_2_wd;
-  logic bank0_info0_page_cfg_2_rd_en_2_qs;
-  logic bank0_info0_page_cfg_2_rd_en_2_wd;
-  logic bank0_info0_page_cfg_2_prog_en_2_qs;
-  logic bank0_info0_page_cfg_2_prog_en_2_wd;
-  logic bank0_info0_page_cfg_2_erase_en_2_qs;
-  logic bank0_info0_page_cfg_2_erase_en_2_wd;
-  logic bank0_info0_page_cfg_2_scramble_en_2_qs;
-  logic bank0_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank0_info0_page_cfg_2_ecc_en_2_qs;
-  logic bank0_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank0_info0_page_cfg_2_he_en_2_qs;
-  logic bank0_info0_page_cfg_2_he_en_2_wd;
-  logic bank0_info0_page_cfg_3_we;
-  logic bank0_info0_page_cfg_3_en_3_qs;
-  logic bank0_info0_page_cfg_3_en_3_wd;
-  logic bank0_info0_page_cfg_3_rd_en_3_qs;
-  logic bank0_info0_page_cfg_3_rd_en_3_wd;
-  logic bank0_info0_page_cfg_3_prog_en_3_qs;
-  logic bank0_info0_page_cfg_3_prog_en_3_wd;
-  logic bank0_info0_page_cfg_3_erase_en_3_qs;
-  logic bank0_info0_page_cfg_3_erase_en_3_wd;
-  logic bank0_info0_page_cfg_3_scramble_en_3_qs;
-  logic bank0_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank0_info0_page_cfg_3_ecc_en_3_qs;
-  logic bank0_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank0_info0_page_cfg_3_he_en_3_qs;
-  logic bank0_info0_page_cfg_3_he_en_3_wd;
-  logic bank0_info0_page_cfg_4_we;
-  logic bank0_info0_page_cfg_4_en_4_qs;
-  logic bank0_info0_page_cfg_4_en_4_wd;
-  logic bank0_info0_page_cfg_4_rd_en_4_qs;
-  logic bank0_info0_page_cfg_4_rd_en_4_wd;
-  logic bank0_info0_page_cfg_4_prog_en_4_qs;
-  logic bank0_info0_page_cfg_4_prog_en_4_wd;
-  logic bank0_info0_page_cfg_4_erase_en_4_qs;
-  logic bank0_info0_page_cfg_4_erase_en_4_wd;
-  logic bank0_info0_page_cfg_4_scramble_en_4_qs;
-  logic bank0_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank0_info0_page_cfg_4_ecc_en_4_qs;
-  logic bank0_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank0_info0_page_cfg_4_he_en_4_qs;
-  logic bank0_info0_page_cfg_4_he_en_4_wd;
-  logic bank0_info0_page_cfg_5_we;
-  logic bank0_info0_page_cfg_5_en_5_qs;
-  logic bank0_info0_page_cfg_5_en_5_wd;
-  logic bank0_info0_page_cfg_5_rd_en_5_qs;
-  logic bank0_info0_page_cfg_5_rd_en_5_wd;
-  logic bank0_info0_page_cfg_5_prog_en_5_qs;
-  logic bank0_info0_page_cfg_5_prog_en_5_wd;
-  logic bank0_info0_page_cfg_5_erase_en_5_qs;
-  logic bank0_info0_page_cfg_5_erase_en_5_wd;
-  logic bank0_info0_page_cfg_5_scramble_en_5_qs;
-  logic bank0_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank0_info0_page_cfg_5_ecc_en_5_qs;
-  logic bank0_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank0_info0_page_cfg_5_he_en_5_qs;
-  logic bank0_info0_page_cfg_5_he_en_5_wd;
-  logic bank0_info0_page_cfg_6_we;
-  logic bank0_info0_page_cfg_6_en_6_qs;
-  logic bank0_info0_page_cfg_6_en_6_wd;
-  logic bank0_info0_page_cfg_6_rd_en_6_qs;
-  logic bank0_info0_page_cfg_6_rd_en_6_wd;
-  logic bank0_info0_page_cfg_6_prog_en_6_qs;
-  logic bank0_info0_page_cfg_6_prog_en_6_wd;
-  logic bank0_info0_page_cfg_6_erase_en_6_qs;
-  logic bank0_info0_page_cfg_6_erase_en_6_wd;
-  logic bank0_info0_page_cfg_6_scramble_en_6_qs;
-  logic bank0_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank0_info0_page_cfg_6_ecc_en_6_qs;
-  logic bank0_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank0_info0_page_cfg_6_he_en_6_qs;
-  logic bank0_info0_page_cfg_6_he_en_6_wd;
-  logic bank0_info0_page_cfg_7_we;
-  logic bank0_info0_page_cfg_7_en_7_qs;
-  logic bank0_info0_page_cfg_7_en_7_wd;
-  logic bank0_info0_page_cfg_7_rd_en_7_qs;
-  logic bank0_info0_page_cfg_7_rd_en_7_wd;
-  logic bank0_info0_page_cfg_7_prog_en_7_qs;
-  logic bank0_info0_page_cfg_7_prog_en_7_wd;
-  logic bank0_info0_page_cfg_7_erase_en_7_qs;
-  logic bank0_info0_page_cfg_7_erase_en_7_wd;
-  logic bank0_info0_page_cfg_7_scramble_en_7_qs;
-  logic bank0_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank0_info0_page_cfg_7_ecc_en_7_qs;
-  logic bank0_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank0_info0_page_cfg_7_he_en_7_qs;
-  logic bank0_info0_page_cfg_7_he_en_7_wd;
-  logic bank0_info0_page_cfg_8_we;
-  logic bank0_info0_page_cfg_8_en_8_qs;
-  logic bank0_info0_page_cfg_8_en_8_wd;
-  logic bank0_info0_page_cfg_8_rd_en_8_qs;
-  logic bank0_info0_page_cfg_8_rd_en_8_wd;
-  logic bank0_info0_page_cfg_8_prog_en_8_qs;
-  logic bank0_info0_page_cfg_8_prog_en_8_wd;
-  logic bank0_info0_page_cfg_8_erase_en_8_qs;
-  logic bank0_info0_page_cfg_8_erase_en_8_wd;
-  logic bank0_info0_page_cfg_8_scramble_en_8_qs;
-  logic bank0_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank0_info0_page_cfg_8_ecc_en_8_qs;
-  logic bank0_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank0_info0_page_cfg_8_he_en_8_qs;
-  logic bank0_info0_page_cfg_8_he_en_8_wd;
-  logic bank0_info0_page_cfg_9_we;
-  logic bank0_info0_page_cfg_9_en_9_qs;
-  logic bank0_info0_page_cfg_9_en_9_wd;
-  logic bank0_info0_page_cfg_9_rd_en_9_qs;
-  logic bank0_info0_page_cfg_9_rd_en_9_wd;
-  logic bank0_info0_page_cfg_9_prog_en_9_qs;
-  logic bank0_info0_page_cfg_9_prog_en_9_wd;
-  logic bank0_info0_page_cfg_9_erase_en_9_qs;
-  logic bank0_info0_page_cfg_9_erase_en_9_wd;
-  logic bank0_info0_page_cfg_9_scramble_en_9_qs;
-  logic bank0_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank0_info0_page_cfg_9_ecc_en_9_qs;
-  logic bank0_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank0_info0_page_cfg_9_he_en_9_qs;
-  logic bank0_info0_page_cfg_9_he_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_0_re;
+  logic bank0_info0_page_cfg_shadowed_0_we;
+  logic bank0_info0_page_cfg_shadowed_0_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_1_re;
+  logic bank0_info0_page_cfg_shadowed_1_we;
+  logic bank0_info0_page_cfg_shadowed_1_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_he_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_2_re;
+  logic bank0_info0_page_cfg_shadowed_2_we;
+  logic bank0_info0_page_cfg_shadowed_2_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_rd_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_rd_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_prog_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_prog_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_erase_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_erase_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_scramble_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_ecc_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_he_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_he_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_3_re;
+  logic bank0_info0_page_cfg_shadowed_3_we;
+  logic bank0_info0_page_cfg_shadowed_3_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_rd_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_rd_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_prog_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_prog_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_erase_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_erase_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_scramble_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_ecc_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_he_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_he_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_4_re;
+  logic bank0_info0_page_cfg_shadowed_4_we;
+  logic bank0_info0_page_cfg_shadowed_4_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_rd_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_rd_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_prog_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_prog_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_erase_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_erase_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_scramble_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_ecc_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_he_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_he_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_5_re;
+  logic bank0_info0_page_cfg_shadowed_5_we;
+  logic bank0_info0_page_cfg_shadowed_5_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_rd_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_rd_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_prog_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_prog_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_erase_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_erase_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_scramble_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_ecc_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_he_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_he_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_6_re;
+  logic bank0_info0_page_cfg_shadowed_6_we;
+  logic bank0_info0_page_cfg_shadowed_6_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_rd_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_rd_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_prog_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_prog_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_erase_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_erase_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_scramble_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_ecc_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_he_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_he_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_7_re;
+  logic bank0_info0_page_cfg_shadowed_7_we;
+  logic bank0_info0_page_cfg_shadowed_7_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_rd_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_rd_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_prog_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_prog_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_erase_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_erase_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_scramble_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_ecc_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_he_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_he_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_8_re;
+  logic bank0_info0_page_cfg_shadowed_8_we;
+  logic bank0_info0_page_cfg_shadowed_8_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_rd_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_rd_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_prog_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_prog_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_erase_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_erase_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_scramble_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_ecc_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_he_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_he_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_9_re;
+  logic bank0_info0_page_cfg_shadowed_9_we;
+  logic bank0_info0_page_cfg_shadowed_9_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_rd_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_rd_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_prog_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_prog_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_erase_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_erase_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_scramble_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_ecc_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_he_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_he_en_9_wd;
   logic bank0_info1_regwen_we;
   logic bank0_info1_regwen_qs;
   logic bank0_info1_regwen_wd;
-  logic bank0_info1_page_cfg_we;
-  logic bank0_info1_page_cfg_en_0_qs;
-  logic bank0_info1_page_cfg_en_0_wd;
-  logic bank0_info1_page_cfg_rd_en_0_qs;
-  logic bank0_info1_page_cfg_rd_en_0_wd;
-  logic bank0_info1_page_cfg_prog_en_0_qs;
-  logic bank0_info1_page_cfg_prog_en_0_wd;
-  logic bank0_info1_page_cfg_erase_en_0_qs;
-  logic bank0_info1_page_cfg_erase_en_0_wd;
-  logic bank0_info1_page_cfg_scramble_en_0_qs;
-  logic bank0_info1_page_cfg_scramble_en_0_wd;
-  logic bank0_info1_page_cfg_ecc_en_0_qs;
-  logic bank0_info1_page_cfg_ecc_en_0_wd;
-  logic bank0_info1_page_cfg_he_en_0_qs;
-  logic bank0_info1_page_cfg_he_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_re;
+  logic bank0_info1_page_cfg_shadowed_we;
+  logic bank0_info1_page_cfg_shadowed_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_rd_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_rd_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_prog_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_prog_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_erase_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_erase_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_scramble_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_scramble_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_ecc_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_ecc_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_he_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_he_en_0_wd;
   logic bank0_info2_regwen_0_we;
   logic bank0_info2_regwen_0_qs;
   logic bank0_info2_regwen_0_wd;
   logic bank0_info2_regwen_1_we;
   logic bank0_info2_regwen_1_qs;
   logic bank0_info2_regwen_1_wd;
-  logic bank0_info2_page_cfg_0_we;
-  logic bank0_info2_page_cfg_0_en_0_qs;
-  logic bank0_info2_page_cfg_0_en_0_wd;
-  logic bank0_info2_page_cfg_0_rd_en_0_qs;
-  logic bank0_info2_page_cfg_0_rd_en_0_wd;
-  logic bank0_info2_page_cfg_0_prog_en_0_qs;
-  logic bank0_info2_page_cfg_0_prog_en_0_wd;
-  logic bank0_info2_page_cfg_0_erase_en_0_qs;
-  logic bank0_info2_page_cfg_0_erase_en_0_wd;
-  logic bank0_info2_page_cfg_0_scramble_en_0_qs;
-  logic bank0_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info2_page_cfg_0_ecc_en_0_qs;
-  logic bank0_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info2_page_cfg_0_he_en_0_qs;
-  logic bank0_info2_page_cfg_0_he_en_0_wd;
-  logic bank0_info2_page_cfg_1_we;
-  logic bank0_info2_page_cfg_1_en_1_qs;
-  logic bank0_info2_page_cfg_1_en_1_wd;
-  logic bank0_info2_page_cfg_1_rd_en_1_qs;
-  logic bank0_info2_page_cfg_1_rd_en_1_wd;
-  logic bank0_info2_page_cfg_1_prog_en_1_qs;
-  logic bank0_info2_page_cfg_1_prog_en_1_wd;
-  logic bank0_info2_page_cfg_1_erase_en_1_qs;
-  logic bank0_info2_page_cfg_1_erase_en_1_wd;
-  logic bank0_info2_page_cfg_1_scramble_en_1_qs;
-  logic bank0_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info2_page_cfg_1_ecc_en_1_qs;
-  logic bank0_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info2_page_cfg_1_he_en_1_qs;
-  logic bank0_info2_page_cfg_1_he_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_0_re;
+  logic bank0_info2_page_cfg_shadowed_0_we;
+  logic bank0_info2_page_cfg_shadowed_0_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_1_re;
+  logic bank0_info2_page_cfg_shadowed_1_we;
+  logic bank0_info2_page_cfg_shadowed_1_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_he_en_1_wd;
   logic bank1_info0_regwen_0_we;
   logic bank1_info0_regwen_0_qs;
   logic bank1_info0_regwen_0_wd;
@@ -684,218 +707,232 @@ module flash_ctrl_core_reg_top (
   logic bank1_info0_regwen_9_we;
   logic bank1_info0_regwen_9_qs;
   logic bank1_info0_regwen_9_wd;
-  logic bank1_info0_page_cfg_0_we;
-  logic bank1_info0_page_cfg_0_en_0_qs;
-  logic bank1_info0_page_cfg_0_en_0_wd;
-  logic bank1_info0_page_cfg_0_rd_en_0_qs;
-  logic bank1_info0_page_cfg_0_rd_en_0_wd;
-  logic bank1_info0_page_cfg_0_prog_en_0_qs;
-  logic bank1_info0_page_cfg_0_prog_en_0_wd;
-  logic bank1_info0_page_cfg_0_erase_en_0_qs;
-  logic bank1_info0_page_cfg_0_erase_en_0_wd;
-  logic bank1_info0_page_cfg_0_scramble_en_0_qs;
-  logic bank1_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info0_page_cfg_0_ecc_en_0_qs;
-  logic bank1_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info0_page_cfg_0_he_en_0_qs;
-  logic bank1_info0_page_cfg_0_he_en_0_wd;
-  logic bank1_info0_page_cfg_1_we;
-  logic bank1_info0_page_cfg_1_en_1_qs;
-  logic bank1_info0_page_cfg_1_en_1_wd;
-  logic bank1_info0_page_cfg_1_rd_en_1_qs;
-  logic bank1_info0_page_cfg_1_rd_en_1_wd;
-  logic bank1_info0_page_cfg_1_prog_en_1_qs;
-  logic bank1_info0_page_cfg_1_prog_en_1_wd;
-  logic bank1_info0_page_cfg_1_erase_en_1_qs;
-  logic bank1_info0_page_cfg_1_erase_en_1_wd;
-  logic bank1_info0_page_cfg_1_scramble_en_1_qs;
-  logic bank1_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info0_page_cfg_1_ecc_en_1_qs;
-  logic bank1_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info0_page_cfg_1_he_en_1_qs;
-  logic bank1_info0_page_cfg_1_he_en_1_wd;
-  logic bank1_info0_page_cfg_2_we;
-  logic bank1_info0_page_cfg_2_en_2_qs;
-  logic bank1_info0_page_cfg_2_en_2_wd;
-  logic bank1_info0_page_cfg_2_rd_en_2_qs;
-  logic bank1_info0_page_cfg_2_rd_en_2_wd;
-  logic bank1_info0_page_cfg_2_prog_en_2_qs;
-  logic bank1_info0_page_cfg_2_prog_en_2_wd;
-  logic bank1_info0_page_cfg_2_erase_en_2_qs;
-  logic bank1_info0_page_cfg_2_erase_en_2_wd;
-  logic bank1_info0_page_cfg_2_scramble_en_2_qs;
-  logic bank1_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank1_info0_page_cfg_2_ecc_en_2_qs;
-  logic bank1_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank1_info0_page_cfg_2_he_en_2_qs;
-  logic bank1_info0_page_cfg_2_he_en_2_wd;
-  logic bank1_info0_page_cfg_3_we;
-  logic bank1_info0_page_cfg_3_en_3_qs;
-  logic bank1_info0_page_cfg_3_en_3_wd;
-  logic bank1_info0_page_cfg_3_rd_en_3_qs;
-  logic bank1_info0_page_cfg_3_rd_en_3_wd;
-  logic bank1_info0_page_cfg_3_prog_en_3_qs;
-  logic bank1_info0_page_cfg_3_prog_en_3_wd;
-  logic bank1_info0_page_cfg_3_erase_en_3_qs;
-  logic bank1_info0_page_cfg_3_erase_en_3_wd;
-  logic bank1_info0_page_cfg_3_scramble_en_3_qs;
-  logic bank1_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank1_info0_page_cfg_3_ecc_en_3_qs;
-  logic bank1_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank1_info0_page_cfg_3_he_en_3_qs;
-  logic bank1_info0_page_cfg_3_he_en_3_wd;
-  logic bank1_info0_page_cfg_4_we;
-  logic bank1_info0_page_cfg_4_en_4_qs;
-  logic bank1_info0_page_cfg_4_en_4_wd;
-  logic bank1_info0_page_cfg_4_rd_en_4_qs;
-  logic bank1_info0_page_cfg_4_rd_en_4_wd;
-  logic bank1_info0_page_cfg_4_prog_en_4_qs;
-  logic bank1_info0_page_cfg_4_prog_en_4_wd;
-  logic bank1_info0_page_cfg_4_erase_en_4_qs;
-  logic bank1_info0_page_cfg_4_erase_en_4_wd;
-  logic bank1_info0_page_cfg_4_scramble_en_4_qs;
-  logic bank1_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank1_info0_page_cfg_4_ecc_en_4_qs;
-  logic bank1_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank1_info0_page_cfg_4_he_en_4_qs;
-  logic bank1_info0_page_cfg_4_he_en_4_wd;
-  logic bank1_info0_page_cfg_5_we;
-  logic bank1_info0_page_cfg_5_en_5_qs;
-  logic bank1_info0_page_cfg_5_en_5_wd;
-  logic bank1_info0_page_cfg_5_rd_en_5_qs;
-  logic bank1_info0_page_cfg_5_rd_en_5_wd;
-  logic bank1_info0_page_cfg_5_prog_en_5_qs;
-  logic bank1_info0_page_cfg_5_prog_en_5_wd;
-  logic bank1_info0_page_cfg_5_erase_en_5_qs;
-  logic bank1_info0_page_cfg_5_erase_en_5_wd;
-  logic bank1_info0_page_cfg_5_scramble_en_5_qs;
-  logic bank1_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank1_info0_page_cfg_5_ecc_en_5_qs;
-  logic bank1_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank1_info0_page_cfg_5_he_en_5_qs;
-  logic bank1_info0_page_cfg_5_he_en_5_wd;
-  logic bank1_info0_page_cfg_6_we;
-  logic bank1_info0_page_cfg_6_en_6_qs;
-  logic bank1_info0_page_cfg_6_en_6_wd;
-  logic bank1_info0_page_cfg_6_rd_en_6_qs;
-  logic bank1_info0_page_cfg_6_rd_en_6_wd;
-  logic bank1_info0_page_cfg_6_prog_en_6_qs;
-  logic bank1_info0_page_cfg_6_prog_en_6_wd;
-  logic bank1_info0_page_cfg_6_erase_en_6_qs;
-  logic bank1_info0_page_cfg_6_erase_en_6_wd;
-  logic bank1_info0_page_cfg_6_scramble_en_6_qs;
-  logic bank1_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank1_info0_page_cfg_6_ecc_en_6_qs;
-  logic bank1_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank1_info0_page_cfg_6_he_en_6_qs;
-  logic bank1_info0_page_cfg_6_he_en_6_wd;
-  logic bank1_info0_page_cfg_7_we;
-  logic bank1_info0_page_cfg_7_en_7_qs;
-  logic bank1_info0_page_cfg_7_en_7_wd;
-  logic bank1_info0_page_cfg_7_rd_en_7_qs;
-  logic bank1_info0_page_cfg_7_rd_en_7_wd;
-  logic bank1_info0_page_cfg_7_prog_en_7_qs;
-  logic bank1_info0_page_cfg_7_prog_en_7_wd;
-  logic bank1_info0_page_cfg_7_erase_en_7_qs;
-  logic bank1_info0_page_cfg_7_erase_en_7_wd;
-  logic bank1_info0_page_cfg_7_scramble_en_7_qs;
-  logic bank1_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank1_info0_page_cfg_7_ecc_en_7_qs;
-  logic bank1_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank1_info0_page_cfg_7_he_en_7_qs;
-  logic bank1_info0_page_cfg_7_he_en_7_wd;
-  logic bank1_info0_page_cfg_8_we;
-  logic bank1_info0_page_cfg_8_en_8_qs;
-  logic bank1_info0_page_cfg_8_en_8_wd;
-  logic bank1_info0_page_cfg_8_rd_en_8_qs;
-  logic bank1_info0_page_cfg_8_rd_en_8_wd;
-  logic bank1_info0_page_cfg_8_prog_en_8_qs;
-  logic bank1_info0_page_cfg_8_prog_en_8_wd;
-  logic bank1_info0_page_cfg_8_erase_en_8_qs;
-  logic bank1_info0_page_cfg_8_erase_en_8_wd;
-  logic bank1_info0_page_cfg_8_scramble_en_8_qs;
-  logic bank1_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank1_info0_page_cfg_8_ecc_en_8_qs;
-  logic bank1_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank1_info0_page_cfg_8_he_en_8_qs;
-  logic bank1_info0_page_cfg_8_he_en_8_wd;
-  logic bank1_info0_page_cfg_9_we;
-  logic bank1_info0_page_cfg_9_en_9_qs;
-  logic bank1_info0_page_cfg_9_en_9_wd;
-  logic bank1_info0_page_cfg_9_rd_en_9_qs;
-  logic bank1_info0_page_cfg_9_rd_en_9_wd;
-  logic bank1_info0_page_cfg_9_prog_en_9_qs;
-  logic bank1_info0_page_cfg_9_prog_en_9_wd;
-  logic bank1_info0_page_cfg_9_erase_en_9_qs;
-  logic bank1_info0_page_cfg_9_erase_en_9_wd;
-  logic bank1_info0_page_cfg_9_scramble_en_9_qs;
-  logic bank1_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank1_info0_page_cfg_9_ecc_en_9_qs;
-  logic bank1_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank1_info0_page_cfg_9_he_en_9_qs;
-  logic bank1_info0_page_cfg_9_he_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_0_re;
+  logic bank1_info0_page_cfg_shadowed_0_we;
+  logic bank1_info0_page_cfg_shadowed_0_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_1_re;
+  logic bank1_info0_page_cfg_shadowed_1_we;
+  logic bank1_info0_page_cfg_shadowed_1_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_he_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_2_re;
+  logic bank1_info0_page_cfg_shadowed_2_we;
+  logic bank1_info0_page_cfg_shadowed_2_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_rd_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_rd_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_prog_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_prog_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_erase_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_erase_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_scramble_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_ecc_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_he_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_he_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_3_re;
+  logic bank1_info0_page_cfg_shadowed_3_we;
+  logic bank1_info0_page_cfg_shadowed_3_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_rd_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_rd_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_prog_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_prog_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_erase_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_erase_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_scramble_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_ecc_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_he_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_he_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_4_re;
+  logic bank1_info0_page_cfg_shadowed_4_we;
+  logic bank1_info0_page_cfg_shadowed_4_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_rd_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_rd_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_prog_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_prog_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_erase_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_erase_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_scramble_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_ecc_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_he_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_he_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_5_re;
+  logic bank1_info0_page_cfg_shadowed_5_we;
+  logic bank1_info0_page_cfg_shadowed_5_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_rd_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_rd_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_prog_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_prog_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_erase_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_erase_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_scramble_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_ecc_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_he_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_he_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_6_re;
+  logic bank1_info0_page_cfg_shadowed_6_we;
+  logic bank1_info0_page_cfg_shadowed_6_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_rd_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_rd_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_prog_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_prog_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_erase_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_erase_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_scramble_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_ecc_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_he_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_he_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_7_re;
+  logic bank1_info0_page_cfg_shadowed_7_we;
+  logic bank1_info0_page_cfg_shadowed_7_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_rd_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_rd_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_prog_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_prog_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_erase_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_erase_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_scramble_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_ecc_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_he_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_he_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_8_re;
+  logic bank1_info0_page_cfg_shadowed_8_we;
+  logic bank1_info0_page_cfg_shadowed_8_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_rd_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_rd_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_prog_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_prog_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_erase_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_erase_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_scramble_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_ecc_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_he_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_he_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_9_re;
+  logic bank1_info0_page_cfg_shadowed_9_we;
+  logic bank1_info0_page_cfg_shadowed_9_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_rd_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_rd_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_prog_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_prog_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_erase_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_erase_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_scramble_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_ecc_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_he_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_he_en_9_wd;
   logic bank1_info1_regwen_we;
   logic bank1_info1_regwen_qs;
   logic bank1_info1_regwen_wd;
-  logic bank1_info1_page_cfg_we;
-  logic bank1_info1_page_cfg_en_0_qs;
-  logic bank1_info1_page_cfg_en_0_wd;
-  logic bank1_info1_page_cfg_rd_en_0_qs;
-  logic bank1_info1_page_cfg_rd_en_0_wd;
-  logic bank1_info1_page_cfg_prog_en_0_qs;
-  logic bank1_info1_page_cfg_prog_en_0_wd;
-  logic bank1_info1_page_cfg_erase_en_0_qs;
-  logic bank1_info1_page_cfg_erase_en_0_wd;
-  logic bank1_info1_page_cfg_scramble_en_0_qs;
-  logic bank1_info1_page_cfg_scramble_en_0_wd;
-  logic bank1_info1_page_cfg_ecc_en_0_qs;
-  logic bank1_info1_page_cfg_ecc_en_0_wd;
-  logic bank1_info1_page_cfg_he_en_0_qs;
-  logic bank1_info1_page_cfg_he_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_re;
+  logic bank1_info1_page_cfg_shadowed_we;
+  logic bank1_info1_page_cfg_shadowed_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_rd_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_rd_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_prog_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_prog_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_erase_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_erase_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_scramble_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_scramble_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_ecc_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_ecc_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_he_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_he_en_0_wd;
   logic bank1_info2_regwen_0_we;
   logic bank1_info2_regwen_0_qs;
   logic bank1_info2_regwen_0_wd;
   logic bank1_info2_regwen_1_we;
   logic bank1_info2_regwen_1_qs;
   logic bank1_info2_regwen_1_wd;
-  logic bank1_info2_page_cfg_0_we;
-  logic bank1_info2_page_cfg_0_en_0_qs;
-  logic bank1_info2_page_cfg_0_en_0_wd;
-  logic bank1_info2_page_cfg_0_rd_en_0_qs;
-  logic bank1_info2_page_cfg_0_rd_en_0_wd;
-  logic bank1_info2_page_cfg_0_prog_en_0_qs;
-  logic bank1_info2_page_cfg_0_prog_en_0_wd;
-  logic bank1_info2_page_cfg_0_erase_en_0_qs;
-  logic bank1_info2_page_cfg_0_erase_en_0_wd;
-  logic bank1_info2_page_cfg_0_scramble_en_0_qs;
-  logic bank1_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info2_page_cfg_0_ecc_en_0_qs;
-  logic bank1_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info2_page_cfg_0_he_en_0_qs;
-  logic bank1_info2_page_cfg_0_he_en_0_wd;
-  logic bank1_info2_page_cfg_1_we;
-  logic bank1_info2_page_cfg_1_en_1_qs;
-  logic bank1_info2_page_cfg_1_en_1_wd;
-  logic bank1_info2_page_cfg_1_rd_en_1_qs;
-  logic bank1_info2_page_cfg_1_rd_en_1_wd;
-  logic bank1_info2_page_cfg_1_prog_en_1_qs;
-  logic bank1_info2_page_cfg_1_prog_en_1_wd;
-  logic bank1_info2_page_cfg_1_erase_en_1_qs;
-  logic bank1_info2_page_cfg_1_erase_en_1_wd;
-  logic bank1_info2_page_cfg_1_scramble_en_1_qs;
-  logic bank1_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info2_page_cfg_1_ecc_en_1_qs;
-  logic bank1_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info2_page_cfg_1_he_en_1_qs;
-  logic bank1_info2_page_cfg_1_he_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_0_re;
+  logic bank1_info2_page_cfg_shadowed_0_we;
+  logic bank1_info2_page_cfg_shadowed_0_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_1_re;
+  logic bank1_info2_page_cfg_shadowed_1_we;
+  logic bank1_info2_page_cfg_shadowed_1_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_he_en_1_wd;
   logic bank_cfg_regwen_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
-  logic mp_bank_cfg_we;
-  logic mp_bank_cfg_erase_en_0_qs;
-  logic mp_bank_cfg_erase_en_0_wd;
-  logic mp_bank_cfg_erase_en_1_qs;
-  logic mp_bank_cfg_erase_en_1_wd;
+  logic mp_bank_cfg_shadowed_re;
+  logic mp_bank_cfg_shadowed_we;
+  logic mp_bank_cfg_shadowed_erase_en_0_qs;
+  logic mp_bank_cfg_shadowed_erase_en_0_wd;
+  logic mp_bank_cfg_shadowed_erase_en_1_qs;
+  logic mp_bank_cfg_shadowed_erase_en_1_wd;
   logic op_status_we;
   logic op_status_done_qs;
   logic op_status_done_wd;
@@ -1947,20 +1984,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg mp_region_cfg
-  // R[mp_region_cfg_0]: V(False)
+  // Subregister 0 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_en_0 (
+  ) u_mp_region_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1968,24 +2007,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_rd_en_0 (
+  ) u_mp_region_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_rd_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1993,24 +2038,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_rd_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_prog_en_0 (
+  ) u_mp_region_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_prog_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2018,24 +2069,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_prog_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_erase_en_0 (
+  ) u_mp_region_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_erase_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2043,24 +2100,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_erase_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_scramble_en_0 (
+  ) u_mp_region_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_scramble_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2068,24 +2131,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_scramble_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_ecc_en_0 (
+  ) u_mp_region_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_ecc_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2093,24 +2162,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_ecc_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_he_en_0 (
+  ) u_mp_region_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_he_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2118,24 +2193,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_he_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].he_en.err_storage)
   );
 
   //   F[base_0]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_0_base_0 (
+  ) u_mp_region_cfg_shadowed_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_base_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_base_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2143,24 +2224,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_base_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_base_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].base.err_storage)
   );
 
   //   F[size_0]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_0_size_0 (
+  ) u_mp_region_cfg_shadowed_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_size_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_size_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2168,27 +2255,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_size_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_size_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].size.err_storage)
   );
 
 
-  // Subregister 1 of Multireg mp_region_cfg
-  // R[mp_region_cfg_1]: V(False)
+  // Subregister 1 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_en_1 (
+  ) u_mp_region_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2196,24 +2289,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_rd_en_1 (
+  ) u_mp_region_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_rd_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2221,24 +2320,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_rd_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_prog_en_1 (
+  ) u_mp_region_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_prog_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2246,24 +2351,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_prog_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_erase_en_1 (
+  ) u_mp_region_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_erase_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2271,24 +2382,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_erase_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_scramble_en_1 (
+  ) u_mp_region_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_scramble_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2296,24 +2413,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_scramble_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_ecc_en_1 (
+  ) u_mp_region_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_ecc_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2321,24 +2444,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_ecc_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_he_en_1 (
+  ) u_mp_region_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_he_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2346,24 +2475,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_he_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].he_en.err_storage)
   );
 
   //   F[base_1]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_1_base_1 (
+  ) u_mp_region_cfg_shadowed_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_base_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_base_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2371,24 +2506,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_base_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_base_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].base.err_storage)
   );
 
   //   F[size_1]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_1_size_1 (
+  ) u_mp_region_cfg_shadowed_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_size_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_size_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2396,27 +2537,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_size_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_size_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].size.err_storage)
   );
 
 
-  // Subregister 2 of Multireg mp_region_cfg
-  // R[mp_region_cfg_2]: V(False)
+  // Subregister 2 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_2]: V(False)
   //   F[en_2]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_en_2 (
+  ) u_mp_region_cfg_shadowed_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2424,24 +2571,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].en.err_storage)
   );
 
   //   F[rd_en_2]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_rd_en_2 (
+  ) u_mp_region_cfg_shadowed_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_rd_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_rd_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2449,24 +2602,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_rd_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].rd_en.err_storage)
   );
 
   //   F[prog_en_2]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_prog_en_2 (
+  ) u_mp_region_cfg_shadowed_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_prog_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_prog_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2474,24 +2633,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_prog_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_prog_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_storage)
   );
 
   //   F[erase_en_2]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_erase_en_2 (
+  ) u_mp_region_cfg_shadowed_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_erase_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_erase_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2499,24 +2664,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_erase_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].erase_en.err_storage)
   );
 
   //   F[scramble_en_2]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_scramble_en_2 (
+  ) u_mp_region_cfg_shadowed_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_scramble_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_scramble_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2524,24 +2695,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_scramble_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_scramble_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_storage)
   );
 
   //   F[ecc_en_2]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_ecc_en_2 (
+  ) u_mp_region_cfg_shadowed_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_ecc_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_ecc_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2549,24 +2726,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_ecc_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].ecc_en.err_storage)
   );
 
   //   F[he_en_2]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_he_en_2 (
+  ) u_mp_region_cfg_shadowed_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_he_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_he_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2574,24 +2757,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_he_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].he_en.err_storage)
   );
 
   //   F[base_2]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_2_base_2 (
+  ) u_mp_region_cfg_shadowed_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_base_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_base_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2599,24 +2788,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_base_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_base_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].base.err_storage)
   );
 
   //   F[size_2]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_2_size_2 (
+  ) u_mp_region_cfg_shadowed_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_size_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_size_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2624,27 +2819,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_size_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_size_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].size.err_storage)
   );
 
 
-  // Subregister 3 of Multireg mp_region_cfg
-  // R[mp_region_cfg_3]: V(False)
+  // Subregister 3 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_3]: V(False)
   //   F[en_3]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_en_3 (
+  ) u_mp_region_cfg_shadowed_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2652,24 +2853,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].en.err_storage)
   );
 
   //   F[rd_en_3]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_rd_en_3 (
+  ) u_mp_region_cfg_shadowed_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_rd_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_rd_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2677,24 +2884,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_rd_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].rd_en.err_storage)
   );
 
   //   F[prog_en_3]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_prog_en_3 (
+  ) u_mp_region_cfg_shadowed_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_prog_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_prog_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2702,24 +2915,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_prog_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_prog_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_storage)
   );
 
   //   F[erase_en_3]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_erase_en_3 (
+  ) u_mp_region_cfg_shadowed_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_erase_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_erase_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2727,24 +2946,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_erase_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].erase_en.err_storage)
   );
 
   //   F[scramble_en_3]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_scramble_en_3 (
+  ) u_mp_region_cfg_shadowed_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_scramble_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_scramble_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2752,24 +2977,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_scramble_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_scramble_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_storage)
   );
 
   //   F[ecc_en_3]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_ecc_en_3 (
+  ) u_mp_region_cfg_shadowed_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_ecc_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_ecc_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2777,24 +3008,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_ecc_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].ecc_en.err_storage)
   );
 
   //   F[he_en_3]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_he_en_3 (
+  ) u_mp_region_cfg_shadowed_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_he_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_he_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2802,24 +3039,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_he_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].he_en.err_storage)
   );
 
   //   F[base_3]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_3_base_3 (
+  ) u_mp_region_cfg_shadowed_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_base_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_base_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2827,24 +3070,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_base_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_base_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].base.err_storage)
   );
 
   //   F[size_3]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_3_size_3 (
+  ) u_mp_region_cfg_shadowed_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_size_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_size_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2852,27 +3101,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_size_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_size_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].size.err_storage)
   );
 
 
-  // Subregister 4 of Multireg mp_region_cfg
-  // R[mp_region_cfg_4]: V(False)
+  // Subregister 4 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_4]: V(False)
   //   F[en_4]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_en_4 (
+  ) u_mp_region_cfg_shadowed_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2880,24 +3135,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].en.err_storage)
   );
 
   //   F[rd_en_4]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_rd_en_4 (
+  ) u_mp_region_cfg_shadowed_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_rd_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_rd_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2905,24 +3166,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_rd_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].rd_en.err_storage)
   );
 
   //   F[prog_en_4]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_prog_en_4 (
+  ) u_mp_region_cfg_shadowed_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_prog_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_prog_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2930,24 +3197,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_prog_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_prog_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_storage)
   );
 
   //   F[erase_en_4]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_erase_en_4 (
+  ) u_mp_region_cfg_shadowed_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_erase_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_erase_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2955,24 +3228,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_erase_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].erase_en.err_storage)
   );
 
   //   F[scramble_en_4]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_scramble_en_4 (
+  ) u_mp_region_cfg_shadowed_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_scramble_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_scramble_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2980,24 +3259,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_scramble_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_scramble_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_storage)
   );
 
   //   F[ecc_en_4]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_ecc_en_4 (
+  ) u_mp_region_cfg_shadowed_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_ecc_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_ecc_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3005,24 +3290,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_ecc_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].ecc_en.err_storage)
   );
 
   //   F[he_en_4]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_he_en_4 (
+  ) u_mp_region_cfg_shadowed_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_he_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_he_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3030,24 +3321,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_he_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].he_en.err_storage)
   );
 
   //   F[base_4]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_4_base_4 (
+  ) u_mp_region_cfg_shadowed_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_base_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_base_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3055,24 +3352,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_base_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_base_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].base.err_storage)
   );
 
   //   F[size_4]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_4_size_4 (
+  ) u_mp_region_cfg_shadowed_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_size_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_size_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3080,27 +3383,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_size_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_size_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].size.err_storage)
   );
 
 
-  // Subregister 5 of Multireg mp_region_cfg
-  // R[mp_region_cfg_5]: V(False)
+  // Subregister 5 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_5]: V(False)
   //   F[en_5]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_en_5 (
+  ) u_mp_region_cfg_shadowed_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3108,24 +3417,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].en.err_storage)
   );
 
   //   F[rd_en_5]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_rd_en_5 (
+  ) u_mp_region_cfg_shadowed_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_rd_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_rd_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3133,24 +3448,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_rd_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].rd_en.err_storage)
   );
 
   //   F[prog_en_5]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_prog_en_5 (
+  ) u_mp_region_cfg_shadowed_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_prog_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_prog_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3158,24 +3479,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_prog_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_prog_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_storage)
   );
 
   //   F[erase_en_5]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_erase_en_5 (
+  ) u_mp_region_cfg_shadowed_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_erase_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_erase_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3183,24 +3510,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_erase_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].erase_en.err_storage)
   );
 
   //   F[scramble_en_5]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_scramble_en_5 (
+  ) u_mp_region_cfg_shadowed_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_scramble_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_scramble_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3208,24 +3541,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_scramble_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_scramble_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_storage)
   );
 
   //   F[ecc_en_5]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_ecc_en_5 (
+  ) u_mp_region_cfg_shadowed_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_ecc_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_ecc_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3233,24 +3572,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_ecc_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].ecc_en.err_storage)
   );
 
   //   F[he_en_5]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_he_en_5 (
+  ) u_mp_region_cfg_shadowed_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_he_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_he_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3258,24 +3603,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_he_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].he_en.err_storage)
   );
 
   //   F[base_5]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_5_base_5 (
+  ) u_mp_region_cfg_shadowed_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_base_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_base_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3283,24 +3634,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_base_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_base_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].base.err_storage)
   );
 
   //   F[size_5]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_5_size_5 (
+  ) u_mp_region_cfg_shadowed_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_size_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_size_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3308,27 +3665,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_size_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_size_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].size.err_storage)
   );
 
 
-  // Subregister 6 of Multireg mp_region_cfg
-  // R[mp_region_cfg_6]: V(False)
+  // Subregister 6 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_6]: V(False)
   //   F[en_6]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_en_6 (
+  ) u_mp_region_cfg_shadowed_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3336,24 +3699,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].en.err_storage)
   );
 
   //   F[rd_en_6]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_rd_en_6 (
+  ) u_mp_region_cfg_shadowed_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_rd_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_rd_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3361,24 +3730,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_rd_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].rd_en.err_storage)
   );
 
   //   F[prog_en_6]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_prog_en_6 (
+  ) u_mp_region_cfg_shadowed_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_prog_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_prog_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3386,24 +3761,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_prog_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_prog_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_storage)
   );
 
   //   F[erase_en_6]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_erase_en_6 (
+  ) u_mp_region_cfg_shadowed_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_erase_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_erase_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3411,24 +3792,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_erase_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].erase_en.err_storage)
   );
 
   //   F[scramble_en_6]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_scramble_en_6 (
+  ) u_mp_region_cfg_shadowed_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_scramble_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_scramble_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3436,24 +3823,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_scramble_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_scramble_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_storage)
   );
 
   //   F[ecc_en_6]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_ecc_en_6 (
+  ) u_mp_region_cfg_shadowed_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_ecc_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_ecc_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3461,24 +3854,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_ecc_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].ecc_en.err_storage)
   );
 
   //   F[he_en_6]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_he_en_6 (
+  ) u_mp_region_cfg_shadowed_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_he_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_he_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3486,24 +3885,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_he_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].he_en.err_storage)
   );
 
   //   F[base_6]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_6_base_6 (
+  ) u_mp_region_cfg_shadowed_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_base_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_base_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3511,24 +3916,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_base_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_base_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].base.err_storage)
   );
 
   //   F[size_6]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_6_size_6 (
+  ) u_mp_region_cfg_shadowed_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_size_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_size_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3536,27 +3947,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_size_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_size_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].size.err_storage)
   );
 
 
-  // Subregister 7 of Multireg mp_region_cfg
-  // R[mp_region_cfg_7]: V(False)
+  // Subregister 7 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_7]: V(False)
   //   F[en_7]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_en_7 (
+  ) u_mp_region_cfg_shadowed_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3564,24 +3981,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].en.err_storage)
   );
 
   //   F[rd_en_7]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_rd_en_7 (
+  ) u_mp_region_cfg_shadowed_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_rd_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_rd_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3589,24 +4012,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_rd_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].rd_en.err_storage)
   );
 
   //   F[prog_en_7]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_prog_en_7 (
+  ) u_mp_region_cfg_shadowed_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_prog_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_prog_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3614,24 +4043,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_prog_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_prog_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_storage)
   );
 
   //   F[erase_en_7]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_erase_en_7 (
+  ) u_mp_region_cfg_shadowed_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_erase_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_erase_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3639,24 +4074,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_erase_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].erase_en.err_storage)
   );
 
   //   F[scramble_en_7]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_scramble_en_7 (
+  ) u_mp_region_cfg_shadowed_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_scramble_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_scramble_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3664,24 +4105,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_scramble_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_scramble_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_storage)
   );
 
   //   F[ecc_en_7]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_ecc_en_7 (
+  ) u_mp_region_cfg_shadowed_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_ecc_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_ecc_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3689,24 +4136,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_ecc_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].ecc_en.err_storage)
   );
 
   //   F[he_en_7]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_he_en_7 (
+  ) u_mp_region_cfg_shadowed_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_he_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_he_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3714,24 +4167,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_he_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].he_en.err_storage)
   );
 
   //   F[base_7]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_7_base_7 (
+  ) u_mp_region_cfg_shadowed_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_base_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_base_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3739,24 +4198,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_base_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_base_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].base.err_storage)
   );
 
   //   F[size_7]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_7_size_7 (
+  ) u_mp_region_cfg_shadowed_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_size_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_size_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3764,26 +4229,32 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_size_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_size_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].size.err_storage)
   );
 
 
-  // R[default_region]: V(False)
+  // R[default_region_shadowed]: V(False)
   //   F[rd_en]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_rd_en (
+  ) u_default_region_shadowed_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_rd_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_rd_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3791,24 +4262,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.rd_en.q),
+    .q      (reg2hw.default_region_shadowed.rd_en.q),
 
     // to register interface (read)
-    .qs     (default_region_rd_en_qs)
+    .qs     (default_region_shadowed_rd_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.rd_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.rd_en.err_storage)
   );
 
   //   F[prog_en]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_prog_en (
+  ) u_default_region_shadowed_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_prog_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_prog_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3816,24 +4293,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.prog_en.q),
+    .q      (reg2hw.default_region_shadowed.prog_en.q),
 
     // to register interface (read)
-    .qs     (default_region_prog_en_qs)
+    .qs     (default_region_shadowed_prog_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.prog_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.prog_en.err_storage)
   );
 
   //   F[erase_en]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_erase_en (
+  ) u_default_region_shadowed_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_erase_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_erase_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3841,24 +4324,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.erase_en.q),
+    .q      (reg2hw.default_region_shadowed.erase_en.q),
 
     // to register interface (read)
-    .qs     (default_region_erase_en_qs)
+    .qs     (default_region_shadowed_erase_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.erase_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.erase_en.err_storage)
   );
 
   //   F[scramble_en]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_scramble_en (
+  ) u_default_region_shadowed_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_scramble_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_scramble_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3866,24 +4355,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.scramble_en.q),
+    .q      (reg2hw.default_region_shadowed.scramble_en.q),
 
     // to register interface (read)
-    .qs     (default_region_scramble_en_qs)
+    .qs     (default_region_shadowed_scramble_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.scramble_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.scramble_en.err_storage)
   );
 
   //   F[ecc_en]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_ecc_en (
+  ) u_default_region_shadowed_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_ecc_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_ecc_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3891,24 +4386,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.ecc_en.q),
+    .q      (reg2hw.default_region_shadowed.ecc_en.q),
 
     // to register interface (read)
-    .qs     (default_region_ecc_en_qs)
+    .qs     (default_region_shadowed_ecc_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.ecc_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.ecc_en.err_storage)
   );
 
   //   F[he_en]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_he_en (
+  ) u_default_region_shadowed_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_he_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_he_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3916,10 +4417,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.he_en.q),
+    .q      (reg2hw.default_region_shadowed.he_en.q),
 
     // to register interface (read)
-    .qs     (default_region_he_en_qs)
+    .qs     (default_region_shadowed_he_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.he_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.he_en.err_storage)
   );
 
 
@@ -4193,20 +4698,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4214,24 +4721,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_rd_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_rd_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4239,24 +4752,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_rd_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_prog_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_prog_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4264,24 +4783,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_prog_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_erase_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_erase_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4289,24 +4814,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_erase_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_scramble_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_scramble_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4314,24 +4845,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_ecc_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_ecc_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4339,24 +4876,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_he_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_he_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4364,27 +4907,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_he_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4392,24 +4941,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_rd_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_rd_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4417,24 +4972,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_rd_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_prog_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_prog_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4442,24 +5003,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_prog_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_erase_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_erase_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4467,24 +5034,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_scramble_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_scramble_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4492,24 +5065,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_ecc_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_ecc_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4517,24 +5096,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_he_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_he_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4542,27 +5127,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_he_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
-  // Subregister 2 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_2]: V(False)
+  // Subregister 2 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_2]: V(False)
   //   F[en_2]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4570,24 +5161,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_storage)
   );
 
   //   F[rd_en_2]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_rd_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_rd_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_rd_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4595,24 +5192,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_rd_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.err_storage)
   );
 
   //   F[prog_en_2]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_prog_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_prog_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_prog_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4620,24 +5223,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_prog_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_prog_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_storage)
   );
 
   //   F[erase_en_2]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_erase_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_erase_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_erase_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4645,24 +5254,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_erase_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.err_storage)
   );
 
   //   F[scramble_en_2]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_scramble_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_scramble_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_scramble_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4670,24 +5285,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_storage)
   );
 
   //   F[ecc_en_2]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_ecc_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_ecc_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_ecc_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4695,24 +5316,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_storage)
   );
 
   //   F[he_en_2]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_he_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_he_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_he_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4720,27 +5347,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_he_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.err_storage)
   );
 
 
-  // Subregister 3 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_3]: V(False)
+  // Subregister 3 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_3]: V(False)
   //   F[en_3]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4748,24 +5381,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_storage)
   );
 
   //   F[rd_en_3]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_rd_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_rd_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_rd_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4773,24 +5412,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_rd_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.err_storage)
   );
 
   //   F[prog_en_3]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_prog_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_prog_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_prog_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4798,24 +5443,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_prog_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_prog_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_storage)
   );
 
   //   F[erase_en_3]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_erase_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_erase_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_erase_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4823,24 +5474,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.err_storage)
   );
 
   //   F[scramble_en_3]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_scramble_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_scramble_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_scramble_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4848,24 +5505,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_storage)
   );
 
   //   F[ecc_en_3]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_ecc_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_ecc_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_ecc_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4873,24 +5536,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_storage)
   );
 
   //   F[he_en_3]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_he_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_he_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_he_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4898,27 +5567,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_he_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.err_storage)
   );
 
 
-  // Subregister 4 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_4]: V(False)
+  // Subregister 4 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_4]: V(False)
   //   F[en_4]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4926,24 +5601,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_storage)
   );
 
   //   F[rd_en_4]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_rd_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_rd_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_rd_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4951,24 +5632,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_rd_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.err_storage)
   );
 
   //   F[prog_en_4]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_prog_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_prog_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_prog_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4976,24 +5663,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_prog_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_prog_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_storage)
   );
 
   //   F[erase_en_4]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_erase_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_erase_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_erase_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5001,24 +5694,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_erase_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.err_storage)
   );
 
   //   F[scramble_en_4]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_scramble_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_scramble_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_scramble_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5026,24 +5725,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_scramble_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_storage)
   );
 
   //   F[ecc_en_4]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_ecc_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_ecc_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_ecc_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5051,24 +5756,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_ecc_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_storage)
   );
 
   //   F[he_en_4]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_he_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_he_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_he_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5076,27 +5787,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_he_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.err_storage)
   );
 
 
-  // Subregister 5 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_5]: V(False)
+  // Subregister 5 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_5]: V(False)
   //   F[en_5]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5104,24 +5821,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_storage)
   );
 
   //   F[rd_en_5]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_rd_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_rd_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_rd_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5129,24 +5852,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_rd_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.err_storage)
   );
 
   //   F[prog_en_5]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_prog_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_prog_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_prog_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5154,24 +5883,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_prog_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_prog_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_storage)
   );
 
   //   F[erase_en_5]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_erase_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_erase_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_erase_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5179,24 +5914,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_erase_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.err_storage)
   );
 
   //   F[scramble_en_5]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_scramble_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_scramble_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_scramble_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5204,24 +5945,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_scramble_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_storage)
   );
 
   //   F[ecc_en_5]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_ecc_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_ecc_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_ecc_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5229,24 +5976,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_ecc_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_storage)
   );
 
   //   F[he_en_5]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_he_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_he_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_he_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5254,27 +6007,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_he_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.err_storage)
   );
 
 
-  // Subregister 6 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_6]: V(False)
+  // Subregister 6 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_6]: V(False)
   //   F[en_6]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5282,24 +6041,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_storage)
   );
 
   //   F[rd_en_6]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_rd_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_rd_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_rd_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5307,24 +6072,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_rd_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.err_storage)
   );
 
   //   F[prog_en_6]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_prog_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_prog_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_prog_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5332,24 +6103,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_prog_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_prog_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_storage)
   );
 
   //   F[erase_en_6]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_erase_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_erase_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_erase_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5357,24 +6134,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_erase_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.err_storage)
   );
 
   //   F[scramble_en_6]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_scramble_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_scramble_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_scramble_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5382,24 +6165,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_scramble_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_storage)
   );
 
   //   F[ecc_en_6]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_ecc_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_ecc_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_ecc_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5407,24 +6196,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_ecc_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_storage)
   );
 
   //   F[he_en_6]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_he_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_he_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_he_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5432,27 +6227,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_he_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.err_storage)
   );
 
 
-  // Subregister 7 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_7]: V(False)
+  // Subregister 7 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_7]: V(False)
   //   F[en_7]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5460,24 +6261,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_storage)
   );
 
   //   F[rd_en_7]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_rd_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_rd_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_rd_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5485,24 +6292,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_rd_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.err_storage)
   );
 
   //   F[prog_en_7]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_prog_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_prog_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_prog_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5510,24 +6323,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_prog_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_prog_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_storage)
   );
 
   //   F[erase_en_7]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_erase_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_erase_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_erase_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5535,24 +6354,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_erase_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.err_storage)
   );
 
   //   F[scramble_en_7]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_scramble_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_scramble_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_scramble_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5560,24 +6385,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_scramble_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_storage)
   );
 
   //   F[ecc_en_7]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_ecc_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_ecc_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_ecc_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5585,24 +6416,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_ecc_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_storage)
   );
 
   //   F[he_en_7]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_he_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_he_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_he_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5610,27 +6447,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_he_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.err_storage)
   );
 
 
-  // Subregister 8 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_8]: V(False)
+  // Subregister 8 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_8]: V(False)
   //   F[en_8]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5638,24 +6481,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_storage)
   );
 
   //   F[rd_en_8]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_rd_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_rd_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_rd_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5663,24 +6512,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_rd_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.err_storage)
   );
 
   //   F[prog_en_8]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_prog_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_prog_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_prog_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5688,24 +6543,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_prog_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_prog_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_storage)
   );
 
   //   F[erase_en_8]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_erase_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_erase_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_erase_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5713,24 +6574,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_erase_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.err_storage)
   );
 
   //   F[scramble_en_8]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_scramble_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_scramble_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_scramble_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5738,24 +6605,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_scramble_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_storage)
   );
 
   //   F[ecc_en_8]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_ecc_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_ecc_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_ecc_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5763,24 +6636,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_ecc_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_storage)
   );
 
   //   F[he_en_8]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_he_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_he_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_he_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5788,27 +6667,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_he_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.err_storage)
   );
 
 
-  // Subregister 9 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_9]: V(False)
+  // Subregister 9 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_9]: V(False)
   //   F[en_9]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5816,24 +6701,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_storage)
   );
 
   //   F[rd_en_9]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_rd_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_rd_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_rd_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5841,24 +6732,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_rd_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.err_storage)
   );
 
   //   F[prog_en_9]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_prog_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_prog_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_prog_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5866,24 +6763,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_prog_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_prog_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_storage)
   );
 
   //   F[erase_en_9]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_erase_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_erase_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_erase_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5891,24 +6794,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_erase_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.err_storage)
   );
 
   //   F[scramble_en_9]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_scramble_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_scramble_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_scramble_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5916,24 +6825,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_scramble_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_storage)
   );
 
   //   F[ecc_en_9]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_ecc_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_ecc_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_ecc_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5941,24 +6856,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_ecc_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_storage)
   );
 
   //   F[he_en_9]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_he_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_he_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_he_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5966,10 +6887,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_he_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.err_storage)
   );
 
 
@@ -6000,20 +6925,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank0_info1_page_cfg
-  // R[bank0_info1_page_cfg]: V(False)
+  // Subregister 0 of Multireg bank0_info1_page_cfg_shadowed
+  // R[bank0_info1_page_cfg_shadowed]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6021,24 +6948,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_rd_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_rd_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6046,24 +6979,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_rd_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_prog_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_prog_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6071,24 +7010,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_prog_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_erase_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_erase_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6096,24 +7041,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_erase_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_scramble_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_scramble_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6121,24 +7072,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_scramble_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_ecc_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_ecc_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6146,24 +7103,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_ecc_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_he_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_he_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6171,10 +7134,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_he_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
@@ -6232,20 +7199,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank0_info2_page_cfg
-  // R[bank0_info2_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank0_info2_page_cfg_shadowed
+  // R[bank0_info2_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6253,24 +7222,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_rd_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_rd_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6278,24 +7253,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_rd_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_prog_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_prog_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6303,24 +7284,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_prog_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_erase_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_erase_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6328,24 +7315,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_erase_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_scramble_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_scramble_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6353,24 +7346,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_ecc_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_ecc_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6378,24 +7377,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_he_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_he_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6403,27 +7408,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_he_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank0_info2_page_cfg
-  // R[bank0_info2_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank0_info2_page_cfg_shadowed
+  // R[bank0_info2_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6431,24 +7442,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_rd_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_rd_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6456,24 +7473,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_rd_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_prog_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_prog_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6481,24 +7504,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_prog_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_erase_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_erase_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6506,24 +7535,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_erase_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_scramble_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_scramble_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6531,24 +7566,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_ecc_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_ecc_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6556,24 +7597,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_he_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_he_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6581,10 +7628,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_he_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
@@ -6858,20 +7909,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6879,24 +7932,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_rd_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_rd_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6904,24 +7963,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_rd_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_prog_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_prog_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6929,24 +7994,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_prog_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_erase_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_erase_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6954,24 +8025,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_erase_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_scramble_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_scramble_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6979,24 +8056,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_ecc_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_ecc_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7004,24 +8087,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_he_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_he_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7029,27 +8118,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_he_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7057,24 +8152,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_rd_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_rd_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7082,24 +8183,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_rd_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_prog_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_prog_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7107,24 +8214,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_prog_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_erase_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_erase_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7132,24 +8245,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_scramble_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_scramble_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7157,24 +8276,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_ecc_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_ecc_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7182,24 +8307,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_he_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_he_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7207,27 +8338,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_he_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
-  // Subregister 2 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_2]: V(False)
+  // Subregister 2 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_2]: V(False)
   //   F[en_2]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7235,24 +8372,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_storage)
   );
 
   //   F[rd_en_2]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_rd_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_rd_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_rd_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7260,24 +8403,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_rd_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.err_storage)
   );
 
   //   F[prog_en_2]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_prog_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_prog_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_prog_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7285,24 +8434,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_prog_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_prog_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_storage)
   );
 
   //   F[erase_en_2]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_erase_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_erase_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_erase_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7310,24 +8465,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_erase_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.err_storage)
   );
 
   //   F[scramble_en_2]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_scramble_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_scramble_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_scramble_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7335,24 +8496,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_storage)
   );
 
   //   F[ecc_en_2]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_ecc_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_ecc_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_ecc_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7360,24 +8527,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_storage)
   );
 
   //   F[he_en_2]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_he_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_he_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_he_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7385,27 +8558,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_he_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.err_storage)
   );
 
 
-  // Subregister 3 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_3]: V(False)
+  // Subregister 3 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_3]: V(False)
   //   F[en_3]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7413,24 +8592,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_storage)
   );
 
   //   F[rd_en_3]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_rd_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_rd_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_rd_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7438,24 +8623,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_rd_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.err_storage)
   );
 
   //   F[prog_en_3]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_prog_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_prog_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_prog_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7463,24 +8654,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_prog_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_prog_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_storage)
   );
 
   //   F[erase_en_3]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_erase_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_erase_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_erase_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7488,24 +8685,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.err_storage)
   );
 
   //   F[scramble_en_3]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_scramble_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_scramble_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_scramble_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7513,24 +8716,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_storage)
   );
 
   //   F[ecc_en_3]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_ecc_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_ecc_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_ecc_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7538,24 +8747,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_storage)
   );
 
   //   F[he_en_3]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_he_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_he_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_he_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7563,27 +8778,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_he_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.err_storage)
   );
 
 
-  // Subregister 4 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_4]: V(False)
+  // Subregister 4 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_4]: V(False)
   //   F[en_4]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7591,24 +8812,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_storage)
   );
 
   //   F[rd_en_4]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_rd_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_rd_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_rd_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7616,24 +8843,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_rd_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.err_storage)
   );
 
   //   F[prog_en_4]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_prog_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_prog_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_prog_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7641,24 +8874,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_prog_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_prog_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_storage)
   );
 
   //   F[erase_en_4]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_erase_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_erase_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_erase_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7666,24 +8905,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_erase_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.err_storage)
   );
 
   //   F[scramble_en_4]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_scramble_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_scramble_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_scramble_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7691,24 +8936,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_scramble_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_storage)
   );
 
   //   F[ecc_en_4]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_ecc_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_ecc_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_ecc_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7716,24 +8967,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_ecc_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_storage)
   );
 
   //   F[he_en_4]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_he_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_he_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_he_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7741,27 +8998,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_he_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.err_storage)
   );
 
 
-  // Subregister 5 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_5]: V(False)
+  // Subregister 5 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_5]: V(False)
   //   F[en_5]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7769,24 +9032,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_storage)
   );
 
   //   F[rd_en_5]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_rd_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_rd_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_rd_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7794,24 +9063,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_rd_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.err_storage)
   );
 
   //   F[prog_en_5]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_prog_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_prog_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_prog_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7819,24 +9094,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_prog_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_prog_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_storage)
   );
 
   //   F[erase_en_5]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_erase_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_erase_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_erase_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7844,24 +9125,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_erase_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.err_storage)
   );
 
   //   F[scramble_en_5]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_scramble_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_scramble_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_scramble_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7869,24 +9156,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_scramble_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_storage)
   );
 
   //   F[ecc_en_5]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_ecc_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_ecc_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_ecc_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7894,24 +9187,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_ecc_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_storage)
   );
 
   //   F[he_en_5]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_he_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_he_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_he_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7919,27 +9218,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_he_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.err_storage)
   );
 
 
-  // Subregister 6 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_6]: V(False)
+  // Subregister 6 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_6]: V(False)
   //   F[en_6]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7947,24 +9252,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_storage)
   );
 
   //   F[rd_en_6]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_rd_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_rd_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_rd_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7972,24 +9283,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_rd_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.err_storage)
   );
 
   //   F[prog_en_6]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_prog_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_prog_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_prog_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7997,24 +9314,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_prog_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_prog_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_storage)
   );
 
   //   F[erase_en_6]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_erase_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_erase_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_erase_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8022,24 +9345,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_erase_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.err_storage)
   );
 
   //   F[scramble_en_6]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_scramble_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_scramble_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_scramble_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8047,24 +9376,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_scramble_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_storage)
   );
 
   //   F[ecc_en_6]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_ecc_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_ecc_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_ecc_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8072,24 +9407,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_ecc_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_storage)
   );
 
   //   F[he_en_6]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_he_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_he_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_he_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8097,27 +9438,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_he_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.err_storage)
   );
 
 
-  // Subregister 7 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_7]: V(False)
+  // Subregister 7 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_7]: V(False)
   //   F[en_7]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8125,24 +9472,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_storage)
   );
 
   //   F[rd_en_7]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_rd_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_rd_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_rd_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8150,24 +9503,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_rd_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.err_storage)
   );
 
   //   F[prog_en_7]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_prog_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_prog_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_prog_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8175,24 +9534,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_prog_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_prog_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_storage)
   );
 
   //   F[erase_en_7]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_erase_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_erase_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_erase_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8200,24 +9565,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_erase_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.err_storage)
   );
 
   //   F[scramble_en_7]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_scramble_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_scramble_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_scramble_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8225,24 +9596,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_scramble_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_storage)
   );
 
   //   F[ecc_en_7]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_ecc_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_ecc_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_ecc_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8250,24 +9627,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_ecc_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_storage)
   );
 
   //   F[he_en_7]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_he_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_he_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_he_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8275,27 +9658,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_he_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.err_storage)
   );
 
 
-  // Subregister 8 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_8]: V(False)
+  // Subregister 8 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_8]: V(False)
   //   F[en_8]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8303,24 +9692,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_storage)
   );
 
   //   F[rd_en_8]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_rd_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_rd_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_rd_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8328,24 +9723,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_rd_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.err_storage)
   );
 
   //   F[prog_en_8]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_prog_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_prog_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_prog_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8353,24 +9754,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_prog_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_prog_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_storage)
   );
 
   //   F[erase_en_8]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_erase_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_erase_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_erase_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8378,24 +9785,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_erase_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.err_storage)
   );
 
   //   F[scramble_en_8]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_scramble_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_scramble_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_scramble_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8403,24 +9816,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_scramble_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_storage)
   );
 
   //   F[ecc_en_8]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_ecc_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_ecc_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_ecc_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8428,24 +9847,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_ecc_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_storage)
   );
 
   //   F[he_en_8]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_he_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_he_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_he_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8453,27 +9878,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_he_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.err_storage)
   );
 
 
-  // Subregister 9 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_9]: V(False)
+  // Subregister 9 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_9]: V(False)
   //   F[en_9]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8481,24 +9912,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_storage)
   );
 
   //   F[rd_en_9]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_rd_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_rd_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_rd_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8506,24 +9943,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_rd_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.err_storage)
   );
 
   //   F[prog_en_9]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_prog_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_prog_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_prog_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8531,24 +9974,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_prog_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_prog_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_storage)
   );
 
   //   F[erase_en_9]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_erase_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_erase_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_erase_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8556,24 +10005,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_erase_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.err_storage)
   );
 
   //   F[scramble_en_9]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_scramble_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_scramble_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_scramble_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8581,24 +10036,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_scramble_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_storage)
   );
 
   //   F[ecc_en_9]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_ecc_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_ecc_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_ecc_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8606,24 +10067,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_ecc_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_storage)
   );
 
   //   F[he_en_9]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_he_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_he_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_he_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8631,10 +10098,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_he_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.err_storage)
   );
 
 
@@ -8665,20 +10136,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank1_info1_page_cfg
-  // R[bank1_info1_page_cfg]: V(False)
+  // Subregister 0 of Multireg bank1_info1_page_cfg_shadowed
+  // R[bank1_info1_page_cfg_shadowed]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8686,24 +10159,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_rd_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_rd_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8711,24 +10190,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_rd_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_prog_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_prog_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8736,24 +10221,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_prog_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_erase_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_erase_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8761,24 +10252,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_erase_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_scramble_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_scramble_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8786,24 +10283,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_scramble_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_ecc_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_ecc_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8811,24 +10314,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_ecc_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_he_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_he_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8836,10 +10345,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_he_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
@@ -8897,20 +10410,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank1_info2_page_cfg
-  // R[bank1_info2_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank1_info2_page_cfg_shadowed
+  // R[bank1_info2_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8918,24 +10433,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_rd_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_rd_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8943,24 +10464,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_rd_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_prog_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_prog_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8968,24 +10495,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_prog_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_erase_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_erase_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8993,24 +10526,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_erase_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_scramble_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_scramble_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9018,24 +10557,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_ecc_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_ecc_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9043,24 +10588,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_he_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_he_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9068,27 +10619,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_he_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank1_info2_page_cfg
-  // R[bank1_info2_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank1_info2_page_cfg_shadowed
+  // R[bank1_info2_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9096,24 +10653,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_rd_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_rd_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9121,24 +10684,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_rd_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_prog_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_prog_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9146,24 +10715,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_prog_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_erase_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_erase_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9171,24 +10746,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_erase_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_scramble_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_scramble_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9196,24 +10777,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_ecc_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_ecc_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9221,24 +10808,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_he_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_he_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9246,10 +10839,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_he_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
@@ -9279,20 +10876,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg mp_bank_cfg
-  // R[mp_bank_cfg]: V(False)
+  // Subregister 0 of Multireg mp_bank_cfg_shadowed
+  // R[mp_bank_cfg_shadowed]: V(False)
   //   F[erase_en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_bank_cfg_erase_en_0 (
+  ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
-    .wd     (mp_bank_cfg_erase_en_0_wd),
+    .re     (mp_bank_cfg_shadowed_re),
+    .we     (mp_bank_cfg_shadowed_we & bank_cfg_regwen_qs),
+    .wd     (mp_bank_cfg_shadowed_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9300,24 +10899,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_bank_cfg[0].q),
+    .q      (reg2hw.mp_bank_cfg_shadowed[0].q),
 
     // to register interface (read)
-    .qs     (mp_bank_cfg_erase_en_0_qs)
+    .qs     (mp_bank_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_bank_cfg_shadowed[0].err_update),
+    .err_storage (reg2hw.mp_bank_cfg_shadowed[0].err_storage)
   );
 
   //   F[erase_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_bank_cfg_erase_en_1 (
+  ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
-    .wd     (mp_bank_cfg_erase_en_1_wd),
+    .re     (mp_bank_cfg_shadowed_re),
+    .we     (mp_bank_cfg_shadowed_we & bank_cfg_regwen_qs),
+    .wd     (mp_bank_cfg_shadowed_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9325,10 +10930,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_bank_cfg[1].q),
+    .q      (reg2hw.mp_bank_cfg_shadowed[1].q),
 
     // to register interface (read)
-    .qs     (mp_bank_cfg_erase_en_1_qs)
+    .qs     (mp_bank_cfg_shadowed_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_bank_cfg_shadowed[1].err_update),
+    .err_storage (reg2hw.mp_bank_cfg_shadowed[1].err_storage)
   );
 
 
@@ -10331,15 +11940,15 @@ module flash_ctrl_core_reg_top (
     addr_hit[16] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET);
     addr_hit[17] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET);
     addr_hit[18] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
-    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
-    addr_hit[24] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
-    addr_hit[25] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
-    addr_hit[26] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
-    addr_hit[27] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_1_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_2_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_3_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_4_OFFSET);
+    addr_hit[24] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_5_OFFSET);
+    addr_hit[25] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_6_OFFSET);
+    addr_hit[26] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_7_OFFSET);
+    addr_hit[27] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_SHADOWED_OFFSET);
     addr_hit[28] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET);
     addr_hit[29] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET);
     addr_hit[30] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET);
@@ -10350,22 +11959,22 @@ module flash_ctrl_core_reg_top (
     addr_hit[35] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET);
     addr_hit[36] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET);
     addr_hit[37] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET);
-    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1_OFFSET);
+    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2_OFFSET);
+    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3_OFFSET);
+    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4_OFFSET);
+    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5_OFFSET);
+    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6_OFFSET);
+    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7_OFFSET);
+    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8_OFFSET);
+    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9_OFFSET);
     addr_hit[48] = (reg_addr == FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET);
-    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED_OFFSET);
     addr_hit[50] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET);
     addr_hit[51] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET);
-    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1_OFFSET);
     addr_hit[54] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET);
     addr_hit[55] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET);
     addr_hit[56] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET);
@@ -10376,24 +11985,24 @@ module flash_ctrl_core_reg_top (
     addr_hit[61] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET);
     addr_hit[62] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET);
     addr_hit[63] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET);
-    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1_OFFSET);
+    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2_OFFSET);
+    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3_OFFSET);
+    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4_OFFSET);
+    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5_OFFSET);
+    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6_OFFSET);
+    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7_OFFSET);
+    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8_OFFSET);
+    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9_OFFSET);
     addr_hit[74] = (reg_addr == FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET);
-    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED_OFFSET);
     addr_hit[76] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET);
     addr_hit[77] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET);
-    addr_hit[78] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[79] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[78] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[79] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1_OFFSET);
     addr_hit[80] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[81] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[81] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_SHADOWED_OFFSET);
     addr_hit[82] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
     addr_hit[83] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
     addr_hit[84] = (reg_addr == FLASH_CTRL_ERR_CODE_OFFSET);
@@ -10615,171 +12224,180 @@ module flash_ctrl_core_reg_top (
   assign region_cfg_regwen_7_we = addr_hit[18] & reg_we & !reg_error;
 
   assign region_cfg_regwen_7_wd = reg_wdata[0];
-  assign mp_region_cfg_0_we = addr_hit[19] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_0_re = addr_hit[19] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_0_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
-  assign mp_region_cfg_1_we = addr_hit[20] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_0_size_0_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_1_re = addr_hit[20] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_1_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
-  assign mp_region_cfg_2_we = addr_hit[21] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_1_size_1_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_2_re = addr_hit[21] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_2_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
-  assign mp_region_cfg_3_we = addr_hit[22] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_2_size_2_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_3_re = addr_hit[22] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_3_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
-  assign mp_region_cfg_4_we = addr_hit[23] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_3_size_3_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_4_re = addr_hit[23] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_4_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
-  assign mp_region_cfg_5_we = addr_hit[24] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_4_size_4_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_5_re = addr_hit[24] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_5_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
-  assign mp_region_cfg_6_we = addr_hit[25] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_5_size_5_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_6_re = addr_hit[25] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_6_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
-  assign mp_region_cfg_7_we = addr_hit[26] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_6_size_6_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_7_re = addr_hit[26] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_7_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
-  assign default_region_we = addr_hit[27] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_7_size_7_wd = reg_wdata[26:17];
+  assign default_region_shadowed_re = addr_hit[27] & reg_re & !reg_error;
+  assign default_region_shadowed_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign default_region_rd_en_wd = reg_wdata[0];
+  assign default_region_shadowed_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_wd = reg_wdata[1];
+  assign default_region_shadowed_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_wd = reg_wdata[2];
+  assign default_region_shadowed_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_wd = reg_wdata[3];
+  assign default_region_shadowed_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_wd = reg_wdata[4];
+  assign default_region_shadowed_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_wd = reg_wdata[5];
+  assign default_region_shadowed_he_en_wd = reg_wdata[5];
   assign bank0_info0_regwen_0_we = addr_hit[28] & reg_we & !reg_error;
 
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
@@ -10810,210 +12428,223 @@ module flash_ctrl_core_reg_top (
   assign bank0_info0_regwen_9_we = addr_hit[37] & reg_we & !reg_error;
 
   assign bank0_info0_regwen_9_wd = reg_wdata[0];
-  assign bank0_info0_page_cfg_0_we = addr_hit[38] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_0_re = addr_hit[38] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_0_we = addr_hit[38] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_1_we = addr_hit[39] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_1_re = addr_hit[39] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_1_we = addr_hit[39] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_2_we = addr_hit[40] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_2_re = addr_hit[40] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_2_we = addr_hit[40] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_3_we = addr_hit[41] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_2_he_en_2_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_3_re = addr_hit[41] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_3_we = addr_hit[41] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_4_we = addr_hit[42] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_3_he_en_3_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_4_re = addr_hit[42] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_4_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_5_we = addr_hit[43] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_4_he_en_4_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_5_re = addr_hit[43] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_5_we = addr_hit[43] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_6_we = addr_hit[44] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_5_he_en_5_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_6_re = addr_hit[44] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_6_we = addr_hit[44] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_7_we = addr_hit[45] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_6_he_en_6_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_7_re = addr_hit[45] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_7_we = addr_hit[45] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_8_we = addr_hit[46] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_7_he_en_7_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_8_re = addr_hit[46] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_8_we = addr_hit[46] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_9_we = addr_hit[47] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_8_he_en_8_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_9_re = addr_hit[47] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_9_we = addr_hit[47] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_9_he_en_9_wd = reg_wdata[6];
   assign bank0_info1_regwen_we = addr_hit[48] & reg_we & !reg_error;
 
   assign bank0_info1_regwen_wd = reg_wdata[0];
-  assign bank0_info1_page_cfg_we = addr_hit[49] & reg_we & !reg_error;
+  assign bank0_info1_page_cfg_shadowed_re = addr_hit[49] & reg_re & !reg_error;
+  assign bank0_info1_page_cfg_shadowed_we = addr_hit[49] & reg_we & !reg_error;
 
-  assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
+  assign bank0_info1_page_cfg_shadowed_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
+  assign bank0_info1_page_cfg_shadowed_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
+  assign bank0_info1_page_cfg_shadowed_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
+  assign bank0_info1_page_cfg_shadowed_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
+  assign bank0_info1_page_cfg_shadowed_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
+  assign bank0_info1_page_cfg_shadowed_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
+  assign bank0_info1_page_cfg_shadowed_he_en_0_wd = reg_wdata[6];
   assign bank0_info2_regwen_0_we = addr_hit[50] & reg_we & !reg_error;
 
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
   assign bank0_info2_regwen_1_we = addr_hit[51] & reg_we & !reg_error;
 
   assign bank0_info2_regwen_1_wd = reg_wdata[0];
-  assign bank0_info2_page_cfg_0_we = addr_hit[52] & reg_we & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_0_re = addr_hit[52] & reg_re & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_0_we = addr_hit[52] & reg_we & !reg_error;
 
-  assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank0_info2_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank0_info2_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank0_info2_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank0_info2_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank0_info2_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank0_info2_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank0_info2_page_cfg_1_we = addr_hit[53] & reg_we & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info2_page_cfg_shadowed_1_re = addr_hit[53] & reg_re & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_1_we = addr_hit[53] & reg_we & !reg_error;
 
-  assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank0_info2_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank0_info2_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank0_info2_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank0_info2_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank0_info2_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank0_info2_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank0_info2_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
   assign bank1_info0_regwen_0_we = addr_hit[54] & reg_we & !reg_error;
 
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
@@ -11044,218 +12675,232 @@ module flash_ctrl_core_reg_top (
   assign bank1_info0_regwen_9_we = addr_hit[63] & reg_we & !reg_error;
 
   assign bank1_info0_regwen_9_wd = reg_wdata[0];
-  assign bank1_info0_page_cfg_0_we = addr_hit[64] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_0_re = addr_hit[64] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_0_we = addr_hit[64] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_1_we = addr_hit[65] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_1_re = addr_hit[65] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_1_we = addr_hit[65] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_2_we = addr_hit[66] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_2_re = addr_hit[66] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_2_we = addr_hit[66] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_3_we = addr_hit[67] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_2_he_en_2_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_3_re = addr_hit[67] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_3_we = addr_hit[67] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_4_we = addr_hit[68] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_3_he_en_3_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_4_re = addr_hit[68] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_4_we = addr_hit[68] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_5_we = addr_hit[69] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_4_he_en_4_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_5_re = addr_hit[69] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_5_we = addr_hit[69] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_6_we = addr_hit[70] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_5_he_en_5_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_6_re = addr_hit[70] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_6_we = addr_hit[70] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_7_we = addr_hit[71] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_6_he_en_6_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_7_re = addr_hit[71] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_7_we = addr_hit[71] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_8_we = addr_hit[72] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_7_he_en_7_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_8_re = addr_hit[72] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_8_we = addr_hit[72] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_9_we = addr_hit[73] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_8_he_en_8_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_9_re = addr_hit[73] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_9_we = addr_hit[73] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_9_he_en_9_wd = reg_wdata[6];
   assign bank1_info1_regwen_we = addr_hit[74] & reg_we & !reg_error;
 
   assign bank1_info1_regwen_wd = reg_wdata[0];
-  assign bank1_info1_page_cfg_we = addr_hit[75] & reg_we & !reg_error;
+  assign bank1_info1_page_cfg_shadowed_re = addr_hit[75] & reg_re & !reg_error;
+  assign bank1_info1_page_cfg_shadowed_we = addr_hit[75] & reg_we & !reg_error;
 
-  assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
+  assign bank1_info1_page_cfg_shadowed_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
+  assign bank1_info1_page_cfg_shadowed_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
+  assign bank1_info1_page_cfg_shadowed_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
+  assign bank1_info1_page_cfg_shadowed_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
+  assign bank1_info1_page_cfg_shadowed_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
+  assign bank1_info1_page_cfg_shadowed_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
+  assign bank1_info1_page_cfg_shadowed_he_en_0_wd = reg_wdata[6];
   assign bank1_info2_regwen_0_we = addr_hit[76] & reg_we & !reg_error;
 
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
   assign bank1_info2_regwen_1_we = addr_hit[77] & reg_we & !reg_error;
 
   assign bank1_info2_regwen_1_wd = reg_wdata[0];
-  assign bank1_info2_page_cfg_0_we = addr_hit[78] & reg_we & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_0_re = addr_hit[78] & reg_re & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_0_we = addr_hit[78] & reg_we & !reg_error;
 
-  assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank1_info2_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank1_info2_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank1_info2_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank1_info2_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank1_info2_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank1_info2_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank1_info2_page_cfg_1_we = addr_hit[79] & reg_we & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info2_page_cfg_shadowed_1_re = addr_hit[79] & reg_re & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_1_we = addr_hit[79] & reg_we & !reg_error;
 
-  assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank1_info2_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank1_info2_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank1_info2_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank1_info2_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank1_info2_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank1_info2_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank1_info2_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
   assign bank_cfg_regwen_we = addr_hit[80] & reg_we & !reg_error;
 
   assign bank_cfg_regwen_wd = reg_wdata[0];
-  assign mp_bank_cfg_we = addr_hit[81] & reg_we & !reg_error;
+  assign mp_bank_cfg_shadowed_re = addr_hit[81] & reg_re & !reg_error;
+  assign mp_bank_cfg_shadowed_we = addr_hit[81] & reg_we & !reg_error;
 
-  assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
+  assign mp_bank_cfg_shadowed_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
+  assign mp_bank_cfg_shadowed_erase_en_1_wd = reg_wdata[1];
   assign op_status_we = addr_hit[82] & reg_we & !reg_error;
 
   assign op_status_done_wd = reg_wdata[0];
@@ -11406,108 +13051,108 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[0] = mp_region_cfg_0_en_0_qs;
-        reg_rdata_next[1] = mp_region_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = mp_region_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = mp_region_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = mp_region_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = mp_region_cfg_0_he_en_0_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_0_base_0_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_0_size_0_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_0_he_en_0_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_0_base_0_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_0_size_0_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[0] = mp_region_cfg_1_en_1_qs;
-        reg_rdata_next[1] = mp_region_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = mp_region_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = mp_region_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = mp_region_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = mp_region_cfg_1_he_en_1_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_1_base_1_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_1_size_1_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_1_he_en_1_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_1_base_1_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_1_size_1_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[0] = mp_region_cfg_2_en_2_qs;
-        reg_rdata_next[1] = mp_region_cfg_2_rd_en_2_qs;
-        reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
-        reg_rdata_next[3] = mp_region_cfg_2_erase_en_2_qs;
-        reg_rdata_next[4] = mp_region_cfg_2_scramble_en_2_qs;
-        reg_rdata_next[5] = mp_region_cfg_2_ecc_en_2_qs;
-        reg_rdata_next[6] = mp_region_cfg_2_he_en_2_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_2_base_2_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_2_size_2_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_2_en_2_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_2_rd_en_2_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_2_prog_en_2_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_2_erase_en_2_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_2_scramble_en_2_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_2_ecc_en_2_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_2_he_en_2_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_2_base_2_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_2_size_2_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[0] = mp_region_cfg_3_en_3_qs;
-        reg_rdata_next[1] = mp_region_cfg_3_rd_en_3_qs;
-        reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
-        reg_rdata_next[3] = mp_region_cfg_3_erase_en_3_qs;
-        reg_rdata_next[4] = mp_region_cfg_3_scramble_en_3_qs;
-        reg_rdata_next[5] = mp_region_cfg_3_ecc_en_3_qs;
-        reg_rdata_next[6] = mp_region_cfg_3_he_en_3_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_3_base_3_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_3_size_3_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_3_en_3_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_3_rd_en_3_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_3_prog_en_3_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_3_erase_en_3_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_3_scramble_en_3_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_3_ecc_en_3_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_3_he_en_3_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_3_base_3_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_3_size_3_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[0] = mp_region_cfg_4_en_4_qs;
-        reg_rdata_next[1] = mp_region_cfg_4_rd_en_4_qs;
-        reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
-        reg_rdata_next[3] = mp_region_cfg_4_erase_en_4_qs;
-        reg_rdata_next[4] = mp_region_cfg_4_scramble_en_4_qs;
-        reg_rdata_next[5] = mp_region_cfg_4_ecc_en_4_qs;
-        reg_rdata_next[6] = mp_region_cfg_4_he_en_4_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_4_base_4_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_4_size_4_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_4_en_4_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_4_rd_en_4_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_4_prog_en_4_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_4_erase_en_4_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_4_scramble_en_4_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_4_ecc_en_4_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_4_he_en_4_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_4_base_4_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_4_size_4_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[0] = mp_region_cfg_5_en_5_qs;
-        reg_rdata_next[1] = mp_region_cfg_5_rd_en_5_qs;
-        reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
-        reg_rdata_next[3] = mp_region_cfg_5_erase_en_5_qs;
-        reg_rdata_next[4] = mp_region_cfg_5_scramble_en_5_qs;
-        reg_rdata_next[5] = mp_region_cfg_5_ecc_en_5_qs;
-        reg_rdata_next[6] = mp_region_cfg_5_he_en_5_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_5_base_5_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_5_size_5_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_5_en_5_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_5_rd_en_5_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_5_prog_en_5_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_5_erase_en_5_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_5_scramble_en_5_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_5_ecc_en_5_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_5_he_en_5_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_5_base_5_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_5_size_5_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[0] = mp_region_cfg_6_en_6_qs;
-        reg_rdata_next[1] = mp_region_cfg_6_rd_en_6_qs;
-        reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
-        reg_rdata_next[3] = mp_region_cfg_6_erase_en_6_qs;
-        reg_rdata_next[4] = mp_region_cfg_6_scramble_en_6_qs;
-        reg_rdata_next[5] = mp_region_cfg_6_ecc_en_6_qs;
-        reg_rdata_next[6] = mp_region_cfg_6_he_en_6_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_6_base_6_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_6_size_6_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_6_en_6_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_6_rd_en_6_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_6_prog_en_6_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_6_erase_en_6_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_6_scramble_en_6_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_6_ecc_en_6_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_6_he_en_6_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_6_base_6_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_6_size_6_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[0] = mp_region_cfg_7_en_7_qs;
-        reg_rdata_next[1] = mp_region_cfg_7_rd_en_7_qs;
-        reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
-        reg_rdata_next[3] = mp_region_cfg_7_erase_en_7_qs;
-        reg_rdata_next[4] = mp_region_cfg_7_scramble_en_7_qs;
-        reg_rdata_next[5] = mp_region_cfg_7_ecc_en_7_qs;
-        reg_rdata_next[6] = mp_region_cfg_7_he_en_7_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_7_base_7_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_7_size_7_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_7_en_7_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_7_rd_en_7_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_7_prog_en_7_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_7_erase_en_7_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_7_scramble_en_7_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_7_ecc_en_7_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_7_he_en_7_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_7_base_7_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_7_size_7_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[0] = default_region_rd_en_qs;
-        reg_rdata_next[1] = default_region_prog_en_qs;
-        reg_rdata_next[2] = default_region_erase_en_qs;
-        reg_rdata_next[3] = default_region_scramble_en_qs;
-        reg_rdata_next[4] = default_region_ecc_en_qs;
-        reg_rdata_next[5] = default_region_he_en_qs;
+        reg_rdata_next[0] = default_region_shadowed_rd_en_qs;
+        reg_rdata_next[1] = default_region_shadowed_prog_en_qs;
+        reg_rdata_next[2] = default_region_shadowed_erase_en_qs;
+        reg_rdata_next[3] = default_region_shadowed_scramble_en_qs;
+        reg_rdata_next[4] = default_region_shadowed_ecc_en_qs;
+        reg_rdata_next[5] = default_region_shadowed_he_en_qs;
       end
 
       addr_hit[28]: begin
@@ -11551,103 +13196,103 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[38]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[39]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[40]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_2_en_2_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_2_rd_en_2_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_2_erase_en_2_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_2_scramble_en_2_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_2_ecc_en_2_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_2_he_en_2_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_2_en_2_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_2_rd_en_2_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_2_prog_en_2_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_2_he_en_2_qs;
       end
 
       addr_hit[41]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_3_en_3_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_3_rd_en_3_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_3_erase_en_3_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_3_scramble_en_3_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_3_ecc_en_3_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_3_he_en_3_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_3_en_3_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_3_rd_en_3_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_3_prog_en_3_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_3_he_en_3_qs;
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_4_en_4_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_4_rd_en_4_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_4_prog_en_4_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_4_erase_en_4_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_4_scramble_en_4_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_4_ecc_en_4_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_4_he_en_4_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_4_en_4_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_4_rd_en_4_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_4_prog_en_4_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_4_erase_en_4_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_4_he_en_4_qs;
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_5_en_5_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_5_rd_en_5_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_5_prog_en_5_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_5_erase_en_5_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_5_scramble_en_5_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_5_ecc_en_5_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_5_he_en_5_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_5_en_5_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_5_rd_en_5_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_5_prog_en_5_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_5_erase_en_5_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_5_he_en_5_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_6_en_6_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_6_rd_en_6_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_6_prog_en_6_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_6_erase_en_6_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_6_scramble_en_6_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_6_ecc_en_6_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_6_he_en_6_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_6_en_6_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_6_rd_en_6_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_6_prog_en_6_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_6_erase_en_6_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_6_he_en_6_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_7_en_7_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_7_rd_en_7_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_7_prog_en_7_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_7_erase_en_7_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_7_scramble_en_7_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_7_ecc_en_7_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_7_he_en_7_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_7_en_7_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_7_rd_en_7_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_7_prog_en_7_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_7_erase_en_7_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_7_he_en_7_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_8_en_8_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_8_rd_en_8_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_8_prog_en_8_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_8_erase_en_8_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_8_scramble_en_8_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_8_ecc_en_8_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_8_he_en_8_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_8_en_8_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_8_rd_en_8_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_8_prog_en_8_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_8_erase_en_8_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_8_he_en_8_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_9_en_9_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_9_rd_en_9_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_9_prog_en_9_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_9_erase_en_9_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_9_scramble_en_9_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_9_ecc_en_9_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_9_he_en_9_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_9_en_9_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_9_rd_en_9_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_9_prog_en_9_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_9_erase_en_9_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_9_he_en_9_qs;
       end
 
       addr_hit[48]: begin
@@ -11655,13 +13300,13 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[0] = bank0_info1_page_cfg_en_0_qs;
-        reg_rdata_next[1] = bank0_info1_page_cfg_rd_en_0_qs;
-        reg_rdata_next[2] = bank0_info1_page_cfg_prog_en_0_qs;
-        reg_rdata_next[3] = bank0_info1_page_cfg_erase_en_0_qs;
-        reg_rdata_next[4] = bank0_info1_page_cfg_scramble_en_0_qs;
-        reg_rdata_next[5] = bank0_info1_page_cfg_ecc_en_0_qs;
-        reg_rdata_next[6] = bank0_info1_page_cfg_he_en_0_qs;
+        reg_rdata_next[0] = bank0_info1_page_cfg_shadowed_en_0_qs;
+        reg_rdata_next[1] = bank0_info1_page_cfg_shadowed_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info1_page_cfg_shadowed_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info1_page_cfg_shadowed_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info1_page_cfg_shadowed_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_shadowed_ecc_en_0_qs;
+        reg_rdata_next[6] = bank0_info1_page_cfg_shadowed_he_en_0_qs;
       end
 
       addr_hit[50]: begin
@@ -11673,23 +13318,23 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[0] = bank0_info2_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank0_info2_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank0_info2_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank0_info2_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank0_info2_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank0_info2_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank0_info2_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank0_info2_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank0_info2_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info2_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info2_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank0_info2_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[0] = bank0_info2_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank0_info2_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank0_info2_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank0_info2_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank0_info2_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank0_info2_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank0_info2_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank0_info2_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank0_info2_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank0_info2_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank0_info2_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank0_info2_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[54]: begin
@@ -11733,103 +13378,103 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[65]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[66]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_2_en_2_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_2_rd_en_2_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_2_erase_en_2_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_2_scramble_en_2_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_2_ecc_en_2_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_2_he_en_2_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_2_en_2_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_2_rd_en_2_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_2_prog_en_2_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_2_he_en_2_qs;
       end
 
       addr_hit[67]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_3_en_3_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_3_rd_en_3_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_3_erase_en_3_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_3_scramble_en_3_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_3_ecc_en_3_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_3_he_en_3_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_3_en_3_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_3_rd_en_3_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_3_prog_en_3_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_3_he_en_3_qs;
       end
 
       addr_hit[68]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_4_en_4_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_4_rd_en_4_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_4_prog_en_4_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_4_erase_en_4_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_4_scramble_en_4_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_4_ecc_en_4_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_4_he_en_4_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_4_en_4_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_4_rd_en_4_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_4_prog_en_4_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_4_erase_en_4_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_4_he_en_4_qs;
       end
 
       addr_hit[69]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_5_en_5_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_5_rd_en_5_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_5_prog_en_5_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_5_erase_en_5_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_5_scramble_en_5_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_5_ecc_en_5_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_5_he_en_5_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_5_en_5_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_5_rd_en_5_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_5_prog_en_5_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_5_erase_en_5_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_5_he_en_5_qs;
       end
 
       addr_hit[70]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_6_en_6_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_6_rd_en_6_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_6_prog_en_6_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_6_erase_en_6_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_6_scramble_en_6_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_6_ecc_en_6_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_6_he_en_6_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_6_en_6_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_6_rd_en_6_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_6_prog_en_6_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_6_erase_en_6_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_6_he_en_6_qs;
       end
 
       addr_hit[71]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_7_en_7_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_7_rd_en_7_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_7_prog_en_7_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_7_erase_en_7_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_7_scramble_en_7_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_7_ecc_en_7_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_7_he_en_7_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_7_en_7_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_7_rd_en_7_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_7_prog_en_7_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_7_erase_en_7_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_7_he_en_7_qs;
       end
 
       addr_hit[72]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_8_en_8_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_8_rd_en_8_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_8_prog_en_8_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_8_erase_en_8_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_8_scramble_en_8_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_8_ecc_en_8_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_8_he_en_8_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_8_en_8_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_8_rd_en_8_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_8_prog_en_8_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_8_erase_en_8_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_8_he_en_8_qs;
       end
 
       addr_hit[73]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_9_en_9_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_9_rd_en_9_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_9_prog_en_9_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_9_erase_en_9_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_9_scramble_en_9_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_9_ecc_en_9_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_9_he_en_9_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_9_en_9_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_9_rd_en_9_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_9_prog_en_9_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_9_erase_en_9_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_9_he_en_9_qs;
       end
 
       addr_hit[74]: begin
@@ -11837,13 +13482,13 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[75]: begin
-        reg_rdata_next[0] = bank1_info1_page_cfg_en_0_qs;
-        reg_rdata_next[1] = bank1_info1_page_cfg_rd_en_0_qs;
-        reg_rdata_next[2] = bank1_info1_page_cfg_prog_en_0_qs;
-        reg_rdata_next[3] = bank1_info1_page_cfg_erase_en_0_qs;
-        reg_rdata_next[4] = bank1_info1_page_cfg_scramble_en_0_qs;
-        reg_rdata_next[5] = bank1_info1_page_cfg_ecc_en_0_qs;
-        reg_rdata_next[6] = bank1_info1_page_cfg_he_en_0_qs;
+        reg_rdata_next[0] = bank1_info1_page_cfg_shadowed_en_0_qs;
+        reg_rdata_next[1] = bank1_info1_page_cfg_shadowed_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info1_page_cfg_shadowed_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info1_page_cfg_shadowed_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info1_page_cfg_shadowed_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_shadowed_ecc_en_0_qs;
+        reg_rdata_next[6] = bank1_info1_page_cfg_shadowed_he_en_0_qs;
       end
 
       addr_hit[76]: begin
@@ -11855,23 +13500,23 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[78]: begin
-        reg_rdata_next[0] = bank1_info2_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank1_info2_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank1_info2_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank1_info2_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank1_info2_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank1_info2_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank1_info2_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank1_info2_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank1_info2_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info2_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info2_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank1_info2_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[79]: begin
-        reg_rdata_next[0] = bank1_info2_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank1_info2_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank1_info2_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank1_info2_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank1_info2_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank1_info2_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank1_info2_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank1_info2_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank1_info2_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank1_info2_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank1_info2_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank1_info2_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[80]: begin
@@ -11879,8 +13524,8 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[81]: begin
-        reg_rdata_next[0] = mp_bank_cfg_erase_en_0_qs;
-        reg_rdata_next[1] = mp_bank_cfg_erase_en_1_qs;
+        reg_rdata_next[0] = mp_bank_cfg_shadowed_erase_en_0_qs;
+        reg_rdata_next[1] = mp_bank_cfg_shadowed_erase_en_1_qs;
       end
 
       addr_hit[82]: begin
@@ -11974,7 +13619,26 @@ module flash_ctrl_core_reg_top (
 
   // shadow busy
   logic shadow_busy;
-  assign shadow_busy = 1'b0;
+  logic rst_done;
+  logic shadow_rst_done;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rst_done <= '0;
+    end else begin
+      rst_done <= 1'b1;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_shadowed_ni) begin
+    if (!rst_shadowed_ni) begin
+      shadow_rst_done <= '0;
+    end else begin
+      shadow_rst_done <= 1'b1;
+    end
+  end
+
+  // both shadow and normal resets have been released
+  assign shadow_busy = ~(rst_done & shadow_rst_done);
 
   // register busy
   logic reg_busy_sel;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -956,6 +956,8 @@ module flash_ctrl_core_reg_top (
   logic err_code_prog_type_err_wd;
   logic err_code_flash_phy_err_qs;
   logic err_code_flash_phy_err_wd;
+  logic err_code_update_err_qs;
+  logic err_code_update_err_wd;
   logic fault_status_oob_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
@@ -965,6 +967,7 @@ module flash_ctrl_core_reg_top (
   logic fault_status_reg_intg_err_qs;
   logic fault_status_phy_intg_err_qs;
   logic fault_status_lcmgr_err_qs;
+  logic fault_status_storage_err_qs;
   logic [31:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
@@ -11271,6 +11274,31 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_flash_phy_err_qs)
   );
 
+  //   F[update_err]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_err_code_update_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (err_code_we),
+    .wd     (err_code_update_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.update_err.de),
+    .d      (hw2reg.err_code.update_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_update_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[oob_err]: 0:0
@@ -11496,6 +11524,31 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (fault_status_lcmgr_err_qs)
+  );
+
+  //   F[storage_err]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_storage_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.storage_err.de),
+    .d      (hw2reg.fault_status.storage_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.storage_err.q),
+
+    // to register interface (read)
+    .qs     (fault_status_storage_err_qs)
   );
 
 
@@ -12919,6 +12972,8 @@ module flash_ctrl_core_reg_top (
   assign err_code_prog_type_err_wd = reg_wdata[4];
 
   assign err_code_flash_phy_err_wd = reg_wdata[5];
+
+  assign err_code_update_err_wd = reg_wdata[6];
   assign ecc_single_err_cnt_we = addr_hit[87] & reg_we & !reg_error;
 
   assign ecc_single_err_cnt_ecc_single_err_cnt_0_wd = reg_wdata[7:0];
@@ -13548,6 +13603,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[3] = err_code_prog_win_err_qs;
         reg_rdata_next[4] = err_code_prog_type_err_qs;
         reg_rdata_next[5] = err_code_flash_phy_err_qs;
+        reg_rdata_next[6] = err_code_update_err_qs;
       end
 
       addr_hit[85]: begin
@@ -13560,6 +13616,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[6] = fault_status_reg_intg_err_qs;
         reg_rdata_next[7] = fault_status_phy_intg_err_qs;
         reg_rdata_next[8] = fault_status_lcmgr_err_qs;
+        reg_rdata_next[9] = fault_status_storage_err_qs;
       end
 
       addr_hit[86]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -114,8 +114,65 @@ package flash_ctrl_pkg;
   } flash_lcmgr_phase_e;
 
   // alias for super long reg_pkg typedef
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t info_page_cfg_t;
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_mreg_t mp_region_cfg_t;
+  typedef struct packed {
+    logic        q;
+  } bank_cfg_t;
+
+  // This is identical to the reg structures but do not have err_updates / storage
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
+      logic        q;
+    } he_en;
+  } info_page_cfg_t;
+
+  // This is identical to the reg structures but do not have err_updates / storage
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
+      logic        q;
+    } he_en;
+    struct packed {
+      logic [8:0]  q;
+    } base;
+    struct packed {
+      logic [9:0] q;
+    } size;
+  } mp_region_cfg_t;
 
   // memory protection specific structs
   typedef struct packed {

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -113,6 +113,16 @@ package flash_ctrl_pkg;
     PhaseInvalid
   } flash_lcmgr_phase_e;
 
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_default_region_shadowed_reg_t;
+
+  typedef flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t sw_bank_cfg_t;
+  typedef flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t sw_region_cfg_t;
+  typedef flash_ctrl_reg2hw_default_region_shadowed_reg_t sw_default_cfg_t;
+  typedef flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t sw_info_cfg_t;
+
   // alias for super long reg_pkg typedef
   typedef struct packed {
     logic        q;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -503,6 +503,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } lcmgr_err;
+    struct packed {
+      logic        q;
+    } storage_err;
   } flash_ctrl_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -641,6 +644,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } flash_phy_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } update_err;
   } flash_ctrl_hw2reg_err_code_reg_t;
 
   typedef struct packed {
@@ -680,6 +687,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } lcmgr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } storage_err;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -714,32 +725,32 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [553:548]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [547:542]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [541:530]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [529:526]
-    flash_ctrl_reg2hw_flash_disable_reg_t flash_disable; // [525:525]
-    flash_ctrl_reg2hw_init_reg_t init; // [524:524]
-    flash_ctrl_reg2hw_control_reg_t control; // [523:504]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [503:472]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [471:470]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [469:469]
-    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [468:261]
-    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [260:255]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [554:549]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [548:543]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [542:531]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [530:527]
+    flash_ctrl_reg2hw_flash_disable_reg_t flash_disable; // [526:526]
+    flash_ctrl_reg2hw_init_reg_t init; // [525:525]
+    flash_ctrl_reg2hw_control_reg_t control; // [524:505]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [504:473]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [472:471]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [470:470]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [469:262]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [261:256]
     flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank0_info0_page_cfg_shadowed; // [254:185]
+        bank0_info0_page_cfg_shadowed; // [255:186]
     flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank0_info1_page_cfg_shadowed; // [184:178]
+        bank0_info1_page_cfg_shadowed; // [185:179]
     flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank0_info2_page_cfg_shadowed; // [177:164]
+        bank0_info2_page_cfg_shadowed; // [178:165]
     flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank1_info0_page_cfg_shadowed; // [163:94]
+        bank1_info0_page_cfg_shadowed; // [164:95]
     flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank1_info1_page_cfg_shadowed; // [93:87]
+        bank1_info1_page_cfg_shadowed; // [94:88]
     flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank1_info2_page_cfg_shadowed; // [86:73]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [72:71]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:62]
+        bank1_info2_page_cfg_shadowed; // [87:74]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [73:72]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [71:62]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [61:46]
     flash_ctrl_reg2hw_phy_err_cfg_reg_t phy_err_cfg; // [45:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -750,14 +761,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [159:148]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [147:147]
-    flash_ctrl_hw2reg_control_reg_t control; // [146:145]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [144:143]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [142:139]
-    flash_ctrl_hw2reg_status_reg_t status; // [138:129]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [128:117]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [116:99]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [163:152]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [151:151]
+    flash_ctrl_hw2reg_control_reg_t control; // [150:149]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [148:147]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [146:143]
+    flash_ctrl_hw2reg_status_reg_t status; // [142:133]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [132:119]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [118:99]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [98:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [47:6]

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -163,201 +163,317 @@ package flash_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
     struct packed {
       logic [8:0]  q;
+      logic        err_update;
+      logic        err_storage;
     } base;
     struct packed {
       logic [9:0] q;
+      logic        err_update;
+      logic        err_storage;
     } size;
-  } flash_ctrl_reg2hw_mp_region_cfg_mreg_t;
+  } flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_default_region_reg_t;
+  } flash_ctrl_reg2hw_default_region_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     logic        q;
-  } flash_ctrl_reg2hw_mp_bank_cfg_mreg_t;
+    logic        err_update;
+    logic        err_storage;
+  } flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -608,15 +724,21 @@ package flash_ctrl_reg_pkg;
     flash_ctrl_reg2hw_addr_reg_t addr; // [503:472]
     flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [471:470]
     flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [469:469]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [468:261]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [260:255]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [254:185]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [184:178]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [177:164]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [163:94]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [93:87]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [86:73]
-    flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [72:71]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [468:261]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [260:255]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
+        bank0_info0_page_cfg_shadowed; // [254:185]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
+        bank0_info1_page_cfg_shadowed; // [184:178]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
+        bank0_info2_page_cfg_shadowed; // [177:164]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
+        bank1_info0_page_cfg_shadowed; // [163:94]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
+        bank1_info1_page_cfg_shadowed; // [93:87]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
+        bank1_info2_page_cfg_shadowed; // [86:73]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [72:71]
     flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:62]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [61:46]
     flash_ctrl_reg2hw_phy_err_cfg_reg_t phy_err_cfg; // [45:45]
@@ -662,15 +784,15 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET = 9'h 40;
   parameter logic [CoreAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET = 9'h 44;
   parameter logic [CoreAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET = 9'h 48;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 9'h 4c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 9'h 50;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 9'h 54;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 9'h 58;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 9'h 5c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 9'h 60;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 9'h 64;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 9'h 68;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 9'h 6c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_OFFSET = 9'h 4c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_1_OFFSET = 9'h 50;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_2_OFFSET = 9'h 54;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_3_OFFSET = 9'h 58;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_4_OFFSET = 9'h 5c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_5_OFFSET = 9'h 60;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_6_OFFSET = 9'h 64;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_7_OFFSET = 9'h 68;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_DEFAULT_REGION_SHADOWED_OFFSET = 9'h 6c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET = 9'h 70;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET = 9'h 74;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET = 9'h 78;
@@ -681,22 +803,22 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET = 9'h 8c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET = 9'h 90;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET = 9'h 94;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 9'h 98;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 9'h 9c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 9'h a0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 9'h a4;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET = 9'h a8;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET = 9'h ac;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET = 9'h b0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET = 9'h b4;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET = 9'h b8;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET = 9'h bc;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_OFFSET = 9'h 98;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1_OFFSET = 9'h 9c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2_OFFSET = 9'h a0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3_OFFSET = 9'h a4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4_OFFSET = 9'h a8;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5_OFFSET = 9'h ac;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6_OFFSET = 9'h b0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7_OFFSET = 9'h b4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8_OFFSET = 9'h b8;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9_OFFSET = 9'h bc;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET = 9'h c0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET = 9'h c4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED_OFFSET = 9'h c4;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET = 9'h c8;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET = 9'h cc;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET = 9'h d0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET = 9'h d4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0_OFFSET = 9'h d0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1_OFFSET = 9'h d4;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET = 9'h d8;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET = 9'h dc;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET = 9'h e0;
@@ -707,24 +829,24 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET = 9'h f4;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET = 9'h f8;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET = 9'h fc;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 9'h 100;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 9'h 104;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 9'h 108;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 9'h 10c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET = 9'h 110;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET = 9'h 114;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET = 9'h 118;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET = 9'h 11c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET = 9'h 120;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET = 9'h 124;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0_OFFSET = 9'h 100;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1_OFFSET = 9'h 104;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2_OFFSET = 9'h 108;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3_OFFSET = 9'h 10c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4_OFFSET = 9'h 110;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5_OFFSET = 9'h 114;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6_OFFSET = 9'h 118;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7_OFFSET = 9'h 11c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8_OFFSET = 9'h 120;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9_OFFSET = 9'h 124;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET = 9'h 128;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET = 9'h 12c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED_OFFSET = 9'h 12c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET = 9'h 130;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET = 9'h 134;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET = 9'h 138;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET = 9'h 13c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0_OFFSET = 9'h 138;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1_OFFSET = 9'h 13c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 9'h 140;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 9'h 144;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_BANK_CFG_SHADOWED_OFFSET = 9'h 144;
   parameter logic [CoreAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 148;
   parameter logic [CoreAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 14c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 150;
@@ -782,15 +904,15 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_REGION_CFG_REGWEN_5,
     FLASH_CTRL_REGION_CFG_REGWEN_6,
     FLASH_CTRL_REGION_CFG_REGWEN_7,
-    FLASH_CTRL_MP_REGION_CFG_0,
-    FLASH_CTRL_MP_REGION_CFG_1,
-    FLASH_CTRL_MP_REGION_CFG_2,
-    FLASH_CTRL_MP_REGION_CFG_3,
-    FLASH_CTRL_MP_REGION_CFG_4,
-    FLASH_CTRL_MP_REGION_CFG_5,
-    FLASH_CTRL_MP_REGION_CFG_6,
-    FLASH_CTRL_MP_REGION_CFG_7,
-    FLASH_CTRL_DEFAULT_REGION,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_0,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_1,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_2,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_3,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_4,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_5,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_6,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_7,
+    FLASH_CTRL_DEFAULT_REGION_SHADOWED,
     FLASH_CTRL_BANK0_INFO0_REGWEN_0,
     FLASH_CTRL_BANK0_INFO0_REGWEN_1,
     FLASH_CTRL_BANK0_INFO0_REGWEN_2,
@@ -801,22 +923,22 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_BANK0_INFO0_REGWEN_7,
     FLASH_CTRL_BANK0_INFO0_REGWEN_8,
     FLASH_CTRL_BANK0_INFO0_REGWEN_9,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9,
     FLASH_CTRL_BANK0_INFO1_REGWEN,
-    FLASH_CTRL_BANK0_INFO1_PAGE_CFG,
+    FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED,
     FLASH_CTRL_BANK0_INFO2_REGWEN_0,
     FLASH_CTRL_BANK0_INFO2_REGWEN_1,
-    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0,
-    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1,
+    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1,
     FLASH_CTRL_BANK1_INFO0_REGWEN_0,
     FLASH_CTRL_BANK1_INFO0_REGWEN_1,
     FLASH_CTRL_BANK1_INFO0_REGWEN_2,
@@ -827,24 +949,24 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_BANK1_INFO0_REGWEN_7,
     FLASH_CTRL_BANK1_INFO0_REGWEN_8,
     FLASH_CTRL_BANK1_INFO0_REGWEN_9,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9,
     FLASH_CTRL_BANK1_INFO1_REGWEN,
-    FLASH_CTRL_BANK1_INFO1_PAGE_CFG,
+    FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED,
     FLASH_CTRL_BANK1_INFO2_REGWEN_0,
     FLASH_CTRL_BANK1_INFO2_REGWEN_1,
-    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0,
-    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1,
+    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1,
     FLASH_CTRL_BANK_CFG_REGWEN,
-    FLASH_CTRL_MP_BANK_CFG,
+    FLASH_CTRL_MP_BANK_CFG_SHADOWED,
     FLASH_CTRL_OP_STATUS,
     FLASH_CTRL_STATUS,
     FLASH_CTRL_ERR_CODE,
@@ -883,15 +1005,15 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[16] FLASH_CTRL_REGION_CFG_REGWEN_5
     4'b 0001, // index[17] FLASH_CTRL_REGION_CFG_REGWEN_6
     4'b 0001, // index[18] FLASH_CTRL_REGION_CFG_REGWEN_7
-    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_0
-    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_1
-    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_2
-    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_3
-    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_4
-    4'b 1111, // index[24] FLASH_CTRL_MP_REGION_CFG_5
-    4'b 1111, // index[25] FLASH_CTRL_MP_REGION_CFG_6
-    4'b 1111, // index[26] FLASH_CTRL_MP_REGION_CFG_7
-    4'b 0001, // index[27] FLASH_CTRL_DEFAULT_REGION
+    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_SHADOWED_0
+    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_SHADOWED_1
+    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_SHADOWED_2
+    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_SHADOWED_3
+    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_SHADOWED_4
+    4'b 1111, // index[24] FLASH_CTRL_MP_REGION_CFG_SHADOWED_5
+    4'b 1111, // index[25] FLASH_CTRL_MP_REGION_CFG_SHADOWED_6
+    4'b 1111, // index[26] FLASH_CTRL_MP_REGION_CFG_SHADOWED_7
+    4'b 0001, // index[27] FLASH_CTRL_DEFAULT_REGION_SHADOWED
     4'b 0001, // index[28] FLASH_CTRL_BANK0_INFO0_REGWEN_0
     4'b 0001, // index[29] FLASH_CTRL_BANK0_INFO0_REGWEN_1
     4'b 0001, // index[30] FLASH_CTRL_BANK0_INFO0_REGWEN_2
@@ -902,22 +1024,22 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[35] FLASH_CTRL_BANK0_INFO0_REGWEN_7
     4'b 0001, // index[36] FLASH_CTRL_BANK0_INFO0_REGWEN_8
     4'b 0001, // index[37] FLASH_CTRL_BANK0_INFO0_REGWEN_9
-    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
-    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
-    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
-    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
-    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4
-    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5
-    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6
-    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7
-    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8
-    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9
+    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1
+    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2
+    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3
+    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4
+    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5
+    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6
+    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7
+    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8
+    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9
     4'b 0001, // index[48] FLASH_CTRL_BANK0_INFO1_REGWEN
-    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO1_PAGE_CFG
+    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED
     4'b 0001, // index[50] FLASH_CTRL_BANK0_INFO2_REGWEN_0
     4'b 0001, // index[51] FLASH_CTRL_BANK0_INFO2_REGWEN_1
-    4'b 0001, // index[52] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0
-    4'b 0001, // index[53] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1
+    4'b 0001, // index[52] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[53] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1
     4'b 0001, // index[54] FLASH_CTRL_BANK1_INFO0_REGWEN_0
     4'b 0001, // index[55] FLASH_CTRL_BANK1_INFO0_REGWEN_1
     4'b 0001, // index[56] FLASH_CTRL_BANK1_INFO0_REGWEN_2
@@ -928,24 +1050,24 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[61] FLASH_CTRL_BANK1_INFO0_REGWEN_7
     4'b 0001, // index[62] FLASH_CTRL_BANK1_INFO0_REGWEN_8
     4'b 0001, // index[63] FLASH_CTRL_BANK1_INFO0_REGWEN_9
-    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
-    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
-    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
-    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
-    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4
-    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5
-    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6
-    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7
-    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8
-    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9
+    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1
+    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2
+    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3
+    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4
+    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5
+    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6
+    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7
+    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8
+    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9
     4'b 0001, // index[74] FLASH_CTRL_BANK1_INFO1_REGWEN
-    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO1_PAGE_CFG
+    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED
     4'b 0001, // index[76] FLASH_CTRL_BANK1_INFO2_REGWEN_0
     4'b 0001, // index[77] FLASH_CTRL_BANK1_INFO2_REGWEN_1
-    4'b 0001, // index[78] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0
-    4'b 0001, // index[79] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1
+    4'b 0001, // index[78] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[79] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1
     4'b 0001, // index[80] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[81] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[81] FLASH_CTRL_MP_BANK_CFG_SHADOWED
     4'b 0001, // index[82] FLASH_CTRL_OP_STATUS
     4'b 0001, // index[83] FLASH_CTRL_STATUS
     4'b 0001, // index[84] FLASH_CTRL_ERR_CODE

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
@@ -1,0 +1,254 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash control region configuration processing
+//
+// There are two main purpose of this module:
+// 1. strip the error conditions away from reg packages (see #8282)
+// 2. generate shadow update and storage errors
+
+module flash_ctrl_region_cfg
+  import flash_ctrl_pkg::*;
+  import flash_ctrl_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+  input lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en_i,
+  input sw_bank_cfg_t [NumBanks-1:0] bank_cfg_i,
+  input sw_region_cfg_t [MpRegions-1:0] region_cfg_i,
+  input sw_default_cfg_t default_cfg_i,
+  input sw_info_cfg_t [NumInfos0-1:0] bank0_info0_cfg_i,
+  input sw_info_cfg_t [NumInfos1-1:0] bank0_info1_cfg_i,
+  input sw_info_cfg_t [NumInfos2-1:0] bank0_info2_cfg_i,
+  input sw_info_cfg_t [NumInfos0-1:0] bank1_info0_cfg_i,
+  input sw_info_cfg_t [NumInfos1-1:0] bank1_info1_cfg_i,
+  input sw_info_cfg_t [NumInfos2-1:0] bank1_info2_cfg_i,
+
+  output bank_cfg_t [NumBanks-1:0] bank_cfg_o,
+  output mp_region_cfg_t [MpRegions:0] region_cfgs_o,
+  output info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs_o,
+
+  output logic update_err_o,
+  output logic storage_err_o
+);
+
+  //////////////////////////////////////
+  // Life cycle synchronizer
+  //////////////////////////////////////
+
+  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
+
+  // synchronize enables into local domain
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_creator_seed_sw_rw_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_creator_seed_sw_rw_en_i),
+    .lc_en_o(lc_creator_seed_sw_rw_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_owner_seed_sw_rw_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_owner_seed_sw_rw_en_i),
+    .lc_en_o(lc_owner_seed_sw_rw_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_iso_part_sw_rd_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_iso_part_sw_rd_en_i),
+    .lc_en_o(lc_iso_part_sw_rd_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_iso_part_sw_wr_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_iso_part_sw_wr_en_i),
+    .lc_en_o(lc_iso_part_sw_wr_en)
+  );
+
+  //////////////////////////////////////
+  // Bank speicfic configuration
+  //////////////////////////////////////
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_cfg
+    assign bank_cfg_o[i].q = bank_cfg_i[i].q;
+  end
+
+  //////////////////////////////////////
+  // Data partition regions
+  //////////////////////////////////////
+  // extra region is the default region
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_mp_regions
+    assign region_cfgs_o[i].base.q        = region_cfg_i[i].base.q;
+    assign region_cfgs_o[i].size.q        = region_cfg_i[i].size.q;
+    assign region_cfgs_o[i].en.q          = region_cfg_i[i].en.q;
+    assign region_cfgs_o[i].rd_en.q       = region_cfg_i[i].rd_en.q;
+    assign region_cfgs_o[i].prog_en.q     = region_cfg_i[i].prog_en.q;
+    assign region_cfgs_o[i].erase_en.q    = region_cfg_i[i].erase_en.q;
+    assign region_cfgs_o[i].scramble_en.q = region_cfg_i[i].scramble_en.q;
+    assign region_cfgs_o[i].ecc_en.q      = region_cfg_i[i].ecc_en.q;
+    assign region_cfgs_o[i].he_en.q       = region_cfg_i[i].he_en.q;
+  end
+
+  //default region
+  assign region_cfgs_o[MpRegions].base.q        = '0;
+  assign region_cfgs_o[MpRegions].size.q        = NumBanks * PagesPerBank;
+  assign region_cfgs_o[MpRegions].en.q          = 1'b1;
+  assign region_cfgs_o[MpRegions].rd_en.q       = default_cfg_i.rd_en.q;
+  assign region_cfgs_o[MpRegions].prog_en.q     = default_cfg_i.prog_en.q;
+  assign region_cfgs_o[MpRegions].erase_en.q    = default_cfg_i.erase_en.q;
+  assign region_cfgs_o[MpRegions].scramble_en.q = default_cfg_i.scramble_en.q;
+  assign region_cfgs_o[MpRegions].ecc_en.q      = default_cfg_i.ecc_en.q;
+  assign region_cfgs_o[MpRegions].he_en.q       = default_cfg_i.he_en.q;
+
+  //////////////////////////////////////
+  // Info partition properties configuration
+  //////////////////////////////////////
+  sw_info_cfg_t   [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] sw_info_cfgs;
+  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_cfgs;
+  localparam int InfoBits = $bits(sw_info_cfg_t) * InfosPerBank;
+
+  // transform from unique names reg output to structure
+  // Not all types have the maximum number of banks, so those are packed to 0
+  assign sw_info_cfgs[0][0] = InfoBits'(bank0_info0_cfg_i);
+  assign sw_info_cfgs[0][1] = InfoBits'(bank0_info1_cfg_i);
+  assign sw_info_cfgs[0][2] = InfoBits'(bank0_info2_cfg_i);
+  assign sw_info_cfgs[1][0] = InfoBits'(bank1_info0_cfg_i);
+  assign sw_info_cfgs[1][1] = InfoBits'(bank1_info1_cfg_i);
+  assign sw_info_cfgs[1][2] = InfoBits'(bank1_info2_cfg_i);
+
+  // strip error indications
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_cfg_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_cfg_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_cfg_page
+        assign info_cfgs[i][j][k].en.q = sw_info_cfgs[i][j][k].en.q;
+        assign info_cfgs[i][j][k].rd_en.q = sw_info_cfgs[i][j][k].rd_en.q;
+        assign info_cfgs[i][j][k].prog_en.q = sw_info_cfgs[i][j][k].prog_en.q;
+        assign info_cfgs[i][j][k].erase_en.q = sw_info_cfgs[i][j][k].erase_en.q;
+        assign info_cfgs[i][j][k].scramble_en.q = sw_info_cfgs[i][j][k].scramble_en.q;
+        assign info_cfgs[i][j][k].ecc_en.q = sw_info_cfgs[i][j][k].ecc_en.q;
+        assign info_cfgs[i][j][k].he_en.q = sw_info_cfgs[i][j][k].he_en.q;
+      end
+    end
+  end
+
+  // qualify software settings with creator / owner privileges
+  for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
+      flash_ctrl_info_cfg # (
+        .Bank(i),
+        .InfoSel(j)
+      ) u_info_cfg (
+        .cfgs_i(info_cfgs[i][j]),
+        .creator_seed_priv_i(lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On),
+        .owner_seed_priv_i(lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .cfgs_o(info_page_cfgs_o[i][j])
+      );
+    end
+  end
+
+  //////////////////////////////////////
+  // Update / storage error generation
+  //////////////////////////////////////
+
+  // shadow errors and faults
+  logic [NumBanks-1:0] bank_update_err, bank_store_err;
+  logic [MpRegions-1:0] data_update_err, data_store_err;
+  logic default_update_err, default_store_err;
+  logic [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_update_err, info_store_err;
+
+  assign update_err_o = |data_update_err |
+                        |default_update_err |
+                        |info_update_err |
+                        |bank_update_err;
+
+  assign storage_err_o = |data_store_err |
+                         |default_store_err |
+                         |info_store_err |
+                         |bank_store_err;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_err
+    assign bank_update_err[i] = bank_cfg_i[i].err_update;
+    assign bank_store_err[i] = bank_cfg_i[i].err_storage;
+  end
+
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_data_err
+    assign data_update_err[i] = region_cfg_i[i].base.err_update |
+                                region_cfg_i[i].size.err_update |
+                                region_cfg_i[i].en.err_update |
+                                region_cfg_i[i].rd_en.err_update |
+                                region_cfg_i[i].prog_en.err_update |
+                                region_cfg_i[i].erase_en.err_update |
+                                region_cfg_i[i].scramble_en.err_update |
+                                region_cfg_i[i].ecc_en.err_update |
+                                region_cfg_i[i].he_en.err_update;
+
+    assign data_store_err[i] = region_cfg_i[i].base.err_storage |
+                               region_cfg_i[i].size.err_storage |
+                               region_cfg_i[i].en.err_storage |
+                               region_cfg_i[i].rd_en.err_storage |
+                               region_cfg_i[i].prog_en.err_storage |
+                               region_cfg_i[i].erase_en.err_storage |
+                               region_cfg_i[i].scramble_en.err_storage |
+                               region_cfg_i[i].ecc_en.err_storage |
+                               region_cfg_i[i].he_en.err_storage;
+  end
+
+  assign default_update_err =  default_cfg_i.rd_en.err_update |
+                               default_cfg_i.prog_en.err_update |
+                               default_cfg_i.erase_en.err_update |
+                               default_cfg_i.scramble_en.err_update |
+                               default_cfg_i.ecc_en.err_update |
+                               default_cfg_i.he_en.err_update;
+
+  assign default_store_err =  default_cfg_i.rd_en.err_storage |
+                              default_cfg_i.prog_en.err_storage |
+                              default_cfg_i.erase_en.err_storage |
+                              default_cfg_i.scramble_en.err_storage |
+                              default_cfg_i.ecc_en.err_storage |
+                              default_cfg_i.he_en.err_storage;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_err_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_err_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_err_page
+        assign info_update_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_update |
+                                          sw_info_cfgs[i][j][k].rd_en.err_update |
+                                          sw_info_cfgs[i][j][k].prog_en.err_update |
+                                          sw_info_cfgs[i][j][k].erase_en.err_update |
+                                          sw_info_cfgs[i][j][k].scramble_en.err_update |
+                                          sw_info_cfgs[i][j][k].ecc_en.err_update |
+                                          sw_info_cfgs[i][j][k].he_en.err_update;
+
+        assign info_store_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_storage |
+                                         sw_info_cfgs[i][j][k].rd_en.err_storage |
+                                         sw_info_cfgs[i][j][k].prog_en.err_storage |
+                                         sw_info_cfgs[i][j][k].erase_en.err_storage |
+                                         sw_info_cfgs[i][j][k].scramble_en.err_storage |
+                                         sw_info_cfgs[i][j][k].ecc_en.err_storage |
+                                         sw_info_cfgs[i][j][k].he_en.err_storage;
+      end
+    end
+  end
+
+  //////////////////////////////////////
+  // unused
+  //////////////////////////////////////
+
+endmodule // flash_ctrl_reg_wrap

--- a/hw/ip/flash_ctrl/rtl/flash_mp.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_mp.sv
@@ -16,7 +16,7 @@ module flash_mp import flash_ctrl_pkg::*; import flash_ctrl_reg_pkg::*; (
 
   // configuration from sw
   input mp_region_cfg_t [MpRegions:0] region_cfgs_i,
-  input flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [NumBanks-1:0] bank_cfgs_i,
+  input bank_cfg_t [NumBanks-1:0] bank_cfgs_i,
   input info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs_i,
   input erase_suspend_i,
   output logic erase_suspend_done_o,

--- a/hw/ip/flash_ctrl/util/flash_ctrl_gen.py
+++ b/hw/ip/flash_ctrl/util/flash_ctrl_gen.py
@@ -69,10 +69,12 @@ def main():
     current = Path(__file__).parent.absolute()
 
     hjson_tpl = Template(filename=str(current / '../data/flash_ctrl.hjson.tpl'))
+    region_cfg_tpl = Template(filename=str(current / '../data/flash_ctrl_region_cfg.sv.tpl'))
     rtl_tpl = Template(filename=str(current / '../data/flash_ctrl.sv.tpl'))
     pkg_tpl = Template(filename=str(current / '../data/flash_ctrl_pkg.sv.tpl'))
 
     hjson_out = current / '../data/flash_ctrl.hjson'
+    region_cfg_out = current / '../rtl/flash_ctrl_region_cfg.sv'
     rtl_out = current / '../rtl/flash_ctrl.sv'
     pkg_out = current / '../rtl/flash_ctrl_pkg.sv'
     cfgpath = current / '../../../top_earlgrey/data/autogen/top_earlgrey.gen.hjson'
@@ -98,6 +100,9 @@ def main():
 
     # generate rtl package
     pkg_out.write_text(pkg_tpl.render(cfg=cfg))
+
+    # generate reg wrap
+    region_cfg_out.write_text(region_cfg_tpl.render(cfg=cfg))
 
     # generate top level
     rtl_out.write_text(rtl_tpl.render(cfg=cfg))

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -291,7 +291,7 @@
         [
           "0"
         ]
-        shadowed: false
+        shadowed: true
         sw: false
         path: rstmgr_aon_resets.rst_lc_n
         parent: lc_src

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -601,13 +601,16 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "MP_REGION_CFG",
+          name: "MP_REGION_CFG_SHADOWED",
           desc: "Memory property configuration for data partition",
           count: "NumRegions",
           swaccess: "rw",
           hwaccess: "hro",
           regwen: "REGION_CFG_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -677,10 +680,13 @@
       },
 
       // Default region properties for data partition
-      { name: "DEFAULT_REGION",
+      { name: "DEFAULT_REGION_SHADOWED",
         desc: "Default region properties",
         swaccess: "rw",
         hwaccess: "hro",
+        shadowed: "true",
+        update_err_alert: "recov_err",
+        storage_err_alert: "fatal_err",
         resval: "0",
         fields: [
           { bits: "0",
@@ -763,7 +769,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK0_INFO0_PAGE_CFG",
+          name: "BANK0_INFO0_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank0,
                   Unlike data partition, each page is individually configured.
@@ -773,6 +779,9 @@
           hwaccess: "hro",
           regwen: "BANK0_INFO0_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -860,7 +869,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK0_INFO1_PAGE_CFG",
+          name: "BANK0_INFO1_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank0,
                   Unlike data partition, each page is individually configured.
@@ -870,6 +879,9 @@
           hwaccess: "hro",
           regwen: "BANK0_INFO1_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -957,7 +969,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK0_INFO2_PAGE_CFG",
+          name: "BANK0_INFO2_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank0,
                   Unlike data partition, each page is individually configured.
@@ -967,6 +979,9 @@
           hwaccess: "hro",
           regwen: "BANK0_INFO2_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1054,7 +1069,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK1_INFO0_PAGE_CFG",
+          name: "BANK1_INFO0_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank1,
                   Unlike data partition, each page is individually configured.
@@ -1064,6 +1079,9 @@
           hwaccess: "hro",
           regwen: "BANK1_INFO0_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1151,7 +1169,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK1_INFO1_PAGE_CFG",
+          name: "BANK1_INFO1_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank1,
                   Unlike data partition, each page is individually configured.
@@ -1161,6 +1179,9 @@
           hwaccess: "hro",
           regwen: "BANK1_INFO1_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1248,7 +1269,7 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "BANK1_INFO2_PAGE_CFG",
+          name: "BANK1_INFO2_PAGE_CFG_SHADOWED",
           desc: '''
                   Memory property configuration for info partition in bank1,
                   Unlike data partition, each page is individually configured.
@@ -1258,6 +1279,9 @@
           hwaccess: "hro",
           regwen: "BANK1_INFO2_REGWEN",
           regwen_multi: true,
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "EN",
@@ -1341,12 +1365,15 @@
 
       { multireg: {
           cname: "FLASH_CTRL",
-          name: "MP_BANK_CFG",
+          name: "MP_BANK_CFG_SHADOWED",
           desc: "Memory properties bank configuration",
           count: "RegNumBanks",
           swaccess: "rw",
           hwaccess: "hro",
-          regwen: "BANK_CFG_REGWEN"
+          regwen: "BANK_CFG_REGWEN",
+          shadowed: "true",
+          update_err_alert: "recov_err",
+          storage_err_alert: "fatal_err",
           fields: [
               { bits: "0",
                 name: "ERASE_EN",
@@ -1443,6 +1470,12 @@
               This is a synchronous error.
             '''
           },
+          { bits: "6",
+            name: "update_err",
+            desc: '''
+              A shadow register encountered an update error.
+            '''
+          },
         ]
       },
 
@@ -1511,7 +1544,13 @@
               The life cycle management interface has encountered a fatal error.
               There is an error with the RMA state machine or counts.
               '''
-          }
+          },
+          { bits: "9",
+            name: "storage_err",
+            desc: '''
+              A shadow register encountered a storage fault.
+            '''
+          },
         ]
       },
 

--- a/hw/top_earlgrey/ip/flash_ctrl/flash_ctrl_system.core
+++ b/hw/top_earlgrey/ip/flash_ctrl/flash_ctrl_system.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:ip:flash_ctrl_pkg
     files:
       - rtl/autogen/flash_ctrl_core_reg_top.sv
+      - rtl/autogen/flash_ctrl_region_cfg.sv
       - rtl/autogen/flash_ctrl.sv
     file_type: systemVerilogSource
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -26,6 +26,7 @@ module flash_ctrl
 ) (
   input        clk_i,
   input        rst_ni,
+  input        rst_shadowed_ni,
 
   input        clk_otp_i,
   input        rst_otp_ni,
@@ -97,9 +98,13 @@ module flash_ctrl
 
   // Register module
   logic intg_err;
+  logic update_err;
+  logic storage_err;
+
   flash_ctrl_core_reg_top u_reg_core (
     .clk_i,
     .rst_ni,
+    .rst_shadowed_ni,
 
     .tl_i(core_tl_i),
     .tl_o(core_tl_o),
@@ -112,6 +117,33 @@ module flash_ctrl
 
     .intg_err_o (intg_err),
     .devmode_i  (1'b1)
+  );
+
+  bank_cfg_t [NumBanks-1:0] bank_cfgs;
+  mp_region_cfg_t [MpRegions:0] region_cfgs;
+  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs;
+
+  flash_ctrl_region_cfg u_region_cfg (
+    .clk_i,
+    .rst_ni,
+    .lc_creator_seed_sw_rw_en_i,
+    .lc_owner_seed_sw_rw_en_i,
+    .lc_iso_part_sw_wr_en_i,
+    .lc_iso_part_sw_rd_en_i,
+    .bank_cfg_i(reg2hw.mp_bank_cfg_shadowed),
+    .region_cfg_i(reg2hw.mp_region_cfg_shadowed),
+    .default_cfg_i(reg2hw.default_region_shadowed),
+    .bank0_info0_cfg_i(reg2hw.bank0_info0_page_cfg_shadowed),
+    .bank0_info1_cfg_i(reg2hw.bank0_info1_page_cfg_shadowed),
+    .bank0_info2_cfg_i(reg2hw.bank0_info2_page_cfg_shadowed),
+    .bank1_info0_cfg_i(reg2hw.bank1_info0_page_cfg_shadowed),
+    .bank1_info1_cfg_i(reg2hw.bank1_info1_page_cfg_shadowed),
+    .bank1_info2_cfg_i(reg2hw.bank1_info2_page_cfg_shadowed),
+    .bank_cfg_o(bank_cfgs),
+    .region_cfgs_o(region_cfgs),
+    .info_page_cfgs_o(info_page_cfgs),
+    .update_err_o(update_err),
+    .storage_err_o(storage_err)
   );
 
   // FIFO Connections
@@ -189,8 +221,6 @@ module flash_ctrl
   flash_sel_e if_sel;
   logic sw_sel;
   flash_lcmgr_phase_e hw_phase;
-  logic creator_seed_priv;
-  logic owner_seed_priv;
   logic lcmgr_err;
 
   // Flash control arbitration connections to software interface
@@ -233,51 +263,10 @@ module flash_ctrl
   flash_req_t flash_phy_req;
 
   // life cycle connections
-  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
-  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
   lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
   // flash functional disable
   lc_ctrl_pkg::lc_tx_t flash_disable;
-
-  // synchronize enables into local domain
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_creator_seed_sw_rw_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_creator_seed_sw_rw_en_i),
-    .lc_en_o(lc_creator_seed_sw_rw_en)
-  );
-
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_owner_seed_sw_rw_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_owner_seed_sw_rw_en_i),
-    .lc_en_o(lc_owner_seed_sw_rw_en)
-  );
-
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_iso_part_sw_rd_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_iso_part_sw_rd_en_i),
-    .lc_en_o(lc_iso_part_sw_rd_en)
-  );
-
-  prim_lc_sync #(
-    .NumCopies(1)
-  ) u_lc_iso_part_sw_wr_en_sync (
-    .clk_i,
-    .rst_ni,
-    .lc_en_i(lc_iso_part_sw_wr_en_i),
-    .lc_en_o(lc_iso_part_sw_wr_en)
-  );
 
   prim_lc_sync #(
     .NumCopies(1)
@@ -399,12 +388,6 @@ module flash_ctrl
   assign prog_op       = op_type == FlashOpProgram;
   assign erase_op      = op_type == FlashOpErase;
   assign sw_sel        = if_sel == SwSel;
-
-  // software privilege to creator seed
-  assign creator_seed_priv = lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On;
-
-  // software privilege to owner seed
-  assign owner_seed_priv = lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On;
 
   // hardware interface
   flash_ctrl_lcmgr #(
@@ -681,56 +664,12 @@ module flash_ctrl
     endcase // unique case (op_type)
   end
 
-  //////////////////////////////////////
-  // Data partition properties configuration
-  //////////////////////////////////////
-  // extra region is the default region
-  mp_region_cfg_t [MpRegions:0] region_cfgs;
-  assign region_cfgs[MpRegions-1:0] = reg2hw.mp_region_cfg[MpRegions-1:0];
 
-  //default region
-  assign region_cfgs[MpRegions].base.q = '0;
-  assign region_cfgs[MpRegions].size.q = NumBanks * PagesPerBank;
-  assign region_cfgs[MpRegions].en.q = 1'b1;
-  assign region_cfgs[MpRegions].rd_en.q = reg2hw.default_region.rd_en.q;
-  assign region_cfgs[MpRegions].prog_en.q = reg2hw.default_region.prog_en.q;
-  assign region_cfgs[MpRegions].erase_en.q = reg2hw.default_region.erase_en.q;
-  assign region_cfgs[MpRegions].scramble_en.q = reg2hw.default_region.scramble_en.q;
-  assign region_cfgs[MpRegions].ecc_en.q = reg2hw.default_region.ecc_en.q;
-  assign region_cfgs[MpRegions].he_en.q = reg2hw.default_region.he_en.q;
 
   //////////////////////////////////////
   // Info partition properties configuration
   //////////////////////////////////////
-  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] reg2hw_info_page_cfgs;
-  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs;
-  localparam int InfoBits = $bits(info_page_cfg_t) * InfosPerBank;
 
-  // transform from reg output to structure
-  // Not all types have the maximum number of banks, so those are packed to 0
-  assign reg2hw_info_page_cfgs[0][0] = InfoBits'(reg2hw.bank0_info0_page_cfg);
-  assign reg2hw_info_page_cfgs[0][1] = InfoBits'(reg2hw.bank0_info1_page_cfg);
-  assign reg2hw_info_page_cfgs[0][2] = InfoBits'(reg2hw.bank0_info2_page_cfg);
-  assign reg2hw_info_page_cfgs[1][0] = InfoBits'(reg2hw.bank1_info0_page_cfg);
-  assign reg2hw_info_page_cfgs[1][1] = InfoBits'(reg2hw.bank1_info1_page_cfg);
-  assign reg2hw_info_page_cfgs[1][2] = InfoBits'(reg2hw.bank1_info2_page_cfg);
-
-  // qualify reg2hw settings with creator / owner privileges
-  for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
-    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
-      flash_ctrl_info_cfg # (
-        .Bank(i),
-        .InfoSel(j)
-      ) u_info_cfg (
-        .cfgs_i(reg2hw_info_page_cfgs[i][j]),
-        .creator_seed_priv_i(creator_seed_priv),
-        .owner_seed_priv_i(owner_seed_priv),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
-        .cfgs_o(info_page_cfgs[i][j])
-      );
-    end
-  end
 
   //////////////////////////////////////
   // flash memory properties
@@ -756,7 +695,7 @@ module flash_ctrl
 
     // sw configuration for data partition
     .region_cfgs_i(region_cfgs),
-    .bank_cfgs_i(reg2hw.mp_bank_cfg),
+    .bank_cfgs_i(bank_cfgs),
 
     // sw configuration for info partition
     .info_page_cfgs_i(info_page_cfgs),
@@ -873,13 +812,14 @@ module flash_ctrl
   // Alert senders
   //////////////////////////////////////
 
+
   logic [NumAlerts-1:0] alert_srcs;
   logic [NumAlerts-1:0] alert_tests;
 
-  // TODO Add shadow update
   // An excessive number of recoverable errors may also indicate an attack
   logic recov_err;
-  assign recov_err = sw_ctrl_done & |sw_ctrl_err;
+  assign recov_err = (sw_ctrl_done & |sw_ctrl_err) |
+                     update_err;
 
   logic fatal_err;
   assign fatal_err = |reg2hw.fault_status;
@@ -932,6 +872,8 @@ module flash_ctrl
   // Errors and Interrupts
   //////////////////////////////////////
 
+
+
   // all software interface errors are treated as synchronous errors
   assign hw2reg.err_code.oob_err.d        = 1'b1;
   assign hw2reg.err_code.mp_err.d         = 1'b1;
@@ -939,12 +881,14 @@ module flash_ctrl
   assign hw2reg.err_code.prog_win_err.d   = 1'b1;
   assign hw2reg.err_code.prog_type_err.d  = 1'b1;
   assign hw2reg.err_code.flash_phy_err.d  = 1'b1;
+  assign hw2reg.err_code.update_err.d     = 1'b1;
   assign hw2reg.err_code.oob_err.de       = sw_ctrl_err.oob_err;
   assign hw2reg.err_code.mp_err.de        = sw_ctrl_err.mp_err;
   assign hw2reg.err_code.rd_err.de        = sw_ctrl_err.rd_err;
   assign hw2reg.err_code.prog_win_err.de  = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de = sw_ctrl_err.prog_type_err;
   assign hw2reg.err_code.flash_phy_err.de = sw_ctrl_err.phy_err;
+  assign hw2reg.err_code.update_err.de    = update_err;
   assign hw2reg.err_addr.d                = {reg2hw.addr.q[31:BusAddrW],ctrl_err_addr};
   assign hw2reg.err_addr.de               = sw_ctrl_err.mp_err |
                                             sw_ctrl_err.rd_err |
@@ -960,6 +904,7 @@ module flash_ctrl
   assign hw2reg.fault_status.reg_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.phy_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.lcmgr_err.d      = 1'b1;
+  assign hw2reg.fault_status.storage_err.d    = 1'b1;
   assign hw2reg.fault_status.oob_err.de       = hw_err.oob_err;
   assign hw2reg.fault_status.mp_err.de        = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de        = hw_err.rd_err;
@@ -969,6 +914,7 @@ module flash_ctrl
   assign hw2reg.fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.fault_status.lcmgr_err.de     = lcmgr_err;
+  assign hw2reg.fault_status.storage_err.de   = storage_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -9,6 +9,7 @@
 module flash_ctrl_core_reg_top (
   input clk_i,
   input rst_ni,
+  input rst_shadowed_ni,
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
@@ -255,171 +256,180 @@ module flash_ctrl_core_reg_top (
   logic region_cfg_regwen_7_we;
   logic region_cfg_regwen_7_qs;
   logic region_cfg_regwen_7_wd;
-  logic mp_region_cfg_0_we;
-  logic mp_region_cfg_0_en_0_qs;
-  logic mp_region_cfg_0_en_0_wd;
-  logic mp_region_cfg_0_rd_en_0_qs;
-  logic mp_region_cfg_0_rd_en_0_wd;
-  logic mp_region_cfg_0_prog_en_0_qs;
-  logic mp_region_cfg_0_prog_en_0_wd;
-  logic mp_region_cfg_0_erase_en_0_qs;
-  logic mp_region_cfg_0_erase_en_0_wd;
-  logic mp_region_cfg_0_scramble_en_0_qs;
-  logic mp_region_cfg_0_scramble_en_0_wd;
-  logic mp_region_cfg_0_ecc_en_0_qs;
-  logic mp_region_cfg_0_ecc_en_0_wd;
-  logic mp_region_cfg_0_he_en_0_qs;
-  logic mp_region_cfg_0_he_en_0_wd;
-  logic [8:0] mp_region_cfg_0_base_0_qs;
-  logic [8:0] mp_region_cfg_0_base_0_wd;
-  logic [9:0] mp_region_cfg_0_size_0_qs;
-  logic [9:0] mp_region_cfg_0_size_0_wd;
-  logic mp_region_cfg_1_we;
-  logic mp_region_cfg_1_en_1_qs;
-  logic mp_region_cfg_1_en_1_wd;
-  logic mp_region_cfg_1_rd_en_1_qs;
-  logic mp_region_cfg_1_rd_en_1_wd;
-  logic mp_region_cfg_1_prog_en_1_qs;
-  logic mp_region_cfg_1_prog_en_1_wd;
-  logic mp_region_cfg_1_erase_en_1_qs;
-  logic mp_region_cfg_1_erase_en_1_wd;
-  logic mp_region_cfg_1_scramble_en_1_qs;
-  logic mp_region_cfg_1_scramble_en_1_wd;
-  logic mp_region_cfg_1_ecc_en_1_qs;
-  logic mp_region_cfg_1_ecc_en_1_wd;
-  logic mp_region_cfg_1_he_en_1_qs;
-  logic mp_region_cfg_1_he_en_1_wd;
-  logic [8:0] mp_region_cfg_1_base_1_qs;
-  logic [8:0] mp_region_cfg_1_base_1_wd;
-  logic [9:0] mp_region_cfg_1_size_1_qs;
-  logic [9:0] mp_region_cfg_1_size_1_wd;
-  logic mp_region_cfg_2_we;
-  logic mp_region_cfg_2_en_2_qs;
-  logic mp_region_cfg_2_en_2_wd;
-  logic mp_region_cfg_2_rd_en_2_qs;
-  logic mp_region_cfg_2_rd_en_2_wd;
-  logic mp_region_cfg_2_prog_en_2_qs;
-  logic mp_region_cfg_2_prog_en_2_wd;
-  logic mp_region_cfg_2_erase_en_2_qs;
-  logic mp_region_cfg_2_erase_en_2_wd;
-  logic mp_region_cfg_2_scramble_en_2_qs;
-  logic mp_region_cfg_2_scramble_en_2_wd;
-  logic mp_region_cfg_2_ecc_en_2_qs;
-  logic mp_region_cfg_2_ecc_en_2_wd;
-  logic mp_region_cfg_2_he_en_2_qs;
-  logic mp_region_cfg_2_he_en_2_wd;
-  logic [8:0] mp_region_cfg_2_base_2_qs;
-  logic [8:0] mp_region_cfg_2_base_2_wd;
-  logic [9:0] mp_region_cfg_2_size_2_qs;
-  logic [9:0] mp_region_cfg_2_size_2_wd;
-  logic mp_region_cfg_3_we;
-  logic mp_region_cfg_3_en_3_qs;
-  logic mp_region_cfg_3_en_3_wd;
-  logic mp_region_cfg_3_rd_en_3_qs;
-  logic mp_region_cfg_3_rd_en_3_wd;
-  logic mp_region_cfg_3_prog_en_3_qs;
-  logic mp_region_cfg_3_prog_en_3_wd;
-  logic mp_region_cfg_3_erase_en_3_qs;
-  logic mp_region_cfg_3_erase_en_3_wd;
-  logic mp_region_cfg_3_scramble_en_3_qs;
-  logic mp_region_cfg_3_scramble_en_3_wd;
-  logic mp_region_cfg_3_ecc_en_3_qs;
-  logic mp_region_cfg_3_ecc_en_3_wd;
-  logic mp_region_cfg_3_he_en_3_qs;
-  logic mp_region_cfg_3_he_en_3_wd;
-  logic [8:0] mp_region_cfg_3_base_3_qs;
-  logic [8:0] mp_region_cfg_3_base_3_wd;
-  logic [9:0] mp_region_cfg_3_size_3_qs;
-  logic [9:0] mp_region_cfg_3_size_3_wd;
-  logic mp_region_cfg_4_we;
-  logic mp_region_cfg_4_en_4_qs;
-  logic mp_region_cfg_4_en_4_wd;
-  logic mp_region_cfg_4_rd_en_4_qs;
-  logic mp_region_cfg_4_rd_en_4_wd;
-  logic mp_region_cfg_4_prog_en_4_qs;
-  logic mp_region_cfg_4_prog_en_4_wd;
-  logic mp_region_cfg_4_erase_en_4_qs;
-  logic mp_region_cfg_4_erase_en_4_wd;
-  logic mp_region_cfg_4_scramble_en_4_qs;
-  logic mp_region_cfg_4_scramble_en_4_wd;
-  logic mp_region_cfg_4_ecc_en_4_qs;
-  logic mp_region_cfg_4_ecc_en_4_wd;
-  logic mp_region_cfg_4_he_en_4_qs;
-  logic mp_region_cfg_4_he_en_4_wd;
-  logic [8:0] mp_region_cfg_4_base_4_qs;
-  logic [8:0] mp_region_cfg_4_base_4_wd;
-  logic [9:0] mp_region_cfg_4_size_4_qs;
-  logic [9:0] mp_region_cfg_4_size_4_wd;
-  logic mp_region_cfg_5_we;
-  logic mp_region_cfg_5_en_5_qs;
-  logic mp_region_cfg_5_en_5_wd;
-  logic mp_region_cfg_5_rd_en_5_qs;
-  logic mp_region_cfg_5_rd_en_5_wd;
-  logic mp_region_cfg_5_prog_en_5_qs;
-  logic mp_region_cfg_5_prog_en_5_wd;
-  logic mp_region_cfg_5_erase_en_5_qs;
-  logic mp_region_cfg_5_erase_en_5_wd;
-  logic mp_region_cfg_5_scramble_en_5_qs;
-  logic mp_region_cfg_5_scramble_en_5_wd;
-  logic mp_region_cfg_5_ecc_en_5_qs;
-  logic mp_region_cfg_5_ecc_en_5_wd;
-  logic mp_region_cfg_5_he_en_5_qs;
-  logic mp_region_cfg_5_he_en_5_wd;
-  logic [8:0] mp_region_cfg_5_base_5_qs;
-  logic [8:0] mp_region_cfg_5_base_5_wd;
-  logic [9:0] mp_region_cfg_5_size_5_qs;
-  logic [9:0] mp_region_cfg_5_size_5_wd;
-  logic mp_region_cfg_6_we;
-  logic mp_region_cfg_6_en_6_qs;
-  logic mp_region_cfg_6_en_6_wd;
-  logic mp_region_cfg_6_rd_en_6_qs;
-  logic mp_region_cfg_6_rd_en_6_wd;
-  logic mp_region_cfg_6_prog_en_6_qs;
-  logic mp_region_cfg_6_prog_en_6_wd;
-  logic mp_region_cfg_6_erase_en_6_qs;
-  logic mp_region_cfg_6_erase_en_6_wd;
-  logic mp_region_cfg_6_scramble_en_6_qs;
-  logic mp_region_cfg_6_scramble_en_6_wd;
-  logic mp_region_cfg_6_ecc_en_6_qs;
-  logic mp_region_cfg_6_ecc_en_6_wd;
-  logic mp_region_cfg_6_he_en_6_qs;
-  logic mp_region_cfg_6_he_en_6_wd;
-  logic [8:0] mp_region_cfg_6_base_6_qs;
-  logic [8:0] mp_region_cfg_6_base_6_wd;
-  logic [9:0] mp_region_cfg_6_size_6_qs;
-  logic [9:0] mp_region_cfg_6_size_6_wd;
-  logic mp_region_cfg_7_we;
-  logic mp_region_cfg_7_en_7_qs;
-  logic mp_region_cfg_7_en_7_wd;
-  logic mp_region_cfg_7_rd_en_7_qs;
-  logic mp_region_cfg_7_rd_en_7_wd;
-  logic mp_region_cfg_7_prog_en_7_qs;
-  logic mp_region_cfg_7_prog_en_7_wd;
-  logic mp_region_cfg_7_erase_en_7_qs;
-  logic mp_region_cfg_7_erase_en_7_wd;
-  logic mp_region_cfg_7_scramble_en_7_qs;
-  logic mp_region_cfg_7_scramble_en_7_wd;
-  logic mp_region_cfg_7_ecc_en_7_qs;
-  logic mp_region_cfg_7_ecc_en_7_wd;
-  logic mp_region_cfg_7_he_en_7_qs;
-  logic mp_region_cfg_7_he_en_7_wd;
-  logic [8:0] mp_region_cfg_7_base_7_qs;
-  logic [8:0] mp_region_cfg_7_base_7_wd;
-  logic [9:0] mp_region_cfg_7_size_7_qs;
-  logic [9:0] mp_region_cfg_7_size_7_wd;
-  logic default_region_we;
-  logic default_region_rd_en_qs;
-  logic default_region_rd_en_wd;
-  logic default_region_prog_en_qs;
-  logic default_region_prog_en_wd;
-  logic default_region_erase_en_qs;
-  logic default_region_erase_en_wd;
-  logic default_region_scramble_en_qs;
-  logic default_region_scramble_en_wd;
-  logic default_region_ecc_en_qs;
-  logic default_region_ecc_en_wd;
-  logic default_region_he_en_qs;
-  logic default_region_he_en_wd;
+  logic mp_region_cfg_shadowed_0_re;
+  logic mp_region_cfg_shadowed_0_we;
+  logic mp_region_cfg_shadowed_0_en_0_qs;
+  logic mp_region_cfg_shadowed_0_en_0_wd;
+  logic mp_region_cfg_shadowed_0_rd_en_0_qs;
+  logic mp_region_cfg_shadowed_0_rd_en_0_wd;
+  logic mp_region_cfg_shadowed_0_prog_en_0_qs;
+  logic mp_region_cfg_shadowed_0_prog_en_0_wd;
+  logic mp_region_cfg_shadowed_0_erase_en_0_qs;
+  logic mp_region_cfg_shadowed_0_erase_en_0_wd;
+  logic mp_region_cfg_shadowed_0_scramble_en_0_qs;
+  logic mp_region_cfg_shadowed_0_scramble_en_0_wd;
+  logic mp_region_cfg_shadowed_0_ecc_en_0_qs;
+  logic mp_region_cfg_shadowed_0_ecc_en_0_wd;
+  logic mp_region_cfg_shadowed_0_he_en_0_qs;
+  logic mp_region_cfg_shadowed_0_he_en_0_wd;
+  logic [8:0] mp_region_cfg_shadowed_0_base_0_qs;
+  logic [8:0] mp_region_cfg_shadowed_0_base_0_wd;
+  logic [9:0] mp_region_cfg_shadowed_0_size_0_qs;
+  logic [9:0] mp_region_cfg_shadowed_0_size_0_wd;
+  logic mp_region_cfg_shadowed_1_re;
+  logic mp_region_cfg_shadowed_1_we;
+  logic mp_region_cfg_shadowed_1_en_1_qs;
+  logic mp_region_cfg_shadowed_1_en_1_wd;
+  logic mp_region_cfg_shadowed_1_rd_en_1_qs;
+  logic mp_region_cfg_shadowed_1_rd_en_1_wd;
+  logic mp_region_cfg_shadowed_1_prog_en_1_qs;
+  logic mp_region_cfg_shadowed_1_prog_en_1_wd;
+  logic mp_region_cfg_shadowed_1_erase_en_1_qs;
+  logic mp_region_cfg_shadowed_1_erase_en_1_wd;
+  logic mp_region_cfg_shadowed_1_scramble_en_1_qs;
+  logic mp_region_cfg_shadowed_1_scramble_en_1_wd;
+  logic mp_region_cfg_shadowed_1_ecc_en_1_qs;
+  logic mp_region_cfg_shadowed_1_ecc_en_1_wd;
+  logic mp_region_cfg_shadowed_1_he_en_1_qs;
+  logic mp_region_cfg_shadowed_1_he_en_1_wd;
+  logic [8:0] mp_region_cfg_shadowed_1_base_1_qs;
+  logic [8:0] mp_region_cfg_shadowed_1_base_1_wd;
+  logic [9:0] mp_region_cfg_shadowed_1_size_1_qs;
+  logic [9:0] mp_region_cfg_shadowed_1_size_1_wd;
+  logic mp_region_cfg_shadowed_2_re;
+  logic mp_region_cfg_shadowed_2_we;
+  logic mp_region_cfg_shadowed_2_en_2_qs;
+  logic mp_region_cfg_shadowed_2_en_2_wd;
+  logic mp_region_cfg_shadowed_2_rd_en_2_qs;
+  logic mp_region_cfg_shadowed_2_rd_en_2_wd;
+  logic mp_region_cfg_shadowed_2_prog_en_2_qs;
+  logic mp_region_cfg_shadowed_2_prog_en_2_wd;
+  logic mp_region_cfg_shadowed_2_erase_en_2_qs;
+  logic mp_region_cfg_shadowed_2_erase_en_2_wd;
+  logic mp_region_cfg_shadowed_2_scramble_en_2_qs;
+  logic mp_region_cfg_shadowed_2_scramble_en_2_wd;
+  logic mp_region_cfg_shadowed_2_ecc_en_2_qs;
+  logic mp_region_cfg_shadowed_2_ecc_en_2_wd;
+  logic mp_region_cfg_shadowed_2_he_en_2_qs;
+  logic mp_region_cfg_shadowed_2_he_en_2_wd;
+  logic [8:0] mp_region_cfg_shadowed_2_base_2_qs;
+  logic [8:0] mp_region_cfg_shadowed_2_base_2_wd;
+  logic [9:0] mp_region_cfg_shadowed_2_size_2_qs;
+  logic [9:0] mp_region_cfg_shadowed_2_size_2_wd;
+  logic mp_region_cfg_shadowed_3_re;
+  logic mp_region_cfg_shadowed_3_we;
+  logic mp_region_cfg_shadowed_3_en_3_qs;
+  logic mp_region_cfg_shadowed_3_en_3_wd;
+  logic mp_region_cfg_shadowed_3_rd_en_3_qs;
+  logic mp_region_cfg_shadowed_3_rd_en_3_wd;
+  logic mp_region_cfg_shadowed_3_prog_en_3_qs;
+  logic mp_region_cfg_shadowed_3_prog_en_3_wd;
+  logic mp_region_cfg_shadowed_3_erase_en_3_qs;
+  logic mp_region_cfg_shadowed_3_erase_en_3_wd;
+  logic mp_region_cfg_shadowed_3_scramble_en_3_qs;
+  logic mp_region_cfg_shadowed_3_scramble_en_3_wd;
+  logic mp_region_cfg_shadowed_3_ecc_en_3_qs;
+  logic mp_region_cfg_shadowed_3_ecc_en_3_wd;
+  logic mp_region_cfg_shadowed_3_he_en_3_qs;
+  logic mp_region_cfg_shadowed_3_he_en_3_wd;
+  logic [8:0] mp_region_cfg_shadowed_3_base_3_qs;
+  logic [8:0] mp_region_cfg_shadowed_3_base_3_wd;
+  logic [9:0] mp_region_cfg_shadowed_3_size_3_qs;
+  logic [9:0] mp_region_cfg_shadowed_3_size_3_wd;
+  logic mp_region_cfg_shadowed_4_re;
+  logic mp_region_cfg_shadowed_4_we;
+  logic mp_region_cfg_shadowed_4_en_4_qs;
+  logic mp_region_cfg_shadowed_4_en_4_wd;
+  logic mp_region_cfg_shadowed_4_rd_en_4_qs;
+  logic mp_region_cfg_shadowed_4_rd_en_4_wd;
+  logic mp_region_cfg_shadowed_4_prog_en_4_qs;
+  logic mp_region_cfg_shadowed_4_prog_en_4_wd;
+  logic mp_region_cfg_shadowed_4_erase_en_4_qs;
+  logic mp_region_cfg_shadowed_4_erase_en_4_wd;
+  logic mp_region_cfg_shadowed_4_scramble_en_4_qs;
+  logic mp_region_cfg_shadowed_4_scramble_en_4_wd;
+  logic mp_region_cfg_shadowed_4_ecc_en_4_qs;
+  logic mp_region_cfg_shadowed_4_ecc_en_4_wd;
+  logic mp_region_cfg_shadowed_4_he_en_4_qs;
+  logic mp_region_cfg_shadowed_4_he_en_4_wd;
+  logic [8:0] mp_region_cfg_shadowed_4_base_4_qs;
+  logic [8:0] mp_region_cfg_shadowed_4_base_4_wd;
+  logic [9:0] mp_region_cfg_shadowed_4_size_4_qs;
+  logic [9:0] mp_region_cfg_shadowed_4_size_4_wd;
+  logic mp_region_cfg_shadowed_5_re;
+  logic mp_region_cfg_shadowed_5_we;
+  logic mp_region_cfg_shadowed_5_en_5_qs;
+  logic mp_region_cfg_shadowed_5_en_5_wd;
+  logic mp_region_cfg_shadowed_5_rd_en_5_qs;
+  logic mp_region_cfg_shadowed_5_rd_en_5_wd;
+  logic mp_region_cfg_shadowed_5_prog_en_5_qs;
+  logic mp_region_cfg_shadowed_5_prog_en_5_wd;
+  logic mp_region_cfg_shadowed_5_erase_en_5_qs;
+  logic mp_region_cfg_shadowed_5_erase_en_5_wd;
+  logic mp_region_cfg_shadowed_5_scramble_en_5_qs;
+  logic mp_region_cfg_shadowed_5_scramble_en_5_wd;
+  logic mp_region_cfg_shadowed_5_ecc_en_5_qs;
+  logic mp_region_cfg_shadowed_5_ecc_en_5_wd;
+  logic mp_region_cfg_shadowed_5_he_en_5_qs;
+  logic mp_region_cfg_shadowed_5_he_en_5_wd;
+  logic [8:0] mp_region_cfg_shadowed_5_base_5_qs;
+  logic [8:0] mp_region_cfg_shadowed_5_base_5_wd;
+  logic [9:0] mp_region_cfg_shadowed_5_size_5_qs;
+  logic [9:0] mp_region_cfg_shadowed_5_size_5_wd;
+  logic mp_region_cfg_shadowed_6_re;
+  logic mp_region_cfg_shadowed_6_we;
+  logic mp_region_cfg_shadowed_6_en_6_qs;
+  logic mp_region_cfg_shadowed_6_en_6_wd;
+  logic mp_region_cfg_shadowed_6_rd_en_6_qs;
+  logic mp_region_cfg_shadowed_6_rd_en_6_wd;
+  logic mp_region_cfg_shadowed_6_prog_en_6_qs;
+  logic mp_region_cfg_shadowed_6_prog_en_6_wd;
+  logic mp_region_cfg_shadowed_6_erase_en_6_qs;
+  logic mp_region_cfg_shadowed_6_erase_en_6_wd;
+  logic mp_region_cfg_shadowed_6_scramble_en_6_qs;
+  logic mp_region_cfg_shadowed_6_scramble_en_6_wd;
+  logic mp_region_cfg_shadowed_6_ecc_en_6_qs;
+  logic mp_region_cfg_shadowed_6_ecc_en_6_wd;
+  logic mp_region_cfg_shadowed_6_he_en_6_qs;
+  logic mp_region_cfg_shadowed_6_he_en_6_wd;
+  logic [8:0] mp_region_cfg_shadowed_6_base_6_qs;
+  logic [8:0] mp_region_cfg_shadowed_6_base_6_wd;
+  logic [9:0] mp_region_cfg_shadowed_6_size_6_qs;
+  logic [9:0] mp_region_cfg_shadowed_6_size_6_wd;
+  logic mp_region_cfg_shadowed_7_re;
+  logic mp_region_cfg_shadowed_7_we;
+  logic mp_region_cfg_shadowed_7_en_7_qs;
+  logic mp_region_cfg_shadowed_7_en_7_wd;
+  logic mp_region_cfg_shadowed_7_rd_en_7_qs;
+  logic mp_region_cfg_shadowed_7_rd_en_7_wd;
+  logic mp_region_cfg_shadowed_7_prog_en_7_qs;
+  logic mp_region_cfg_shadowed_7_prog_en_7_wd;
+  logic mp_region_cfg_shadowed_7_erase_en_7_qs;
+  logic mp_region_cfg_shadowed_7_erase_en_7_wd;
+  logic mp_region_cfg_shadowed_7_scramble_en_7_qs;
+  logic mp_region_cfg_shadowed_7_scramble_en_7_wd;
+  logic mp_region_cfg_shadowed_7_ecc_en_7_qs;
+  logic mp_region_cfg_shadowed_7_ecc_en_7_wd;
+  logic mp_region_cfg_shadowed_7_he_en_7_qs;
+  logic mp_region_cfg_shadowed_7_he_en_7_wd;
+  logic [8:0] mp_region_cfg_shadowed_7_base_7_qs;
+  logic [8:0] mp_region_cfg_shadowed_7_base_7_wd;
+  logic [9:0] mp_region_cfg_shadowed_7_size_7_qs;
+  logic [9:0] mp_region_cfg_shadowed_7_size_7_wd;
+  logic default_region_shadowed_re;
+  logic default_region_shadowed_we;
+  logic default_region_shadowed_rd_en_qs;
+  logic default_region_shadowed_rd_en_wd;
+  logic default_region_shadowed_prog_en_qs;
+  logic default_region_shadowed_prog_en_wd;
+  logic default_region_shadowed_erase_en_qs;
+  logic default_region_shadowed_erase_en_wd;
+  logic default_region_shadowed_scramble_en_qs;
+  logic default_region_shadowed_scramble_en_wd;
+  logic default_region_shadowed_ecc_en_qs;
+  logic default_region_shadowed_ecc_en_wd;
+  logic default_region_shadowed_he_en_qs;
+  logic default_region_shadowed_he_en_wd;
   logic bank0_info0_regwen_0_we;
   logic bank0_info0_regwen_0_qs;
   logic bank0_info0_regwen_0_wd;
@@ -450,210 +460,223 @@ module flash_ctrl_core_reg_top (
   logic bank0_info0_regwen_9_we;
   logic bank0_info0_regwen_9_qs;
   logic bank0_info0_regwen_9_wd;
-  logic bank0_info0_page_cfg_0_we;
-  logic bank0_info0_page_cfg_0_en_0_qs;
-  logic bank0_info0_page_cfg_0_en_0_wd;
-  logic bank0_info0_page_cfg_0_rd_en_0_qs;
-  logic bank0_info0_page_cfg_0_rd_en_0_wd;
-  logic bank0_info0_page_cfg_0_prog_en_0_qs;
-  logic bank0_info0_page_cfg_0_prog_en_0_wd;
-  logic bank0_info0_page_cfg_0_erase_en_0_qs;
-  logic bank0_info0_page_cfg_0_erase_en_0_wd;
-  logic bank0_info0_page_cfg_0_scramble_en_0_qs;
-  logic bank0_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info0_page_cfg_0_ecc_en_0_qs;
-  logic bank0_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info0_page_cfg_0_he_en_0_qs;
-  logic bank0_info0_page_cfg_0_he_en_0_wd;
-  logic bank0_info0_page_cfg_1_we;
-  logic bank0_info0_page_cfg_1_en_1_qs;
-  logic bank0_info0_page_cfg_1_en_1_wd;
-  logic bank0_info0_page_cfg_1_rd_en_1_qs;
-  logic bank0_info0_page_cfg_1_rd_en_1_wd;
-  logic bank0_info0_page_cfg_1_prog_en_1_qs;
-  logic bank0_info0_page_cfg_1_prog_en_1_wd;
-  logic bank0_info0_page_cfg_1_erase_en_1_qs;
-  logic bank0_info0_page_cfg_1_erase_en_1_wd;
-  logic bank0_info0_page_cfg_1_scramble_en_1_qs;
-  logic bank0_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info0_page_cfg_1_ecc_en_1_qs;
-  logic bank0_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info0_page_cfg_1_he_en_1_qs;
-  logic bank0_info0_page_cfg_1_he_en_1_wd;
-  logic bank0_info0_page_cfg_2_we;
-  logic bank0_info0_page_cfg_2_en_2_qs;
-  logic bank0_info0_page_cfg_2_en_2_wd;
-  logic bank0_info0_page_cfg_2_rd_en_2_qs;
-  logic bank0_info0_page_cfg_2_rd_en_2_wd;
-  logic bank0_info0_page_cfg_2_prog_en_2_qs;
-  logic bank0_info0_page_cfg_2_prog_en_2_wd;
-  logic bank0_info0_page_cfg_2_erase_en_2_qs;
-  logic bank0_info0_page_cfg_2_erase_en_2_wd;
-  logic bank0_info0_page_cfg_2_scramble_en_2_qs;
-  logic bank0_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank0_info0_page_cfg_2_ecc_en_2_qs;
-  logic bank0_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank0_info0_page_cfg_2_he_en_2_qs;
-  logic bank0_info0_page_cfg_2_he_en_2_wd;
-  logic bank0_info0_page_cfg_3_we;
-  logic bank0_info0_page_cfg_3_en_3_qs;
-  logic bank0_info0_page_cfg_3_en_3_wd;
-  logic bank0_info0_page_cfg_3_rd_en_3_qs;
-  logic bank0_info0_page_cfg_3_rd_en_3_wd;
-  logic bank0_info0_page_cfg_3_prog_en_3_qs;
-  logic bank0_info0_page_cfg_3_prog_en_3_wd;
-  logic bank0_info0_page_cfg_3_erase_en_3_qs;
-  logic bank0_info0_page_cfg_3_erase_en_3_wd;
-  logic bank0_info0_page_cfg_3_scramble_en_3_qs;
-  logic bank0_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank0_info0_page_cfg_3_ecc_en_3_qs;
-  logic bank0_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank0_info0_page_cfg_3_he_en_3_qs;
-  logic bank0_info0_page_cfg_3_he_en_3_wd;
-  logic bank0_info0_page_cfg_4_we;
-  logic bank0_info0_page_cfg_4_en_4_qs;
-  logic bank0_info0_page_cfg_4_en_4_wd;
-  logic bank0_info0_page_cfg_4_rd_en_4_qs;
-  logic bank0_info0_page_cfg_4_rd_en_4_wd;
-  logic bank0_info0_page_cfg_4_prog_en_4_qs;
-  logic bank0_info0_page_cfg_4_prog_en_4_wd;
-  logic bank0_info0_page_cfg_4_erase_en_4_qs;
-  logic bank0_info0_page_cfg_4_erase_en_4_wd;
-  logic bank0_info0_page_cfg_4_scramble_en_4_qs;
-  logic bank0_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank0_info0_page_cfg_4_ecc_en_4_qs;
-  logic bank0_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank0_info0_page_cfg_4_he_en_4_qs;
-  logic bank0_info0_page_cfg_4_he_en_4_wd;
-  logic bank0_info0_page_cfg_5_we;
-  logic bank0_info0_page_cfg_5_en_5_qs;
-  logic bank0_info0_page_cfg_5_en_5_wd;
-  logic bank0_info0_page_cfg_5_rd_en_5_qs;
-  logic bank0_info0_page_cfg_5_rd_en_5_wd;
-  logic bank0_info0_page_cfg_5_prog_en_5_qs;
-  logic bank0_info0_page_cfg_5_prog_en_5_wd;
-  logic bank0_info0_page_cfg_5_erase_en_5_qs;
-  logic bank0_info0_page_cfg_5_erase_en_5_wd;
-  logic bank0_info0_page_cfg_5_scramble_en_5_qs;
-  logic bank0_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank0_info0_page_cfg_5_ecc_en_5_qs;
-  logic bank0_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank0_info0_page_cfg_5_he_en_5_qs;
-  logic bank0_info0_page_cfg_5_he_en_5_wd;
-  logic bank0_info0_page_cfg_6_we;
-  logic bank0_info0_page_cfg_6_en_6_qs;
-  logic bank0_info0_page_cfg_6_en_6_wd;
-  logic bank0_info0_page_cfg_6_rd_en_6_qs;
-  logic bank0_info0_page_cfg_6_rd_en_6_wd;
-  logic bank0_info0_page_cfg_6_prog_en_6_qs;
-  logic bank0_info0_page_cfg_6_prog_en_6_wd;
-  logic bank0_info0_page_cfg_6_erase_en_6_qs;
-  logic bank0_info0_page_cfg_6_erase_en_6_wd;
-  logic bank0_info0_page_cfg_6_scramble_en_6_qs;
-  logic bank0_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank0_info0_page_cfg_6_ecc_en_6_qs;
-  logic bank0_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank0_info0_page_cfg_6_he_en_6_qs;
-  logic bank0_info0_page_cfg_6_he_en_6_wd;
-  logic bank0_info0_page_cfg_7_we;
-  logic bank0_info0_page_cfg_7_en_7_qs;
-  logic bank0_info0_page_cfg_7_en_7_wd;
-  logic bank0_info0_page_cfg_7_rd_en_7_qs;
-  logic bank0_info0_page_cfg_7_rd_en_7_wd;
-  logic bank0_info0_page_cfg_7_prog_en_7_qs;
-  logic bank0_info0_page_cfg_7_prog_en_7_wd;
-  logic bank0_info0_page_cfg_7_erase_en_7_qs;
-  logic bank0_info0_page_cfg_7_erase_en_7_wd;
-  logic bank0_info0_page_cfg_7_scramble_en_7_qs;
-  logic bank0_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank0_info0_page_cfg_7_ecc_en_7_qs;
-  logic bank0_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank0_info0_page_cfg_7_he_en_7_qs;
-  logic bank0_info0_page_cfg_7_he_en_7_wd;
-  logic bank0_info0_page_cfg_8_we;
-  logic bank0_info0_page_cfg_8_en_8_qs;
-  logic bank0_info0_page_cfg_8_en_8_wd;
-  logic bank0_info0_page_cfg_8_rd_en_8_qs;
-  logic bank0_info0_page_cfg_8_rd_en_8_wd;
-  logic bank0_info0_page_cfg_8_prog_en_8_qs;
-  logic bank0_info0_page_cfg_8_prog_en_8_wd;
-  logic bank0_info0_page_cfg_8_erase_en_8_qs;
-  logic bank0_info0_page_cfg_8_erase_en_8_wd;
-  logic bank0_info0_page_cfg_8_scramble_en_8_qs;
-  logic bank0_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank0_info0_page_cfg_8_ecc_en_8_qs;
-  logic bank0_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank0_info0_page_cfg_8_he_en_8_qs;
-  logic bank0_info0_page_cfg_8_he_en_8_wd;
-  logic bank0_info0_page_cfg_9_we;
-  logic bank0_info0_page_cfg_9_en_9_qs;
-  logic bank0_info0_page_cfg_9_en_9_wd;
-  logic bank0_info0_page_cfg_9_rd_en_9_qs;
-  logic bank0_info0_page_cfg_9_rd_en_9_wd;
-  logic bank0_info0_page_cfg_9_prog_en_9_qs;
-  logic bank0_info0_page_cfg_9_prog_en_9_wd;
-  logic bank0_info0_page_cfg_9_erase_en_9_qs;
-  logic bank0_info0_page_cfg_9_erase_en_9_wd;
-  logic bank0_info0_page_cfg_9_scramble_en_9_qs;
-  logic bank0_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank0_info0_page_cfg_9_ecc_en_9_qs;
-  logic bank0_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank0_info0_page_cfg_9_he_en_9_qs;
-  logic bank0_info0_page_cfg_9_he_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_0_re;
+  logic bank0_info0_page_cfg_shadowed_0_we;
+  logic bank0_info0_page_cfg_shadowed_0_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank0_info0_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank0_info0_page_cfg_shadowed_1_re;
+  logic bank0_info0_page_cfg_shadowed_1_we;
+  logic bank0_info0_page_cfg_shadowed_1_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank0_info0_page_cfg_shadowed_1_he_en_1_wd;
+  logic bank0_info0_page_cfg_shadowed_2_re;
+  logic bank0_info0_page_cfg_shadowed_2_we;
+  logic bank0_info0_page_cfg_shadowed_2_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_rd_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_rd_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_prog_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_prog_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_erase_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_erase_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_scramble_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_ecc_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_2_he_en_2_qs;
+  logic bank0_info0_page_cfg_shadowed_2_he_en_2_wd;
+  logic bank0_info0_page_cfg_shadowed_3_re;
+  logic bank0_info0_page_cfg_shadowed_3_we;
+  logic bank0_info0_page_cfg_shadowed_3_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_rd_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_rd_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_prog_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_prog_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_erase_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_erase_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_scramble_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_ecc_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_3_he_en_3_qs;
+  logic bank0_info0_page_cfg_shadowed_3_he_en_3_wd;
+  logic bank0_info0_page_cfg_shadowed_4_re;
+  logic bank0_info0_page_cfg_shadowed_4_we;
+  logic bank0_info0_page_cfg_shadowed_4_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_rd_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_rd_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_prog_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_prog_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_erase_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_erase_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_scramble_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_ecc_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_4_he_en_4_qs;
+  logic bank0_info0_page_cfg_shadowed_4_he_en_4_wd;
+  logic bank0_info0_page_cfg_shadowed_5_re;
+  logic bank0_info0_page_cfg_shadowed_5_we;
+  logic bank0_info0_page_cfg_shadowed_5_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_rd_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_rd_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_prog_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_prog_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_erase_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_erase_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_scramble_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_ecc_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_5_he_en_5_qs;
+  logic bank0_info0_page_cfg_shadowed_5_he_en_5_wd;
+  logic bank0_info0_page_cfg_shadowed_6_re;
+  logic bank0_info0_page_cfg_shadowed_6_we;
+  logic bank0_info0_page_cfg_shadowed_6_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_rd_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_rd_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_prog_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_prog_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_erase_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_erase_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_scramble_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_ecc_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_6_he_en_6_qs;
+  logic bank0_info0_page_cfg_shadowed_6_he_en_6_wd;
+  logic bank0_info0_page_cfg_shadowed_7_re;
+  logic bank0_info0_page_cfg_shadowed_7_we;
+  logic bank0_info0_page_cfg_shadowed_7_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_rd_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_rd_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_prog_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_prog_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_erase_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_erase_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_scramble_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_ecc_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_7_he_en_7_qs;
+  logic bank0_info0_page_cfg_shadowed_7_he_en_7_wd;
+  logic bank0_info0_page_cfg_shadowed_8_re;
+  logic bank0_info0_page_cfg_shadowed_8_we;
+  logic bank0_info0_page_cfg_shadowed_8_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_rd_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_rd_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_prog_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_prog_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_erase_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_erase_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_scramble_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_ecc_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_8_he_en_8_qs;
+  logic bank0_info0_page_cfg_shadowed_8_he_en_8_wd;
+  logic bank0_info0_page_cfg_shadowed_9_re;
+  logic bank0_info0_page_cfg_shadowed_9_we;
+  logic bank0_info0_page_cfg_shadowed_9_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_rd_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_rd_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_prog_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_prog_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_erase_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_erase_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_scramble_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_ecc_en_9_wd;
+  logic bank0_info0_page_cfg_shadowed_9_he_en_9_qs;
+  logic bank0_info0_page_cfg_shadowed_9_he_en_9_wd;
   logic bank0_info1_regwen_we;
   logic bank0_info1_regwen_qs;
   logic bank0_info1_regwen_wd;
-  logic bank0_info1_page_cfg_we;
-  logic bank0_info1_page_cfg_en_0_qs;
-  logic bank0_info1_page_cfg_en_0_wd;
-  logic bank0_info1_page_cfg_rd_en_0_qs;
-  logic bank0_info1_page_cfg_rd_en_0_wd;
-  logic bank0_info1_page_cfg_prog_en_0_qs;
-  logic bank0_info1_page_cfg_prog_en_0_wd;
-  logic bank0_info1_page_cfg_erase_en_0_qs;
-  logic bank0_info1_page_cfg_erase_en_0_wd;
-  logic bank0_info1_page_cfg_scramble_en_0_qs;
-  logic bank0_info1_page_cfg_scramble_en_0_wd;
-  logic bank0_info1_page_cfg_ecc_en_0_qs;
-  logic bank0_info1_page_cfg_ecc_en_0_wd;
-  logic bank0_info1_page_cfg_he_en_0_qs;
-  logic bank0_info1_page_cfg_he_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_re;
+  logic bank0_info1_page_cfg_shadowed_we;
+  logic bank0_info1_page_cfg_shadowed_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_rd_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_rd_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_prog_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_prog_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_erase_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_erase_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_scramble_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_scramble_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_ecc_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_ecc_en_0_wd;
+  logic bank0_info1_page_cfg_shadowed_he_en_0_qs;
+  logic bank0_info1_page_cfg_shadowed_he_en_0_wd;
   logic bank0_info2_regwen_0_we;
   logic bank0_info2_regwen_0_qs;
   logic bank0_info2_regwen_0_wd;
   logic bank0_info2_regwen_1_we;
   logic bank0_info2_regwen_1_qs;
   logic bank0_info2_regwen_1_wd;
-  logic bank0_info2_page_cfg_0_we;
-  logic bank0_info2_page_cfg_0_en_0_qs;
-  logic bank0_info2_page_cfg_0_en_0_wd;
-  logic bank0_info2_page_cfg_0_rd_en_0_qs;
-  logic bank0_info2_page_cfg_0_rd_en_0_wd;
-  logic bank0_info2_page_cfg_0_prog_en_0_qs;
-  logic bank0_info2_page_cfg_0_prog_en_0_wd;
-  logic bank0_info2_page_cfg_0_erase_en_0_qs;
-  logic bank0_info2_page_cfg_0_erase_en_0_wd;
-  logic bank0_info2_page_cfg_0_scramble_en_0_qs;
-  logic bank0_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank0_info2_page_cfg_0_ecc_en_0_qs;
-  logic bank0_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank0_info2_page_cfg_0_he_en_0_qs;
-  logic bank0_info2_page_cfg_0_he_en_0_wd;
-  logic bank0_info2_page_cfg_1_we;
-  logic bank0_info2_page_cfg_1_en_1_qs;
-  logic bank0_info2_page_cfg_1_en_1_wd;
-  logic bank0_info2_page_cfg_1_rd_en_1_qs;
-  logic bank0_info2_page_cfg_1_rd_en_1_wd;
-  logic bank0_info2_page_cfg_1_prog_en_1_qs;
-  logic bank0_info2_page_cfg_1_prog_en_1_wd;
-  logic bank0_info2_page_cfg_1_erase_en_1_qs;
-  logic bank0_info2_page_cfg_1_erase_en_1_wd;
-  logic bank0_info2_page_cfg_1_scramble_en_1_qs;
-  logic bank0_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank0_info2_page_cfg_1_ecc_en_1_qs;
-  logic bank0_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank0_info2_page_cfg_1_he_en_1_qs;
-  logic bank0_info2_page_cfg_1_he_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_0_re;
+  logic bank0_info2_page_cfg_shadowed_0_we;
+  logic bank0_info2_page_cfg_shadowed_0_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank0_info2_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank0_info2_page_cfg_shadowed_1_re;
+  logic bank0_info2_page_cfg_shadowed_1_we;
+  logic bank0_info2_page_cfg_shadowed_1_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank0_info2_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank0_info2_page_cfg_shadowed_1_he_en_1_wd;
   logic bank1_info0_regwen_0_we;
   logic bank1_info0_regwen_0_qs;
   logic bank1_info0_regwen_0_wd;
@@ -684,218 +707,232 @@ module flash_ctrl_core_reg_top (
   logic bank1_info0_regwen_9_we;
   logic bank1_info0_regwen_9_qs;
   logic bank1_info0_regwen_9_wd;
-  logic bank1_info0_page_cfg_0_we;
-  logic bank1_info0_page_cfg_0_en_0_qs;
-  logic bank1_info0_page_cfg_0_en_0_wd;
-  logic bank1_info0_page_cfg_0_rd_en_0_qs;
-  logic bank1_info0_page_cfg_0_rd_en_0_wd;
-  logic bank1_info0_page_cfg_0_prog_en_0_qs;
-  logic bank1_info0_page_cfg_0_prog_en_0_wd;
-  logic bank1_info0_page_cfg_0_erase_en_0_qs;
-  logic bank1_info0_page_cfg_0_erase_en_0_wd;
-  logic bank1_info0_page_cfg_0_scramble_en_0_qs;
-  logic bank1_info0_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info0_page_cfg_0_ecc_en_0_qs;
-  logic bank1_info0_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info0_page_cfg_0_he_en_0_qs;
-  logic bank1_info0_page_cfg_0_he_en_0_wd;
-  logic bank1_info0_page_cfg_1_we;
-  logic bank1_info0_page_cfg_1_en_1_qs;
-  logic bank1_info0_page_cfg_1_en_1_wd;
-  logic bank1_info0_page_cfg_1_rd_en_1_qs;
-  logic bank1_info0_page_cfg_1_rd_en_1_wd;
-  logic bank1_info0_page_cfg_1_prog_en_1_qs;
-  logic bank1_info0_page_cfg_1_prog_en_1_wd;
-  logic bank1_info0_page_cfg_1_erase_en_1_qs;
-  logic bank1_info0_page_cfg_1_erase_en_1_wd;
-  logic bank1_info0_page_cfg_1_scramble_en_1_qs;
-  logic bank1_info0_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info0_page_cfg_1_ecc_en_1_qs;
-  logic bank1_info0_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info0_page_cfg_1_he_en_1_qs;
-  logic bank1_info0_page_cfg_1_he_en_1_wd;
-  logic bank1_info0_page_cfg_2_we;
-  logic bank1_info0_page_cfg_2_en_2_qs;
-  logic bank1_info0_page_cfg_2_en_2_wd;
-  logic bank1_info0_page_cfg_2_rd_en_2_qs;
-  logic bank1_info0_page_cfg_2_rd_en_2_wd;
-  logic bank1_info0_page_cfg_2_prog_en_2_qs;
-  logic bank1_info0_page_cfg_2_prog_en_2_wd;
-  logic bank1_info0_page_cfg_2_erase_en_2_qs;
-  logic bank1_info0_page_cfg_2_erase_en_2_wd;
-  logic bank1_info0_page_cfg_2_scramble_en_2_qs;
-  logic bank1_info0_page_cfg_2_scramble_en_2_wd;
-  logic bank1_info0_page_cfg_2_ecc_en_2_qs;
-  logic bank1_info0_page_cfg_2_ecc_en_2_wd;
-  logic bank1_info0_page_cfg_2_he_en_2_qs;
-  logic bank1_info0_page_cfg_2_he_en_2_wd;
-  logic bank1_info0_page_cfg_3_we;
-  logic bank1_info0_page_cfg_3_en_3_qs;
-  logic bank1_info0_page_cfg_3_en_3_wd;
-  logic bank1_info0_page_cfg_3_rd_en_3_qs;
-  logic bank1_info0_page_cfg_3_rd_en_3_wd;
-  logic bank1_info0_page_cfg_3_prog_en_3_qs;
-  logic bank1_info0_page_cfg_3_prog_en_3_wd;
-  logic bank1_info0_page_cfg_3_erase_en_3_qs;
-  logic bank1_info0_page_cfg_3_erase_en_3_wd;
-  logic bank1_info0_page_cfg_3_scramble_en_3_qs;
-  logic bank1_info0_page_cfg_3_scramble_en_3_wd;
-  logic bank1_info0_page_cfg_3_ecc_en_3_qs;
-  logic bank1_info0_page_cfg_3_ecc_en_3_wd;
-  logic bank1_info0_page_cfg_3_he_en_3_qs;
-  logic bank1_info0_page_cfg_3_he_en_3_wd;
-  logic bank1_info0_page_cfg_4_we;
-  logic bank1_info0_page_cfg_4_en_4_qs;
-  logic bank1_info0_page_cfg_4_en_4_wd;
-  logic bank1_info0_page_cfg_4_rd_en_4_qs;
-  logic bank1_info0_page_cfg_4_rd_en_4_wd;
-  logic bank1_info0_page_cfg_4_prog_en_4_qs;
-  logic bank1_info0_page_cfg_4_prog_en_4_wd;
-  logic bank1_info0_page_cfg_4_erase_en_4_qs;
-  logic bank1_info0_page_cfg_4_erase_en_4_wd;
-  logic bank1_info0_page_cfg_4_scramble_en_4_qs;
-  logic bank1_info0_page_cfg_4_scramble_en_4_wd;
-  logic bank1_info0_page_cfg_4_ecc_en_4_qs;
-  logic bank1_info0_page_cfg_4_ecc_en_4_wd;
-  logic bank1_info0_page_cfg_4_he_en_4_qs;
-  logic bank1_info0_page_cfg_4_he_en_4_wd;
-  logic bank1_info0_page_cfg_5_we;
-  logic bank1_info0_page_cfg_5_en_5_qs;
-  logic bank1_info0_page_cfg_5_en_5_wd;
-  logic bank1_info0_page_cfg_5_rd_en_5_qs;
-  logic bank1_info0_page_cfg_5_rd_en_5_wd;
-  logic bank1_info0_page_cfg_5_prog_en_5_qs;
-  logic bank1_info0_page_cfg_5_prog_en_5_wd;
-  logic bank1_info0_page_cfg_5_erase_en_5_qs;
-  logic bank1_info0_page_cfg_5_erase_en_5_wd;
-  logic bank1_info0_page_cfg_5_scramble_en_5_qs;
-  logic bank1_info0_page_cfg_5_scramble_en_5_wd;
-  logic bank1_info0_page_cfg_5_ecc_en_5_qs;
-  logic bank1_info0_page_cfg_5_ecc_en_5_wd;
-  logic bank1_info0_page_cfg_5_he_en_5_qs;
-  logic bank1_info0_page_cfg_5_he_en_5_wd;
-  logic bank1_info0_page_cfg_6_we;
-  logic bank1_info0_page_cfg_6_en_6_qs;
-  logic bank1_info0_page_cfg_6_en_6_wd;
-  logic bank1_info0_page_cfg_6_rd_en_6_qs;
-  logic bank1_info0_page_cfg_6_rd_en_6_wd;
-  logic bank1_info0_page_cfg_6_prog_en_6_qs;
-  logic bank1_info0_page_cfg_6_prog_en_6_wd;
-  logic bank1_info0_page_cfg_6_erase_en_6_qs;
-  logic bank1_info0_page_cfg_6_erase_en_6_wd;
-  logic bank1_info0_page_cfg_6_scramble_en_6_qs;
-  logic bank1_info0_page_cfg_6_scramble_en_6_wd;
-  logic bank1_info0_page_cfg_6_ecc_en_6_qs;
-  logic bank1_info0_page_cfg_6_ecc_en_6_wd;
-  logic bank1_info0_page_cfg_6_he_en_6_qs;
-  logic bank1_info0_page_cfg_6_he_en_6_wd;
-  logic bank1_info0_page_cfg_7_we;
-  logic bank1_info0_page_cfg_7_en_7_qs;
-  logic bank1_info0_page_cfg_7_en_7_wd;
-  logic bank1_info0_page_cfg_7_rd_en_7_qs;
-  logic bank1_info0_page_cfg_7_rd_en_7_wd;
-  logic bank1_info0_page_cfg_7_prog_en_7_qs;
-  logic bank1_info0_page_cfg_7_prog_en_7_wd;
-  logic bank1_info0_page_cfg_7_erase_en_7_qs;
-  logic bank1_info0_page_cfg_7_erase_en_7_wd;
-  logic bank1_info0_page_cfg_7_scramble_en_7_qs;
-  logic bank1_info0_page_cfg_7_scramble_en_7_wd;
-  logic bank1_info0_page_cfg_7_ecc_en_7_qs;
-  logic bank1_info0_page_cfg_7_ecc_en_7_wd;
-  logic bank1_info0_page_cfg_7_he_en_7_qs;
-  logic bank1_info0_page_cfg_7_he_en_7_wd;
-  logic bank1_info0_page_cfg_8_we;
-  logic bank1_info0_page_cfg_8_en_8_qs;
-  logic bank1_info0_page_cfg_8_en_8_wd;
-  logic bank1_info0_page_cfg_8_rd_en_8_qs;
-  logic bank1_info0_page_cfg_8_rd_en_8_wd;
-  logic bank1_info0_page_cfg_8_prog_en_8_qs;
-  logic bank1_info0_page_cfg_8_prog_en_8_wd;
-  logic bank1_info0_page_cfg_8_erase_en_8_qs;
-  logic bank1_info0_page_cfg_8_erase_en_8_wd;
-  logic bank1_info0_page_cfg_8_scramble_en_8_qs;
-  logic bank1_info0_page_cfg_8_scramble_en_8_wd;
-  logic bank1_info0_page_cfg_8_ecc_en_8_qs;
-  logic bank1_info0_page_cfg_8_ecc_en_8_wd;
-  logic bank1_info0_page_cfg_8_he_en_8_qs;
-  logic bank1_info0_page_cfg_8_he_en_8_wd;
-  logic bank1_info0_page_cfg_9_we;
-  logic bank1_info0_page_cfg_9_en_9_qs;
-  logic bank1_info0_page_cfg_9_en_9_wd;
-  logic bank1_info0_page_cfg_9_rd_en_9_qs;
-  logic bank1_info0_page_cfg_9_rd_en_9_wd;
-  logic bank1_info0_page_cfg_9_prog_en_9_qs;
-  logic bank1_info0_page_cfg_9_prog_en_9_wd;
-  logic bank1_info0_page_cfg_9_erase_en_9_qs;
-  logic bank1_info0_page_cfg_9_erase_en_9_wd;
-  logic bank1_info0_page_cfg_9_scramble_en_9_qs;
-  logic bank1_info0_page_cfg_9_scramble_en_9_wd;
-  logic bank1_info0_page_cfg_9_ecc_en_9_qs;
-  logic bank1_info0_page_cfg_9_ecc_en_9_wd;
-  logic bank1_info0_page_cfg_9_he_en_9_qs;
-  logic bank1_info0_page_cfg_9_he_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_0_re;
+  logic bank1_info0_page_cfg_shadowed_0_we;
+  logic bank1_info0_page_cfg_shadowed_0_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank1_info0_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank1_info0_page_cfg_shadowed_1_re;
+  logic bank1_info0_page_cfg_shadowed_1_we;
+  logic bank1_info0_page_cfg_shadowed_1_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank1_info0_page_cfg_shadowed_1_he_en_1_wd;
+  logic bank1_info0_page_cfg_shadowed_2_re;
+  logic bank1_info0_page_cfg_shadowed_2_we;
+  logic bank1_info0_page_cfg_shadowed_2_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_rd_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_rd_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_prog_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_prog_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_erase_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_erase_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_scramble_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_ecc_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_2_he_en_2_qs;
+  logic bank1_info0_page_cfg_shadowed_2_he_en_2_wd;
+  logic bank1_info0_page_cfg_shadowed_3_re;
+  logic bank1_info0_page_cfg_shadowed_3_we;
+  logic bank1_info0_page_cfg_shadowed_3_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_rd_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_rd_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_prog_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_prog_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_erase_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_erase_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_scramble_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_ecc_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_3_he_en_3_qs;
+  logic bank1_info0_page_cfg_shadowed_3_he_en_3_wd;
+  logic bank1_info0_page_cfg_shadowed_4_re;
+  logic bank1_info0_page_cfg_shadowed_4_we;
+  logic bank1_info0_page_cfg_shadowed_4_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_rd_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_rd_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_prog_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_prog_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_erase_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_erase_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_scramble_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_ecc_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_4_he_en_4_qs;
+  logic bank1_info0_page_cfg_shadowed_4_he_en_4_wd;
+  logic bank1_info0_page_cfg_shadowed_5_re;
+  logic bank1_info0_page_cfg_shadowed_5_we;
+  logic bank1_info0_page_cfg_shadowed_5_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_rd_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_rd_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_prog_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_prog_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_erase_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_erase_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_scramble_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_ecc_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_5_he_en_5_qs;
+  logic bank1_info0_page_cfg_shadowed_5_he_en_5_wd;
+  logic bank1_info0_page_cfg_shadowed_6_re;
+  logic bank1_info0_page_cfg_shadowed_6_we;
+  logic bank1_info0_page_cfg_shadowed_6_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_rd_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_rd_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_prog_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_prog_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_erase_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_erase_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_scramble_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_ecc_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_6_he_en_6_qs;
+  logic bank1_info0_page_cfg_shadowed_6_he_en_6_wd;
+  logic bank1_info0_page_cfg_shadowed_7_re;
+  logic bank1_info0_page_cfg_shadowed_7_we;
+  logic bank1_info0_page_cfg_shadowed_7_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_rd_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_rd_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_prog_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_prog_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_erase_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_erase_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_scramble_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_ecc_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_7_he_en_7_qs;
+  logic bank1_info0_page_cfg_shadowed_7_he_en_7_wd;
+  logic bank1_info0_page_cfg_shadowed_8_re;
+  logic bank1_info0_page_cfg_shadowed_8_we;
+  logic bank1_info0_page_cfg_shadowed_8_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_rd_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_rd_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_prog_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_prog_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_erase_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_erase_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_scramble_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_ecc_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_8_he_en_8_qs;
+  logic bank1_info0_page_cfg_shadowed_8_he_en_8_wd;
+  logic bank1_info0_page_cfg_shadowed_9_re;
+  logic bank1_info0_page_cfg_shadowed_9_we;
+  logic bank1_info0_page_cfg_shadowed_9_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_rd_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_rd_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_prog_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_prog_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_erase_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_erase_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_scramble_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_ecc_en_9_wd;
+  logic bank1_info0_page_cfg_shadowed_9_he_en_9_qs;
+  logic bank1_info0_page_cfg_shadowed_9_he_en_9_wd;
   logic bank1_info1_regwen_we;
   logic bank1_info1_regwen_qs;
   logic bank1_info1_regwen_wd;
-  logic bank1_info1_page_cfg_we;
-  logic bank1_info1_page_cfg_en_0_qs;
-  logic bank1_info1_page_cfg_en_0_wd;
-  logic bank1_info1_page_cfg_rd_en_0_qs;
-  logic bank1_info1_page_cfg_rd_en_0_wd;
-  logic bank1_info1_page_cfg_prog_en_0_qs;
-  logic bank1_info1_page_cfg_prog_en_0_wd;
-  logic bank1_info1_page_cfg_erase_en_0_qs;
-  logic bank1_info1_page_cfg_erase_en_0_wd;
-  logic bank1_info1_page_cfg_scramble_en_0_qs;
-  logic bank1_info1_page_cfg_scramble_en_0_wd;
-  logic bank1_info1_page_cfg_ecc_en_0_qs;
-  logic bank1_info1_page_cfg_ecc_en_0_wd;
-  logic bank1_info1_page_cfg_he_en_0_qs;
-  logic bank1_info1_page_cfg_he_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_re;
+  logic bank1_info1_page_cfg_shadowed_we;
+  logic bank1_info1_page_cfg_shadowed_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_rd_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_rd_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_prog_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_prog_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_erase_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_erase_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_scramble_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_scramble_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_ecc_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_ecc_en_0_wd;
+  logic bank1_info1_page_cfg_shadowed_he_en_0_qs;
+  logic bank1_info1_page_cfg_shadowed_he_en_0_wd;
   logic bank1_info2_regwen_0_we;
   logic bank1_info2_regwen_0_qs;
   logic bank1_info2_regwen_0_wd;
   logic bank1_info2_regwen_1_we;
   logic bank1_info2_regwen_1_qs;
   logic bank1_info2_regwen_1_wd;
-  logic bank1_info2_page_cfg_0_we;
-  logic bank1_info2_page_cfg_0_en_0_qs;
-  logic bank1_info2_page_cfg_0_en_0_wd;
-  logic bank1_info2_page_cfg_0_rd_en_0_qs;
-  logic bank1_info2_page_cfg_0_rd_en_0_wd;
-  logic bank1_info2_page_cfg_0_prog_en_0_qs;
-  logic bank1_info2_page_cfg_0_prog_en_0_wd;
-  logic bank1_info2_page_cfg_0_erase_en_0_qs;
-  logic bank1_info2_page_cfg_0_erase_en_0_wd;
-  logic bank1_info2_page_cfg_0_scramble_en_0_qs;
-  logic bank1_info2_page_cfg_0_scramble_en_0_wd;
-  logic bank1_info2_page_cfg_0_ecc_en_0_qs;
-  logic bank1_info2_page_cfg_0_ecc_en_0_wd;
-  logic bank1_info2_page_cfg_0_he_en_0_qs;
-  logic bank1_info2_page_cfg_0_he_en_0_wd;
-  logic bank1_info2_page_cfg_1_we;
-  logic bank1_info2_page_cfg_1_en_1_qs;
-  logic bank1_info2_page_cfg_1_en_1_wd;
-  logic bank1_info2_page_cfg_1_rd_en_1_qs;
-  logic bank1_info2_page_cfg_1_rd_en_1_wd;
-  logic bank1_info2_page_cfg_1_prog_en_1_qs;
-  logic bank1_info2_page_cfg_1_prog_en_1_wd;
-  logic bank1_info2_page_cfg_1_erase_en_1_qs;
-  logic bank1_info2_page_cfg_1_erase_en_1_wd;
-  logic bank1_info2_page_cfg_1_scramble_en_1_qs;
-  logic bank1_info2_page_cfg_1_scramble_en_1_wd;
-  logic bank1_info2_page_cfg_1_ecc_en_1_qs;
-  logic bank1_info2_page_cfg_1_ecc_en_1_wd;
-  logic bank1_info2_page_cfg_1_he_en_1_qs;
-  logic bank1_info2_page_cfg_1_he_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_0_re;
+  logic bank1_info2_page_cfg_shadowed_0_we;
+  logic bank1_info2_page_cfg_shadowed_0_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_rd_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_rd_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_prog_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_prog_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_erase_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_erase_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_scramble_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_ecc_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_0_he_en_0_qs;
+  logic bank1_info2_page_cfg_shadowed_0_he_en_0_wd;
+  logic bank1_info2_page_cfg_shadowed_1_re;
+  logic bank1_info2_page_cfg_shadowed_1_we;
+  logic bank1_info2_page_cfg_shadowed_1_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_rd_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_rd_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_prog_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_prog_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_erase_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_erase_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_scramble_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_ecc_en_1_wd;
+  logic bank1_info2_page_cfg_shadowed_1_he_en_1_qs;
+  logic bank1_info2_page_cfg_shadowed_1_he_en_1_wd;
   logic bank_cfg_regwen_we;
   logic bank_cfg_regwen_qs;
   logic bank_cfg_regwen_wd;
-  logic mp_bank_cfg_we;
-  logic mp_bank_cfg_erase_en_0_qs;
-  logic mp_bank_cfg_erase_en_0_wd;
-  logic mp_bank_cfg_erase_en_1_qs;
-  logic mp_bank_cfg_erase_en_1_wd;
+  logic mp_bank_cfg_shadowed_re;
+  logic mp_bank_cfg_shadowed_we;
+  logic mp_bank_cfg_shadowed_erase_en_0_qs;
+  logic mp_bank_cfg_shadowed_erase_en_0_wd;
+  logic mp_bank_cfg_shadowed_erase_en_1_qs;
+  logic mp_bank_cfg_shadowed_erase_en_1_wd;
   logic op_status_we;
   logic op_status_done_qs;
   logic op_status_done_wd;
@@ -919,6 +956,8 @@ module flash_ctrl_core_reg_top (
   logic err_code_prog_type_err_wd;
   logic err_code_flash_phy_err_qs;
   logic err_code_flash_phy_err_wd;
+  logic err_code_update_err_qs;
+  logic err_code_update_err_wd;
   logic fault_status_oob_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
@@ -928,6 +967,7 @@ module flash_ctrl_core_reg_top (
   logic fault_status_reg_intg_err_qs;
   logic fault_status_phy_intg_err_qs;
   logic fault_status_lcmgr_err_qs;
+  logic fault_status_storage_err_qs;
   logic [31:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
@@ -1947,20 +1987,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg mp_region_cfg
-  // R[mp_region_cfg_0]: V(False)
+  // Subregister 0 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_en_0 (
+  ) u_mp_region_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1968,24 +2010,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_rd_en_0 (
+  ) u_mp_region_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_rd_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1993,24 +2041,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_rd_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_prog_en_0 (
+  ) u_mp_region_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_prog_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2018,24 +2072,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_prog_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_erase_en_0 (
+  ) u_mp_region_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_erase_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2043,24 +2103,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_erase_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_scramble_en_0 (
+  ) u_mp_region_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_scramble_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2068,24 +2134,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_scramble_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_ecc_en_0 (
+  ) u_mp_region_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_ecc_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2093,24 +2165,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_ecc_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_0_he_en_0 (
+  ) u_mp_region_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_he_en_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2118,24 +2196,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_he_en_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].he_en.err_storage)
   );
 
   //   F[base_0]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_0_base_0 (
+  ) u_mp_region_cfg_shadowed_0_base_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_base_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_base_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2143,24 +2227,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_base_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_base_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].base.err_storage)
   );
 
   //   F[size_0]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_0_size_0 (
+  ) u_mp_region_cfg_shadowed_0_size_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_0_we & region_cfg_regwen_0_qs),
-    .wd     (mp_region_cfg_0_size_0_wd),
+    .re     (mp_region_cfg_shadowed_0_re),
+    .we     (mp_region_cfg_shadowed_0_we & region_cfg_regwen_0_qs),
+    .wd     (mp_region_cfg_shadowed_0_size_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2168,27 +2258,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[0].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[0].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_0_size_0_qs)
+    .qs     (mp_region_cfg_shadowed_0_size_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[0].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[0].size.err_storage)
   );
 
 
-  // Subregister 1 of Multireg mp_region_cfg
-  // R[mp_region_cfg_1]: V(False)
+  // Subregister 1 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_en_1 (
+  ) u_mp_region_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2196,24 +2292,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_rd_en_1 (
+  ) u_mp_region_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_rd_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2221,24 +2323,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_rd_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_prog_en_1 (
+  ) u_mp_region_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_prog_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2246,24 +2354,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_prog_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_erase_en_1 (
+  ) u_mp_region_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_erase_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2271,24 +2385,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_erase_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_scramble_en_1 (
+  ) u_mp_region_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_scramble_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2296,24 +2416,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_scramble_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_ecc_en_1 (
+  ) u_mp_region_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_ecc_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2321,24 +2447,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_ecc_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_1_he_en_1 (
+  ) u_mp_region_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_he_en_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2346,24 +2478,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_he_en_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].he_en.err_storage)
   );
 
   //   F[base_1]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_1_base_1 (
+  ) u_mp_region_cfg_shadowed_1_base_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_base_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_base_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2371,24 +2509,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_base_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_base_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].base.err_storage)
   );
 
   //   F[size_1]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_1_size_1 (
+  ) u_mp_region_cfg_shadowed_1_size_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_1_we & region_cfg_regwen_1_qs),
-    .wd     (mp_region_cfg_1_size_1_wd),
+    .re     (mp_region_cfg_shadowed_1_re),
+    .we     (mp_region_cfg_shadowed_1_we & region_cfg_regwen_1_qs),
+    .wd     (mp_region_cfg_shadowed_1_size_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2396,27 +2540,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[1].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[1].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_1_size_1_qs)
+    .qs     (mp_region_cfg_shadowed_1_size_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[1].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[1].size.err_storage)
   );
 
 
-  // Subregister 2 of Multireg mp_region_cfg
-  // R[mp_region_cfg_2]: V(False)
+  // Subregister 2 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_2]: V(False)
   //   F[en_2]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_en_2 (
+  ) u_mp_region_cfg_shadowed_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2424,24 +2574,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].en.err_storage)
   );
 
   //   F[rd_en_2]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_rd_en_2 (
+  ) u_mp_region_cfg_shadowed_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_rd_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_rd_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2449,24 +2605,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_rd_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].rd_en.err_storage)
   );
 
   //   F[prog_en_2]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_prog_en_2 (
+  ) u_mp_region_cfg_shadowed_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_prog_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_prog_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2474,24 +2636,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_prog_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_prog_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_storage)
   );
 
   //   F[erase_en_2]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_erase_en_2 (
+  ) u_mp_region_cfg_shadowed_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_erase_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_erase_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2499,24 +2667,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_erase_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].erase_en.err_storage)
   );
 
   //   F[scramble_en_2]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_scramble_en_2 (
+  ) u_mp_region_cfg_shadowed_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_scramble_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_scramble_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2524,24 +2698,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_scramble_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_scramble_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_storage)
   );
 
   //   F[ecc_en_2]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_ecc_en_2 (
+  ) u_mp_region_cfg_shadowed_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_ecc_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_ecc_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2549,24 +2729,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_ecc_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].ecc_en.err_storage)
   );
 
   //   F[he_en_2]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_2_he_en_2 (
+  ) u_mp_region_cfg_shadowed_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_he_en_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_he_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2574,24 +2760,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_he_en_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].he_en.err_storage)
   );
 
   //   F[base_2]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_2_base_2 (
+  ) u_mp_region_cfg_shadowed_2_base_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_base_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_base_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2599,24 +2791,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_base_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_base_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].base.err_storage)
   );
 
   //   F[size_2]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_2_size_2 (
+  ) u_mp_region_cfg_shadowed_2_size_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_2_we & region_cfg_regwen_2_qs),
-    .wd     (mp_region_cfg_2_size_2_wd),
+    .re     (mp_region_cfg_shadowed_2_re),
+    .we     (mp_region_cfg_shadowed_2_we & region_cfg_regwen_2_qs),
+    .wd     (mp_region_cfg_shadowed_2_size_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2624,27 +2822,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[2].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[2].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_2_size_2_qs)
+    .qs     (mp_region_cfg_shadowed_2_size_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[2].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[2].size.err_storage)
   );
 
 
-  // Subregister 3 of Multireg mp_region_cfg
-  // R[mp_region_cfg_3]: V(False)
+  // Subregister 3 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_3]: V(False)
   //   F[en_3]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_en_3 (
+  ) u_mp_region_cfg_shadowed_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2652,24 +2856,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].en.err_storage)
   );
 
   //   F[rd_en_3]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_rd_en_3 (
+  ) u_mp_region_cfg_shadowed_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_rd_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_rd_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2677,24 +2887,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_rd_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].rd_en.err_storage)
   );
 
   //   F[prog_en_3]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_prog_en_3 (
+  ) u_mp_region_cfg_shadowed_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_prog_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_prog_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2702,24 +2918,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_prog_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_prog_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_storage)
   );
 
   //   F[erase_en_3]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_erase_en_3 (
+  ) u_mp_region_cfg_shadowed_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_erase_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_erase_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2727,24 +2949,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_erase_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].erase_en.err_storage)
   );
 
   //   F[scramble_en_3]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_scramble_en_3 (
+  ) u_mp_region_cfg_shadowed_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_scramble_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_scramble_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2752,24 +2980,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_scramble_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_scramble_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_storage)
   );
 
   //   F[ecc_en_3]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_ecc_en_3 (
+  ) u_mp_region_cfg_shadowed_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_ecc_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_ecc_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2777,24 +3011,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_ecc_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].ecc_en.err_storage)
   );
 
   //   F[he_en_3]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_3_he_en_3 (
+  ) u_mp_region_cfg_shadowed_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_he_en_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_he_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2802,24 +3042,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_he_en_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].he_en.err_storage)
   );
 
   //   F[base_3]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_3_base_3 (
+  ) u_mp_region_cfg_shadowed_3_base_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_base_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_base_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2827,24 +3073,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_base_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_base_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].base.err_storage)
   );
 
   //   F[size_3]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_3_size_3 (
+  ) u_mp_region_cfg_shadowed_3_size_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_3_we & region_cfg_regwen_3_qs),
-    .wd     (mp_region_cfg_3_size_3_wd),
+    .re     (mp_region_cfg_shadowed_3_re),
+    .we     (mp_region_cfg_shadowed_3_we & region_cfg_regwen_3_qs),
+    .wd     (mp_region_cfg_shadowed_3_size_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2852,27 +3104,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[3].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[3].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_3_size_3_qs)
+    .qs     (mp_region_cfg_shadowed_3_size_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[3].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[3].size.err_storage)
   );
 
 
-  // Subregister 4 of Multireg mp_region_cfg
-  // R[mp_region_cfg_4]: V(False)
+  // Subregister 4 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_4]: V(False)
   //   F[en_4]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_en_4 (
+  ) u_mp_region_cfg_shadowed_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2880,24 +3138,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].en.err_storage)
   );
 
   //   F[rd_en_4]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_rd_en_4 (
+  ) u_mp_region_cfg_shadowed_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_rd_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_rd_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2905,24 +3169,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_rd_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].rd_en.err_storage)
   );
 
   //   F[prog_en_4]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_prog_en_4 (
+  ) u_mp_region_cfg_shadowed_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_prog_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_prog_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2930,24 +3200,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_prog_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_prog_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_storage)
   );
 
   //   F[erase_en_4]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_erase_en_4 (
+  ) u_mp_region_cfg_shadowed_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_erase_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_erase_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2955,24 +3231,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_erase_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].erase_en.err_storage)
   );
 
   //   F[scramble_en_4]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_scramble_en_4 (
+  ) u_mp_region_cfg_shadowed_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_scramble_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_scramble_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -2980,24 +3262,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_scramble_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_scramble_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_storage)
   );
 
   //   F[ecc_en_4]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_ecc_en_4 (
+  ) u_mp_region_cfg_shadowed_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_ecc_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_ecc_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3005,24 +3293,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_ecc_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].ecc_en.err_storage)
   );
 
   //   F[he_en_4]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_4_he_en_4 (
+  ) u_mp_region_cfg_shadowed_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_he_en_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_he_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3030,24 +3324,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_he_en_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].he_en.err_storage)
   );
 
   //   F[base_4]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_4_base_4 (
+  ) u_mp_region_cfg_shadowed_4_base_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_base_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_base_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3055,24 +3355,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_base_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_base_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].base.err_storage)
   );
 
   //   F[size_4]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_4_size_4 (
+  ) u_mp_region_cfg_shadowed_4_size_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_4_we & region_cfg_regwen_4_qs),
-    .wd     (mp_region_cfg_4_size_4_wd),
+    .re     (mp_region_cfg_shadowed_4_re),
+    .we     (mp_region_cfg_shadowed_4_we & region_cfg_regwen_4_qs),
+    .wd     (mp_region_cfg_shadowed_4_size_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3080,27 +3386,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[4].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[4].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_4_size_4_qs)
+    .qs     (mp_region_cfg_shadowed_4_size_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[4].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[4].size.err_storage)
   );
 
 
-  // Subregister 5 of Multireg mp_region_cfg
-  // R[mp_region_cfg_5]: V(False)
+  // Subregister 5 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_5]: V(False)
   //   F[en_5]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_en_5 (
+  ) u_mp_region_cfg_shadowed_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3108,24 +3420,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].en.err_storage)
   );
 
   //   F[rd_en_5]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_rd_en_5 (
+  ) u_mp_region_cfg_shadowed_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_rd_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_rd_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3133,24 +3451,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_rd_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].rd_en.err_storage)
   );
 
   //   F[prog_en_5]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_prog_en_5 (
+  ) u_mp_region_cfg_shadowed_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_prog_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_prog_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3158,24 +3482,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_prog_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_prog_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_storage)
   );
 
   //   F[erase_en_5]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_erase_en_5 (
+  ) u_mp_region_cfg_shadowed_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_erase_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_erase_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3183,24 +3513,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_erase_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].erase_en.err_storage)
   );
 
   //   F[scramble_en_5]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_scramble_en_5 (
+  ) u_mp_region_cfg_shadowed_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_scramble_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_scramble_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3208,24 +3544,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_scramble_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_scramble_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_storage)
   );
 
   //   F[ecc_en_5]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_ecc_en_5 (
+  ) u_mp_region_cfg_shadowed_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_ecc_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_ecc_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3233,24 +3575,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_ecc_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].ecc_en.err_storage)
   );
 
   //   F[he_en_5]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_5_he_en_5 (
+  ) u_mp_region_cfg_shadowed_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_he_en_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_he_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3258,24 +3606,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_he_en_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].he_en.err_storage)
   );
 
   //   F[base_5]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_5_base_5 (
+  ) u_mp_region_cfg_shadowed_5_base_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_base_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_base_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3283,24 +3637,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_base_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_base_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].base.err_storage)
   );
 
   //   F[size_5]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_5_size_5 (
+  ) u_mp_region_cfg_shadowed_5_size_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_5_we & region_cfg_regwen_5_qs),
-    .wd     (mp_region_cfg_5_size_5_wd),
+    .re     (mp_region_cfg_shadowed_5_re),
+    .we     (mp_region_cfg_shadowed_5_we & region_cfg_regwen_5_qs),
+    .wd     (mp_region_cfg_shadowed_5_size_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3308,27 +3668,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[5].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[5].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_5_size_5_qs)
+    .qs     (mp_region_cfg_shadowed_5_size_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[5].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[5].size.err_storage)
   );
 
 
-  // Subregister 6 of Multireg mp_region_cfg
-  // R[mp_region_cfg_6]: V(False)
+  // Subregister 6 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_6]: V(False)
   //   F[en_6]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_en_6 (
+  ) u_mp_region_cfg_shadowed_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3336,24 +3702,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].en.err_storage)
   );
 
   //   F[rd_en_6]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_rd_en_6 (
+  ) u_mp_region_cfg_shadowed_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_rd_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_rd_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3361,24 +3733,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_rd_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].rd_en.err_storage)
   );
 
   //   F[prog_en_6]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_prog_en_6 (
+  ) u_mp_region_cfg_shadowed_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_prog_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_prog_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3386,24 +3764,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_prog_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_prog_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_storage)
   );
 
   //   F[erase_en_6]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_erase_en_6 (
+  ) u_mp_region_cfg_shadowed_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_erase_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_erase_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3411,24 +3795,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_erase_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].erase_en.err_storage)
   );
 
   //   F[scramble_en_6]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_scramble_en_6 (
+  ) u_mp_region_cfg_shadowed_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_scramble_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_scramble_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3436,24 +3826,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_scramble_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_scramble_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_storage)
   );
 
   //   F[ecc_en_6]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_ecc_en_6 (
+  ) u_mp_region_cfg_shadowed_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_ecc_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_ecc_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3461,24 +3857,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_ecc_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].ecc_en.err_storage)
   );
 
   //   F[he_en_6]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_6_he_en_6 (
+  ) u_mp_region_cfg_shadowed_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_he_en_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_he_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3486,24 +3888,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_he_en_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].he_en.err_storage)
   );
 
   //   F[base_6]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_6_base_6 (
+  ) u_mp_region_cfg_shadowed_6_base_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_base_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_base_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3511,24 +3919,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_base_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_base_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].base.err_storage)
   );
 
   //   F[size_6]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_6_size_6 (
+  ) u_mp_region_cfg_shadowed_6_size_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_6_we & region_cfg_regwen_6_qs),
-    .wd     (mp_region_cfg_6_size_6_wd),
+    .re     (mp_region_cfg_shadowed_6_re),
+    .we     (mp_region_cfg_shadowed_6_we & region_cfg_regwen_6_qs),
+    .wd     (mp_region_cfg_shadowed_6_size_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3536,27 +3950,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[6].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[6].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_6_size_6_qs)
+    .qs     (mp_region_cfg_shadowed_6_size_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[6].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[6].size.err_storage)
   );
 
 
-  // Subregister 7 of Multireg mp_region_cfg
-  // R[mp_region_cfg_7]: V(False)
+  // Subregister 7 of Multireg mp_region_cfg_shadowed
+  // R[mp_region_cfg_shadowed_7]: V(False)
   //   F[en_7]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_en_7 (
+  ) u_mp_region_cfg_shadowed_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3564,24 +3984,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].en.err_storage)
   );
 
   //   F[rd_en_7]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_rd_en_7 (
+  ) u_mp_region_cfg_shadowed_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_rd_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_rd_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3589,24 +4015,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].rd_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].rd_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_rd_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].rd_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].rd_en.err_storage)
   );
 
   //   F[prog_en_7]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_prog_en_7 (
+  ) u_mp_region_cfg_shadowed_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_prog_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_prog_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3614,24 +4046,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].prog_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].prog_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_prog_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_prog_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_storage)
   );
 
   //   F[erase_en_7]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_erase_en_7 (
+  ) u_mp_region_cfg_shadowed_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_erase_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_erase_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3639,24 +4077,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].erase_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].erase_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_erase_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].erase_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].erase_en.err_storage)
   );
 
   //   F[scramble_en_7]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_scramble_en_7 (
+  ) u_mp_region_cfg_shadowed_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_scramble_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_scramble_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3664,24 +4108,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].scramble_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].scramble_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_scramble_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_scramble_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_storage)
   );
 
   //   F[ecc_en_7]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_ecc_en_7 (
+  ) u_mp_region_cfg_shadowed_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_ecc_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_ecc_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3689,24 +4139,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].ecc_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].ecc_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_ecc_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].ecc_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].ecc_en.err_storage)
   );
 
   //   F[he_en_7]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_region_cfg_7_he_en_7 (
+  ) u_mp_region_cfg_shadowed_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_he_en_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_he_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3714,24 +4170,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].he_en.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].he_en.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_he_en_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].he_en.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].he_en.err_storage)
   );
 
   //   F[base_7]: 16:8
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (9'h0)
-  ) u_mp_region_cfg_7_base_7 (
+  ) u_mp_region_cfg_shadowed_7_base_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_base_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_base_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3739,24 +4201,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].base.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].base.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_base_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_base_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].base.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].base.err_storage)
   );
 
   //   F[size_7]: 26:17
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (10),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (10'h0)
-  ) u_mp_region_cfg_7_size_7 (
+  ) u_mp_region_cfg_shadowed_7_size_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_region_cfg_7_we & region_cfg_regwen_7_qs),
-    .wd     (mp_region_cfg_7_size_7_wd),
+    .re     (mp_region_cfg_shadowed_7_re),
+    .we     (mp_region_cfg_shadowed_7_we & region_cfg_regwen_7_qs),
+    .wd     (mp_region_cfg_shadowed_7_size_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3764,26 +4232,32 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_region_cfg[7].size.q),
+    .q      (reg2hw.mp_region_cfg_shadowed[7].size.q),
 
     // to register interface (read)
-    .qs     (mp_region_cfg_7_size_7_qs)
+    .qs     (mp_region_cfg_shadowed_7_size_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_region_cfg_shadowed[7].size.err_update),
+    .err_storage (reg2hw.mp_region_cfg_shadowed[7].size.err_storage)
   );
 
 
-  // R[default_region]: V(False)
+  // R[default_region_shadowed]: V(False)
   //   F[rd_en]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_rd_en (
+  ) u_default_region_shadowed_rd_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_rd_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_rd_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3791,24 +4265,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.rd_en.q),
+    .q      (reg2hw.default_region_shadowed.rd_en.q),
 
     // to register interface (read)
-    .qs     (default_region_rd_en_qs)
+    .qs     (default_region_shadowed_rd_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.rd_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.rd_en.err_storage)
   );
 
   //   F[prog_en]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_prog_en (
+  ) u_default_region_shadowed_prog_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_prog_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_prog_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3816,24 +4296,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.prog_en.q),
+    .q      (reg2hw.default_region_shadowed.prog_en.q),
 
     // to register interface (read)
-    .qs     (default_region_prog_en_qs)
+    .qs     (default_region_shadowed_prog_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.prog_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.prog_en.err_storage)
   );
 
   //   F[erase_en]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_erase_en (
+  ) u_default_region_shadowed_erase_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_erase_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_erase_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3841,24 +4327,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.erase_en.q),
+    .q      (reg2hw.default_region_shadowed.erase_en.q),
 
     // to register interface (read)
-    .qs     (default_region_erase_en_qs)
+    .qs     (default_region_shadowed_erase_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.erase_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.erase_en.err_storage)
   );
 
   //   F[scramble_en]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_scramble_en (
+  ) u_default_region_shadowed_scramble_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_scramble_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_scramble_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3866,24 +4358,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.scramble_en.q),
+    .q      (reg2hw.default_region_shadowed.scramble_en.q),
 
     // to register interface (read)
-    .qs     (default_region_scramble_en_qs)
+    .qs     (default_region_shadowed_scramble_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.scramble_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.scramble_en.err_storage)
   );
 
   //   F[ecc_en]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_ecc_en (
+  ) u_default_region_shadowed_ecc_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_ecc_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_ecc_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3891,24 +4389,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.ecc_en.q),
+    .q      (reg2hw.default_region_shadowed.ecc_en.q),
 
     // to register interface (read)
-    .qs     (default_region_ecc_en_qs)
+    .qs     (default_region_shadowed_ecc_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.ecc_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.ecc_en.err_storage)
   );
 
   //   F[he_en]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_default_region_he_en (
+  ) u_default_region_shadowed_he_en (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (default_region_we),
-    .wd     (default_region_he_en_wd),
+    .re     (default_region_shadowed_re),
+    .we     (default_region_shadowed_we),
+    .wd     (default_region_shadowed_he_en_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -3916,10 +4420,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.default_region.he_en.q),
+    .q      (reg2hw.default_region_shadowed.he_en.q),
 
     // to register interface (read)
-    .qs     (default_region_he_en_qs)
+    .qs     (default_region_shadowed_he_en_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.default_region_shadowed.he_en.err_update),
+    .err_storage (reg2hw.default_region_shadowed.he_en.err_storage)
   );
 
 
@@ -4193,20 +4701,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4214,24 +4724,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_rd_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_rd_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4239,24 +4755,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_rd_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_prog_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_prog_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4264,24 +4786,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_prog_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_erase_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_erase_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4289,24 +4817,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_erase_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_scramble_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_scramble_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4314,24 +4848,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_ecc_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_ecc_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4339,24 +4879,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_0_he_en_0 (
+  ) u_bank0_info0_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_0_we & bank0_info0_regwen_0_qs),
-    .wd     (bank0_info0_page_cfg_0_he_en_0_wd),
+    .re     (bank0_info0_page_cfg_shadowed_0_re),
+    .we     (bank0_info0_page_cfg_shadowed_0_we & bank0_info0_regwen_0_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4364,27 +4910,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_0_he_en_0_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4392,24 +4944,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_rd_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_rd_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4417,24 +4975,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_rd_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_prog_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_prog_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4442,24 +5006,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_prog_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_erase_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_erase_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4467,24 +5037,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_erase_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_scramble_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_scramble_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4492,24 +5068,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_ecc_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_ecc_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4517,24 +5099,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_1_he_en_1 (
+  ) u_bank0_info0_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_1_we & bank0_info0_regwen_1_qs),
-    .wd     (bank0_info0_page_cfg_1_he_en_1_wd),
+    .re     (bank0_info0_page_cfg_shadowed_1_re),
+    .we     (bank0_info0_page_cfg_shadowed_1_we & bank0_info0_regwen_1_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4542,27 +5130,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_1_he_en_1_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
-  // Subregister 2 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_2]: V(False)
+  // Subregister 2 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_2]: V(False)
   //   F[en_2]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4570,24 +5164,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_storage)
   );
 
   //   F[rd_en_2]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_rd_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_rd_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_rd_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4595,24 +5195,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_rd_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.err_storage)
   );
 
   //   F[prog_en_2]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_prog_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_prog_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_prog_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4620,24 +5226,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_prog_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_prog_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_storage)
   );
 
   //   F[erase_en_2]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_erase_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_erase_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_erase_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4645,24 +5257,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_erase_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.err_storage)
   );
 
   //   F[scramble_en_2]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_scramble_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_scramble_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_scramble_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4670,24 +5288,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_scramble_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_storage)
   );
 
   //   F[ecc_en_2]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_ecc_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_ecc_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_ecc_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4695,24 +5319,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_ecc_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_storage)
   );
 
   //   F[he_en_2]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_2_he_en_2 (
+  ) u_bank0_info0_page_cfg_shadowed_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_2_we & bank0_info0_regwen_2_qs),
-    .wd     (bank0_info0_page_cfg_2_he_en_2_wd),
+    .re     (bank0_info0_page_cfg_shadowed_2_re),
+    .we     (bank0_info0_page_cfg_shadowed_2_we & bank0_info0_regwen_2_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_2_he_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4720,27 +5350,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[2].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_2_he_en_2_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.err_storage)
   );
 
 
-  // Subregister 3 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_3]: V(False)
+  // Subregister 3 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_3]: V(False)
   //   F[en_3]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4748,24 +5384,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_storage)
   );
 
   //   F[rd_en_3]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_rd_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_rd_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_rd_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4773,24 +5415,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_rd_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.err_storage)
   );
 
   //   F[prog_en_3]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_prog_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_prog_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_prog_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4798,24 +5446,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_prog_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_prog_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_storage)
   );
 
   //   F[erase_en_3]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_erase_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_erase_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_erase_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4823,24 +5477,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_erase_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.err_storage)
   );
 
   //   F[scramble_en_3]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_scramble_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_scramble_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_scramble_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4848,24 +5508,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_scramble_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_storage)
   );
 
   //   F[ecc_en_3]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_ecc_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_ecc_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_ecc_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4873,24 +5539,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_ecc_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_storage)
   );
 
   //   F[he_en_3]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_3_he_en_3 (
+  ) u_bank0_info0_page_cfg_shadowed_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_3_we & bank0_info0_regwen_3_qs),
-    .wd     (bank0_info0_page_cfg_3_he_en_3_wd),
+    .re     (bank0_info0_page_cfg_shadowed_3_re),
+    .we     (bank0_info0_page_cfg_shadowed_3_we & bank0_info0_regwen_3_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_3_he_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4898,27 +5570,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[3].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_3_he_en_3_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.err_storage)
   );
 
 
-  // Subregister 4 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_4]: V(False)
+  // Subregister 4 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_4]: V(False)
   //   F[en_4]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4926,24 +5604,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_storage)
   );
 
   //   F[rd_en_4]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_rd_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_rd_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_rd_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4951,24 +5635,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_rd_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.err_storage)
   );
 
   //   F[prog_en_4]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_prog_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_prog_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_prog_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -4976,24 +5666,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_prog_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_prog_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_storage)
   );
 
   //   F[erase_en_4]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_erase_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_erase_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_erase_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5001,24 +5697,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_erase_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.err_storage)
   );
 
   //   F[scramble_en_4]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_scramble_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_scramble_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_scramble_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5026,24 +5728,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_scramble_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_storage)
   );
 
   //   F[ecc_en_4]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_ecc_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_ecc_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_ecc_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5051,24 +5759,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_ecc_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_storage)
   );
 
   //   F[he_en_4]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_4_he_en_4 (
+  ) u_bank0_info0_page_cfg_shadowed_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_4_we & bank0_info0_regwen_4_qs),
-    .wd     (bank0_info0_page_cfg_4_he_en_4_wd),
+    .re     (bank0_info0_page_cfg_shadowed_4_re),
+    .we     (bank0_info0_page_cfg_shadowed_4_we & bank0_info0_regwen_4_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_4_he_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5076,27 +5790,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[4].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_4_he_en_4_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.err_storage)
   );
 
 
-  // Subregister 5 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_5]: V(False)
+  // Subregister 5 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_5]: V(False)
   //   F[en_5]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5104,24 +5824,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_storage)
   );
 
   //   F[rd_en_5]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_rd_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_rd_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_rd_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5129,24 +5855,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_rd_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.err_storage)
   );
 
   //   F[prog_en_5]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_prog_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_prog_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_prog_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5154,24 +5886,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_prog_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_prog_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_storage)
   );
 
   //   F[erase_en_5]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_erase_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_erase_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_erase_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5179,24 +5917,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_erase_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.err_storage)
   );
 
   //   F[scramble_en_5]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_scramble_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_scramble_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_scramble_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5204,24 +5948,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_scramble_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_storage)
   );
 
   //   F[ecc_en_5]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_ecc_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_ecc_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_ecc_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5229,24 +5979,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_ecc_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_storage)
   );
 
   //   F[he_en_5]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_5_he_en_5 (
+  ) u_bank0_info0_page_cfg_shadowed_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_5_we & bank0_info0_regwen_5_qs),
-    .wd     (bank0_info0_page_cfg_5_he_en_5_wd),
+    .re     (bank0_info0_page_cfg_shadowed_5_re),
+    .we     (bank0_info0_page_cfg_shadowed_5_we & bank0_info0_regwen_5_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_5_he_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5254,27 +6010,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[5].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_5_he_en_5_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.err_storage)
   );
 
 
-  // Subregister 6 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_6]: V(False)
+  // Subregister 6 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_6]: V(False)
   //   F[en_6]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5282,24 +6044,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_storage)
   );
 
   //   F[rd_en_6]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_rd_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_rd_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_rd_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5307,24 +6075,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_rd_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.err_storage)
   );
 
   //   F[prog_en_6]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_prog_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_prog_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_prog_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5332,24 +6106,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_prog_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_prog_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_storage)
   );
 
   //   F[erase_en_6]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_erase_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_erase_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_erase_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5357,24 +6137,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_erase_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.err_storage)
   );
 
   //   F[scramble_en_6]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_scramble_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_scramble_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_scramble_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5382,24 +6168,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_scramble_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_storage)
   );
 
   //   F[ecc_en_6]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_ecc_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_ecc_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_ecc_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5407,24 +6199,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_ecc_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_storage)
   );
 
   //   F[he_en_6]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_6_he_en_6 (
+  ) u_bank0_info0_page_cfg_shadowed_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_6_we & bank0_info0_regwen_6_qs),
-    .wd     (bank0_info0_page_cfg_6_he_en_6_wd),
+    .re     (bank0_info0_page_cfg_shadowed_6_re),
+    .we     (bank0_info0_page_cfg_shadowed_6_we & bank0_info0_regwen_6_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_6_he_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5432,27 +6230,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[6].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_6_he_en_6_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.err_storage)
   );
 
 
-  // Subregister 7 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_7]: V(False)
+  // Subregister 7 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_7]: V(False)
   //   F[en_7]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5460,24 +6264,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_storage)
   );
 
   //   F[rd_en_7]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_rd_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_rd_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_rd_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5485,24 +6295,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_rd_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.err_storage)
   );
 
   //   F[prog_en_7]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_prog_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_prog_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_prog_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5510,24 +6326,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_prog_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_prog_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_storage)
   );
 
   //   F[erase_en_7]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_erase_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_erase_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_erase_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5535,24 +6357,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_erase_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.err_storage)
   );
 
   //   F[scramble_en_7]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_scramble_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_scramble_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_scramble_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5560,24 +6388,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_scramble_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_storage)
   );
 
   //   F[ecc_en_7]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_ecc_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_ecc_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_ecc_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5585,24 +6419,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_ecc_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_storage)
   );
 
   //   F[he_en_7]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_7_he_en_7 (
+  ) u_bank0_info0_page_cfg_shadowed_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_7_we & bank0_info0_regwen_7_qs),
-    .wd     (bank0_info0_page_cfg_7_he_en_7_wd),
+    .re     (bank0_info0_page_cfg_shadowed_7_re),
+    .we     (bank0_info0_page_cfg_shadowed_7_we & bank0_info0_regwen_7_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_7_he_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5610,27 +6450,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[7].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_7_he_en_7_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.err_storage)
   );
 
 
-  // Subregister 8 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_8]: V(False)
+  // Subregister 8 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_8]: V(False)
   //   F[en_8]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5638,24 +6484,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_storage)
   );
 
   //   F[rd_en_8]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_rd_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_rd_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_rd_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5663,24 +6515,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_rd_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.err_storage)
   );
 
   //   F[prog_en_8]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_prog_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_prog_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_prog_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5688,24 +6546,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_prog_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_prog_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_storage)
   );
 
   //   F[erase_en_8]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_erase_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_erase_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_erase_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5713,24 +6577,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_erase_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.err_storage)
   );
 
   //   F[scramble_en_8]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_scramble_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_scramble_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_scramble_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5738,24 +6608,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_scramble_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_storage)
   );
 
   //   F[ecc_en_8]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_ecc_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_ecc_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_ecc_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5763,24 +6639,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_ecc_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_storage)
   );
 
   //   F[he_en_8]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_8_he_en_8 (
+  ) u_bank0_info0_page_cfg_shadowed_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_8_we & bank0_info0_regwen_8_qs),
-    .wd     (bank0_info0_page_cfg_8_he_en_8_wd),
+    .re     (bank0_info0_page_cfg_shadowed_8_re),
+    .we     (bank0_info0_page_cfg_shadowed_8_we & bank0_info0_regwen_8_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_8_he_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5788,27 +6670,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[8].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_8_he_en_8_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.err_storage)
   );
 
 
-  // Subregister 9 of Multireg bank0_info0_page_cfg
-  // R[bank0_info0_page_cfg_9]: V(False)
+  // Subregister 9 of Multireg bank0_info0_page_cfg_shadowed
+  // R[bank0_info0_page_cfg_shadowed_9]: V(False)
   //   F[en_9]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5816,24 +6704,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_storage)
   );
 
   //   F[rd_en_9]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_rd_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_rd_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_rd_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5841,24 +6735,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].rd_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_rd_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.err_storage)
   );
 
   //   F[prog_en_9]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_prog_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_prog_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_prog_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5866,24 +6766,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].prog_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_prog_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_prog_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_storage)
   );
 
   //   F[erase_en_9]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_erase_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_erase_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_erase_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5891,24 +6797,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].erase_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_erase_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.err_storage)
   );
 
   //   F[scramble_en_9]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_scramble_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_scramble_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_scramble_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5916,24 +6828,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].scramble_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_scramble_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_storage)
   );
 
   //   F[ecc_en_9]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_ecc_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_ecc_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_ecc_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5941,24 +6859,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].ecc_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_ecc_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_storage)
   );
 
   //   F[he_en_9]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info0_page_cfg_9_he_en_9 (
+  ) u_bank0_info0_page_cfg_shadowed_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info0_page_cfg_9_we & bank0_info0_regwen_9_qs),
-    .wd     (bank0_info0_page_cfg_9_he_en_9_wd),
+    .re     (bank0_info0_page_cfg_shadowed_9_re),
+    .we     (bank0_info0_page_cfg_shadowed_9_we & bank0_info0_regwen_9_qs),
+    .wd     (bank0_info0_page_cfg_shadowed_9_he_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -5966,10 +6890,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info0_page_cfg[9].he_en.q),
+    .q      (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info0_page_cfg_9_he_en_9_qs)
+    .qs     (bank0_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.err_update),
+    .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.err_storage)
   );
 
 
@@ -6000,20 +6928,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank0_info1_page_cfg
-  // R[bank0_info1_page_cfg]: V(False)
+  // Subregister 0 of Multireg bank0_info1_page_cfg_shadowed
+  // R[bank0_info1_page_cfg_shadowed]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6021,24 +6951,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_rd_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_rd_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6046,24 +6982,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_rd_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_prog_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_prog_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6071,24 +7013,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_prog_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_erase_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_erase_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6096,24 +7044,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_erase_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_scramble_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_scramble_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6121,24 +7075,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_scramble_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_ecc_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_ecc_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6146,24 +7106,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_ecc_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info1_page_cfg_he_en_0 (
+  ) u_bank0_info1_page_cfg_shadowed_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info1_page_cfg_we & bank0_info1_regwen_qs),
-    .wd     (bank0_info1_page_cfg_he_en_0_wd),
+    .re     (bank0_info1_page_cfg_shadowed_re),
+    .we     (bank0_info1_page_cfg_shadowed_we & bank0_info1_regwen_qs),
+    .wd     (bank0_info1_page_cfg_shadowed_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6171,10 +7137,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info1_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info1_page_cfg_he_en_0_qs)
+    .qs     (bank0_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
@@ -6232,20 +7202,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank0_info2_page_cfg
-  // R[bank0_info2_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank0_info2_page_cfg_shadowed
+  // R[bank0_info2_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6253,24 +7225,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_rd_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_rd_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6278,24 +7256,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_rd_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_prog_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_prog_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6303,24 +7287,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_prog_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_erase_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_erase_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6328,24 +7318,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_erase_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_scramble_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_scramble_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6353,24 +7349,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_ecc_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_ecc_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6378,24 +7380,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_0_he_en_0 (
+  ) u_bank0_info2_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_0_we & bank0_info2_regwen_0_qs),
-    .wd     (bank0_info2_page_cfg_0_he_en_0_wd),
+    .re     (bank0_info2_page_cfg_shadowed_0_re),
+    .we     (bank0_info2_page_cfg_shadowed_0_we & bank0_info2_regwen_0_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6403,27 +7411,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_0_he_en_0_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank0_info2_page_cfg
-  // R[bank0_info2_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank0_info2_page_cfg_shadowed
+  // R[bank0_info2_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6431,24 +7445,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_rd_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_rd_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6456,24 +7476,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_rd_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_prog_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_prog_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6481,24 +7507,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_prog_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_erase_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_erase_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6506,24 +7538,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_erase_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_scramble_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_scramble_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6531,24 +7569,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_ecc_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_ecc_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6556,24 +7600,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank0_info2_page_cfg_1_he_en_1 (
+  ) u_bank0_info2_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank0_info2_page_cfg_1_we & bank0_info2_regwen_1_qs),
-    .wd     (bank0_info2_page_cfg_1_he_en_1_wd),
+    .re     (bank0_info2_page_cfg_shadowed_1_re),
+    .we     (bank0_info2_page_cfg_shadowed_1_we & bank0_info2_regwen_1_qs),
+    .wd     (bank0_info2_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6581,10 +7631,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank0_info2_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank0_info2_page_cfg_1_he_en_1_qs)
+    .qs     (bank0_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
@@ -6858,20 +7912,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6879,24 +7935,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_rd_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_rd_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6904,24 +7966,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_rd_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_prog_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_prog_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6929,24 +7997,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_prog_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_erase_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_erase_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6954,24 +8028,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_erase_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_scramble_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_scramble_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -6979,24 +8059,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_ecc_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_ecc_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7004,24 +8090,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_0_he_en_0 (
+  ) u_bank1_info0_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_0_we & bank1_info0_regwen_0_qs),
-    .wd     (bank1_info0_page_cfg_0_he_en_0_wd),
+    .re     (bank1_info0_page_cfg_shadowed_0_re),
+    .we     (bank1_info0_page_cfg_shadowed_0_we & bank1_info0_regwen_0_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7029,27 +8121,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_0_he_en_0_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7057,24 +8155,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_rd_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_rd_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7082,24 +8186,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_rd_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_prog_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_prog_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7107,24 +8217,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_prog_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_erase_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_erase_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7132,24 +8248,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_erase_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_scramble_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_scramble_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7157,24 +8279,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_ecc_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_ecc_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7182,24 +8310,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_1_he_en_1 (
+  ) u_bank1_info0_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_1_we & bank1_info0_regwen_1_qs),
-    .wd     (bank1_info0_page_cfg_1_he_en_1_wd),
+    .re     (bank1_info0_page_cfg_shadowed_1_re),
+    .we     (bank1_info0_page_cfg_shadowed_1_we & bank1_info0_regwen_1_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7207,27 +8341,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_1_he_en_1_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
-  // Subregister 2 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_2]: V(False)
+  // Subregister 2 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_2]: V(False)
   //   F[en_2]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7235,24 +8375,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_storage)
   );
 
   //   F[rd_en_2]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_rd_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_rd_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_rd_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_rd_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7260,24 +8406,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_rd_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.err_storage)
   );
 
   //   F[prog_en_2]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_prog_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_prog_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_prog_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_prog_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7285,24 +8437,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_prog_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_prog_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_storage)
   );
 
   //   F[erase_en_2]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_erase_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_erase_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_erase_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_erase_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7310,24 +8468,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_erase_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.err_storage)
   );
 
   //   F[scramble_en_2]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_scramble_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_scramble_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_scramble_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_scramble_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7335,24 +8499,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_scramble_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_storage)
   );
 
   //   F[ecc_en_2]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_ecc_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_ecc_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_ecc_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_ecc_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7360,24 +8530,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_ecc_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_storage)
   );
 
   //   F[he_en_2]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_2_he_en_2 (
+  ) u_bank1_info0_page_cfg_shadowed_2_he_en_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_2_we & bank1_info0_regwen_2_qs),
-    .wd     (bank1_info0_page_cfg_2_he_en_2_wd),
+    .re     (bank1_info0_page_cfg_shadowed_2_re),
+    .we     (bank1_info0_page_cfg_shadowed_2_we & bank1_info0_regwen_2_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_2_he_en_2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7385,27 +8561,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[2].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_2_he_en_2_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.err_storage)
   );
 
 
-  // Subregister 3 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_3]: V(False)
+  // Subregister 3 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_3]: V(False)
   //   F[en_3]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7413,24 +8595,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_storage)
   );
 
   //   F[rd_en_3]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_rd_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_rd_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_rd_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_rd_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7438,24 +8626,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_rd_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.err_storage)
   );
 
   //   F[prog_en_3]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_prog_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_prog_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_prog_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_prog_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7463,24 +8657,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_prog_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_prog_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_storage)
   );
 
   //   F[erase_en_3]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_erase_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_erase_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_erase_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_erase_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7488,24 +8688,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_erase_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.err_storage)
   );
 
   //   F[scramble_en_3]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_scramble_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_scramble_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_scramble_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_scramble_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7513,24 +8719,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_scramble_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_storage)
   );
 
   //   F[ecc_en_3]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_ecc_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_ecc_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_ecc_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_ecc_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7538,24 +8750,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_ecc_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_storage)
   );
 
   //   F[he_en_3]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_3_he_en_3 (
+  ) u_bank1_info0_page_cfg_shadowed_3_he_en_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_3_we & bank1_info0_regwen_3_qs),
-    .wd     (bank1_info0_page_cfg_3_he_en_3_wd),
+    .re     (bank1_info0_page_cfg_shadowed_3_re),
+    .we     (bank1_info0_page_cfg_shadowed_3_we & bank1_info0_regwen_3_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_3_he_en_3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7563,27 +8781,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[3].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_3_he_en_3_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.err_storage)
   );
 
 
-  // Subregister 4 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_4]: V(False)
+  // Subregister 4 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_4]: V(False)
   //   F[en_4]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7591,24 +8815,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_storage)
   );
 
   //   F[rd_en_4]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_rd_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_rd_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_rd_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_rd_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7616,24 +8846,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_rd_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.err_storage)
   );
 
   //   F[prog_en_4]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_prog_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_prog_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_prog_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_prog_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7641,24 +8877,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_prog_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_prog_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_storage)
   );
 
   //   F[erase_en_4]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_erase_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_erase_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_erase_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_erase_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7666,24 +8908,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_erase_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.err_storage)
   );
 
   //   F[scramble_en_4]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_scramble_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_scramble_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_scramble_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_scramble_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7691,24 +8939,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_scramble_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_storage)
   );
 
   //   F[ecc_en_4]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_ecc_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_ecc_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_ecc_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_ecc_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7716,24 +8970,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_ecc_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_storage)
   );
 
   //   F[he_en_4]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_4_he_en_4 (
+  ) u_bank1_info0_page_cfg_shadowed_4_he_en_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_4_we & bank1_info0_regwen_4_qs),
-    .wd     (bank1_info0_page_cfg_4_he_en_4_wd),
+    .re     (bank1_info0_page_cfg_shadowed_4_re),
+    .we     (bank1_info0_page_cfg_shadowed_4_we & bank1_info0_regwen_4_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_4_he_en_4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7741,27 +9001,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[4].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_4_he_en_4_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.err_storage)
   );
 
 
-  // Subregister 5 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_5]: V(False)
+  // Subregister 5 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_5]: V(False)
   //   F[en_5]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7769,24 +9035,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_storage)
   );
 
   //   F[rd_en_5]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_rd_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_rd_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_rd_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_rd_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7794,24 +9066,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_rd_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.err_storage)
   );
 
   //   F[prog_en_5]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_prog_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_prog_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_prog_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_prog_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7819,24 +9097,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_prog_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_prog_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_storage)
   );
 
   //   F[erase_en_5]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_erase_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_erase_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_erase_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_erase_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7844,24 +9128,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_erase_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.err_storage)
   );
 
   //   F[scramble_en_5]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_scramble_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_scramble_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_scramble_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_scramble_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7869,24 +9159,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_scramble_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_storage)
   );
 
   //   F[ecc_en_5]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_ecc_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_ecc_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_ecc_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_ecc_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7894,24 +9190,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_ecc_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_storage)
   );
 
   //   F[he_en_5]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_5_he_en_5 (
+  ) u_bank1_info0_page_cfg_shadowed_5_he_en_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_5_we & bank1_info0_regwen_5_qs),
-    .wd     (bank1_info0_page_cfg_5_he_en_5_wd),
+    .re     (bank1_info0_page_cfg_shadowed_5_re),
+    .we     (bank1_info0_page_cfg_shadowed_5_we & bank1_info0_regwen_5_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_5_he_en_5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7919,27 +9221,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[5].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_5_he_en_5_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.err_storage)
   );
 
 
-  // Subregister 6 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_6]: V(False)
+  // Subregister 6 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_6]: V(False)
   //   F[en_6]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7947,24 +9255,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_storage)
   );
 
   //   F[rd_en_6]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_rd_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_rd_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_rd_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_rd_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7972,24 +9286,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_rd_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.err_storage)
   );
 
   //   F[prog_en_6]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_prog_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_prog_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_prog_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_prog_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7997,24 +9317,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_prog_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_prog_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_storage)
   );
 
   //   F[erase_en_6]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_erase_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_erase_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_erase_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_erase_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8022,24 +9348,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_erase_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.err_storage)
   );
 
   //   F[scramble_en_6]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_scramble_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_scramble_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_scramble_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_scramble_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8047,24 +9379,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_scramble_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_storage)
   );
 
   //   F[ecc_en_6]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_ecc_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_ecc_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_ecc_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_ecc_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8072,24 +9410,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_ecc_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_storage)
   );
 
   //   F[he_en_6]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_6_he_en_6 (
+  ) u_bank1_info0_page_cfg_shadowed_6_he_en_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_6_we & bank1_info0_regwen_6_qs),
-    .wd     (bank1_info0_page_cfg_6_he_en_6_wd),
+    .re     (bank1_info0_page_cfg_shadowed_6_re),
+    .we     (bank1_info0_page_cfg_shadowed_6_we & bank1_info0_regwen_6_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_6_he_en_6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8097,27 +9441,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[6].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_6_he_en_6_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.err_storage)
   );
 
 
-  // Subregister 7 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_7]: V(False)
+  // Subregister 7 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_7]: V(False)
   //   F[en_7]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8125,24 +9475,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_storage)
   );
 
   //   F[rd_en_7]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_rd_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_rd_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_rd_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_rd_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8150,24 +9506,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_rd_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.err_storage)
   );
 
   //   F[prog_en_7]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_prog_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_prog_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_prog_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_prog_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8175,24 +9537,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_prog_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_prog_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_storage)
   );
 
   //   F[erase_en_7]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_erase_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_erase_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_erase_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_erase_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8200,24 +9568,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_erase_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.err_storage)
   );
 
   //   F[scramble_en_7]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_scramble_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_scramble_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_scramble_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_scramble_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8225,24 +9599,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_scramble_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_storage)
   );
 
   //   F[ecc_en_7]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_ecc_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_ecc_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_ecc_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_ecc_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8250,24 +9630,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_ecc_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_storage)
   );
 
   //   F[he_en_7]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_7_he_en_7 (
+  ) u_bank1_info0_page_cfg_shadowed_7_he_en_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_7_we & bank1_info0_regwen_7_qs),
-    .wd     (bank1_info0_page_cfg_7_he_en_7_wd),
+    .re     (bank1_info0_page_cfg_shadowed_7_re),
+    .we     (bank1_info0_page_cfg_shadowed_7_we & bank1_info0_regwen_7_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_7_he_en_7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8275,27 +9661,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[7].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_7_he_en_7_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.err_storage)
   );
 
 
-  // Subregister 8 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_8]: V(False)
+  // Subregister 8 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_8]: V(False)
   //   F[en_8]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8303,24 +9695,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_storage)
   );
 
   //   F[rd_en_8]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_rd_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_rd_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_rd_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_rd_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8328,24 +9726,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_rd_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.err_storage)
   );
 
   //   F[prog_en_8]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_prog_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_prog_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_prog_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_prog_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8353,24 +9757,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_prog_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_prog_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_storage)
   );
 
   //   F[erase_en_8]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_erase_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_erase_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_erase_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_erase_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8378,24 +9788,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_erase_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.err_storage)
   );
 
   //   F[scramble_en_8]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_scramble_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_scramble_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_scramble_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_scramble_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8403,24 +9819,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_scramble_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_storage)
   );
 
   //   F[ecc_en_8]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_ecc_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_ecc_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_ecc_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_ecc_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8428,24 +9850,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_ecc_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_storage)
   );
 
   //   F[he_en_8]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_8_he_en_8 (
+  ) u_bank1_info0_page_cfg_shadowed_8_he_en_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_8_we & bank1_info0_regwen_8_qs),
-    .wd     (bank1_info0_page_cfg_8_he_en_8_wd),
+    .re     (bank1_info0_page_cfg_shadowed_8_re),
+    .we     (bank1_info0_page_cfg_shadowed_8_we & bank1_info0_regwen_8_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_8_he_en_8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8453,27 +9881,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[8].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_8_he_en_8_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.err_storage)
   );
 
 
-  // Subregister 9 of Multireg bank1_info0_page_cfg
-  // R[bank1_info0_page_cfg_9]: V(False)
+  // Subregister 9 of Multireg bank1_info0_page_cfg_shadowed
+  // R[bank1_info0_page_cfg_shadowed_9]: V(False)
   //   F[en_9]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8481,24 +9915,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_storage)
   );
 
   //   F[rd_en_9]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_rd_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_rd_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_rd_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_rd_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8506,24 +9946,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].rd_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_rd_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.err_storage)
   );
 
   //   F[prog_en_9]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_prog_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_prog_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_prog_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_prog_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8531,24 +9977,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].prog_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_prog_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_prog_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_storage)
   );
 
   //   F[erase_en_9]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_erase_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_erase_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_erase_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_erase_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8556,24 +10008,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].erase_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_erase_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.err_storage)
   );
 
   //   F[scramble_en_9]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_scramble_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_scramble_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_scramble_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_scramble_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8581,24 +10039,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].scramble_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_scramble_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_storage)
   );
 
   //   F[ecc_en_9]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_ecc_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_ecc_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_ecc_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_ecc_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8606,24 +10070,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].ecc_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_ecc_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_storage)
   );
 
   //   F[he_en_9]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info0_page_cfg_9_he_en_9 (
+  ) u_bank1_info0_page_cfg_shadowed_9_he_en_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info0_page_cfg_9_we & bank1_info0_regwen_9_qs),
-    .wd     (bank1_info0_page_cfg_9_he_en_9_wd),
+    .re     (bank1_info0_page_cfg_shadowed_9_re),
+    .we     (bank1_info0_page_cfg_shadowed_9_we & bank1_info0_regwen_9_qs),
+    .wd     (bank1_info0_page_cfg_shadowed_9_he_en_9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8631,10 +10101,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info0_page_cfg[9].he_en.q),
+    .q      (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info0_page_cfg_9_he_en_9_qs)
+    .qs     (bank1_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.err_update),
+    .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.err_storage)
   );
 
 
@@ -8665,20 +10139,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank1_info1_page_cfg
-  // R[bank1_info1_page_cfg]: V(False)
+  // Subregister 0 of Multireg bank1_info1_page_cfg_shadowed
+  // R[bank1_info1_page_cfg_shadowed]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8686,24 +10162,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_rd_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_rd_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8711,24 +10193,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_rd_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_prog_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_prog_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8736,24 +10224,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_prog_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_erase_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_erase_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8761,24 +10255,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_erase_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_scramble_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_scramble_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8786,24 +10286,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_scramble_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_ecc_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_ecc_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8811,24 +10317,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_ecc_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info1_page_cfg_he_en_0 (
+  ) u_bank1_info1_page_cfg_shadowed_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info1_page_cfg_we & bank1_info1_regwen_qs),
-    .wd     (bank1_info1_page_cfg_he_en_0_wd),
+    .re     (bank1_info1_page_cfg_shadowed_re),
+    .we     (bank1_info1_page_cfg_shadowed_we & bank1_info1_regwen_qs),
+    .wd     (bank1_info1_page_cfg_shadowed_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8836,10 +10348,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info1_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info1_page_cfg_he_en_0_qs)
+    .qs     (bank1_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
@@ -8897,20 +10413,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg bank1_info2_page_cfg
-  // R[bank1_info2_page_cfg_0]: V(False)
+  // Subregister 0 of Multireg bank1_info2_page_cfg_shadowed
+  // R[bank1_info2_page_cfg_shadowed_0]: V(False)
   //   F[en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8918,24 +10436,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_storage)
   );
 
   //   F[rd_en_0]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_rd_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_rd_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_rd_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_rd_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8943,24 +10467,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].rd_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_rd_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.err_storage)
   );
 
   //   F[prog_en_0]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_prog_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_prog_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_prog_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_prog_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8968,24 +10498,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].prog_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_prog_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_prog_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_storage)
   );
 
   //   F[erase_en_0]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_erase_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_erase_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -8993,24 +10529,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].erase_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_erase_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.err_storage)
   );
 
   //   F[scramble_en_0]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_scramble_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_scramble_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_scramble_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_scramble_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9018,24 +10560,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].scramble_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_scramble_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_storage)
   );
 
   //   F[ecc_en_0]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_ecc_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_ecc_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_ecc_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_ecc_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9043,24 +10591,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].ecc_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_ecc_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_storage)
   );
 
   //   F[he_en_0]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_0_he_en_0 (
+  ) u_bank1_info2_page_cfg_shadowed_0_he_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_0_we & bank1_info2_regwen_0_qs),
-    .wd     (bank1_info2_page_cfg_0_he_en_0_wd),
+    .re     (bank1_info2_page_cfg_shadowed_0_re),
+    .we     (bank1_info2_page_cfg_shadowed_0_we & bank1_info2_regwen_0_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_0_he_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9068,27 +10622,33 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[0].he_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_0_he_en_0_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.err_storage)
   );
 
 
-  // Subregister 1 of Multireg bank1_info2_page_cfg
-  // R[bank1_info2_page_cfg_1]: V(False)
+  // Subregister 1 of Multireg bank1_info2_page_cfg_shadowed
+  // R[bank1_info2_page_cfg_shadowed_1]: V(False)
   //   F[en_1]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9096,24 +10656,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_storage)
   );
 
   //   F[rd_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_rd_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_rd_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_rd_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_rd_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9121,24 +10687,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].rd_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_rd_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.err_storage)
   );
 
   //   F[prog_en_1]: 2:2
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_prog_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_prog_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_prog_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_prog_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9146,24 +10718,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].prog_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_prog_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_prog_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_storage)
   );
 
   //   F[erase_en_1]: 3:3
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_erase_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_erase_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9171,24 +10749,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].erase_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_erase_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.err_storage)
   );
 
   //   F[scramble_en_1]: 4:4
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_scramble_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_scramble_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_scramble_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_scramble_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9196,24 +10780,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].scramble_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_scramble_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_storage)
   );
 
   //   F[ecc_en_1]: 5:5
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_ecc_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_ecc_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_ecc_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_ecc_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9221,24 +10811,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].ecc_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_ecc_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_storage)
   );
 
   //   F[he_en_1]: 6:6
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_bank1_info2_page_cfg_1_he_en_1 (
+  ) u_bank1_info2_page_cfg_shadowed_1_he_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (bank1_info2_page_cfg_1_we & bank1_info2_regwen_1_qs),
-    .wd     (bank1_info2_page_cfg_1_he_en_1_wd),
+    .re     (bank1_info2_page_cfg_shadowed_1_re),
+    .we     (bank1_info2_page_cfg_shadowed_1_we & bank1_info2_regwen_1_qs),
+    .wd     (bank1_info2_page_cfg_shadowed_1_he_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9246,10 +10842,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.bank1_info2_page_cfg[1].he_en.q),
+    .q      (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.q),
 
     // to register interface (read)
-    .qs     (bank1_info2_page_cfg_1_he_en_1_qs)
+    .qs     (bank1_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.err_update),
+    .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.err_storage)
   );
 
 
@@ -9279,20 +10879,22 @@ module flash_ctrl_core_reg_top (
   );
 
 
-  // Subregister 0 of Multireg mp_bank_cfg
-  // R[mp_bank_cfg]: V(False)
+  // Subregister 0 of Multireg mp_bank_cfg_shadowed
+  // R[mp_bank_cfg_shadowed]: V(False)
   //   F[erase_en_0]: 0:0
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_bank_cfg_erase_en_0 (
+  ) u_mp_bank_cfg_shadowed_erase_en_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
-    .wd     (mp_bank_cfg_erase_en_0_wd),
+    .re     (mp_bank_cfg_shadowed_re),
+    .we     (mp_bank_cfg_shadowed_we & bank_cfg_regwen_qs),
+    .wd     (mp_bank_cfg_shadowed_erase_en_0_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9300,24 +10902,30 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_bank_cfg[0].q),
+    .q      (reg2hw.mp_bank_cfg_shadowed[0].q),
 
     // to register interface (read)
-    .qs     (mp_bank_cfg_erase_en_0_qs)
+    .qs     (mp_bank_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_bank_cfg_shadowed[0].err_update),
+    .err_storage (reg2hw.mp_bank_cfg_shadowed[0].err_storage)
   );
 
   //   F[erase_en_1]: 1:1
-  prim_subreg #(
+  prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_mp_bank_cfg_erase_en_1 (
+  ) u_mp_bank_cfg_shadowed_erase_en_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
 
     // from register interface
-    .we     (mp_bank_cfg_we & bank_cfg_regwen_qs),
-    .wd     (mp_bank_cfg_erase_en_1_wd),
+    .re     (mp_bank_cfg_shadowed_re),
+    .we     (mp_bank_cfg_shadowed_we & bank_cfg_regwen_qs),
+    .wd     (mp_bank_cfg_shadowed_erase_en_1_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -9325,10 +10933,14 @@ module flash_ctrl_core_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.mp_bank_cfg[1].q),
+    .q      (reg2hw.mp_bank_cfg_shadowed[1].q),
 
     // to register interface (read)
-    .qs     (mp_bank_cfg_erase_en_1_qs)
+    .qs     (mp_bank_cfg_shadowed_erase_en_1_qs),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.mp_bank_cfg_shadowed[1].err_update),
+    .err_storage (reg2hw.mp_bank_cfg_shadowed[1].err_storage)
   );
 
 
@@ -9662,6 +11274,31 @@ module flash_ctrl_core_reg_top (
     .qs     (err_code_flash_phy_err_qs)
   );
 
+  //   F[update_err]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_err_code_update_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (err_code_we),
+    .wd     (err_code_update_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.update_err.de),
+    .d      (hw2reg.err_code.update_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_update_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[oob_err]: 0:0
@@ -9887,6 +11524,31 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (fault_status_lcmgr_err_qs)
+  );
+
+  //   F[storage_err]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_storage_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.storage_err.de),
+    .d      (hw2reg.fault_status.storage_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.storage_err.q),
+
+    // to register interface (read)
+    .qs     (fault_status_storage_err_qs)
   );
 
 
@@ -10331,15 +11993,15 @@ module flash_ctrl_core_reg_top (
     addr_hit[16] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET);
     addr_hit[17] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET);
     addr_hit[18] = (reg_addr == FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET);
-    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_0_OFFSET);
-    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_1_OFFSET);
-    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_2_OFFSET);
-    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_3_OFFSET);
-    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_4_OFFSET);
-    addr_hit[24] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_5_OFFSET);
-    addr_hit[25] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_6_OFFSET);
-    addr_hit[26] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_7_OFFSET);
-    addr_hit[27] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_OFFSET);
+    addr_hit[19] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_OFFSET);
+    addr_hit[20] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_1_OFFSET);
+    addr_hit[21] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_2_OFFSET);
+    addr_hit[22] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_3_OFFSET);
+    addr_hit[23] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_4_OFFSET);
+    addr_hit[24] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_5_OFFSET);
+    addr_hit[25] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_6_OFFSET);
+    addr_hit[26] = (reg_addr == FLASH_CTRL_MP_REGION_CFG_SHADOWED_7_OFFSET);
+    addr_hit[27] = (reg_addr == FLASH_CTRL_DEFAULT_REGION_SHADOWED_OFFSET);
     addr_hit[28] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET);
     addr_hit[29] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET);
     addr_hit[30] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET);
@@ -10350,22 +12012,22 @@ module flash_ctrl_core_reg_top (
     addr_hit[35] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET);
     addr_hit[36] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET);
     addr_hit[37] = (reg_addr == FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET);
-    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[38] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[39] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1_OFFSET);
+    addr_hit[40] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2_OFFSET);
+    addr_hit[41] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3_OFFSET);
+    addr_hit[42] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4_OFFSET);
+    addr_hit[43] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5_OFFSET);
+    addr_hit[44] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6_OFFSET);
+    addr_hit[45] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7_OFFSET);
+    addr_hit[46] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8_OFFSET);
+    addr_hit[47] = (reg_addr == FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9_OFFSET);
     addr_hit[48] = (reg_addr == FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET);
-    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[49] = (reg_addr == FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED_OFFSET);
     addr_hit[50] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET);
     addr_hit[51] = (reg_addr == FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET);
-    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[52] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[53] = (reg_addr == FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1_OFFSET);
     addr_hit[54] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET);
     addr_hit[55] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET);
     addr_hit[56] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET);
@@ -10376,24 +12038,24 @@ module flash_ctrl_core_reg_top (
     addr_hit[61] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET);
     addr_hit[62] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET);
     addr_hit[63] = (reg_addr == FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET);
-    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET);
-    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET);
-    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET);
-    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET);
-    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET);
-    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET);
-    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET);
-    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET);
-    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET);
-    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET);
+    addr_hit[64] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[65] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1_OFFSET);
+    addr_hit[66] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2_OFFSET);
+    addr_hit[67] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3_OFFSET);
+    addr_hit[68] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4_OFFSET);
+    addr_hit[69] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5_OFFSET);
+    addr_hit[70] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6_OFFSET);
+    addr_hit[71] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7_OFFSET);
+    addr_hit[72] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8_OFFSET);
+    addr_hit[73] = (reg_addr == FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9_OFFSET);
     addr_hit[74] = (reg_addr == FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET);
-    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET);
+    addr_hit[75] = (reg_addr == FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED_OFFSET);
     addr_hit[76] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET);
     addr_hit[77] = (reg_addr == FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET);
-    addr_hit[78] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET);
-    addr_hit[79] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET);
+    addr_hit[78] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0_OFFSET);
+    addr_hit[79] = (reg_addr == FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1_OFFSET);
     addr_hit[80] = (reg_addr == FLASH_CTRL_BANK_CFG_REGWEN_OFFSET);
-    addr_hit[81] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_OFFSET);
+    addr_hit[81] = (reg_addr == FLASH_CTRL_MP_BANK_CFG_SHADOWED_OFFSET);
     addr_hit[82] = (reg_addr == FLASH_CTRL_OP_STATUS_OFFSET);
     addr_hit[83] = (reg_addr == FLASH_CTRL_STATUS_OFFSET);
     addr_hit[84] = (reg_addr == FLASH_CTRL_ERR_CODE_OFFSET);
@@ -10615,171 +12277,180 @@ module flash_ctrl_core_reg_top (
   assign region_cfg_regwen_7_we = addr_hit[18] & reg_we & !reg_error;
 
   assign region_cfg_regwen_7_wd = reg_wdata[0];
-  assign mp_region_cfg_0_we = addr_hit[19] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_0_re = addr_hit[19] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_0_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign mp_region_cfg_0_en_0_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign mp_region_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign mp_region_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign mp_region_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign mp_region_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign mp_region_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign mp_region_cfg_0_he_en_0_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
 
-  assign mp_region_cfg_0_base_0_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_0_base_0_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_0_size_0_wd = reg_wdata[26:17];
-  assign mp_region_cfg_1_we = addr_hit[20] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_0_size_0_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_1_re = addr_hit[20] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_1_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign mp_region_cfg_1_en_1_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign mp_region_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign mp_region_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign mp_region_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign mp_region_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign mp_region_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign mp_region_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
 
-  assign mp_region_cfg_1_base_1_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_1_base_1_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_1_size_1_wd = reg_wdata[26:17];
-  assign mp_region_cfg_2_we = addr_hit[21] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_1_size_1_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_2_re = addr_hit[21] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_2_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign mp_region_cfg_2_en_2_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_2_en_2_wd = reg_wdata[0];
 
-  assign mp_region_cfg_2_rd_en_2_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_2_rd_en_2_wd = reg_wdata[1];
 
-  assign mp_region_cfg_2_prog_en_2_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_2_prog_en_2_wd = reg_wdata[2];
 
-  assign mp_region_cfg_2_erase_en_2_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_2_erase_en_2_wd = reg_wdata[3];
 
-  assign mp_region_cfg_2_scramble_en_2_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign mp_region_cfg_2_ecc_en_2_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign mp_region_cfg_2_he_en_2_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_2_he_en_2_wd = reg_wdata[6];
 
-  assign mp_region_cfg_2_base_2_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_2_base_2_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_2_size_2_wd = reg_wdata[26:17];
-  assign mp_region_cfg_3_we = addr_hit[22] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_2_size_2_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_3_re = addr_hit[22] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_3_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign mp_region_cfg_3_en_3_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_3_en_3_wd = reg_wdata[0];
 
-  assign mp_region_cfg_3_rd_en_3_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_3_rd_en_3_wd = reg_wdata[1];
 
-  assign mp_region_cfg_3_prog_en_3_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_3_prog_en_3_wd = reg_wdata[2];
 
-  assign mp_region_cfg_3_erase_en_3_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_3_erase_en_3_wd = reg_wdata[3];
 
-  assign mp_region_cfg_3_scramble_en_3_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign mp_region_cfg_3_ecc_en_3_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign mp_region_cfg_3_he_en_3_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_3_he_en_3_wd = reg_wdata[6];
 
-  assign mp_region_cfg_3_base_3_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_3_base_3_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_3_size_3_wd = reg_wdata[26:17];
-  assign mp_region_cfg_4_we = addr_hit[23] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_3_size_3_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_4_re = addr_hit[23] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_4_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign mp_region_cfg_4_en_4_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_4_en_4_wd = reg_wdata[0];
 
-  assign mp_region_cfg_4_rd_en_4_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_4_rd_en_4_wd = reg_wdata[1];
 
-  assign mp_region_cfg_4_prog_en_4_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_4_prog_en_4_wd = reg_wdata[2];
 
-  assign mp_region_cfg_4_erase_en_4_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_4_erase_en_4_wd = reg_wdata[3];
 
-  assign mp_region_cfg_4_scramble_en_4_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign mp_region_cfg_4_ecc_en_4_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign mp_region_cfg_4_he_en_4_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_4_he_en_4_wd = reg_wdata[6];
 
-  assign mp_region_cfg_4_base_4_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_4_base_4_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_4_size_4_wd = reg_wdata[26:17];
-  assign mp_region_cfg_5_we = addr_hit[24] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_4_size_4_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_5_re = addr_hit[24] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_5_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign mp_region_cfg_5_en_5_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_5_en_5_wd = reg_wdata[0];
 
-  assign mp_region_cfg_5_rd_en_5_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_5_rd_en_5_wd = reg_wdata[1];
 
-  assign mp_region_cfg_5_prog_en_5_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_5_prog_en_5_wd = reg_wdata[2];
 
-  assign mp_region_cfg_5_erase_en_5_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_5_erase_en_5_wd = reg_wdata[3];
 
-  assign mp_region_cfg_5_scramble_en_5_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign mp_region_cfg_5_ecc_en_5_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign mp_region_cfg_5_he_en_5_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_5_he_en_5_wd = reg_wdata[6];
 
-  assign mp_region_cfg_5_base_5_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_5_base_5_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_5_size_5_wd = reg_wdata[26:17];
-  assign mp_region_cfg_6_we = addr_hit[25] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_5_size_5_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_6_re = addr_hit[25] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_6_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign mp_region_cfg_6_en_6_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_6_en_6_wd = reg_wdata[0];
 
-  assign mp_region_cfg_6_rd_en_6_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_6_rd_en_6_wd = reg_wdata[1];
 
-  assign mp_region_cfg_6_prog_en_6_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_6_prog_en_6_wd = reg_wdata[2];
 
-  assign mp_region_cfg_6_erase_en_6_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_6_erase_en_6_wd = reg_wdata[3];
 
-  assign mp_region_cfg_6_scramble_en_6_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign mp_region_cfg_6_ecc_en_6_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign mp_region_cfg_6_he_en_6_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_6_he_en_6_wd = reg_wdata[6];
 
-  assign mp_region_cfg_6_base_6_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_6_base_6_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_6_size_6_wd = reg_wdata[26:17];
-  assign mp_region_cfg_7_we = addr_hit[26] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_6_size_6_wd = reg_wdata[26:17];
+  assign mp_region_cfg_shadowed_7_re = addr_hit[26] & reg_re & !reg_error;
+  assign mp_region_cfg_shadowed_7_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign mp_region_cfg_7_en_7_wd = reg_wdata[0];
+  assign mp_region_cfg_shadowed_7_en_7_wd = reg_wdata[0];
 
-  assign mp_region_cfg_7_rd_en_7_wd = reg_wdata[1];
+  assign mp_region_cfg_shadowed_7_rd_en_7_wd = reg_wdata[1];
 
-  assign mp_region_cfg_7_prog_en_7_wd = reg_wdata[2];
+  assign mp_region_cfg_shadowed_7_prog_en_7_wd = reg_wdata[2];
 
-  assign mp_region_cfg_7_erase_en_7_wd = reg_wdata[3];
+  assign mp_region_cfg_shadowed_7_erase_en_7_wd = reg_wdata[3];
 
-  assign mp_region_cfg_7_scramble_en_7_wd = reg_wdata[4];
+  assign mp_region_cfg_shadowed_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign mp_region_cfg_7_ecc_en_7_wd = reg_wdata[5];
+  assign mp_region_cfg_shadowed_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign mp_region_cfg_7_he_en_7_wd = reg_wdata[6];
+  assign mp_region_cfg_shadowed_7_he_en_7_wd = reg_wdata[6];
 
-  assign mp_region_cfg_7_base_7_wd = reg_wdata[16:8];
+  assign mp_region_cfg_shadowed_7_base_7_wd = reg_wdata[16:8];
 
-  assign mp_region_cfg_7_size_7_wd = reg_wdata[26:17];
-  assign default_region_we = addr_hit[27] & reg_we & !reg_error;
+  assign mp_region_cfg_shadowed_7_size_7_wd = reg_wdata[26:17];
+  assign default_region_shadowed_re = addr_hit[27] & reg_re & !reg_error;
+  assign default_region_shadowed_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign default_region_rd_en_wd = reg_wdata[0];
+  assign default_region_shadowed_rd_en_wd = reg_wdata[0];
 
-  assign default_region_prog_en_wd = reg_wdata[1];
+  assign default_region_shadowed_prog_en_wd = reg_wdata[1];
 
-  assign default_region_erase_en_wd = reg_wdata[2];
+  assign default_region_shadowed_erase_en_wd = reg_wdata[2];
 
-  assign default_region_scramble_en_wd = reg_wdata[3];
+  assign default_region_shadowed_scramble_en_wd = reg_wdata[3];
 
-  assign default_region_ecc_en_wd = reg_wdata[4];
+  assign default_region_shadowed_ecc_en_wd = reg_wdata[4];
 
-  assign default_region_he_en_wd = reg_wdata[5];
+  assign default_region_shadowed_he_en_wd = reg_wdata[5];
   assign bank0_info0_regwen_0_we = addr_hit[28] & reg_we & !reg_error;
 
   assign bank0_info0_regwen_0_wd = reg_wdata[0];
@@ -10810,210 +12481,223 @@ module flash_ctrl_core_reg_top (
   assign bank0_info0_regwen_9_we = addr_hit[37] & reg_we & !reg_error;
 
   assign bank0_info0_regwen_9_wd = reg_wdata[0];
-  assign bank0_info0_page_cfg_0_we = addr_hit[38] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_0_re = addr_hit[38] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_0_we = addr_hit[38] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_1_we = addr_hit[39] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_1_re = addr_hit[39] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_1_we = addr_hit[39] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_2_we = addr_hit[40] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_2_re = addr_hit[40] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_2_we = addr_hit[40] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_2_en_2_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_2_en_2_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_3_we = addr_hit[41] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_2_he_en_2_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_3_re = addr_hit[41] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_3_we = addr_hit[41] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_3_en_3_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_3_en_3_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_4_we = addr_hit[42] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_3_he_en_3_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_4_re = addr_hit[42] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_4_we = addr_hit[42] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_4_en_4_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_4_en_4_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_5_we = addr_hit[43] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_4_he_en_4_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_5_re = addr_hit[43] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_5_we = addr_hit[43] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_5_en_5_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_5_en_5_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_6_we = addr_hit[44] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_5_he_en_5_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_6_re = addr_hit[44] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_6_we = addr_hit[44] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_6_en_6_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_6_en_6_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_7_we = addr_hit[45] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_6_he_en_6_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_7_re = addr_hit[45] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_7_we = addr_hit[45] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_7_en_7_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_7_en_7_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_8_we = addr_hit[46] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_7_he_en_7_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_8_re = addr_hit[46] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_8_we = addr_hit[46] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_8_en_8_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_8_en_8_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
-  assign bank0_info0_page_cfg_9_we = addr_hit[47] & reg_we & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_8_he_en_8_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_9_re = addr_hit[47] & reg_re & !reg_error;
+  assign bank0_info0_page_cfg_shadowed_9_we = addr_hit[47] & reg_we & !reg_error;
 
-  assign bank0_info0_page_cfg_9_en_9_wd = reg_wdata[0];
+  assign bank0_info0_page_cfg_shadowed_9_en_9_wd = reg_wdata[0];
 
-  assign bank0_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
+  assign bank0_info0_page_cfg_shadowed_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank0_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
+  assign bank0_info0_page_cfg_shadowed_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank0_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
+  assign bank0_info0_page_cfg_shadowed_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank0_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
+  assign bank0_info0_page_cfg_shadowed_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank0_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
+  assign bank0_info0_page_cfg_shadowed_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank0_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
+  assign bank0_info0_page_cfg_shadowed_9_he_en_9_wd = reg_wdata[6];
   assign bank0_info1_regwen_we = addr_hit[48] & reg_we & !reg_error;
 
   assign bank0_info1_regwen_wd = reg_wdata[0];
-  assign bank0_info1_page_cfg_we = addr_hit[49] & reg_we & !reg_error;
+  assign bank0_info1_page_cfg_shadowed_re = addr_hit[49] & reg_re & !reg_error;
+  assign bank0_info1_page_cfg_shadowed_we = addr_hit[49] & reg_we & !reg_error;
 
-  assign bank0_info1_page_cfg_en_0_wd = reg_wdata[0];
+  assign bank0_info1_page_cfg_shadowed_en_0_wd = reg_wdata[0];
 
-  assign bank0_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
+  assign bank0_info1_page_cfg_shadowed_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
+  assign bank0_info1_page_cfg_shadowed_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
+  assign bank0_info1_page_cfg_shadowed_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
+  assign bank0_info1_page_cfg_shadowed_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
+  assign bank0_info1_page_cfg_shadowed_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info1_page_cfg_he_en_0_wd = reg_wdata[6];
+  assign bank0_info1_page_cfg_shadowed_he_en_0_wd = reg_wdata[6];
   assign bank0_info2_regwen_0_we = addr_hit[50] & reg_we & !reg_error;
 
   assign bank0_info2_regwen_0_wd = reg_wdata[0];
   assign bank0_info2_regwen_1_we = addr_hit[51] & reg_we & !reg_error;
 
   assign bank0_info2_regwen_1_wd = reg_wdata[0];
-  assign bank0_info2_page_cfg_0_we = addr_hit[52] & reg_we & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_0_re = addr_hit[52] & reg_re & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_0_we = addr_hit[52] & reg_we & !reg_error;
 
-  assign bank0_info2_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank0_info2_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank0_info2_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank0_info2_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank0_info2_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank0_info2_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank0_info2_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank0_info2_page_cfg_1_we = addr_hit[53] & reg_we & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank0_info2_page_cfg_shadowed_1_re = addr_hit[53] & reg_re & !reg_error;
+  assign bank0_info2_page_cfg_shadowed_1_we = addr_hit[53] & reg_we & !reg_error;
 
-  assign bank0_info2_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank0_info2_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank0_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank0_info2_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank0_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank0_info2_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank0_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank0_info2_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank0_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank0_info2_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank0_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank0_info2_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank0_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank0_info2_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
   assign bank1_info0_regwen_0_we = addr_hit[54] & reg_we & !reg_error;
 
   assign bank1_info0_regwen_0_wd = reg_wdata[0];
@@ -11044,218 +12728,232 @@ module flash_ctrl_core_reg_top (
   assign bank1_info0_regwen_9_we = addr_hit[63] & reg_we & !reg_error;
 
   assign bank1_info0_regwen_9_wd = reg_wdata[0];
-  assign bank1_info0_page_cfg_0_we = addr_hit[64] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_0_re = addr_hit[64] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_0_we = addr_hit[64] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_1_we = addr_hit[65] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_1_re = addr_hit[65] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_1_we = addr_hit[65] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_1_he_en_1_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_2_we = addr_hit[66] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_2_re = addr_hit[66] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_2_we = addr_hit[66] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_2_en_2_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_2_en_2_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_2_rd_en_2_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_2_rd_en_2_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_2_prog_en_2_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_2_prog_en_2_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_2_erase_en_2_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_2_erase_en_2_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_2_scramble_en_2_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_2_scramble_en_2_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_2_ecc_en_2_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_2_ecc_en_2_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_2_he_en_2_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_3_we = addr_hit[67] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_2_he_en_2_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_3_re = addr_hit[67] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_3_we = addr_hit[67] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_3_en_3_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_3_en_3_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_3_rd_en_3_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_3_rd_en_3_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_3_prog_en_3_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_3_prog_en_3_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_3_erase_en_3_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_3_erase_en_3_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_3_scramble_en_3_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_3_scramble_en_3_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_3_ecc_en_3_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_3_ecc_en_3_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_3_he_en_3_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_4_we = addr_hit[68] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_3_he_en_3_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_4_re = addr_hit[68] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_4_we = addr_hit[68] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_4_en_4_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_4_en_4_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_4_rd_en_4_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_4_rd_en_4_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_4_prog_en_4_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_4_prog_en_4_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_4_erase_en_4_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_4_erase_en_4_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_4_scramble_en_4_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_4_scramble_en_4_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_4_ecc_en_4_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_4_ecc_en_4_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_4_he_en_4_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_5_we = addr_hit[69] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_4_he_en_4_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_5_re = addr_hit[69] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_5_we = addr_hit[69] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_5_en_5_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_5_en_5_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_5_rd_en_5_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_5_rd_en_5_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_5_prog_en_5_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_5_prog_en_5_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_5_erase_en_5_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_5_erase_en_5_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_5_scramble_en_5_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_5_scramble_en_5_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_5_ecc_en_5_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_5_ecc_en_5_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_5_he_en_5_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_6_we = addr_hit[70] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_5_he_en_5_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_6_re = addr_hit[70] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_6_we = addr_hit[70] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_6_en_6_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_6_en_6_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_6_rd_en_6_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_6_rd_en_6_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_6_prog_en_6_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_6_prog_en_6_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_6_erase_en_6_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_6_erase_en_6_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_6_scramble_en_6_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_6_scramble_en_6_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_6_ecc_en_6_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_6_ecc_en_6_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_6_he_en_6_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_7_we = addr_hit[71] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_6_he_en_6_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_7_re = addr_hit[71] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_7_we = addr_hit[71] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_7_en_7_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_7_en_7_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_7_rd_en_7_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_7_rd_en_7_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_7_prog_en_7_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_7_prog_en_7_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_7_erase_en_7_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_7_erase_en_7_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_7_scramble_en_7_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_7_scramble_en_7_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_7_ecc_en_7_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_7_ecc_en_7_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_7_he_en_7_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_8_we = addr_hit[72] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_7_he_en_7_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_8_re = addr_hit[72] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_8_we = addr_hit[72] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_8_en_8_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_8_en_8_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_8_rd_en_8_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_8_rd_en_8_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_8_prog_en_8_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_8_prog_en_8_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_8_erase_en_8_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_8_erase_en_8_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_8_scramble_en_8_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_8_scramble_en_8_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_8_ecc_en_8_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_8_ecc_en_8_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_8_he_en_8_wd = reg_wdata[6];
-  assign bank1_info0_page_cfg_9_we = addr_hit[73] & reg_we & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_8_he_en_8_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_9_re = addr_hit[73] & reg_re & !reg_error;
+  assign bank1_info0_page_cfg_shadowed_9_we = addr_hit[73] & reg_we & !reg_error;
 
-  assign bank1_info0_page_cfg_9_en_9_wd = reg_wdata[0];
+  assign bank1_info0_page_cfg_shadowed_9_en_9_wd = reg_wdata[0];
 
-  assign bank1_info0_page_cfg_9_rd_en_9_wd = reg_wdata[1];
+  assign bank1_info0_page_cfg_shadowed_9_rd_en_9_wd = reg_wdata[1];
 
-  assign bank1_info0_page_cfg_9_prog_en_9_wd = reg_wdata[2];
+  assign bank1_info0_page_cfg_shadowed_9_prog_en_9_wd = reg_wdata[2];
 
-  assign bank1_info0_page_cfg_9_erase_en_9_wd = reg_wdata[3];
+  assign bank1_info0_page_cfg_shadowed_9_erase_en_9_wd = reg_wdata[3];
 
-  assign bank1_info0_page_cfg_9_scramble_en_9_wd = reg_wdata[4];
+  assign bank1_info0_page_cfg_shadowed_9_scramble_en_9_wd = reg_wdata[4];
 
-  assign bank1_info0_page_cfg_9_ecc_en_9_wd = reg_wdata[5];
+  assign bank1_info0_page_cfg_shadowed_9_ecc_en_9_wd = reg_wdata[5];
 
-  assign bank1_info0_page_cfg_9_he_en_9_wd = reg_wdata[6];
+  assign bank1_info0_page_cfg_shadowed_9_he_en_9_wd = reg_wdata[6];
   assign bank1_info1_regwen_we = addr_hit[74] & reg_we & !reg_error;
 
   assign bank1_info1_regwen_wd = reg_wdata[0];
-  assign bank1_info1_page_cfg_we = addr_hit[75] & reg_we & !reg_error;
+  assign bank1_info1_page_cfg_shadowed_re = addr_hit[75] & reg_re & !reg_error;
+  assign bank1_info1_page_cfg_shadowed_we = addr_hit[75] & reg_we & !reg_error;
 
-  assign bank1_info1_page_cfg_en_0_wd = reg_wdata[0];
+  assign bank1_info1_page_cfg_shadowed_en_0_wd = reg_wdata[0];
 
-  assign bank1_info1_page_cfg_rd_en_0_wd = reg_wdata[1];
+  assign bank1_info1_page_cfg_shadowed_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info1_page_cfg_prog_en_0_wd = reg_wdata[2];
+  assign bank1_info1_page_cfg_shadowed_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info1_page_cfg_erase_en_0_wd = reg_wdata[3];
+  assign bank1_info1_page_cfg_shadowed_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info1_page_cfg_scramble_en_0_wd = reg_wdata[4];
+  assign bank1_info1_page_cfg_shadowed_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info1_page_cfg_ecc_en_0_wd = reg_wdata[5];
+  assign bank1_info1_page_cfg_shadowed_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info1_page_cfg_he_en_0_wd = reg_wdata[6];
+  assign bank1_info1_page_cfg_shadowed_he_en_0_wd = reg_wdata[6];
   assign bank1_info2_regwen_0_we = addr_hit[76] & reg_we & !reg_error;
 
   assign bank1_info2_regwen_0_wd = reg_wdata[0];
   assign bank1_info2_regwen_1_we = addr_hit[77] & reg_we & !reg_error;
 
   assign bank1_info2_regwen_1_wd = reg_wdata[0];
-  assign bank1_info2_page_cfg_0_we = addr_hit[78] & reg_we & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_0_re = addr_hit[78] & reg_re & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_0_we = addr_hit[78] & reg_we & !reg_error;
 
-  assign bank1_info2_page_cfg_0_en_0_wd = reg_wdata[0];
+  assign bank1_info2_page_cfg_shadowed_0_en_0_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_0_rd_en_0_wd = reg_wdata[1];
+  assign bank1_info2_page_cfg_shadowed_0_rd_en_0_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_0_prog_en_0_wd = reg_wdata[2];
+  assign bank1_info2_page_cfg_shadowed_0_prog_en_0_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_0_erase_en_0_wd = reg_wdata[3];
+  assign bank1_info2_page_cfg_shadowed_0_erase_en_0_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_0_scramble_en_0_wd = reg_wdata[4];
+  assign bank1_info2_page_cfg_shadowed_0_scramble_en_0_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_0_ecc_en_0_wd = reg_wdata[5];
+  assign bank1_info2_page_cfg_shadowed_0_ecc_en_0_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_0_he_en_0_wd = reg_wdata[6];
-  assign bank1_info2_page_cfg_1_we = addr_hit[79] & reg_we & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_0_he_en_0_wd = reg_wdata[6];
+  assign bank1_info2_page_cfg_shadowed_1_re = addr_hit[79] & reg_re & !reg_error;
+  assign bank1_info2_page_cfg_shadowed_1_we = addr_hit[79] & reg_we & !reg_error;
 
-  assign bank1_info2_page_cfg_1_en_1_wd = reg_wdata[0];
+  assign bank1_info2_page_cfg_shadowed_1_en_1_wd = reg_wdata[0];
 
-  assign bank1_info2_page_cfg_1_rd_en_1_wd = reg_wdata[1];
+  assign bank1_info2_page_cfg_shadowed_1_rd_en_1_wd = reg_wdata[1];
 
-  assign bank1_info2_page_cfg_1_prog_en_1_wd = reg_wdata[2];
+  assign bank1_info2_page_cfg_shadowed_1_prog_en_1_wd = reg_wdata[2];
 
-  assign bank1_info2_page_cfg_1_erase_en_1_wd = reg_wdata[3];
+  assign bank1_info2_page_cfg_shadowed_1_erase_en_1_wd = reg_wdata[3];
 
-  assign bank1_info2_page_cfg_1_scramble_en_1_wd = reg_wdata[4];
+  assign bank1_info2_page_cfg_shadowed_1_scramble_en_1_wd = reg_wdata[4];
 
-  assign bank1_info2_page_cfg_1_ecc_en_1_wd = reg_wdata[5];
+  assign bank1_info2_page_cfg_shadowed_1_ecc_en_1_wd = reg_wdata[5];
 
-  assign bank1_info2_page_cfg_1_he_en_1_wd = reg_wdata[6];
+  assign bank1_info2_page_cfg_shadowed_1_he_en_1_wd = reg_wdata[6];
   assign bank_cfg_regwen_we = addr_hit[80] & reg_we & !reg_error;
 
   assign bank_cfg_regwen_wd = reg_wdata[0];
-  assign mp_bank_cfg_we = addr_hit[81] & reg_we & !reg_error;
+  assign mp_bank_cfg_shadowed_re = addr_hit[81] & reg_re & !reg_error;
+  assign mp_bank_cfg_shadowed_we = addr_hit[81] & reg_we & !reg_error;
 
-  assign mp_bank_cfg_erase_en_0_wd = reg_wdata[0];
+  assign mp_bank_cfg_shadowed_erase_en_0_wd = reg_wdata[0];
 
-  assign mp_bank_cfg_erase_en_1_wd = reg_wdata[1];
+  assign mp_bank_cfg_shadowed_erase_en_1_wd = reg_wdata[1];
   assign op_status_we = addr_hit[82] & reg_we & !reg_error;
 
   assign op_status_done_wd = reg_wdata[0];
@@ -11274,6 +12972,8 @@ module flash_ctrl_core_reg_top (
   assign err_code_prog_type_err_wd = reg_wdata[4];
 
   assign err_code_flash_phy_err_wd = reg_wdata[5];
+
+  assign err_code_update_err_wd = reg_wdata[6];
   assign ecc_single_err_cnt_we = addr_hit[87] & reg_we & !reg_error;
 
   assign ecc_single_err_cnt_ecc_single_err_cnt_0_wd = reg_wdata[7:0];
@@ -11406,108 +13106,108 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[0] = mp_region_cfg_0_en_0_qs;
-        reg_rdata_next[1] = mp_region_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = mp_region_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = mp_region_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = mp_region_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = mp_region_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = mp_region_cfg_0_he_en_0_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_0_base_0_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_0_size_0_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_0_he_en_0_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_0_base_0_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_0_size_0_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[0] = mp_region_cfg_1_en_1_qs;
-        reg_rdata_next[1] = mp_region_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = mp_region_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = mp_region_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = mp_region_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = mp_region_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = mp_region_cfg_1_he_en_1_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_1_base_1_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_1_size_1_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_1_he_en_1_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_1_base_1_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_1_size_1_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[0] = mp_region_cfg_2_en_2_qs;
-        reg_rdata_next[1] = mp_region_cfg_2_rd_en_2_qs;
-        reg_rdata_next[2] = mp_region_cfg_2_prog_en_2_qs;
-        reg_rdata_next[3] = mp_region_cfg_2_erase_en_2_qs;
-        reg_rdata_next[4] = mp_region_cfg_2_scramble_en_2_qs;
-        reg_rdata_next[5] = mp_region_cfg_2_ecc_en_2_qs;
-        reg_rdata_next[6] = mp_region_cfg_2_he_en_2_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_2_base_2_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_2_size_2_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_2_en_2_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_2_rd_en_2_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_2_prog_en_2_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_2_erase_en_2_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_2_scramble_en_2_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_2_ecc_en_2_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_2_he_en_2_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_2_base_2_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_2_size_2_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[0] = mp_region_cfg_3_en_3_qs;
-        reg_rdata_next[1] = mp_region_cfg_3_rd_en_3_qs;
-        reg_rdata_next[2] = mp_region_cfg_3_prog_en_3_qs;
-        reg_rdata_next[3] = mp_region_cfg_3_erase_en_3_qs;
-        reg_rdata_next[4] = mp_region_cfg_3_scramble_en_3_qs;
-        reg_rdata_next[5] = mp_region_cfg_3_ecc_en_3_qs;
-        reg_rdata_next[6] = mp_region_cfg_3_he_en_3_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_3_base_3_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_3_size_3_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_3_en_3_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_3_rd_en_3_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_3_prog_en_3_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_3_erase_en_3_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_3_scramble_en_3_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_3_ecc_en_3_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_3_he_en_3_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_3_base_3_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_3_size_3_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[0] = mp_region_cfg_4_en_4_qs;
-        reg_rdata_next[1] = mp_region_cfg_4_rd_en_4_qs;
-        reg_rdata_next[2] = mp_region_cfg_4_prog_en_4_qs;
-        reg_rdata_next[3] = mp_region_cfg_4_erase_en_4_qs;
-        reg_rdata_next[4] = mp_region_cfg_4_scramble_en_4_qs;
-        reg_rdata_next[5] = mp_region_cfg_4_ecc_en_4_qs;
-        reg_rdata_next[6] = mp_region_cfg_4_he_en_4_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_4_base_4_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_4_size_4_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_4_en_4_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_4_rd_en_4_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_4_prog_en_4_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_4_erase_en_4_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_4_scramble_en_4_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_4_ecc_en_4_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_4_he_en_4_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_4_base_4_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_4_size_4_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[0] = mp_region_cfg_5_en_5_qs;
-        reg_rdata_next[1] = mp_region_cfg_5_rd_en_5_qs;
-        reg_rdata_next[2] = mp_region_cfg_5_prog_en_5_qs;
-        reg_rdata_next[3] = mp_region_cfg_5_erase_en_5_qs;
-        reg_rdata_next[4] = mp_region_cfg_5_scramble_en_5_qs;
-        reg_rdata_next[5] = mp_region_cfg_5_ecc_en_5_qs;
-        reg_rdata_next[6] = mp_region_cfg_5_he_en_5_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_5_base_5_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_5_size_5_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_5_en_5_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_5_rd_en_5_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_5_prog_en_5_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_5_erase_en_5_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_5_scramble_en_5_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_5_ecc_en_5_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_5_he_en_5_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_5_base_5_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_5_size_5_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[0] = mp_region_cfg_6_en_6_qs;
-        reg_rdata_next[1] = mp_region_cfg_6_rd_en_6_qs;
-        reg_rdata_next[2] = mp_region_cfg_6_prog_en_6_qs;
-        reg_rdata_next[3] = mp_region_cfg_6_erase_en_6_qs;
-        reg_rdata_next[4] = mp_region_cfg_6_scramble_en_6_qs;
-        reg_rdata_next[5] = mp_region_cfg_6_ecc_en_6_qs;
-        reg_rdata_next[6] = mp_region_cfg_6_he_en_6_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_6_base_6_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_6_size_6_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_6_en_6_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_6_rd_en_6_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_6_prog_en_6_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_6_erase_en_6_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_6_scramble_en_6_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_6_ecc_en_6_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_6_he_en_6_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_6_base_6_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_6_size_6_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[0] = mp_region_cfg_7_en_7_qs;
-        reg_rdata_next[1] = mp_region_cfg_7_rd_en_7_qs;
-        reg_rdata_next[2] = mp_region_cfg_7_prog_en_7_qs;
-        reg_rdata_next[3] = mp_region_cfg_7_erase_en_7_qs;
-        reg_rdata_next[4] = mp_region_cfg_7_scramble_en_7_qs;
-        reg_rdata_next[5] = mp_region_cfg_7_ecc_en_7_qs;
-        reg_rdata_next[6] = mp_region_cfg_7_he_en_7_qs;
-        reg_rdata_next[16:8] = mp_region_cfg_7_base_7_qs;
-        reg_rdata_next[26:17] = mp_region_cfg_7_size_7_qs;
+        reg_rdata_next[0] = mp_region_cfg_shadowed_7_en_7_qs;
+        reg_rdata_next[1] = mp_region_cfg_shadowed_7_rd_en_7_qs;
+        reg_rdata_next[2] = mp_region_cfg_shadowed_7_prog_en_7_qs;
+        reg_rdata_next[3] = mp_region_cfg_shadowed_7_erase_en_7_qs;
+        reg_rdata_next[4] = mp_region_cfg_shadowed_7_scramble_en_7_qs;
+        reg_rdata_next[5] = mp_region_cfg_shadowed_7_ecc_en_7_qs;
+        reg_rdata_next[6] = mp_region_cfg_shadowed_7_he_en_7_qs;
+        reg_rdata_next[16:8] = mp_region_cfg_shadowed_7_base_7_qs;
+        reg_rdata_next[26:17] = mp_region_cfg_shadowed_7_size_7_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[0] = default_region_rd_en_qs;
-        reg_rdata_next[1] = default_region_prog_en_qs;
-        reg_rdata_next[2] = default_region_erase_en_qs;
-        reg_rdata_next[3] = default_region_scramble_en_qs;
-        reg_rdata_next[4] = default_region_ecc_en_qs;
-        reg_rdata_next[5] = default_region_he_en_qs;
+        reg_rdata_next[0] = default_region_shadowed_rd_en_qs;
+        reg_rdata_next[1] = default_region_shadowed_prog_en_qs;
+        reg_rdata_next[2] = default_region_shadowed_erase_en_qs;
+        reg_rdata_next[3] = default_region_shadowed_scramble_en_qs;
+        reg_rdata_next[4] = default_region_shadowed_ecc_en_qs;
+        reg_rdata_next[5] = default_region_shadowed_he_en_qs;
       end
 
       addr_hit[28]: begin
@@ -11551,103 +13251,103 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[38]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[39]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[40]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_2_en_2_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_2_rd_en_2_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_2_prog_en_2_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_2_erase_en_2_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_2_scramble_en_2_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_2_ecc_en_2_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_2_he_en_2_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_2_en_2_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_2_rd_en_2_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_2_prog_en_2_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_2_he_en_2_qs;
       end
 
       addr_hit[41]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_3_en_3_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_3_rd_en_3_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_3_prog_en_3_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_3_erase_en_3_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_3_scramble_en_3_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_3_ecc_en_3_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_3_he_en_3_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_3_en_3_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_3_rd_en_3_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_3_prog_en_3_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_3_he_en_3_qs;
       end
 
       addr_hit[42]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_4_en_4_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_4_rd_en_4_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_4_prog_en_4_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_4_erase_en_4_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_4_scramble_en_4_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_4_ecc_en_4_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_4_he_en_4_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_4_en_4_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_4_rd_en_4_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_4_prog_en_4_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_4_erase_en_4_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_4_he_en_4_qs;
       end
 
       addr_hit[43]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_5_en_5_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_5_rd_en_5_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_5_prog_en_5_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_5_erase_en_5_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_5_scramble_en_5_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_5_ecc_en_5_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_5_he_en_5_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_5_en_5_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_5_rd_en_5_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_5_prog_en_5_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_5_erase_en_5_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_5_he_en_5_qs;
       end
 
       addr_hit[44]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_6_en_6_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_6_rd_en_6_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_6_prog_en_6_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_6_erase_en_6_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_6_scramble_en_6_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_6_ecc_en_6_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_6_he_en_6_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_6_en_6_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_6_rd_en_6_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_6_prog_en_6_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_6_erase_en_6_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_6_he_en_6_qs;
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_7_en_7_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_7_rd_en_7_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_7_prog_en_7_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_7_erase_en_7_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_7_scramble_en_7_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_7_ecc_en_7_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_7_he_en_7_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_7_en_7_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_7_rd_en_7_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_7_prog_en_7_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_7_erase_en_7_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_7_he_en_7_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_8_en_8_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_8_rd_en_8_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_8_prog_en_8_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_8_erase_en_8_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_8_scramble_en_8_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_8_ecc_en_8_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_8_he_en_8_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_8_en_8_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_8_rd_en_8_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_8_prog_en_8_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_8_erase_en_8_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_8_he_en_8_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[0] = bank0_info0_page_cfg_9_en_9_qs;
-        reg_rdata_next[1] = bank0_info0_page_cfg_9_rd_en_9_qs;
-        reg_rdata_next[2] = bank0_info0_page_cfg_9_prog_en_9_qs;
-        reg_rdata_next[3] = bank0_info0_page_cfg_9_erase_en_9_qs;
-        reg_rdata_next[4] = bank0_info0_page_cfg_9_scramble_en_9_qs;
-        reg_rdata_next[5] = bank0_info0_page_cfg_9_ecc_en_9_qs;
-        reg_rdata_next[6] = bank0_info0_page_cfg_9_he_en_9_qs;
+        reg_rdata_next[0] = bank0_info0_page_cfg_shadowed_9_en_9_qs;
+        reg_rdata_next[1] = bank0_info0_page_cfg_shadowed_9_rd_en_9_qs;
+        reg_rdata_next[2] = bank0_info0_page_cfg_shadowed_9_prog_en_9_qs;
+        reg_rdata_next[3] = bank0_info0_page_cfg_shadowed_9_erase_en_9_qs;
+        reg_rdata_next[4] = bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+        reg_rdata_next[5] = bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+        reg_rdata_next[6] = bank0_info0_page_cfg_shadowed_9_he_en_9_qs;
       end
 
       addr_hit[48]: begin
@@ -11655,13 +13355,13 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[0] = bank0_info1_page_cfg_en_0_qs;
-        reg_rdata_next[1] = bank0_info1_page_cfg_rd_en_0_qs;
-        reg_rdata_next[2] = bank0_info1_page_cfg_prog_en_0_qs;
-        reg_rdata_next[3] = bank0_info1_page_cfg_erase_en_0_qs;
-        reg_rdata_next[4] = bank0_info1_page_cfg_scramble_en_0_qs;
-        reg_rdata_next[5] = bank0_info1_page_cfg_ecc_en_0_qs;
-        reg_rdata_next[6] = bank0_info1_page_cfg_he_en_0_qs;
+        reg_rdata_next[0] = bank0_info1_page_cfg_shadowed_en_0_qs;
+        reg_rdata_next[1] = bank0_info1_page_cfg_shadowed_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info1_page_cfg_shadowed_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info1_page_cfg_shadowed_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info1_page_cfg_shadowed_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info1_page_cfg_shadowed_ecc_en_0_qs;
+        reg_rdata_next[6] = bank0_info1_page_cfg_shadowed_he_en_0_qs;
       end
 
       addr_hit[50]: begin
@@ -11673,23 +13373,23 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[52]: begin
-        reg_rdata_next[0] = bank0_info2_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank0_info2_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank0_info2_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank0_info2_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank0_info2_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank0_info2_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank0_info2_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank0_info2_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank0_info2_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank0_info2_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank0_info2_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank0_info2_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[53]: begin
-        reg_rdata_next[0] = bank0_info2_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank0_info2_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank0_info2_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank0_info2_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank0_info2_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank0_info2_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank0_info2_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank0_info2_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank0_info2_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank0_info2_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank0_info2_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank0_info2_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[54]: begin
@@ -11733,103 +13433,103 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[64]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[65]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[66]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_2_en_2_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_2_rd_en_2_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_2_prog_en_2_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_2_erase_en_2_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_2_scramble_en_2_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_2_ecc_en_2_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_2_he_en_2_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_2_en_2_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_2_rd_en_2_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_2_prog_en_2_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_2_erase_en_2_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_2_he_en_2_qs;
       end
 
       addr_hit[67]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_3_en_3_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_3_rd_en_3_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_3_prog_en_3_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_3_erase_en_3_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_3_scramble_en_3_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_3_ecc_en_3_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_3_he_en_3_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_3_en_3_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_3_rd_en_3_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_3_prog_en_3_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_3_erase_en_3_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_3_he_en_3_qs;
       end
 
       addr_hit[68]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_4_en_4_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_4_rd_en_4_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_4_prog_en_4_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_4_erase_en_4_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_4_scramble_en_4_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_4_ecc_en_4_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_4_he_en_4_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_4_en_4_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_4_rd_en_4_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_4_prog_en_4_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_4_erase_en_4_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_4_he_en_4_qs;
       end
 
       addr_hit[69]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_5_en_5_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_5_rd_en_5_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_5_prog_en_5_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_5_erase_en_5_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_5_scramble_en_5_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_5_ecc_en_5_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_5_he_en_5_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_5_en_5_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_5_rd_en_5_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_5_prog_en_5_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_5_erase_en_5_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_5_he_en_5_qs;
       end
 
       addr_hit[70]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_6_en_6_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_6_rd_en_6_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_6_prog_en_6_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_6_erase_en_6_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_6_scramble_en_6_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_6_ecc_en_6_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_6_he_en_6_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_6_en_6_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_6_rd_en_6_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_6_prog_en_6_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_6_erase_en_6_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_6_he_en_6_qs;
       end
 
       addr_hit[71]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_7_en_7_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_7_rd_en_7_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_7_prog_en_7_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_7_erase_en_7_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_7_scramble_en_7_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_7_ecc_en_7_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_7_he_en_7_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_7_en_7_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_7_rd_en_7_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_7_prog_en_7_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_7_erase_en_7_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_7_he_en_7_qs;
       end
 
       addr_hit[72]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_8_en_8_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_8_rd_en_8_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_8_prog_en_8_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_8_erase_en_8_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_8_scramble_en_8_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_8_ecc_en_8_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_8_he_en_8_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_8_en_8_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_8_rd_en_8_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_8_prog_en_8_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_8_erase_en_8_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_8_he_en_8_qs;
       end
 
       addr_hit[73]: begin
-        reg_rdata_next[0] = bank1_info0_page_cfg_9_en_9_qs;
-        reg_rdata_next[1] = bank1_info0_page_cfg_9_rd_en_9_qs;
-        reg_rdata_next[2] = bank1_info0_page_cfg_9_prog_en_9_qs;
-        reg_rdata_next[3] = bank1_info0_page_cfg_9_erase_en_9_qs;
-        reg_rdata_next[4] = bank1_info0_page_cfg_9_scramble_en_9_qs;
-        reg_rdata_next[5] = bank1_info0_page_cfg_9_ecc_en_9_qs;
-        reg_rdata_next[6] = bank1_info0_page_cfg_9_he_en_9_qs;
+        reg_rdata_next[0] = bank1_info0_page_cfg_shadowed_9_en_9_qs;
+        reg_rdata_next[1] = bank1_info0_page_cfg_shadowed_9_rd_en_9_qs;
+        reg_rdata_next[2] = bank1_info0_page_cfg_shadowed_9_prog_en_9_qs;
+        reg_rdata_next[3] = bank1_info0_page_cfg_shadowed_9_erase_en_9_qs;
+        reg_rdata_next[4] = bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs;
+        reg_rdata_next[5] = bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs;
+        reg_rdata_next[6] = bank1_info0_page_cfg_shadowed_9_he_en_9_qs;
       end
 
       addr_hit[74]: begin
@@ -11837,13 +13537,13 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[75]: begin
-        reg_rdata_next[0] = bank1_info1_page_cfg_en_0_qs;
-        reg_rdata_next[1] = bank1_info1_page_cfg_rd_en_0_qs;
-        reg_rdata_next[2] = bank1_info1_page_cfg_prog_en_0_qs;
-        reg_rdata_next[3] = bank1_info1_page_cfg_erase_en_0_qs;
-        reg_rdata_next[4] = bank1_info1_page_cfg_scramble_en_0_qs;
-        reg_rdata_next[5] = bank1_info1_page_cfg_ecc_en_0_qs;
-        reg_rdata_next[6] = bank1_info1_page_cfg_he_en_0_qs;
+        reg_rdata_next[0] = bank1_info1_page_cfg_shadowed_en_0_qs;
+        reg_rdata_next[1] = bank1_info1_page_cfg_shadowed_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info1_page_cfg_shadowed_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info1_page_cfg_shadowed_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info1_page_cfg_shadowed_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info1_page_cfg_shadowed_ecc_en_0_qs;
+        reg_rdata_next[6] = bank1_info1_page_cfg_shadowed_he_en_0_qs;
       end
 
       addr_hit[76]: begin
@@ -11855,23 +13555,23 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[78]: begin
-        reg_rdata_next[0] = bank1_info2_page_cfg_0_en_0_qs;
-        reg_rdata_next[1] = bank1_info2_page_cfg_0_rd_en_0_qs;
-        reg_rdata_next[2] = bank1_info2_page_cfg_0_prog_en_0_qs;
-        reg_rdata_next[3] = bank1_info2_page_cfg_0_erase_en_0_qs;
-        reg_rdata_next[4] = bank1_info2_page_cfg_0_scramble_en_0_qs;
-        reg_rdata_next[5] = bank1_info2_page_cfg_0_ecc_en_0_qs;
-        reg_rdata_next[6] = bank1_info2_page_cfg_0_he_en_0_qs;
+        reg_rdata_next[0] = bank1_info2_page_cfg_shadowed_0_en_0_qs;
+        reg_rdata_next[1] = bank1_info2_page_cfg_shadowed_0_rd_en_0_qs;
+        reg_rdata_next[2] = bank1_info2_page_cfg_shadowed_0_prog_en_0_qs;
+        reg_rdata_next[3] = bank1_info2_page_cfg_shadowed_0_erase_en_0_qs;
+        reg_rdata_next[4] = bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs;
+        reg_rdata_next[5] = bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs;
+        reg_rdata_next[6] = bank1_info2_page_cfg_shadowed_0_he_en_0_qs;
       end
 
       addr_hit[79]: begin
-        reg_rdata_next[0] = bank1_info2_page_cfg_1_en_1_qs;
-        reg_rdata_next[1] = bank1_info2_page_cfg_1_rd_en_1_qs;
-        reg_rdata_next[2] = bank1_info2_page_cfg_1_prog_en_1_qs;
-        reg_rdata_next[3] = bank1_info2_page_cfg_1_erase_en_1_qs;
-        reg_rdata_next[4] = bank1_info2_page_cfg_1_scramble_en_1_qs;
-        reg_rdata_next[5] = bank1_info2_page_cfg_1_ecc_en_1_qs;
-        reg_rdata_next[6] = bank1_info2_page_cfg_1_he_en_1_qs;
+        reg_rdata_next[0] = bank1_info2_page_cfg_shadowed_1_en_1_qs;
+        reg_rdata_next[1] = bank1_info2_page_cfg_shadowed_1_rd_en_1_qs;
+        reg_rdata_next[2] = bank1_info2_page_cfg_shadowed_1_prog_en_1_qs;
+        reg_rdata_next[3] = bank1_info2_page_cfg_shadowed_1_erase_en_1_qs;
+        reg_rdata_next[4] = bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs;
+        reg_rdata_next[5] = bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs;
+        reg_rdata_next[6] = bank1_info2_page_cfg_shadowed_1_he_en_1_qs;
       end
 
       addr_hit[80]: begin
@@ -11879,8 +13579,8 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[81]: begin
-        reg_rdata_next[0] = mp_bank_cfg_erase_en_0_qs;
-        reg_rdata_next[1] = mp_bank_cfg_erase_en_1_qs;
+        reg_rdata_next[0] = mp_bank_cfg_shadowed_erase_en_0_qs;
+        reg_rdata_next[1] = mp_bank_cfg_shadowed_erase_en_1_qs;
       end
 
       addr_hit[82]: begin
@@ -11903,6 +13603,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[3] = err_code_prog_win_err_qs;
         reg_rdata_next[4] = err_code_prog_type_err_qs;
         reg_rdata_next[5] = err_code_flash_phy_err_qs;
+        reg_rdata_next[6] = err_code_update_err_qs;
       end
 
       addr_hit[85]: begin
@@ -11915,6 +13616,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[6] = fault_status_reg_intg_err_qs;
         reg_rdata_next[7] = fault_status_phy_intg_err_qs;
         reg_rdata_next[8] = fault_status_lcmgr_err_qs;
+        reg_rdata_next[9] = fault_status_storage_err_qs;
       end
 
       addr_hit[86]: begin
@@ -11974,7 +13676,26 @@ module flash_ctrl_core_reg_top (
 
   // shadow busy
   logic shadow_busy;
-  assign shadow_busy = 1'b0;
+  logic rst_done;
+  logic shadow_rst_done;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rst_done <= '0;
+    end else begin
+      rst_done <= 1'b1;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_shadowed_ni) begin
+    if (!rst_shadowed_ni) begin
+      shadow_rst_done <= '0;
+    end else begin
+      shadow_rst_done <= 1'b1;
+    end
+  end
+
+  // both shadow and normal resets have been released
+  assign shadow_busy = ~(rst_done & shadow_rst_done);
 
   // register busy
   logic reg_busy_sel;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -119,9 +119,76 @@ package flash_ctrl_pkg;
     PhaseInvalid
   } flash_lcmgr_phase_e;
 
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t;
+  import flash_ctrl_reg_pkg::flash_ctrl_reg2hw_default_region_shadowed_reg_t;
+
+  typedef flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t sw_bank_cfg_t;
+  typedef flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t sw_region_cfg_t;
+  typedef flash_ctrl_reg2hw_default_region_shadowed_reg_t sw_default_cfg_t;
+  typedef flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t sw_info_cfg_t;
+
   // alias for super long reg_pkg typedef
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t info_page_cfg_t;
-  typedef flash_ctrl_reg_pkg::flash_ctrl_reg2hw_mp_region_cfg_mreg_t mp_region_cfg_t;
+  typedef struct packed {
+    logic        q;
+  } bank_cfg_t;
+
+  // This is identical to the reg structures but do not have err_updates / storage
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
+      logic        q;
+    } he_en;
+  } info_page_cfg_t;
+
+  // This is identical to the reg structures but do not have err_updates / storage
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } en;
+    struct packed {
+      logic        q;
+    } rd_en;
+    struct packed {
+      logic        q;
+    } prog_en;
+    struct packed {
+      logic        q;
+    } erase_en;
+    struct packed {
+      logic        q;
+    } scramble_en;
+    struct packed {
+      logic        q;
+    } ecc_en;
+    struct packed {
+      logic        q;
+    } he_en;
+    struct packed {
+      logic [8:0]  q;
+    } base;
+    struct packed {
+      logic [9:0] q;
+    } size;
+  } mp_region_cfg_t;
 
   // memory protection specific structs
   typedef struct packed {

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -163,201 +163,317 @@ package flash_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
     struct packed {
       logic [8:0]  q;
+      logic        err_update;
+      logic        err_storage;
     } base;
     struct packed {
       logic [9:0] q;
+      logic        err_update;
+      logic        err_storage;
     } size;
-  } flash_ctrl_reg2hw_mp_region_cfg_mreg_t;
+  } flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_default_region_reg_t;
+  } flash_ctrl_reg2hw_default_region_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } rd_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } prog_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } erase_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } scramble_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } ecc_en;
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } he_en;
-  } flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t;
+  } flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     logic        q;
-  } flash_ctrl_reg2hw_mp_bank_cfg_mreg_t;
+    logic        err_update;
+    logic        err_storage;
+  } flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -387,6 +503,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } lcmgr_err;
+    struct packed {
+      logic        q;
+    } storage_err;
   } flash_ctrl_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -525,6 +644,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } flash_phy_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } update_err;
   } flash_ctrl_hw2reg_err_code_reg_t;
 
   typedef struct packed {
@@ -564,6 +687,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } lcmgr_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } storage_err;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -598,26 +725,32 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [553:548]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [547:542]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [541:530]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [529:526]
-    flash_ctrl_reg2hw_flash_disable_reg_t flash_disable; // [525:525]
-    flash_ctrl_reg2hw_init_reg_t init; // [524:524]
-    flash_ctrl_reg2hw_control_reg_t control; // [523:504]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [503:472]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [471:470]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [469:469]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [468:261]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [260:255]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [254:185]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [184:178]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [177:164]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [163:94]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [93:87]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [86:73]
-    flash_ctrl_reg2hw_mp_bank_cfg_mreg_t [1:0] mp_bank_cfg; // [72:71]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:62]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [554:549]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [548:543]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [542:531]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [530:527]
+    flash_ctrl_reg2hw_flash_disable_reg_t flash_disable; // [526:526]
+    flash_ctrl_reg2hw_init_reg_t init; // [525:525]
+    flash_ctrl_reg2hw_control_reg_t control; // [524:505]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [504:473]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [472:471]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [470:470]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [469:262]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [261:256]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
+        bank0_info0_page_cfg_shadowed; // [255:186]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
+        bank0_info1_page_cfg_shadowed; // [185:179]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
+        bank0_info2_page_cfg_shadowed; // [178:165]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
+        bank1_info0_page_cfg_shadowed; // [164:95]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
+        bank1_info1_page_cfg_shadowed; // [94:88]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
+        bank1_info2_page_cfg_shadowed; // [87:74]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [73:72]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [71:62]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [61:46]
     flash_ctrl_reg2hw_phy_err_cfg_reg_t phy_err_cfg; // [45:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -628,14 +761,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [159:148]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [147:147]
-    flash_ctrl_hw2reg_control_reg_t control; // [146:145]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [144:143]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [142:139]
-    flash_ctrl_hw2reg_status_reg_t status; // [138:129]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [128:117]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [116:99]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [163:152]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [151:151]
+    flash_ctrl_hw2reg_control_reg_t control; // [150:149]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [148:147]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [146:143]
+    flash_ctrl_hw2reg_status_reg_t status; // [142:133]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [132:119]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [118:99]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [98:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [47:6]
@@ -662,15 +795,15 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_5_OFFSET = 9'h 40;
   parameter logic [CoreAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_6_OFFSET = 9'h 44;
   parameter logic [CoreAw-1:0] FLASH_CTRL_REGION_CFG_REGWEN_7_OFFSET = 9'h 48;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_0_OFFSET = 9'h 4c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_1_OFFSET = 9'h 50;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_2_OFFSET = 9'h 54;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_3_OFFSET = 9'h 58;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_4_OFFSET = 9'h 5c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_5_OFFSET = 9'h 60;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_6_OFFSET = 9'h 64;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_7_OFFSET = 9'h 68;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_DEFAULT_REGION_OFFSET = 9'h 6c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_OFFSET = 9'h 4c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_1_OFFSET = 9'h 50;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_2_OFFSET = 9'h 54;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_3_OFFSET = 9'h 58;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_4_OFFSET = 9'h 5c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_5_OFFSET = 9'h 60;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_6_OFFSET = 9'h 64;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_REGION_CFG_SHADOWED_7_OFFSET = 9'h 68;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_DEFAULT_REGION_SHADOWED_OFFSET = 9'h 6c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_0_OFFSET = 9'h 70;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_1_OFFSET = 9'h 74;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_2_OFFSET = 9'h 78;
@@ -681,22 +814,22 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_7_OFFSET = 9'h 8c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_8_OFFSET = 9'h 90;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_REGWEN_9_OFFSET = 9'h 94;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_OFFSET = 9'h 98;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1_OFFSET = 9'h 9c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2_OFFSET = 9'h a0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3_OFFSET = 9'h a4;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4_OFFSET = 9'h a8;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5_OFFSET = 9'h ac;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6_OFFSET = 9'h b0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7_OFFSET = 9'h b4;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8_OFFSET = 9'h b8;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9_OFFSET = 9'h bc;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_OFFSET = 9'h 98;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1_OFFSET = 9'h 9c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2_OFFSET = 9'h a0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3_OFFSET = 9'h a4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4_OFFSET = 9'h a8;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5_OFFSET = 9'h ac;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6_OFFSET = 9'h b0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7_OFFSET = 9'h b4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8_OFFSET = 9'h b8;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9_OFFSET = 9'h bc;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO1_REGWEN_OFFSET = 9'h c0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_OFFSET = 9'h c4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED_OFFSET = 9'h c4;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_0_OFFSET = 9'h c8;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_REGWEN_1_OFFSET = 9'h cc;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0_OFFSET = 9'h d0;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1_OFFSET = 9'h d4;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0_OFFSET = 9'h d0;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1_OFFSET = 9'h d4;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_0_OFFSET = 9'h d8;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_1_OFFSET = 9'h dc;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_2_OFFSET = 9'h e0;
@@ -707,24 +840,24 @@ package flash_ctrl_reg_pkg;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_7_OFFSET = 9'h f4;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_8_OFFSET = 9'h f8;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_REGWEN_9_OFFSET = 9'h fc;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_OFFSET = 9'h 100;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1_OFFSET = 9'h 104;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2_OFFSET = 9'h 108;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3_OFFSET = 9'h 10c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4_OFFSET = 9'h 110;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5_OFFSET = 9'h 114;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6_OFFSET = 9'h 118;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7_OFFSET = 9'h 11c;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8_OFFSET = 9'h 120;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9_OFFSET = 9'h 124;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0_OFFSET = 9'h 100;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1_OFFSET = 9'h 104;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2_OFFSET = 9'h 108;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3_OFFSET = 9'h 10c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4_OFFSET = 9'h 110;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5_OFFSET = 9'h 114;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6_OFFSET = 9'h 118;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7_OFFSET = 9'h 11c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8_OFFSET = 9'h 120;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9_OFFSET = 9'h 124;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO1_REGWEN_OFFSET = 9'h 128;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_OFFSET = 9'h 12c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED_OFFSET = 9'h 12c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_0_OFFSET = 9'h 130;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_REGWEN_1_OFFSET = 9'h 134;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0_OFFSET = 9'h 138;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1_OFFSET = 9'h 13c;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0_OFFSET = 9'h 138;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1_OFFSET = 9'h 13c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_BANK_CFG_REGWEN_OFFSET = 9'h 140;
-  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_BANK_CFG_OFFSET = 9'h 144;
+  parameter logic [CoreAw-1:0] FLASH_CTRL_MP_BANK_CFG_SHADOWED_OFFSET = 9'h 144;
   parameter logic [CoreAw-1:0] FLASH_CTRL_OP_STATUS_OFFSET = 9'h 148;
   parameter logic [CoreAw-1:0] FLASH_CTRL_STATUS_OFFSET = 9'h 14c;
   parameter logic [CoreAw-1:0] FLASH_CTRL_ERR_CODE_OFFSET = 9'h 150;
@@ -782,15 +915,15 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_REGION_CFG_REGWEN_5,
     FLASH_CTRL_REGION_CFG_REGWEN_6,
     FLASH_CTRL_REGION_CFG_REGWEN_7,
-    FLASH_CTRL_MP_REGION_CFG_0,
-    FLASH_CTRL_MP_REGION_CFG_1,
-    FLASH_CTRL_MP_REGION_CFG_2,
-    FLASH_CTRL_MP_REGION_CFG_3,
-    FLASH_CTRL_MP_REGION_CFG_4,
-    FLASH_CTRL_MP_REGION_CFG_5,
-    FLASH_CTRL_MP_REGION_CFG_6,
-    FLASH_CTRL_MP_REGION_CFG_7,
-    FLASH_CTRL_DEFAULT_REGION,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_0,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_1,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_2,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_3,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_4,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_5,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_6,
+    FLASH_CTRL_MP_REGION_CFG_SHADOWED_7,
+    FLASH_CTRL_DEFAULT_REGION_SHADOWED,
     FLASH_CTRL_BANK0_INFO0_REGWEN_0,
     FLASH_CTRL_BANK0_INFO0_REGWEN_1,
     FLASH_CTRL_BANK0_INFO0_REGWEN_2,
@@ -801,22 +934,22 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_BANK0_INFO0_REGWEN_7,
     FLASH_CTRL_BANK0_INFO0_REGWEN_8,
     FLASH_CTRL_BANK0_INFO0_REGWEN_9,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8,
-    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8,
+    FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9,
     FLASH_CTRL_BANK0_INFO1_REGWEN,
-    FLASH_CTRL_BANK0_INFO1_PAGE_CFG,
+    FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED,
     FLASH_CTRL_BANK0_INFO2_REGWEN_0,
     FLASH_CTRL_BANK0_INFO2_REGWEN_1,
-    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0,
-    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1,
+    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1,
     FLASH_CTRL_BANK1_INFO0_REGWEN_0,
     FLASH_CTRL_BANK1_INFO0_REGWEN_1,
     FLASH_CTRL_BANK1_INFO0_REGWEN_2,
@@ -827,24 +960,24 @@ package flash_ctrl_reg_pkg;
     FLASH_CTRL_BANK1_INFO0_REGWEN_7,
     FLASH_CTRL_BANK1_INFO0_REGWEN_8,
     FLASH_CTRL_BANK1_INFO0_REGWEN_9,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8,
-    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8,
+    FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9,
     FLASH_CTRL_BANK1_INFO1_REGWEN,
-    FLASH_CTRL_BANK1_INFO1_PAGE_CFG,
+    FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED,
     FLASH_CTRL_BANK1_INFO2_REGWEN_0,
     FLASH_CTRL_BANK1_INFO2_REGWEN_1,
-    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0,
-    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1,
+    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0,
+    FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1,
     FLASH_CTRL_BANK_CFG_REGWEN,
-    FLASH_CTRL_MP_BANK_CFG,
+    FLASH_CTRL_MP_BANK_CFG_SHADOWED,
     FLASH_CTRL_OP_STATUS,
     FLASH_CTRL_STATUS,
     FLASH_CTRL_ERR_CODE,
@@ -883,15 +1016,15 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[16] FLASH_CTRL_REGION_CFG_REGWEN_5
     4'b 0001, // index[17] FLASH_CTRL_REGION_CFG_REGWEN_6
     4'b 0001, // index[18] FLASH_CTRL_REGION_CFG_REGWEN_7
-    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_0
-    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_1
-    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_2
-    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_3
-    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_4
-    4'b 1111, // index[24] FLASH_CTRL_MP_REGION_CFG_5
-    4'b 1111, // index[25] FLASH_CTRL_MP_REGION_CFG_6
-    4'b 1111, // index[26] FLASH_CTRL_MP_REGION_CFG_7
-    4'b 0001, // index[27] FLASH_CTRL_DEFAULT_REGION
+    4'b 1111, // index[19] FLASH_CTRL_MP_REGION_CFG_SHADOWED_0
+    4'b 1111, // index[20] FLASH_CTRL_MP_REGION_CFG_SHADOWED_1
+    4'b 1111, // index[21] FLASH_CTRL_MP_REGION_CFG_SHADOWED_2
+    4'b 1111, // index[22] FLASH_CTRL_MP_REGION_CFG_SHADOWED_3
+    4'b 1111, // index[23] FLASH_CTRL_MP_REGION_CFG_SHADOWED_4
+    4'b 1111, // index[24] FLASH_CTRL_MP_REGION_CFG_SHADOWED_5
+    4'b 1111, // index[25] FLASH_CTRL_MP_REGION_CFG_SHADOWED_6
+    4'b 1111, // index[26] FLASH_CTRL_MP_REGION_CFG_SHADOWED_7
+    4'b 0001, // index[27] FLASH_CTRL_DEFAULT_REGION_SHADOWED
     4'b 0001, // index[28] FLASH_CTRL_BANK0_INFO0_REGWEN_0
     4'b 0001, // index[29] FLASH_CTRL_BANK0_INFO0_REGWEN_1
     4'b 0001, // index[30] FLASH_CTRL_BANK0_INFO0_REGWEN_2
@@ -902,22 +1035,22 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[35] FLASH_CTRL_BANK0_INFO0_REGWEN_7
     4'b 0001, // index[36] FLASH_CTRL_BANK0_INFO0_REGWEN_8
     4'b 0001, // index[37] FLASH_CTRL_BANK0_INFO0_REGWEN_9
-    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0
-    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_1
-    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_2
-    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_3
-    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_4
-    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_5
-    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_6
-    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_7
-    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_8
-    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_9
+    4'b 0001, // index[38] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[39] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_1
+    4'b 0001, // index[40] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_2
+    4'b 0001, // index[41] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_3
+    4'b 0001, // index[42] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_4
+    4'b 0001, // index[43] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_5
+    4'b 0001, // index[44] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_6
+    4'b 0001, // index[45] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_7
+    4'b 0001, // index[46] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_8
+    4'b 0001, // index[47] FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_9
     4'b 0001, // index[48] FLASH_CTRL_BANK0_INFO1_REGWEN
-    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO1_PAGE_CFG
+    4'b 0001, // index[49] FLASH_CTRL_BANK0_INFO1_PAGE_CFG_SHADOWED
     4'b 0001, // index[50] FLASH_CTRL_BANK0_INFO2_REGWEN_0
     4'b 0001, // index[51] FLASH_CTRL_BANK0_INFO2_REGWEN_1
-    4'b 0001, // index[52] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_0
-    4'b 0001, // index[53] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_1
+    4'b 0001, // index[52] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[53] FLASH_CTRL_BANK0_INFO2_PAGE_CFG_SHADOWED_1
     4'b 0001, // index[54] FLASH_CTRL_BANK1_INFO0_REGWEN_0
     4'b 0001, // index[55] FLASH_CTRL_BANK1_INFO0_REGWEN_1
     4'b 0001, // index[56] FLASH_CTRL_BANK1_INFO0_REGWEN_2
@@ -928,24 +1061,24 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[61] FLASH_CTRL_BANK1_INFO0_REGWEN_7
     4'b 0001, // index[62] FLASH_CTRL_BANK1_INFO0_REGWEN_8
     4'b 0001, // index[63] FLASH_CTRL_BANK1_INFO0_REGWEN_9
-    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0
-    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_1
-    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_2
-    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_3
-    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_4
-    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_5
-    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_6
-    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_7
-    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_8
-    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_9
+    4'b 0001, // index[64] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[65] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_1
+    4'b 0001, // index[66] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_2
+    4'b 0001, // index[67] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_3
+    4'b 0001, // index[68] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_4
+    4'b 0001, // index[69] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_5
+    4'b 0001, // index[70] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_6
+    4'b 0001, // index[71] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_7
+    4'b 0001, // index[72] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_8
+    4'b 0001, // index[73] FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_9
     4'b 0001, // index[74] FLASH_CTRL_BANK1_INFO1_REGWEN
-    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO1_PAGE_CFG
+    4'b 0001, // index[75] FLASH_CTRL_BANK1_INFO1_PAGE_CFG_SHADOWED
     4'b 0001, // index[76] FLASH_CTRL_BANK1_INFO2_REGWEN_0
     4'b 0001, // index[77] FLASH_CTRL_BANK1_INFO2_REGWEN_1
-    4'b 0001, // index[78] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_0
-    4'b 0001, // index[79] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_1
+    4'b 0001, // index[78] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_0
+    4'b 0001, // index[79] FLASH_CTRL_BANK1_INFO2_PAGE_CFG_SHADOWED_1
     4'b 0001, // index[80] FLASH_CTRL_BANK_CFG_REGWEN
-    4'b 0001, // index[81] FLASH_CTRL_MP_BANK_CFG
+    4'b 0001, // index[81] FLASH_CTRL_MP_BANK_CFG_SHADOWED
     4'b 0001, // index[82] FLASH_CTRL_OP_STATUS
     4'b 0001, // index[83] FLASH_CTRL_STATUS
     4'b 0001, // index[84] FLASH_CTRL_ERR_CODE

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv
@@ -1,0 +1,260 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// ------------------- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! -------------------//
+// PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Flash control region configuration processing
+//
+// There are two main purpose of this module:
+// 1. strip the error conditions away from reg packages (see #8282)
+// 2. generate shadow update and storage errors
+
+module flash_ctrl_region_cfg
+  import flash_ctrl_pkg::*;
+  import flash_ctrl_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+  input lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en_i,
+  input sw_bank_cfg_t [NumBanks-1:0] bank_cfg_i,
+  input sw_region_cfg_t [MpRegions-1:0] region_cfg_i,
+  input sw_default_cfg_t default_cfg_i,
+  input sw_info_cfg_t [NumInfos0-1:0] bank0_info0_cfg_i,
+  input sw_info_cfg_t [NumInfos1-1:0] bank0_info1_cfg_i,
+  input sw_info_cfg_t [NumInfos2-1:0] bank0_info2_cfg_i,
+  input sw_info_cfg_t [NumInfos0-1:0] bank1_info0_cfg_i,
+  input sw_info_cfg_t [NumInfos1-1:0] bank1_info1_cfg_i,
+  input sw_info_cfg_t [NumInfos2-1:0] bank1_info2_cfg_i,
+
+  output bank_cfg_t [NumBanks-1:0] bank_cfg_o,
+  output mp_region_cfg_t [MpRegions:0] region_cfgs_o,
+  output info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_page_cfgs_o,
+
+  output logic update_err_o,
+  output logic storage_err_o
+);
+
+  //////////////////////////////////////
+  // Life cycle synchronizer
+  //////////////////////////////////////
+
+  lc_ctrl_pkg::lc_tx_t lc_creator_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_owner_seed_sw_rw_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_rd_en;
+  lc_ctrl_pkg::lc_tx_t lc_iso_part_sw_wr_en;
+
+  // synchronize enables into local domain
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_creator_seed_sw_rw_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_creator_seed_sw_rw_en_i),
+    .lc_en_o(lc_creator_seed_sw_rw_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_owner_seed_sw_rw_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_owner_seed_sw_rw_en_i),
+    .lc_en_o(lc_owner_seed_sw_rw_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_iso_part_sw_rd_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_iso_part_sw_rd_en_i),
+    .lc_en_o(lc_iso_part_sw_rd_en)
+  );
+
+  prim_lc_sync #(
+    .NumCopies(1)
+  ) u_lc_iso_part_sw_wr_en_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_iso_part_sw_wr_en_i),
+    .lc_en_o(lc_iso_part_sw_wr_en)
+  );
+
+  //////////////////////////////////////
+  // Bank speicfic configuration
+  //////////////////////////////////////
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_cfg
+    assign bank_cfg_o[i].q = bank_cfg_i[i].q;
+  end
+
+  //////////////////////////////////////
+  // Data partition regions
+  //////////////////////////////////////
+  // extra region is the default region
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_mp_regions
+    assign region_cfgs_o[i].base.q        = region_cfg_i[i].base.q;
+    assign region_cfgs_o[i].size.q        = region_cfg_i[i].size.q;
+    assign region_cfgs_o[i].en.q          = region_cfg_i[i].en.q;
+    assign region_cfgs_o[i].rd_en.q       = region_cfg_i[i].rd_en.q;
+    assign region_cfgs_o[i].prog_en.q     = region_cfg_i[i].prog_en.q;
+    assign region_cfgs_o[i].erase_en.q    = region_cfg_i[i].erase_en.q;
+    assign region_cfgs_o[i].scramble_en.q = region_cfg_i[i].scramble_en.q;
+    assign region_cfgs_o[i].ecc_en.q      = region_cfg_i[i].ecc_en.q;
+    assign region_cfgs_o[i].he_en.q       = region_cfg_i[i].he_en.q;
+  end
+
+  //default region
+  assign region_cfgs_o[MpRegions].base.q        = '0;
+  assign region_cfgs_o[MpRegions].size.q        = NumBanks * PagesPerBank;
+  assign region_cfgs_o[MpRegions].en.q          = 1'b1;
+  assign region_cfgs_o[MpRegions].rd_en.q       = default_cfg_i.rd_en.q;
+  assign region_cfgs_o[MpRegions].prog_en.q     = default_cfg_i.prog_en.q;
+  assign region_cfgs_o[MpRegions].erase_en.q    = default_cfg_i.erase_en.q;
+  assign region_cfgs_o[MpRegions].scramble_en.q = default_cfg_i.scramble_en.q;
+  assign region_cfgs_o[MpRegions].ecc_en.q      = default_cfg_i.ecc_en.q;
+  assign region_cfgs_o[MpRegions].he_en.q       = default_cfg_i.he_en.q;
+
+  //////////////////////////////////////
+  // Info partition properties configuration
+  //////////////////////////////////////
+  sw_info_cfg_t   [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] sw_info_cfgs;
+  info_page_cfg_t [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_cfgs;
+  localparam int InfoBits = $bits(sw_info_cfg_t) * InfosPerBank;
+
+  // transform from unique names reg output to structure
+  // Not all types have the maximum number of banks, so those are packed to 0
+  assign sw_info_cfgs[0][0] = InfoBits'(bank0_info0_cfg_i);
+  assign sw_info_cfgs[0][1] = InfoBits'(bank0_info1_cfg_i);
+  assign sw_info_cfgs[0][2] = InfoBits'(bank0_info2_cfg_i);
+  assign sw_info_cfgs[1][0] = InfoBits'(bank1_info0_cfg_i);
+  assign sw_info_cfgs[1][1] = InfoBits'(bank1_info1_cfg_i);
+  assign sw_info_cfgs[1][2] = InfoBits'(bank1_info2_cfg_i);
+
+  // strip error indications
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_cfg_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_cfg_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_cfg_page
+        assign info_cfgs[i][j][k].en.q = sw_info_cfgs[i][j][k].en.q;
+        assign info_cfgs[i][j][k].rd_en.q = sw_info_cfgs[i][j][k].rd_en.q;
+        assign info_cfgs[i][j][k].prog_en.q = sw_info_cfgs[i][j][k].prog_en.q;
+        assign info_cfgs[i][j][k].erase_en.q = sw_info_cfgs[i][j][k].erase_en.q;
+        assign info_cfgs[i][j][k].scramble_en.q = sw_info_cfgs[i][j][k].scramble_en.q;
+        assign info_cfgs[i][j][k].ecc_en.q = sw_info_cfgs[i][j][k].ecc_en.q;
+        assign info_cfgs[i][j][k].he_en.q = sw_info_cfgs[i][j][k].he_en.q;
+      end
+    end
+  end
+
+  // qualify software settings with creator / owner privileges
+  for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
+      flash_ctrl_info_cfg # (
+        .Bank(i),
+        .InfoSel(j)
+      ) u_info_cfg (
+        .cfgs_i(info_cfgs[i][j]),
+        .creator_seed_priv_i(lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On),
+        .owner_seed_priv_i(lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On),
+        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
+        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .cfgs_o(info_page_cfgs_o[i][j])
+      );
+    end
+  end
+
+  //////////////////////////////////////
+  // Update / storage error generation
+  //////////////////////////////////////
+
+  // shadow errors and faults
+  logic [NumBanks-1:0] bank_update_err, bank_store_err;
+  logic [MpRegions-1:0] data_update_err, data_store_err;
+  logic default_update_err, default_store_err;
+  logic [NumBanks-1:0][InfoTypes-1:0][InfosPerBank-1:0] info_update_err, info_store_err;
+
+  assign update_err_o = |data_update_err |
+                        |default_update_err |
+                        |info_update_err |
+                        |bank_update_err;
+
+  assign storage_err_o = |data_store_err |
+                         |default_store_err |
+                         |info_store_err |
+                         |bank_store_err;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_bank_err
+    assign bank_update_err[i] = bank_cfg_i[i].err_update;
+    assign bank_store_err[i] = bank_cfg_i[i].err_storage;
+  end
+
+  for (genvar i = 0; i < MpRegions; i++) begin : gen_data_err
+    assign data_update_err[i] = region_cfg_i[i].base.err_update |
+                                region_cfg_i[i].size.err_update |
+                                region_cfg_i[i].en.err_update |
+                                region_cfg_i[i].rd_en.err_update |
+                                region_cfg_i[i].prog_en.err_update |
+                                region_cfg_i[i].erase_en.err_update |
+                                region_cfg_i[i].scramble_en.err_update |
+                                region_cfg_i[i].ecc_en.err_update |
+                                region_cfg_i[i].he_en.err_update;
+
+    assign data_store_err[i] = region_cfg_i[i].base.err_storage |
+                               region_cfg_i[i].size.err_storage |
+                               region_cfg_i[i].en.err_storage |
+                               region_cfg_i[i].rd_en.err_storage |
+                               region_cfg_i[i].prog_en.err_storage |
+                               region_cfg_i[i].erase_en.err_storage |
+                               region_cfg_i[i].scramble_en.err_storage |
+                               region_cfg_i[i].ecc_en.err_storage |
+                               region_cfg_i[i].he_en.err_storage;
+  end
+
+  assign default_update_err =  default_cfg_i.rd_en.err_update |
+                               default_cfg_i.prog_en.err_update |
+                               default_cfg_i.erase_en.err_update |
+                               default_cfg_i.scramble_en.err_update |
+                               default_cfg_i.ecc_en.err_update |
+                               default_cfg_i.he_en.err_update;
+
+  assign default_store_err =  default_cfg_i.rd_en.err_storage |
+                              default_cfg_i.prog_en.err_storage |
+                              default_cfg_i.erase_en.err_storage |
+                              default_cfg_i.scramble_en.err_storage |
+                              default_cfg_i.ecc_en.err_storage |
+                              default_cfg_i.he_en.err_storage;
+
+  for (genvar i = 0; i < NumBanks; i++) begin : gen_info_err_bank
+    for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_err_type
+      for (genvar k = 0; k < InfosPerBank; k++) begin : gen_info_err_page
+        assign info_update_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_update |
+                                          sw_info_cfgs[i][j][k].rd_en.err_update |
+                                          sw_info_cfgs[i][j][k].prog_en.err_update |
+                                          sw_info_cfgs[i][j][k].erase_en.err_update |
+                                          sw_info_cfgs[i][j][k].scramble_en.err_update |
+                                          sw_info_cfgs[i][j][k].ecc_en.err_update |
+                                          sw_info_cfgs[i][j][k].he_en.err_update;
+
+        assign info_store_err[i][j][k] = sw_info_cfgs[i][j][k].en.err_storage |
+                                         sw_info_cfgs[i][j][k].rd_en.err_storage |
+                                         sw_info_cfgs[i][j][k].prog_en.err_storage |
+                                         sw_info_cfgs[i][j][k].erase_en.err_storage |
+                                         sw_info_cfgs[i][j][k].scramble_en.err_storage |
+                                         sw_info_cfgs[i][j][k].ecc_en.err_storage |
+                                         sw_info_cfgs[i][j][k].he_en.err_storage;
+      end
+    end
+  end
+
+  //////////////////////////////////////
+  // unused
+  //////////////////////////////////////
+
+endmodule // flash_ctrl_reg_wrap

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -495,7 +495,7 @@ module rstmgr
   assign rst_en_o.rst_por_usb[Domain0Sel] = lc_ctrl_pkg::On;
   // Generating resets for lc
   // Power Domains: ['0']
-  // Shadowed: False
+  // Shadowed: True
   logic [PowerDomains-1:0] rst_lc_n;
   assign rst_lc_n[DomainAonSel] = 1'b0;
   assign resets_o.rst_lc_n[DomainAonSel] = rst_lc_n[DomainAonSel];
@@ -527,6 +527,38 @@ module rstmgr
     .rst_ni(rst_lc_n[Domain0Sel]),
     .lc_en_i(lc_ctrl_pkg::Off),
     .lc_en_o(rst_en_o.rst_lc[Domain0Sel])
+  );
+  logic [PowerDomains-1:0] rst_lc_shadowed_n;
+  assign rst_lc_shadowed_n[DomainAonSel] = 1'b0;
+  assign resets_o.rst_lc_shadowed_n[DomainAonSel] = rst_lc_shadowed_n[DomainAonSel];
+  assign rst_en_o.rst_lc_shadowed[DomainAonSel] = lc_ctrl_pkg::On;
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_0_lc_shadowed (
+    .clk_i(clk_main_i),
+    .rst_ni(rst_lc_src_n[Domain0Sel]),
+    .d_i(1'b1),
+    .q_o(rst_lc_shadowed_n[Domain0Sel])
+  );
+
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_0_lc_shadowed_mux (
+    .clk0_i(rst_lc_shadowed_n[Domain0Sel]),
+    .clk1_i(scan_rst_ni),
+    .sel_i(leaf_rst_scanmode[5] == lc_ctrl_pkg::On),
+    .clk_o(resets_o.rst_lc_shadowed_n[Domain0Sel])
+  );
+
+  // reset asserted indication for alert handler
+  prim_lc_sender #(
+    .ResetValueIsOn(1)
+  ) u_prim_lc_sender_lc_shadowed_domain_0 (
+    .clk_i(clk_main_i),
+    .rst_ni(rst_lc_shadowed_n[Domain0Sel]),
+    .lc_en_i(lc_ctrl_pkg::Off),
+    .lc_en_o(rst_en_o.rst_lc_shadowed[Domain0Sel])
   );
   // Generating resets for lc_io_div4
   // Power Domains: ['0', 'Aon']

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -42,6 +42,7 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_por_io_div2_n;
     logic [PowerDomains-1:0] rst_por_io_div4_n;
     logic [PowerDomains-1:0] rst_por_usb_n;
+    logic [PowerDomains-1:0] rst_lc_shadowed_n;
     logic [PowerDomains-1:0] rst_lc_n;
     logic [PowerDomains-1:0] rst_lc_io_div4_shadowed_n;
     logic [PowerDomains-1:0] rst_lc_io_div4_n;
@@ -70,6 +71,7 @@ package rstmgr_pkg;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_por_io_div2;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_por_io_div4;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_por_usb;
+    lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_lc_shadowed;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_lc;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_lc_io_div4_shadowed;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_lc_io_div4;
@@ -90,7 +92,7 @@ package rstmgr_pkg;
     lc_ctrl_pkg::lc_tx_t [PowerDomains-1:0] rst_i2c2;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 24 * PowerDomains;
+  parameter int NumOutputRst = 25 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1901,6 +1901,7 @@ module top_earlgrey #(
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_main_infra),
       .clk_otp_i (clkmgr_aon_clocks.clk_io_div4_infra),
+      .rst_shadowed_ni (rstmgr_aon_resets.rst_lc_shadowed_n[rstmgr_pkg::Domain0Sel]),
       .rst_ni (rstmgr_aon_resets.rst_lc_n[rstmgr_pkg::Domain0Sel]),
       .rst_otp_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );

--- a/sw/device/lib/flash_ctrl.c
+++ b/sw/device/lib/flash_ctrl.c
@@ -9,6 +9,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 #define FLASH_CTRL0_BASE_ADDR TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
+
 #define PROGRAM_RESOLUTION_WORDS \
   (FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t))
 
@@ -29,14 +30,20 @@ typedef enum erase_type {
 
 /* Wait for flash command to complete and set ACK in controller */
 static inline void wait_done_and_ack(void) {
-  while ((REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_OP_STATUS_REG_OFFSET) &
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
+
+  while ((mmio_region_read32(flash_ctrl_base, FLASH_CTRL_OP_STATUS_REG_OFFSET) &
           (1 << FLASH_CTRL_OP_STATUS_DONE_BIT)) == 0) {
   }
   REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_OP_STATUS_REG_OFFSET) = 0;
 }
 
 void flash_init_block(void) {
-  while ((REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_STATUS_REG_OFFSET) &
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
+
+  while ((mmio_region_read32(flash_ctrl_base, FLASH_CTRL_STATUS_REG_OFFSET) &
           (1 << FLASH_CTRL_STATUS_INIT_WIP_BIT)) > 0) {
   }
 }
@@ -170,56 +177,82 @@ int flash_read(uint32_t addr, part_type_t part, uint32_t size, uint32_t *data) {
 }
 
 void flash_cfg_bank_erase(bank_index_t bank, bool erase_en) {
-  REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_MP_BANK_CFG_REG_OFFSET) =
-      (erase_en) ? SETBIT(REG32(FLASH_CTRL0_BASE_ADDR +
-                                FLASH_CTRL_MP_BANK_CFG_REG_OFFSET),
-                          bank)
-                 : CLRBIT(REG32(FLASH_CTRL0_BASE_ADDR +
-                                FLASH_CTRL_MP_BANK_CFG_REG_OFFSET),
-                          bank);
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
+
+  uint32_t val =
+      (erase_en)
+          ? SETBIT(
+                mmio_region_read32(flash_ctrl_base,
+                                   FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET),
+                bank)
+          : CLRBIT(
+                mmio_region_read32(flash_ctrl_base,
+                                   FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET),
+                bank);
+
+  mmio_region_write32_shadowed(flash_ctrl_base,
+                               FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET, val);
 }
 
 void flash_default_region_access(bool rd_en, bool prog_en, bool erase_en) {
-  REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET) =
-      rd_en << FLASH_CTRL_DEFAULT_REGION_RD_EN_BIT |
-      prog_en << FLASH_CTRL_DEFAULT_REGION_PROG_EN_BIT |
-      erase_en << FLASH_CTRL_DEFAULT_REGION_ERASE_EN_BIT;
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
+
+  mmio_region_write32_shadowed(
+      flash_ctrl_base, FLASH_CTRL_DEFAULT_REGION_SHADOWED_REG_OFFSET,
+      rd_en << FLASH_CTRL_DEFAULT_REGION_SHADOWED_RD_EN_BIT |
+          prog_en << FLASH_CTRL_DEFAULT_REGION_SHADOWED_PROG_EN_BIT |
+          erase_en << FLASH_CTRL_DEFAULT_REGION_SHADOWED_ERASE_EN_BIT);
 }
 
 void flash_cfg_region(const mp_region_t *region_cfg) {
   uint32_t reg_value;
   bank_index_t bank_sel;
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
 
   if (region_cfg->part == kDataPartition) {
-    REG32(FLASH_CTRL0_BASE_ADDR + FLASH_CTRL_MP_REGION_CFG_0_REG_OFFSET +
-          region_cfg->num * 4) =
-        region_cfg->base << FLASH_CTRL_MP_REGION_CFG_0_BASE_0_OFFSET |
-        region_cfg->size << FLASH_CTRL_MP_REGION_CFG_0_SIZE_0_OFFSET |
-        region_cfg->rd_en << FLASH_CTRL_MP_REGION_CFG_0_RD_EN_0_BIT |
-        region_cfg->prog_en << FLASH_CTRL_MP_REGION_CFG_0_PROG_EN_0_BIT |
-        region_cfg->erase_en << FLASH_CTRL_MP_REGION_CFG_0_ERASE_EN_0_BIT |
-        region_cfg->scramble_en
-            << FLASH_CTRL_MP_REGION_CFG_0_SCRAMBLE_EN_0_BIT |
-        0x1 << FLASH_CTRL_MP_REGION_CFG_0_EN_0_BIT;
+    mmio_region_write32_shadowed(
+        flash_ctrl_base,
+        FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_REG_OFFSET + region_cfg->num * 4,
+        region_cfg->base << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_BASE_0_OFFSET |
+            region_cfg->size
+                << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_SIZE_0_OFFSET |
+            region_cfg->rd_en
+                << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_RD_EN_0_BIT |
+            region_cfg->prog_en
+                << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_PROG_EN_0_BIT |
+            region_cfg->erase_en
+                << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_ERASE_EN_0_BIT |
+            region_cfg->scramble_en
+                << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_SCRAMBLE_EN_0_BIT |
+            0x1 << FLASH_CTRL_MP_REGION_CFG_SHADOWED_0_EN_0_BIT);
   } else if (region_cfg->part == kInfoPartition) {
     reg_value =
-        region_cfg->rd_en << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_RD_EN_0_BIT |
-        region_cfg->prog_en << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_PROG_EN_0_BIT |
+        region_cfg->rd_en
+            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_RD_EN_0_BIT |
+        region_cfg->prog_en
+            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_PROG_EN_0_BIT |
         region_cfg->erase_en
-            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_ERASE_EN_0_BIT |
+            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_ERASE_EN_0_BIT |
         region_cfg->scramble_en
-            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_SCRAMBLE_EN_0_BIT |
-        0x1 << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_EN_0_BIT;
+            << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_SCRAMBLE_EN_0_BIT |
+        0x1 << FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_EN_0_BIT;
 
     bank_sel = region_cfg->base / flash_get_pages_per_bank();
     if (bank_sel == FLASH_BANK_0) {
-      REG32(FLASH_CTRL0_BASE_ADDR +
-            FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_REG_OFFSET +
-            region_cfg->num * 4) = reg_value;
+      mmio_region_write32_shadowed(
+          flash_ctrl_base,
+          FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_REG_OFFSET +
+              region_cfg->num * 4,
+          reg_value);
     } else {
-      REG32(FLASH_CTRL0_BASE_ADDR +
-            FLASH_CTRL_BANK1_INFO0_PAGE_CFG_0_REG_OFFSET +
-            region_cfg->num * 4) = reg_value;
+      mmio_region_write32_shadowed(
+          flash_ctrl_base,
+          FLASH_CTRL_BANK1_INFO0_PAGE_CFG_SHADOWED_0_REG_OFFSET +
+              region_cfg->num * 4,
+          reg_value);
     }
   }
 }
@@ -249,12 +282,14 @@ uint32_t flash_read_scratch_reg(void) {
 }
 
 bool flash_get_init_status(void) {
-  mmio_region_t flash_base = mmio_region_from_addr(FLASH_CTRL0_BASE_ADDR);
-  return mmio_region_get_bit32(flash_base, FLASH_CTRL_STATUS_REG_OFFSET,
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
+  return mmio_region_get_bit32(flash_ctrl_base, FLASH_CTRL_STATUS_REG_OFFSET,
                                FLASH_CTRL_STATUS_INIT_WIP_BIT);
 }
 
 void flash_init(void) {
-  mmio_region_t flash_base = mmio_region_from_addr(FLASH_CTRL0_BASE_ADDR);
-  mmio_region_write32(flash_base, FLASH_CTRL_INIT_REG_OFFSET, 1);
+  mmio_region_t flash_ctrl_base =
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR);
+  mmio_region_write32(flash_ctrl_base, FLASH_CTRL_INIT_REG_OFFSET, 1);
 }

--- a/util/topgen-fusesoc.py
+++ b/util/topgen-fusesoc.py
@@ -150,6 +150,7 @@ def main():
                     'ip/clkmgr/rtl/autogen/clkmgr.sv',
                     'ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv',
                     'ip/flash_ctrl/rtl/autogen/flash_ctrl.sv',
+                    'ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv',
                     'ip/rstmgr/rtl/autogen/rstmgr_pkg.sv',
                     'ip/rstmgr/rtl/autogen/rstmgr.sv',
                     'ip/rv_plic/rtl/autogen/rv_plic.sv',

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -601,7 +601,10 @@ def generate_flash(topcfg, out_path):
     # Read template files from ip directory.
     tpls = []
     outputs = []
-    names = ['flash_ctrl.hjson', 'flash_ctrl.sv', 'flash_ctrl_pkg.sv']
+    names = ['flash_ctrl.hjson',
+             'flash_ctrl.sv',
+             'flash_ctrl_pkg.sv',
+             'flash_ctrl_region_cfg.sv']
 
     for x in names:
         tpls.append(tpl_path / Path(x + ".tpl"))


### PR DESCRIPTION
This PR just adds shadow registers to the "pmp"-like function of the flash controller.

Since there are a lot of registers, and the data needs to be manipulated, a new `region_cfg` module is created to make the code a bit more readeable.

`flash_ctrl.c` right now is in a bit of a terrible state because it's somewhere between really old code and a DIF.
I will clean it up separately in another PR to at least make it DIF-like in structure (though it will not qualify as a real DIF). 

The first 3 commits will be rebased away, and the the remaining ones will be squashed once reviews are complete. 

@rswarbrick this PR is the main reason that I wanted to separate the metadata structure from the primary data structure.
Let me know if you think there's a smarter way as well...