### PR TITLE
[dif/i2c] autogen i2c IRQ DIFs and integrate into src tree

### DIFF
--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -1,0 +1,225 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_I2C_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_I2C_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/i2c/doc/">I2C</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to i2c.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_i2c {
+  /**
+   * The base address for the i2c hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_i2c_t;
+
+/**
+ * A i2c interrupt request type.
+ */
+typedef enum dif_i2c_irq {
+  /**
+   * Raised when the FMT FIFO depth falls below the low watermark.
+   */
+  kDifI2cIrqFmtWatermark = 0,
+  /**
+   * Raised if the RX FIFO is past the high watermark.
+   */
+  kDifI2cIrqRxWatermark = 1,
+  /**
+   * Raised if the FMT FIFO has overflowed.
+   */
+  kDifI2cIrqFmtOverflow = 2,
+  /**
+   * Raised if the RX FIFO has overflowed.
+   */
+  kDifI2cIrqRxOverflow = 3,
+  /**
+   * Raised if there is no ACK in response to an address or data write
+   */
+  kDifI2cIrqNak = 4,
+  /**
+   * Raised if the SCL line drops early (not supported without clock
+   * synchronization).
+   */
+  kDifI2cIrqSclInterference = 5,
+  /**
+   * Raised if the SDA line goes low when host is trying to assert high
+   */
+  kDifI2cIrqSdaInterference = 6,
+  /**
+   * Raised if target stretches the clock beyond the allowed timeout period
+   */
+  kDifI2cIrqStretchTimeout = 7,
+  /**
+   * Raised if the target does not assert a constant value of SDA during
+   * transmission.
+   */
+  kDifI2cIrqSdaUnstable = 8,
+  /**
+   * Raised if the host terminates the transaction by issuing STOP or repeated
+   * START.
+   */
+  kDifI2cIrqTransComplete = 9,
+  /**
+   * Raised if the target needs data to transmit and TX FIFO is empty.
+   */
+  kDifI2cIrqTxEmpty = 10,
+  /**
+   * Raised if there are extra bytes left in TX FIFO at the end of a read.
+   */
+  kDifI2cIrqTxNonempty = 11,
+  /**
+   * Raised if TX FIFO has overflowed.
+   */
+  kDifI2cIrqTxOverflow = 12,
+  /**
+   * Raised if ACQ FIFO has overflowed.
+   */
+  kDifI2cIrqAcqOverflow = 13,
+  /**
+   * Raised if STOP is received after ACK (host sends both signals).
+   */
+  kDifI2cIrqAckStop = 14,
+  /**
+   * Raised if the host stops sending the clock during an ongoing transaction.
+   */
+  kDifI2cIrqHostTimeout = 15,
+} dif_i2c_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_i2c_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_i2c_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_i2c_irq_disable_all()` and `dif_i2c_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_i2c_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_get_state(const dif_i2c_t *i2c,
+                                   dif_i2c_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_is_pending(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
+                                    bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_acknowledge(const dif_i2c_t *i2c, dif_i2c_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_get_enabled(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
+                                     dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_set_enabled(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
+                                     dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param i2c A i2c handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_force(const dif_i2c_t *i2c, dif_i2c_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param i2c A i2c handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_disable_all(const dif_i2c_t *i2c,
+                                     dif_i2c_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param i2c A i2c handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_irq_restore_all(
+    const dif_i2c_t *i2c, const dif_i2c_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_I2C_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -1,0 +1,285 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_i2c.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "i2c_regs.h"  // Generated.
+
+namespace dif_i2c_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class I2cTest : public Test, public MmioTest {
+ protected:
+  dif_i2c_t i2c_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public I2cTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_i2c_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_i2c_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_get_state(&i2c_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_i2c_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_i2c_irq_get_state(&i2c_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_i2c_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_i2c_irq_get_state(&i2c_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public I2cTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_i2c_irq_is_pending(nullptr, kDifI2cIrqFmtWatermark, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqFmtWatermark, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_is_pending(nullptr, kDifI2cIrqFmtWatermark, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, (dif_i2c_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
+                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqFmtWatermark, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
+                {{I2C_INTR_STATE_HOST_TIMEOUT_BIT, false}});
+  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqHostTimeout, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public I2cTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_i2c_irq_acknowledge(nullptr, kDifI2cIrqFmtWatermark),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_i2c_irq_acknowledge(nullptr, (dif_i2c_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET,
+                 {{I2C_INTR_STATE_FMT_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_i2c_irq_acknowledge(&i2c_, kDifI2cIrqFmtWatermark), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET,
+                 {{I2C_INTR_STATE_HOST_TIMEOUT_BIT, true}});
+  EXPECT_EQ(dif_i2c_irq_acknowledge(&i2c_, kDifI2cIrqHostTimeout), kDifOk);
+}
+
+class IrqGetEnabledTest : public I2cTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_i2c_irq_get_enabled(nullptr, kDifI2cIrqFmtWatermark, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_get_enabled(&i2c_, kDifI2cIrqFmtWatermark, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_get_enabled(nullptr, kDifI2cIrqFmtWatermark, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_i2c_irq_get_enabled(&i2c_, (dif_i2c_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(I2C_INTR_ENABLE_REG_OFFSET,
+                {{I2C_INTR_ENABLE_FMT_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_i2c_irq_get_enabled(&i2c_, kDifI2cIrqFmtWatermark, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(I2C_INTR_ENABLE_REG_OFFSET,
+                {{I2C_INTR_ENABLE_HOST_TIMEOUT_BIT, false}});
+  EXPECT_EQ(dif_i2c_irq_get_enabled(&i2c_, kDifI2cIrqHostTimeout, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public I2cTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_i2c_irq_set_enabled(nullptr, kDifI2cIrqFmtWatermark, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, (dif_i2c_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
+                {{I2C_INTR_ENABLE_FMT_WATERMARK_BIT, 0x1, true}});
+  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqFmtWatermark, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
+                {{I2C_INTR_ENABLE_HOST_TIMEOUT_BIT, 0x1, false}});
+  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqHostTimeout, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public I2cTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_i2c_irq_force(nullptr, kDifI2cIrqFmtWatermark), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_i2c_irq_force(nullptr, (dif_i2c_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET,
+                 {{I2C_INTR_TEST_FMT_WATERMARK_BIT, true}});
+  EXPECT_EQ(dif_i2c_irq_force(&i2c_, kDifI2cIrqFmtWatermark), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET,
+                 {{I2C_INTR_TEST_HOST_TIMEOUT_BIT, true}});
+  EXPECT_EQ(dif_i2c_irq_force(&i2c_, kDifI2cIrqHostTimeout), kDifOk);
+}
+
+class IrqDisableAllTest : public I2cTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_i2c_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_i2c_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(I2C_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_i2c_irq_disable_all(&i2c_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_i2c_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(I2C_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(I2C_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_i2c_irq_disable_all(&i2c_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_i2c_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(I2C_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(I2C_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_i2c_irq_disable_all(&i2c_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public I2cTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_i2c_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_i2c_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_restore_all(&i2c_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_i2c_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_i2c_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(I2C_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_i2c_irq_restore_all(&i2c_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_i2c_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(I2C_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_i2c_irq_restore_all(&i2c_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_i2c_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen GPIO DIF library
-sw_lib_dif_autogen_gpio = declare_dependency(
+# Autogen I2C Controller DIF library
+sw_lib_dif_autogen_i2c = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_gpio',
+    'sw_lib_dif_autogen_i2c',
     sources: [
-      hw_ip_gpio_reg_h,
-      'dif_gpio_autogen.c',
+      hw_ip_i2c_reg_h,
+      'dif_i2c_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -37,6 +37,20 @@ sw_lib_dif_autogen_alert_handler = declare_dependency(
     sources: [
       hw_ip_alert_handler_reg_h,
       'dif_alert_handler_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen GPIO DIF library
+sw_lib_dif_autogen_gpio = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_gpio',
+    sources: [
+      hw_ip_gpio_reg_h,
+      'dif_gpio_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -5,6 +5,9 @@
 #include "sw/device/lib/dif/dif_i2c.h"
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
 
 #include "i2c_regs.h"  // Generated
 
@@ -75,10 +78,10 @@ static dif_i2c_config_t default_timing_for_speed(dif_i2c_speed_t speed,
 
 static const uint32_t kNanosPerKBaud = 1000000;  // One million.
 
-dif_i2c_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
-                                        dif_i2c_config_t *config) {
+dif_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
+                                    dif_i2c_config_t *config) {
   if (config == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
   uint32_t lowest_target_device_speed_khz;
   switch (timing_config.lowest_target_device_speed) {
@@ -92,7 +95,7 @@ dif_i2c_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
       lowest_target_device_speed_khz = 1000;
       break;
     default:
-      return kDifI2cBadArg;
+      return kDifBadArg;
   }
 
   // This code follows the algorithm given in
@@ -123,23 +126,22 @@ dif_i2c_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
     config->scl_time_high_cycles = lengthened_high_cycles;
   }
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_init(dif_i2c_params_t params, dif_i2c_t *i2c) {
+dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
-  i2c->params = params;
+  i2c->base_addr = base_addr;
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_configure(const dif_i2c_t *i2c,
-                                   dif_i2c_config_t config) {
+dif_result_t dif_i2c_configure(const dif_i2c_t *i2c, dif_i2c_config_t config) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   uint32_t timing0 = 0;
@@ -147,70 +149,68 @@ dif_i2c_result_t dif_i2c_configure(const dif_i2c_t *i2c,
                                    config.scl_time_high_cycles);
   timing0 = bitfield_field32_write(timing0, I2C_TIMING0_TLOW_FIELD,
                                    config.scl_time_low_cycles);
-  mmio_region_write32(i2c->params.base_addr, I2C_TIMING0_REG_OFFSET, timing0);
+  mmio_region_write32(i2c->base_addr, I2C_TIMING0_REG_OFFSET, timing0);
 
   uint32_t timing1 = 0;
   timing1 = bitfield_field32_write(timing1, I2C_TIMING1_T_R_FIELD,
                                    config.rise_cycles);
   timing1 = bitfield_field32_write(timing1, I2C_TIMING1_T_F_FIELD,
                                    config.fall_cycles);
-  mmio_region_write32(i2c->params.base_addr, I2C_TIMING1_REG_OFFSET, timing1);
+  mmio_region_write32(i2c->base_addr, I2C_TIMING1_REG_OFFSET, timing1);
 
   uint32_t timing2 = 0;
   timing2 = bitfield_field32_write(timing2, I2C_TIMING2_TSU_STA_FIELD,
                                    config.start_signal_setup_cycles);
   timing2 = bitfield_field32_write(timing2, I2C_TIMING2_THD_STA_FIELD,
                                    config.start_signal_hold_cycles);
-  mmio_region_write32(i2c->params.base_addr, I2C_TIMING2_REG_OFFSET, timing2);
+  mmio_region_write32(i2c->base_addr, I2C_TIMING2_REG_OFFSET, timing2);
 
   uint32_t timing3 = 0;
   timing3 = bitfield_field32_write(timing3, I2C_TIMING3_TSU_DAT_FIELD,
                                    config.data_signal_setup_cycles);
   timing3 = bitfield_field32_write(timing3, I2C_TIMING3_THD_DAT_FIELD,
                                    config.data_signal_hold_cycles);
-  mmio_region_write32(i2c->params.base_addr, I2C_TIMING3_REG_OFFSET, timing3);
+  mmio_region_write32(i2c->base_addr, I2C_TIMING3_REG_OFFSET, timing3);
 
   uint32_t timing4 = 0;
   timing4 = bitfield_field32_write(timing4, I2C_TIMING4_TSU_STO_FIELD,
                                    config.stop_signal_setup_cycles);
   timing4 = bitfield_field32_write(timing4, I2C_TIMING4_T_BUF_FIELD,
                                    config.stop_signal_hold_cycles);
-  mmio_region_write32(i2c->params.base_addr, I2C_TIMING4_REG_OFFSET, timing4);
+  mmio_region_write32(i2c->base_addr, I2C_TIMING4_REG_OFFSET, timing4);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_reset_rx_fifo(const dif_i2c_t *i2c) {
+dif_result_t dif_i2c_reset_rx_fifo(const dif_i2c_t *i2c) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t reg =
-      mmio_region_read32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET);
   reg = bitfield_bit32_write(reg, I2C_FIFO_CTRL_RXRST_BIT, true);
-  mmio_region_write32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET, reg);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_reset_fmt_fifo(const dif_i2c_t *i2c) {
+dif_result_t dif_i2c_reset_fmt_fifo(const dif_i2c_t *i2c) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t reg =
-      mmio_region_read32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET);
   reg = bitfield_bit32_write(reg, I2C_FIFO_CTRL_FMTRST_BIT, true);
-  mmio_region_write32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET, reg);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
-                                        dif_i2c_level_t rx_level,
-                                        dif_i2c_level_t fmt_level) {
+dif_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
+                                    dif_i2c_level_t rx_level,
+                                    dif_i2c_level_t fmt_level) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   ptrdiff_t rx_level_value;
@@ -231,7 +231,7 @@ dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
       rx_level_value = I2C_FIFO_CTRL_RXILVL_VALUE_RXLVL30;
       break;
     default:
-      return kDifI2cBadArg;
+      return kDifBadArg;
   }
 
   ptrdiff_t fmt_level_value;
@@ -249,262 +249,93 @@ dif_i2c_result_t dif_i2c_set_watermarks(const dif_i2c_t *i2c,
       fmt_level_value = I2C_FIFO_CTRL_FMTILVL_VALUE_FMTLVL16;
       break;
     default:
-      return kDifI2cBadArg;
+      return kDifBadArg;
   }
 
   uint32_t ctrl_value =
-      mmio_region_read32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET);
+      mmio_region_read32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET);
   ctrl_value = bitfield_field32_write(ctrl_value, I2C_FIFO_CTRL_RXILVL_FIELD,
                                       rx_level_value);
   ctrl_value = bitfield_field32_write(ctrl_value, I2C_FIFO_CTRL_FMTILVL_FIELD,
                                       fmt_level_value);
-  mmio_region_write32(i2c->params.base_addr, I2C_FIFO_CTRL_REG_OFFSET,
-                      ctrl_value);
+  mmio_region_write32(i2c->base_addr, I2C_FIFO_CTRL_REG_OFFSET, ctrl_value);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-OT_WARN_UNUSED_RESULT
-static bool irq_index(dif_i2c_irq_t irq, bitfield_bit32_index_t *bit_index) {
-  switch (irq) {
-    case kDifI2cIrqFmtWatermarkUnderflow:
-      *bit_index = I2C_INTR_COMMON_FMT_WATERMARK_BIT;
-      break;
-    case kDifI2cIrqRxWatermarkOverflow:
-      *bit_index = I2C_INTR_COMMON_RX_WATERMARK_BIT;
-      break;
-    case kDifI2cIrqFmtFifoOverflow:
-      *bit_index = I2C_INTR_COMMON_FMT_OVERFLOW_BIT;
-      break;
-    case kDifI2cIrqRxFifoOverflow:
-      *bit_index = I2C_INTR_COMMON_RX_OVERFLOW_BIT;
-      break;
-    case kDifI2cIrqNak:
-      *bit_index = I2C_INTR_COMMON_NAK_BIT;
-      break;
-    case kDifI2cIrqSclInterference:
-      *bit_index = I2C_INTR_COMMON_SCL_INTERFERENCE_BIT;
-      break;
-    case kDifI2cIrqSdaInterference:
-      *bit_index = I2C_INTR_COMMON_SDA_INTERFERENCE_BIT;
-      break;
-    case kDifI2cIrqClockStretchTimeout:
-      *bit_index = I2C_INTR_COMMON_STRETCH_TIMEOUT_BIT;
-      break;
-    case kDifI2cIrqSdaUnstable:
-      *bit_index = I2C_INTR_COMMON_SDA_UNSTABLE_BIT;
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-
-dif_i2c_result_t dif_i2c_irq_is_pending(const dif_i2c_t *i2c, dif_i2c_irq_t irq,
-                                        bool *is_pending) {
-  if (i2c == NULL || is_pending == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifI2cBadArg;
-  }
-
-  uint32_t reg =
-      mmio_region_read32(i2c->params.base_addr, I2C_INTR_STATE_REG_OFFSET);
-  *is_pending = bitfield_bit32_read(reg, index);
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_irq_acknowledge(const dif_i2c_t *i2c,
-                                         dif_i2c_irq_t irq) {
+dif_result_t dif_i2c_host_set_enabled(const dif_i2c_t *i2c,
+                                      dif_toggle_t state) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifI2cBadArg;
-  }
-
-  uint32_t reg = bitfield_bit32_write(0, index, true);
-  mmio_region_write32(i2c->params.base_addr, I2C_INTR_STATE_REG_OFFSET, reg);
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_irq_get_enabled(const dif_i2c_t *i2c,
-                                         dif_i2c_irq_t irq,
-                                         dif_i2c_toggle_t *state) {
-  if (i2c == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifI2cBadArg;
-  }
-
-  uint32_t reg =
-      mmio_region_read32(i2c->params.base_addr, I2C_INTR_ENABLE_REG_OFFSET);
-  bool is_enabled = bitfield_bit32_read(reg, index);
-  *state = is_enabled ? kDifI2cToggleEnabled : kDifI2cToggleDisabled;
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_irq_set_enabled(const dif_i2c_t *i2c,
-                                         dif_i2c_irq_t irq,
-                                         dif_i2c_toggle_t state) {
-  if (i2c == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   bool flag;
   switch (state) {
-    case kDifI2cToggleEnabled:
+    case kDifToggleEnabled:
       flag = true;
       break;
-    case kDifI2cToggleDisabled:
+    case kDifToggleDisabled:
       flag = false;
       break;
     default:
-      return kDifI2cBadArg;
+      return kDifBadArg;
   }
 
-  uint32_t reg =
-      mmio_region_read32(i2c->params.base_addr, I2C_INTR_ENABLE_REG_OFFSET);
-  reg = bitfield_bit32_write(reg, index, flag);
-  mmio_region_write32(i2c->params.base_addr, I2C_INTR_ENABLE_REG_OFFSET, reg);
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_irq_force(const dif_i2c_t *i2c, dif_i2c_irq_t irq) {
-  if (i2c == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  if (!irq_index(irq, &index)) {
-    return kDifI2cBadArg;
-  }
-
-  uint32_t reg = bitfield_bit32_write(0, index, true);
-  mmio_region_write32(i2c->params.base_addr, I2C_INTR_TEST_REG_OFFSET, reg);
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_irq_disable_all(const dif_i2c_t *i2c,
-                                         dif_i2c_irq_snapshot_t *snapshot) {
-  if (i2c == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  if (snapshot != NULL) {
-    *snapshot =
-        mmio_region_read32(i2c->params.base_addr, I2C_INTR_ENABLE_REG_OFFSET);
-  }
-
-  mmio_region_write32(i2c->params.base_addr, I2C_INTR_ENABLE_REG_OFFSET, 0);
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_irq_restore_all(
-    const dif_i2c_t *i2c, const dif_i2c_irq_snapshot_t *snapshot) {
-  if (i2c == NULL || snapshot == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  mmio_region_write32(i2c->params.base_addr, I2C_INTR_ENABLE_REG_OFFSET,
-                      *snapshot);
-
-  return kDifI2cOk;
-}
-
-dif_i2c_result_t dif_i2c_host_set_enabled(const dif_i2c_t *i2c,
-                                          dif_i2c_toggle_t state) {
-  if (i2c == NULL) {
-    return kDifI2cBadArg;
-  }
-
-  bool flag;
-  switch (state) {
-    case kDifI2cToggleEnabled:
-      flag = true;
-      break;
-    case kDifI2cToggleDisabled:
-      flag = false;
-      break;
-    default:
-      return kDifI2cBadArg;
-  }
-
-  uint32_t reg = mmio_region_read32(i2c->params.base_addr, I2C_CTRL_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(i2c->base_addr, I2C_CTRL_REG_OFFSET);
   reg = bitfield_bit32_write(reg, I2C_CTRL_ENABLEHOST_BIT, flag);
-  mmio_region_write32(i2c->params.base_addr, I2C_CTRL_REG_OFFSET, reg);
+  mmio_region_write32(i2c->base_addr, I2C_CTRL_REG_OFFSET, reg);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_override_set_enabled(const dif_i2c_t *i2c,
-                                              dif_i2c_toggle_t state) {
+dif_result_t dif_i2c_override_set_enabled(const dif_i2c_t *i2c,
+                                          dif_toggle_t state) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   bool flag;
   switch (state) {
-    case kDifI2cToggleEnabled:
+    case kDifToggleEnabled:
       flag = true;
       break;
-    case kDifI2cToggleDisabled:
+    case kDifToggleDisabled:
       flag = false;
       break;
     default:
-      return kDifI2cBadArg;
+      return kDifBadArg;
   }
 
-  uint32_t reg = mmio_region_read32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET);
+  uint32_t reg = mmio_region_read32(i2c->base_addr, I2C_OVRD_REG_OFFSET);
   reg = bitfield_bit32_write(reg, I2C_OVRD_TXOVRDEN_BIT, flag);
-  mmio_region_write32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET, reg);
+  mmio_region_write32(i2c->base_addr, I2C_OVRD_REG_OFFSET, reg);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_override_drive_pins(const dif_i2c_t *i2c, bool scl,
-                                             bool sda) {
+dif_result_t dif_i2c_override_drive_pins(const dif_i2c_t *i2c, bool scl,
+                                         bool sda) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   uint32_t override_val =
-      mmio_region_read32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET);
+      mmio_region_read32(i2c->base_addr, I2C_OVRD_REG_OFFSET);
   override_val = bitfield_bit32_write(override_val, I2C_OVRD_SCLVAL_BIT, scl);
   override_val = bitfield_bit32_write(override_val, I2C_OVRD_SDAVAL_BIT, sda);
-  mmio_region_write32(i2c->params.base_addr, I2C_OVRD_REG_OFFSET, override_val);
+  mmio_region_write32(i2c->base_addr, I2C_OVRD_REG_OFFSET, override_val);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
-                                              uint16_t *scl_samples,
-                                              uint16_t *sda_samples) {
+dif_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
+                                          uint16_t *scl_samples,
+                                          uint16_t *sda_samples) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t samples =
-      mmio_region_read32(i2c->params.base_addr, I2C_VAL_REG_OFFSET);
+  uint32_t samples = mmio_region_read32(i2c->base_addr, I2C_VAL_REG_OFFSET);
   if (scl_samples != NULL) {
     *scl_samples = bitfield_field32_read(samples, I2C_VAL_SCL_RX_FIELD);
   }
@@ -513,18 +344,18 @@ dif_i2c_result_t dif_i2c_override_sample_pins(const dif_i2c_t *i2c,
     *sda_samples = bitfield_field32_read(samples, I2C_VAL_SDA_RX_FIELD);
   }
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
-                                         uint8_t *fmt_fifo_level,
-                                         uint8_t *rx_fifo_level) {
+dif_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
+                                     uint8_t *fmt_fifo_level,
+                                     uint8_t *rx_fifo_level) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   uint32_t values =
-      mmio_region_read32(i2c->params.base_addr, I2C_FIFO_STATUS_REG_OFFSET);
+      mmio_region_read32(i2c->base_addr, I2C_FIFO_STATUS_REG_OFFSET);
   if (fmt_fifo_level != NULL) {
     *fmt_fifo_level =
         bitfield_field32_read(values, I2C_FIFO_STATUS_FMTLVL_FIELD);
@@ -533,38 +364,37 @@ dif_i2c_result_t dif_i2c_get_fifo_levels(const dif_i2c_t *i2c,
     *rx_fifo_level = bitfield_field32_read(values, I2C_FIFO_STATUS_RXLVL_FIELD);
   }
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_read_byte(const dif_i2c_t *i2c, uint8_t *byte) {
+dif_result_t dif_i2c_read_byte(const dif_i2c_t *i2c, uint8_t *byte) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t values =
-      mmio_region_read32(i2c->params.base_addr, I2C_RDATA_REG_OFFSET);
+  uint32_t values = mmio_region_read32(i2c->base_addr, I2C_RDATA_REG_OFFSET);
   if (byte != NULL) {
     *byte = bitfield_field32_read(values, I2C_RDATA_RDATA_FIELD);
   }
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
-                                        dif_i2c_fmt_flags_t flags) {
+dif_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
+                                    dif_i2c_fmt_flags_t flags) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
   // Validate that "write only" flags and "read only" flags are not set
   // simultaneously.
   bool has_write_flags = flags.start || flags.stop || flags.suppress_nak_irq;
   bool has_read_flags = flags.read || flags.read_cont;
   if (has_write_flags && has_read_flags) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
   // Also, read_cont requires read.
   if (flags.read_cont && !flags.read) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   uint32_t fmt_byte = 0;
@@ -576,15 +406,15 @@ dif_i2c_result_t dif_i2c_write_byte_raw(const dif_i2c_t *i2c, uint8_t byte,
       bitfield_bit32_write(fmt_byte, I2C_FDATA_RCONT_BIT, flags.read_cont);
   fmt_byte = bitfield_bit32_write(fmt_byte, I2C_FDATA_NAKOK_BIT,
                                   flags.suppress_nak_irq);
-  mmio_region_write32(i2c->params.base_addr, I2C_FDATA_REG_OFFSET, fmt_byte);
+  mmio_region_write32(i2c->base_addr, I2C_FDATA_REG_OFFSET, fmt_byte);
 
-  return kDifI2cOk;
+  return kDifOk;
 }
 
-dif_i2c_result_t dif_i2c_write_byte(const dif_i2c_t *i2c, uint8_t byte,
-                                    dif_i2c_fmt_t code, bool suppress_nak_irq) {
+dif_result_t dif_i2c_write_byte(const dif_i2c_t *i2c, uint8_t byte,
+                                dif_i2c_fmt_t code, bool suppress_nak_irq) {
   if (i2c == NULL) {
-    return kDifI2cBadArg;
+    return kDifBadArg;
   }
 
   // Validate that `suppress_nak_irq` has not been mixed with an Rx code.
@@ -593,7 +423,7 @@ dif_i2c_result_t dif_i2c_write_byte(const dif_i2c_t *i2c, uint8_t byte,
       case kDifI2cFmtRx:
       case kDifI2cFmtRxContinue:
       case kDifI2cFmtRxStop:
-        return kDifI2cBadArg;
+        return kDifBadArg;
       default:
         break;
     }
@@ -622,7 +452,7 @@ dif_i2c_result_t dif_i2c_write_byte(const dif_i2c_t *i2c, uint8_t byte,
       flags.stop = true;
       break;
     default:
-      return kDifI2cBadArg;
+      return kDifBadArg;
   }
 
   return dif_i2c_write_byte_raw(i2c, byte, flags);

--- a/sw/device/lib/dif/dif_i2c_unittest.cc
+++ b/sw/device/lib/dif/dif_i2c_unittest.cc
@@ -51,6 +51,11 @@ using ::mock_mmio::LeInt;
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
 
+class I2cTest : public testing::Test, public MmioTest {
+ protected:
+  dif_i2c_t i2c_ = {.base_addr = dev().region()};
+};
+
 // "Base" configs consisting of harware timings, in "slow" and "fast" variants.
 constexpr dif_i2c_timing_config_t kBaseConfigSlow = {
     .lowest_target_device_speed =
@@ -86,7 +91,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .stop_signal_setup_cycles = 45,
       .stop_signal_hold_cycles = 53,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 
   config = kBaseConfigFast;
@@ -103,7 +108,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .stop_signal_setup_cycles = 200,
       .stop_signal_hold_cycles = 235,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 
   config = kBaseConfigSlow;
@@ -121,7 +126,7 @@ TEST(ComputeTimingTest, StandardSpeed) {
       .stop_signal_setup_cycles = 45,
       .stop_signal_hold_cycles = 53,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 }
 
@@ -143,7 +148,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .stop_signal_setup_cycles = 7,
       .stop_signal_hold_cycles = 15,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 
   config = kBaseConfigFast;
@@ -160,7 +165,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .stop_signal_setup_cycles = 30,
       .stop_signal_hold_cycles = 65,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 
   config = kBaseConfigSlow;
@@ -178,7 +183,7 @@ TEST(ComputeTimingTest, FastSpeed) {
       .stop_signal_setup_cycles = 7,
       .stop_signal_hold_cycles = 15,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 }
 
@@ -200,7 +205,7 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 
   config = kBaseConfigFast;
@@ -218,18 +223,13 @@ TEST(ComputeTimingTest, FastPlusSpeed) {
       .stop_signal_setup_cycles = 13,
       .stop_signal_hold_cycles = 25,
   };
-  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_compute_timing(config, &params), kDifOk);
   EXPECT_EQ(params, expected);
 }
 
 TEST(ComputeTimingTest, NullArgs) {
-  EXPECT_EQ(dif_i2c_compute_timing(kBaseConfigFast, nullptr), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_compute_timing(kBaseConfigFast, nullptr), kDifBadArg);
 }
-
-class I2cTest : public testing::Test, public MmioTest {
- protected:
-  dif_i2c_t i2c_ = {.params = {.base_addr = dev().region()}};
-};
 
 class ConfigTest : public I2cTest {};
 
@@ -276,11 +276,11 @@ TEST_F(ConfigTest, NormalInit) {
           {I2C_TIMING4_T_BUF_OFFSET, config.stop_signal_hold_cycles},
       });
 
-  EXPECT_EQ(dif_i2c_configure(&i2c_, config), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_configure(&i2c_, config), kDifOk);
 }
 
 TEST_F(ConfigTest, NullArgs) {
-  EXPECT_EQ(dif_i2c_configure(nullptr, {}), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_configure(nullptr, {}), kDifBadArg);
 }
 
 class FifoCtrlTest : public I2cTest {};
@@ -288,21 +288,21 @@ class FifoCtrlTest : public I2cTest {};
 TEST_F(FifoCtrlTest, RxReset) {
   EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
                 {{I2C_FIFO_CTRL_RXRST_BIT, 0x1, 0x1}});
-  EXPECT_EQ(dif_i2c_reset_rx_fifo(&i2c_), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_reset_rx_fifo(&i2c_), kDifOk);
 }
 
 TEST_F(FifoCtrlTest, RxNullArgs) {
-  EXPECT_EQ(dif_i2c_reset_rx_fifo(nullptr), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_reset_rx_fifo(nullptr), kDifBadArg);
 }
 
 TEST_F(FifoCtrlTest, FmtReset) {
   EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
                 {{I2C_FIFO_CTRL_FMTRST_BIT, 0x1, 0x1}});
-  EXPECT_EQ(dif_i2c_reset_fmt_fifo(&i2c_), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_reset_fmt_fifo(&i2c_), kDifOk);
 }
 
 TEST_F(FifoCtrlTest, FmtNullArgs) {
-  EXPECT_EQ(dif_i2c_reset_fmt_fifo(nullptr), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_reset_fmt_fifo(nullptr), kDifBadArg);
 }
 
 TEST_F(FifoCtrlTest, SetLevels) {
@@ -320,7 +320,7 @@ TEST_F(FifoCtrlTest, SetLevels) {
                     },
                 });
   EXPECT_EQ(dif_i2c_set_watermarks(&i2c_, kDifI2cLevel1Byte, kDifI2cLevel1Byte),
-            kDifI2cOk);
+            kDifOk);
 
   EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
                 {
@@ -337,7 +337,7 @@ TEST_F(FifoCtrlTest, SetLevels) {
                 });
   EXPECT_EQ(
       dif_i2c_set_watermarks(&i2c_, kDifI2cLevel4Byte, kDifI2cLevel16Byte),
-      kDifI2cOk);
+      kDifOk);
 
   EXPECT_MASK32(I2C_FIFO_CTRL_REG_OFFSET,
                 {
@@ -354,145 +354,46 @@ TEST_F(FifoCtrlTest, SetLevels) {
                 });
   EXPECT_EQ(
       dif_i2c_set_watermarks(&i2c_, kDifI2cLevel30Byte, kDifI2cLevel8Byte),
-      kDifI2cOk);
+      kDifOk);
 
   EXPECT_EQ(
       dif_i2c_set_watermarks(&i2c_, kDifI2cLevel30Byte, kDifI2cLevel30Byte),
-      kDifI2cBadArg);
+      kDifBadArg);
 }
 
 TEST_F(FifoCtrlTest, SetLevelsNullArgs) {
   EXPECT_EQ(
       dif_i2c_set_watermarks(nullptr, kDifI2cLevel4Byte, kDifI2cLevel16Byte),
-      kDifI2cBadArg);
-}
-
-class IrqTest : public I2cTest {};
-
-TEST_F(IrqTest, Get) {
-  bool flag;
-
-  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1}});
-  EXPECT_EQ(
-      dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqFmtWatermarkUnderflow, &flag),
-      kDifI2cOk);
-  EXPECT_TRUE(flag);
-
-  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x0}});
-  EXPECT_EQ(
-      dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqFmtWatermarkUnderflow, &flag),
-      kDifI2cOk);
-  EXPECT_FALSE(flag);
-
-  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK_BIT, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqNak, &flag), kDifI2cOk);
-  EXPECT_TRUE(flag);
-
-  EXPECT_READ32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK_BIT, 0x0}});
-  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqNak, &flag), kDifI2cOk);
-  EXPECT_FALSE(flag);
-}
-
-TEST_F(IrqTest, GetNullArgs) {
-  bool flag;
-
-  EXPECT_EQ(dif_i2c_irq_is_pending(nullptr, kDifI2cIrqNak, &flag),
-            kDifI2cBadArg);
-  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, kDifI2cIrqNak, nullptr),
-            kDifI2cBadArg);
-}
-
-TEST_F(IrqTest, Clear) {
-  EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET,
-                 {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_acknowledge(&i2c_, kDifI2cIrqFmtWatermarkUnderflow),
-            kDifI2cOk);
-
-  EXPECT_WRITE32(I2C_INTR_STATE_REG_OFFSET, {{I2C_INTR_STATE_NAK_BIT, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_acknowledge(&i2c_, kDifI2cIrqNak), kDifI2cOk);
-}
-
-TEST_F(IrqTest, ClearNullArgs) {
-  EXPECT_EQ(dif_i2c_irq_acknowledge(nullptr, kDifI2cIrqNak), kDifI2cBadArg);
-}
-
-TEST_F(IrqTest, Enable) {
-  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqFmtWatermarkUnderflow,
-                                    kDifI2cToggleEnabled),
-            kDifI2cOk);
-
-  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
-                {{I2C_INTR_STATE_FMT_WATERMARK_BIT, 0x1, 0x0}});
-  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqFmtWatermarkUnderflow,
-                                    kDifI2cToggleDisabled),
-            kDifI2cOk);
-
-  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
-                {{I2C_INTR_STATE_NAK_BIT, 0x1, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqNak, kDifI2cToggleEnabled),
-            kDifI2cOk);
-
-  EXPECT_MASK32(I2C_INTR_ENABLE_REG_OFFSET,
-                {{I2C_INTR_STATE_NAK_BIT, 0x1, 0x0}});
-  EXPECT_EQ(
-      dif_i2c_irq_set_enabled(&i2c_, kDifI2cIrqNak, kDifI2cToggleDisabled),
-      kDifI2cOk);
-}
-
-TEST_F(IrqTest, EnableNullArgs) {
-  EXPECT_EQ(
-      dif_i2c_irq_set_enabled(nullptr, kDifI2cIrqNak, kDifI2cToggleEnabled),
-      kDifI2cBadArg);
-}
-
-TEST_F(IrqTest, Force) {
-  EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET,
-                 {{I2C_INTR_TEST_FMT_WATERMARK_BIT, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_force(&i2c_, kDifI2cIrqFmtWatermarkUnderflow),
-            kDifI2cOk);
-
-  EXPECT_WRITE32(I2C_INTR_TEST_REG_OFFSET, {{I2C_INTR_TEST_NAK_BIT, 0x1}});
-  EXPECT_EQ(dif_i2c_irq_force(&i2c_, kDifI2cIrqNak), kDifI2cOk);
-}
-
-TEST_F(IrqTest, ForceNullArgs) {
-  EXPECT_EQ(dif_i2c_irq_force(nullptr, kDifI2cIrqNak), kDifI2cBadArg);
+      kDifBadArg);
 }
 
 class ControlTest : public I2cTest {};
 
 TEST_F(ControlTest, HostEnable) {
   EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLEHOST_BIT, 0x1, 0x1}});
-  EXPECT_EQ(dif_i2c_host_set_enabled(&i2c_, kDifI2cToggleEnabled), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_host_set_enabled(&i2c_, kDifToggleEnabled), kDifOk);
 
   EXPECT_MASK32(I2C_CTRL_REG_OFFSET, {{I2C_CTRL_ENABLEHOST_BIT, 0x1, 0x0}});
-  EXPECT_EQ(dif_i2c_host_set_enabled(&i2c_, kDifI2cToggleDisabled), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_host_set_enabled(&i2c_, kDifToggleDisabled), kDifOk);
 }
 
 TEST_F(ControlTest, HostEnableNullArgs) {
-  EXPECT_EQ(dif_i2c_host_set_enabled(nullptr, kDifI2cToggleEnabled),
-            kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_host_set_enabled(nullptr, kDifToggleEnabled), kDifBadArg);
 }
 
 class OverrideTest : public I2cTest {};
 
 TEST_F(OverrideTest, Enable) {
   EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {{I2C_OVRD_TXOVRDEN_BIT, 0x1, 0x1}});
-  EXPECT_EQ(dif_i2c_override_set_enabled(&i2c_, kDifI2cToggleEnabled),
-            kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_set_enabled(&i2c_, kDifToggleEnabled), kDifOk);
 
   EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {{I2C_OVRD_TXOVRDEN_BIT, 0x1, 0x0}});
-  EXPECT_EQ(dif_i2c_override_set_enabled(&i2c_, kDifI2cToggleDisabled),
-            kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_set_enabled(&i2c_, kDifToggleDisabled), kDifOk);
 }
 
 TEST_F(OverrideTest, EnableNullArgs) {
-  EXPECT_EQ(dif_i2c_override_set_enabled(nullptr, kDifI2cToggleEnabled),
-            kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_override_set_enabled(nullptr, kDifToggleEnabled),
+            kDifBadArg);
 }
 
 TEST_F(OverrideTest, Drive) {
@@ -500,48 +401,48 @@ TEST_F(OverrideTest, Drive) {
                                          {I2C_OVRD_SCLVAL_BIT, 0x1, 0x0},
                                          {I2C_OVRD_SDAVAL_BIT, 0x1, 0x0},
                                      });
-  EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, false, false), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, false, false), kDifOk);
 
   EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {
                                          {I2C_OVRD_SCLVAL_BIT, 0x1, 0x0},
                                          {I2C_OVRD_SDAVAL_BIT, 0x1, 0x1},
                                      });
-  EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, false, true), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, false, true), kDifOk);
 
   EXPECT_MASK32(I2C_OVRD_REG_OFFSET, {
                                          {I2C_OVRD_SCLVAL_BIT, 0x1, 0x1},
                                          {I2C_OVRD_SDAVAL_BIT, 0x1, 0x1},
                                      });
-  EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, true, true), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_drive_pins(&i2c_, true, true), kDifOk);
 }
 
 TEST_F(OverrideTest, DriveNullArgs) {
-  EXPECT_EQ(dif_i2c_override_drive_pins(nullptr, false, false), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_override_drive_pins(nullptr, false, false), kDifBadArg);
 }
 
 TEST_F(OverrideTest, Sample) {
   uint16_t scl, sda;
   EXPECT_READ32(I2C_VAL_REG_OFFSET, 0x10293847);
-  EXPECT_EQ(dif_i2c_override_sample_pins(&i2c_, &scl, &sda), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_sample_pins(&i2c_, &scl, &sda), kDifOk);
   EXPECT_EQ(scl, 0x3847);
   EXPECT_EQ(sda, 0x1029);
 
   scl = 0, sda = 0;
   EXPECT_READ32(I2C_VAL_REG_OFFSET, 0x10293847);
-  EXPECT_EQ(dif_i2c_override_sample_pins(&i2c_, nullptr, &sda), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_sample_pins(&i2c_, nullptr, &sda), kDifOk);
   EXPECT_EQ(scl, 0x0);
   EXPECT_EQ(sda, 0x1029);
 
   scl = 0, sda = 0;
   EXPECT_READ32(I2C_VAL_REG_OFFSET, 0x10293847);
-  EXPECT_EQ(dif_i2c_override_sample_pins(&i2c_, &scl, nullptr), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_override_sample_pins(&i2c_, &scl, nullptr), kDifOk);
   EXPECT_EQ(scl, 0x3847);
   EXPECT_EQ(sda, 0x0);
 }
 
 TEST_F(OverrideTest, SampleNullArgs) {
   uint16_t scl, sda;
-  EXPECT_EQ(dif_i2c_override_sample_pins(nullptr, &scl, &sda), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_override_sample_pins(nullptr, &scl, &sda), kDifBadArg);
 }
 
 class FifoTest : public I2cTest {};
@@ -549,26 +450,26 @@ class FifoTest : public I2cTest {};
 TEST_F(FifoTest, GetLevels) {
   uint8_t rx, fmt;
   EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
-  EXPECT_EQ(dif_i2c_get_fifo_levels(&i2c_, &rx, &fmt), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_get_fifo_levels(&i2c_, &rx, &fmt), kDifOk);
   EXPECT_EQ(rx, 0x47);
   EXPECT_EQ(fmt, 0x29);
 
   rx = 0, fmt = 0;
   EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
-  EXPECT_EQ(dif_i2c_get_fifo_levels(&i2c_, nullptr, &fmt), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_get_fifo_levels(&i2c_, nullptr, &fmt), kDifOk);
   EXPECT_EQ(rx, 0x0);
   EXPECT_EQ(fmt, 0x29);
 
   rx = 0, fmt = 0;
   EXPECT_READ32(I2C_FIFO_STATUS_REG_OFFSET, 0x10293847);
-  EXPECT_EQ(dif_i2c_get_fifo_levels(&i2c_, &rx, nullptr), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_get_fifo_levels(&i2c_, &rx, nullptr), kDifOk);
   EXPECT_EQ(rx, 0x47);
   EXPECT_EQ(fmt, 0x0);
 }
 
 TEST_F(FifoTest, GetLevelsNullArgs) {
   uint8_t rx, fmt;
-  EXPECT_EQ(dif_i2c_get_fifo_levels(nullptr, &rx, &fmt), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_get_fifo_levels(nullptr, &rx, &fmt), kDifBadArg);
 }
 
 TEST_F(FifoTest, Read) {
@@ -578,17 +479,17 @@ TEST_F(FifoTest, Read) {
   EXPECT_READ32(I2C_RDATA_REG_OFFSET, 0xcd);
   EXPECT_READ32(I2C_RDATA_REG_OFFSET, 0xef);
 
-  EXPECT_EQ(dif_i2c_read_byte(&i2c_, &val), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_read_byte(&i2c_, &val), kDifOk);
   EXPECT_EQ(val, 0xab);
-  EXPECT_EQ(dif_i2c_read_byte(&i2c_, &val), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_read_byte(&i2c_, &val), kDifOk);
   EXPECT_EQ(val, 0xcd);
-  EXPECT_EQ(dif_i2c_read_byte(&i2c_, nullptr), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_read_byte(&i2c_, nullptr), kDifOk);
   EXPECT_EQ(val, 0xcd);
 }
 
 TEST_F(FifoTest, ReadNullArgs) {
   uint8_t val;
-  EXPECT_EQ(dif_i2c_read_byte(nullptr, &val), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_read_byte(nullptr, &val), kDifBadArg);
 }
 
 // NOTE: `false` settings on the below designated initializers are only
@@ -604,12 +505,12 @@ TEST_F(FifoTest, WriteRaw) {
                                    {
                                        .start = true,
                                    }),
-            kDifI2cOk);
+            kDifOk);
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x55},
                                        });
-  EXPECT_EQ(dif_i2c_write_byte_raw(&i2c_, 0x55, {}), kDifI2cOk);
+  EXPECT_EQ(dif_i2c_write_byte_raw(&i2c_, 0x55, {}), kDifOk);
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x66},
@@ -624,7 +525,7 @@ TEST_F(FifoTest, WriteRaw) {
                                        .read_cont = false,
                                        .suppress_nak_irq = true,
                                    }),
-            kDifI2cOk);
+            kDifOk);
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x00},
@@ -638,7 +539,7 @@ TEST_F(FifoTest, WriteRaw) {
                                        .read = true,
                                        .read_cont = true,
                                    }),
