### PR TITLE
[rstmgr] Reset consistency check

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -313,5 +313,31 @@
                "excl:CsrAllTests:CsrExclWrite"]
       }
     }
+
+    { name: "ERR_CODE",
+      desc: '''
+        A bit vector of all the errors that have occurred in reset manager
+      ''',
+      swaccess: "rw1c",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "REG_INTG_ERR",
+          desc: '''
+            The register file has experienced an integrity error.
+          '''
+          resval: "0"
+        },
+
+        { bits: "1",
+          name: "RESET_CONSISTENCY_ERR",
+          desc: '''
+            A inconsistent parent / child reset was observed.
+          '''
+          resval: "0"
+        },
+
+      ]
+    },
   ]
 }

--- a/hw/ip/rstmgr/doc/_index.md
+++ b/hw/ip/rstmgr/doc/_index.md
@@ -16,6 +16,7 @@ This document describes the functionality of the reset controller and its intera
 *   Always-on reset information register.
 *   Always-on alert crash dump register.
 *   Always-on cpu crash dump register.
+*   Reset consistency checks.
 
 # Theory of Operation
 
@@ -143,7 +144,28 @@ These are registers stored in two-or-more constantly checking copies to ensure t
 For these components, the reset manager outputs a shadow reset dedicated to resetting only the shadow storage.
 This reset separation ensures that a targetted attack on the reset line cannot easily defeat shadow registers.
 
-Shadow resets have not been implemented yet.
+### Reset Consistency Checks
+
+The reset manager implements reset consistency checks to ensure that triggered resets are supposed to happen and not due to some fault in the system.
+Every leaf reset in the system has an associated consistency checker.
+
+The consistency check ensures that when a leaf reset asserts, either its parent reset must have asserted, or the software request, if available, has asserted.
+While this sounds simple in principle, the check itself crosses up to 3 clock domains and must be carefully managed.
+
+First, the parent and leaf resets are used to asynchronously assert a flag indication.
+This flag indication is then synchronized into the reset manager's local clock domain.
+
+The reset manager then checks as follows:
+- If a leaf reset has asserted, check to see either its parent or software request (synchronous to the local domain) has asserted.
+
+- If the condition is not true, it is possible the parent reset indication is still being synchronized, thus we wait for the parent indication.
+
+- It is also possible the parent indication was seen first, but the leaf condition was not, in this case, we wait for the leaf indication.
+
+- A timeout period corresponding to the maximum synchronization delay is used to cover both waits.
+  - If the appropriate pairing is not seen in the given amount of time, signal an error, as the leaf reset asserted without cause.
+
+- If all reset conditions are satisfied, wait for the reset release to gracefully complete the cycle.
 
 ## Hardware Interfaces
 

--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -20,7 +20,9 @@ filesets:
     files:
       - rtl/rstmgr_ctrl.sv
       - rtl/rstmgr_por.sv
+      - rtl/rstmgr_cnsty_chk.sv
       - rtl/rstmgr_crash_info.sv
+      - rtl/rstmgr_leaf_rst.sv
       - "fileset_ip ? (rtl/rstmgr.sv)"
     file_type: systemVerilogSource
 

