### PR TITLE
[alert_handler] Add support for low-power groups

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -25,8 +25,21 @@ class alert_monitor extends alert_esc_base_monitor;
     join_none
   endtask : run_phase
 
+  virtual task reset_thread();
+    forever begin
+      @(negedge cfg.vif.rst_n);
+      under_reset = 1;
+      @(posedge cfg.vif.rst_n);
+      // Reset signals at posedge rst_n to avoid race condition at negedge rst_n
+      reset_signals();
+      // Wait for alert init with an intentional integrity fail to finish.
+      wait (cfg.vif.monitor_cb.alert_tx_final.alert_p == cfg.vif.monitor_cb.alert_tx_final.alert_n);
+      wait (cfg.vif.monitor_cb.alert_tx_final.alert_p != cfg.vif.monitor_cb.alert_tx_final.alert_n);
+      under_reset = 0;
+    end
+  endtask : reset_thread
+
   virtual function void reset_signals();
-    under_reset = 1;
     under_ping_rsp = 0;
   endfunction : reset_signals
 

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -174,6 +174,16 @@ class alert_receiver_driver extends alert_esc_base_driver;
     cfg.vif.alert_rx_int.ping_n <= 1'b1;
     cfg.vif.alert_rx_int.ack_p <= 1'b0;
     cfg.vif.alert_rx_int.ack_n <= 1'b1;
+
+    // Drive alert init signal integrity error handshake.
+    repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
+    cfg.vif.alert_rx_int.ping_n <= 1'b0;
+    wait (cfg.vif.receiver_cb.alert_tx.alert_p == cfg.vif.receiver_cb.alert_tx.alert_n);
+    cfg.vif.alert_rx_int.ack_n <= 1'b0;
+    repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
+    cfg.vif.alert_rx_int.ack_n  <= 1'b1;
+    cfg.vif.alert_rx_int.ping_n <= 1'b1;
+    wait (cfg.vif.receiver_cb.alert_tx.alert_p != cfg.vif.receiver_cb.alert_tx.alert_n);
   endtask
 
 endclass : alert_receiver_driver

--- a/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_sender_driver.sv
@@ -24,6 +24,7 @@ class alert_sender_driver extends alert_esc_base_driver;
       @(posedge cfg.vif.rst_n);
       void'(alert_atomic.try_get(1));
       alert_atomic.put(1);
+      do_post_reset();
       under_reset = 0;
     end
   endtask
@@ -213,6 +214,17 @@ class alert_sender_driver extends alert_esc_base_driver;
 
   virtual task do_reset();
     cfg.vif.alert_tx_int.alert_p <= 1'b0;
+    cfg.vif.alert_tx_int.alert_n <= 1'b1;
+  endtask
+
+  // This task handles alert init request.
+  //
+  // After alert_receiver is reset, it will send a signal integrity fail via `ping_n` and `ack_n`,
+  // alert_sender acknowledged the init via sending an `alert_n` integrity fail.
+  virtual task do_post_reset();
+    wait (cfg.vif.alert_rx.ping_p == cfg.vif.alert_rx.ping_n);
+    cfg.vif.alert_tx_int.alert_n <= 1'b0;
+    wait (cfg.vif.alert_rx.ping_p != cfg.vif.alert_rx.ping_n);
     cfg.vif.alert_tx_int.alert_n <= 1'b1;
   endtask
 

--- a/hw/ip/alert_handler/alert_handler_component.core
+++ b/hw/ip/alert_handler/alert_handler_component.core
@@ -14,10 +14,13 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:prim:edn_req
       - lowrisc:prim:buf
+      - lowrisc:prim:lc_sync
+      - lowrisc:prim:lc_combine
       - "fileset_topgen ? (lowrisc:systems:topgen-reg-only)"
     files:
       - rtl/alert_pkg.sv
       - rtl/alert_handler_reg_wrap.sv
+      - rtl/alert_handler_lp_ctrl.sv
       - rtl/alert_handler_class.sv
       - rtl/alert_handler_ping_timer.sv
       - rtl/alert_handler_esc_timer.sv

--- a/hw/ip/alert_handler/data/alert_handler.hjson
+++ b/hw/ip/alert_handler/data/alert_handler.hjson
@@ -10,6 +10,8 @@
 #  - accu_cnt_dw: Width of accumulator
 #  - async_on:    Enables asynchronous sygnalling between specific alert RX/TX pairs
 #  - n_classes:   Number of supported classes (leave this at 4 at the moment)
