### PR TITLE
[otbn] Update ControllerStateValid assertion

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -374,7 +374,7 @@ module otbn_controller
   `ASSERT(ErrSetOnFatalErr, fatal_err |-> err)
 
   `ASSERT(ControllerStateValid, state_q inside {OtbnStateHalt, OtbnStateRun,
-                                                OtbnStateStall})
+                                                OtbnStateStall, OtbnStateLocked})
   // Branch only takes effect in OtbnStateRun so must not go into stall state for branch
   // instructions.
   `ASSERT(NoStallOnBranch,


### PR DESCRIPTION
With commit 7973806, we can now end up in a locked state.

(This is triggered, once the fix in #8357 is taken, by the `tl_intg_err` test)