### PR TITLE
[otbn,sw] Get rid of imem_start / dmem_start

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -24,8 +24,6 @@ SECTIONS
 {
     .text ORIGIN(imem) : ALIGN(4)
     {
-        _imem_start = .;
-
         *(.text*)
 
         /* Align section end. Shouldn't really matter, but might make binary
@@ -37,8 +35,6 @@ SECTIONS
 
     .data ORIGIN(dmem) : ALIGN(32)
     {
-        _dmem_start = .;
-
         *(.data*)
         . = ALIGN(32);
         *(.bss*)

--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -22,17 +22,9 @@
  */
 typedef struct otbn_app {
   /**
-   * Start of OTBN instruction memory.
-   */
-  const uint8_t *imem_start;
-  /**
    * End of OTBN instruction memory.
    */
   const uint8_t *imem_end;
-  /**
-   * Start of OTBN data memory.
-   */
-  const uint8_t *dmem_start;
   /**
    * End of OTBN data memory.
    */
@@ -112,9 +104,7 @@ typedef struct otbn {
  *                 name of the main (assembly) source file.
  */
 #define OTBN_DECLARE_APP_SYMBOLS(app_name)                   \
-  extern const uint8_t _otbn_app_##app_name##__imem_start[]; \
   extern const uint8_t _otbn_app_##app_name##__imem_end[];   \
-  extern const uint8_t _otbn_app_##app_name##__dmem_start[]; \
   extern const uint8_t _otbn_app_##app_name##__dmem_end[]
 
 /**
@@ -129,9 +119,7 @@ typedef struct otbn {
  */
 #define OTBN_APP_T_INIT(app_name)                       \
   ((otbn_app_t){                                        \
-      .imem_start = _otbn_app_##app_name##__imem_start, \
       .imem_end = _otbn_app_##app_name##__imem_end,     \
-      .dmem_start = _otbn_app_##app_name##__dmem_start, \
       .dmem_end = _otbn_app_##app_name##__dmem_end,     \
   })
 


### PR DESCRIPTION
These are always both zero (a Harvard architecture) so there's no need
to track them explicitly.
