### PR TITLE
[opentitantool] IO interface & instance refactor

### DIFF
--- a/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
+++ b/sw/host/opentitanlib/opentitantool_derive/src/lib.rs
@@ -30,11 +30,12 @@ use syn::{parse_macro_input, Data, DataEnum, DeriveInput, Fields, Ident, Variant
 /// impl opentitanlib::app::command::CommandDispatch for Hello {
 ///     fn run(
 ///         &self,
+///         context: &dyn std::any::Any,
 ///         backend: &mut dyn opentitanlib::transport::Transport
 ///     ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
 ///         match self {
-///             Hello::World(ref __field) => __field.run(backend),
-///             Hello::People(ref __field) => __field.run(backend),
+///             Hello::World(ref __field) => __field.run(context, backend),
+///             Hello::People(ref __field) => __field.run(context, backend),
 ///         }
 ///     }
 /// }
@@ -72,6 +73,7 @@ fn dispatch_enum(name: &Ident, e: &DataEnum) -> TokenStream {
             impl opentitanlib::app::command::CommandDispatch for #name {
                 fn run(
                     &self,
+                    context: &dyn std::any::Any,
                     backend: &mut dyn opentitanlib::transport::Transport
                 ) -> anyhow::Result<Option<Box<dyn erased_serde::Serialize>>> {
                     match self {
@@ -100,6 +102,6 @@ fn dispatch_variant(name: &Ident, variant: &Variant) -> TokenStream {
     }
     quote! {
         #name::#ident(ref __field) =>
-            opentitanlib::app::command::CommandDispatch::run(__field, backend)
+            opentitanlib::app::command::CommandDispatch::run(__field, context, backend)
     }
 }

--- a/sw/host/opentitanlib/src/app/command.rs
+++ b/sw/host/opentitanlib/src/app/command.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::any::Any;
 use crate::transport::Transport;
 use anyhow::Result;
 use erased_serde::Serialize;
@@ -11,6 +12,14 @@ pub use opentitantool_derive::*;
 /// in the application's command hierarchy.  It can be automatically derived
 /// on internal nodes in the heirarchy.  See the documentation for
 /// [`opentitantool_derive`].
+///
+/// The `context` parameter can be used to carry information from prior levels
+/// in the command hierarchy to the next level.  This is typically used to
+/// implement parameters on interior nodes before the next layer of subcommands.
 pub trait CommandDispatch {
-    fn run(&self, transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>>;
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>>;
 }

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -68,17 +68,17 @@ pub trait Target {
     /// Gets the current SPI transfer mode.
     fn get_transfer_mode(&self) -> Result<TransferMode>;
     /// Sets the current SPI transfer mode.
-    fn set_transfer_mode(&mut self, mode: TransferMode) -> Result<()>;
+    fn set_transfer_mode(&self, mode: TransferMode) -> Result<()>;
 
     /// Gets the current number of bits per word.
     fn get_bits_per_word(&self) -> Result<u32>;
     /// Sets the current number of bits per word.
-    fn set_bits_per_word(&mut self, bits_per_word: u32) -> Result<()>;
+    fn set_bits_per_word(&self, bits_per_word: u32) -> Result<()>;
 
     /// Gets the maximum allowed speed of the SPI bus.
     fn get_max_speed(&self) -> Result<u32>;
     /// Sets the maximum allowed speed of the SPI bus.
-    fn set_max_speed(&mut self, max_speed: u32) -> Result<()>;
+    fn set_max_speed(&self, max_speed: u32) -> Result<()>;
 
     /// Returns the maximum number of transfers allowed in a single transaction.
     fn get_max_transfer_count(&self) -> usize;

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -3,18 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use std::io::{Read, Write};
 use std::time::Duration;
 
 /// A trait which represents a UART.
-pub trait Uart: Read + Write {
+pub trait Uart {
     /// Returns the UART baudrate.  May return zero for virtual UARTs.
     fn get_baudrate(&self) -> u32;
 
     /// Sets the UART baudrate.  May do nothing for virtual UARTs.
-    fn set_baudrate(&mut self, baudrate: u32) -> Result<()>;
+    fn set_baudrate(&self, baudrate: u32) -> Result<()>;
 
-    /// Reads UART recieve data into `buf`, returning the number of bytes read.
+    /// Reads UART receive data into `buf`, returning the number of bytes read.
+    /// This function _may_ block.
+    fn read(&self, buf: &mut [u8]) -> Result<usize>;
+
+    /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// The `timeout` may be used to specify a duration to wait for data.
-    fn read_timeout(&mut self, buf: &mut [u8], timeout: Duration) -> Result<usize>;
+    fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize>;
+
+    /// Writes data from `buf` to the UART.
+    fn write(&self, buf: &[u8]) -> Result<usize>;
 }

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -5,6 +5,7 @@
 use anyhow::{anyhow, Result};
 use bitflags::bitflags;
 use std::rc::Rc;
+use thiserror::Error;
 
 use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
@@ -59,6 +60,13 @@ impl Capabilities {
     }
 }
 
+/// Errors related to the SPI interface and SPI transactions.
+#[derive(Error, Debug)]
+pub enum TransportError {
+    #[error("This transport does not support {0} instance {1}")]
+    InvalidInstance(&'static str, u32),
+}
+
 /// A transport object is a factory for the low-level interfaces provided
 /// by a given communications backend.
 pub trait Transport {
@@ -67,11 +75,11 @@ pub trait Transport {
     fn capabilities(&self) -> Capabilities;
 
     /// Returns a SPI [`Target`] implementation.
-    fn spi(&self) -> Result<Rc<dyn Target>> {
+    fn spi(&self, _instance: u32) -> Result<Rc<dyn Target>> {
         unimplemented!();
     }
     /// Returns a [`Uart`] implementation.
-    fn uart(&self) -> Result<Rc<dyn Uart>> {
+    fn uart(&self, _instance: u32) -> Result<Rc<dyn Uart>> {
         unimplemented!();
     }
     /// Returns a [`Gpio`] implementation.

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{anyhow, Result};
 use bitflags::bitflags;
+use std::rc::Rc;
 
 use crate::io::gpio::Gpio;
 use crate::io::spi::Target;
@@ -66,15 +67,15 @@ pub trait Transport {
     fn capabilities(&self) -> Capabilities;
 
     /// Returns a SPI [`Target`] implementation.
-    fn spi(&self) -> Result<Box<dyn Target>> {
+    fn spi(&self) -> Result<Rc<dyn Target>> {
         unimplemented!();
     }
     /// Returns a [`Uart`] implementation.
-    fn uart(&self) -> Result<Box<dyn Uart>> {
+    fn uart(&self) -> Result<Rc<dyn Uart>> {
         unimplemented!();
     }
     /// Returns a [`Gpio`] implementation.
-    fn gpio(&self) -> Result<Box<dyn Gpio>> {
+    fn gpio(&self) -> Result<Rc<dyn Gpio>> {
         unimplemented!();
     }
 }

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use lazy_static::lazy_static;
 use log::info;
 use regex::Regex;
@@ -13,7 +13,7 @@ use std::time::Duration;
 use crate::io::uart::Uart;
 use crate::transport::verilator::subprocess::{Options, Subprocess};
 use crate::transport::verilator::uart::VerilatorUart;
-use crate::transport::{Capabilities, Capability, Transport};
+use crate::transport::{Capabilities, Capability, Transport, TransportError};
 
 #[derive(Default)]
 struct Inner {
@@ -85,7 +85,11 @@ impl Transport for Verilator {
         Capabilities::new(Capability::UART)
     }
 
-    fn uart(&self) -> Result<Rc<dyn Uart>> {
+    fn uart(&self, instance: u32) -> Result<Rc<dyn Uart>> {
+        ensure!(
+            instance == 0,
+            TransportError::InvalidInstance("uart", instance)
+        );
         let mut inner = self.inner.borrow_mut();
         if inner.uart.is_none() {
             inner.uart = Some(Rc::new(VerilatorUart::open(&self.uart_file)?));

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -117,7 +117,7 @@ impl InnerConsole {
         stdin: &mut (impl Read + AsRawFd),
         stdout: &mut impl Write,
     ) -> Result<()> {
-        let mut uart = transport.uart()?;
+        let uart = transport.uart()?;
         let mut buf = [0u8; 256];
 
         loop {
@@ -145,7 +145,7 @@ impl InnerConsole {
             // better way to approach waiting on the UART and keyboard.
 
             // Check for input on the uart.
-            match self.uart_read(&mut *uart, Duration::from_millis(10), stdout)? {
+            match self.uart_read(&*uart, Duration::from_millis(10), stdout)? {
                 ExitStatus::None => {}
                 ExitStatus::ExitSuccess => {
                     break;
@@ -161,7 +161,7 @@ impl InnerConsole {
                 if len == 1 && buf[0] == InnerConsole::CTRL_C {
                     break;
                 }
-                uart.write_all(&buf[..len])?;
+                uart.write(&buf[..len])?;
             }
         }
         Ok(())
@@ -181,7 +181,7 @@ impl InnerConsole {
     // Read from the uart and process the data read.
     fn uart_read(
         &mut self,
-        uart: &mut dyn Uart,
+        uart: &dyn Uart,
         timeout: Duration,
         stdout: &mut impl Write,
     ) -> Result<ExitStatus> {

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use erased_serde::Serialize;
+use std::any::Any;
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -24,7 +25,11 @@ pub struct GpioReadResult {
 }
 
 impl CommandDispatch for GpioRead {
-    fn run(&self, transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
         transport.capabilities().request(Capability::GPIO).ok()?;
         let gpio = transport.gpio()?;
         let value = gpio.read(&self.pin)?;
@@ -49,7 +54,11 @@ pub struct GpioWrite {
 }
 
 impl CommandDispatch for GpioWrite {
-    fn run(&self, transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
         transport.capabilities().request(Capability::GPIO).ok()?;
         let gpio = transport.gpio()?;
 
@@ -73,7 +82,11 @@ pub struct GpioSetDirection {
 }
 
 impl CommandDispatch for GpioSetDirection {
-    fn run(&self, transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
         transport.capabilities().request(Capability::GPIO).ok()?;
         let gpio = transport.gpio()?;
         gpio.set_direction(&self.pin, self.direction)?;

--- a/sw/host/opentitantool/src/command/hello.rs
+++ b/sw/host/opentitantool/src/command/hello.rs
@@ -9,6 +9,7 @@
 
 use anyhow::Result;
 use erased_serde::Serialize;
+use std::any::Any;
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
@@ -28,7 +29,11 @@ pub struct HelloMessage {
 }
 
 impl CommandDispatch for HelloWorld {
-    fn run(&self, _transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
         // Is the world cruel or not?
         let msg = if self.cruel {
             "Hello cruel World!"
@@ -48,7 +53,11 @@ pub struct HelloPeople {
 }
 
 impl CommandDispatch for HelloPeople {
-    fn run(&self, _transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
         // The `hello people` command produces no result.
         Ok(None)
     }
@@ -75,7 +84,11 @@ pub struct GoodbyeMessage {
 }
 
 impl CommandDispatch for GoodbyeCommand {
-    fn run(&self, _transport: &mut dyn Transport) -> Result<Option<Box<dyn Serialize>>> {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
         Ok(Some(Box::new(GoodbyeMessage {
             message: "Goodbye!".to_owned(),
         })))

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
 
     let mut interface = backend::create(&opts.backend_opts)?;
 
-    if let Some(value) = opts.command.run(&mut *interface)? {
+    if let Some(value) = opts.command.run(&opts, &mut *interface)? {
         println!("{}", serde_json::to_string_pretty(&value)?);
     }
     Ok(())


### PR DESCRIPTION
This PR has two commits:

1. A refactor of the IO APIs to be more ergonomic.  The IO APIs no longer have methods which require `mut self` and manage mutations through the interior mutability pattern.
2. A refactor to support multiple SPI or UART interfaces.  This includes some changes to the CommandDispatch trait to allow passing context between layers in the structopt-generated command hierarchy.  This allows for interior nodes in the hierarchy to have options that be passed down the the next layer in the hierarchy (e.g. `opentitantool spi --bus 1 read foo.bin`).
