### PR TITLE
[keymgr] Move FSM enum to keymgr_pkg

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -72,45 +72,6 @@ module keymgr_ctrl
   localparam int EntropyRndWidth = prim_util_pkg::vbits(EntropyRounds);
   localparam int CntWidth = EntropyRounds > CDIs ? EntropyRndWidth : CdiWidth;
 
-  // Enumeration for working state
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 11 -n 10 \
-  //      -s 4101887575 --language=sv
-  //
-  // Hamming distance histogram:
-  //
-  //  0: --
-  //  1: --
-  //  2: --
-  //  3: --
-  //  4: --
-  //  5: |||||||||||||||||||| (54.55%)
-  //  6: |||||||||||||||| (45.45%)
-  //  7: --
-  //  8: --
-  //  9: --
-  // 10: --
-  //
-  // Minimum Hamming distance: 5
-  // Maximum Hamming distance: 6
-  // Minimum Hamming weight: 2
-  // Maximum Hamming weight: 8
-  //
-  localparam int StateWidth = 10;
-  typedef enum logic [StateWidth-1:0] {
-    StCtrlReset          = 10'b1101100001,
-    StCtrlEntropyReseed  = 10'b1110010010,
-    StCtrlRandom         = 10'b0011110100,
-    StCtrlRootKey        = 10'b0110101111,
-    StCtrlInit           = 10'b0100000100,
-    StCtrlCreatorRootKey = 10'b1000011101,
-    StCtrlOwnerIntKey    = 10'b0001001010,
-    StCtrlOwnerKey       = 10'b1101111110,
-    StCtrlDisabled       = 10'b1010101000,
-    StCtrlWipe           = 10'b0000110011,
-    StCtrlInvalid        = 10'b1011000111
-  } keymgr_ctrl_state_e;
-
   // Enumeration for operation handling
   typedef enum logic [1:0] {
     StIdle,
@@ -237,11 +198,11 @@ module keymgr_ctrl
   // Main Control FSM
   //////////////////////////
 
-  logic [StateWidth-1:0] state_raw_q;
+  logic [CtrlStateWidth-1:0] state_raw_q;
   assign state_q = keymgr_ctrl_state_e'(state_raw_q);
   prim_flop #(
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StCtrlReset))
+    .Width(CtrlStateWidth),
+    .ResetValue(CtrlStateWidth'(StCtrlReset))
   ) u_state_regs (
     .clk_i,
     .rst_ni,

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -40,39 +40,6 @@ module keymgr_kmac_if import keymgr_pkg::*;(
 );
 
 
-  // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 6 -n 10 \
-  //      -s 2292624416 --language=sv
-  //
-  // Hamming distance histogram:
-  //
-  //  0: --
-  //  1: --
-  //  2: --
-  //  3: --
-  //  4: --
-  //  5: |||||||||||||||||||| (46.67%)
-  //  6: ||||||||||||||||| (40.00%)
-  //  7: ||||| (13.33%)
-  //  8: --
-  //  9: --
-  // 10: --
-  //
-  // Minimum Hamming distance: 5
-  // Maximum Hamming distance: 7
-  // Minimum Hamming weight: 2
-  // Maximum Hamming weight: 9
-  //
-  localparam int StateWidth = 10;
-  typedef enum logic [StateWidth-1:0] {
-    StIdle    = 10'b1110100010,
-    StTx      = 10'b0010011011,
-    StTxLast  = 10'b0101000000,
-    StOpWait  = 10'b1000101001,
-    StClean   = 10'b1111111101,
-    StError   = 10'b0011101110
-  } data_state_e;
-
   localparam int AdvRem = AdvDataWidth % KmacDataIfWidth;
   localparam int IdRem  = IdDataWidth  % KmacDataIfWidth;
   localparam int GenRem = GenDataWidth % KmacDataIfWidth;
@@ -120,7 +87,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   logic [3:0] inputs_invalid_d, inputs_invalid_q;
   logic clr_err;
 
-  data_state_e state_q, state_d;
+  keymgr_kmac_state_e state_q, state_d;
 
   // 0 pad to the appropriate width
   // this is basically for scenarios where *DataWidth % KmacDataIfWidth != 0
@@ -156,12 +123,12 @@ module keymgr_kmac_if import keymgr_pkg::*;(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = data_state_e'(state_raw_q);
+  logic [KmacIfStateWidth-1:0] state_raw_q;
+  assign state_q = keymgr_kmac_state_e'(state_raw_q);
 
   prim_flop #(
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
+    .Width(KmacIfStateWidth),
+    .ResetValue(KmacIfStateWidth'(StIdle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,

--- a/hw/ip/keymgr/rtl/keymgr_pkg.sv
+++ b/hw/ip/keymgr/rtl/keymgr_pkg.sv
@@ -242,6 +242,78 @@ package keymgr_pkg;
     KeyMgrEnLast
   } keymgr_lc_en_usage_e;
 
+  // Enumeration for working state
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 11 -n 10 \
+  //      -s 4101887575 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: --
+  //  4: --
+  //  5: |||||||||||||||||||| (54.55%)
+  //  6: |||||||||||||||| (45.45%)
+  //  7: --
+  //  8: --
+  //  9: --
+  // 10: --
+  //
+  // Minimum Hamming distance: 5
+  // Maximum Hamming distance: 6
+  // Minimum Hamming weight: 2
+  // Maximum Hamming weight: 8
+  //
+  parameter int CtrlStateWidth = 10;
+  typedef enum logic [CtrlStateWidth-1:0] {
+    StCtrlReset          = 10'b1101100001,
+    StCtrlEntropyReseed  = 10'b1110010010,
+    StCtrlRandom         = 10'b0011110100,
+    StCtrlRootKey        = 10'b0110101111,
+    StCtrlInit           = 10'b0100000100,
+    StCtrlCreatorRootKey = 10'b1000011101,
+    StCtrlOwnerIntKey    = 10'b0001001010,
+    StCtrlOwnerKey       = 10'b1101111110,
+    StCtrlDisabled       = 10'b1010101000,
+    StCtrlWipe           = 10'b0000110011,
+    StCtrlInvalid        = 10'b1011000111
+  } keymgr_ctrl_state_e;
+
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 5 -m 6 -n 10 \
+  //      -s 2292624416 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: --
+  //  4: --
+  //  5: |||||||||||||||||||| (46.67%)
+  //  6: ||||||||||||||||| (40.00%)
+  //  7: ||||| (13.33%)
+  //  8: --
+  //  9: --
+  // 10: --
+  //
+  // Minimum Hamming distance: 5
+  // Maximum Hamming distance: 7
+  // Minimum Hamming weight: 2
+  // Maximum Hamming weight: 9
+  //
+  parameter int KmacIfStateWidth = 10;
+  typedef enum logic [KmacIfStateWidth-1:0] {
+    StIdle    = 10'b1110100010,
+    StTx      = 10'b0010011011,
+    StTxLast  = 10'b0101000000,
+    StOpWait  = 10'b1000101001,
+    StClean   = 10'b1111111101,
+    StError   = 10'b0011101110
+  } keymgr_kmac_state_e;
+
   // perm_data
   function automatic logic[RandWidth-1:0] perm_data (logic [RandWidth-1:0] data,
     rand_perm_t perm_sel);


### PR DESCRIPTION
As discussed at #8156, DV needs to use these enums as well
Signed-off-by: Weicai Yang <weicai@google.com>