### PR TITLE
[dv] Add ip_name in reg_block

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -33,6 +33,10 @@ class dv_base_reg extends uvm_reg;
     foreach (m_fields[i]) `downcast(dv_fields[i], m_fields[i])
   endfunction
 
+  function dv_base_reg_block get_dv_base_reg_block();
+    `downcast(get_dv_base_reg_block, get_parent())
+  endfunction
+
   // get_n_bits will return number of all the bits in the csr
   // while this function will return actual number of bits used in reg field
   function uint get_n_used_bits();
@@ -348,13 +352,11 @@ class dv_base_reg extends uvm_reg;
   endfunction
 
   function string get_update_err_alert_name();
-    string parent_name = this.get_parent().get_name();
-
     // block level alert name is input alert name from hjson
     if (get_parent().get_parent() == null) return update_err_alert_name;
 
-    // top-level alert name is ${block_name} + alert name from hjson
-    return ($sformatf("%0s_%0s", parent_name, update_err_alert_name));
+    // top-level alert name is ${ip_name} + alert name from hjson
+    return ($sformatf("%0s_%0s", get_dv_base_reg_block().get_ip_name(), update_err_alert_name));
   endfunction
 
   function void lock_shadow_reg();
@@ -366,13 +368,13 @@ class dv_base_reg extends uvm_reg;
   endfunction
 
   function string get_storage_err_alert_name();
-    string parent_name = this.get_parent().get_name();
+    string ip_name;
 
     // block level alert name is input alert name from hjson
     if (get_parent().get_parent() == null) return storage_err_alert_name;
 
-    // top-level alert name is ${block_name} + alert name from hjson
-    return ($sformatf("%0s_%0s", parent_name, storage_err_alert_name));
+    // top-level alert name is ${ip_name} + alert name from hjson
+    return ($sformatf("%0s_%0s", get_dv_base_reg_block().get_ip_name(), storage_err_alert_name));
   endfunction
 
 endclass

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -6,6 +6,12 @@
 class dv_base_reg_block extends uvm_reg_block;
   `uvm_object_utils(dv_base_reg_block)
 
+  // Since an IP may contains more than one reg block we construct reg_block name as
+  // {ip_name}_{reg_interface_name}.
+  // All the reg_blocks in the IP share the same alert. In top-level, We construct the alert
+  // name as {ip_name}_{alert_name}. Hence, we need this ip_name in reg_block
+  local string ip_name;
+
   csr_excl_item csr_excl;
 
   // The address mask for the register block specific to a map. This will be (1 << K) - 1 for some
@@ -27,6 +33,17 @@ class dv_base_reg_block extends uvm_reg_block;
 
   function new (string name = "", int has_coverage = UVM_NO_COVERAGE);
     super.new(name, has_coverage);
+  endfunction
+
+  function void set_ip_name(string name);
+    ip_name = name;
+  endfunction
+
+  function string get_ip_name();
+    // `DV_CHECK_NE_FATAL can't take "" as an input
+    string empty_str = "";
+    `DV_CHECK_NE_FATAL(ip_name, empty_str, "ip_name hasn't been set yet")
+    return ip_name;
   endfunction
 
   // provide build function to supply base addr

--- a/util/topgen/top_uvm_reg.sv.tpl
+++ b/util/topgen/top_uvm_reg.sv.tpl
@@ -144,6 +144,7 @@ ${make_ral_pkg_window_class(dv_base_prefix, 'chip', window)}
 %>\
       ${if_inst} =
           ${bcname(esc_if_name)}::type_id::create("${if_inst}");
+      ${if_inst}.set_ip_name("${inst_name}");
       ${if_inst}.configure(.parent(this));
       ${if_inst}.build(.base_addr(base_addr + ${base_addr_txt}), .csr_excl(csr_excl));
       ${if_inst}.set_hdl_path_root("${hdl_path}",


### PR DESCRIPTION
Address #8298
Some IP may contains more than one reg_block, but all the reg_block
share the same alert (called ip_name_alert_name).
Need to get this info from reggen

Also fix alert name for top-level

Signed-off-by: Weicai Yang <weicai@google.com>