### PR TITLE
[keymgr/dv] Fix coverage null object

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
@@ -76,7 +76,8 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
                                                     keymgr_pkg::keymgr_ops_e op,
                                                     bit aes_sl_avail,
                                                     bit kmac_sl_avail,
-                                                    bit otbn_sl_avail);
+                                                    bit otbn_sl_avail,
+                                                    bit regwen);
     sideload_clear_cp: coverpoint sideload_clear {
       bins clear_none  = {0};
       bins clear_one[] = {[1:3]};
@@ -89,9 +90,12 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
     aes_sl_avail_cp:   coverpoint aes_sl_avail;
     kmac_sl_avail_cp:  coverpoint kmac_sl_avail;
     otbn_sl_avail_cp:  coverpoint otbn_sl_avail;
+    regwen_cp:         coverpoint regwen;
+
     sideload_clear_x_state_op_cross: cross sideload_clear, state, op;
     sideload_clear_x_sl_avail_cross: cross sideload_clear_cp, aes_sl_avail, kmac_sl_avail,
                                            otbn_sl_avail;
+    sideload_clear_x_regwen_cross:   cross sideload_clear_cp, regwen_cp;
   endgroup
 
   covergroup err_code_cg with function sample(keymgr_pkg::keymgr_err_pos_e err_code);

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -410,6 +410,14 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
         bit cfg_regwen = (current_op_status == keymgr_pkg::OpWip);
         if (csr.get_name() == "control") begin
           cov.control_w_regwen_cg.sample(item.a_data, cfg_regwen);
+        end else if (csr.get_name() == "sideload_clear") begin
+          cov.sideload_clear_cg.sample(`gmv(ral.sideload_clear.val),
+                                       current_state,
+                                       get_operation(),
+                                       cfg.keymgr_vif.aes_sideload_status == SideLoadAvail,
+                                       cfg.keymgr_vif.kmac_sideload_status == SideLoadAvail,
+                                       cfg.keymgr_vif.otbn_sideload_status == SideLoadAvail,
+                                       cfg_regwen);
         end else begin
           cov.sw_input_cg_wrap[csr.get_name()].sample(item.a_data, cfg_regwen);
         end
@@ -675,15 +683,6 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
       end
       "sideload_clear": begin
         if (addr_phase_write) begin
-          if (cfg.en_cov) begin
-            cov.sideload_clear_cg.sample(`gmv(ral.sideload_clear.val),
-                                         current_state,
-                                         get_operation(),
-                                         cfg.keymgr_vif.aes_sideload_status == SideLoadAvail,
-                                         cfg.keymgr_vif.kmac_sideload_status == SideLoadAvail,
-                                         cfg.keymgr_vif.otbn_sideload_status == SideLoadAvail);
-          end
-
           fork
             begin
               cfg.clk_rst_vif.wait_clks(1);


### PR DESCRIPTION
Design changed sideload_clear to be gated by cfg_regwen
Updated env for this change to fix regression failures

Signed-off-by: Weicai Yang <weicai@google.com>