### PR TITLE
[dif/gpio] autogen GPIO IRQ DIFs and integrate into src tree

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -38,12 +38,11 @@ static bool bootstrap_requested(void) {
 
   // Initialize GPIO device.
   dif_gpio_t gpio;
-  dif_gpio_params_t gpio_params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
-  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
+                      &gpio) == kDifOk);
 
   dif_gpio_state_t gpio_in;
-  CHECK(dif_gpio_read_all(&gpio, &gpio_in) == kDifGpioOk);
+  CHECK(dif_gpio_read_all(&gpio, &gpio_in) == kDifOk);
   return (gpio_in & GPIO_BOOTSTRAP_BIT_MASK) != 0;
 }
 

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -18,12 +18,12 @@ void demo_gpio_startup(dif_gpio_t *gpio) {
   LOG_INFO("Watch the LEDs!");
 
   // Give a LED pattern as startup indicator for 5 seconds.
-  CHECK(dif_gpio_write_all(gpio, 0xff00) == kDifGpioOk);
+  CHECK(dif_gpio_write_all(gpio, 0xff00) == kDifOk);
   for (int i = 0; i < 32; ++i) {
     usleep(5 * 1000);  // 5 ms
-    CHECK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2) == kDifGpioOk);
+    CHECK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2) == kDifOk);
   }
