### PR TITLE
[dv/shadow_reg] Shadow register write by field

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -106,6 +106,7 @@ virtual task check_csr_read_clear_staged_val(dv_base_reg shadowed_csr);
   string         alert_name = shadowed_csr.get_update_err_alert_name();
   `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
 
+  `uvm_info(`gfn, $sformatf("%0s check csr read clear", shadowed_csr.get_name()), UVM_HIGH);
   csr_wr(.ptr(shadowed_csr), .value(wdata), .en_shadow_wr(0), .predict(1));
   csr_rd_check(.ptr(shadowed_csr), .compare_vs_ral(1));
   wdata = get_shadow_reg_diff_val(shadowed_csr, wdata);
@@ -148,9 +149,8 @@ virtual task poke_and_check_storage_error(dv_base_reg shadowed_csr);
 
   // Check if CSR write is blocked.
   `DV_CHECK_STD_RANDOMIZE_FATAL(rand_val);
-  csr_wr(.ptr(shadowed_csr), .value(rand_val), .en_shadow_wr(1), .predict(0));
-  // TODO: Commented out due to issue #7764.
-  //csr_rd_check(.ptr(shadowed_csr), .compare_vs_ral(1));
+  csr_wr(.ptr(shadowed_csr), .value(rand_val), .en_shadow_wr(1), .predict(1));
+  csr_rd_check(.ptr(shadowed_csr), .compare_vs_ral(1));
 
   // Backdoor write back to original value and ensure the fatal alert is continuously firing.
   csr_poke(.ptr(shadowed_csr), .value(origin_val), .kind(kind), .predict(1));

--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -125,14 +125,6 @@ package csr_utils_pkg;
     return result;
   endfunction : decode_csr_or_field
 
-  // mask and shift data to extract the value specific to that supplied field
-  function automatic uvm_reg_data_t get_field_val(uvm_reg_field   field,
-                                                  uvm_reg_data_t  value);
-    uvm_reg_data_t  mask = (1 << field.get_n_bits()) - 1;
-    uint            shift = field.get_lsb_pos();
-    get_field_val = (value >> shift) & mask;
-  endfunction
-
   // get updated reg value by using new specific field value
   function automatic uvm_reg_data_t get_csr_val_with_updated_field(uvm_reg_field   field,
                                                                    uvm_reg_data_t  csr_value,

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -8,11 +8,13 @@ class dv_base_reg extends uvm_reg;
   // hence, backdoor write isn't available
   local bit is_ext_reg;
 
-  local uvm_reg_data_t staged_shadow_val, committed_val, shadowed_val;
   local bit            is_shadowed;
   local bit            shadow_wr_staged; // stage the first shadow reg write
   local bit            shadow_update_err;
-  // In certain shadow reg (e.g. in AES), fatal error can lock write access
+  local bit            backdoor_write_shadow_val; // flag to avoid predict `shadow_wr_staged`
+  // Update internal shadow committed and shadowed values when register access is not `RW`.
+  local bit            do_update_shadow_vals;
+  // In certain shadow reg (e.g. in AES), fatal error can lock write access.
   local bit            shadow_fatal_lock;
   local string         update_err_alert_name;
   local string         storage_err_alert_name;
@@ -26,7 +28,6 @@ class dv_base_reg extends uvm_reg;
                int          has_coverage);
     super.new(name, n_bits, has_coverage);
     atomic_en_shadow_wr = new(1);
-    shadowed_val = ~committed_val;
   endfunction : new
 
   function void get_dv_base_reg_fields(ref dv_base_reg_field dv_fields[$]);
@@ -146,14 +147,10 @@ class dv_base_reg extends uvm_reg;
     is_shadowed = 1;
   endfunction
 
-  function uvm_reg_data_t get_staged_shadow_val();
-    return staged_shadow_val;
-  endfunction
-
   // A helper function for shadow register or field read to clear the `shadow_wr_staged` flag.
   virtual function void clear_shadow_wr_staged();
     if (is_shadowed) begin
-      if (shadow_wr_staged) `uvm_info(`gfn, "clear shadow_wr_staged", UVM_MEDIUM)
+      if (shadow_wr_staged) `uvm_info(`gfn, "clear shadow_wr_staged", UVM_HIGH)
       shadow_wr_staged = 0;
     end
   endfunction
