### PR TITLE
[dv/alert_handler] Add a ping timeout sequence

### DIFF
--- a/hw/ip/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip/alert_handler/data/alert_handler_testplan.hjson
@@ -81,6 +81,20 @@
       tests: ["alert_handler_random_classes"]
     }
     {
+      name: ping_timeout
+      desc: '''
+            Based on entropy test, this test request alert_sender and esc_receiver drivers to
+            randomly create ping requests timeout stimulus.
+
+            Checks:
+            - Verify interrupt pin and states.
+            - Verify alert and local alert causes.
+            - Verify escalation states and counts.
+            '''
+      milestone: V2
+      tests: ["alert_handler_ping_timeout"]
+    }
+    {
       name: stress_all
       desc: '''
             Combine above sequences in one test to run sequentially with the following exclusions:

--- a/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
+++ b/hw/ip/alert_handler/dv/alert_handler_generic_sim_cfg.hjson
@@ -82,6 +82,11 @@
     }
 
     {
+      name: alert_handler_ping_timeout
+      uvm_test_seq: alert_handler_ping_timeout_vseq
+    }
+
+    {
       name: alert_handler_stress_all
       run_opts: ["+test_timeout_ns=15_000_000_000"]
     }

--- a/hw/ip/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/ip/alert_handler/dv/env/alert_handler_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/alert_handler_esc_alert_accum_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_sig_int_fail_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_entropy_vseq.sv: {is_include_file: true}
+      - seq_lib/alert_handler_ping_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/alert_handler_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -268,7 +268,7 @@ class alert_handler_base_vseq extends cip_base_vseq #(
 
   virtual task wr_ping_timeout_cycle(bit[TL_DW-1:0] timeout_val);
     csr_wr(.ptr(ral.ping_timeout_cyc_shadowed), .value(timeout_val));
-    if (!config_locked) begin
+    if (`gmv(ral.ping_timer_regwen)) begin
       if (timeout_val == 0) timeout_val = 1;
       foreach (cfg.alert_host_cfg[i]) cfg.alert_host_cfg[i].ping_timeout_cycle = timeout_val;
       foreach (cfg.esc_device_cfg[i]) cfg.esc_device_cfg[i].ping_timeout_cycle = timeout_val;

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// this sequence test corner cases for alert or escalation pings:
+// 1). ping integrity fail or timeout
+// 2). ping interrupted by a reset signal
+// 3). escalation ping interrupted by real escalation signal (this could happen because escalation
+//     ping and real escalation share the same esc_p/n signals)
+
+class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
+  `uvm_object_utils(alert_handler_ping_timeout_vseq)
+
+  `uvm_object_new
+
+  constraint num_trans_c {
+    num_trans inside {[1:10]};
+  }
+
+  constraint alert_trigger_c {
+    alert_trigger == 0;
+  }
+
+  constraint intr_en_c {
+    intr_en == '1;
+  }
+
+  constraint sig_int_c {
+    alert_int_err          == 0;
+    esc_int_err            == 0;
+    esc_standalone_int_err == 0;
+  }
+
+  constraint loc_alert_en_c {
+    local_alert_en[LocalEscPingFail:LocalAlertPingFail] > 0;
+  }
+
+  constraint ping_fail_c {
+    alert_ping_timeout == '1;
+    esc_ping_timeout   == '1;
+  }
+
+  constraint ping_timeout_cyc_c {
+    ping_timeout_cyc inside {[1:MAX_PING_TIMEOUT_CYCLE]};
+  }
+
+  // disable interrupt timeout
+  constraint esc_intr_timeout_c {
+    foreach (intr_timeout_cyc[i]) {intr_timeout_cyc[i] == 0;}
+  }
+
+  function void pre_randomize();
+    this.enable_classa_only_c.constraint_mode(0);
+  endfunction
+
+  // In this sequence, because we disable all external alerts, so to ensure local alerts are
+  // triggerd, we wait for interrupt pins to fire then wait for alert and escalation handshake
+  // to finish.
+  virtual task wait_alert_esc_done();
+    wait (cfg.intr_vif.pins[NUM_ALERT_CLASSES-1:0]);
+    // Wait two clock cycles to avoid building a cycle-accurate scb.
+    cfg.clk_rst_vif.wait_clks(2);
+    `uvm_info(`gfn, $sformatf("Interrupt pin = %0h", cfg.intr_vif.pins[NUM_ALERT_CLASSES-1:0]),
+              UVM_LOW)
+    check_alert_interrupts();
+    super.wait_alert_esc_done();
+  endtask
+
+endclass : alert_handler_ping_timeout_vseq

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -163,21 +163,27 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
       if ((esc_int_err == 0) && (esc_ping_timeout == 0)) check_alert_interrupts();
 
       // if ping timeout enabled, wait for ping timeout done before checking escalation phases
-      if ((esc_int_err | alert_ping_timeout) > 0) cfg.clk_rst_vif.wait_clks(MAX_PING_TIMEOUT_CYCLE);
+      if ((esc_int_err | alert_ping_timeout) > 0) begin
+        cfg.clk_rst_vif.wait_clks(MAX_PING_TIMEOUT_CYCLE);
+      end
 
       // wait escalation done, and random interrupt with clear_esc
-      wait_alert_handshake_done();
-      if ($urandom_range(0, 1) && (esc_int_err == 0)) begin
-        cfg.clk_rst_vif.wait_clks($urandom_range(0, max_wait_phases_cyc));
-        clear_esc();
-      end
-      wait_esc_handshake_done();
+      wait_alert_esc_done();
 
       read_alert_cause();
       read_esc_status();
       if (do_clr_esc) clear_esc();
       check_alert_interrupts();
     end
+  endtask
+
+  virtual task wait_alert_esc_done();
+    wait_alert_handshake_done();
+    if ($urandom_range(0, 1) && (esc_int_err == 0)) begin
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, max_wait_phases_cyc));
+      clear_esc();
+    end
+    wait_esc_handshake_done();
   endtask
 
 endclass : alert_handler_smoke_vseq

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_vseq_list.sv
@@ -11,4 +11,5 @@
 `include "alert_handler_esc_alert_accum_vseq.sv"
 `include "alert_handler_sig_int_fail_vseq.sv"
 `include "alert_handler_entropy_vseq.sv"
+`include "alert_handler_ping_timeout_vseq.sv"
 `include "alert_handler_stress_all_vseq.sv"


### PR DESCRIPTION
This PR adds a ping timeout sequence in alert_handler.
The previous ping_corner_case sequence was moved because it tries to
cross ping request with escalation request.
This new sequence will focus on ping timeout, and the cross case is
covered in prim_esc testbench.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>