### PR TITLE
[dif/hmac] autogen hmac IRQ DIFs and integrate into src tree

### DIFF
--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_hmac.h"
+
+#include "hmac_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool hmac_get_irq_bit_index(dif_hmac_irq_t irq,
+                                   bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifHmacIrqHmacDone:
+      *index_out = HMAC_INTR_STATE_HMAC_DONE_BIT;
+      break;
+    case kDifHmacIrqFifoEmpty:
+      *index_out = HMAC_INTR_STATE_FIFO_EMPTY_BIT;
+      break;
+    case kDifHmacIrqHmacErr:
+      *index_out = HMAC_INTR_STATE_HMAC_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_get_state(const dif_hmac_t *hmac,
+                                    dif_hmac_irq_state_snapshot_t *snapshot) {
+  if (hmac == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_is_pending(const dif_hmac_t *hmac, dif_hmac_irq_t irq,
+                                     bool *is_pending) {
+  if (hmac == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!hmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_acknowledge(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_t irq) {
+  if (hmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!hmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_get_enabled(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_t irq, dif_toggle_t *state) {
+  if (hmac == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!hmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_set_enabled(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_t irq, dif_toggle_t state) {
+  if (hmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!hmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_force(const dif_hmac_t *hmac, dif_hmac_irq_t irq) {
+  if (hmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!hmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_disable_all(
+    const dif_hmac_t *hmac, dif_hmac_irq_enable_snapshot_t *snapshot) {
+  if (hmac == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_restore_all(
+    const dif_hmac_t *hmac, const dif_hmac_irq_enable_snapshot_t *snapshot) {
+  if (hmac == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(hmac->base_addr, HMAC_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.h
@@ -1,0 +1,171 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_HMAC_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_HMAC_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/hmac/doc/">HMAC</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to hmac.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_hmac {
+  /**
+   * The base address for the hmac hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_hmac_t;
+
+/**
+ * A hmac interrupt request type.
+ */
+typedef enum dif_hmac_irq {
+  /**
+   * HMAC-256 completes a message with key
+   */
+  kDifHmacIrqHmacDone = 0,
+  /**
+   * Message FIFO empty condition
+   */
+  kDifHmacIrqFifoEmpty = 1,
+  /**
+   * HMAC error occurred. ERR_CODE register shows which error occurred
+   */
+  kDifHmacIrqHmacErr = 2,
+} dif_hmac_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_hmac_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_hmac_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_hmac_irq_disable_all()` and `dif_hmac_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_hmac_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_get_state(const dif_hmac_t *hmac,
+                                    dif_hmac_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_is_pending(const dif_hmac_t *hmac, dif_hmac_irq_t irq,
+                                     bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_acknowledge(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_get_enabled(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_t irq, dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_set_enabled(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_t irq, dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param hmac A hmac handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_force(const dif_hmac_t *hmac, dif_hmac_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param hmac A hmac handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_disable_all(const dif_hmac_t *hmac,
+                                      dif_hmac_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param hmac A hmac handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_irq_restore_all(
+    const dif_hmac_t *hmac, const dif_hmac_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_HMAC_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -1,0 +1,282 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_hmac.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "hmac_regs.h"  // Generated.
+
+namespace dif_hmac_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class HmacTest : public Test, public MmioTest {
+ protected:
+  dif_hmac_t hmac_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public HmacTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_hmac_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_hmac_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_get_state(&hmac_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_hmac_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(HMAC_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_hmac_irq_get_state(&hmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_hmac_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(HMAC_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_hmac_irq_get_state(&hmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public HmacTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_hmac_irq_is_pending(nullptr, kDifHmacIrqHmacDone, &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_is_pending(&hmac_, kDifHmacIrqHmacDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_is_pending(nullptr, kDifHmacIrqHmacDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_hmac_irq_is_pending(&hmac_, (dif_hmac_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(HMAC_INTR_STATE_REG_OFFSET,
+                {{HMAC_INTR_STATE_HMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_is_pending(&hmac_, kDifHmacIrqHmacDone, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(HMAC_INTR_STATE_REG_OFFSET,
+                {{HMAC_INTR_STATE_HMAC_ERR_BIT, false}});
+  EXPECT_EQ(dif_hmac_irq_is_pending(&hmac_, kDifHmacIrqHmacErr, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public HmacTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_hmac_irq_acknowledge(nullptr, kDifHmacIrqHmacDone), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_hmac_irq_acknowledge(nullptr, (dif_hmac_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(HMAC_INTR_STATE_REG_OFFSET,
+                 {{HMAC_INTR_STATE_HMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_acknowledge(&hmac_, kDifHmacIrqHmacDone), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(HMAC_INTR_STATE_REG_OFFSET,
+                 {{HMAC_INTR_STATE_HMAC_ERR_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_acknowledge(&hmac_, kDifHmacIrqHmacErr), kDifOk);
+}
+
+class IrqGetEnabledTest : public HmacTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_hmac_irq_get_enabled(nullptr, kDifHmacIrqHmacDone, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, kDifHmacIrqHmacDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_get_enabled(nullptr, kDifHmacIrqHmacDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, (dif_hmac_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(HMAC_INTR_ENABLE_REG_OFFSET,
+                {{HMAC_INTR_ENABLE_HMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, kDifHmacIrqHmacDone, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(HMAC_INTR_ENABLE_REG_OFFSET,
+                {{HMAC_INTR_ENABLE_HMAC_ERR_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, kDifHmacIrqHmacDone, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public HmacTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_hmac_irq_set_enabled(nullptr, kDifHmacIrqHmacDone, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_hmac_irq_set_enabled(&hmac_, (dif_hmac_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(HMAC_INTR_ENABLE_REG_OFFSET,
+                {{HMAC_INTR_ENABLE_HMAC_DONE_BIT, 0x1, true}});
+  EXPECT_EQ(dif_hmac_irq_set_enabled(&hmac_, kDifHmacIrqHmacDone, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(HMAC_INTR_ENABLE_REG_OFFSET,
+                {{HMAC_INTR_ENABLE_HMAC_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(dif_hmac_irq_set_enabled(&hmac_, kDifHmacIrqHmacErr, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public HmacTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_hmac_irq_force(nullptr, kDifHmacIrqHmacDone), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_hmac_irq_force(nullptr, (dif_hmac_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(HMAC_INTR_TEST_REG_OFFSET,
+                 {{HMAC_INTR_TEST_HMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_force(&hmac_, kDifHmacIrqHmacDone), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(HMAC_INTR_TEST_REG_OFFSET,
+                 {{HMAC_INTR_TEST_HMAC_ERR_BIT, true}});
+  EXPECT_EQ(dif_hmac_irq_force(&hmac_, kDifHmacIrqHmacErr), kDifOk);
+}
+
+class IrqDisableAllTest : public HmacTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_hmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_hmac_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(HMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_hmac_irq_disable_all(&hmac_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_hmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(HMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(HMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_hmac_irq_disable_all(&hmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_hmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(HMAC_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(HMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_hmac_irq_disable_all(&hmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public HmacTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_hmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_hmac_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_restore_all(&hmac_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_hmac_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_hmac_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(HMAC_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_hmac_irq_restore_all(&hmac_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_hmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(HMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_hmac_irq_restore_all(&hmac_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_hmac_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -16,13 +16,13 @@ sw_lib_dif_autogen_aes = declare_dependency(
   )
 )
 
-# Autogen UART DIF library
-sw_lib_dif_autogen_uart = declare_dependency(
+# Autogen HMAC DIF library
+sw_lib_dif_autogen_hmac = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_uart',
+    'sw_lib_dif_autogen_hmac',
     sources: [
-      hw_ip_uart_reg_h,
-      'dif_uart_autogen.c',
+      hw_ip_hmac_reg_h,
+      'dif_hmac_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -37,6 +37,20 @@ sw_lib_dif_autogen_lc_ctrl = declare_dependency(
     sources: [
       hw_ip_lc_ctrl_reg_h,
       'dif_lc_ctrl_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen UART DIF library
+sw_lib_dif_autogen_uart = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_uart',
+    sources: [
+      hw_ip_uart_reg_h,
+      'dif_uart_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -303,8 +303,30 @@ sw_lib_dif_hmac = declare_dependency(
     dependencies: [
       sw_lib_bitfield,
       sw_lib_mmio,
+      sw_lib_dif_autogen_hmac,
     ],
   )
+)
+
+test('dif_hmac_unittest', executable(
+    'dif_hmac_unittest',
+    sources: [
+      #'dif_hmac_unittest.cc',
+      'autogen/dif_hmac_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/base/memory.c',
+      meson.source_root() / 'sw/device/lib/dif/dif_hmac.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_hmac_autogen.c',
+      hw_ip_hmac_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO'],
+    cpp_args: ['-DMOCK_MMIO'],
+  ),
+  suite: 'dif',
 )
 
 # KMAC device DIF library


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "hmac".