### PR TITLE
A experiment of binding interface

### DIFF
--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:rom_ctrl_pkg
     files:
+      - rtl/cm_count_if.sv
       - rtl/keymgr_reg_top.sv
       - rtl/keymgr_sideload_key_ctrl.sv
       - rtl/keymgr_sideload_key.sv

--- a/hw/ip/keymgr/rtl/cm_count_if.sv
+++ b/hw/ip/keymgr/rtl/cm_count_if.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//----------------------------- DESCRIPTION ------------------------------------
+//
+// Generic countermeasure interface for hardened counter
+//
+//------------------------------------------------------------------------------
+
+interface cm_count_if();
+
+  initial begin
+    $display("%m");
+  end
+
+endinterface

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -66,6 +66,7 @@ module keymgr_ctrl
   output logic prng_reseed_req_o,
   output logic prng_en_o
 );
+bind prim_count cm_count_if u_cm_count_if();
 
   localparam int EntropyWidth = LfsrWidth / 2;
   localparam int EntropyRounds = KeyWidth / EntropyWidth;

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -39,7 +39,7 @@ module keymgr_kmac_if import keymgr_pkg::*;(
   output logic cmd_error_o
 );
 
-
+bind prim_count cm_count_if u_cm_count_if();
   // Encoding generated with:
   // $ ./util/design/sparse-fsm-encode.py -d 5 -m 6 -n 10 \
   //      -s 2292624416 --language=sv


### PR DESCRIPTION
@sriyerg @cindychip 
this is to show how I did this experiment to use
`bind prim_count cm_count_if u_cm_count_if();` in 2 modules.
Both modules contains prim_count, we can assume these 2 modules are 2 IPs.

The result is that it doesn't work.
Here is the error message.
```
                Error-[V2KIDGN] Illegal duplicate name created
                ../src/lowrisc_ip_keymgr_0.1/rtl/keymgr_kmac_if.sv, 42
                "cm_count_if u_cm_count_if();"
                  Illegal duplicate name created during elaboration.
                  Multiple declarations created for: u_cm_count_if.
```
Comment out one of the bind, then it will pass.

Signed-off-by: Weicai Yang <weicai@google.com>