### PR TITLE
[dv] Disable CSR value checks in tl_intg_err sequence

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -531,7 +531,8 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   // override csr_vseq to control adapter to abort transaction
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1'b1,
+                            bit    enable_value_check = 1'b1);
 
     `DV_CHECK_MEMBER_RANDOMIZE_FATAL(csr_access_abort_pct)
     foreach (cfg.m_tl_agent_cfgs[i]) begin
@@ -541,7 +542,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     // checking the status.
     if (csr_access_abort_pct > 0) csr_utils_pkg::default_csr_check = UVM_NO_CHECK;
     else                          csr_utils_pkg::default_csr_check = UVM_CHECK;
-    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset);
+    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset, enable_value_check);
   endtask
 
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -267,10 +267,12 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
     `uvm_info(`gfn, $sformatf("Running run_tl_intg_err_vseq %0d/%0d", trans, num_times),
               UVM_LOW)
     fork
-      // run csr_rw seq to send some normal CSR accesses in parallel
       begin
+        // run csr_rw seq to send some normal CSR accesses in parallel. We disable checking register
+        // values because generating a TL error might cause the block to update status registers in
+        // ways that we can't predict (because we've turned off its scoreboard).
         `uvm_info(`gfn, "Run csr_rw seq", UVM_HIGH)
-        run_csr_vseq("rw");
+        run_csr_vseq(.csr_test_type("rw"), .enable_value_check(1'b0));
       end
       begin
         bit [BUS_AW-1:0] addr;

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -189,7 +189,8 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
   // plusarg, provide ability to set a random number of csrs to test from higher level sequence
   virtual task run_csr_vseq(string          csr_test_type = "",
                             int             num_test_csrs = 0,
-                            bit             do_rand_wr_and_reset = 1);
+                            bit             do_rand_wr_and_reset = 1'b1,
+                            bit             enable_value_check = 1'b1);
     csr_base_seq  m_csr_seq;
 
     // env needs to have a ral instance
@@ -246,6 +247,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
       m_csr_seq.models[i] = cfg.ral_models[i];
     end
     m_csr_seq.external_checker = cfg.en_scb;
+    m_csr_seq.enable_value_check = enable_value_check;
     m_csr_seq.num_test_csrs = num_test_csrs;
     m_csr_seq.start(null);
   endtask

--- a/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -31,11 +31,12 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   // such as `class_clr` and `clr_regwen` registers are not correct.
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1'b1,
+                            bit    enable_value_check = 1'b1);
     if (common_seq_type == "tl_intg_err") begin
       csr_wr(.ptr(ral.loc_alert_regwen[LocalBusIntgFail]), .value(0), .predict(1));
     end
-    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset);
+    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset, enable_value_check);
   endtask
 
   virtual function void predict_shadow_reg_status(bit predict_update_err  = 0,

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -43,9 +43,10 @@ class keymgr_common_vseq extends keymgr_base_vseq;
 
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1'b1,
+                            bit    enable_value_check = 1'b1);
     csr_vseq_done = 0;
-    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset);
+    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset, enable_value_check);
     csr_vseq_done = 1;
   endtask
 


### PR DESCRIPTION
Here's one possible way to address #8376. (There are probably others!)