### PR TITLE
[sw/testing] add CHECK_DIF_OK macro

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -52,10 +52,10 @@ index 8861f54ba..8442bb896 100644
 -  mmio_region_write32(reg32, reg_offset, reg_value & mask);
  }
 diff --git a/sw/device/sca/aes_serial.c b/sw/device/sca/aes_serial.c
-index a2087eb4f..d8d347e1e 100644
+index 5dc1286af..1e2dced96 100644
 --- a/sw/device/sca/aes_serial.c
 +++ b/sw/device/sca/aes_serial.c
-@@ -201,18 +201,13 @@ int main(void) {
+@@ -198,18 +198,13 @@ int main(void) {
    sca_init(kScaTriggerSourceAes, kScaPeripheralAes);
    sca_get_uart(&uart1);
  
@@ -75,7 +75,7 @@ index a2087eb4f..d8d347e1e 100644
      simple_serial_process_packet();
    }
 diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
-index 093d215b1..dd231b2cc 100644
+index ef4443533..5629a15d8 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
 @@ -56,7 +56,6 @@ enum {
@@ -102,7 +102,7 @@ index 093d215b1..dd231b2cc 100644
  }
  
  /**
-@@ -149,32 +144,11 @@ void handler_irq_timer(void) {
+@@ -148,32 +143,11 @@ void handler_irq_timer(void) {
   * @param disable Set of peripherals to disable.
   */
  void sca_disable_peripherals(sca_peripherals_t disable) {
@@ -136,7 +136,7 @@ index 093d215b1..dd231b2cc 100644
    dif_clkmgr_t clkmgr;
    IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr));
  
-@@ -188,19 +162,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
+@@ -187,19 +161,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
          &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
          kDifClkmgrToggleDisabled));
    }
@@ -157,7 +157,7 @@ index 093d215b1..dd231b2cc 100644
      IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
          &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
 diff --git a/sw/device/tests/aes_smoketest.c b/sw/device/tests/aes_smoketest.c
-index dff8bd9b6..396123ef7 100644
+index 1a5fef16c..214e08151 100644
 --- a/sw/device/tests/aes_smoketest.c
 +++ b/sw/device/tests/aes_smoketest.c
 @@ -7,7 +7,6 @@
@@ -176,10 +176,10 @@ index dff8bd9b6..396123ef7 100644
 -  entropy_testutils_boot_mode_init();
 -
    // Initialise AES.
-   CHECK(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes) ==
-         kDifOk);
+   CHECK_DIF_OK(
+       dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index 7abdc2045..829968cb9 100644
+index 1b1c8ae72..66635fb0a 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
 @@ -207,7 +207,6 @@ aes_smoketest_lib = declare_dependency(

--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
@@ -114,9 +114,8 @@ static dif_uart_t uart;
         Test for some common mistakes.
 */
 void portable_init(core_portable *p, int *argc, char *argv[]) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart) == kDifOk,
-        "failed to init UART");
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
   CHECK(dif_uart_configure(&uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -40,9 +40,8 @@ void _boot_start(void) {
   while (flash_get_init_status())
     ;
 
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart0) == kDifOk,
-        "failed to init UART");
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,

--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -38,11 +38,11 @@ static bool bootstrap_requested(void) {
 
   // Initialize GPIO device.
   dif_gpio_t gpio;
-  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-                      &gpio) == kDifOk);
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
 
   dif_gpio_state_t gpio_in;
-  CHECK(dif_gpio_read_all(&gpio, &gpio_in) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_read_all(&gpio, &gpio_in));
   return (gpio_in & GPIO_BOOTSTRAP_BIT_MASK) != 0;
 }
 
@@ -72,8 +72,7 @@ static void compute_sha256(const dif_hmac_t *hmac, const void *data, size_t len,
       .digest_endianness = kDifHmacEndiannessLittle,
       .message_endianness = kDifHmacEndiannessLittle,
   };