@@ -167,12 +164,11 @@ class dv_base_reg extends uvm_reg;
   endfunction
 
   function bit get_shadow_storage_err();
-    uvm_reg_data_t mask = get_reg_mask();
-    uvm_reg_data_t shadowed_val_temp = (~shadowed_val) & mask;
-    uvm_reg_data_t committed_val_temp = committed_val & mask;
-    `uvm_info(`gfn, $sformatf("shadow_val %0h, commmit_val %0h", shadowed_val & mask,
-                              committed_val_temp), UVM_HIGH)
-    return shadowed_val_temp != committed_val_temp;
+    dv_base_reg_field flds[$];
+    this.get_dv_base_reg_fields(flds);
+    foreach (flds[i]) begin
+      get_shadow_storage_err |= flds[i].get_shadow_storage_err();
+    end
   endfunction
 
   virtual function void clear_shadow_update_err();
@@ -186,50 +182,47 @@ class dv_base_reg extends uvm_reg;
   // TODO: create an `enable_field_access_policy` variable and set the template code during
   // automation.
   virtual function void pre_do_predict(uvm_reg_item rw, uvm_predict_e kind);
-    dv_base_reg_field dv_fields[$];
-    get_dv_base_reg_fields(dv_fields);
 
     // Skip updating shadow value or access type if:
-    // 1). access is not OK, as access is aborted
-    // 2). the operation is not write
-    // 3). a storage error is triggered
-    // 4). the register is "RO". This condition is used to cover enable register locks shadowed
-    // register's write access. This condition assumes shadow register's all fields share the same
-    // access policy.
-    if (rw.status != UVM_IS_OK || kind != UVM_PREDICT_WRITE || get_shadow_storage_err() ||
-        dv_fields[0].get_access() == "RO") return;
+    // 1). Access is not OK, as access is aborted.
+    // 2). The operation is not write.
+    // 3). The update is triggered by backdoor poke.
+    if (rw.status != UVM_IS_OK || kind != UVM_PREDICT_WRITE || backdoor_write_shadow_val) return;
 
     if (is_shadowed && !shadow_fatal_lock) begin
-      // first write
-      if (!shadow_wr_staged) begin
-        shadow_wr_staged = 1;
-        // rw.value is a dynamic array
-        staged_shadow_val = rw.value[0] & get_reg_mask();
-        return;
-      end begin
-        // second write
-        shadow_wr_staged = 0;
-        if (staged_shadow_val != (rw.value[0] & get_reg_mask())) begin
+      dv_base_reg_field flds[$];
+      this.get_dv_base_reg_fields(flds);
 
-          // Compare second write value by field, if any field matches the first write value, will
-          // update the committed_val in the specific field.
-          foreach (dv_fields[i]) begin
-            uvm_reg_data_t mask = (1 << dv_fields[i].get_n_bits()) - 1;
-            mask = mask << dv_fields[i].get_lsb_pos();
-            if ((staged_shadow_val & mask) == (rw.value[0] & mask)) begin
-              committed_val = (committed_val & ~mask) | (staged_shadow_val & mask);
-            end
+      foreach (flds[i]) begin
+        // `rw.value` is a dynamic array.
+        uvm_reg_data_t wr_data = get_field_val(flds[i], rw.value[0]);
+
+        // Skip updating shadow value or access type for this field if:
+        // 1). A storage error is triggered, which means the field is locked to error status.
+        // 2). The register is "RO". This condition is used to cover enable register locks shadowed
+        // register's write access.
+        if (flds[i].get_shadow_storage_err() || flds[i].get_access() == "RO") continue;
+
+        // first write
+        if (!shadow_wr_staged) begin
+          flds[i].update_staged_val(wr_data);
+          continue;
+        end begin
+          // second write
+          if (flds[i].get_staged_val() == wr_data) begin
+             flds[i].update_committed_val(wr_data);
+             flds[i].update_shadowed_val(~wr_data);
+          end else begin
+            shadow_update_err = 1;
           end
-          shadow_update_err = 1;
-        end else begin
-          // If there is no shadow_update error, update the entire committed value.
-          committed_val = staged_shadow_val;
         end
