### PR TITLE
[bazel] Added buildifier to lint Starlark

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,4 +2,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
 package(default_visibility = ["//visibility:public"])
+
+buildifier(
+    name = "buildifier",
+    exclude_patterns = ["./**/vendor/**"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,3 +49,46 @@ http_archive(
     strip_prefix = "abseil-cpp-master",
     urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
 )
+
+# Buildifier is a linting tool for our WORKSPACE and BUILD files
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+    urls = [
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
+    urls = [
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()
+
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-master",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-main",
+    url = "https://github.com/bazelbuild/buildtools/archive/main.zip",
+)

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/BUILD
+++ b/hw/ip/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/aes/BUILD
+++ b/hw/ip/aes/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/aon_timer/BUILD
+++ b/hw/ip/aon_timer/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/csrng/BUILD
+++ b/hw/ip/csrng/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/edn/BUILD
+++ b/hw/ip/edn/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/entropy_src/BUILD
+++ b/hw/ip/entropy_src/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/gpio/BUILD
+++ b/hw/ip/gpio/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/hmac/BUILD
+++ b/hw/ip/hmac/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/i2c/BUILD
+++ b/hw/ip/i2c/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/keymgr/BUILD
+++ b/hw/ip/keymgr/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/kmac/BUILD
+++ b/hw/ip/kmac/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/lc_ctrl/BUILD
+++ b/hw/ip/lc_ctrl/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/otbn/BUILD
+++ b/hw/ip/otbn/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/otp_ctrl/BUILD
+++ b/hw/ip/otp_ctrl/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/rv_timer/BUILD
+++ b/hw/ip/rv_timer/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/spi_device/BUILD
+++ b/hw/ip/spi_device/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/sram_ctrl/BUILD
+++ b/hw/ip/sram_ctrl/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/uart/BUILD
+++ b/hw/ip/uart/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/ip/usbdev/BUILD
+++ b/hw/ip/usbdev/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/BUILD
+++ b/hw/top_earlgrey/ip/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/alert_handler/BUILD
+++ b/hw/top_earlgrey/ip/alert_handler/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/alert_handler/data/BUILD
+++ b/hw/top_earlgrey/ip/alert_handler/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/clkmgr/BUILD
+++ b/hw/top_earlgrey/ip/clkmgr/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/clkmgr/data/BUILD
+++ b/hw/top_earlgrey/ip/clkmgr/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/flash_ctrl/BUILD
+++ b/hw/top_earlgrey/ip/flash_ctrl/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/flash_ctrl/data/BUILD
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/pinmux/BUILD
+++ b/hw/top_earlgrey/ip/pinmux/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/pinmux/data/BUILD
+++ b/hw/top_earlgrey/ip/pinmux/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/pwrmgr/BUILD
+++ b/hw/top_earlgrey/ip/pwrmgr/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/pwrmgr/data/BUILD
+++ b/hw/top_earlgrey/ip/pwrmgr/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/rstmgr/BUILD
+++ b/hw/top_earlgrey/ip/rstmgr/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/rstmgr/data/BUILD
+++ b/hw/top_earlgrey/ip/rstmgr/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/rv_plic/BUILD
+++ b/hw/top_earlgrey/ip/rv_plic/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/ip/rv_plic/data/BUILD
+++ b/hw/top_earlgrey/ip/rv_plic/data/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/hw/top_earlgrey/sw/BUILD
+++ b/hw/top_earlgrey/sw/BUILD
@@ -1,4 +1,3 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -6,9 +6,6 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "base",
-    copts = [
-        "-fno-builtin",
-    ],
     srcs = [
         "bitfield.c",
         "hardened.c",
@@ -24,8 +21,10 @@ cc_library(
         "mmio.h",
         "stdasm.h",
     ],
+    copts = [
+        "-fno-builtin",
+    ],
 )
-
 
 cc_library(
     name = "mmio",


### PR DESCRIPTION
Tested="bazel run //:buildifier -- -r"
to have buildifier run linting checks on the whole directory

Buildifier excludes the directories named "//**/vendor/**

This also has all the fixes buildifier applies to the directory so that
it can be run at root without changing unmodified files anymore.

Added rules for autogen dif_lc_ctrl

Signed-off-by: Drew Macrae <drewmacrae@google.com>