-  CHECK(dif_gpio_write_all(gpio, 0x0000) == kDifGpioOk);  // All LEDs off.
+  CHECK(dif_gpio_write_all(gpio, 0x0000) == kDifOk);  // All LEDs off.
 }
 
 /**
@@ -39,7 +39,7 @@ static const uint32_t kFtdiMask = 0x10000;
 
 uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   uint32_t gpio_state;
-  CHECK(dif_gpio_read_all(gpio, &gpio_state) == kDifGpioOk);
+  CHECK(dif_gpio_read_all(gpio, &gpio_state) == kDifOk);
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
@@ -86,6 +86,6 @@ void demo_uart_to_uart_and_gpio_echo(dif_uart_t *uart, dif_gpio_t *gpio) {
     uint8_t rcv_char;
     CHECK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL) == kDifOk);
     CHECK(dif_uart_byte_send_polled(uart, rcv_char) == kDifOk);
-    CHECK(dif_gpio_write_all(gpio, rcv_char << 8) == kDifGpioOk);
+    CHECK(dif_gpio_write_all(gpio, rcv_char << 8) == kDifOk);
   }
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -137,12 +137,10 @@ int main(int argc, char **argv) {
                       .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
                   }) == kDifSpiDeviceOk);
 
-  dif_gpio_params_t gpio_params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-  };
-  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
+                      &gpio) == kDifOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifGpioOk);
+  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifOk);
 
   LOG_INFO("Hello, USB!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -153,7 +151,7 @@ int main(int argc, char **argv) {
   // simulation has finished all of the printing, which takes a while
   // if `--trace` was passed in.
   uint32_t gpio_state;
-  CHECK(dif_gpio_read_all(&gpio, &gpio_state) == kDifGpioOk);
+  CHECK(dif_gpio_read_all(&gpio, &gpio_state) == kDifOk);
   bool pinflip = gpio_state & kPinflipMask ? true : false;
   bool differential = gpio_state & kDiffMask ? true : false;
   bool uphy = gpio_state & kUPhyMask ? true : false;
@@ -189,7 +187,7 @@ int main(int argc, char **argv) {
       CHECK(dif_uart_bytes_receive(&uart, 1, &rcv_char, NULL) == kDifOk);
       CHECK(dif_uart_byte_send_polled(&uart, rcv_char) == kDifOk);
 
-      CHECK(dif_gpio_write_all(&gpio, rcv_char << 8) == kDifGpioOk);
+      CHECK(dif_gpio_write_all(&gpio, rcv_char << 8) == kDifOk);
 
       if (rcv_char == '/') {
         uint32_t usb_irq_state =

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -50,12 +50,10 @@ int main(int argc, char **argv) {
                       .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
                   }) == kDifSpiDeviceOk);
 
-  dif_gpio_params_t gpio_params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-  };
-  CHECK(dif_gpio_init(gpio_params, &gpio) == kDifGpioOk);
+  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
+                      &gpio) == kDifOk);
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifGpioOk);
+  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifOk);
 
   // Add DATE and TIME because I keep fooling myself with old versions
   LOG_INFO("Hello World!");
@@ -65,7 +63,7 @@ int main(int argc, char **argv) {
 
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
-  CHECK(dif_gpio_write_all(&gpio, 0x0000) == kDifGpioOk);
+  CHECK(dif_gpio_write_all(&gpio, 0x0000) == kDifOk);
   LOG_INFO("Try out the switches on the board");
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -177,9 +177,9 @@ TEST_F(IrqGetEnabledTest, Success) {
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(ALERT_HANDLER_INTR_ENABLE_REG_OFFSET,
-                {{ALERT_HANDLER_INTR_ENABLE_CLASSD_BIT, true}});
+                {{ALERT_HANDLER_INTR_ENABLE_CLASSD_BIT, false}});
   EXPECT_EQ(dif_alert_handler_irq_get_enabled(
-                &alert_handler_, kDifAlertHandlerIrqClassa, &irq_state),
+                &alert_handler_, kDifAlertHandlerIrqClassd, &irq_state),
             kDifOk);
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -1,0 +1,265 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_gpio.h"
+
+#include "gpio_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool gpio_get_irq_bit_index(dif_gpio_irq_t irq,
+                                   bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifGpioIrqGpio0:
+      *index_out = 0;
+      break;
+    case kDifGpioIrqGpio1:
+      *index_out = 1;
+      break;
+    case kDifGpioIrqGpio2:
+      *index_out = 2;
+      break;
+    case kDifGpioIrqGpio3:
+      *index_out = 3;
+      break;
+    case kDifGpioIrqGpio4:
+      *index_out = 4;
+      break;
+    case kDifGpioIrqGpio5:
+      *index_out = 5;
+      break;
+    case kDifGpioIrqGpio6:
+      *index_out = 6;
+      break;
+    case kDifGpioIrqGpio7:
+      *index_out = 7;
+      break;
+    case kDifGpioIrqGpio8:
+      *index_out = 8;
+      break;
+    case kDifGpioIrqGpio9:
+      *index_out = 9;
+      break;
+    case kDifGpioIrqGpio10:
+      *index_out = 10;
+      break;
+    case kDifGpioIrqGpio11:
+      *index_out = 11;
+      break;
+    case kDifGpioIrqGpio12:
+      *index_out = 12;
+      break;
+    case kDifGpioIrqGpio13:
+      *index_out = 13;
+      break;
+    case kDifGpioIrqGpio14:
+      *index_out = 14;
+      break;
+    case kDifGpioIrqGpio15:
+      *index_out = 15;
+      break;
+    case kDifGpioIrqGpio16:
+      *index_out = 16;
+      break;
+    case kDifGpioIrqGpio17:
+      *index_out = 17;
+      break;
+    case kDifGpioIrqGpio18:
+      *index_out = 18;
+      break;
+    case kDifGpioIrqGpio19:
+      *index_out = 19;
+      break;
+    case kDifGpioIrqGpio20:
+      *index_out = 20;
+      break;
+    case kDifGpioIrqGpio21:
+      *index_out = 21;
+      break;
+    case kDifGpioIrqGpio22:
+      *index_out = 22;
+      break;
+    case kDifGpioIrqGpio23:
+      *index_out = 23;
+      break;
+    case kDifGpioIrqGpio24:
+      *index_out = 24;
+      break;
+    case kDifGpioIrqGpio25:
+      *index_out = 25;
+      break;
+    case kDifGpioIrqGpio26:
+      *index_out = 26;
+      break;
+    case kDifGpioIrqGpio27:
+      *index_out = 27;
+      break;
+    case kDifGpioIrqGpio28:
+      *index_out = 28;
+      break;
+    case kDifGpioIrqGpio29:
+      *index_out = 29;
+      break;
+    case kDifGpioIrqGpio30:
+      *index_out = 30;
+      break;
+    case kDifGpioIrqGpio31:
+      *index_out = 31;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_get_state(const dif_gpio_t *gpio,
+                                    dif_gpio_irq_state_snapshot_t *snapshot) {
+  if (gpio == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(gpio->base_addr, GPIO_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_is_pending(const dif_gpio_t *gpio, dif_gpio_irq_t irq,
+                                     bool *is_pending) {
+  if (gpio == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!gpio_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(gpio->base_addr, GPIO_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_acknowledge(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_t irq) {
+  if (gpio == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!gpio_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_get_enabled(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_t irq, dif_toggle_t *state) {
+  if (gpio == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!gpio_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_set_enabled(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_t irq, dif_toggle_t state) {
+  if (gpio == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!gpio_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_force(const dif_gpio_t *gpio, dif_gpio_irq_t irq) {
+  if (gpio == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!gpio_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_disable_all(
+    const dif_gpio_t *gpio, dif_gpio_irq_enable_snapshot_t *snapshot) {
+  if (gpio == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_restore_all(
+    const dif_gpio_t *gpio, const dif_gpio_irq_enable_snapshot_t *snapshot) {
+  if (gpio == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.h
@@ -1,0 +1,194 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_GPIO_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_GPIO_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/gpio/doc/">GPIO</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to gpio.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_gpio {
+  /**
+   * The base address for the gpio hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_gpio_t;
+
+/**
+ * A gpio interrupt request type.
+ */
+typedef enum dif_gpio_irq {
+  /**
+   * Raised if any of GPIO pin detects configured interrupt mode
+   */
+  kDifGpioIrqGpio0 = 0,
+  kDifGpioIrqGpio1 = 1,
+  kDifGpioIrqGpio2 = 2,
+  kDifGpioIrqGpio3 = 3,
+  kDifGpioIrqGpio4 = 4,
+  kDifGpioIrqGpio5 = 5,
+  kDifGpioIrqGpio6 = 6,
+  kDifGpioIrqGpio7 = 7,
+  kDifGpioIrqGpio8 = 8,
+  kDifGpioIrqGpio9 = 9,
+  kDifGpioIrqGpio10 = 10,
+  kDifGpioIrqGpio11 = 11,
+  kDifGpioIrqGpio12 = 12,
+  kDifGpioIrqGpio13 = 13,
+  kDifGpioIrqGpio14 = 14,
+  kDifGpioIrqGpio15 = 15,
+  kDifGpioIrqGpio16 = 16,
+  kDifGpioIrqGpio17 = 17,
+  kDifGpioIrqGpio18 = 18,
+  kDifGpioIrqGpio19 = 19,
+  kDifGpioIrqGpio20 = 20,
+  kDifGpioIrqGpio21 = 21,
+  kDifGpioIrqGpio22 = 22,
+  kDifGpioIrqGpio23 = 23,
+  kDifGpioIrqGpio24 = 24,
+  kDifGpioIrqGpio25 = 25,
+  kDifGpioIrqGpio26 = 26,
+  kDifGpioIrqGpio27 = 27,
+  kDifGpioIrqGpio28 = 28,
+  kDifGpioIrqGpio29 = 29,
+  kDifGpioIrqGpio30 = 30,
+  kDifGpioIrqGpio31 = 31,
+} dif_gpio_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_gpio_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_gpio_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_gpio_irq_disable_all()` and `dif_gpio_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_gpio_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_get_state(const dif_gpio_t *gpio,
+                                    dif_gpio_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_is_pending(const dif_gpio_t *gpio, dif_gpio_irq_t irq,
+                                     bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_acknowledge(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_get_enabled(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_t irq, dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_set_enabled(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_t irq, dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param gpio A gpio handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_force(const dif_gpio_t *gpio, dif_gpio_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param gpio A gpio handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_disable_all(const dif_gpio_t *gpio,
+                                      dif_gpio_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param gpio A gpio handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_irq_restore_all(
+    const dif_gpio_t *gpio, const dif_gpio_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_GPIO_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -1,0 +1,272 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_gpio.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "gpio_regs.h"  // Generated.
+
+namespace dif_gpio_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class GpioTest : public Test, public MmioTest {
+ protected:
+  dif_gpio_t gpio_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public GpioTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_gpio_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_gpio_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_get_state(&gpio_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_gpio_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_gpio_irq_get_state(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_gpio_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_gpio_irq_get_state(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public GpioTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_gpio_irq_is_pending(nullptr, kDifGpioIrqGpio0, &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio0, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_is_pending(nullptr, kDifGpioIrqGpio0, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, (dif_gpio_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, {{0, true}});
+  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio0, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, {{31, false}});
+  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio31, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public GpioTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, kDifGpioIrqGpio0), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, (dif_gpio_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET, {{0, true}});
+  EXPECT_EQ(dif_gpio_irq_acknowledge(&gpio_, kDifGpioIrqGpio0), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET, {{31, true}});
+  EXPECT_EQ(dif_gpio_irq_acknowledge(&gpio_, kDifGpioIrqGpio31), kDifOk);
+}
+
+class IrqGetEnabledTest : public GpioTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_gpio_irq_get_enabled(nullptr, kDifGpioIrqGpio0, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio0, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_get_enabled(nullptr, kDifGpioIrqGpio0, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, (dif_gpio_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, {{0, true}});
+  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio0, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, {{31, false}});
+  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio31, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public GpioTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_gpio_irq_set_enabled(nullptr, kDifGpioIrqGpio0, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, (dif_gpio_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(GPIO_INTR_ENABLE_REG_OFFSET, {{0, 0x1, true}});
+  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, kDifGpioIrqGpio0, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(GPIO_INTR_ENABLE_REG_OFFSET, {{31, 0x1, false}});
+  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, kDifGpioIrqGpio31, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public GpioTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_gpio_irq_force(nullptr, kDifGpioIrqGpio0), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_gpio_irq_force(nullptr, (dif_gpio_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(GPIO_INTR_TEST_REG_OFFSET, {{0, true}});
+  EXPECT_EQ(dif_gpio_irq_force(&gpio_, kDifGpioIrqGpio0), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(GPIO_INTR_TEST_REG_OFFSET, {{31, true}});
+  EXPECT_EQ(dif_gpio_irq_force(&gpio_, kDifGpioIrqGpio31), kDifOk);
+}
+
+class IrqDisableAllTest : public GpioTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_gpio_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_gpio_irq_disable_all(&gpio_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_gpio_irq_disable_all(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_gpio_irq_disable_all(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public GpioTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_gpio_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_restore_all(&gpio_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_gpio_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_gpio_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_gpio_irq_restore_all(&gpio_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_gpio_irq_restore_all(&gpio_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_gpio_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -154,8 +154,8 @@ TEST_F(IrqGetEnabledTest, Success) {
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(HMAC_INTR_ENABLE_REG_OFFSET,
-                {{HMAC_INTR_ENABLE_HMAC_ERR_BIT, true}});
-  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, kDifHmacIrqHmacDone, &irq_state),
+                {{HMAC_INTR_ENABLE_HMAC_ERR_BIT, false}});
+  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, kDifHmacIrqHmacErr, &irq_state),
             kDifOk);
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -158,9 +158,9 @@ TEST_F(IrqGetEnabledTest, Success) {
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(UART_INTR_ENABLE_REG_OFFSET,
-                {{UART_INTR_ENABLE_RX_PARITY_ERR_BIT, true}});
+                {{UART_INTR_ENABLE_RX_PARITY_ERR_BIT, false}});
   EXPECT_EQ(
-      dif_uart_irq_get_enabled(&uart_, kDifUartIrqTxWatermark, &irq_state),
+      dif_uart_irq_get_enabled(&uart_, kDifUartIrqRxParityErr, &irq_state),
       kDifOk);
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,6 +2,20 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Autogen GPIO DIF library
+sw_lib_dif_autogen_gpio = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_gpio',
+    sources: [
+      hw_ip_gpio_reg_h,
+      'dif_gpio_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen AES DIF library
 sw_lib_dif_autogen_aes = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -63,13 +63,13 @@ typedef enum dif_result {
  */
 typedef enum dif_toggle {
   /**
-   * The "enabled" state.
-   */
-  kDifToggleEnabled,
-  /**
    * The "disabled" state.
    */
-  kDifToggleDisabled,
+  kDifToggleDisabled = 0,
+  /**
+   * The "enabled" state.
+   */
+  kDifToggleEnabled = 1,
 } dif_toggle_t;
 
 #ifdef __cplusplus

--- a/sw/device/lib/dif/dif_gpio.c
+++ b/sw/device/lib/dif/dif_gpio.c
@@ -37,26 +37,26 @@ static uint32_t index_to_mask(uint32_t index) { return 1u << index; }
  * @param val Value to write.
  */
 OT_WARN_UNUSED_RESULT
-static dif_gpio_result_t gpio_masked_write(const dif_gpio_t *gpio,
-                                           ptrdiff_t reg_lower_offset,
-                                           ptrdiff_t reg_upper_offset,
-                                           uint32_t mask, uint32_t val) {
+static dif_result_t gpio_masked_write(const dif_gpio_t *gpio,
+                                      ptrdiff_t reg_lower_offset,
+                                      ptrdiff_t reg_upper_offset, uint32_t mask,
+                                      uint32_t val) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
   const uint32_t mask_lower_half = mask & 0x0000FFFFu;
   const uint32_t mask_upper_half = mask & 0xFFFF0000u;
   if (mask_lower_half != 0) {
-    mmio_region_write32(gpio->params.base_addr, reg_lower_offset,
+    mmio_region_write32(gpio->base_addr, reg_lower_offset,
                         (mask_lower_half << 16) | (val & 0x0000FFFFu));
   }
   if (mask_upper_half != 0) {
-    mmio_region_write32(gpio->params.base_addr, reg_upper_offset,
+    mmio_region_write32(gpio->base_addr, reg_upper_offset,
                         mask_upper_half | ((val & 0xFFFF0000u) >> 16));
   }
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
 /**
@@ -79,12 +79,12 @@ static dif_gpio_result_t gpio_masked_write(const dif_gpio_t *gpio,
  * @param val Value to write.
  */
 OT_WARN_UNUSED_RESULT
-static dif_gpio_result_t gpio_masked_bit_write(const dif_gpio_t *gpio,
-                                               ptrdiff_t reg_lower_offset,
-                                               ptrdiff_t reg_upper_offset,
-                                               uint32_t index, bool val) {
+static dif_result_t gpio_masked_bit_write(const dif_gpio_t *gpio,
+                                          ptrdiff_t reg_lower_offset,
+                                          ptrdiff_t reg_upper_offset,
+                                          uint32_t index, bool val) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
   // Write to reg_lower_offset if the bit is in the lower half, write to
@@ -93,348 +93,195 @@ static dif_gpio_result_t gpio_masked_bit_write(const dif_gpio_t *gpio,
   // Since masked access writes to half of a register, index mod 16 gives the
   // index of the bit in the half-word mask.
   const uint32_t mask = index_to_mask(index % 16);
-  mmio_region_write32(gpio->params.base_addr, offset,
+  mmio_region_write32(gpio->base_addr, offset,
                       (mask << 16) | (val ? mask : 0u));
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_init(dif_gpio_params_t params, dif_gpio_t *gpio) {
+dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
-  gpio->params = params;
+  gpio->base_addr = base_addr;
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_reset(const dif_gpio_t *gpio) {
+dif_result_t dif_gpio_reset(const dif_gpio_t *gpio) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
   // We don't need to write to `GPIO_MASKED_OE_*` and `GPIO_MASKED_OUT_*`
   // since we directly reset `GPIO_DIRECT_OE` and `GPIO_DIRECT_OUT` below.
-  mmio_region_write32(gpio->params.base_addr, GPIO_INTR_ENABLE_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr, GPIO_DIRECT_OE_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr, GPIO_DIRECT_OUT_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr,
-                      GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr,
-                      GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr,
-                      GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr,
-                      GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, 0);
-  mmio_region_write32(gpio->params.base_addr,
-                      GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_ENABLE_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_DIRECT_OE_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_DIRECT_OUT_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, 0);
+  mmio_region_write32(gpio->base_addr, GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, 0);
   // Also clear all pending interrupts
-  mmio_region_write32(gpio->params.base_addr, GPIO_INTR_STATE_REG_OFFSET,
-                      0xFFFFFFFFu);
+  mmio_region_write32(gpio->base_addr, GPIO_INTR_STATE_REG_OFFSET, 0xFFFFFFFFu);
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_irq_is_pending(const dif_gpio_t *gpio,
-                                          dif_gpio_pin_t pin,
-                                          bool *is_pending) {
-  if (gpio == NULL || is_pending == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  *is_pending = mmio_region_get_bit32(gpio->params.base_addr,
-                                      GPIO_INTR_STATE_REG_OFFSET, pin);
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_is_pending_all(const dif_gpio_t *gpio,
-                                              dif_gpio_state_t *is_pending) {
-  if (gpio == NULL || is_pending == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  *is_pending =
-      mmio_region_read32(gpio->params.base_addr, GPIO_INTR_STATE_REG_OFFSET);
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_acknowledge(const dif_gpio_t *gpio,
-                                           dif_gpio_pin_t pin) {
+dif_result_t dif_gpio_irq_set_trigger(const dif_gpio_t *gpio,
+                                      dif_gpio_mask_t mask,
+                                      dif_gpio_irq_trigger_t trigger) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  mmio_region_write32(gpio->params.base_addr, GPIO_INTR_STATE_REG_OFFSET,
-                      index_to_mask(pin));
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_get_enabled(const dif_gpio_t *gpio,
-                                           dif_gpio_pin_t pin,
-                                           dif_gpio_toggle_t *state) {
-  if (gpio == NULL || state == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  bool is_enabled = mmio_region_get_bit32(gpio->params.base_addr,
-                                          GPIO_INTR_ENABLE_REG_OFFSET, pin);
-  *state = is_enabled ? kDifGpioToggleEnabled : kDifGpioToggleDisabled;
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_set_enabled(const dif_gpio_t *gpio,
-                                           dif_gpio_pin_t pin,
-                                           dif_gpio_toggle_t state) {
-  if (gpio == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  switch (state) {
-    case kDifGpioToggleEnabled:
-      mmio_region_nonatomic_set_bit32(gpio->params.base_addr,
-                                      GPIO_INTR_ENABLE_REG_OFFSET, pin);
-      break;
-    case kDifGpioToggleDisabled:
-      mmio_region_nonatomic_clear_bit32(gpio->params.base_addr,
-                                        GPIO_INTR_ENABLE_REG_OFFSET, pin);
-      break;
-    default:
-      return kDifGpioBadArg;
-  }
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_set_enabled_masked(const dif_gpio_t *gpio,
-                                                  dif_gpio_mask_t mask,
-                                                  dif_gpio_toggle_t state) {
-  if (gpio == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  switch (state) {
-    case kDifGpioToggleEnabled:
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_INTR_ENABLE_REG_OFFSET, mask, 0);
-      break;
-    case kDifGpioToggleDisabled:
-      mmio_region_nonatomic_clear_mask32(gpio->params.base_addr,
-                                         GPIO_INTR_ENABLE_REG_OFFSET, mask, 0);
-      break;
-    default:
-      return kDifGpioBadArg;
-  }
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_force(const dif_gpio_t *gpio,
-                                     dif_gpio_pin_t pin) {
-  if (gpio == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  mmio_region_write32(gpio->params.base_addr, GPIO_INTR_TEST_REG_OFFSET,
-                      index_to_mask(pin));
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_disable_all(const dif_gpio_t *gpio,
-                                           dif_gpio_state_t *snapshot) {
-  if (gpio == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  if (snapshot != NULL) {
-    *snapshot =
-        mmio_region_read32(gpio->params.base_addr, GPIO_INTR_ENABLE_REG_OFFSET);
-  }
-  mmio_region_write32(gpio->params.base_addr, GPIO_INTR_ENABLE_REG_OFFSET, 0);
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_restore_all(const dif_gpio_t *gpio,
-                                           const dif_gpio_state_t *snapshot) {
-  if (gpio == NULL || snapshot == NULL) {
-    return kDifGpioBadArg;
-  }
-
-  mmio_region_write32(gpio->params.base_addr, GPIO_INTR_ENABLE_REG_OFFSET,
-                      *snapshot);
-
-  return kDifGpioOk;
-}
-
-dif_gpio_result_t dif_gpio_irq_set_trigger(const dif_gpio_t *gpio,
-                                           dif_gpio_mask_t mask,
-                                           dif_gpio_irq_trigger_t trigger) {
-  if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
   // Disable all interrupt triggers for the given mask.
   mmio_region_nonatomic_clear_mask32(
-      gpio->params.base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
+      gpio->base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
   mmio_region_nonatomic_clear_mask32(
-      gpio->params.base_addr, GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, mask, 0);
+      gpio->base_addr, GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, mask, 0);
   mmio_region_nonatomic_clear_mask32(
-      gpio->params.base_addr, GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, mask, 0);
+      gpio->base_addr, GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, mask, 0);
   mmio_region_nonatomic_clear_mask32(
-      gpio->params.base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, mask, 0);
+      gpio->base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, mask, 0);
 
   switch (trigger) {
     case kDifGpioIrqTriggerEdgeRising:
       mmio_region_nonatomic_set_mask32(
-          gpio->params.base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
+          gpio->base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
       break;
     case kDifGpioIrqTriggerEdgeFalling:
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET,
-                                       mask, 0);
+      mmio_region_nonatomic_set_mask32(
+          gpio->base_addr, GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, mask, 0);
       break;
     case kDifGpioIrqTriggerLevelLow:
       mmio_region_nonatomic_set_mask32(
-          gpio->params.base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, mask, 0);
+          gpio->base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, mask, 0);
       break;
     case kDifGpioIrqTriggerLevelHigh:
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET,
-                                       mask, 0);
+      mmio_region_nonatomic_set_mask32(
+          gpio->base_addr, GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, mask, 0);
       break;
     case kDifGpioIrqTriggerEdgeRisingFalling:
       mmio_region_nonatomic_set_mask32(
-          gpio->params.base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET,
-                                       mask, 0);
+          gpio->base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
+      mmio_region_nonatomic_set_mask32(
+          gpio->base_addr, GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, mask, 0);
       break;
     case kDifGpioIrqTriggerEdgeRisingLevelLow:
       mmio_region_nonatomic_set_mask32(
-          gpio->params.base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
+          gpio->base_addr, GPIO_INTR_CTRL_EN_RISING_REG_OFFSET, mask, 0);
       mmio_region_nonatomic_set_mask32(
-          gpio->params.base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, mask, 0);
+          gpio->base_addr, GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, mask, 0);
       break;
     case kDifGpioIrqTriggerEdgeFallingLevelHigh:
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET,
-                                       mask, 0);
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET,
-                                       mask, 0);
+      mmio_region_nonatomic_set_mask32(
+          gpio->base_addr, GPIO_INTR_CTRL_EN_FALLING_REG_OFFSET, mask, 0);
+      mmio_region_nonatomic_set_mask32(
+          gpio->base_addr, GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, mask, 0);
       break;
     default:
-      return kDifGpioError;
+      return kDifError;
   }
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_read_all(const dif_gpio_t *gpio,
-                                    dif_gpio_state_t *state) {
+dif_result_t dif_gpio_read_all(const dif_gpio_t *gpio,
+                               dif_gpio_state_t *state) {
   if (gpio == NULL || state == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
-  *state = mmio_region_read32(gpio->params.base_addr, GPIO_DATA_IN_REG_OFFSET);
+  *state = mmio_region_read32(gpio->base_addr, GPIO_DATA_IN_REG_OFFSET);
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_read(const dif_gpio_t *gpio, dif_gpio_pin_t pin,
-                                bool *state) {
+dif_result_t dif_gpio_read(const dif_gpio_t *gpio, dif_gpio_pin_t pin,
+                           bool *state) {
   if (gpio == NULL || state == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
-  *state = mmio_region_get_bit32(gpio->params.base_addr,
-                                 GPIO_DATA_IN_REG_OFFSET, pin);
+  *state = mmio_region_get_bit32(gpio->base_addr, GPIO_DATA_IN_REG_OFFSET, pin);
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_write_all(const dif_gpio_t *gpio,
-                                     dif_gpio_state_t state) {
+dif_result_t dif_gpio_write_all(const dif_gpio_t *gpio,
+                                dif_gpio_state_t state) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
-  mmio_region_write32(gpio->params.base_addr, GPIO_DIRECT_OUT_REG_OFFSET,
-                      state);
+  mmio_region_write32(gpio->base_addr, GPIO_DIRECT_OUT_REG_OFFSET, state);
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_write(const dif_gpio_t *gpio, dif_gpio_pin_t pin,
-                                 bool state) {
+dif_result_t dif_gpio_write(const dif_gpio_t *gpio, dif_gpio_pin_t pin,
+                            bool state) {
   return gpio_masked_bit_write(gpio, GPIO_MASKED_OUT_LOWER_REG_OFFSET,
                                GPIO_MASKED_OUT_UPPER_REG_OFFSET, pin, state);
 }
 
-dif_gpio_result_t dif_gpio_write_masked(const dif_gpio_t *gpio,
-                                        dif_gpio_mask_t mask,
-                                        dif_gpio_state_t state) {
+dif_result_t dif_gpio_write_masked(const dif_gpio_t *gpio, dif_gpio_mask_t mask,
+                                   dif_gpio_state_t state) {
   return gpio_masked_write(gpio, GPIO_MASKED_OUT_LOWER_REG_OFFSET,
                            GPIO_MASKED_OUT_UPPER_REG_OFFSET, mask, state);
 }
 
-dif_gpio_result_t dif_gpio_output_set_enabled_all(const dif_gpio_t *gpio,
-                                                  dif_gpio_state_t state) {
+dif_result_t dif_gpio_output_set_enabled_all(const dif_gpio_t *gpio,
+                                             dif_gpio_state_t state) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
-  mmio_region_write32(gpio->params.base_addr, GPIO_DIRECT_OE_REG_OFFSET, state);
+  mmio_region_write32(gpio->base_addr, GPIO_DIRECT_OE_REG_OFFSET, state);
 
-  return kDifGpioOk;
+  return kDifOk;
 }
 
-dif_gpio_result_t dif_gpio_output_set_enabled(const dif_gpio_t *gpio,
-                                              dif_gpio_pin_t pin,
-                                              dif_gpio_toggle_t state) {
+dif_result_t dif_gpio_output_set_enabled(const dif_gpio_t *gpio,
+                                         dif_gpio_pin_t pin,
+                                         dif_toggle_t state) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
   return gpio_masked_bit_write(gpio, GPIO_MASKED_OE_LOWER_REG_OFFSET,
                                GPIO_MASKED_OE_UPPER_REG_OFFSET, pin, state);
-
-  return kDifGpioOk;
 }
 
-dif_gpio_result_t dif_gpio_output_set_enabled_masked(const dif_gpio_t *gpio,
-                                                     dif_gpio_mask_t mask,
-                                                     dif_gpio_state_t state) {
+dif_result_t dif_gpio_output_set_enabled_masked(const dif_gpio_t *gpio,
+                                                dif_gpio_mask_t mask,
+                                                dif_gpio_state_t state) {
   return gpio_masked_write(gpio, GPIO_MASKED_OE_LOWER_REG_OFFSET,
                            GPIO_MASKED_OE_UPPER_REG_OFFSET, mask, state);
 }
 
-dif_gpio_result_t dif_gpio_input_noise_filter_set_enabled(
-    const dif_gpio_t *gpio, dif_gpio_mask_t mask, dif_gpio_toggle_t state) {
+dif_result_t dif_gpio_input_noise_filter_set_enabled(const dif_gpio_t *gpio,
+                                                     dif_gpio_mask_t mask,
+                                                     dif_toggle_t state) {
   if (gpio == NULL) {
-    return kDifGpioBadArg;
+    return kDifBadArg;
   }
 
   switch (state) {
-    case kDifGpioToggleEnabled:
-      mmio_region_nonatomic_set_mask32(gpio->params.base_addr,
-                                       GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET,
-                                       mask, 0);
+    case kDifToggleEnabled:
+      mmio_region_nonatomic_set_mask32(
+          gpio->base_addr, GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, mask, 0);
       break;
-    case kDifGpioToggleDisabled:
-      mmio_region_nonatomic_clear_mask32(gpio->params.base_addr,
-                                         GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET,
-                                         mask, 0);
+    case kDifToggleDisabled:
+      mmio_region_nonatomic_clear_mask32(
+          gpio->base_addr, GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, mask, 0);
       break;
     default:
-      return kDifGpioBadArg;
+      return kDifBadArg;
   }
 
-  return kDifGpioOk;
+  return kDifOk;
 }

--- a/sw/device/lib/dif/dif_gpio_unittest.cc
+++ b/sw/device/lib/dif/dif_gpio_unittest.cc
@@ -23,36 +23,31 @@ uint32_t AllZerosExcept(uint32_t index) { return 1 << index; }
 uint32_t AllOnesExcept(uint32_t index) { return ~AllZerosExcept(index); }
 
 // Base class for the test fixtures in this file.
-class DifGpioTest : public testing::Test, public mock_mmio::MmioTest {};
+class GpioTest : public testing::Test, public mock_mmio::MmioTest {};
 
 // Init tests
-class InitTest : public DifGpioTest {};
+class InitTest : public GpioTest {};
 
 TEST_F(InitTest, NullArgs) {
-  dif_gpio_params_t params{.base_addr = dev().region()};
-
-  EXPECT_EQ(dif_gpio_init(params, nullptr), kDifGpioBadArg);
+  EXPECT_EQ(dif_gpio_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Init) {
-  dif_gpio_params_t params{.base_addr = dev().region()};
   dif_gpio_t gpio;
-  EXPECT_EQ(dif_gpio_init(params, &gpio), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_init(dev().region(), &gpio), kDifOk);
 }
 
 // Base class for the rest of the tests in this file, provides a
 // `dif_gpio_t` instance.
-class DifGpioTestInitialized : public DifGpioTest {
+class GpioTestInitialized : public GpioTest {
  protected:
-  const dif_gpio_t gpio_ = {.params = {.base_addr = dev().region()}};
+  const dif_gpio_t gpio_ = {.base_addr = dev().region()};
 };
 
 // Reset tests
-class ResetTest : public DifGpioTestInitialized {};
+class ResetTest : public GpioTestInitialized {};
 
-TEST_F(ResetTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_reset(nullptr), kDifGpioBadArg);
-}
+TEST_F(ResetTest, NullArgs) { EXPECT_EQ(dif_gpio_reset(nullptr), kDifBadArg); }
 
 TEST_F(ResetTest, Reset) {
   EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
@@ -65,23 +60,23 @@ TEST_F(ResetTest, Reset) {
   EXPECT_WRITE32(GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, 0);
   EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET, kAllOnes);
 
-  EXPECT_EQ(dif_gpio_reset(&gpio_), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_reset(&gpio_), kDifOk);
 }
 
 // Read tests
-class ReadTest : public DifGpioTestInitialized {};
+class ReadTest : public GpioTestInitialized {};
 
 TEST_F(ReadTest, NullArgs) {
   dif_gpio_state_t out_arg_uint32_t;
   bool out_arg_bool;
 
-  EXPECT_EQ(dif_gpio_read_all(nullptr, &out_arg_uint32_t), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_read_all(&gpio_, nullptr), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_read_all(nullptr, nullptr), kDifGpioBadArg);
+  EXPECT_EQ(dif_gpio_read_all(nullptr, &out_arg_uint32_t), kDifBadArg);
+  EXPECT_EQ(dif_gpio_read_all(&gpio_, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_gpio_read_all(nullptr, nullptr), kDifBadArg);
 
-  EXPECT_EQ(dif_gpio_read(nullptr, 0, &out_arg_bool), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_read(&gpio_, 0, nullptr), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_read(nullptr, 0, nullptr), kDifGpioBadArg);
+  EXPECT_EQ(dif_gpio_read(nullptr, 0, &out_arg_bool), kDifBadArg);
+  EXPECT_EQ(dif_gpio_read(&gpio_, 0, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_gpio_read(nullptr, 0, nullptr), kDifBadArg);
 }
 
 TEST_F(ReadTest, AllPins) {
@@ -89,7 +84,7 @@ TEST_F(ReadTest, AllPins) {
   EXPECT_READ32(GPIO_DATA_IN_REG_OFFSET, kVal);
 
   dif_gpio_state_t pin_values = 0;
-  EXPECT_EQ(dif_gpio_read_all(&gpio_, &pin_values), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_read_all(&gpio_, &pin_values), kDifOk);
   EXPECT_EQ(pin_values, kVal);
 }
 
@@ -101,26 +96,26 @@ TEST_F(ReadTest, SinglePin) {
       EXPECT_READ32(GPIO_DATA_IN_REG_OFFSET, reg_val);
 
       bool pin_val = !exp_pin_val;
-      EXPECT_EQ(dif_gpio_read(&gpio_, pin, &pin_val), kDifGpioOk);
+      EXPECT_EQ(dif_gpio_read(&gpio_, pin, &pin_val), kDifOk);
       EXPECT_EQ(pin_val, exp_pin_val);
     }
   }
 }
 
 // Write tests
-class WriteTest : public DifGpioTestInitialized {};
+class WriteTest : public GpioTestInitialized {};
 
 TEST_F(WriteTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_write_all(nullptr, kAllOnes), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_write(nullptr, 0, true), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_write_masked(nullptr, kAllOnes, kAllOnes), kDifGpioBadArg);
+  EXPECT_EQ(dif_gpio_write_all(nullptr, kAllOnes), kDifBadArg);
+  EXPECT_EQ(dif_gpio_write(nullptr, 0, true), kDifBadArg);
+  EXPECT_EQ(dif_gpio_write_masked(nullptr, kAllOnes, kAllOnes), kDifBadArg);
 }
 
 TEST_F(WriteTest, AllPins) {
   constexpr uint32_t kVal = 0xA5A5A5A5;
   EXPECT_WRITE32(GPIO_DIRECT_OUT_REG_OFFSET, kVal);
 
-  EXPECT_EQ(dif_gpio_write_all(&gpio_, kVal), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write_all(&gpio_, kVal), kDifOk);
 }
 
 // The GPIO device provides masked bit-level atomic writes to its DIRECT_OUT
@@ -145,91 +140,89 @@ TEST_F(WriteTest, AllPins) {
 
 TEST_F(WriteTest, SinglePin) {
   EXPECT_WRITE32(GPIO_MASKED_OUT_LOWER_REG_OFFSET, {{16, 1}, {0, 1}});
-  EXPECT_EQ(dif_gpio_write(&gpio_, 0, true), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write(&gpio_, 0, true), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OUT_LOWER_REG_OFFSET, {{31, 1}, {15, 0}});
-  EXPECT_EQ(dif_gpio_write(&gpio_, 15, false), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write(&gpio_, 15, false), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OUT_UPPER_REG_OFFSET, {{16, 1}, {0, 1}});
-  EXPECT_EQ(dif_gpio_write(&gpio_, 16, true), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write(&gpio_, 16, true), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OUT_UPPER_REG_OFFSET, {{31, 1}, {15, 0}});
-  EXPECT_EQ(dif_gpio_write(&gpio_, 31, false), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write(&gpio_, 31, false), kDifOk);
 }
 
 TEST_F(WriteTest, Masked) {
   EXPECT_WRITE32(GPIO_MASKED_OUT_LOWER_REG_OFFSET, 0xCDCD3322);
   EXPECT_WRITE32(GPIO_MASKED_OUT_UPPER_REG_OFFSET, 0xABAB5544);
-  EXPECT_EQ(dif_gpio_write_masked(&gpio_, 0xABABCDCD, 0x55443322), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write_masked(&gpio_, 0xABABCDCD, 0x55443322), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OUT_UPPER_REG_OFFSET, 0xABAB5544);
-  EXPECT_EQ(dif_gpio_write_masked(&gpio_, 0xABAB0000, 0x55443322), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write_masked(&gpio_, 0xABAB0000, 0x55443322), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OUT_LOWER_REG_OFFSET, 0xCDCD3322);
-  EXPECT_EQ(dif_gpio_write_masked(&gpio_, 0x0000CDCD, 0x55443322), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_write_masked(&gpio_, 0x0000CDCD, 0x55443322), kDifOk);
 }
 
 // Output mode tests
-class OutputModeTest : public DifGpioTestInitialized {};
+class OutputModeTest : public GpioTestInitialized {};
 
 TEST_F(OutputModeTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_output_set_enabled_all(nullptr, kAllOnes), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_output_set_enabled(nullptr, 0, kDifGpioToggleEnabled),
-            kDifGpioBadArg);
+  EXPECT_EQ(dif_gpio_output_set_enabled_all(nullptr, kAllOnes), kDifBadArg);
+  EXPECT_EQ(dif_gpio_output_set_enabled(nullptr, 0, kDifToggleEnabled),
+            kDifBadArg);
   EXPECT_EQ(dif_gpio_output_set_enabled_masked(nullptr, kAllOnes, kAllOnes),
-            kDifGpioBadArg);
+            kDifBadArg);
 }
 
 TEST_F(OutputModeTest, AllPins) {
   constexpr uint32_t kVal = 0xA5A5A5A5;
   EXPECT_WRITE32(GPIO_DIRECT_OE_REG_OFFSET, kVal);
 
-  EXPECT_EQ(dif_gpio_output_set_enabled_all(&gpio_, kVal), kDifGpioOk);
+  EXPECT_EQ(dif_gpio_output_set_enabled_all(&gpio_, kVal), kDifOk);
 }
 
 TEST_F(OutputModeTest, SinglePin) {
   EXPECT_WRITE32(GPIO_MASKED_OE_LOWER_REG_OFFSET, {{16, 1}, {0, 1}});
-  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 0, kDifGpioToggleEnabled),
-            kDifGpioOk);
+  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 0, kDifToggleEnabled), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OE_LOWER_REG_OFFSET, {{31, 1}, {15, 0}});
-  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 15, kDifGpioToggleDisabled),
-            kDifGpioOk);
+  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 15, kDifToggleDisabled),
+            kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OE_UPPER_REG_OFFSET, {{16, 1}, {0, 1}});
-  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 16, kDifGpioToggleEnabled),
-            kDifGpioOk);
+  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 16, kDifToggleEnabled), kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OE_UPPER_REG_OFFSET, {{31, 1}, {15, 0}});
-  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 31, kDifGpioToggleDisabled),
-            kDifGpioOk);
+  EXPECT_EQ(dif_gpio_output_set_enabled(&gpio_, 31, kDifToggleDisabled),
+            kDifOk);
 }
 
 TEST_F(OutputModeTest, Masked) {
   EXPECT_WRITE32(GPIO_MASKED_OE_LOWER_REG_OFFSET, 0xCDCD3322);
   EXPECT_WRITE32(GPIO_MASKED_OE_UPPER_REG_OFFSET, 0xABAB5544);
   EXPECT_EQ(dif_gpio_output_set_enabled_masked(&gpio_, 0xABABCDCD, 0x55443322),
-            kDifGpioOk);
+            kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OE_LOWER_REG_OFFSET, 0xCDCD3322);
   EXPECT_EQ(dif_gpio_output_set_enabled_masked(&gpio_, 0x0000CDCD, 0x55443322),
-            kDifGpioOk);
+            kDifOk);
 
   EXPECT_WRITE32(GPIO_MASKED_OE_UPPER_REG_OFFSET, 0xABAB5544);
   EXPECT_EQ(dif_gpio_output_set_enabled_masked(&gpio_, 0xABAB0000, 0x55443322),
-            kDifGpioOk);
+            kDifOk);
 }
 
 // Input noise filter tests
-class InputFilterTest : public DifGpioTestInitialized {};
+class InputFilterTest : public GpioTestInitialized {};
 
 TEST_F(InputFilterTest, NullArgs) {
   EXPECT_EQ(dif_gpio_input_noise_filter_set_enabled(nullptr, kAllOnes,
-                                                    kDifGpioToggleEnabled),
-            kDifGpioBadArg);
+                                                    kDifToggleEnabled),
+            kDifBadArg);
   EXPECT_EQ(dif_gpio_input_noise_filter_set_enabled(nullptr, kAllOnes,
-                                                    kDifGpioToggleDisabled),
-            kDifGpioBadArg);
+                                                    kDifToggleDisabled),
+            kDifBadArg);
 }
 
 TEST_F(InputFilterTest, MaskedEnable) {
@@ -237,9 +230,9 @@ TEST_F(InputFilterTest, MaskedEnable) {
   EXPECT_READ32(GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, 0x0);
   EXPECT_WRITE32(GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, kVal);
 
-  EXPECT_EQ(dif_gpio_input_noise_filter_set_enabled(&gpio_, kVal,
-                                                    kDifGpioToggleEnabled),
-            kDifGpioOk);
+  EXPECT_EQ(
+      dif_gpio_input_noise_filter_set_enabled(&gpio_, kVal, kDifToggleEnabled),
+      kDifOk);
 }
 
 TEST_F(InputFilterTest, MaskedDisable) {
@@ -247,12 +240,12 @@ TEST_F(InputFilterTest, MaskedDisable) {
   EXPECT_READ32(GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, kAllOnes);
   EXPECT_WRITE32(GPIO_CTRL_EN_INPUT_FILTER_REG_OFFSET, ~kVal);
 
-  EXPECT_EQ(dif_gpio_input_noise_filter_set_enabled(&gpio_, kVal,
-                                                    kDifGpioToggleDisabled),
-            kDifGpioOk);
+  EXPECT_EQ(
+      dif_gpio_input_noise_filter_set_enabled(&gpio_, kVal, kDifToggleDisabled),
+      kDifOk);
 }
 
-class IrqTest : public DifGpioTestInitialized {
+class IrqTest : public GpioTestInitialized {
  protected:
   // Expectations for disabling the interrupt triggers of the pins given by
   // `pins`.
@@ -268,86 +261,6 @@ class IrqTest : public DifGpioTestInitialized {
   }
 };
 
-TEST_F(IrqTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_irq_force(nullptr, 0), kDifGpioBadArg);
-
-  dif_gpio_state_t out_arg_uint32_t;
-  EXPECT_EQ(dif_gpio_irq_is_pending_all(nullptr, &out_arg_uint32_t),
-            kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_irq_is_pending_all(&gpio_, nullptr), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_irq_is_pending_all(nullptr, nullptr), kDifGpioBadArg);
-
-  bool out_arg_bool;
-  EXPECT_EQ(dif_gpio_irq_is_pending(nullptr, 0, &out_arg_bool), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, 0, nullptr), kDifGpioBadArg);
-  EXPECT_EQ(dif_gpio_irq_is_pending(nullptr, 0, nullptr), kDifGpioBadArg);
-
-  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, 0), kDifGpioBadArg);
-
-  EXPECT_EQ(
-      dif_gpio_irq_set_enabled_masked(nullptr, kAllOnes, kDifGpioToggleEnabled),
-      kDifGpioBadArg);
-
-  EXPECT_EQ(
-      dif_gpio_irq_set_trigger(nullptr, kAllOnes, kDifGpioIrqTriggerEdgeRising),
-      kDifGpioBadArg);
-}
-
-TEST_F(IrqTest, ForceSinglePin) {
-  for (uint32_t pin = 0; pin < 32; ++pin) {
-    EXPECT_WRITE32(GPIO_INTR_TEST_REG_OFFSET, {{pin, 1}});
-    EXPECT_EQ(dif_gpio_irq_force(&gpio_, pin), kDifGpioOk);
-  }
-}
-
-TEST_F(IrqTest, ReadAllPins) {
-  constexpr uint32_t kVal = 0xABABABAB;
-  EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, kVal);
-  dif_gpio_state_t irq_state = 0;
-  EXPECT_EQ(dif_gpio_irq_is_pending_all(&gpio_, &irq_state), kDifGpioOk);
-  EXPECT_EQ(irq_state, kVal);
-}
-
-TEST_F(IrqTest, ReadSinglePin) {
-  for (uint32_t pin = 0; pin < 32; ++pin) {
-    for (const bool exp_irq_state : {true, false}) {
-      const uint32_t reg_val =
-          exp_irq_state ? AllZerosExcept(pin) : AllOnesExcept(pin);
-      EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, reg_val);
-      bool irq_state = !exp_irq_state;
-      EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, pin, &irq_state), kDifGpioOk);
-      EXPECT_EQ(irq_state, exp_irq_state);
-    }
-  }
-}
-
-TEST_F(IrqTest, ClearSinglePin) {
-  for (uint32_t pin = 0; pin < 32; ++pin) {
-    EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET, {{pin, 1}});
-    EXPECT_EQ(dif_gpio_irq_acknowledge(&gpio_, pin), kDifGpioOk);
-  }
-}
-
-TEST_F(IrqTest, MaskedEnable) {
-  constexpr uint32_t kVal = 0xABABABAB;
-  EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, 0x0);
-  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, kVal);
-
-  EXPECT_EQ(
-      dif_gpio_irq_set_enabled_masked(&gpio_, kVal, kDifGpioToggleEnabled),
-      kDifGpioOk);
-}
-
-TEST_F(IrqTest, MaskedDisable) {
-  constexpr uint32_t kVal = 0xABABABAB;
-  EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, kAllOnes);
-  EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, ~kVal);
-
-  EXPECT_EQ(
-      dif_gpio_irq_set_enabled_masked(&gpio_, kVal, kDifGpioToggleDisabled),
-      kDifGpioOk);
-}
-
 TEST_F(IrqTest, MaskedConfigTriggerEdgeRising) {
   SCOPED_TRACE("IrqTest.MaskedConfigTriggerEdgeRising");
   constexpr uint32_t kVal = 0xABABABAB;
@@ -357,7 +270,7 @@ TEST_F(IrqTest, MaskedConfigTriggerEdgeRising) {
 
   EXPECT_EQ(
       dif_gpio_irq_set_trigger(&gpio_, kVal, kDifGpioIrqTriggerEdgeRising),
-      kDifGpioOk);
+      kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerEdgeFalling) {
@@ -369,7 +282,7 @@ TEST_F(IrqTest, MaskedConfigTriggerEdgeFalling) {
 
   EXPECT_EQ(
       dif_gpio_irq_set_trigger(&gpio_, kVal, kDifGpioIrqTriggerEdgeFalling),
-      kDifGpioOk);
+      kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerLevelLow) {
@@ -380,7 +293,7 @@ TEST_F(IrqTest, MaskedConfigTriggerLevelLow) {
   EXPECT_WRITE32(GPIO_INTR_CTRL_EN_LVLLOW_REG_OFFSET, kVal);
 
   EXPECT_EQ(dif_gpio_irq_set_trigger(&gpio_, kVal, kDifGpioIrqTriggerLevelLow),
-            kDifGpioOk);
+            kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerLevelHigh) {
@@ -391,7 +304,7 @@ TEST_F(IrqTest, MaskedConfigTriggerLevelHigh) {
   EXPECT_WRITE32(GPIO_INTR_CTRL_EN_LVLHIGH_REG_OFFSET, kVal);
 
   EXPECT_EQ(dif_gpio_irq_set_trigger(&gpio_, kVal, kDifGpioIrqTriggerLevelHigh),
-            kDifGpioOk);
+            kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerEdgeRisingFalling) {
@@ -405,7 +318,7 @@ TEST_F(IrqTest, MaskedConfigTriggerEdgeRisingFalling) {
 
   EXPECT_EQ(dif_gpio_irq_set_trigger(&gpio_, kVal,
                                      kDifGpioIrqTriggerEdgeRisingFalling),
-            kDifGpioOk);
+            kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerEdgeRisingLevelLow) {
@@ -419,7 +332,7 @@ TEST_F(IrqTest, MaskedConfigTriggerEdgeRisingLevelLow) {
 
   EXPECT_EQ(dif_gpio_irq_set_trigger(&gpio_, kVal,
                                      kDifGpioIrqTriggerEdgeRisingLevelLow),
-            kDifGpioOk);
+            kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerEdgeFallingLevelHigh) {
@@ -433,7 +346,7 @@ TEST_F(IrqTest, MaskedConfigTriggerEdgeFallingLevelHigh) {
 
   EXPECT_EQ(dif_gpio_irq_set_trigger(&gpio_, kVal,
                                      kDifGpioIrqTriggerEdgeFallingLevelHigh),
-            kDifGpioOk);
+            kDifOk);
 }
 
 TEST_F(IrqTest, MaskedConfigTriggerGeneralError) {
@@ -443,7 +356,7 @@ TEST_F(IrqTest, MaskedConfigTriggerGeneralError) {
 
   EXPECT_EQ(dif_gpio_irq_set_trigger(
                 &gpio_, kVal, static_cast<dif_gpio_irq_trigger_t>(kAllOnes)),
-            kDifGpioError);
+            kDifError);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -161,6 +161,7 @@ sw_lib_dif_gpio = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_dif_autogen_gpio,
     ],
   )
 )
@@ -168,9 +169,11 @@ sw_lib_dif_gpio = declare_dependency(
 test('dif_gpio_unittest', executable(
     'dif_gpio_unittest',
     sources: [
-      hw_ip_gpio_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_gpio.c',
       'dif_gpio_unittest.cc',
+      'autogen/dif_gpio_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_gpio.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_gpio_autogen.c',
+      hw_ip_gpio_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -90,9 +90,8 @@ static void sca_init_uart(void) {
  * @param trigger Trigger source.
  */
 static void sca_init_gpio(sca_trigger_source_t trigger) {
-  dif_gpio_params_t gpio_params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR)};
-  IGNORE_RESULT(dif_gpio_init(gpio_params, &gpio));
+  IGNORE_RESULT(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
 
   uint32_t select_mask =
       bitfield_field32_write(0, kTriggerSourceBitfield, UINT32_MAX);

--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -46,10 +46,10 @@ static const uint32_t kGpioMask = 0x0000FFFF;
  * @param write_val Value to write.
  */
 static void test_gpio_write(uint32_t write_val) {
-  CHECK(dif_gpio_write_all(&gpio, write_val) == kDifGpioOk);
+  CHECK(dif_gpio_write_all(&gpio, write_val) == kDifOk);
 
   uint32_t read_val = 0;
-  CHECK(dif_gpio_read_all(&gpio, &read_val) == kDifGpioOk);
+  CHECK(dif_gpio_read_all(&gpio, &read_val) == kDifOk);
 
   uint32_t expected = write_val & kGpioMask;
   uint32_t actual = read_val & kGpioMask;
@@ -63,12 +63,9 @@ static void test_gpio_write(uint32_t write_val) {
  * NOTE: This test can currently run only on FPGA and DV.
  */
 bool test_main(void) {
-  CHECK(dif_gpio_init(
-            (dif_gpio_params_t){
-                .base_addr = mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-            },
-            &gpio) == kDifGpioOk);
-  CHECK(dif_gpio_output_set_enabled_all(&gpio, kGpioMask) == kDifGpioOk);
+  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
+                      &gpio) == kDifOk);
+  CHECK(dif_gpio_output_set_enabled_all(&gpio, kGpioMask) == kDifOk);
 
   for (uint8_t i = 0; i < ARRAYSIZE(kGpioVals); ++i) {
     test_gpio_write(kGpioVals[i]);

--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -69,6 +69,7 @@ class Irq:
             [word.capitalize() for word in self.name_snake.split("_")])
         _multiline_description = irq["desc"][0].upper() + irq["desc"][1:]
         self.description = _multiline_description.replace("\n", " ")
+        self.width = irq["width"] if "width" in irq else 1
 
 
 class Ip:
@@ -200,7 +201,8 @@ def main():
                             f"dif_{ip.name_snake}_autogen{filetype}")
 
                 # Read in template.
-                template = Template(template_file.read_text())
+                template = Template(template_file.read_text(),
+                                    strict_undefined=True)
 
                 # Generate output file.
                 out_file.write_text(template.render(ip=ip, irqs=ip.irqs))

--- a/util/make_new_dif/dif_autogen.c.tpl
+++ b/util/make_new_dif/dif_autogen.c.tpl
@@ -44,9 +44,19 @@
 
     switch (irq) {
   % for irq in irqs:
+    ## This handles the GPIO IP case where there is a multi-bit interrupt.
+    % if irq.width > 1:
+      % for irq_idx in range(irq.width):
+        case kDif${ip.name_camel}Irq${irq.name_camel}${irq_idx}:
+          *index_out = ${irq_idx};
+          break;
+      % endfor
+    ## This handles all other IPs.
+    % else:
       case kDif${ip.name_camel}Irq${irq.name_camel}:
         *index_out = ${ip.name_upper}_INTR_STATE_${irq.name_upper}_BIT;
         break;
+    % endif
   % endfor
       default:
         return false;

--- a/util/make_new_dif/dif_autogen.h.tpl
+++ b/util/make_new_dif/dif_autogen.h.tpl
@@ -61,7 +61,15 @@ typedef struct dif_${ip.name_snake} {
     /**
      * ${irq.description}
      */
-    kDif${ip.name_camel}Irq${irq.name_camel} = ${loop.index},
+    ## This handles the GPIO IP case where there is a multi-bit interrupt.
+    % if irq.width > 1:
+      % for irq_idx in range(irq.width):
+        kDif${ip.name_camel}Irq${irq.name_camel}${irq_idx} = ${loop.index},
+      % endfor
+    ## This handles all other IPs.
+    % else:
+        kDif${ip.name_camel}Irq${irq.name_camel} = ${loop.index},
+    % endif
   % endfor
   } dif_${ip.name_snake}_irq_t;
 

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -90,19 +90,31 @@ namespace {
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
         nullptr, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         &is_pending),
       kDifBadArg);
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         nullptr),
       kDifBadArg);
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
         nullptr,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         nullptr),
       kDifBadArg);
   }
@@ -123,10 +135,18 @@ namespace {
     // Get the first IRQ state.
     irq_state = false;
     EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                  {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+        {{0, true}});
+      % else:
+        {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         &irq_state),
       kDifOk);
     EXPECT_TRUE(irq_state);
@@ -134,10 +154,18 @@ namespace {
     // Get the last IRQ state.
     irq_state = true;
     EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                  {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, false}});
+      % if irqs[0].width > 1:
+        {{${irqs[0].width - 1}, false}});
+      % else:
+        {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, false}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}${irqs[0].width - 1},
+      % else:
         kDif${ip.name_camel}Irq${irqs[-1].name_camel},
+      % endif
         &irq_state),
       kDifOk);
     EXPECT_FALSE(irq_state);
@@ -148,7 +176,11 @@ namespace {
   TEST_F(IrqAcknowledgeTest, NullArgs) {
     EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
         nullptr, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0),
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      % endif
       kDifBadArg);
   }
 
@@ -162,18 +194,34 @@ namespace {
   TEST_F(IrqAcknowledgeTest, Success) {
     // Clear the first IRQ state.
     EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                   {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+         {{0, true}});
+      % else:
+        {{${ip.name_upper}_INTR_STATE_${irqs[0].name_upper}_BIT, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0),
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      % endif
       kDifOk);
 
     // Clear the last IRQ state.
     EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
-                   {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+        {{${irqs[0].width - 1}, true}});
+      % else:
+        {{${ip.name_upper}_INTR_STATE_${irqs[-1].name_upper}_BIT, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}${irqs[0].width - 1}),
+      % else:
         kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
+      % endif
       kDifOk);
   }
 
@@ -184,19 +232,31 @@ namespace {
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
         nullptr, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         &irq_state),
       kDifBadArg);
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         nullptr),
       kDifBadArg);
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
         nullptr, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         nullptr),
       kDifBadArg);
   }
@@ -217,10 +277,18 @@ namespace {
     // First IRQ is enabled.
     irq_state = kDifToggleDisabled;
     EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                  {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+        {{0, true}});
+      % else:
+        {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         &irq_state),
       kDifOk);
     EXPECT_EQ(irq_state, kDifToggleEnabled);
@@ -228,10 +296,18 @@ namespace {
     // Last IRQ is disabled.
     irq_state = kDifToggleEnabled;
     EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                  {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+        {{${irqs[0].width - 1}, false}});
+      % else:
+        {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, false}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_,
-        kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}${irqs[0].width - 1},
+      % else:
+        kDif${ip.name_camel}Irq${irqs[-1].name_camel},
+      % endif
         &irq_state),
       kDifOk);
     EXPECT_EQ(irq_state, kDifToggleDisabled);
@@ -244,7 +320,11 @@ namespace {
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
         nullptr, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         irq_state),
       kDifBadArg);
   }
@@ -265,24 +345,36 @@ namespace {
     // Enable first IRQ.
     irq_state = kDifToggleEnabled;
     EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                  {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT,
-                    0x1,
-                    true}});
+      % if irqs[0].width > 1:
+        {{0, 0x1, true}});
+      % else:
+        {{${ip.name_upper}_INTR_ENABLE_${irqs[0].name_upper}_BIT, 0x1, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0,
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel},
+      % endif
         irq_state),
       kDifOk);
 
     // Disable last IRQ.
     irq_state = kDifToggleDisabled;
     EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
-                  {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, 
-                    0x1, 
-                    false}});
+      % if irqs[0].width > 1:
+        {{${irqs[0].width - 1}, 0x1, false}});
+      % else:
+        {{${ip.name_upper}_INTR_ENABLE_${irqs[-1].name_upper}_BIT, 0x1, false}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}${irqs[0].width - 1},
+      % else:
         kDif${ip.name_camel}Irq${irqs[-1].name_camel},