-            kDifI2cOk);
+            kDifOk);
 
   EXPECT_WRITE32(I2C_FDATA_REG_OFFSET, {
                                            {I2C_FDATA_FBYTE_OFFSET, 0x77},
@@ -650,18 +551,18 @@ TEST_F(FifoTest, WriteRaw) {
                                        .stop = false,
                                        .read = true,
                                    }),
-            kDifI2cOk);
+            kDifOk);
 }
 
 TEST_F(FifoTest, WriteRawBadArgs) {
-  EXPECT_EQ(dif_i2c_write_byte_raw(nullptr, 0xff, {}), kDifI2cBadArg);
+  EXPECT_EQ(dif_i2c_write_byte_raw(nullptr, 0xff, {}), kDifBadArg);
   EXPECT_EQ(dif_i2c_write_byte_raw(&i2c_, 0xff,
                                    {
                                        .start = false,
                                        .stop = true,
                                        .read = true,
                                    }),
-            kDifI2cBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_i2c_write_byte_raw(&i2c_, 0xff,
                                    {
                                        .start = false,
@@ -670,7 +571,7 @@ TEST_F(FifoTest, WriteRawBadArgs) {
                                        .read_cont = true,
                                        .suppress_nak_irq = true,
                                    }),
-            kDifI2cBadArg);
+            kDifBadArg);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -258,6 +258,7 @@ sw_lib_dif_i2c = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_dif_autogen_i2c,
     ],
   )
 )
@@ -265,9 +266,11 @@ sw_lib_dif_i2c = declare_dependency(
 test('dif_i2c_unittest', executable(
     'dif_i2c_unittest',
     sources: [
-      hw_ip_i2c_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_i2c.c',
       'dif_i2c_unittest.cc',
+      'autogen/dif_i2c_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_i2c.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_i2c_autogen.c',
+      hw_ip_i2c_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "i2c".