### PR TITLE
[dif/lc_ctrl] remove non-global return results

### DIFF
--- a/sw/device/boot_rom/bootstrap.c
+++ b/sw/device/boot_rom/bootstrap.c
@@ -88,8 +88,8 @@ static void compute_sha256(const dif_hmac_t *hmac, const void *data, size_t len,
   }
 
   CHECK_DIF_OK(dif_hmac_process(hmac));
-  dif_result_t digest_result = kDifIpBusy;
-  while (digest_result == kDifIpBusy) {
+  dif_result_t digest_result = kDifUnavailable;
+  while (digest_result == kDifUnavailable) {
     digest_result = dif_hmac_finish(hmac, digest);
   }
   CHECK_DIF_OK(digest_result);

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -230,7 +230,7 @@ dif_result_t dif_aes_start_ecb(const dif_aes_t *aes,
   }
 
   if (!aes_idle(aes)) {
-    return kDifIpBusy;
+    return kDifUnavailable;
   }
 
   dif_result_t result = configure(aes, transaction, kAesModeFieldValEcb);
@@ -255,7 +255,7 @@ dif_result_t dif_aes_start_cbc(const dif_aes_t *aes,
   }
 
   if (!aes_idle(aes)) {
-    return kDifIpBusy;
+    return kDifUnavailable;
   }
 
   dif_result_t result = configure(aes, transaction, kAesModeFieldValCbc);
@@ -282,7 +282,7 @@ dif_result_t dif_aes_start_ctr(const dif_aes_t *aes,
   }
 
   if (!aes_idle(aes)) {
-    return kDifIpBusy;
+    return kDifUnavailable;
   }
 
   dif_result_t result = configure(aes, transaction, kAesModeFieldValCtr);
@@ -307,7 +307,7 @@ dif_result_t dif_aes_end(const dif_aes_t *aes) {
   }
 
   if (!aes_idle(aes)) {
-    return kDifIpBusy;
+    return kDifUnavailable;
   }
 
   aes_clear_internal_state(aes);
@@ -322,7 +322,7 @@ dif_result_t dif_aes_load_data(const dif_aes_t *aes,
   }
 
   if (!aes_input_ready(aes)) {
-    return kDifIpBusy;
+    return kDifUnavailable;
   }
 
   aes_set_multireg(aes, &data.data[0], AES_DATA_IN_MULTIREG_COUNT,

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -48,7 +48,7 @@ typedef enum dif_result {
    * retried at any time, and is guaranteed to have not produced any side
    * effects.
    */
-  kDifIpBusy = 4,
+  kDifUnavailable = 4,
   /**
    * Indicates that the Ip's FIFO (if it has one or more of) is full.
    */

--- a/sw/device/lib/dif/dif_hmac.c
+++ b/sw/device/lib/dif/dif_hmac.c
@@ -275,7 +275,7 @@ dif_result_t dif_hmac_finish(const dif_hmac_t *hmac,
     mmio_region_nonatomic_set_bit32(hmac->base_addr, HMAC_INTR_STATE_REG_OFFSET,
                                     HMAC_INTR_STATE_HMAC_DONE_BIT);
   } else {
-    return kDifIpBusy;
+    return kDifUnavailable;
   }
 
   // Read the digest.

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -300,59 +300,6 @@ typedef struct dif_lc_ctrl_device_id {
 } dif_lc_ctrl_device_id_t;
 
 /**
- * The result of a lifecycle attempt counter operation.
- */
-typedef enum dif_lc_ctrl_attempts_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifLcCtrlAttemptsOk = kDifOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifLcCtrlAttemptsError = kDifError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifLcCtrlAttemptsBadArg = kDifBadArg,
-  /**
-   * Indicates that too many lifecycle transitions have occurred, such that the
-   * hardware can no longer keep a count.
-   */
-  kDifLcCtrlAttemptsTooMany,
-} dif_lc_ctrl_attempts_result_t;
-
-/**
- * The result of a lifecycle controller operation involving the hardware mutex.
- */
-typedef enum dif_lc_ctrl_mutex_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifLcCtrlMutexOk = kDifOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifLcCtrlMutexError = kDifError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifLcCtrlMutexBadArg = kDifBadArg,
-
-  /**
-   * Indicates that a mutex-guarded operation failed because someone (other
-   * than software) is holding it.
-   */
-  kDifLcCtrlMutexAlreadyTaken = 3,
-} dif_lc_ctrl_mutex_result_t;
-
-/**
  * An alert that can be raised by the hardware.
  */
 typedef enum dif_lc_ctrl_alert {
@@ -402,8 +349,7 @@ dif_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_attempts_result_t dif_lc_ctrl_get_attempts(const dif_lc_ctrl_t *lc,
-                                                       uint8_t *count);
+dif_result_t dif_lc_ctrl_get_attempts(const dif_lc_ctrl_t *lc, uint8_t *count);
 
 /**
  * Returns the current status of the lifecycle controller.
@@ -463,8 +409,7 @@ dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
 // Open Q: do we want to be checking REGWEN for all operations dependent on the
 // mutex?
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_try_acquire(
-    const dif_lc_ctrl_t *lc);
+dif_result_t dif_lc_ctrl_mutex_try_acquire(const dif_lc_ctrl_t *lc);
 
 /**
  * Releases the lifecycle controller's HW mutex.
@@ -476,7 +421,7 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_try_acquire(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_release(const dif_lc_ctrl_t *lc);
+dif_result_t dif_lc_ctrl_mutex_release(const dif_lc_ctrl_t *lc);
 
 /**
  * Performs a lifecycle transition.
@@ -490,9 +435,10 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_mutex_release(const dif_lc_ctrl_t *lc);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_mutex_result_t dif_lc_ctrl_transition(
-    const dif_lc_ctrl_t *lc, dif_lc_ctrl_state_t state,
-    const dif_lc_ctrl_token_t *token, const dif_lc_ctrl_settings_t *settings);
+dif_result_t dif_lc_ctrl_transition(const dif_lc_ctrl_t *lc,
+                                    dif_lc_ctrl_state_t state,
+                                    const dif_lc_ctrl_token_t *token,
+                                    const dif_lc_ctrl_settings_t *settings);
 
 /**
  * Writes settings to the vendor-specific OTP test control register.
@@ -502,8 +448,8 @@ dif_lc_ctrl_mutex_result_t dif_lc_ctrl_transition(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_lc_ctrl_mutex_result_t dif_lc_ctrl_set_otp_vendor_test_reg(
-    const dif_lc_ctrl_t *lc, uint32_t settings);
+dif_result_t dif_lc_ctrl_set_otp_vendor_test_reg(const dif_lc_ctrl_t *lc,
+                                                 uint32_t settings);
 
 /**
  * Reads settings from the vendor-specific OTP test control register.

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -93,14 +93,13 @@ TEST_F(StateTest, GetAttempts) {
 
   EXPECT_READ32(LC_CTRL_LC_TRANSITION_CNT_REG_OFFSET,
                 {{LC_CTRL_LC_TRANSITION_CNT_CNT_OFFSET, 13}});
-  EXPECT_EQ(dif_lc_ctrl_get_attempts(&lc_, &attempts), kDifLcCtrlAttemptsOk);
+  EXPECT_EQ(dif_lc_ctrl_get_attempts(&lc_, &attempts), kDifOk);
   EXPECT_EQ(attempts, 13);
 
   EXPECT_READ32(LC_CTRL_LC_TRANSITION_CNT_REG_OFFSET,
                 {{LC_CTRL_LC_TRANSITION_CNT_CNT_OFFSET,
                   LC_CTRL_LC_TRANSITION_CNT_CNT_MASK}});
-  EXPECT_EQ(dif_lc_ctrl_get_attempts(&lc_, &attempts),
-            kDifLcCtrlAttemptsTooMany);
+  EXPECT_EQ(dif_lc_ctrl_get_attempts(&lc_, &attempts), kDifError);
 }
 
 TEST_F(StateTest, GetStatus) {
@@ -149,9 +148,8 @@ TEST_F(StateTest, NullArgs) {
   EXPECT_EQ(dif_lc_ctrl_get_state(&lc_, nullptr), kDifBadArg);
 
   uint8_t attempts;
-  EXPECT_EQ(dif_lc_ctrl_get_attempts(nullptr, &attempts),
-            kDifLcCtrlAttemptsBadArg);
-  EXPECT_EQ(dif_lc_ctrl_get_attempts(&lc_, nullptr), kDifLcCtrlAttemptsBadArg);
+  EXPECT_EQ(dif_lc_ctrl_get_attempts(nullptr, &attempts), kDifBadArg);
+  EXPECT_EQ(dif_lc_ctrl_get_attempts(&lc_, nullptr), kDifBadArg);
 
   dif_lc_ctrl_status_t status;
   EXPECT_EQ(dif_lc_ctrl_get_status(nullptr, &status), kDifBadArg);
@@ -180,25 +178,25 @@ class MutexTest : public LcCtrlTest {};
 TEST_F(MutexTest, Acquire) {
   EXPECT_WRITE32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0xa5);
   EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0xa5);
-  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(&lc_), kDifLcCtrlMutexOk);
+  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(&lc_), kDifOk);
 
   EXPECT_WRITE32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0xa5);
   EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0);
-  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(&lc_), kDifLcCtrlMutexAlreadyTaken);
+  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(&lc_), kDifUnavailable);
 }
 
 TEST_F(MutexTest, Release) {
   EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0xa5);
   EXPECT_WRITE32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0);
-  EXPECT_EQ(dif_lc_ctrl_mutex_release(&lc_), kDifLcCtrlMutexOk);
+  EXPECT_EQ(dif_lc_ctrl_mutex_release(&lc_), kDifOk);
 
   EXPECT_READ32(LC_CTRL_CLAIM_TRANSITION_IF_REG_OFFSET, 0);
-  EXPECT_EQ(dif_lc_ctrl_mutex_release(&lc_), kDifLcCtrlMutexError);
+  EXPECT_EQ(dif_lc_ctrl_mutex_release(&lc_), kDifError);
 }
 
 TEST_F(MutexTest, NullArgs) {
-  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(nullptr), kDifLcCtrlMutexBadArg);
-  EXPECT_EQ(dif_lc_ctrl_mutex_release(nullptr), kDifLcCtrlMutexBadArg);
+  EXPECT_EQ(dif_lc_ctrl_mutex_try_acquire(nullptr), kDifBadArg);
+  EXPECT_EQ(dif_lc_ctrl_mutex_release(nullptr), kDifBadArg);
 }
 
 class TransitionTest : public LcCtrlTest {};
@@ -210,7 +208,7 @@ TEST_F(TransitionTest, NoToken) {
   EXPECT_WRITE32(LC_CTRL_TRANSITION_CTRL_REG_OFFSET, 0x0);
   EXPECT_WRITE32(LC_CTRL_TRANSITION_CMD_REG_OFFSET, true);
   EXPECT_EQ(dif_lc_ctrl_transition(&lc_, kDifLcCtrlStateProd, nullptr, nullptr),
-            kDifLcCtrlMutexOk);
+            kDifOk);
 }
 
 TEST_F(TransitionTest, WithToken) {
@@ -228,7 +226,7 @@ TEST_F(TransitionTest, WithToken) {
   EXPECT_WRITE32(LC_CTRL_TRANSITION_CMD_REG_OFFSET, true);
   EXPECT_EQ(dif_lc_ctrl_transition(&lc_, kDifLcCtrlStateTestUnlocked2, &token,
                                    &settings),
-            kDifLcCtrlMutexOk);
+            kDifOk);
 
   EXPECT_READ32(LC_CTRL_TRANSITION_REGWEN_REG_OFFSET, true);
   EXPECT_WRITE32(LC_CTRL_TRANSITION_TARGET_REG_OFFSET,
@@ -241,20 +239,20 @@ TEST_F(TransitionTest, WithToken) {
   EXPECT_WRITE32(LC_CTRL_TRANSITION_CMD_REG_OFFSET, true);
   EXPECT_EQ(dif_lc_ctrl_transition(&lc_, kDifLcCtrlStateTestUnlocked6, &token,
                                    &settings),
-            kDifLcCtrlMutexOk);
+            kDifOk);
 }
 
 TEST_F(TransitionTest, Locked) {
   EXPECT_READ32(LC_CTRL_TRANSITION_REGWEN_REG_OFFSET, false);
   EXPECT_EQ(dif_lc_ctrl_transition(&lc_, kDifLcCtrlStateProd, nullptr, nullptr),
-            kDifLcCtrlMutexAlreadyTaken);
+            kDifUnavailable);
 }
 
 TEST_F(TransitionTest, NullArgs) {
   dif_lc_ctrl_token_t token = {"this is a token"};
   EXPECT_EQ(
       dif_lc_ctrl_transition(nullptr, kDifLcCtrlStateProd, &token, nullptr),
-      kDifLcCtrlMutexBadArg);
+      kDifBadArg);
 }
 
 class OtpVendorTestRegTest : public LcCtrlTest {};
@@ -269,7 +267,7 @@ TEST_F(OtpVendorTestRegTest, Read) {
 TEST_F(OtpVendorTestRegTest, Write) {
   EXPECT_READ32(LC_CTRL_TRANSITION_REGWEN_REG_OFFSET, true);
   EXPECT_WRITE32(LC_CTRL_OTP_VENDOR_TEST_CTRL_REG_OFFSET, 0xA5);
-  EXPECT_EQ(dif_lc_ctrl_set_otp_vendor_test_reg(&lc_, 0xA5), kDifLcCtrlMutexOk);
+  EXPECT_EQ(dif_lc_ctrl_set_otp_vendor_test_reg(&lc_, 0xA5), kDifOk);
 }
 
 }  // namespace

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -144,7 +144,7 @@ static void check_digest(const dif_hmac_t *hmac,
     CHECK(res != kDifBadArg,
           "Invalid arguments encountered reading HMAC digest.");
 
-    hmac_done = (res != kDifIpBusy);
+    hmac_done = (res != kDifUnavailable);
 
     if (hmac_done) {
       CHECK(res == kDifOk, "Unknown error encountered reading HMAC digest.");

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_test.c
@@ -44,7 +44,7 @@ static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
 static void check_lc_state_transition_count(uint8_t exp_lc_count) {
   LOG_INFO("Read LC count and check with expect_val=%0d", exp_lc_count);
   uint8_t lc_count;
-  CHECK(dif_lc_ctrl_get_attempts(&lc, &lc_count) == kDifLcCtrlAttemptsOk,
+  CHECK(dif_lc_ctrl_get_attempts(&lc, &lc_count) == kDifOk,
         "Read lc_count register failed!");
   CHECK(lc_count == exp_lc_count,
         "LC_count error, expected %0d but actual count is %0d", exp_lc_count,
@@ -94,9 +94,9 @@ bool test_main(void) {
     for (int i = 0; i < LC_TOKEN_SIZE; i++) {
       token.data[i] = kLcExitToken[i];
     }
-    CHECK(dif_lc_ctrl_mutex_try_acquire(&lc) == kDifLcCtrlMutexOk);
+    CHECK(dif_lc_ctrl_mutex_try_acquire(&lc) == kDifOk);
     CHECK(dif_lc_ctrl_transition(&lc, kDifLcCtrlStateDev, &token, &settings) ==
-              kDifLcCtrlMutexOk,
+              kDifOk,
           "LC_transition failed!");
 
     LOG_INFO("Waiting for LC transtition done and reboot.");


### PR DESCRIPTION
This partially addressed #8142, which deprecates non-global DIF return
codes to aid autogeneration of some DIF code.

Additionally, a global DIF return result has been added for dealing with
IP's that implement resource mutexes.