+      % endif
         irq_state),
       kDifOk);
   }
@@ -292,7 +384,11 @@ namespace {
   TEST_F(IrqForceTest, NullArgs) {
     EXPECT_EQ(dif_${ip.name_snake}_irq_force(
         nullptr, 
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0),
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      % endif
       kDifBadArg);
   }
 
@@ -306,18 +402,34 @@ namespace {
   TEST_F(IrqForceTest, Success) {
     // Force first IRQ.
     EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
-                   {{${ip.name_upper}_INTR_TEST_${irqs[0].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+         {{0, true}});
+      % else:
+         {{${ip.name_upper}_INTR_TEST_${irqs[0].name_upper}_BIT, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_force(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[0].name_camel}0),
+      % else:
         kDif${ip.name_camel}Irq${irqs[0].name_camel}),
+      % endif
       kDifOk);
 
     // Force last IRQ.
     EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
-                   {{${ip.name_upper}_INTR_TEST_${irqs[-1].name_upper}_BIT, true}});
+      % if irqs[0].width > 1:
+        {{${irqs[0].width - 1}, true}});
+      % else:
+        {{${ip.name_upper}_INTR_TEST_${irqs[-1].name_upper}_BIT, true}});
+      % endif
     EXPECT_EQ(dif_${ip.name_snake}_irq_force(
         &${ip.name_snake}_,
+      % if irqs[0].width > 1:
+        kDif${ip.name_camel}Irq${irqs[-1].name_camel}${irqs[0].width - 1}),
+      % else:
         kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
+      % endif
       kDifOk);
   }
 


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "gpio".