### PR TITLE
[otbn] Use correct bus_intg_violation signal in ERR_BITS

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -625,7 +625,7 @@ module otbn
   assign hw2reg.err_bits.reg_intg_violation.d = err_bits.reg_intg_violation;
 
   assign hw2reg.err_bits.bus_intg_violation.de = done;
-  assign hw2reg.err_bits.bus_intg_violation.d = bus_intg_violation;
+  assign hw2reg.err_bits.bus_intg_violation.d = err_bits.bus_intg_violation;
 
   assign hw2reg.err_bits.illegal_bus_access.de = done;
   assign hw2reg.err_bits.illegal_bus_access.d = err_bits.illegal_bus_access;


### PR DESCRIPTION
The `bus_intg_violation` signal is driven at the toplevel, and then
wired through to the controller to be assigned to the `err_bits` struct.
We then wire the whole struct back up to the toplevel to assign it to
the `ERR_BITS` external CSR.

Previously, we used the signal that happens to be around in the
toplevel, where we should have used the one coming from the controller
instead. Fix that.

(The FATAL_ALERT_CAUSE external CSR is using the signal directly from
the toplevel.)