### PR TITLE
[opentitantool] Minor cleanups

### DIFF
--- a/sw/host/opentitanlib/src/app/command.rs
+++ b/sw/host/opentitanlib/src/app/command.rs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::any::Any;
 use crate::transport::Transport;
 use anyhow::Result;
 use erased_serde::Serialize;
 pub use opentitantool_derive::*;
+use std::any::Any;
 
 /// The `CommandDispatch` trait should be implemented for all leaf structures
 /// in the application's command hierarchy.  It can be automatically derived

--- a/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
@@ -52,7 +52,7 @@ impl Uart for UltradebugUart {
         // Note: my recollection is that there is no way to set a read timeout
         // for the UART.  If there are no characters ready, the FTDI device
         // simply returns a zero-length read.
-        Ok(self.read(buf)?)
+        self.read(buf)
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize> {

--- a/sw/host/opentitantool/Cargo.toml
+++ b/sw/host/opentitantool/Cargo.toml
@@ -23,3 +23,6 @@ indicatif = "0.16.2"
 serde = {version="1", features=["serde_derive"]}
 serde_json = "1"
 erased-serde = "0.3.12"
+
+[features]
+demo_commands = []

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -19,6 +19,7 @@ enum RootCommandHierarchy {
     Spi(command::spi::SpiCommand),
 
     // Flattened because `Greetings` is a subcommand hierarchy.
+    #[cfg(feature = "demo_commands")]
     #[structopt(flatten)]
     Greetings(command::hello::Greetings),
 }


### PR DESCRIPTION
1. Put the demo commands (`hello world`) behind a feature flag.
2. `cargo fmt`.
3. `cargo clippy`: useless `?` operator in `uart.rs`.

Signed-off-by: Chris Frantz <cfrantz@google.com>