### PR TITLE
[alert_handler] Output crashdump continuously until latched

### DIFF
--- a/hw/ip/alert_handler/doc/_index.md
+++ b/hw/ip/alert_handler/doc/_index.md
@@ -191,8 +191,8 @@ The `crashdump_o` struct outputs a snapshot of CSRs and alert handler state bits
 This can be useful for extracting more information about possible failures or bugs without having to use the tile-link bus interface (which may become unresponsive under certain circumstances).
 It is recommended for the top level to store this information in an always-on location.
 
-Note that the crashdump state is latched exactly once when the trigger condition is true for the first time (see {{< regref CLASSA_CRASHDUMP_TRIGGER_SHADOWED >}}).
-After that, the alert_handler has to be reset in order to re-arm the crashdump latching mechanism.
+Note that the crashdump state is continuously output via `crashdump_o` until the latching trigger condition is true for the first time (see {{< regref CLASSA_CRASHDUMP_TRIGGER_SHADOWED >}}).
+After that, the `crashdump_o` is held constant and the alert handler has to be reset in order to re-arm the crashdump latching mechanism.
 This is done so that it is possible to capture the true alert cause before spurious alert events start to pop up due to escalation countermeasures with excessive side effects (like life cycle scrapping for example).
 
 ## Design Details

--- a/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/ip/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -346,7 +346,9 @@ module alert_handler_reg_wrap import alert_pkg::*; (
     end
   end
 
-  assign crashdump_o = crashdump_q;
+  // As long as the crashdump has not been latched yet, we output the current alert handler state.
+  // Once it has been latched, we switch to the latched snapshot.
+  assign crashdump_o = (crashump_latched_q) ? crashdump_q : crashdump_d;
 
   /////////////////////////////
   // aggregate shadow errors //


### PR DESCRIPTION
Signed-off-by: Michael Schaffner <msf@google.com>