-        shadowed_val = ~committed_val;
       end
-      lock_lockable_flds(committed_val);
-    end else begin
-      lock_lockable_flds(rw.value[0]);
+      if (!shadow_wr_staged) shadow_wr_staged = 1;
+      else shadow_wr_staged = 0;
+
+      // Update committed and shadowed values if the field access is not "RW".
+      // Used for register with special access policy such as `RW1S`.
+      if (!shadow_wr_staged && flds[0].get_access() != "RW") do_update_shadow_vals = 1;
     end
   endfunction
 
@@ -250,26 +243,41 @@ class dv_base_reg extends uvm_reg;
   // Skip predict in one of the following conditions:
   // 1). It is shadow_reg's first write.
   // 2). The shadow_reg is locked due to fatal storage error and it is not a backdoor write.
-  // Note that if shadow_register write has update error, we will still try to update the value,
-  // because it might be partially updated.
+  // Note that if shadow_register write has update error, we only update the value with correct
+  // fields.
   virtual function void do_predict(uvm_reg_item      rw,
                                    uvm_predict_e     kind = UVM_PREDICT_DIRECT,
                                    uvm_reg_byte_en_t be = -1);
     pre_do_predict(rw, kind);
     if (is_shadowed && kind != UVM_PREDICT_READ) begin
-      if (shadow_update_err) begin
-        `uvm_info(`gfn, $sformatf(
-            "Shadow reg %0s has update error, update rw.value from %0h to %0h",
-            get_name(), rw.value[0], committed_val), UVM_HIGH)
-        rw.value[0] = committed_val;
-      end else if (shadow_wr_staged || (shadow_fatal_lock && rw.path != UVM_BACKDOOR)) begin
+      if (shadow_wr_staged || (shadow_fatal_lock && rw.path != UVM_BACKDOOR)) begin
         `uvm_info(`gfn, $sformatf(
             "skip predict %s: due to shadow_reg_first_wr=%0b, shadow_fatal_lock=%0b",
             get_name(), shadow_wr_staged, shadow_fatal_lock), UVM_HIGH)
         return;
+      end else begin
+        `uvm_info(`gfn, $sformatf(
+            "Shadow reg %0s has update error, update rw.value from %0h to %0h",
+            get_name(), rw.value[0], get_committed_val()), UVM_HIGH)
+        rw.value[0] = get_committed_val();
       end
     end
     super.do_predict(rw, kind, be);
+
+    // For register with special access policies, update committed and shadowed value again with
+    // the actual predicted value.
+    if (do_update_shadow_vals) begin
+      dv_base_reg_field flds[$];
+      this.get_dv_base_reg_fields(flds);
+      foreach (flds[i]) begin
+        if (!flds[i].get_shadow_storage_err()) begin
+          flds[i].update_committed_val(`gmv(flds[i]));
+          flds[i].update_shadowed_val(~`gmv(flds[i]));
+        end
+      end
+      do_update_shadow_vals = 0;
+    end
+    lock_lockable_flds(rw.value[0]);
   endfunction
 
   // This function is used for wen_reg to lock its lockable flds by changing the lockable flds'
@@ -302,31 +310,35 @@ class dv_base_reg extends uvm_reg;
                     input uvm_object        extension = null,
                     input string            fname = "",
                     input int               lineno = 0);
-    if (kind == "BkdrRegPathRtlShadow") shadowed_val = value;
-    else if (kind == "BkdrRegPathRtlCommitted") committed_val = value;
 
+    dv_base_reg_field flds[$];
+    this.get_dv_base_reg_fields(flds);
+    foreach (flds[i]) begin
+      if (kind == "BkdrRegPathRtlShadow") begin
+        flds[i].update_shadowed_val(get_field_val(flds[i], value));
+        backdoor_write_shadow_val = 1;
+      end else if (kind == "BkdrRegPathRtlCommitted") begin
+        flds[i].update_committed_val(get_field_val(flds[i], value));
+        backdoor_write_shadow_val = 1;
+      end
+    end
     super.poke(status, value, kind, parent, extension, fname, lineno);
+    backdoor_write_shadow_val = 0;
   endtask
