### PR TITLE
[dif/uart] remove non-global return results

### DIFF
--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
@@ -116,14 +116,13 @@ static dif_uart_t uart;
 void portable_init(core_portable *p, int *argc, char *argv[]) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK(dif_uart_configure(&uart,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "failed to configure UART");
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart, (dif_uart_config_t){
+                                    .baudrate = kUartBaudrate,
+                                    .clk_freq_hz = kClockFreqPeripheralHz,
+                                    .parity_enable = kDifToggleDisabled,
+                                    .parity = kDifUartParityEven,
+                                }));
 
   if (sizeof(ee_ptr_int) != sizeof(ee_u8 *)) {
     ee_printf(

--- a/sw/device/boot_rom/boot_rom.c
+++ b/sw/device/boot_rom/boot_rom.c
@@ -42,14 +42,13 @@ void _boot_start(void) {
 
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK(dif_uart_configure(&uart0,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "failed to configure UART");
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                 }));
   base_uart_stdout(&uart0);
 
   LOG_INFO("%s", chip_info);

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -110,12 +110,13 @@ static const uint32_t kUPhyMask = 4;
 int main(int argc, char **argv) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK(dif_uart_configure(&uart, (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  }) == kDifUartConfigOk);
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart, (dif_uart_config_t){
+                                    .baudrate = kUartBaudrate,
+                                    .clk_freq_hz = kClockFreqPeripheralHz,
+                                    .parity_enable = kDifToggleDisabled,
+                                    .parity = kDifUartParityEven,
+                                }));
   base_uart_stdout(&uart);
 
   pinmux_init();

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -23,12 +23,13 @@ static dif_uart_t uart;
 int main(int argc, char **argv) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
-  CHECK(dif_uart_configure(&uart, (dif_uart_config_t){
-                                      .baudrate = kUartBaudrate,
-                                      .clk_freq_hz = kClockFreqPeripheralHz,
-                                      .parity_enable = kDifToggleDisabled,
-                                      .parity = kDifUartParityEven,
-                                  }) == kDifUartConfigOk);
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart, (dif_uart_config_t){
+                                    .baudrate = kUartBaudrate,
+                                    .clk_freq_hz = kClockFreqPeripheralHz,
+                                    .parity_enable = kDifToggleDisabled,
+                                    .parity = kDifUartParityEven,
+                                }));
   base_uart_stdout(&uart);
 
   pinmux_init();

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -95,14 +95,14 @@ dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart) {
   return kDifOk;
 }
 
