### PR TITLE
[otbn] Plan and track coverage for external CSRs

### DIFF
--- a/hw/ip/otbn/doc/dv/index.md
+++ b/hw/ip/otbn/doc/dv/index.md
@@ -173,6 +173,29 @@ See the instruction counter saturate.
 
 > This is tracked in the `insn_cnt_if` interface with the `InsnCntSaturated_C` cover property.
 
+#### External (bus-accessible) CSRs
+
+The OTBN block exposes functionality to a bus host through bus-accessible CSRs.
+Behavior of some CSRs depends on [OTBN's operational state]({{< relref "..#design-details-operational-states" >}}).
+
+Events we want to see:
+- For the `CMD` CSR, we want to see all valid commands being written crossed with all operational states to ensure commands are ignored as expected when OTBN is busy or locked.
+
+  Tracked in the `csr_ext_cmd_cg` covergroup.
+- For the `STATUS` CSR we want to see a read of all valid status codes.
+
+  Tracked in the `csr_ext_status_cg` covergroup.
+- For the `ERR_BITS` CSR, we want to see that every valid bit is read at least once, and we want to see a read in each operational state.
+
+  Tracked in the `csr_ext_err_bits_cg` covergroup.
+- For the `FATAL_ALERT_CAUSE` CSR, we want to see that every valid bit is read at least once, and we want to see a read in each operational state.
+
+  Tracked in the `csr_ext_fatal_alert_cause_cg` covergroup.
+- For `INSN_CNT` we want to see a read returning a zero and a non-zero value.
+  We also want to see a read in every operational state.
+
+  Tracked in the `csr_ext_fatal_insn_cnt_cg` covergroup.
+
 ### Instruction-based coverage
 
 As a processor, much of OTBN's coverage points are described in terms of instructions being executed.

--- a/hw/ip/otbn/dv/uvm/env/otbn_controller_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_controller_if.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bound into the otbn_controller and used to help collect operational state information for
+// coverage.
+
+interface otbn_controller_if (
+  input       clk_i,
+  input       rst_ni,
+
+  // Signal names matching the ones in otbn_controller.
+  input otbn_pkg::otbn_state_e state_q
+);
+
+  import otbn_pkg::*;
+
+  function automatic otbn_env_pkg::operational_state_e get_operational_state();
+    unique case (state_q)
+      OtbnStateUrndRefresh,
+      OtbnStateRun,
+      OtbnStateStall:
+        return otbn_env_pkg::OperationalStateBusy;
+
+      OtbnStateLocked:
+        return otbn_env_pkg::OperationalStateLocked;
+
+      OtbnStateHalt:
+        return otbn_env_pkg::OperationalStateIdle;
+      default: ;
+    endcase
+  endfunction
+
+endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -21,6 +21,7 @@ filesets:
       - otbn_mac_bignum_if.sv
       - otbn_rf_base_if.sv
       - otbn_insn_cnt_if.sv
+      - otbn_controller_if.sv
       - otbn_trace_item.sv: {is_include_file: true}
       - otbn_trace_monitor.sv: {is_include_file: true}
       - otbn_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -43,6 +43,10 @@ class otbn_env extends cip_base_env #(
                                                       cfg.rf_base_vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_rf_base_if handle from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual otbn_controller_if)::get(this, "", "controller_vif",
+                                                      cfg.controller_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_controller_if handle from uvm_config_db")
+    end
 
     trace_monitor = otbn_trace_monitor::type_id::create("trace_monitor", this);
     trace_monitor.cfg = cfg;

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -12,12 +12,12 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
 
   `uvm_object_new
 
-  // Handles used by otbn_trace_monitor
   virtual otbn_trace_if      trace_vif;
   virtual otbn_loop_if       loop_vif;
   virtual otbn_alu_bignum_if alu_bignum_vif;
   virtual otbn_mac_bignum_if mac_bignum_vif;
   virtual otbn_rf_base_if    rf_base_vif;
+  virtual otbn_controller_if controller_vif;
 
   // The directory in which to look for ELF files (set by the test in build_phase; controlled by the
   // +otbn_elf_dir plusarg).

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -50,13 +50,15 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     // Tell the CIP base code how many interrupts we have (defaults to zero)
     num_interrupts = 1;
 
-    // Tell the CIP base code what alert we generate if we see a TL fault and the field in the
-    // FATAL_ALERT_CAUSE register that it should expect to see get set.
+    // Tell the CIP base code what alert we generate if we see a TL fault.
     tl_intg_alert_name = "fatal";
 
     model_agent_cfg = otbn_model_agent_cfg::type_id::create("model_agent_cfg");
 
     super.initialize(csr_base_addr);
+
+    // Tell the CIP base code the field in the FATAL_ALERT_CAUSE register that it should expect to
+    // see get set in case of a TL fault.
     tl_intg_alert_fields[ral.fatal_alert_cause.bus_intg_violation] = 1;
   endfunction
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -290,6 +290,78 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     illegal_bins bad = default;        \
   }
 
+  // Non-core covergroups //////////////////////////////////////////////////////
+
+  // CMD external CSR
+  covergroup ext_csr_cmd_cg
+    with function sample(otbn_pkg::cmd_e value, otbn_env_pkg::operational_state_e state);
+
+    cmd_cp: coverpoint value;
+    state_cp: coverpoint state;
+
+    // We want to see an attempt to issue every command in every state.
+    cmd_state_cross: cross cmd_cp, state_cp;
+  endgroup
+
+  // STATUS external CSR
+  covergroup ext_csr_status_cg
+    with function sample(otbn_pkg::status_e value);
+
+    status_cp: coverpoint value;
+  endgroup
+
+  // ERR_BITS external CSR
+  covergroup ext_csr_err_bits_cg
+    with function sample(otbn_pkg::err_bits_t value, otbn_env_pkg::operational_state_e state);
+
+    // We want to see every error bit at least once.
+    `DEF_SEEN_CP(err_bits_bad_data_addr_cp, value.bad_data_addr)
+    `DEF_SEEN_CP(err_bits_bad_insn_addr_cp, value.bad_insn_addr)
+    `DEF_SEEN_CP(err_bits_call_stack_cp, value.call_stack)
+    `DEF_SEEN_CP(err_bits_illegal_insn_cp, value.illegal_insn)
+    `DEF_SEEN_CP(err_bits_loop_cp, value.loop)
+    `DEF_SEEN_CP(err_bits_imem_intg_violation_cp, value.imem_intg_violation)
+    `DEF_SEEN_CP(err_bits_dmem_intg_violation_cp, value.dmem_intg_violation)
+    `DEF_SEEN_CP(err_bits_reg_intg_violation_cp, value.reg_intg_violation)
+    `DEF_SEEN_CP(err_bits_bus_intg_violation_cp, value.bus_intg_violation)
+    `DEF_SEEN_CP(err_bits_illegal_bus_access_cp, value.illegal_bus_access)
+    `DEF_SEEN_CP(err_bits_lifecycle_escalation_cp, value.lifecycle_escalation)
+
+    // We want to see an access to ERR_BITS in every operational state, but don't need a full cross
+    // with all possible error values.
+    state_cp: coverpoint state;
+  endgroup
+
+  // FATAL_ALERT_CAUSE external CSR
+  covergroup ext_csr_fatal_alert_cause_cg
+    with function sample(logic [31:0] value, otbn_env_pkg::operational_state_e state);
+
+    // We want to see every valid bit at least once.
+    `DEF_SEEN_CP(fatal_alert_cause_imem_intg_violation_cp, value[0])
+    `DEF_SEEN_CP(fatal_alert_cause_dmem_intg_violation_cp, value[1])
+    `DEF_SEEN_CP(fatal_alert_cause_reg_intg_violation_cp, value[2])
+    `DEF_SEEN_CP(fatal_alert_cause_bus_intg_violation_cp, value[3])
+    `DEF_SEEN_CP(fatal_alert_cause_illegal_bus_access_cp, value[4])
+    `DEF_SEEN_CP(fatal_alert_cause_lifecycle_escalation_cp, value[5])
+
+    // We want to see an access to FATAL_ALERT_CAUSE in every operational state, but don't need to
+    // see all possible values that could be read.
+    state_cp: coverpoint state;
+  endgroup
+
+  // INSN_CNT external CSR
+  covergroup ext_csr_insn_cnt_cg
+    with function sample(logic [31:0] value, otbn_env_pkg::operational_state_e state);
+
+    // We want to see at least one non-zero value of INSN_CNT to ensure it's doing something.
+    // The actual values are cross-checked with the ISS.
+    `DEF_NZ_CP(insn_cnt_cp, value)
+
+    // We want to see an access to INSN_CNT in all operational states, but don't care about the
+    // cross between the actual value and the state.
+    state_cp: coverpoint state;
+  endgroup
+
   // Non-instruction covergroups ///////////////////////////////////////////////
 
   covergroup call_stack_cg
@@ -1509,6 +1581,12 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   function new(string name, uvm_component parent);
     super.new(name, parent);
 
+    ext_csr_cmd_cg = new;
+    ext_csr_status_cg = new;
+    ext_csr_err_bits_cg = new;
+    ext_csr_fatal_alert_cause_cg = new;
+    ext_csr_insn_cnt_cg = new;
+
     call_stack_cg = new;
     flag_write_cg = new;
 
@@ -1616,6 +1694,30 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     insn_encodings[mnem_bn_wsrr]       = "wcsr";
     insn_encodings[mnem_bn_wsrw]       = "wcsr";
     insn_encodings[mnem_dummy]         = "dummy";
+  endfunction
+
+  // Handle coverage for external (bus-accessible) CSRs
+  function void on_ext_csr_access(uvm_reg csr, otbn_env_pkg::access_e access_type,
+                                  logic [31:0] data, otbn_env_pkg::operational_state_e state);
+
+    case (csr.get_name())
+      "cmd": begin
+        ext_csr_cmd_cg.sample(otbn_pkg::cmd_e'(data), state);
+      end
+      "status": begin
+        ext_csr_status_cg.sample(otbn_pkg::status_e'(data));
+      end
+      "err_bits": begin
+        ext_csr_err_bits_cg.sample(otbn_pkg::err_bits_t'(data), state);
+      end
+      "fatal_alert_cause": begin
+        ext_csr_fatal_alert_cause_cg.sample(data, state);
+      end
+      "insn_cnt": begin
+        ext_csr_insn_cnt_cg.sample(data, state);
+      end
+      default: ; // We only track some registers with functional coverage.
+    endcase
   endfunction
 
   // Handle coverage for an instruction that was executed

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -77,6 +77,17 @@ package otbn_env_pkg;
     logic push;
   } call_stack_flags_t;
 
+  typedef enum {
+    OperationalStateIdle,
+    OperationalStateBusy,
+    OperationalStateLocked
+  } operational_state_e;
+
+  typedef enum {
+    AccessSoftwareRead,
+    AccessSoftwareWrite
+  } access_e;
+
   // package sources
   `include "otbn_env_cfg.sv"
   `include "otbn_trace_item.sv"

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -120,6 +120,8 @@ module tb;
 
   bind dut.u_otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
+  bind dut.u_otbn_core.u_otbn_controller otbn_controller_if i_otbn_controller_if (.*);
+
   bind dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller
     otbn_loop_if i_otbn_loop_if (
       .clk_i,
@@ -240,6 +242,9 @@ module tb;
 
     uvm_config_db#(virtual otbn_trace_if)::set(null, "*.env", "trace_vif",
                                                dut.u_otbn_core.i_otbn_trace_if);
+    uvm_config_db#(virtual otbn_controller_if)::set(
+      null, "*.env", "controller_vif",
+      dut.u_otbn_core.u_otbn_controller.i_otbn_controller_if);
     uvm_config_db#(virtual otbn_loop_if)::set(
       null, "*.env", "loop_vif",
       dut.u_otbn_core.u_otbn_controller.u_otbn_loop_controller.i_otbn_loop_if);


### PR DESCRIPTION
By testing the external CSRs, we test both the interface of OTBN to Ibex,
as well as ensuring that OTBN is behaving as expected depending on the
operational state it is in. For example, if OTBN is locked or busy, writes
to CMD should be ignored. The functional coverage ensures that we see a
write to CMD in every operational state.

The coverage for the error registers isn't exhaustive, as it doesn't 
explicitly require multi-error cases to be covered. There is already 
coverage for such errors as part of the per-instruction coverage; 
replicating it seems unnecessary.

Fixes #8024