### PR TITLE
[dv] Add verible lint waiver file

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim.core
+++ b/hw/top_earlgrey/dv/chip_sim.core
@@ -32,10 +32,16 @@ filesets:
       - tb/tb.sv
     file_type: systemVerilogSource
 
+  files_veriblelint_waiver:
+    files:
+      - lint/chip_sim.vbw
+    file_type: veribleLintWaiver
+
 targets:
   default: &default_target
     toplevel: tb
     filesets:
+      - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
       - files_dv
 
@@ -45,4 +51,3 @@ targets:
 
   lint:
     <<: *default_target
-

--- a/hw/top_earlgrey/dv/lint/chip_sim.vbw
+++ b/hw/top_earlgrey/dv/lint/chip_sim.vbw
@@ -1,0 +1,3 @@
+
+# These lines are too long due to templating
+waive --rule=line-length --location=".*ral_pkg.*"


### PR DESCRIPTION
- ral_pkg files can have lines that get too long for specific modules.
- A specific example of something that caused a problem is the following ```flash_ctrl_flash_ctrl_core_reg_bank1_info0_page_cfg_shadowed```

Signed-off-by: Timothy Chen <timothytim@google.com>