### PR TITLE
[otbn,sw] Ensure entry points are at address zero

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -22,10 +22,15 @@ MEMORY
 
 SECTIONS
 {
-    .text ORIGIN(imem) : ALIGN(4)
+    .start ORIGIN(imem) : ALIGN(4)
     {
         _imem_start = .;
 
+        *(.text.start*)
+    } >imem AT>imem_load
+
+    .text : ALIGN(4)
+    {
         *(.text*)
 
         /* Align section end. Shouldn't really matter, but might make binary

--- a/sw/otbn/code-snippets/barrett384.s
+++ b/sw/otbn/code-snippets/barrett384.s
@@ -224,6 +224,7 @@ barrett384:
  *                               here).
  * @param[out] dmem[559:512]: c, result, max. length 384 bit.
  */
+.section .text.start
 .globl wrap_barrett384
 wrap_barrett384:
   bn.xor w31, w31, w31

--- a/sw/otbn/code-snippets/err_test.s
+++ b/sw/otbn/code-snippets/err_test.s
@@ -4,7 +4,7 @@
 
 /* Test to trigger a BadDataAddr error */
 
-.section .text
+.section .text.start
 
 /* Test entry point, no arguments need to be passed in nor results returned */
 .globl err_test

--- a/sw/otbn/code-snippets/p256_ecdsa.s
+++ b/sw/otbn/code-snippets/p256_ecdsa.s
@@ -8,7 +8,7 @@
  * Uses OTBN ECC P-256 lib to perform an ECDSA operations.
  */
 
-.text
+.section .text.start
 .globl start
 start:
   /* Read mode, then tail-call either p256_ecdsa_sign or p256_ecdsa_verify */
@@ -24,6 +24,7 @@ start:
   /* Mode is neither 1 (= sign) nor 2 (= verify). Fail. */
   unimp
 
+.text
 p256_ecdsa_sign:
   jal      x1, p256_ecdsa_setup_rand
   jal      x1, p256_sign

--- a/sw/otbn/code-snippets/randomness.s
+++ b/sw/otbn/code-snippets/randomness.s
@@ -4,8 +4,7 @@
 
 /* Test access to randomness from OTBN. */
 
-.text
-
+.section .text.start
 /* Test entry point, no arguments need to be passed in nor results returned */
 .globl main
 main:
@@ -14,6 +13,8 @@ main:
 
   jal x0, exit_success
 
+
+.text
 /**
  * Tests access to cryptographic-strength randomness.
  *

--- a/sw/otbn/code-snippets/rsa.s
+++ b/sw/otbn/code-snippets/rsa.s
@@ -2,7 +2,7 @@
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-.text
+.section .text.start
 .globl start
 start:
   /* Read mode, then tail-call either rsa_encrypt or rsa_decrypt */
@@ -18,7 +18,7 @@ start:
   /* Mode is neither 1 (= encrypt) nor 2 (= decrypt). Fail. */
   unimp
 
-
+.text
 /**
  * RSA encryption
  */


### PR DESCRIPTION
In order to remove the START_ADDR functionality, we need to make sure
that the software we want to run really does start at address zero!
This patch adds a new input section to the linker script called
".text.start". The idea is that you should put the entry point there,
which will force it to appear at address zero.

The patch also ports each software code snippet that we load from Ibex
so that it uses the .text.start section.