-  CHECK(dif_hmac_mode_sha256_start(hmac, config) == kDifOk,
-        "Error on hmac start.");
+  CHECK_DIF_OK(dif_hmac_mode_sha256_start(hmac, config));
   const char *data8 = (const char *)data;
   size_t data_left = len;
   while (data_left > 0) {
@@ -88,12 +87,12 @@ static void compute_sha256(const dif_hmac_t *hmac, const void *data, size_t len,
     data_left -= bytes_sent;
   }
 
-  CHECK(dif_hmac_process(hmac) == kDifOk, "Error processing digest.");
+  CHECK_DIF_OK(dif_hmac_process(hmac));
   dif_result_t digest_result = kDifIpBusy;
   while (digest_result == kDifIpBusy) {
     digest_result = dif_hmac_finish(hmac, digest);
   }
-  CHECK(digest_result == kDifOk, "Error reading the digest.");
+  CHECK_DIF_OK(digest_result);
 }
 
 /**
@@ -213,9 +212,8 @@ int bootstrap(void) {
       "Failed to configure SPI.");
 
   dif_hmac_t hmac;
-  CHECK(dif_hmac_init(mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR),
-                      &hmac) == kDifOk,
-        "Failed to configure HMAC.");
+  CHECK_DIF_OK(
+      dif_hmac_init(mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR), &hmac));
 
   LOG_INFO("HW initialisation completed, waiting for SPI input...");
   int error = bootstrap_flash(&spi, &hmac);

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -18,12 +18,12 @@ void demo_gpio_startup(dif_gpio_t *gpio) {
   LOG_INFO("Watch the LEDs!");
 
   // Give a LED pattern as startup indicator for 5 seconds.
-  CHECK(dif_gpio_write_all(gpio, 0xff00) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, 0xff00));
   for (int i = 0; i < 32; ++i) {
     usleep(5 * 1000);  // 5 ms
-    CHECK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2) == kDifOk);
+    CHECK_DIF_OK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2));
   }
-  CHECK(dif_gpio_write_all(gpio, 0x0000) == kDifOk);  // All LEDs off.
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, 0x0000));  // All LEDs off.
 }
 
 /**
@@ -39,7 +39,7 @@ static const uint32_t kFtdiMask = 0x10000;
 
 uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   uint32_t gpio_state;
-  CHECK(dif_gpio_read_all(gpio, &gpio_state) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_read_all(gpio, &gpio_state));
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
@@ -84,8 +84,8 @@ void demo_uart_to_uart_and_gpio_echo(dif_uart_t *uart, dif_gpio_t *gpio) {
     }
 
     uint8_t rcv_char;
-    CHECK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL) == kDifOk);
-    CHECK(dif_uart_byte_send_polled(uart, rcv_char) == kDifOk);
-    CHECK(dif_gpio_write_all(gpio, rcv_char << 8) == kDifOk);
+    CHECK_DIF_OK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL));
+    CHECK_DIF_OK(dif_uart_byte_send_polled(uart, rcv_char));
+    CHECK_DIF_OK(dif_gpio_write_all(gpio, rcv_char << 8));
   }
 }

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -78,12 +78,12 @@ static dif_uart_t uart;
  */
 static void usb_receipt_callback_0(uint8_t c) {
   c = make_printable(c, '?');
-  CHECK(dif_uart_byte_send_polled(&uart, c) == kDifOk);
+  CHECK_DIF_OK(dif_uart_byte_send_polled(&uart, c));
   ++usb_chars_recved_total;
 }
 static void usb_receipt_callback_1(uint8_t c) {
   c = make_printable(c + 1, '?');
-  CHECK(dif_uart_byte_send_polled(&uart, c) == kDifOk);
+  CHECK_DIF_OK(dif_uart_byte_send_polled(&uart, c));
   ++usb_chars_recved_total;
 }
 
@@ -108,8 +108,8 @@ static const uint32_t kDiffMask = 2;
 static const uint32_t kUPhyMask = 4;
 
 int main(int argc, char **argv) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart) == kDifOk);
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
   CHECK(dif_uart_configure(&uart, (dif_uart_config_t){
                                       .baudrate = kUartBaudrate,
                                       .clk_freq_hz = kClockFreqPeripheralHz,
@@ -137,10 +137,10 @@ int main(int argc, char **argv) {
                       .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
                   }) == kDifSpiDeviceOk);
 
-  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-                      &gpio) == kDifOk);
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00));
 
   LOG_INFO("Hello, USB!");
   LOG_INFO("Built at: " __DATE__ ", " __TIME__);
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
   // simulation has finished all of the printing, which takes a while
   // if `--trace` was passed in.
   uint32_t gpio_state;
-  CHECK(dif_gpio_read_all(&gpio, &gpio_state) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_read_all(&gpio, &gpio_state));
   bool pinflip = gpio_state & kPinflipMask ? true : false;
   bool differential = gpio_state & kDiffMask ? true : false;
   bool uphy = gpio_state & kUPhyMask ? true : false;
@@ -184,10 +184,10 @@ int main(int argc, char **argv) {
       }
 
       uint8_t rcv_char;
-      CHECK(dif_uart_bytes_receive(&uart, 1, &rcv_char, NULL) == kDifOk);
-      CHECK(dif_uart_byte_send_polled(&uart, rcv_char) == kDifOk);
+      CHECK_DIF_OK(dif_uart_bytes_receive(&uart, 1, &rcv_char, NULL));
+      CHECK_DIF_OK(dif_uart_byte_send_polled(&uart, rcv_char));
 
-      CHECK(dif_gpio_write_all(&gpio, rcv_char << 8) == kDifOk);
+      CHECK_DIF_OK(dif_gpio_write_all(&gpio, rcv_char << 8));
 
       if (rcv_char == '/') {
         uint32_t usb_irq_state =

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -21,8 +21,8 @@ static dif_spi_device_t spi;
 static dif_uart_t uart;
 
 int main(int argc, char **argv) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart) == kDifOk);
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
   CHECK(dif_uart_configure(&uart, (dif_uart_config_t){
                                       .baudrate = kUartBaudrate,
                                       .clk_freq_hz = kClockFreqPeripheralHz,
@@ -50,10 +50,10 @@ int main(int argc, char **argv) {
                       .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
                   }) == kDifSpiDeviceOk);
 
-  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-                      &gpio) == kDifOk);
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00));
 
   // Add DATE and TIME because I keep fooling myself with old versions
   LOG_INFO("Hello World!");
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
 
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
-  CHECK(dif_gpio_write_all(&gpio, 0x0000) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_write_all(&gpio, 0x0000));
   LOG_INFO("Try out the switches on the board");
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");

--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -9,6 +9,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/test_status.h"
@@ -70,6 +71,36 @@
     } else {                                                                  \
       result_ = true;                                                         \
     }                                                                         \