--- a/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -1,0 +1,236 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module implements reset consistency checks
+// The main goal is to check whether conditions allow for a reset to be asserted
+// For example, if a child reset asserts, it must be the case that its parent
+// reset or software controls (if available) have asserted.
+// If a child reset asserts and neither of the above case is true, it is considered
+// a fatal error.
+
+`include "prim_assert.sv"
+
+module rstmgr_cnsty_chk
+  import rstmgr_pkg::*;
+  import rstmgr_reg_pkg::*;
+#(
+  parameter int MaxSyncDelay = 2
+)
+(
+  input clk_i,
+  input rst_ni,
+  input child_clk_i,
+  input child_rst_ni,
+  input parent_rst_ni,
+  input sw_rst_req_i,
+  output logic err_o
+);
+
+  localparam int CntWidth = prim_util_pkg::vbits(MaxSyncDelay + 1);
+
+  // These two flops below are completely async.
+  // The value from these flops are always fed through synchronizers before use.
+  logic parent_rst_asserted;
+  always_ff @(posedge clk_i or negedge parent_rst_ni) begin
+    if (!parent_rst_ni) begin
+      parent_rst_asserted <= 1'b1;
+    end else begin
+      parent_rst_asserted <= '0;
+    end
+  end
+
+  logic child_rst_asserted;
+  always_ff @(posedge clk_i or negedge child_rst_ni) begin
+    if (!child_rst_ni) begin
+      child_rst_asserted <= 1'b1;
+    end else begin
+      child_rst_asserted <= '0;
+    end
+  end
+
+  logic sync_parent_rst;
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue(1)
+  ) u_parent_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(parent_rst_asserted),
+    .q_o(sync_parent_rst)
+  );
+
+  logic sync_child_rst;
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue(1)
+  ) u_child_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(child_rst_asserted),
+    .q_o(sync_child_rst)
+  );
+
+
+  typedef enum logic [2:0] {
+    Reset,
+    Idle,
+    WaitForParent,
+    WaitForChild,
+    WaitForSrcRelease,
+    WaitForChildRelease,
+    Error
+  } state_e;
+
+  state_e state_q, state_d;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      state_q <= Reset;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  logic timeout;
+  logic cnt_inc;
+  logic cnt_clr;
+  logic [CntWidth-1:0] cnt;
+
+  // the timeout count is on clk_i because the synchronizers are
+  // also operating on clk_i.  We are mainly trying to wait out the reset assertion delays.
+  // parent resets are asynchronous assertion so there is at most a one cycle separation.
+  // if needed we can make this timeout bigger.
+  assign timeout = cnt > MaxSyncDelay;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      cnt <= '0;
+    end else if (cnt_clr) begin
+      cnt <= '0;
+    end else if (cnt_inc && !timeout) begin
+      cnt <= cnt + 1'b1;
+    end
+  end
+
+  logic src_valid;
+  assign src_valid = sync_parent_rst || sw_rst_req_i;
+
+  logic sync_child_ack;
+
+  always_comb begin
+    state_d = state_q;
+    err_o = '0;
+    cnt_inc = '0;
+    cnt_clr = '0;
+
+    unique case (state_q)
+      Reset: begin
+        // when the checker itself comes out of reset, conditions
+        // may be ambiguous, wait for things to stabilize
+        if (!sync_child_rst && !sync_parent_rst) begin
+          state_d = Idle;
+        end
+      end
+
+      Idle: begin
+        // If a child reset asserts, one of the conditions must be true.
+        // It is possible for the child to assert but parent to remain de-asserted
+        // due to CDC latency (or vice versa), wait for the other corresponding reset
+        // when this occurs.
+        if (sync_child_rst && src_valid) begin
+          state_d = WaitForSrcRelease;
+        end else if (sync_child_rst && !sync_parent_rst) begin
+          state_d = WaitForParent;
+        end else if (sync_parent_rst && !sync_child_rst) begin
+          state_d = WaitForChild;
+        end
+      end
+
+      // parent reset must show up within timeout region
+      WaitForParent: begin
+        cnt_inc = 1'b1;
+
+        if (timeout && !sync_parent_rst) begin
+          state_d = Error;
+        end else if (sync_parent_rst) begin
+          state_d = WaitForSrcRelease;
+          cnt_clr = 1'b1;
+        end
+      end
+
+      // child reset must show up within timeout region
+      WaitForChild: begin
+        cnt_inc = 1'b1;
+
+        if (timeout && !sync_child_rst) begin
+          state_d = Error;
+        end else if (sync_child_rst) begin
+          state_d = WaitForSrcRelease;
+          cnt_clr = 1'b1;
+        end
+      end
+
+      // waiting for parent reset to release
+      WaitForSrcRelease: begin
+        // it is not possible for the child reset to release
+        // ahead of the parent reset
+        if (!sync_child_rst && src_valid) begin
+          state_d = Error;
+        end else if (!src_valid) begin
+          cnt_clr = 1'b1;
+          state_d = WaitForChildRelease;
+        end
+      end
+
+      // waiting for child reset to release
+      WaitForChildRelease: begin
+        // operate only on child ack to keep things in sync
+        // This is needed because the reset releases are synchronous to the child clock.
+        // So if we have a situation where the child clock is way slower than the local
+        // clock used to increment the count, we may timeout incorrectly.
+        // By using sync_child_ack, we ensure that the count is advanced only when a
+        // child clock edge is seen.  This usage is conservative, because by the time
+        // sync_child_ack is seen, there may have been more than one child clock, yet the
+        // count is only incremented by 1.
+        if (sync_child_ack) begin
+          cnt_inc = 1'b1;
+          if (sync_child_rst && src_valid) begin
+            // This condition covers the case if for whatever reason the parent reset re-asserts
+            // in a valid way.
+            state_d = WaitForSrcRelease;
+            cnt_clr = 1'b1;
+          end else if (sync_child_rst && timeout) begin
+            state_d = Error;
+          end else if (!sync_child_rst) begin
+            state_d = Idle;
+            cnt_clr = 1'b1;
+          end
+        end
+      end
+
+      Error: begin
+        err_o = 1'b1;
+      end
+
+      default: begin
+        state_d = Error;
+      end
+    endcase // unique case (state_q)
+  end // always_comb
+
+  logic child_ack;
+  prim_sync_reqack u_child_handshake (
+    .clk_src_i(clk_i),
+    .rst_src_ni(rst_ni),
+    .clk_dst_i(child_clk_i),
+    .rst_dst_ni(child_rst_ni),
+    .req_chk_i('0),
+    .src_req_i(1'b1),
+    .src_ack_o(sync_child_ack),
+    .dst_req_o(child_ack),
+    .dst_ack_i(child_ack)
+  );
+
+
+endmodule // rstmgr_cnsty_chk

--- a/hw/ip/rstmgr/rtl/rstmgr_leaf_rst.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_leaf_rst.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This module generates the leaf resets and instantiates the associated reset
+// checks.
+
+`include "prim_assert.sv"
+
+module rstmgr_leaf_rst
+  import rstmgr_pkg::*;
+  import rstmgr_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+  input leaf_clk_i,
+  input parent_rst_ni,
+  input sw_rst_req_ni,
+  input scan_rst_ni,
+  input scan_sel,
+  output lc_ctrl_pkg::lc_tx_t rst_en_o,
+  output logic leaf_rst_o,
+  output logic err_o
+);
+
+  logic leaf_rst_sync;
+  prim_flop_2sync #(
+    .Width(1),
+    .ResetValue('0)
+  ) u_rst_sync (
+    .clk_i(leaf_clk_i),
+    .rst_ni(parent_rst_ni),
+    .d_i(sw_rst_req_ni),
+    .q_o(leaf_rst_sync)
+  );
+
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1'b1)
+  ) u_rst_mux (
+    .clk0_i(leaf_rst_sync),
+    .clk1_i(scan_rst_ni),
+    .sel_i(scan_sel),
+    .clk_o(leaf_rst_o)
+  );
+
+  rstmgr_cnsty_chk u_rst_chk (
+    .clk_i,
+    .rst_ni,
+    .child_clk_i(leaf_clk_i),
+    .child_rst_ni(leaf_rst_o),
+    .parent_rst_ni,
+    .sw_rst_req_i(~sw_rst_req_ni),
+    .err_o
+  );
+
+  // reset asserted indication for alert handler
+  prim_lc_sender #(
+    .ResetValueIsOn(1)
+  ) u_prim_lc_sender_rst (
+    .clk_i(leaf_clk_i),
+    .rst_ni(leaf_rst_o),
+    .lc_en_i(lc_ctrl_pkg::Off),
+    .lc_en_o(rst_en_o)
+  );
+
+
+endmodule // rstmgr_leaf_rst

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -391,5 +391,31 @@
                "excl:CsrAllTests:CsrExclWrite"]
       }
     }
