### PR TITLE
[pwrmgr] Uniquify hjson parameter names

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -19,7 +19,7 @@
     { struct: "logic",
       type: "uni",
       act: "req",
-      name: "debug_cable_wakeup",
+      name: "wkup_req",
       package: "",
     }
   ],
@@ -36,7 +36,7 @@
     }
   ],
   wakeup_list: [
-    { name: "debug_cable_wakeup",
+    { name: "wkup_req",
       desc: "USB-C debug cable wakeup request",
     }
   ],

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -49,7 +49,7 @@ module tb;
     .adc_o               (),
     .adc_i               ('0),
     .intr_debug_cable_o  (interrupts[0]),
-    .debug_cable_wakeup_o()
+    .wkup_req_o          ()
   );
 
   initial begin

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl.sv
@@ -42,7 +42,7 @@ module adc_ctrl
   // Debug cable is detected(attached or disconnected); raise the interrupt to CPU
 
   //pwrmgr interface
-  output logic debug_cable_wakeup_o
+  output logic wkup_req_o
   //Debug cable is detected; wake up the GSC(CPU) in normal sleep and deep sleep mode
   //input  [2:0] pwr_sts,//3'b001: deep sleep, 3'b010: normal sleep, 3'b100: fully active
 );
@@ -95,7 +95,7 @@ module adc_ctrl
     .adc_chn_val_o(hw2reg.adc_chn_val),
     .adc_intr_status_o(hw2reg.adc_intr_status),
     .aon_filter_status_o(hw2reg.filter_status),
-    .debug_cable_wakeup_o(debug_cable_wakeup_o),
+    .debug_cable_wakeup_o(wkup_req_o),
     .intr_debug_cable_o(intr_debug_cable_o),
     .adc_i(adc_i),
     .adc_o(adc_o)
@@ -103,7 +103,7 @@ module adc_ctrl
 
   // All outputs should be known value after reset
   `ASSERT_KNOWN(IntrDebugCableKnown, intr_debug_cable_o)
-  `ASSERT_KNOWN(WakeDebugCableKnown, debug_cable_wakeup_o)
+  `ASSERT_KNOWN(WakeDebugCableKnown, wkup_req_o)
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)
   `ASSERT_KNOWN(AdcKnown_A, adc_o)

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -27,7 +27,7 @@
     }
   ],
   wakeup_list: [
-    { name: "aon_timer_wkup_req",
+    { name: "wkup_req",
       desc: "Raised if the wakeup or watchdog timer has hit the specified threshold"
     },
   ],
@@ -47,7 +47,7 @@
     },
     { struct:  "logic",
       type:    "uni",
-      name:    "aon_timer_wkup_req",
+      name:    "wkup_req",
       act:     "req",
       package: "",
       default: "1'b0"

--- a/hw/ip/aon_timer/dv/tb.sv
+++ b/hw/ip/aon_timer/dv/tb.sv
@@ -58,7 +58,7 @@ module tb;
     .lc_escalate_en_i          (lc_escalate_en),
     .intr_wkup_timer_expired_o (wkup_expired),
     .intr_wdog_timer_bark_o    (wdog_bark),
-    .aon_timer_wkup_req_o      (wkup_req),
+    .wkup_req_o                (wkup_req),
     .aon_timer_rst_req_o       (rst_req),
     .sleep_mode_i              (sleep)
   );

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -29,7 +29,7 @@ module aon_timer import aon_timer_reg_pkg::*;
   output logic                nmi_wdog_timer_bark_o,
 
   // clk_aon_i domain
-  output logic                aon_timer_wkup_req_o,
+  output logic                wkup_req_o,
   output logic                aon_timer_rst_req_o,
 
   // async domain
@@ -166,10 +166,10 @@ module aon_timer import aon_timer_reg_pkg::*;
   assign hw2reg.wkup_cause.d  = 1'b1;
 
   // cause register resides in AON domain.
-  assign aon_timer_wkup_req_o = reg2hw.wkup_cause.q;
+  assign wkup_req_o = reg2hw.wkup_cause.q;
 
   // The wakeup signal is not latched in the pwrmgr so must be held until acked by software
-  `ASSERT(WkupStable_A, aon_timer_wkup_req_o |=> aon_timer_wkup_req_o ||
+  `ASSERT(WkupStable_A, wkup_req_o |=> wkup_req_o ||
       $fell(reg2hw.wkup_cause.q) && !aon_sleep_mode, clk_aon_i, !rst_aon_ni)
 
   ////////////////////////