+  } while (false)
+
+/**
+ * Checks that the given DIF call returns kDifOk. If the DIF call returns a
+ * different dif_result_t value (defined in sw/device/lib/dif/dif_base.h), this
+ * function logs and then aborts.
+ *
+ * @param DIF call to invoke and check its return value .
+ * @param ... arguments to a LOG_* macro, which are evaluated if the check
+ * fails.
+ */
+#define CHECK_DIF_OK(dif_call, ...)                       \
+  do {                                                    \
+    if (dif_call != kDifOk) {                             \
+      /* NOTE: because the condition in this if           \
+         statement can be statically determined,          \
+         only one of the below string constants           \
+         will be included in the final binary.*/          \
+      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
+        LOG_ERROR("CHECK-fail: " #dif_call);              \
+      } else {                                            \
+        LOG_ERROR("CHECK-fail: " __VA_ARGS__);            \
+      }                                                   \
+      /* Currently, this macro will call into             \
+         the test failure code, which logs                \
+         "FAIL" and aborts. In the future,                \
+         we will try to condition on whether              \
+         or not this is a test.*/                         \
+      test_status_set(kTestStatusFailed);                 \
+    }                                                     \
   } while (false)
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CHECK_H_

--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -78,7 +78,7 @@
  * different dif_result_t value (defined in sw/device/lib/dif/dif_base.h), this
  * function logs and then aborts.
  *
- * @param DIF call to invoke and check its return value .
+ * @param DIF call to invoke and check its return value.
  * @param ... arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
