### PR TITLE
[sw/dif_pwrmgr] Update missing bit fields

### DIFF
--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -83,6 +83,9 @@ static_assert(kDifPwrmgrWakeupRequestSourceFour ==
 static_assert(kDifPwrmgrWakeupRequestSourceFive ==
                   (1u << PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
+static_assert(kDifPwrmgrWakeupRequestSourceSix ==
+                  (1u << PWRMGR_PARAM_WKUP_REQ_IDX),
+              "Layout of WAKE_INFO register changed.");
 
 /**
  * Relevant bits of the RESET_EN register must start at `0` and be in the same
@@ -90,6 +93,9 @@ static_assert(kDifPwrmgrWakeupRequestSourceFive ==
  */
 static_assert(kDifPwrmgrResetRequestSourceOne ==
                   (1u << PWRMGR_RESET_EN_EN_0_BIT),
+              "Layout of RESET_EN register changed.");
+static_assert(kDifPwrmgrResetRequestSourceTwo ==
+                  (1u << PWRMGR_RESET_EN_EN_1_BIT),
               "Layout of RESET_EN register changed.");
 
 /**
@@ -129,7 +135,8 @@ static const request_reg_info_t request_reg_infos[2] = {
                             kDifPwrmgrWakeupRequestSourceTwo |
                             kDifPwrmgrWakeupRequestSourceThree |
                             kDifPwrmgrWakeupRequestSourceFour |
-                            kDifPwrmgrWakeupRequestSourceFive,
+                            kDifPwrmgrWakeupRequestSourceFive |
+                            kDifPwrmgrWakeupRequestSourceSix,
                     .index = 0,
                 },
         },
@@ -141,7 +148,8 @@ static const request_reg_info_t request_reg_infos[2] = {
             .cur_req_sources_reg_offset = PWRMGR_RESET_STATUS_REG_OFFSET,
             .bitfield =
                 {
-                    .mask = kDifPwrmgrResetRequestSourceOne,
+                    .mask = kDifPwrmgrResetRequestSourceOne |
+                            kDifPwrmgrResetRequestSourceTwo,
                     .index = 0,
                 },
         },

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -131,6 +131,7 @@ typedef enum dif_pwrmgr_wakeup_request_source {
   kDifPwrmgrWakeupRequestSourceThree = (1u << 2),
   kDifPwrmgrWakeupRequestSourceFour = (1u << 3),
   kDifPwrmgrWakeupRequestSourceFive = (1u << 4),
+  kDifPwrmgrWakeupRequestSourceSix = (1u << 5),
 } dif_pwrmgr_wakeup_request_source_t;
 
 /**
@@ -145,6 +146,7 @@ typedef enum dif_pwrmgr_wakeup_request_source {
  */
 typedef enum dif_pwrmgr_reset_request_source {
   kDifPwrmgrResetRequestSourceOne = (1u << 0),
+  kDifPwrmgrResetRequestSourceTwo = (1u << 1),
 } dif_pwrmgr_reset_request_source_t;
 
 /**

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -600,7 +600,7 @@ TEST_F(WakeupRecording, GetReason) {
     dif_pwrmgr_wakeup_reason_t exp_output;
   };
 
-  std::array<TestCase, 5> test_cases = {{
+  std::array<TestCase, 10> test_cases = {{
       // No bits set.
       {
           .read_val = {{
@@ -624,21 +624,38 @@ TEST_F(WakeupRecording, GetReason) {
                            .value = 1,
                        },
                        {
+                           .offset = PWRMGR_PARAM_AON_SYSRST_CTRL_WKUP_REQ_IDX,
+                           .value = 1,
+                       },
+                       {
                            .offset = PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX,
                            .value = 1,
                        },
                        {
                            .offset = PWRMGR_PARAM_AON_WKUP_REQ_IDX,
                            .value = 1,
+                       },
+                       {
+                           .offset = PWRMGR_PARAM_USB_WKUP_REQ_IDX,
+                           .value = 1,
+                       },
+                       {
+                           .offset = PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX,
+                           .value = 1,
+                       },
+                       {
+                           .offset = PWRMGR_PARAM_WKUP_REQ_IDX,
+                           .value = 1,
                        }},
-          .exp_output =
-              {
-                  .types = kDifPwrmgrWakeupTypeAbort |
-                           kDifPwrmgrWakeupTypeFallThrough |
-                           kDifPwrmgrWakeupTypeRequest,
-                  .request_sources = kDifPwrmgrWakeupRequestSourceTwo |
-                                     kDifPwrmgrWakeupRequestSourceThree,
-              },
+          .exp_output = {.types = kDifPwrmgrWakeupTypeAbort |
+                                  kDifPwrmgrWakeupTypeFallThrough |
+                                  kDifPwrmgrWakeupTypeRequest,
+                         .request_sources = kDifPwrmgrWakeupRequestSourceOne |
+                                            kDifPwrmgrWakeupRequestSourceTwo |
+                                            kDifPwrmgrWakeupRequestSourceThree |
+                                            kDifPwrmgrWakeupRequestSourceFour |
+                                            kDifPwrmgrWakeupRequestSourceFive |
+                                            kDifPwrmgrWakeupRequestSourceSix},
       },
       // Only abort.
       {
@@ -667,6 +684,17 @@ TEST_F(WakeupRecording, GetReason) {
       // Only requests from peripherals.
       {
           .read_val = {{
+              .offset = PWRMGR_PARAM_AON_SYSRST_CTRL_WKUP_REQ_IDX,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceOne,
+              },
+      },
+      {
+          .read_val = {{
               .offset = PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX,
               .value = 1,
           }},
@@ -674,6 +702,50 @@ TEST_F(WakeupRecording, GetReason) {
               {
                   .types = kDifPwrmgrWakeupTypeRequest,
                   .request_sources = kDifPwrmgrWakeupRequestSourceTwo,
+              },
+      },
+      {
+          .read_val = {{
+              .offset = PWRMGR_PARAM_AON_WKUP_REQ_IDX,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceThree,
+              },
+      },
+      {
+          .read_val = {{
+              .offset = PWRMGR_PARAM_USB_WKUP_REQ_IDX,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceFour,
+              },
+      },
+      {
+          .read_val = {{
+              .offset = PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceFive,
+              },
+      },
+      {
+          .read_val = {{
+              .offset = PWRMGR_PARAM_WKUP_REQ_IDX,
+              .value = 1,
+          }},
+          .exp_output =
+              {
+                  .types = kDifPwrmgrWakeupTypeRequest,
+                  .request_sources = kDifPwrmgrWakeupRequestSourceSix,
               },
       },
   }};


### PR DESCRIPTION
Add one bit each to reset_info and wakeup.
Update dif_pwrmgr_unittest.cc.

Signed-off-by: Guillermo Maturana <maturana@google.com>