+#  - n_lpg:       Number of low-power groups (LPGs)
+#  - lpg_map:     Defines a mapping from alerts to LPGs.
 
 {
   name: "ALERT_HANDLER",
@@ -41,6 +43,26 @@
       desc: "Number of alert channels.",
       type: "int",
       default: "4",
+      local: "true"
+    },
+    { name: "NLpg",
+      desc: "Number of LPGs.",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "NLpgWidth",
+      desc: "Width of LPG ID.",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "AlertLpgMap",
+      desc: '''
+            Defines a mapping from alerts to LPGs.
+            '''
+      type: "logic [NAlerts-1:0][NLpgWidth-1:0]",
+      default: "'0",
       local: "true"
     },
     { name: "EscCntDw",
@@ -298,7 +320,6 @@
                   desc:     '''Enable register for alerts.
                   ''',
                   count:    "NAlerts",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -325,7 +346,6 @@
                   desc:     '''Class assignment of alerts.
                   ''',
                   count:    "NAlerts",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -397,7 +417,6 @@
                   and "shadow reg storage error" (6).
                   ''',
                   count:    "N_LOC_ALERT",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",
@@ -426,7 +445,6 @@
                   and "shadow reg storage error" (6).
                   ''',
                   count:    "N_LOC_ALERT",
-                  compact:  "false",
                   shadowed: "true",
                   swaccess: "rw",
                   hwaccess: "hro",

--- a/hw/ip/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip/alert_handler/data/alert_handler.hjson.tpl
@@ -10,6 +10,8 @@
 #  - accu_cnt_dw: Width of accumulator
 #  - async_on:    Enables asynchronous sygnalling between specific alert RX/TX pairs
 #  - n_classes:   Number of supported classes (leave this at 4 at the moment)
+#  - n_lpg:       Number of low-power groups (LPGs)
+#  - lpg_map:     Defines a mapping from alerts to LPGs.
 <%
 import math
 chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
@@ -45,6 +47,26 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       desc: "Number of alert channels.",
       type: "int",
       default: "${n_alerts}",
+      local: "true"
+    },
+    { name: "NLpg",
+      desc: "Number of LPGs.",
+      type: "int",
+      default: "${n_lpg}",
+      local: "true"
+    },
+    { name: "NLpgWidth",
+      desc: "Width of LPG ID.",
+      type: "int",
+      default: "${n_lpg.bit_length()}",
+      local: "true"
+    },
+    { name: "AlertLpgMap",
+      desc: '''
+            Defines a mapping from alerts to LPGs.
+            '''
+      type: "logic [NAlerts-1:0][NLpgWidth-1:0]",
+      default: "${lpg_map}",
       local: "true"
     },
     { name: "EscCntDw",

--- a/hw/ip/alert_handler/dv/tb/tb.sv
+++ b/hw/ip/alert_handler/dv/tb/tb.sv
@@ -80,6 +80,9 @@ module tb;
     .intr_classb_o        ( interrupts[1] ),
     .intr_classc_o        ( interrupts[2] ),
     .intr_classd_o        ( interrupts[3] ),
+    // TODO(#8174): top-level integration for LPGs
+    .lpg_cg_en_i          ( {alert_pkg::NLpg{lc_ctrl_pkg::Off}} ),
+    .lpg_rst_en_i         ( {alert_pkg::NLpg{lc_ctrl_pkg::Off}} ),
     .crashdump_o          ( crashdump     ),
     .edn_o                ( edn_if.req    ),
     .edn_i                ( {edn_if.ack, edn_if.d_data} ),

--- a/hw/ip/alert_handler/rtl/alert_handler_lp_ctrl.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_lp_ctrl.sv
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module gathers and synchronizes the clock gating and reset indication signals for all
+// low-power groups (LPGs), synchronizes them to the alert handler clock domain.
+// The clock gating and reset indication signals are then logically OR'ed to produce one multibit
+// value for each LPG. The LPG multibit values are then mapped to the alert channels using
+// the AlertLpgMap parameter, and each multibit output value is buffered independently.
+//
+
+`include "prim_assert.sv"
+
+module alert_handler_lp_ctrl import alert_pkg::*; (
+  input  clk_i,
+  input  rst_ni,
+  // Low power clk and rst indication signals.
+  input  lc_ctrl_pkg::lc_tx_t [NLpg-1:0]    lpg_cg_en_i,
+  input  lc_ctrl_pkg::lc_tx_t [NLpg-1:0]    lpg_rst_en_i,
+  // Init requests going to the individual alert channels.
+  output lc_ctrl_pkg::lc_tx_t [NAlerts-1:0] init_trig_o
+);
+
+  ///////////////////////////////////////////////////
+  // Aggregate multibit indication signals per LPG //
+  ///////////////////////////////////////////////////
+
+  lc_ctrl_pkg::lc_tx_t [NLpg-1:0] lpg_init_trig;
+  for (genvar k = 0; k < NLpg; k++) begin : gen_lpgs
+
+    lc_ctrl_pkg::lc_tx_t [0:0] lpg_cg_en;
+    prim_lc_sync u_prim_lc_sync_clk_en (
+      .clk_i,
+      .rst_ni,
+      .lc_en_i(lpg_cg_en_i[k]),
+      .lc_en_o(lpg_cg_en)
+    );
+    lc_ctrl_pkg::lc_tx_t [0:0] lpg_rst_en;
+    prim_lc_sync u_prim_lc_sync_rst_en (
+      .clk_i,
+      .rst_ni,
+      .lc_en_i(lpg_rst_en_i[k]),
+      .lc_en_o(lpg_rst_en)
+    );
+
+    // Perform a logical OR operation of the multibit life cycle signals.
+    // I.e., if any of the incoming multibit signals is On, the output will also be On.
+    // Otherwise, the output may have any value other than On.
+    prim_lc_combine #(
+      .ActiveLow(0),  // Active Value is "On"
+      .CombineMode(0) // Combo mode is "OR"
+    ) u_prim_lc_combine (
+      .lc_en_a_i(lpg_cg_en[0]),
+      .lc_en_b_i(lpg_rst_en[0]),
+      .lc_en_o  (lpg_init_trig[k])
+    );
+  end
+
+  //////////////////////////////////
+  // LPG to Alert Channel Mapping //
+  //////////////////////////////////
+
+  // select the correct lpg for the alert channel at index j and buffer the multibit signal for each
+  // alert channel.
+  for (genvar j=0; j < NAlerts; j++) begin : gen_alert_map
+    prim_lc_sync #(
+      .AsyncOn(0) // no sync flops
+    ) u_prim_lc_sync_lpg_en (
+      .clk_i,
+      .rst_ni,
+      .lc_en_i(lpg_init_trig[AlertLpgMap[j]]),
+      .lc_en_o({init_trig_o[j]})
+    );
+  end
+
+endmodule : alert_handler_lp_ctrl

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_pkg.sv
@@ -8,6 +8,9 @@ package alert_handler_reg_pkg;
 
   // Param list
   parameter int NAlerts = 4;
+  parameter int NLpg = 1;
+  parameter int NLpgWidth = 1;
+  parameter logic [NAlerts-1:0][NLpgWidth-1:0] AlertLpgMap = '0;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
   parameter logic [NAlerts-1:0] AsyncOn = '0;

--- a/hw/ip/alert_handler/rtl/alert_pkg.sv
+++ b/hw/ip/alert_handler/rtl/alert_pkg.sv
@@ -9,6 +9,9 @@ package alert_pkg;
   localparam int unsigned      NAlerts   = alert_handler_reg_pkg::NAlerts;   // maximum 252
   localparam int unsigned      EscCntDw  = alert_handler_reg_pkg::EscCntDw;  // maximum 32
   localparam int unsigned      AccuCntDw = alert_handler_reg_pkg::AccuCntDw; // maximum 32
+  localparam int unsigned      NLpg      = alert_handler_reg_pkg::NLpg;
+  localparam int unsigned      NLpgWidth = alert_handler_reg_pkg::NLpgWidth;
+  localparam logic [NAlerts-1:0][NLpgWidth-1:0] AlertLpgMap = alert_handler_reg_pkg::AlertLpgMap;
   // enable async transitions for specific RX/TX pairs
   localparam bit [NAlerts-1:0] AsyncOn   = alert_handler_reg_pkg::AsyncOn;
 

--- a/hw/ip/alert_handler/util/reg_alert_handler.py
+++ b/hw/ip/alert_handler/util/reg_alert_handler.py
@@ -22,7 +22,7 @@ def main():
     parser.add_argument('--n_alerts',
                         type=int,
                         default=4,
-                        help='Number of Alert Sources')
+                        help='Number of alert sources')
     parser.add_argument('--esc_cnt_dw',
                         type=int,
                         default=32,
@@ -34,8 +34,16 @@ def main():
     parser.add_argument('--async_on',
                         type=str,
                         default="'0",
-                        help="""Enables asynchronous sygnalling between specific
+                        help="""Enables asynchronous signalling between specific
                         alert RX/TX pairs""")
+    parser.add_argument('--n_lpg',
+                        type=int,
+                        default=1,
+                        help='Number of LPGs')
+    parser.add_argument('--lpg_map',
+                        type=str,
+                        default="'0",
+                        help="""Encodes the alert to LPG mapping""")
 
     args = parser.parse_args()
 
@@ -48,7 +56,9 @@ def main():
                        esc_cnt_dw=args.esc_cnt_dw,
                        accu_cnt_dw=args.accu_cnt_dw,
                        async_on=args.async_on,
-                       n_classes=4)) # leave this constant for now
+                       n_lpg=args.n_lpg,
+                       lpg_map=args.lpg_map,
+                       n_classes=4))  # leave this constant for now
 
     print(out.getvalue())
 

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -91,6 +91,8 @@ module prim_alert_tb;
   ) i_alert_receiver (
     .clk_i(clk),
     .rst_ni(rst_n),
+    // TODO: randomly trigger this
+    .init_trig_i(lc_ctrl_pkg::Off),
     .ping_req_i(ping_req),
     .ping_ok_o(ping_ok),
     .integ_fail_o(integ_fail),
@@ -199,6 +201,12 @@ module prim_alert_tb;
     main_clk.set_period_ps(ClkPeriod);
     main_clk.set_active();
     main_clk.apply_reset();
+
+    // Wait for initialization sequence to end
+    // This should take no more than 20 cycles
+    // if the sender / receiver clocks are on
+    // the same clock domain.
+    main_clk.wait_clks(20);
 
     // Sequence 1). Alert request sequence.
     main_clk.wait_clks($urandom_range(0, 10));

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -298,10 +298,12 @@ module prim_alert_tb;
     $display("Ack signal integrity error sequence finished!");
 
     // Sequence 5) `Ping_p/n` integrity check sequence.
+    // Disable the assertion at least two clock cycles before sending the ping request, because the
+    // `PingDiffOk_A` assertion has ##2 delay.
+    $assertoff(2, prim_alert_tb.i_alert_receiver.PingDiffOk_A);
     main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
     ping_req = 1;
 
-    $assertoff(0, prim_alert_tb.i_alert_receiver.PingDiffOk_A);
     force i_alert_receiver.alert_rx_o.ping_n = 1;
     wait (integ_fail == 1);
     ping_req = 0;

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_bind_fpv.sv
@@ -19,6 +19,7 @@ module prim_alert_rxtx_async_bind_fpv;
     .alert_err_ni,
     .alert_skew_i,
     .alert_test_i,
+    .init_trig_i,
     .alert_req_i,
     .alert_ack_o,
     .alert_state_o,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_bind_fpv.sv
@@ -19,6 +19,7 @@ module prim_alert_rxtx_async_fatal_bind_fpv;
     .alert_err_ni,
     .alert_skew_i,
     .alert_test_i,
+    .init_trig_i,
     .alert_req_i,
     .alert_ack_o,
     .alert_state_o,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fatal_fpv.sv
@@ -23,6 +23,7 @@ module prim_alert_rxtx_async_fatal_fpv
   // normal I/Os
   input        alert_test_i,
   input        alert_req_i,
+  input  lc_ctrl_pkg::lc_tx_t init_trig_i,
   input        ping_req_i,
   output logic alert_ack_o,
   output logic alert_state_o,
@@ -72,8 +73,8 @@ module prim_alert_rxtx_async_fatal_fpv
     .AsyncOn ( AsyncOn ),
     .IsFatal ( IsFatal )
   ) i_prim_alert_sender (
-    .clk_i      ,
-    .rst_ni     ,
+    .clk_i,
+    .rst_ni,
     .alert_test_i,
     .alert_req_i,
     .alert_ack_o,
@@ -85,12 +86,13 @@ module prim_alert_rxtx_async_fatal_fpv
   prim_alert_receiver #(
     .AsyncOn ( AsyncOn )
   ) i_prim_alert_receiver (
-    .clk_i        ,
-    .rst_ni       ,
-    .ping_req_i    ,
-    .ping_ok_o    ,
-    .integ_fail_o ,
-    .alert_o      ,
+    .clk_i,
+    .rst_ni,
+    .init_trig_i,
+    .ping_req_i,
+    .ping_ok_o,
+    .integ_fail_o,
+    .alert_o,
     .alert_rx_o ( alert_rx_out ),
     .alert_tx_i ( alert_tx_in  )
   );

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_async_fpv.sv
@@ -23,6 +23,7 @@ module prim_alert_rxtx_async_fpv
   // normal I/Os
   input        alert_test_i,
   input        alert_req_i,
+  input  lc_ctrl_pkg::lc_tx_t init_trig_i,
   input        ping_req_i,
   output logic alert_ack_o,
   output logic alert_state_o,
@@ -33,6 +34,7 @@ module prim_alert_rxtx_async_fpv
 
   // asynchronous case
   localparam bit AsyncOn = 1'b1;
+  localparam bit IsFatal = 1'b0;
 
   logic ping_pd;
   logic ping_nd;
@@ -68,10 +70,11 @@ module prim_alert_rxtx_async_fpv
   assign alert_tx_in.alert_n = alert_nq[alert_skew_i[1]] ^ alert_err_ni;
 
   prim_alert_sender #(
-    .AsyncOn ( AsyncOn )
+    .AsyncOn ( AsyncOn ),
+    .IsFatal ( IsFatal )
   ) i_prim_alert_sender (
-    .clk_i      ,
-    .rst_ni     ,
+    .clk_i,
+    .rst_ni,
     .alert_test_i,
     .alert_req_i,
     .alert_ack_o,
@@ -83,15 +86,17 @@ module prim_alert_rxtx_async_fpv
   prim_alert_receiver #(
     .AsyncOn ( AsyncOn )
   ) i_prim_alert_receiver (
-    .clk_i        ,
-    .rst_ni       ,
-    .ping_req_i    ,
-    .ping_ok_o    ,
-    .integ_fail_o ,
-    .alert_o      ,
+    .clk_i,
+    .rst_ni,
+    .init_trig_i,
+    .ping_req_i,
+    .ping_ok_o,
+    .integ_fail_o,
+    .alert_o,
     .alert_rx_o ( alert_rx_out ),
     .alert_tx_i ( alert_tx_in  )
   );
+
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_skew_delay
     if (!rst_ni) begin

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_bind_fpv.sv
@@ -19,6 +19,7 @@ module prim_alert_rxtx_bind_fpv;
     .alert_req_i,
     .alert_ack_o,
     .alert_state_o,
+    .init_trig_i,
     .ping_req_i,
     .ping_ok_o,
     .integ_fail_o,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_bind_fpv.sv
@@ -20,6 +20,7 @@ module prim_alert_rxtx_fatal_bind_fpv;
     .alert_req_i,
     .alert_ack_o,
     .alert_state_o,
+    .init_trig_i,
     .ping_req_i,
     .ping_ok_o,
     .integ_fail_o,

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fatal_fpv.sv
@@ -20,6 +20,7 @@ module prim_alert_rxtx_fatal_fpv
   // normal I/Os
   input        alert_test_i,
   input        alert_req_i,
+  input  lc_ctrl_pkg::lc_tx_t init_trig_i,
   input        ping_req_i,
   output logic alert_ack_o,
   output logic alert_state_o,
@@ -47,8 +48,8 @@ module prim_alert_rxtx_fatal_fpv
     .AsyncOn ( AsyncOn ),
     .IsFatal ( IsFatal )
   ) i_prim_alert_sender (
-    .clk_i      ,
-    .rst_ni     ,
+    .clk_i,
+    .rst_ni,
     .alert_test_i,
     .alert_req_i,
     .alert_ack_o,
@@ -60,12 +61,13 @@ module prim_alert_rxtx_fatal_fpv
   prim_alert_receiver #(
     .AsyncOn ( AsyncOn )
   ) i_prim_alert_receiver (
-    .clk_i        ,
-    .rst_ni       ,
-    .ping_req_i    ,
-    .ping_ok_o    ,
-    .integ_fail_o ,
-    .alert_o      ,
+    .clk_i,
+    .rst_ni,
+    .init_trig_i,
+    .ping_req_i,
+    .ping_ok_o,
+    .integ_fail_o,
+    .alert_o,
     .alert_rx_o ( alert_rx_out ),
     .alert_tx_i ( alert_tx_in  )
   );

--- a/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_alert_rxtx_fpv.sv
@@ -20,6 +20,7 @@ module prim_alert_rxtx_fpv
   // normal I/Os
   input        alert_test_i,
   input        alert_req_i,
+  input  lc_ctrl_pkg::lc_tx_t init_trig_i,
   input        ping_req_i,
   output logic alert_ack_o,
   output logic alert_state_o,
@@ -30,6 +31,7 @@ module prim_alert_rxtx_fpv
 
   // synchronous case
   localparam bit AsyncOn = 1'b0;
+  localparam bit IsFatal = 1'b0;
 
   alert_rx_t alert_rx_out, alert_rx_in;
   alert_tx_t alert_tx_out, alert_tx_in;
@@ -43,10 +45,11 @@ module prim_alert_rxtx_fpv
   assign alert_tx_in.alert_n = alert_tx_out.alert_n ^ alert_err_ni;
 
   prim_alert_sender #(
-    .AsyncOn ( AsyncOn )
+    .AsyncOn ( AsyncOn ),
+    .IsFatal ( IsFatal )
   ) i_prim_alert_sender (
-    .clk_i      ,
-    .rst_ni     ,
+    .clk_i,
+    .rst_ni,
     .alert_test_i,
     .alert_req_i,
     .alert_ack_o,
@@ -58,12 +61,13 @@ module prim_alert_rxtx_fpv
   prim_alert_receiver #(
     .AsyncOn ( AsyncOn )
   ) i_prim_alert_receiver (
-    .clk_i        ,
-    .rst_ni       ,
-    .ping_req_i    ,
-    .ping_ok_o    ,
-    .integ_fail_o ,
-    .alert_o      ,
+    .clk_i,
+    .rst_ni,
+    .init_trig_i,
+    .ping_req_i,
+    .ping_ok_o,
+    .integ_fail_o,
+    .alert_o,
     .alert_rx_o ( alert_rx_out ),
     .alert_tx_i ( alert_tx_in  )
   );

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
@@ -131,4 +131,12 @@ module prim_alert_rxtx_assert_fpv (
       prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle)),
       clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
 
+  // check that the in-band reset moves sender FSM into Idle state.
+  `ASSERT(InBandInitFromReceiverToSender_A,
+      init_trig_i == lc_ctrl_pkg::On
+      |->
+      ##[1:20] (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_fpv.i_prim_alert_sender.Idle),
+      clk_i, !rst_ni || error_present)
+
 endmodule : prim_alert_rxtx_assert_fpv

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_assert_fpv.sv
@@ -22,6 +22,7 @@ module prim_alert_rxtx_assert_fpv (
   input        alert_req_i,
   input        alert_ack_o,
   input        alert_state_o,
+  input  lc_ctrl_pkg::lc_tx_t init_trig_i,
   input        ping_req_i,
   input        ping_ok_o,
   input        integ_fail_o,
@@ -32,6 +33,12 @@ module prim_alert_rxtx_assert_fpv (
   assign error_present = ping_err_pi  | ping_err_ni |
                          ack_err_pi   | ack_err_ni  |
                          alert_err_pi | alert_err_ni;
+
+  logic init_pending;
+  assign init_pending = init_trig_i == lc_ctrl_pkg::On ||
+                        prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q inside {
+                        prim_alert_rxtx_fpv.i_prim_alert_receiver.InitReq,
+                        prim_alert_rxtx_fpv.i_prim_alert_receiver.InitAckWait};
 
   // note: we can only detect sigint errors where one wire is flipped.
   `ASSUME_FPV(PingErrorsAreOH_M,  $onehot0({ping_err_pi, ping_err_ni}),   clk_i, !rst_ni)
@@ -55,64 +62,73 @@ module prim_alert_rxtx_assert_fpv (
   endsequence
 
   // note: injected errors may lockup the FSMs, and hence the full HS can
-  // only take place if both FSMs are in a sane state
+  // only take place if both FSMs are in a good state
   `ASSERT(PingHs_A, ##1 $changed(prim_alert_rxtx_fpv.alert_rx_out.ping_p) &&
       (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle) |=> FullHandshake_S,
-      clk_i, !rst_ni || error_present)
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
   `ASSERT(AlertHs_A, alert_req_i &&
       (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle) |=>
-      FullHandshake_S |-> alert_ack_o, clk_i, !rst_ni || error_present)
+      FullHandshake_S |-> alert_ack_o,
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
   `ASSERT(AlertTestHs_A, alert_test_i &&
       (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle) |=>
-      FullHandshake_S, clk_i, !rst_ni || error_present)
+      FullHandshake_S,
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
   // Make sure we eventually get an ACK
   `ASSERT(AlertReqAck_A, alert_req_i &&
       (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle) |-> strong(##[1:$] alert_ack_o),
-      clk_i, !rst_ni || error_present)
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
 
   // transmission of pings
   // note: the complete transmission of pings only happen when no ping handshake is in progress
   `ASSERT(AlertPingOk_A, !(prim_alert_rxtx_fpv.i_prim_alert_sender.state_q inside {
       prim_alert_rxtx_fpv.i_prim_alert_sender.PingHsPhase1,
       prim_alert_rxtx_fpv.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
-      ##[1:9] ping_ok_o, clk_i, !rst_ni || error_present)
+      ##[1:9] ping_ok_o,
+      clk_i, !rst_ni || error_present || init_pending)
   `ASSERT(AlertPingIgnored_A, (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q inside {
       prim_alert_rxtx_fpv.i_prim_alert_sender.PingHsPhase1,
       prim_alert_rxtx_fpv.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
-      ping_ok_o == 0 throughout ping_req_i [->1], clk_i, !rst_ni || error_present)
+      ping_ok_o == 0 throughout ping_req_i [->1],
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
   // transmission of alerts in case of no collision with ping enable
   `ASSERT(AlertCheck0_A, !ping_req_i [*3] ##0 ($rose(alert_req_i) || $rose(alert_test_i)) &&
       (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) |=>
-      alert_o, clk_i, !rst_ni || error_present || ping_req_i)
+      alert_o,
+      clk_i, !rst_ni || error_present || ping_req_i || init_pending)
   // transmission of alerts in the general case which can include continous ping collisions
   `ASSERT(AlertCheck1_A, alert_req_i || alert_test_i |=>
       strong(##[1:$] ((prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) && !ping_req_i) ##1 alert_o),
-      clk_i, !rst_ni || error_present || prim_alert_rxtx_fpv.i_prim_alert_sender.alert_clr)
+      clk_i,
+      !rst_ni || error_present || prim_alert_rxtx_fpv.i_prim_alert_sender.alert_clr ||
+      init_trig_i == lc_ctrl_pkg::On)
 
   // basic liveness of FSMs in case no errors are present
   `ASSERT(FsmLivenessSender_A,
       (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q !=
       prim_alert_rxtx_fpv.i_prim_alert_sender.Idle) |->
       strong(##[1:$] (prim_alert_rxtx_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_fpv.i_prim_alert_sender.Idle)), clk_i, !rst_ni || error_present)
+      prim_alert_rxtx_fpv.i_prim_alert_sender.Idle)),
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
   `ASSERT(FsmLivenessReceiver_A,
       (prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q !=
       prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle) |->
       strong(##[1:$] (prim_alert_rxtx_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle)),clk_i, !rst_ni || error_present)
+      prim_alert_rxtx_fpv.i_prim_alert_receiver.Idle)),
+      clk_i, !rst_ni || error_present || init_trig_i == lc_ctrl_pkg::On)
 
 endmodule : prim_alert_rxtx_assert_fpv

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
@@ -22,6 +22,7 @@ module prim_alert_rxtx_async_assert_fpv (
   input [1:0]  alert_skew_i,
   // normal I/Os
   input        alert_test_i,
+  input  lc_ctrl_pkg::lc_tx_t init_trig_i,
   input        alert_req_i,
   input        alert_ack_o,
   input        alert_state_o,
@@ -35,6 +36,12 @@ module prim_alert_rxtx_async_assert_fpv (
   assign error_present = ping_err_pi  | ping_err_ni |
                          ack_err_pi   | ack_err_ni  |
                          alert_err_pi | alert_err_ni;
+
+  logic init_pending;
+  assign init_pending = init_trig_i == lc_ctrl_pkg::On ||
+                        prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q inside {
+                        prim_alert_rxtx_async_fpv.i_prim_alert_receiver.InitReq,
+                        prim_alert_rxtx_async_fpv.i_prim_alert_receiver.InitAckWait};
 
   // used to check that an error has never occured so far
   // this is used to check the handshake below. the handshake can lock up
@@ -59,10 +66,9 @@ module prim_alert_rxtx_async_assert_fpv (
 
   // ping will stay high until ping ok received, then it must be deasserted
   // TODO: this excludes the case where no ping ok will be returned due to an error
-  `ASSUME_FPV(PingDeassert_M, ping_req_i && ping_ok_o |=> !ping_req_i, clk_i, !rst_ni)
+  `ASSUME_FPV(PingDeassert_M, ping_req_i && ping_ok_o |=> !ping_req_i)
   `ASSUME_FPV(PingEn_M, $rose(ping_req_i) |-> ping_req_i throughout
-      (ping_ok_o || error_present)[->1] ##1 $fell(ping_req_i),
-      clk_i, !rst_ni)
+      (ping_ok_o || error_present)[->1] ##1 $fell(ping_req_i))
 
   // Note: the sequence lengths of the handshake and the following properties needs to
   // be parameterized accordingly if different clock ratios are to be used here.
@@ -78,32 +84,32 @@ module prim_alert_rxtx_async_assert_fpv (
   endsequence
 
   // note: injected errors may lockup the FSMs, and hence the full HS can
-  // only take place if both FSMs are in a sane state
+  // only take place if both FSMs are in a good state
   `ASSERT(PingHs_A, ##1 $changed(prim_alert_rxtx_async_fpv.ping_pd) &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
-      clk_i, !rst_ni || error_setreg_q)
+      clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertHs_A, alert_req_i &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
-      clk_i, !rst_ni || error_setreg_q)
+      clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertTestHs_A, alert_test_i &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> ##[0:5] FullHandshake_S,
-      clk_i, !rst_ni || error_setreg_q)
+      clk_i, !rst_ni || error_setreg_q || init_pending)
   // Make sure we eventually get an ACK
   `ASSERT(AlertReqAck_A, alert_req_i &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |-> strong(##[1:$] alert_ack_o),
-      clk_i, !rst_ni || error_setreg_q)
+      clk_i, !rst_ni || error_setreg_q || init_pending)
 
   // transmission of pings
   // this bound is relatively large as in the worst case, we need to resolve
@@ -112,34 +118,39 @@ module prim_alert_rxtx_async_assert_fpv (
   `ASSERT(AlertPingOk_A, !(prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q inside {
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase1,
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
-      ##[1:23] ping_ok_o, clk_i, !rst_ni || error_setreg_q)
+      ##[1:23] ping_ok_o,
+      clk_i, !rst_ni || error_setreg_q || init_pending)
   `ASSERT(AlertPingIgnored_A, (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q inside {
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase1,
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.PingHsPhase2}) && $rose(ping_req_i) |->
-      ping_ok_o == 0 throughout ping_req_i[->1], clk_i, !rst_ni || error_setreg_q)
+      ping_ok_o == 0 throughout ping_req_i[->1],
+      clk_i, !rst_ni || error_setreg_q)
   // transmission of first alert assertion (no ping collision)
   `ASSERT(AlertCheck0_A, !ping_req_i [*10] ##1 ($rose(alert_req_i) || $rose(alert_test_i)) &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) |->
-      ##[3:5] alert_o, clk_i, !rst_ni || ping_req_i || error_setreg_q)
+      ##[3:5] alert_o,
+      clk_i, !rst_ni || ping_req_i || error_setreg_q || init_pending)
   // eventual transmission of alerts in the general case which can include continous ping
   // collisions
   `ASSERT(AlertCheck1_A, alert_req_i || alert_test_i |->
       strong(##[1:$] (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle && !ping_req_i) ##[3:5] alert_o),
       clk_i, !rst_ni || error_setreg_q ||
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.alert_clr)
+      prim_alert_rxtx_async_fpv.i_prim_alert_sender.alert_clr || init_pending)
 
   // basic liveness of FSMs in case no errors are present
   `ASSERT(FsmLivenessSender_A, !error_present [*2] ##1 !error_present &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q !=
       prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle) |->
       strong(##[1:$] (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle)), clk_i, !rst_ni || error_present)
+      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle)),
+      clk_i, !rst_ni || error_present || init_pending)
   `ASSERT(FsmLivenessReceiver_A, !error_present [*2] ##1 !error_present &&
       (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q !=
       prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle) |->
       strong(##[1:$] (prim_alert_rxtx_async_fpv.i_prim_alert_receiver.state_q ==
-      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle)),clk_i, !rst_ni || error_present)
+      prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle)),
+      clk_i, !rst_ni || error_present || init_pending)
 
 endmodule : prim_alert_rxtx_async_assert_fpv

--- a/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
+++ b/hw/ip/prim/fpv/vip/prim_alert_rxtx_async_assert_fpv.sv
@@ -153,4 +153,12 @@ module prim_alert_rxtx_async_assert_fpv (
       prim_alert_rxtx_async_fpv.i_prim_alert_receiver.Idle)),
       clk_i, !rst_ni || error_present || init_pending)
 