@@ -90,9 +90,9 @@
          only one of the below string constants           \
          will be included in the final binary.*/          \
       if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("CHECK-fail: " #dif_call);              \
+        LOG_ERROR("DIF-fail: " #dif_call);                \
       } else {                                            \
-        LOG_ERROR("CHECK-fail: " __VA_ARGS__);            \
+        LOG_ERROR("DIF-fail: " __VA_ARGS__);              \
       }                                                   \
       /* Currently, this macro will call into             \
          the test failure code, which logs                \

--- a/sw/device/lib/testing/test_framework/ottf.c
+++ b/sw/device/lib/testing/test_framework/ottf.c
@@ -24,8 +24,7 @@ static dif_uart_t uart0;
 
 static void init_uart(void) {
   CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart0) == kDifOk,
-        "failed to init UART");
+                      &uart0) == kDifOk);
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,

--- a/sw/device/lib/testing/test_framework/test_main.c
+++ b/sw/device/lib/testing/test_framework/test_main.c
@@ -16,9 +16,8 @@
 
 static dif_uart_t uart0;
 static void init_uart(void) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart0) == kDifOk,
-        "failed to init UART");
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -20,9 +20,8 @@ extern volatile uint32_t end_signature[];
 static dif_uart_t uart0;
 
 int opentitan_compliance_main(int argc, char **argv) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart0) == kDifOk,
-        "failed to init UART");
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -62,14 +62,14 @@ static void aes_serial_set_key(const uint8_t *key, size_t key_len) {
   dif_aes_key_share_t key_shares;
   memcpy(key_shares.share0, key, sizeof(key_shares.share0));
   memset(key_shares.share1, 0, sizeof(key_shares.share1));
-  SS_CHECK(dif_aes_start_ecb(&aes, &transaction, key_shares) == kDifOk);
+  SS_CHECK_DIF_OK(dif_aes_start_ecb(&aes, &transaction, key_shares));
 }
 
 /**
  * Callback wrapper for AES manual trigger function.
  */
 static void aes_manual_trigger(void) {
-  SS_CHECK(dif_aes_trigger(&aes, kDifAesTriggerStart) == kDifOk);
+  SS_CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerStart));
 }
 
 /**
@@ -86,13 +86,12 @@ static void aes_manual_trigger(void) {
 static void aes_serial_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
   bool ready = false;
   do {
-    SS_CHECK(dif_aes_get_status(&aes, kDifAesStatusInputReady, &ready) ==
-             kDifOk);
+    SS_CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusInputReady, &ready));
   } while (!ready);
   dif_aes_data_t data;
   SS_CHECK(plaintext_len <= sizeof(data.data));
   memcpy(data.data, plaintext, plaintext_len);
-  SS_CHECK(dif_aes_load_data(&aes, data) == kDifOk);
+  SS_CHECK_DIF_OK(dif_aes_load_data(&aes, data));
 
   // Start AES operation (this triggers the capture) and go to sleep.
   // Using the SecAesStartTriggerDelay hardware parameter, the AES unit is
@@ -121,12 +120,11 @@ static void aes_serial_single_encrypt(const uint8_t *plaintext,
 
   bool ready = false;
   do {
-    SS_CHECK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready) ==
-             kDifOk);
+    SS_CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready));
   } while (!ready);
 
   dif_aes_data_t ciphertext;
-  SS_CHECK(dif_aes_read_output(&aes, &ciphertext) == kDifOk);
+  SS_CHECK_DIF_OK(dif_aes_read_output(&aes, &ciphertext));
   simple_serial_send_packet('r', (uint8_t *)ciphertext.data,
                             sizeof(ciphertext.data));
 }
@@ -170,12 +168,11 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
 
   bool ready = false;
   do {
-    SS_CHECK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready) ==
-             kDifOk);
+    SS_CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready));
   } while (!ready);
 
   dif_aes_data_t ciphertext;
-  SS_CHECK(dif_aes_read_output(&aes, &ciphertext) == kDifOk);
+  SS_CHECK_DIF_OK(dif_aes_read_output(&aes, &ciphertext));
   simple_serial_send_packet('r', (uint8_t *)ciphertext.data,
                             sizeof(ciphertext.data));
 }
@@ -184,9 +181,9 @@ static void aes_serial_batch_encrypt(const uint8_t *data, size_t data_len) {
  * Initializes the AES peripheral.
  */
 static void init_aes(void) {
-  SS_CHECK(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR),
-                        &aes) == kDifOk);
-  SS_CHECK(dif_aes_reset(&aes) == kDifOk);
+  SS_CHECK_DIF_OK(
+      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  SS_CHECK_DIF_OK(dif_aes_reset(&aes));
 }
 
 /**

--- a/sw/device/sca/lib/simple_serial.h
+++ b/sw/device/sca/lib/simple_serial.h
@@ -5,10 +5,11 @@
 #ifndef OPENTITAN_SW_DEVICE_SCA_LIB_SIMPLE_SERIAL_H_
 #define OPENTITAN_SW_DEVICE_SCA_LIB_SIMPLE_SERIAL_H_
 
-#include "sw/device/lib/dif/dif_uart.h"
-
 #include <stddef.h>
 #include <stdint.h>
+
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_uart.h"
 
 /**
  * @file
@@ -27,6 +28,17 @@
 #define SS_CHECK(condition)                          \
   do {                                               \
     if (!(condition)) {                              \
+      simple_serial_send_status(kSimpleSerialError); \
+      return;                                        \
+    }                                                \
+  } while (false)
+
+/**
+ * Sends an error message over UART if DIF does not return kDifOk.
+ */
+#define SS_CHECK_DIF_OK(dif_call)                    \
+  do {                                               \
+    if (dif_call != kDifOk) {                        \
       simple_serial_send_status(kSimpleSerialError); \
       return;                                        \
     }                                                \

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -49,14 +49,14 @@ const test_config_t kTestConfig;
 
 static bool aes_input_ready(const dif_aes_t *aes) {
   bool status;
-  CHECK(dif_aes_get_status(aes, kDifAesStatusInputReady, &status) == kDifOk);
+  CHECK_DIF_OK(dif_aes_get_status(aes, kDifAesStatusInputReady, &status));
 
   return status;
 }
 
 static bool aes_output_valid(const dif_aes_t *aes) {
   bool status;
-  CHECK(dif_aes_get_status(aes, kDifAesStatusOutputValid, &status) == kDifOk);
+  CHECK_DIF_OK(dif_aes_get_status(aes, kDifAesStatusOutputValid, &status));
 
   return status;
 }
@@ -70,9 +70,9 @@ bool test_main(void) {
   entropy_testutils_boot_mode_init();
 
   // Initialise AES.
-  CHECK(dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes) ==
-        kDifOk);
-  CHECK(dif_aes_reset(&aes) == kDifOk);
+  CHECK_DIF_OK(
+      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  CHECK_DIF_OK(dif_aes_reset(&aes));
 
   // Mask the key. Note that this should not be done manually. Software is
   // expected to get the key in two shares right from the beginning.
@@ -92,7 +92,7 @@ bool test_main(void) {
       .mode = kDifAesModeEncrypt,
       .operation = kDifAesOperationAuto,
   };
-  CHECK(dif_aes_start_ecb(&aes, &transaction, key) == kDifOk);
+  CHECK_DIF_OK(dif_aes_start_ecb(&aes, &transaction, key));
 
   // "Convert" plain data byte arrays to `dif_aes_data_t`.
   dif_aes_data_t in_data_plain;
@@ -101,16 +101,16 @@ bool test_main(void) {
   // Load the plain text to trigger the encryption operation.
   while (!aes_input_ready(&aes)) {
   }
-  CHECK(dif_aes_load_data(&aes, in_data_plain) == kDifOk);
+  CHECK_DIF_OK(dif_aes_load_data(&aes, in_data_plain));
 
   // Read out the produced cipher text.
   dif_aes_data_t out_data_cipher;
   while (!aes_output_valid(&aes)) {
   }
-  CHECK(dif_aes_read_output(&aes, &out_data_cipher) == kDifOk);
+  CHECK_DIF_OK(dif_aes_read_output(&aes, &out_data_cipher));
 
   // Finish the ECB encryption transaction.
-  CHECK(dif_aes_end(&aes) == kDifOk);
+  CHECK_DIF_OK(dif_aes_end(&aes));
 
   // Check the produced cipher text against the reference.
   uint32_t cipher_text_gold_words[TEXT_LENGTH_IN_WORDS];
@@ -123,22 +123,22 @@ bool test_main(void) {
 
   // Setup ECB decryption transaction.
   transaction.mode = kDifAesModeDecrypt;
-  CHECK(dif_aes_start_ecb(&aes, &transaction, key) == kDifOk);
+  CHECK_DIF_OK(dif_aes_start_ecb(&aes, &transaction, key));
 
   // Load the previously produced cipher text to start the decryption operation.
   while (!aes_input_ready(&aes)) {
   }
-  CHECK(dif_aes_load_data(&aes, out_data_cipher) == kDifOk);
+  CHECK_DIF_OK(dif_aes_load_data(&aes, out_data_cipher));
 
   // Read out the produced plain text.
 
   dif_aes_data_t out_data_plain;
   while (!aes_output_valid(&aes)) {
   }
-  CHECK(dif_aes_read_output(&aes, &out_data_plain) == kDifOk);
+  CHECK_DIF_OK(dif_aes_read_output(&aes, &out_data_plain));
 
   // Finish the ECB encryption transaction.
-  CHECK(dif_aes_end(&aes) == kDifOk);
+  CHECK_DIF_OK(dif_aes_end(&aes));
 
   // Check the produced plain text against the reference.
   uint32_t plain_text_gold_words[TEXT_LENGTH_IN_WORDS];

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -38,9 +38,8 @@ volatile char ensure_bss_exists;
 
 static dif_uart_t uart0;
 static void init_uart(void) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart0) == kDifOk,
-        "failed to init UART");
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
   CHECK(dif_uart_configure(&uart0,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,

--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -46,10 +46,10 @@ static const uint32_t kGpioMask = 0x0000FFFF;
  * @param write_val Value to write.
  */
 static void test_gpio_write(uint32_t write_val) {
-  CHECK(dif_gpio_write_all(&gpio, write_val) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_write_all(&gpio, write_val));
 
   uint32_t read_val = 0;
-  CHECK(dif_gpio_read_all(&gpio, &read_val) == kDifOk);
+  CHECK_DIF_OK(dif_gpio_read_all(&gpio, &read_val));
 
   uint32_t expected = write_val & kGpioMask;
   uint32_t actual = read_val & kGpioMask;
@@ -63,9 +63,9 @@ static void test_gpio_write(uint32_t write_val) {
  * NOTE: This test can currently run only on FPGA and DV.
  */
 bool test_main(void) {
-  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-                      &gpio) == kDifOk);
-  CHECK(dif_gpio_output_set_enabled_all(&gpio, kGpioMask) == kDifOk);
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, kGpioMask));
 
   for (uint8_t i = 0; i < ARRAYSIZE(kGpioVals); ++i) {
     test_gpio_write(kGpioVals[i]);

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -52,10 +52,7 @@ static const uint32_t kExpectedHmacDigest[8] = {
  * Initialize the HMAC engine. Return `true` if the configuration is valid.
  */
 static void test_setup(mmio_region_t base_addr, dif_hmac_t *hmac) {
-  dif_result_t res = dif_hmac_init(base_addr, hmac);
-
-  CHECK(res != kDifBadArg, "Invalid arguments encountered in HMAC init.");
-  CHECK(res == kDifOk, "Unknown error encountered in HMAC init.");
+  CHECK_DIF_OK(dif_hmac_init(base_addr, hmac));
 }
 
 /**
@@ -63,16 +60,12 @@ static void test_setup(mmio_region_t base_addr, dif_hmac_t *hmac) {
  * use the provided key in HMAC mode.
  */
 static void test_start(const dif_hmac_t *hmac, const uint8_t *key) {
-  dif_result_t res;
   // Let a null key indicate we are operating in SHA256-only mode.
   if (key == NULL) {
-    res = dif_hmac_mode_sha256_start(hmac, kHmacTransactionConfig);
+    CHECK_DIF_OK(dif_hmac_mode_sha256_start(hmac, kHmacTransactionConfig));
   } else {
-    res = dif_hmac_mode_hmac_start(hmac, key, kHmacTransactionConfig);
+    CHECK_DIF_OK(dif_hmac_mode_hmac_start(hmac, key, kHmacTransactionConfig));
   }
-
-  CHECK(res != kDifBadArg, "Invalid arguments encountered in HMAC start.");
-  CHECK(res == kDifOk, "Unknown error encountered in HMAC start.");
 }
 
 /**
@@ -112,11 +105,7 @@ static void push_message(const dif_hmac_t *hmac, const char *data, size_t len) {
 static void wait_for_fifo_empty(const dif_hmac_t *hmac) {
   uint32_t fifo_depth;
   do {
-    dif_result_t res = dif_hmac_fifo_count_entries(hmac, &fifo_depth);
-
-    CHECK(res != kDifBadArg,
-          "Invalid arguments encountered checking FIFO depth.");
-    CHECK(res == kDifOk, "Unknown error encountered checking FIFO depth.");
+    CHECK_DIF_OK(dif_hmac_fifo_count_entries(hmac, &fifo_depth));
   } while (fifo_depth > 0);
 }
 
@@ -127,11 +116,7 @@ static void wait_for_fifo_empty(const dif_hmac_t *hmac) {
 static void check_message_length(const dif_hmac_t *hmac,
                                  uint64_t expected_sent_bits) {
   uint64_t sent_bits;
-  dif_result_t res = dif_hmac_get_message_length(hmac, &sent_bits);
-
-  CHECK(res != kDifBadArg,
-        "Invalid arguments encountered checking message length.");
-  CHECK(res == kDifOk, "Unknown error encountered checking message length.");
+  CHECK_DIF_OK(dif_hmac_get_message_length(hmac, &sent_bits));
 
   // TODO: Support 64-bit integers in logging.
   CHECK(expected_sent_bits == sent_bits,
@@ -143,10 +128,7 @@ static void check_message_length(const dif_hmac_t *hmac,
  * Kick off the HMAC (or SHA256) run.
  */
 static void run_hmac(const dif_hmac_t *hmac) {
-  dif_result_t res = dif_hmac_process(hmac);
-
-  CHECK(res != kDifBadArg, "Invalid arguments encountered running HMAC.");
-  CHECK(res == kDifOk, "Unknown error encountered running HMAC.");
+  CHECK_DIF_OK(dif_hmac_process(hmac));
 }
 
 /**

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
@@ -73,7 +73,7 @@ bool test_main(void) {
                         &otp) == kDifOtpCtrlOk);
 
   mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
-  CHECK(dif_lc_ctrl_init(lc_reg, &lc) == kDifOk);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
 
   dif_otp_ctrl_config_t config = {
       .check_timeout = 100000,
@@ -84,8 +84,7 @@ bool test_main(void) {
 
   // Read out Device ID from LC_CTRL's `device_id` registers.
   dif_lc_ctrl_device_id_t lc_device_id;
-  CHECK(dif_lc_ctrl_get_device_id(&lc, &lc_device_id) == kDifOk,
-        "LC_CTRL failed to read device_id registers");
+  CHECK_DIF_OK(dif_lc_ctrl_get_device_id(&lc, &lc_device_id));
 
   // Read out Device ID from OTP DAI read, and compare the value with LC_CTRL's
   // `device_id` registers.

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -58,8 +58,7 @@ static void handle_uart_isr(const dif_rv_plic_irq_id_t interrupt_id) {
       test_status_set(kTestStatusFailed);
   }
 
-  CHECK(dif_uart_irq_acknowledge(&uart0, uart_irq) == kDifOk,
-        "ISR failed to clear IRQ!");
+  CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart0, uart_irq));
 }
 
 /**
@@ -92,7 +91,7 @@ void handler_irq_external(void) {
 }
 
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
-  CHECK(dif_uart_init(base_addr, uart) == kDifOk);
+  CHECK_DIF_OK(dif_uart_init(base_addr, uart));
   CHECK(dif_uart_configure(uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
@@ -113,12 +112,10 @@ static void plic_initialise(mmio_region_t base_addr, dif_rv_plic_t *plic) {
  * Configures all the relevant interrupts in UART.
  */
 static void uart_configure_irqs(dif_uart_t *uart) {
-  CHECK(dif_uart_irq_set_enabled(&uart0, kDifUartIrqRxOverflow,
-                                 kDifToggleEnabled) == kDifOk,
-        "RX overflow IRQ enable failed!");
-  CHECK(dif_uart_irq_set_enabled(&uart0, kDifUartIrqTxEmpty,
-                                 kDifToggleEnabled) == kDifOk,
-        "TX empty IRQ enable failed!");
+  CHECK_DIF_OK(dif_uart_irq_set_enabled(&uart0, kDifUartIrqRxOverflow,
+                                        kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_irq_set_enabled(&uart0, kDifUartIrqTxEmpty, kDifToggleEnabled));
 }
 
 /**
@@ -154,8 +151,7 @@ static void plic_configure_irqs(dif_rv_plic_t *plic) {
 static void execute_test(dif_uart_t *uart) {
   // Force UART RX overflow interrupt.
   uart_rx_overflow_handled = false;
-  CHECK(dif_uart_irq_force(uart, kDifUartIrqRxOverflow) == kDifOk,
-        "failed to force RX overflow IRQ!");
+  CHECK_DIF_OK(dif_uart_irq_force(uart, kDifUartIrqRxOverflow));
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_rx_overflow_handled) {
     usleep(10);
@@ -164,8 +160,7 @@ static void execute_test(dif_uart_t *uart) {
 
   // Force UART TX empty interrupt.
   uart_tx_empty_handled = false;
-  CHECK(dif_uart_irq_force(uart, kDifUartIrqTxEmpty) == kDifOk,
-        "failed to force TX empty IRQ!");
+  CHECK_DIF_OK(dif_uart_irq_force(uart, kDifUartIrqTxEmpty));
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_tx_empty_handled) {
     usleep(10);

--- a/sw/device/tests/sim_dv/gpio_test.c
+++ b/sw/device/tests/sim_dv/gpio_test.c
@@ -102,19 +102,16 @@ static void gpio_output_test(const dif_gpio_t *gpio) {
   LOG_INFO("Starting GPIO output test");
 
   // Set the GPIOs to be in output mode.
-  CHECK(dif_gpio_output_set_enabled_all(gpio, kGpiosAllowedMask) == kDifOk,
-        "dif_gpio_output_set_enabled_all failed");
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(gpio, kGpiosAllowedMask));
 
   // Walk 1s - 0001, 0010, 0100, 1000, etc.
   for (uint32_t i = 0; i < kNumGpios; ++i) {
     uint32_t gpio_val = 1 << i;
-    CHECK(dif_gpio_write_all(gpio, gpio_val) == kDifOk,
-          "dif_gpio_write_all failed");
+    CHECK_DIF_OK(dif_gpio_write_all(gpio, gpio_val));
 
     // Read GPIO_IN to confirm what we wrote.
     uint32_t read_val;
-    CHECK(dif_gpio_read_all(gpio, &read_val) == kDifOk,
-          "dif_gpio_read_all failed");
+    CHECK_DIF_OK(dif_gpio_read_all(gpio, &read_val));
 
     // Check written and read val for correctness.
     // Though we try to set all available GPIOs, only the ones that are exposed
@@ -127,23 +124,19 @@ static void gpio_output_test(const dif_gpio_t *gpio) {
   }
 
   // Write all 0s to the GPIOs.
-  CHECK(dif_gpio_write_all(gpio, ~kGpiosMask) == kDifOk,
-        "dif_gpio_write_all failed");
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, ~kGpiosMask));
 
   // Write all 1s to the GPIOs.
-  CHECK(dif_gpio_write_all(gpio, kGpiosMask) == kDifOk,
-        "dif_gpio_write_all failed");
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, kGpiosMask));
 
   // Now walk 0s - 1110, 1101, 1011, 0111, etc.
   for (uint32_t i = 0; i < kNumGpios; ++i) {
     uint32_t gpio_val = ~(1 << i);
-    CHECK(dif_gpio_write_all(gpio, gpio_val) == kDifOk,
-          "dif_gpio_write_all failed");
+    CHECK_DIF_OK(dif_gpio_write_all(gpio, gpio_val));
 
     // Read GPIO_IN to confirm what we wrote.
     uint32_t read_val;
-    CHECK(dif_gpio_read_all(gpio, &read_val) == kDifOk,
-          "dif_gpio_read_all failed");
+    CHECK_DIF_OK(dif_gpio_read_all(gpio, &read_val));
 
     // Check written and read val for correctness.
     // Though we try to set all available GPIOs, only the ones that are exposed
@@ -156,12 +149,10 @@ static void gpio_output_test(const dif_gpio_t *gpio) {
   }
 
   // Write all 1s to the GPIOs.
-  CHECK(dif_gpio_write_all(gpio, kGpiosMask) == kDifOk,
-        "dif_gpio_write_all failed");
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, kGpiosMask));
 
   // Write all 0s to the GPIOs.
-  CHECK(dif_gpio_write_all(gpio, ~kGpiosMask) == kDifOk,
-        "dif_gpio_write_all failed");
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, ~kGpiosMask));
 }
 
 /**
@@ -178,22 +169,18 @@ static void gpio_input_test(const dif_gpio_t *gpio) {
   LOG_INFO("Starting GPIO input test");
 
   // Enable the noise filter on all GPIOs.
-  CHECK(dif_gpio_input_noise_filter_set_enabled(gpio, kGpiosAllowedMask,
-                                                kDifToggleEnabled) == kDifOk,
-        "dif_gpio_input_noise_filter_set_enabled failed");
+  CHECK_DIF_OK(dif_gpio_input_noise_filter_set_enabled(gpio, kGpiosAllowedMask,
+                                                       kDifToggleEnabled));
 
   // Configure all GPIOs to be rising and falling edge interrupts.
-  CHECK(dif_gpio_irq_set_trigger(gpio, kGpiosAllowedMask,
-                                 kDifGpioIrqTriggerEdgeRisingFalling) == kDifOk,
-        "dif_gpio_irq_set_trigger failed");
+  CHECK_DIF_OK(dif_gpio_irq_set_trigger(gpio, kGpiosAllowedMask,
+                                        kDifGpioIrqTriggerEdgeRisingFalling));
 
   // Enable interrupts on all GPIOs.
-  CHECK(dif_gpio_irq_restore_all(gpio, &kGpiosAllowedMask) == kDifOk,
-        "dif_gpio_irq_restore_all failed");
+  CHECK_DIF_OK(dif_gpio_irq_restore_all(gpio, &kGpiosAllowedMask));
 
   // Set the GPIOs to be in input mode.
-  CHECK(dif_gpio_output_set_enabled_all(gpio, 0u) == kDifOk,
-        "dif_gpio_output_set_enabled_all failed");
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(gpio, 0u));
 
   // Wait for rising edge interrupt on each pin.
   expected_irq_edge = true;
@@ -240,24 +227,21 @@ void handler_irq_external(void) {
 
   // Check if the same interrupt fired at GPIO as well.
   uint32_t gpio_irqs_status;
-  CHECK(dif_gpio_irq_get_state(&gpio, &gpio_irqs_status) == kDifOk,
-        "dif_gpio_irq_get_state failed");
+  CHECK_DIF_OK(dif_gpio_irq_get_state(&gpio, &gpio_irqs_status));
   CHECK(gpio_irqs_status == (1 << expected_gpio_pin_irq),
         "Incorrect GPIO irqs status {exp: %x, obs: %x}",
         (1 << expected_gpio_pin_irq), gpio_irqs_status);
 
   // Read the gpio pin value to ensure the right value is being reflected.
   bool pin_val;
-  CHECK(dif_gpio_read(&gpio, expected_gpio_pin_irq, &pin_val) == kDifOk,
-        "dif_gpio_read failed");
+  CHECK_DIF_OK(dif_gpio_read(&gpio, expected_gpio_pin_irq, &pin_val));
 
   // Check if the pin value is set correctly.
   CHECK(pin_val == expected_irq_edge, "Incorrect GPIO %d pin value (exp: %b)",
         expected_gpio_pin_irq, expected_irq_edge);
 
   // Clear the interrupt at GPIO.
-  CHECK(dif_gpio_irq_acknowledge(&gpio, gpio_pin_irq_fired) == kDifOk,
-        "dif_gpio_irq_acknowledge failed");
+  CHECK_DIF_OK(dif_gpio_irq_acknowledge(&gpio, gpio_pin_irq_fired));
 
   // Complete the IRQ at PLIC.
   CHECK(dif_rv_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
@@ -272,9 +256,8 @@ bool test_main(void) {
   pinmux_init();
 
   // Initialize the GPIO.
-  CHECK(dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR),
-                      &gpio) == kDifOk,
-        "dif_gpio_init failed");
+  CHECK_DIF_OK(
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
 
   // Initialize the PLIC.
   mmio_region_t plic_base_addr =

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
@@ -71,11 +71,11 @@ bool test_main(void) {
   LOG_INFO("Start LC_CTRL transition test.");
 
   mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
-  CHECK(dif_lc_ctrl_init(lc_reg, &lc) == kDifOk);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
 
   LOG_INFO("Read and check LC state.");
   dif_lc_ctrl_state_t curr_state;
-  CHECK(dif_lc_ctrl_get_state(&lc, &curr_state) == kDifOk);
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &curr_state));
 
   // The OTP preload image hardcodes the initial LC state transition count to 8.
   // With each iteration of the test, we increment it.

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -260,13 +260,11 @@ void handler_irq_external(void) {
 
   // Check if the same interrupt fired at UART as well.
   bool is_pending;
-  CHECK(dif_uart_irq_is_pending(&uart, uart_irq, &is_pending) == kDifOk,
-        "dif_uart_irq_is_pending failed");
+  CHECK_DIF_OK(dif_uart_irq_is_pending(&uart, uart_irq, &is_pending));
   CHECK(is_pending, "UART interrupt fired at PLIC did not fire at UART");
 
   // Clear the interrupt at UART.
-  CHECK(dif_uart_irq_acknowledge(&uart, uart_irq) == kDifOk,
-        "dif_uart_irq_acknowledge failed");
+  CHECK_DIF_OK(dif_uart_irq_acknowledge(&uart, uart_irq));
 
   // Complete the IRQ at PLIC.
   CHECK(dif_rv_plic_irq_complete(&plic, kTopEarlgreyPlicTargetIbex0,
@@ -280,7 +278,7 @@ void handler_irq_external(void) {
 static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
   LOG_INFO("Initializing the UART.");
 
-  CHECK(dif_uart_init(base_addr, uart) == kDifOk, "dif_uart_init failed");
+  CHECK_DIF_OK(dif_uart_init(base_addr, uart));
   CHECK(dif_uart_configure(uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
@@ -291,24 +289,18 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
         "dif_uart_configure failed");
 
   // Set the TX and RX watermark to 16 bytes.
-  CHECK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte16) == kDifOk,
-        "dif_uart_watermark_tx_set failed");
-  CHECK(dif_uart_watermark_rx_set(uart, kDifUartWatermarkByte16) == kDifOk,
-        "dif_uart_watermark_rx_set failed");
+  CHECK_DIF_OK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte16));
+  CHECK_DIF_OK(dif_uart_watermark_rx_set(uart, kDifUartWatermarkByte16));
 
   // Enable these UART interrupts - TX/TX watermark, TX empty and RX overflow.
-  CHECK(dif_uart_irq_set_enabled(uart, kDifUartIrqTxWatermark,
-                                 kDifToggleEnabled) == kDifOk,
-        "dif_uart_irq_set_enabled failed");
-  CHECK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
-                                 kDifToggleEnabled) == kDifOk,
-        "dif_uart_irq_set_enabled failed");
-  CHECK(dif_uart_irq_set_enabled(uart, kDifUartIrqTxEmpty, kDifToggleEnabled) ==
-            kDifOk,
-        "dif_uart_irq_set_enabled failed");
-  CHECK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxOverflow,
-                                 kDifToggleEnabled) == kDifOk,
-        "dif_uart_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqTxWatermark,
+                                        kDifToggleEnabled));
+  CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                        kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_irq_set_enabled(uart, kDifUartIrqTxEmpty, kDifToggleEnabled));
+  CHECK_DIF_OK(
+      dif_uart_irq_set_enabled(uart, kDifUartIrqRxOverflow, kDifToggleEnabled));
 }
 
 /**
@@ -487,9 +479,8 @@ static bool execute_test(const dif_uart_t *uart) {
         // At this point we have received the required number of bytes.
         // We disable the RX watermark interrupt and let the fifo
         // overflow by dropping all future incoming data.
-        CHECK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
-                                       kDifToggleDisabled) == kDifOk,
-              "dif_uart_irq_set_enabled failed");
+        CHECK_DIF_OK(dif_uart_irq_set_enabled(uart, kDifUartIrqRxWatermark,
+                                              kDifToggleDisabled));
         // Expect the RX overflow interrupt to fire at some point.
         exp_uart_irq_rx_overflow = true;
       }

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -19,8 +19,8 @@ const test_config_t kTestConfig = {
 
 bool test_main(void) {
   dif_uart_t uart;
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart) == kDifOk);
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
   CHECK(dif_uart_configure(&uart,
                            (dif_uart_config_t){
                                .baudrate = kUartBaudrate,
@@ -30,17 +30,17 @@ bool test_main(void) {
                            }) == kDifUartConfigOk,
         "UART config failed!");
 
-  CHECK(dif_uart_loopback_set(&uart, kDifUartLoopbackSystem,
-                              kDifToggleEnabled) == kDifOk);
-  CHECK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll) == kDifOk);
+  CHECK_DIF_OK(
+      dif_uart_loopback_set(&uart, kDifUartLoopbackSystem, kDifToggleEnabled));
+  CHECK_DIF_OK(dif_uart_fifo_reset(&uart, kDifUartFifoResetAll));
 
   // Send all bytes in `kSendData`, and check that they are received via
   // the loopback mechanism.
   for (int i = 0; i < sizeof(kSendData); ++i) {
-    CHECK(dif_uart_byte_send_polled(&uart, kSendData[i]) == kDifOk);
+    CHECK_DIF_OK(dif_uart_byte_send_polled(&uart, kSendData[i]));
 
     uint8_t receive_byte;
-    CHECK(dif_uart_byte_receive_polled(&uart, &receive_byte) == kDifOk);
+    CHECK_DIF_OK(dif_uart_byte_receive_polled(&uart, &receive_byte));
     CHECK(receive_byte == kSendData[i]);
   }
 


### PR DESCRIPTION
This partially address #8142.

As auto-gen'd DIFs are integrated into the src tree, so is a global DIF error code space (defined in sw/device/lib/dif/dif_base.h). This enables creating a macro that check DIF return codes.