+
+    { name: "ERR_CODE",
+      desc: '''
+        A bit vector of all the errors that have occurred in reset manager
+      ''',
+      swaccess: "rw1c",
+      hwaccess: "hwo",
+      fields: [
+        { bits: "0",
+          name: "REG_INTG_ERR",
+          desc: '''
+            The register file has experienced an integrity error.
+          '''
+          resval: "0"
+        },
+
+        { bits: "1",
+          name: "RESET_CONSISTENCY_ERR",
+          desc: '''
+            A inconsistent parent / child reset was observed.
+          '''
+          resval: "0"
+        },
+
+      ]
+    },
   ]
 }

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -107,6 +107,17 @@ package rstmgr_reg_pkg;
     logic        d;
   } rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t;
 
+  typedef struct packed {
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reset_consistency_err;
+  } rstmgr_hw2reg_err_code_reg_t;
+
   // Register -> HW type
   typedef struct packed {
     rstmgr_reg2hw_alert_test_reg_t alert_test; // [45:44]
@@ -119,14 +130,15 @@ package rstmgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [94:86]
-    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [85:84]
-    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [83:80]
-    rstmgr_hw2reg_alert_info_reg_t alert_info; // [79:48]
-    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [47:46]
-    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [45:42]
-    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [41:10]
-    rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [9:0]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [98:90]
+    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [89:88]
+    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [87:84]
+    rstmgr_hw2reg_alert_info_reg_t alert_info; // [83:52]
+    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [51:50]
+    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [49:46]
+    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [45:14]
+    rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [13:4]
+    rstmgr_hw2reg_err_code_reg_t err_code; // [3:0]
   } rstmgr_hw2reg_t;
 
   // Register offsets
