### PR TITLE
[dv/clkmgr] Fix tl_intg_err test

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cfg.sv
@@ -34,6 +34,9 @@ class clkmgr_env_cfg extends cip_base_env_cfg #(
     list_of_alerts = clkmgr_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
     // clkmgr has no interrupts, alerts, or devmode yet.
+
+    // This is for the integrity error test.
+    tl_intg_alert_fields[ral.fatal_err_code.reg_intg] = 1;
   endfunction
 
 endclass


### PR DESCRIPTION
Set tl_intg_alert_fields array for the common test to work.

Signed-off-by: Guillermo Maturana <maturana@google.com>