+  // check that the in-band reset moves sender FSM into Idle state.
+  `ASSERT(InBandInitFromReceiverToSender_A,
+      init_trig_i == lc_ctrl_pkg::On
+      |->
+      ##[1:30] (prim_alert_rxtx_async_fpv.i_prim_alert_sender.state_q ==
+      prim_alert_rxtx_async_fpv.i_prim_alert_sender.Idle),
+      clk_i, !rst_ni || error_present)
+
 endmodule : prim_alert_rxtx_async_assert_fpv

--- a/hw/ip/prim/prim_alert.core
+++ b/hw/ip/prim/prim_alert.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:diff_decode
       - lowrisc:prim:buf
       - lowrisc:prim:flop
+      - lowrisc:ip:lc_ctrl_pkg
     files:
       - rtl/prim_alert_pkg.sv
       - rtl/prim_alert_receiver.sv

--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -194,7 +194,7 @@ module prim_alert_receiver
         // ping requests. As soon as the init request is dropped however, ping requests are not
         // acked anymore such that the ping mechanism can also flag alert channels that got stuck
         // in the initialization sequence.
-        if (init_trig_i==lc_ctrl_pkg::On) begin
+        if (init_trig_i == lc_ctrl_pkg::On) begin
           ping_ok_o = ping_pending_q;
         // the sender will respond to the sigint error above with a sigint error on the alert lines.
         // hence we treat the alert_sigint like an acknowledgement in this case.
@@ -263,8 +263,9 @@ module prim_alert_receiver
 
   // check encoding of outgoing diffpairs. note that during init, the outgoing diffpairs are
   // supposed to be incorrectly encoded on purpose.
-  `ASSERT(PingDiffOk_A, ##1 $past(send_init) ^ alert_rx_o.ping_p ^ alert_rx_o.ping_n)
-  `ASSERT(AckDiffOk_A, ##1 $past(send_init) ^ alert_rx_o.ack_p ^ alert_rx_o.ack_n)
+  // shift sequence two cycles to the right to avoid reset effects.
+  `ASSERT(PingDiffOk_A, ##2 $past(send_init) ^ alert_rx_o.ping_p ^ alert_rx_o.ping_n)
+  `ASSERT(AckDiffOk_A, ##2 $past(send_init) ^ alert_rx_o.ack_p ^ alert_rx_o.ack_n)
   // ping request at input -> need to see encoded ping request
   `ASSERT(PingRequest0_A, ##1 $rose(ping_req_i) && !send_init |=> $changed(alert_rx_o.ping_p))
   // ping response implies it has been requested
@@ -303,14 +304,15 @@ module prim_alert_receiver
     `ASSERT(SigInt_A,
         alert_tx_i.alert_p == alert_tx_i.alert_n &&
         !(state_q inside {InitReq, InitAckWait}) &&
-        !init_trig_i==lc_ctrl_pkg::On
+        init_trig_i != lc_ctrl_pkg::On
         |->
         integ_fail_o)
     // ping response
     `ASSERT(PingResponse1_A,
         ##1 $rose(alert_tx_i.alert_p) &&
         state_q == Idle &&
-        ping_pending_q |->
+        ping_pending_q
+        |->
         ping_ok_o,
         clk_i, !rst_ni || integ_fail_o || init_trig_i == lc_ctrl_pkg::On)
     // alert
@@ -322,5 +324,42 @@ module prim_alert_receiver
         alert_o,
         clk_i, !rst_ni || integ_fail_o || init_trig_i == lc_ctrl_pkg::On)
   end
+
+  // check in-band init request is always accepted
+  `ASSERT(InBandInitRequest_A,
+      init_trig_i == lc_ctrl_pkg::On &&
+      state_q != InitAckWait
+      |=>
+      state_q == InitReq)
+  // check in-band init sequence moves FSM into IDLE state
+  `ASSERT(InBandInitSequence_A,
+      (state_q == InitReq &&
+      init_trig_i == lc_ctrl_pkg::On [*1:$]) ##1
+      (alert_sigint &&
+      init_trig_i != lc_ctrl_pkg::On) [*1:$] ##1
+      (!alert_sigint &&
+      init_trig_i != lc_ctrl_pkg::On) [*3]
+      |=>
+      state_q == Idle)
+  // check there are no spurious alerts during init
+  `ASSERT(NoSpuriousAlertsDuringInit_A,
+      init_trig_i == lc_ctrl_pkg::On ||
+      (state_q inside {InitReq, InitAckWait})
+      |->
+      !alert_o)
+  // check that there are no spurious ping OKs
+  `ASSERT(NoSpuriousPingOksDuringInit_A,
+      (init_trig_i == lc_ctrl_pkg::On ||
+      (state_q inside {InitReq, InitAckWait})) &&
+      !ping_pending_q
+      |->
+      !ping_ok_o)
+  // check ping request is bypassed when in init state
+  `ASSERT(PingOkBypassDuringInit_A,
+      $rose(ping_req_i) ##1
+      state_q == InitReq &&
+      init_trig_i == lc_ctrl_pkg::On
+      |->
+      ping_ok_o)
 
 endmodule : prim_alert_receiver

--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -37,6 +37,9 @@ module prim_alert_receiver
 ) (
   input             clk_i,
   input             rst_ni,
+  // if set to lc_ctrl_pkg::On, this triggers the in-band alert channel
+  // reset, which resets both the sender and receiver FSMs into IDLE.
+  input lc_ctrl_pkg::lc_tx_t init_trig_i,
   // this triggers a ping test. keep asserted
   // until ping_ok_o is asserted.
   input             ping_req_i,
@@ -85,22 +88,25 @@ module prim_alert_receiver
   /////////////////////////////////////////////////////
   //  main protocol FSM that drives the diff outputs //
   /////////////////////////////////////////////////////
-  typedef enum logic [1:0] {Idle, HsAckWait, Pause0, Pause1} state_e;
+  typedef enum logic [2:0] {Idle, HsAckWait, Pause0, Pause1, InitReq, InitAckWait} state_e;
   state_e state_d, state_q;
   logic ping_rise;
   logic ping_tog_pd, ping_tog_pq, ping_tog_dn, ping_tog_nq;
   logic ack_pd, ack_pq, ack_dn, ack_nq;
   logic ping_req_d, ping_req_q;
   logic ping_pending_d, ping_pending_q;
+  logic send_init;
 
   // signal ping request upon positive transition on ping_req_i
   // signalling is performed by a level change event on the diff output
   assign ping_req_d  = ping_req_i;
   assign ping_rise   = ping_req_i && !ping_req_q;
-  assign ping_tog_pd = (ping_rise) ? ~ping_tog_pq : ping_tog_pq;
+  assign ping_tog_pd = (send_init) ? 1'b0         :
+                       (ping_rise) ? ~ping_tog_pq : ping_tog_pq;
 
-  assign ack_dn = ~ack_pd;
-  assign ping_tog_dn = ~ping_tog_pd;
+  // in-band reset is performed by sending out an integrity error on purpose.
+  assign ack_dn      = (send_init) ? ack_pd      : ~ack_pd;
+  assign ping_tog_dn = (send_init) ? ping_tog_pd : ~ping_tog_pd;
 
   // This prevents further tool optimizations of the differential signal.
   prim_generic_flop #(
@@ -152,6 +158,7 @@ module prim_alert_receiver
     ping_ok_o    = 1'b0;
     integ_fail_o = 1'b0;
     alert_o      = 1'b0;
+    send_init    = 1'b0;
 
     unique case (state_q)
       Idle: begin
@@ -178,22 +185,62 @@ module prim_alert_receiver
       // pause cycles between back-to-back handshakes
       Pause0: state_d = Pause1;
       Pause1: state_d = Idle;
-      default : ; // full case
+      // this state is only reached if an in-band reset is
+      // requested via the low-power logic.
+      InitReq: begin
+        // we deliberately place a sigint error on the ack and ping lines in this case.
+        send_init = 1'b1;
+        // As long as init req is asserted, we remain in this state and acknowledge all incoming
+        // ping requests. As soon as the init request is dropped however, ping requests are not
+        // acked anymore such that the ping mechanism can also flag alert channels that got stuck
+        // in the initialization sequence.
+        if (init_trig_i==lc_ctrl_pkg::On) begin
+          ping_ok_o = ping_pending_q;
+        // the sender will respond to the sigint error above with a sigint error on the alert lines.
+        // hence we treat the alert_sigint like an acknowledgement in this case.
+        end else if (alert_sigint) begin
+          state_d = InitAckWait;
+        end
+      end
+      // We get here if the sender has responded with alert_sigint, and init_trig_i==lc_ctrl_pkg::On has been
+      // deasserted. At this point, we need to wait for the alert_sigint to drop again before
+      // resuming normal operation.
+      InitAckWait: begin
+        if (!alert_sigint) begin
+          state_d = Pause0;
+        end
+      end
+      default: state_d = Idle;
     endcase
 
-    // override in case of sigint
-    if (alert_sigint) begin
-      state_d      = Idle;
-      ack_pd       = 1'b0;
-      ping_ok_o    = 1'b0;
-      integ_fail_o = 1'b1;
-      alert_o      = 1'b0;
+    // once the initialization sequence has been triggered,
+    // overrides are not allowed anymore until the initialization has been completed.
+    if (!(state_q inside {InitReq, InitAckWait})) begin
+      // in this case, abort and jump into the initialization sequence
+      if (init_trig_i == lc_ctrl_pkg::On) begin
+        state_d      = InitReq;
+        ack_pd       = 1'b0;
+        ping_ok_o    = 1'b0;
+        integ_fail_o = 1'b0;
+        alert_o      = 1'b0;
+        send_init    = 1'b1;
+      // if we're not busy with an init request, we clamp down all outputs
+      // and indicate an integrity failure.
+      end else if (alert_sigint) begin
+        state_d      = Idle;
+        ack_pd       = 1'b0;
+        ping_ok_o    = 1'b0;
+        integ_fail_o = 1'b1;
+        alert_o      = 1'b0;
+      end
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_reg
     if (!rst_ni) begin
-      state_q        <= Idle;
+      // Reset into the init request so that an alert handler reset implicitly
+      // triggers an in-band reset of all alert channels.
+      state_q        <= InitReq;
       ping_req_q     <= 1'b0;
       ping_pending_q <= 1'b0;
     end else begin
@@ -214,11 +261,12 @@ module prim_alert_receiver
   `ASSERT_KNOWN(AlertKnownO_A, alert_o)
   `ASSERT_KNOWN(PingPKnownO_A, alert_rx_o)
 
-  // check encoding of outgoing diffpairs
-  `ASSERT(PingDiffOk_A, alert_rx_o.ping_p ^ alert_rx_o.ping_n)
-  `ASSERT(AckDiffOk_A, alert_rx_o.ack_p ^ alert_rx_o.ack_n)
+  // check encoding of outgoing diffpairs. note that during init, the outgoing diffpairs are
+  // supposed to be incorrectly encoded on purpose.
+  `ASSERT(PingDiffOk_A, ##1 $past(send_init) ^ alert_rx_o.ping_p ^ alert_rx_o.ping_n)
+  `ASSERT(AckDiffOk_A, ##1 $past(send_init) ^ alert_rx_o.ack_p ^ alert_rx_o.ack_n)
   // ping request at input -> need to see encoded ping request
-  `ASSERT(PingRequest0_A, ##1 $rose(ping_req_i) |=> $changed(alert_rx_o.ping_p))
+  `ASSERT(PingRequest0_A, ##1 $rose(ping_req_i) && !send_init |=> $changed(alert_rx_o.ping_p))
   // ping response implies it has been requested
   `ASSERT(PingResponse0_A, ping_ok_o |-> ping_pending_q)
   // correctly latch ping request
@@ -226,25 +274,53 @@ module prim_alert_receiver
 
   if (AsyncOn) begin : gen_async_assert
     // signal integrity check propagation
-    `ASSERT(SigInt_A, alert_tx_i.alert_p == alert_tx_i.alert_n [*2] |->
-        ##2 integ_fail_o)
+    `ASSERT(SigInt_A,
+        alert_tx_i.alert_p == alert_tx_i.alert_n [*2] ##2
+        !(state_q inside {InitReq, InitAckWait}) &&
+        init_trig_i != lc_ctrl_pkg::On
+        |->
+        integ_fail_o)
     // TODO: need to add skewed cases as well, the assertions below assume no skew at the moment
     // ping response
-    `ASSERT(PingResponse1_A, ##1 $rose(alert_tx_i.alert_p) &&
-        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2 state_q == Idle && ping_pending_q |->
-        ping_ok_o, clk_i, !rst_ni || integ_fail_o)
+    `ASSERT(PingResponse1_A,
+        ##1 $rose(alert_tx_i.alert_p) &&
+        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
+        state_q == Idle && ping_pending_q
+        |->
+        ping_ok_o,
+        clk_i, !rst_ni || integ_fail_o || init_trig_i == lc_ctrl_pkg::On)
     // alert
-    `ASSERT(Alert_A, ##1 $rose(alert_tx_i.alert_p) && (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
-        state_q == Idle && !ping_pending_q |-> alert_o, clk_i, !rst_ni || integ_fail_o)
+    `ASSERT(Alert_A,
+        ##1 $rose(alert_tx_i.alert_p) &&
+        (alert_tx_i.alert_p ^ alert_tx_i.alert_n) ##2
+        state_q == Idle &&
+        !ping_pending_q
+        |->
+        alert_o,
+        clk_i, !rst_ni || integ_fail_o || init_trig_i == lc_ctrl_pkg::On)
   end else begin : gen_sync_assert
     // signal integrity check propagation
-    `ASSERT(SigInt_A, alert_tx_i.alert_p == alert_tx_i.alert_n |-> integ_fail_o)
+    `ASSERT(SigInt_A,
+        alert_tx_i.alert_p == alert_tx_i.alert_n &&
+        !(state_q inside {InitReq, InitAckWait}) &&
+        !init_trig_i==lc_ctrl_pkg::On
+        |->
+        integ_fail_o)
     // ping response
-    `ASSERT(PingResponse1_A, ##1 $rose(alert_tx_i.alert_p) && state_q == Idle && ping_pending_q |->
-        ping_ok_o, clk_i, !rst_ni || integ_fail_o)
+    `ASSERT(PingResponse1_A,
+        ##1 $rose(alert_tx_i.alert_p) &&
+        state_q == Idle &&
+        ping_pending_q |->
+        ping_ok_o,
+        clk_i, !rst_ni || integ_fail_o || init_trig_i == lc_ctrl_pkg::On)
     // alert
-    `ASSERT(Alert_A, ##1 $rose(alert_tx_i.alert_p) && state_q == Idle && !ping_pending_q |->
-        alert_o, clk_i, !rst_ni || integ_fail_o)
+    `ASSERT(Alert_A,
+        ##1 $rose(alert_tx_i.alert_p) &&
+        state_q == Idle &&
+        !ping_pending_q
+        |->
+        alert_o,
+        clk_i, !rst_ni || integ_fail_o || init_trig_i == lc_ctrl_pkg::On)
   end
 
 endmodule : prim_alert_receiver

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -131,7 +131,6 @@ module prim_alert_sender
     AlertHsPhase2,
     PingHsPhase1,
     PingHsPhase2,
-    SigInt,
     Pause0,
     Pause1
     } state_e;
@@ -234,34 +233,22 @@ module prim_alert_sender
       Pause0: begin
         state_d = Pause1;
       end
-
       // clear and ack alert request if it was set
       Pause1: begin
         state_d = Idle;
       end
-
-      // we have a signal integrity issue at one of
-      // the incoming diff pairs. this condition is
-      // signalled by setting the output diffpair
-      // to the same value and continuously toggling
-      // them.
-      SigInt: begin
-        state_d  = Idle;
-        if (sigint_detected) begin
-          state_d  = SigInt;
-          alert_pd = ~alert_pq;
-          alert_nd = ~alert_pq;
-        end
-      end
       // catch parasitic states
       default : state_d = Idle;
     endcase
-    // bail out if a signal integrity issue has been detected
-    if (sigint_detected && (state_q != SigInt)) begin
-      state_d   = SigInt;
+
+    // we have a signal integrity issue at one of the incoming diff pairs. this condition is
+    // signalled by setting the output diffpair to zero. If the sigint has disappeared, we clear
+    // the ping request state of this sender and go back to idle.
+    if (sigint_detected) begin
+      state_d   = Idle;
       alert_pd  = 1'b0;
       alert_nd  = 1'b0;
-      ping_clr  = 1'b0;
+      ping_clr  = 1'b1;
       alert_clr = 1'b0;
     end
   end

--- a/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
+++ b/hw/top_earlgrey/ip/alert_handler/data/autogen/alert_handler.hjson
@@ -18,6 +18,8 @@
 #  - accu_cnt_dw: Width of accumulator
 #  - async_on:    Enables asynchronous sygnalling between specific alert RX/TX pairs
 #  - n_classes:   Number of supported classes (leave this at 4 at the moment)
+#  - n_lpg:       Number of low-power groups (LPGs)
+#  - lpg_map:     Defines a mapping from alerts to LPGs.
 
 {
   name: "ALERT_HANDLER",
@@ -49,6 +51,26 @@
       desc: "Number of alert channels.",
       type: "int",
       default: "58",
+      local: "true"
+    },
+    { name: "NLpg",
+      desc: "Number of LPGs.",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "NLpgWidth",
+      desc: "Width of LPG ID.",
+      type: "int",
+      default: "1",
+      local: "true"
+    },
+    { name: "AlertLpgMap",
+      desc: '''
+            Defines a mapping from alerts to LPGs.
+            '''
+      type: "logic [NAlerts-1:0][NLpgWidth-1:0]",
+      default: "'0",
       local: "true"
     },
     { name: "EscCntDw",

--- a/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/alert_handler/rtl/autogen/alert_handler_reg_pkg.sv
@@ -8,6 +8,9 @@ package alert_handler_reg_pkg;
 
   // Param list
   parameter int NAlerts = 58;
+  parameter int NLpg = 1;
+  parameter int NLpgWidth = 1;
+  parameter logic [NAlerts-1:0][NLpgWidth-1:0] AlertLpgMap = '0;
   parameter int EscCntDw = 32;
   parameter int AccuCntDw = 16;
   parameter logic [NAlerts-1:0] AsyncOn = 58'h3ffffffffffffff;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1471,6 +1471,10 @@ module top_earlgrey #(
       .alert_rx_o  ( alert_rx ),
       .alert_tx_i  ( alert_tx ),
 
+      // TODO(#8174): top-level integration for LPGs
+      .lpg_cg_en_i ( {lc_ctrl_pkg::Off} ),
+      .lpg_rst_en_i ( {lc_ctrl_pkg::Off} ),
+
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_secure),
       .clk_edn_i (clkmgr_aon_clocks.clk_main_secure),

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -123,6 +123,9 @@ def generate_alert_handler(top, out_path):
     async_on = "'0"
     # leave this constant
     n_classes = 4
+    # TODO(#8174): topgen integration for LPGs
+    n_lpg = 1
+    lpg_map = "'0"
 
     topname = top["name"]
 
@@ -173,7 +176,9 @@ def generate_alert_handler(top, out_path):
                                    esc_cnt_dw=esc_cnt_dw,
                                    accu_cnt_dw=accu_cnt_dw,
                                    async_on=async_on,
-                                   n_classes=n_classes)
+                                   n_classes=n_classes,
+                                   n_lpg=n_lpg,
+                                   lpg_map=lpg_map)
         except:  # noqa: E722
             log.error(exceptions.text_error_template().render())
         log.info("alert_handler hjson: %s" % out)

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -398,6 +398,10 @@ slice = str(alert_idx+w-1) + ":" + str(alert_idx)
       // alert signals
       .alert_rx_o  ( alert_rx ),
       .alert_tx_i  ( alert_tx ),
+
+      // TODO(#8174): top-level integration for LPGs
+      .lpg_cg_en_i ( {lc_ctrl_pkg::Off} ),
+      .lpg_rst_en_i ( {lc_ctrl_pkg::Off} ),
     % endif
     % if block.scan:
       .scanmode_i,


### PR DESCRIPTION
This implements a slightly improved version of the low-power groups solution described in [this document](https://docs.google.com/document/d/1MHksAy_p3yQ4kYbQC3zlOutIvTBffuVCaP53LAy5zUM/edit).
In particular, instead of creating a two-state FSM for each LPG, it combines the synchronized multibit indication signals coming from clock and reset managers, and directly routes them to the receiver FSMs as multibit signals.
This has a couple of advantages:
1. the indication signals remain encoded as multibit signals right up to the point where they are consumed inside the alert receiver FSMs
2. no additional FSMs are required
3. instead, the low-power state is captured for each channel individually via the `InitReq` and `InitAckWait` states inside the receiver FSM. these states would anyways be required to properly perform the in-band reset handshake.
4. this allows to keep track of the low-power state for each individual alert channel. hence, we can leverage the ping mechanism to also guard against alert channels that got stuck during the in-band reset request. i.e., instead of disabling pings for an entire LPG until all channels of that LPG have been reset, pings are enabled right away when an LPG is released. so, if a channel never initializes due to a tampering attempt, this can be flagged by the ping mechanism.

Note that final top-integration will come in a separate PR.
This PR focuses on the alert handler IP and corresponding FPV/DV changes.