@@ -142,6 +154,7 @@ package rstmgr_reg_pkg;
   parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_OFFSET = 6'h 24;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_OFFSET = 6'h 28;
   parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] RSTMGR_ERR_CODE_OFFSET = 6'h 30;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] RSTMGR_ALERT_TEST_RESVAL = 1'h 0;
@@ -179,11 +192,12 @@ package rstmgr_reg_pkg;
     RSTMGR_CPU_INFO_ATTR,
     RSTMGR_CPU_INFO,
     RSTMGR_SW_RST_REGWEN,
-    RSTMGR_SW_RST_CTRL_N
+    RSTMGR_SW_RST_CTRL_N,
+    RSTMGR_ERR_CODE
   } rstmgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RSTMGR_PERMIT [12] = '{
+  parameter logic [3:0] RSTMGR_PERMIT [13] = '{
     4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
     4'b 0001, // index[ 1] RSTMGR_RESET_INFO
     4'b 0001, // index[ 2] RSTMGR_ALERT_REGWEN
@@ -195,7 +209,8 @@ package rstmgr_reg_pkg;
     4'b 0001, // index[ 8] RSTMGR_CPU_INFO_ATTR
     4'b 1111, // index[ 9] RSTMGR_CPU_INFO
     4'b 0011, // index[10] RSTMGR_SW_RST_REGWEN
-    4'b 0011  // index[11] RSTMGR_SW_RST_CTRL_N
+    4'b 0011, // index[11] RSTMGR_SW_RST_CTRL_N
+    4'b 0001  // index[12] RSTMGR_ERR_CODE
   };
 
 endpackage


### PR DESCRIPTION
- If a reset asserts, either its parent or software controls
  must have asserted.

- The checking here is a gigantic mesh of CDC and must be carefully
  reviewed.

- The leaf logic generation logic was creating so many modules
  it was getting difficult to manage.

- This PR wraps up some of the generated logic so it is a little
  easier to read.