@@ -255,7 +255,7 @@ module aon_timer import aon_timer_reg_pkg::*;
   `ASSERT_KNOWN(IntrWkupKnown_A, intr_wkup_timer_expired_o)
   `ASSERT_KNOWN(IntrWdogKnown_A, intr_wdog_timer_bark_o)
   // clk_aon_i domain
-  `ASSERT_KNOWN(WkupReqKnown_A, aon_timer_wkup_req_o, clk_aon_i, !rst_aon_ni)
+  `ASSERT_KNOWN(WkupReqKnown_A, wkup_req_o, clk_aon_i, !rst_aon_ni)
   `ASSERT_KNOWN(RstReqKnown_A, aon_timer_rst_req_o, clk_aon_i, !rst_aon_ni)
 
 endmodule

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -35,7 +35,7 @@
   ],
 
   wakeup_list: [
-    { name: "aon_wkup_req",
+    { name: "pin_wkup_req",
       desc: "pin wake request"
     },
     { name: "usb_wkup_req",
@@ -111,7 +111,7 @@
     },
     { struct:  "logic",
       type:    "uni",
-      name:    "aon_wkup_req",
+      name:    "pin_wkup_req",
       act:     "req",
       package: "",
       default: "1'b0"

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -25,7 +25,7 @@ module pinmux
   input                            clk_aon_i,
   input                            rst_aon_ni,
   // Wakeup request, running on clk_aon_i
-  output logic                     aon_wkup_req_o,
+  output logic                     pin_wkup_req_o,
   output logic                     usb_wkup_req_o,
   // Sleep enable and strap sample enable
   // from pwrmgr, running on clk_i
@@ -435,7 +435,7 @@ module pinmux
   end
 
   // OR' together all wakeup requests
-  assign aon_wkup_req_o = |aon_wkup_req;
+  assign pin_wkup_req_o = |aon_wkup_req;
 
   ////////////////
   // Assertions //
@@ -465,12 +465,12 @@ module pinmux
   `ASSERT_KNOWN(DftStrapsKnown_A, dft_strap_test_o)
 
   // running on slow AON clock
-  `ASSERT_KNOWN(AonWkupReqKnownO_A, aon_wkup_req_o, clk_aon_i, !rst_aon_ni)
+  `ASSERT_KNOWN(AonWkupReqKnownO_A, pin_wkup_req_o, clk_aon_i, !rst_aon_ni)
   `ASSERT_KNOWN(UsbWkupReqKnownO_A, usb_wkup_req_o, clk_aon_i, !rst_aon_ni)
   `ASSERT_KNOWN(UsbStateDebugKnownO_A, usb_state_debug_o, clk_aon_i, !rst_aon_ni)
 
   // The wakeup signal is not latched in the pwrmgr so must be held until acked by software
-  `ASSERT(PinmuxWkupStable_A, aon_wkup_req_o |=> aon_wkup_req_o ||
+  `ASSERT(PinmuxWkupStable_A, pin_wkup_req_o |=> pin_wkup_req_o ||
       $fell(|reg2hw.wkup_cause) && !sleep_en_i, clk_aon_i, !rst_aon_ni)
 
   // Some inputs at the chip-level may be forced to X in chip-level simulations.

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -140,8 +140,8 @@
     },
 
     % for wkup in Wkups:
-    { name: "${wkup['name'].upper()}_IDX",
-      desc: "Vector index for ${wkup['name']}, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "${wkup['module'].upper()}_${wkup['name'].upper()}_IDX",
+      desc: "Vector index for ${wkup['module']} ${wkup['name']}, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "${loop.index}",
       local: "true"

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -22,7 +22,7 @@
     }
   ],
   wakeup_list: [
-    { name: "aon_sysrst_ctrl_wkup_req",
+    { name: "wkup_req",
       desc: "user directed wakeup",
     }
   ],
@@ -72,7 +72,7 @@
     { name: "z3_wakeup", desc: "To enter Z3 mode and exit from Z4 sleep mode" }
   ],
   inter_signal_list: [
-    { name:    "aon_sysrst_ctrl_wkup_req",
+    { name:    "wkup_req",
       package: "",
       struct:  "logic",
       act:     "req"

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
@@ -25,7 +25,7 @@ module sysrst_ctrl
   output prim_alert_pkg::alert_tx_t [NumAlerts-1:0] alert_tx_o,
 
   // Wake, reset and interrupt requests
-  output logic aon_sysrst_ctrl_wkup_req_o,  // OT wake to pwrmgr
+  output logic wkup_req_o,  // OT wake to pwrmgr
   output logic aon_sysrst_ctrl_rst_req_o,  // OT reset to rstmgr
   output logic intr_sysrst_ctrl_o,  // sysrst_ctrl interrupt to PLIC
 
@@ -312,7 +312,7 @@ module sysrst_ctrl
   ///////////////////////////
 
   // OT wakeup signal to pwrmgr, CSRs and signals on AON domain (see #6323)
-  assign aon_sysrst_ctrl_wkup_req_o = reg2hw.wkup_status.q;
+  assign wkup_req_o = reg2hw.wkup_status.q;
   assign hw2reg.wkup_status.de = aon_ulp_wakeup_pulse_int ||
                                  aon_sysrst_ctrl_combo_intr ||
                                  aon_sysrst_ctrl_key_intr;
@@ -325,7 +325,7 @@ module sysrst_ctrl
   ) u_prim_flop_2sync (
     .clk_i,
     .rst_ni,
-    .d_i(aon_sysrst_ctrl_wkup_req_o),
+    .d_i(wkup_req_o),
     .q_o(wkup_req)
   );
 
@@ -347,7 +347,7 @@ module sysrst_ctrl
 
   // All outputs should be known value after reset
   `ASSERT_KNOWN(IntrSysRstCtrlOKnown, intr_sysrst_ctrl_o)
-  `ASSERT_KNOWN(OTWkOKnown, aon_sysrst_ctrl_wkup_req_o)
+  `ASSERT_KNOWN(OTWkOKnown, wkup_req_o)
   `ASSERT_KNOWN(OTRstOKnown, aon_sysrst_ctrl_rst_req_o)
   `ASSERT_KNOWN(TlODValidKnown, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown, tl_o.a_ready)

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3009,7 +3009,7 @@
       inter_signal_list:
       [
         {
-          name: aon_sysrst_ctrl_wkup_req
+          name: wkup_req
           struct: logic
           type: uni
           act: req
@@ -3100,7 +3100,7 @@
           index: -1
         }
         {
-          name: debug_cable_wakeup
+          name: wkup_req
           struct: logic
           type: uni
           act: req
@@ -3344,7 +3344,7 @@
           index: -1
         }
         {
-          name: aon_wkup_req
+          name: pin_wkup_req
           struct: logic
           type: uni
           act: req
@@ -3499,7 +3499,7 @@
           index: -1
         }
         {
-          name: aon_timer_wkup_req
+          name: wkup_req
           struct: logic
           type: uni
           act: req
@@ -7270,11 +7270,11 @@
       ]
       pwrmgr_aon.wakeups:
       [
-        sysrst_ctrl_aon.aon_sysrst_ctrl_wkup_req
-        adc_ctrl_aon.debug_cable_wakeup
-        pinmux_aon.aon_wkup_req
+        sysrst_ctrl_aon.wkup_req
+        adc_ctrl_aon.wkup_req
+        pinmux_aon.pin_wkup_req
         pinmux_aon.usb_wkup_req
-        aon_timer_aon.aon_timer_wkup_req
+        aon_timer_aon.wkup_req
         sensor_ctrl.wkup_req
       ]
       pwrmgr_aon.rstreqs:
@@ -12083,17 +12083,17 @@
   wakeups:
   [
     {
-      name: aon_sysrst_ctrl_wkup_req
+      name: wkup_req
       width: "1"
       module: sysrst_ctrl_aon
     }
     {
-      name: debug_cable_wakeup
+      name: wkup_req
       width: "1"
       module: adc_ctrl_aon
     }
     {
-      name: aon_wkup_req
+      name: pin_wkup_req
       width: "1"
       module: pinmux_aon
     }
@@ -12103,7 +12103,7 @@
       module: pinmux_aon
     }
     {
-      name: aon_timer_wkup_req
+      name: wkup_req
       width: "1"
       module: aon_timer_aon
     }
@@ -15094,7 +15094,7 @@
         index: -1
       }
       {
-        name: aon_sysrst_ctrl_wkup_req
+        name: wkup_req
         struct: logic
         type: uni
         act: req
@@ -15144,7 +15144,7 @@
         index: -1
       }
       {
-        name: debug_cable_wakeup
+        name: wkup_req
         struct: logic
         type: uni
         act: req
@@ -15294,7 +15294,7 @@
         index: -1
       }
       {
-        name: aon_wkup_req
+        name: pin_wkup_req
         struct: logic
         type: uni
         act: req
@@ -15407,7 +15407,7 @@
         index: -1
       }
       {
-        name: aon_timer_wkup_req
+        name: wkup_req
         struct: logic
         type: uni
         act: req

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -31,7 +31,7 @@
   ],
 
   wakeup_list: [
-    { name: "aon_wkup_req",
+    { name: "pin_wkup_req",
       desc: "pin wake request"
     },
     { name: "usb_wkup_req",
@@ -107,7 +107,7 @@
     },
     { struct:  "logic",
       type:    "uni",
-      name:    "aon_wkup_req",
+      name:    "pin_wkup_req",
       act:     "req",
       package: "",
       default: "1'b0"

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -145,43 +145,43 @@
       local: "true"
     },
 
-    { name: "AON_SYSRST_CTRL_WKUP_REQ_IDX",
-      desc: "Vector index for aon_sysrst_ctrl_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "SYSRST_CTRL_AON_WKUP_REQ_IDX",
+      desc: "Vector index for sysrst_ctrl_aon wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "0",
       local: "true"
     },
 
-    { name: "DEBUG_CABLE_WAKEUP_IDX",
-      desc: "Vector index for debug_cable_wakeup, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "ADC_CTRL_AON_WKUP_REQ_IDX",
+      desc: "Vector index for adc_ctrl_aon wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "1",
       local: "true"
     },
 
-    { name: "AON_WKUP_REQ_IDX",
-      desc: "Vector index for aon_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "PINMUX_AON_PIN_WKUP_REQ_IDX",
+      desc: "Vector index for pinmux_aon pin_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "2",
       local: "true"
     },
 
-    { name: "USB_WKUP_REQ_IDX",
-      desc: "Vector index for usb_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "PINMUX_AON_USB_WKUP_REQ_IDX",
+      desc: "Vector index for pinmux_aon usb_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "3",
       local: "true"
     },
 
-    { name: "AON_TIMER_WKUP_REQ_IDX",
-      desc: "Vector index for aon_timer_wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "AON_TIMER_AON_WKUP_REQ_IDX",
+      desc: "Vector index for aon_timer_aon wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "4",
       local: "true"
     },
 
-    { name: "WKUP_REQ_IDX",
-      desc: "Vector index for wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
+    { name: "SENSOR_CTRL_WKUP_REQ_IDX",
+      desc: "Vector index for sensor_ctrl wkup_req, applies for WAKEUP_EN, WAKE_STATUS and WAKE_INFO",
       type: "int",
       default: "5",
       local: "true"

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
@@ -8,12 +8,12 @@ package pwrmgr_reg_pkg;
 
   // Param list
   parameter int NumWkups = 6;
-  parameter int AON_SYSRST_CTRL_WKUP_REQ_IDX = 0;
-  parameter int DEBUG_CABLE_WAKEUP_IDX = 1;
-  parameter int AON_WKUP_REQ_IDX = 2;
-  parameter int USB_WKUP_REQ_IDX = 3;
-  parameter int AON_TIMER_WKUP_REQ_IDX = 4;
-  parameter int WKUP_REQ_IDX = 5;
+  parameter int SYSRST_CTRL_AON_WKUP_REQ_IDX = 0;
+  parameter int ADC_CTRL_AON_WKUP_REQ_IDX = 1;
+  parameter int PINMUX_AON_PIN_WKUP_REQ_IDX = 2;
+  parameter int PINMUX_AON_USB_WKUP_REQ_IDX = 3;
+  parameter int AON_TIMER_AON_WKUP_REQ_IDX = 4;
+  parameter int SENSOR_CTRL_WKUP_REQ_IDX = 5;
   parameter int NumRstReqs = 2;
   parameter int NumAlerts = 1;
 

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1629,7 +1629,7 @@ module top_earlgrey #(
       .alert_rx_i  ( alert_rx[24:24] ),
 
       // Inter-module signals
-      .aon_sysrst_ctrl_wkup_req_o(pwrmgr_aon_wakeups[0]),
+      .wkup_req_o(pwrmgr_aon_wakeups[0]),
       .aon_sysrst_ctrl_rst_req_o(pwrmgr_aon_rstreqs[0]),
       .tl_i(sysrst_ctrl_aon_tl_req),
       .tl_o(sysrst_ctrl_aon_tl_rsp),
@@ -1654,7 +1654,7 @@ module top_earlgrey #(
       // Inter-module signals
       .adc_o(adc_req_o),
       .adc_i(adc_rsp_i),
-      .debug_cable_wakeup_o(pwrmgr_aon_wakeups[1]),
+      .wkup_req_o(pwrmgr_aon_wakeups[1]),
       .tl_i(adc_ctrl_aon_tl_req),
       .tl_o(adc_ctrl_aon_tl_rsp),
 
@@ -1708,7 +1708,7 @@ module top_earlgrey #(
       .dft_hold_tap_sel_i(dft_hold_tap_sel_i),
       .sleep_en_i(pwrmgr_aon_low_power),
       .strap_en_i(pwrmgr_aon_strap),
-      .aon_wkup_req_o(pwrmgr_aon_wakeups[2]),
+      .pin_wkup_req_o(pwrmgr_aon_wakeups[2]),
       .usb_wkup_req_o(pwrmgr_aon_wakeups[3]),
       .usb_out_of_rst_i(usbdev_usb_out_of_rst),
       .usb_aon_wake_en_i(usbdev_usb_aon_wake_en),
@@ -1758,7 +1758,7 @@ module top_earlgrey #(
 
       // Inter-module signals
       .nmi_wdog_timer_bark_o(aon_timer_aon_nmi_wdog_timer_bark),
-      .aon_timer_wkup_req_o(pwrmgr_aon_wakeups[4]),
+      .wkup_req_o(pwrmgr_aon_wakeups[4]),
       .aon_timer_rst_req_o(pwrmgr_aon_rstreqs[1]),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .sleep_mode_i(pwrmgr_aon_low_power),

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1617,11 +1617,11 @@ typedef enum top_earlgrey_pinmux_outsel {
  * Power Manager Wakeup Signals
  */
 typedef enum top_earlgrey_power_manager_wake_ups {
-  kTopEarlgreyPowerManagerWakeUpsSysrstCtrlAonAonSysrstCtrlWkupReq = 0, /**<  */
-  kTopEarlgreyPowerManagerWakeUpsAdcCtrlAonDebugCableWakeup = 1, /**<  */
-  kTopEarlgreyPowerManagerWakeUpsPinmuxAonAonWkupReq = 2, /**<  */
+  kTopEarlgreyPowerManagerWakeUpsSysrstCtrlAonWkupReq = 0, /**<  */
+  kTopEarlgreyPowerManagerWakeUpsAdcCtrlAonWkupReq = 1, /**<  */
+  kTopEarlgreyPowerManagerWakeUpsPinmuxAonPinWkupReq = 2, /**<  */
   kTopEarlgreyPowerManagerWakeUpsPinmuxAonUsbWkupReq = 3, /**<  */
-  kTopEarlgreyPowerManagerWakeUpsAonTimerAonAonTimerWkupReq = 4, /**<  */
+  kTopEarlgreyPowerManagerWakeUpsAonTimerAonWkupReq = 4, /**<  */
   kTopEarlgreyPowerManagerWakeUpsSensorCtrlWkupReq = 5, /**<  */
   kTopEarlgreyPowerManagerWakeUpsLast = 5, /**< \internal Last valid pwrmgr wakeup signal */
 } top_earlgrey_power_manager_wake_ups_t;

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -69,22 +69,22 @@ static_assert(kDifPwrmgrWakeupRequestSourceOne ==
                   (1u << PWRMGR_WAKEUP_EN_EN_0_BIT),
               "Layout of WAKEUP_EN register changed.");
 static_assert(kDifPwrmgrWakeupRequestSourceOne ==
-                  (1u << PWRMGR_PARAM_AON_SYSRST_CTRL_WKUP_REQ_IDX),
+                  (1u << PWRMGR_PARAM_SYSRST_CTRL_AON_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
 static_assert(kDifPwrmgrWakeupRequestSourceTwo ==
-                  (1u << PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX),
+                  (1u << PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
 static_assert(kDifPwrmgrWakeupRequestSourceThree ==
-                  (1u << PWRMGR_PARAM_AON_WKUP_REQ_IDX),
+                  (1u << PWRMGR_PARAM_PINMUX_AON_PIN_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
 static_assert(kDifPwrmgrWakeupRequestSourceFour ==
-                  (1u << PWRMGR_PARAM_USB_WKUP_REQ_IDX),
+                  (1u << PWRMGR_PARAM_PINMUX_AON_USB_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
 static_assert(kDifPwrmgrWakeupRequestSourceFive ==
-                  (1u << PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX),
+                  (1u << PWRMGR_PARAM_AON_TIMER_AON_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
 static_assert(kDifPwrmgrWakeupRequestSourceSix ==
-                  (1u << PWRMGR_PARAM_WKUP_REQ_IDX),
+                  (1u << PWRMGR_PARAM_SENSOR_CTRL_WKUP_REQ_IDX),
               "Layout of WAKE_INFO register changed.");
 
 /**

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -624,27 +624,27 @@ TEST_F(WakeupRecording, GetReason) {
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_PARAM_AON_SYSRST_CTRL_WKUP_REQ_IDX,
+                           .offset = PWRMGR_PARAM_SYSRST_CTRL_AON_WKUP_REQ_IDX,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX,
+                           .offset = PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_PARAM_AON_WKUP_REQ_IDX,
+                           .offset = PWRMGR_PARAM_PINMUX_AON_PIN_WKUP_REQ_IDX,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_PARAM_USB_WKUP_REQ_IDX,
+                           .offset = PWRMGR_PARAM_PINMUX_AON_USB_WKUP_REQ_IDX,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX,
+                           .offset = PWRMGR_PARAM_AON_TIMER_AON_WKUP_REQ_IDX,
                            .value = 1,
                        },
                        {
-                           .offset = PWRMGR_PARAM_WKUP_REQ_IDX,
+                           .offset = PWRMGR_PARAM_SENSOR_CTRL_WKUP_REQ_IDX,
                            .value = 1,
                        }},
           .exp_output = {.types = kDifPwrmgrWakeupTypeAbort |
@@ -684,7 +684,7 @@ TEST_F(WakeupRecording, GetReason) {
       // Only requests from peripherals.
       {
           .read_val = {{
-              .offset = PWRMGR_PARAM_AON_SYSRST_CTRL_WKUP_REQ_IDX,
+              .offset = PWRMGR_PARAM_SYSRST_CTRL_AON_WKUP_REQ_IDX,
               .value = 1,
           }},
           .exp_output =
@@ -695,7 +695,7 @@ TEST_F(WakeupRecording, GetReason) {
       },
       {
           .read_val = {{
-              .offset = PWRMGR_PARAM_DEBUG_CABLE_WAKEUP_IDX,
+              .offset = PWRMGR_PARAM_ADC_CTRL_AON_WKUP_REQ_IDX,
               .value = 1,
           }},
           .exp_output =
@@ -706,7 +706,7 @@ TEST_F(WakeupRecording, GetReason) {
       },
       {
           .read_val = {{
-              .offset = PWRMGR_PARAM_AON_WKUP_REQ_IDX,
+              .offset = PWRMGR_PARAM_PINMUX_AON_PIN_WKUP_REQ_IDX,
               .value = 1,
           }},
           .exp_output =
@@ -717,7 +717,7 @@ TEST_F(WakeupRecording, GetReason) {
       },
       {
           .read_val = {{
-              .offset = PWRMGR_PARAM_USB_WKUP_REQ_IDX,
+              .offset = PWRMGR_PARAM_PINMUX_AON_USB_WKUP_REQ_IDX,
               .value = 1,
           }},
           .exp_output =
@@ -728,7 +728,7 @@ TEST_F(WakeupRecording, GetReason) {
       },
       {
           .read_val = {{
-              .offset = PWRMGR_PARAM_AON_TIMER_WKUP_REQ_IDX,
+              .offset = PWRMGR_PARAM_AON_TIMER_AON_WKUP_REQ_IDX,
               .value = 1,
           }},
           .exp_output =
@@ -739,7 +739,7 @@ TEST_F(WakeupRecording, GetReason) {
       },
       {
           .read_val = {{
-              .offset = PWRMGR_PARAM_WKUP_REQ_IDX,
+              .offset = PWRMGR_PARAM_SENSOR_CTRL_WKUP_REQ_IDX,
               .value = 1,
           }},
           .exp_output =


### PR DESCRIPTION
Fixes #8337.

However, there are some larger structural issues that need to be eventually addressed in #8363 

@tomroberts-lowrisc / @msfschaffner since the uniquification is now done with the module name, i've removed some of the uniquifying at the module level.  I will do this for reset requests separately. 