-dif_uart_config_result_t dif_uart_configure(const dif_uart_t *uart,
-                                            dif_uart_config_t config) {
+dif_result_t dif_uart_configure(const dif_uart_t *uart,
+                                dif_uart_config_t config) {
   if (uart == NULL) {
-    return kDifUartConfigBadArg;
+    return kDifBadArg;
   }
 
   if (config.baudrate == 0 || config.clk_freq_hz == 0) {
-    return kDifUartConfigBadConfig;
+    return kDifBadArg;
   }
 
   // Calculation formula: NCO = 16 * 2^nco_width * baud / fclk.
@@ -125,7 +125,7 @@ dif_uart_config_result_t dif_uart_configure(const dif_uart_t *uart,
 
   // Requested baudrate is too high for the given clock frequency.
   if (nco != nco_masked) {
-    return kDifUartConfigBadNco;
+    return kDifBadArg;
   }
 
   // Must be called before the first write to any of the UART registers.
@@ -147,7 +147,7 @@ dif_uart_config_result_t dif_uart_configure(const dif_uart_t *uart,
   // Disable interrupts.
   mmio_region_write32(uart->base_addr, UART_INTR_ENABLE_REG_OFFSET, 0u);
 
-  return kDifUartConfigOk;
+  return kDifOk;
 }
 
 dif_result_t dif_uart_watermark_rx_set(const dif_uart_t *uart,

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -60,35 +60,6 @@ typedef struct dif_uart_config {
 } dif_uart_config_t;
 
 /**
- * The result of a UART operation.
- */
-typedef enum dif_uart_config_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifUartConfigOk = kDifOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifUartConfigError = kDifError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifUartConfigBadArg = kDifBadArg,
-  /**
-   * Indicates that the given configuration parameters are not valid.
-   */
-  kDifUartConfigBadConfig,
-  /**
-   * Indicates that the calculated NCO value was not valid.
-   */
-  kDifUartConfigBadNco,
-} dif_uart_config_result_t;
-
-/**
  * A UART FIFO watermark depth configuration.
  */
 typedef enum dif_uart_watermark {
@@ -173,8 +144,8 @@ dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_uart_config_result_t dif_uart_configure(const dif_uart_t *uart,
-                                            dif_uart_config_t config);
+dif_result_t dif_uart_configure(const dif_uart_t *uart,
+                                dif_uart_config_t config);
 
 /**
  * Sets the RX FIFO watermark.

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -64,7 +64,7 @@ TEST_F(InitTest, NullArgs) {
 class ConfigTest : public UartTest {};
 
 TEST_F(ConfigTest, NullArgs) {
-  EXPECT_EQ(dif_uart_configure(nullptr, config_), kDifUartConfigBadArg);
+  EXPECT_EQ(dif_uart_configure(nullptr, config_), kDifBadArg);
 }
 
 TEST_F(ConfigTest, Default) {
@@ -78,7 +78,7 @@ TEST_F(ConfigTest, Default) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_EQ(dif_uart_configure(&uart_, config_), kDifUartConfigOk);
+  EXPECT_EQ(dif_uart_configure(&uart_, config_), kDifOk);
 }
 
 TEST_F(ConfigTest, ParityEven) {
@@ -96,7 +96,7 @@ TEST_F(ConfigTest, ParityEven) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_EQ(dif_uart_configure(&uart_, config_), kDifUartConfigOk);
+  EXPECT_EQ(dif_uart_configure(&uart_, config_), kDifOk);
 }
 
 TEST_F(ConfigTest, ParityOdd) {
@@ -115,7 +115,7 @@ TEST_F(ConfigTest, ParityOdd) {
 
   EXPECT_WRITE32(UART_INTR_ENABLE_REG_OFFSET, 0);
 
-  EXPECT_EQ(dif_uart_configure(&uart_, config_), kDifUartConfigOk);
+  EXPECT_EQ(dif_uart_configure(&uart_, config_), kDifOk);
 }
 
 class WatermarkRxSetTest : public UartTest {};

--- a/sw/device/lib/testing/test_framework/ottf.c
+++ b/sw/device/lib/testing/test_framework/ottf.c
@@ -23,16 +23,15 @@
 static dif_uart_t uart0;
 
 static void init_uart(void) {
-  CHECK(dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR),
-                      &uart0) == kDifOk);
-  CHECK(dif_uart_configure(&uart0,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "failed to configure UART");
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                 }));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/lib/testing/test_framework/test_main.c
+++ b/sw/device/lib/testing/test_framework/test_main.c
@@ -18,14 +18,13 @@ static dif_uart_t uart0;
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK(dif_uart_configure(&uart0,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "failed to configure UART");
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                 }));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/riscv_compliance_support/support.c
+++ b/sw/device/riscv_compliance_support/support.c
@@ -22,14 +22,13 @@ static dif_uart_t uart0;
 int opentitan_compliance_main(int argc, char **argv) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK(dif_uart_configure(&uart0,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "failed to configure UART");
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                 }));
   base_uart_stdout(&uart0);
 
   run_rvc_test();

--- a/sw/device/silicon_creator/rom_exts/rom_ext.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/print.h"
@@ -44,7 +45,7 @@ void rom_ext_boot(void) {
     abort();
   }
 
-  dif_uart_config_result_t config_result =
+  dif_result_t config_result =
       dif_uart_configure(&uart, (dif_uart_config_t){
                                     .baudrate = kUartBaudrate,
                                     .clk_freq_hz = kClockFreqPeripheralHz,
@@ -52,7 +53,7 @@ void rom_ext_boot(void) {
                                     .parity = kDifUartParityEven,
                                 });
 
-  if (config_result != kDifUartConfigOk) {
+  if (config_result != kDifOk) {
     abort();
   }
 

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -40,14 +40,13 @@ static dif_uart_t uart0;
 static void init_uart(void) {
   CHECK_DIF_OK(dif_uart_init(
       mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
-  CHECK(dif_uart_configure(&uart0,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "failed to configure UART");
+  CHECK_DIF_OK(
+      dif_uart_configure(&uart0, (dif_uart_config_t){
+                                     .baudrate = kUartBaudrate,
+                                     .clk_freq_hz = kClockFreqPeripheralHz,
+                                     .parity_enable = kDifToggleDisabled,
+                                     .parity = kDifUartParityEven,
+                                 }));
   base_uart_stdout(&uart0);
 }
 

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -92,14 +92,13 @@ void handler_irq_external(void) {
 
 static void uart_initialise(mmio_region_t base_addr, dif_uart_t *uart) {
   CHECK_DIF_OK(dif_uart_init(base_addr, uart));
-  CHECK(dif_uart_configure(uart,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "UART config failed!");
+  CHECK_DIF_OK(
+      dif_uart_configure(uart, (dif_uart_config_t){
+                                   .baudrate = kUartBaudrate,
+                                   .clk_freq_hz = kClockFreqPeripheralHz,
+                                   .parity_enable = kDifToggleDisabled,
+                                   .parity = kDifUartParityEven,
+                               }));
 }
 
 static void plic_initialise(mmio_region_t base_addr, dif_rv_plic_t *plic) {

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -279,14 +279,13 @@ static void uart_init_with_irqs(mmio_region_t base_addr, dif_uart_t *uart) {
   LOG_INFO("Initializing the UART.");
 
   CHECK_DIF_OK(dif_uart_init(base_addr, uart));
-  CHECK(dif_uart_configure(uart,
-                           (dif_uart_config_t){
-                               .baudrate = kUartBaudrate,
-                               .clk_freq_hz = kClockFreqPeripheralHz,
-                               .parity_enable = kDifToggleDisabled,
-                               .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
-        "dif_uart_configure failed");
+  CHECK_DIF_OK(
+      dif_uart_configure(uart, (dif_uart_config_t){
+                                   .baudrate = kUartBaudrate,
+                                   .clk_freq_hz = kClockFreqPeripheralHz,
+                                   .parity_enable = kDifToggleDisabled,
+                                   .parity = kDifUartParityEven,
+                               }));
 
   // Set the TX and RX watermark to 16 bytes.
   CHECK_DIF_OK(dif_uart_watermark_tx_set(uart, kDifUartWatermarkByte16));

--- a/sw/device/tests/uart_smoketest.c
+++ b/sw/device/tests/uart_smoketest.c
@@ -27,7 +27,7 @@ bool test_main(void) {
                                .clk_freq_hz = kClockFreqPeripheralHz,
                                .parity_enable = kDifToggleDisabled,
                                .parity = kDifUartParityEven,
-                           }) == kDifUartConfigOk,
+                           }) == kDifOk,
         "UART config failed!");
 
   CHECK_DIF_OK(


### PR DESCRIPTION
This partially addresses #8142, which deprecates non-global DIF return
codes to aid autogeneration of some DIF code.