### PR TITLE
[util] Standardize auto-generated code warning msg

### DIFF
--- a/util/autogen_banner.py
+++ b/util/autogen_banner.py
@@ -1,0 +1,48 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from textwrap import fill
+
+LICENSE_BANNER = (
+    "Copyright lowRISC contributors.\n"
+    "Licensed under the Apache License, Version 2.0, see LICENSE for details.\n"
+    "SPDX-License-Identifier: Apache-2.0")
+
+AUTOGEN_BANNER = (
+    "THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:\n{command}")
+
+MAX_LEN = 70
+
+
+def get_autogen_banner(command: str, comment: str = "") -> str:
+    """Returns a commented out auto-generated code warning banner.
+
+    command is a fully formatted string representing what command was used
+    to auto-generate the source.
+    comment is the style of comment supported by the file type.
+    """
+    command = fill(command.strip(),
+                   width=MAX_LEN,
+                   break_long_words=False,
+                   break_on_hyphens=False)
+    text = AUTOGEN_BANNER.format(command=command)
+    return apply_comment(text, comment)
+
+
+def get_license_banner(comment: str = "") -> str:
+    """Returns a commented out license banner.
+
+    comment is the style of comment supported by the source file type.
+    """
+    return apply_comment(LICENSE_BANNER, comment)
+
+
+def apply_comment(text: str, comment: str) -> str:
+    """Applies comment to a text paragraph.
+
+    The returned string terminates in a newline.
+    """
+    if comment:
+        comment += " "
+    return "\n".join([f"{comment}{line}" for line in text.split("\n")]) + "\n"


### PR DESCRIPTION
This PR attempts to provide a standalone Python method that returns a
warning message box indicating that the source is autogenerated.

The `get_autogen_banner()` takes two arguments - `command` and
`comment`. It uses `tabulate` to create a text box containing the
warning banner and the supplied command that wraps to ~70 characters and
is center-justified for a clean look. The `comment` which is the correct
style supported by the file is applied to all lines and the final text
is returned as a string. Below are some examples:
Example 1:
```python
# +---------------------------------------------------------------------+
# | ----- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! ----- |
# | DO NOT EDIT THIS FILE DIRECTLY. IT HAS BEEN AUTO-GENERATED WITH THE |
# |                         FOLLOWING COMMAND:                          |
# |    util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson -o     |
# |                           hw/top_earlgrey                           |
# +---------------------------------------------------------------------+
```
Example 2:
```systemverilog
// +---------------------------------------------------------------------+
// | ----- W A R N I N G: A U T O - G E N E R A T E D   C O D E !! ----- |
// | DO NOT EDIT THIS FILE DIRECTLY. IT HAS BEEN AUTO-GENERATED WITH THE |
// |                         FOLLOWING COMMAND:                          |
// |   ./util/dvsim/dvsim.py hw/top_earlgrey/dv/chip_sim_cfg.hjson -i    |
// |         chip_plic_all_irqs --waves -v h --local --run-only          |
// +---------------------------------------------------------------------+
```

It will be great to standardize on how we indicate the source has been
autogenerated, considering we have a lot of scripts that autogenerate
lots of things in our codebase. Happy to hear thoughts and opinions on 
improving how this should look further.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>