### PR TITLE
[fpv]Fixed the target to remove the waranings in simulation

### DIFF
--- a/hw/ip/prim/fpv/prim_esc_rxtx_fpv.core
+++ b/hw/ip/prim/fpv/prim_esc_rxtx_fpv.core
@@ -19,7 +19,7 @@ targets:
   default: &default_target
     # note, this setting is just used
     # to generate a file list for jg
-    formal: icarus
+    default_tool: icarus
     filesets:
       - files_formal
     toplevel:


### PR DESCRIPTION
This Pull request resolves the warning shown during the simulation. Fixed issue #8371

## Before
![image](https://user-images.githubusercontent.com/36025181/134783287-0ea29926-6872-46ad-9931-1eba63804fe2.png)

## After
![image](https://user-images.githubusercontent.com/36025181/134783607-93ad24bf-c14a-455d-a3d5-124da308c02c.png)

Signed-off by: Zeeshan Rafique
zeeshanrafique23@gmail.com
