### PR TITLE
[prim_lc_combine] Add a prim to compute logical AND/OR for LC signals

### DIFF
--- a/hw/ip/prim/prim_lc_combine.core
+++ b/hw/ip/prim/prim_lc_combine.core
@@ -1,0 +1,53 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:lc_combine:0.1"
+description: "Logic combination of life cycle control signals."
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:lc_ctrl_pkg
+    files:
+      - rtl/prim_lc_combine.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      # - lint/prim_lc_combine.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/ip/prim/rtl/prim_lc_combine.sv
+++ b/hw/ip/prim/rtl/prim_lc_combine.sv
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Perform logical OR or AND between two life cycle multibit signals.
+
+module prim_lc_combine #(
+  // 0: use the ON value for the logical combination
+  // 1: use the OFF value for the logical combination
+  parameter bit ActiveLow = 0,
+  // 0: logical combination is an OR function
+  // 1: logical combination is an AND function
+  parameter bit CombineMode = 0
+) (
+  input  lc_ctrl_pkg::lc_tx_t lc_en_a_i,
+  input  lc_ctrl_pkg::lc_tx_t lc_en_b_i,
+  output lc_ctrl_pkg::lc_tx_t lc_en_o
+);
+
+  // Determine whether which multibit value is considered "active" for the
+  // purpose of the logical function below.
+  parameter lc_ctrl_pkg::lc_tx_t ActiveValue = (ActiveLow) ? lc_ctrl_pkg::Off :
+                                                             lc_ctrl_pkg::On;
+  // Truth tables:
+  //
+  // ActiveLow: 0, CombineMode: 0 (active-high "OR")
+  //
+  // A    | B    | OUT
+  //------+------+-----
+  // !On  | !On  | !On
+  // On   | !On  | On
+  // !On  | On   | On
+  // On   | On   | On
+  //
+  // ActiveLow: 0, CombineMode: 1 (active-high "AND")
+  //
+  // A    | B    | OUT
+  //------+------+-----
+  // !On  | !On  | !On
+  // On   | !On  | !On
+  // !On  | On   | !On
+  // On   | On   | On
+  //
+  // ActiveLow: 1, CombineMode: 1 (active-low "AND")
+  //
+  // A    | B    | OUT
+  //------+------+-----
+  // Off  | Off  | Off
+  // !Off | Off  | !Off
+  // Off  | !Off | !Off
+  // !Off | !Off | !Off
+  //
+  // ActiveLow: 1, CombineMode: 0 (active-low "OR")
+  //
+  // A    | B    | OUT
+  //------+------+-----
+  // Off  | Off  | Off
+  // !Off | Off  | Off
+  // Off  | !Off | Off
+  // !Off | !Off | !Off
+  //
+  // Note: the inactive value (e.g. !On) can be any multibit value
+  // different from the active value.
+  //
+  for (genvar k = 0; k < $bits(ActiveValue); k++) begin : gen_loop
+    if (ActiveLow && ActiveValue[k] ||
+       (!ActiveLow && !ActiveValue[k])) begin : gen_and_gate
+      assign lc_en_o[k] = lc_en_a_i[k] && lc_en_b_i[k];
+    end else begin : gen_or_gate
+      assign lc_en_o[k] = lc_en_a_i[k] || lc_en_b_i[k];
+    end
+  end
+
+endmodule : prim_lc_combine


### PR DESCRIPTION
This adds a simple module that implements bit-wise logical combination of two multibit life cycle signals.

To be used in #8296.

Signed-off-by: Michael Schaffner <msf@google.com>