### PR TITLE
[dv/clkmgr] Update naming to pass CI

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -441,7 +441,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     string         access_str = write ? "write" : "read";
     string         channel_str = channel == AddrChannel ? "address" : "data";
 
-    logic          extclk_sel_regwen = ral.extclk_sel_regwen.get_reset();
+    logic          extclk_ctrl_regwen = ral.extclk_ctrl_regwen.get_reset();
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
@@ -475,13 +475,13 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       "intr_test": begin
         // FIXME
       end
-      "extclk_sel_regwen": begin
+      "extclk_ctrl_regwen": begin
         if (addr_phase_write) begin
-          extclk_sel_regwen = item.a_data;
+          extclk_ctrl_regwen = item.a_data;
         end
       end
       "extclk_sel": begin
-        if (addr_phase_write && extclk_sel_regwen) begin
+        if (addr_phase_write && extclk_ctrl_regwen) begin
           cfg.clkmgr_vif.update_extclk_sel(item.a_data);
         end
       end

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -206,7 +206,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   function void update_csrs_with_reset_values();
     cfg.clkmgr_vif.update_clk_enables(ral.clk_enables.get_reset());
     cfg.clkmgr_vif.update_clk_hints(ral.clk_hints.get_reset());
-    cfg.clkmgr_vif.update_extclk_sel(ral.extclk_sel.get_reset());
+    cfg.clkmgr_vif.update_extclk_sel(ral.extclk_ctrl.get_reset());
   endfunction
 
 endclass : clkmgr_base_vseq

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
@@ -69,7 +69,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
   task body();
     update_csrs_with_reset_values();
     set_scanmode_on_low_weight();
-    csr_wr(.ptr(ral.extclk_sel_regwen), .value(1));
+    csr_wr(.ptr(ral.extclk_ctrl_regwen), .value(1));
     fork
       forever
         @cfg.clkmgr_vif.ast_clk_byp_req begin : ast_clk_byp_ack
@@ -105,7 +105,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
       fork
         begin
           cfg.clk_rst_vif.wait_clks(cycles_before_extclk_sel);
-          csr_wr(.ptr(ral.extclk_sel), .value(extclk_sel));
+          csr_wr(.ptr(ral.extclk_ctrl), .value(extclk_sel));
         end
         begin
           cfg.clk_rst_vif.wait_clks(cycles_before_lc_clk_byp_req);
@@ -119,7 +119,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
                 lc_dft_en,
                 scanmode
                 ), UVM_MEDIUM)
-      csr_rd_check(.ptr(ral.extclk_sel), .compare_value(extclk_sel));
+      csr_rd_check(.ptr(ral.extclk_ctrl), .compare_value(extclk_sel));
       cfg.clk_rst_vif.wait_clks(cycles_before_next_trans);
     end
     disable fork;


### PR DESCRIPTION
Update clkmgr csr name from extclk_sel_regwen to extclk_ctrl_regwen

Signed-off-by: Cindy Chen <chencindy@opentitan.org>