+
+  virtual function uvm_reg_data_t get_committed_val();
+    dv_base_reg_field flds[$];
+    this.get_dv_base_reg_fields(flds);
+    foreach (flds[i]) begin
+      get_committed_val |= flds[i].get_committed_val() << flds[i].get_lsb_pos();
+    end
+  endfunction
 
   // Callback function to update shadowed values according to specific design.
   // Should only be called after post-write.
   // If a shadow reg is locked due to fatal error, this function will return without updates
   virtual function void update_shadowed_val(uvm_reg_data_t val, bit do_predict = 1);
-    if (shadow_fatal_lock) return;
-    if (shadow_wr_staged) begin
-      // update value after first write
-      staged_shadow_val = val;
-    end else begin
-      // update value after second write
-      if (staged_shadow_val != val) begin
-        shadow_update_err = 1;
-      end else begin
-        shadow_update_err = 0;
-        committed_val     = staged_shadow_val;
-        shadowed_val      = ~committed_val;
-      end
-    end
-    if (do_predict) void'(predict(val));
+    // TODO: find a better way to support for AES.
   endfunction
 
   virtual function void reset(string kind = "HARD");
@@ -335,8 +347,6 @@ class dv_base_reg extends uvm_reg;
       shadow_update_err = 0;
       shadow_wr_staged  = 0;
       shadow_fatal_lock = 0;
-      committed_val     = get_mirrored_value();
-      shadowed_val      = ~committed_val;
       // in case reset is issued during shadowed writes
       void'(atomic_en_shadow_wr.try_get(1));
       atomic_en_shadow_wr.put(1);

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -73,4 +73,12 @@ package dv_base_reg_pkg;
     end
   endfunction
 
+  // mask and shift data to extract the value specific to that supplied field
+  function automatic uvm_reg_data_t get_field_val(uvm_reg_field   field,
+                                                  uvm_reg_data_t  value);
+    uvm_reg_data_t  mask = (1 << field.get_n_bits()) - 1;
+    uint            shift = field.get_lsb_pos();
+    get_field_val = (value >> shift) & mask;
+  endfunction
+
 endpackage

--- a/hw/ip/gpio/dv/env/gpio_env_pkg.sv
+++ b/hw/ip/gpio/dv/env/gpio_env_pkg.sv
@@ -8,6 +8,7 @@ package gpio_env_pkg;
   import top_pkg::*;
   import dv_utils_pkg::*;
   import csr_utils_pkg::*;
+  import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import dv_lib_pkg::*;
   import cip_base_pkg::*;

--- a/hw/ip/i2c/dv/env/i2c_env_pkg.sv
+++ b/hw/ip/i2c/dv/env/i2c_env_pkg.sv
@@ -8,6 +8,7 @@ package i2c_env_pkg;
   import top_pkg::*;
   import dv_utils_pkg::*;
   import csr_utils_pkg::*;
+  import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import i2c_agent_pkg::*;
   import dv_lib_pkg::*;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -8,6 +8,7 @@ package lc_ctrl_env_pkg;
   import top_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;
+  import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
   import csr_utils_pkg::*;

--- a/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
+++ b/hw/ip/pattgen/dv/env/pattgen_env_pkg.sv
@@ -8,6 +8,7 @@ package pattgen_env_pkg;
   import top_pkg::*;
   import dv_utils_pkg::*;
   import csr_utils_pkg::*;
+  import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import pattgen_agent_pkg::*;
   import dv_lib_pkg::*;

--- a/hw/ip/uart/dv/env/uart_env_pkg.sv
+++ b/hw/ip/uart/dv/env/uart_env_pkg.sv
@@ -11,6 +11,7 @@ package uart_env_pkg;
   import tl_agent_pkg::*;
   import uart_agent_pkg::*;
   import dv_lib_pkg::*;
+  import dv_base_reg_pkg::*;
   import cip_base_pkg::*;
   import uart_ral_pkg::*;
 


### PR DESCRIPTION
This PR moves the committed_val, shaodw_val, and staged_val to
dv_base_reg_field because in design, they are updated by field.
We align in DV to avoid the corner case where shadow_storage_err field
with field 1, but writing valid value to field 2 still works in design.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>