### PR TITLE
[dif/csrng] autogen csrng IRQ DIFs and integrate into src tree

### DIFF
--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -1,0 +1,185 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_csrng.h"
+
+#include "csrng_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool csrng_get_irq_bit_index(dif_csrng_irq_t irq,
+                                    bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifCsrngIrqCsCmdReqDone:
+      *index_out = CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT;
+      break;
+    case kDifCsrngIrqCsEntropyReq:
+      *index_out = CSRNG_INTR_STATE_CS_ENTROPY_REQ_BIT;
+      break;
+    case kDifCsrngIrqCsHwInstExc:
+      *index_out = CSRNG_INTR_STATE_CS_HW_INST_EXC_BIT;
+      break;
+    case kDifCsrngIrqCsFatalErr:
+      *index_out = CSRNG_INTR_STATE_CS_FATAL_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_get_state(const dif_csrng_t *csrng,
+                                     dif_csrng_irq_state_snapshot_t *snapshot) {
+  if (csrng == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(csrng->base_addr, CSRNG_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_is_pending(const dif_csrng_t *csrng,
+                                      dif_csrng_irq_t irq, bool *is_pending) {
+  if (csrng == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!csrng_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(csrng->base_addr, CSRNG_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_acknowledge(const dif_csrng_t *csrng,
+                                       dif_csrng_irq_t irq) {
+  if (csrng == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!csrng_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(csrng->base_addr, CSRNG_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_get_enabled(const dif_csrng_t *csrng,
+                                       dif_csrng_irq_t irq,
+                                       dif_toggle_t *state) {
+  if (csrng == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!csrng_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(csrng->base_addr, CSRNG_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_set_enabled(const dif_csrng_t *csrng,
+                                       dif_csrng_irq_t irq,
+                                       dif_toggle_t state) {
+  if (csrng == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!csrng_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(csrng->base_addr, CSRNG_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(csrng->base_addr, CSRNG_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_force(const dif_csrng_t *csrng,
+                                 dif_csrng_irq_t irq) {
+  if (csrng == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!csrng_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(csrng->base_addr, CSRNG_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_disable_all(
+    const dif_csrng_t *csrng, dif_csrng_irq_enable_snapshot_t *snapshot) {
+  if (csrng == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(csrng->base_addr, CSRNG_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(csrng->base_addr, CSRNG_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_restore_all(
+    const dif_csrng_t *csrng, const dif_csrng_irq_enable_snapshot_t *snapshot) {
+  if (csrng == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(csrng->base_addr, CSRNG_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.h
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_CSRNG_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_CSRNG_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/csrng/doc/">CSRNG</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to csrng.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_csrng {
+  /**
+   * The base address for the csrng hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_csrng_t;
+
+/**
+ * A csrng interrupt request type.
+ */
+typedef enum dif_csrng_irq {
+  /**
+   * Asserted when a command request is completed.
+   */
+  kDifCsrngIrqCsCmdReqDone = 0,
+  /**
+   * Asserted when a request for entropy has been made.
+   */
+  kDifCsrngIrqCsEntropyReq = 1,
+  /**
+   * Asserted when a hardware-attached CSRNG instance encounters a command
+   * exception
+   */
+  kDifCsrngIrqCsHwInstExc = 2,
+  /**
+   * Asserted when a FIFO error or a fatal alert occurs. Check the !!ERR_CODE
+   * register to get more information.
+   */
+  kDifCsrngIrqCsFatalErr = 3,
+} dif_csrng_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_csrng_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_csrng_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_csrng_irq_disable_all()` and `dif_csrng_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_csrng_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_get_state(const dif_csrng_t *csrng,
+                                     dif_csrng_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_is_pending(const dif_csrng_t *csrng,
+                                      dif_csrng_irq_t irq, bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_acknowledge(const dif_csrng_t *csrng,
+                                       dif_csrng_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_get_enabled(const dif_csrng_t *csrng,
+                                       dif_csrng_irq_t irq,
+                                       dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_set_enabled(const dif_csrng_t *csrng,
+                                       dif_csrng_irq_t irq, dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param csrng A csrng handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_force(const dif_csrng_t *csrng, dif_csrng_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param csrng A csrng handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_disable_all(
+    const dif_csrng_t *csrng, dif_csrng_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param csrng A csrng handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_irq_restore_all(
+    const dif_csrng_t *csrng, const dif_csrng_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_CSRNG_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -1,0 +1,298 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_csrng.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "csrng_regs.h"  // Generated.
+
+namespace dif_csrng_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class CsrngTest : public Test, public MmioTest {
+ protected:
+  dif_csrng_t csrng_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public CsrngTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_csrng_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_csrng_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_csrng_irq_get_state(&csrng_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_csrng_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_csrng_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_csrng_irq_get_state(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_csrng_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_csrng_irq_get_state(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public CsrngTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_csrng_irq_is_pending(nullptr, kDifCsrngIrqCsCmdReqDone, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_csrng_irq_is_pending(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_csrng_irq_is_pending(&csrng_, (dif_csrng_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET,
+                {{CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT, true}});
+  EXPECT_EQ(
+      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsCmdReqDone, &irq_state),
+      kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET,
+                {{CSRNG_INTR_STATE_CS_FATAL_ERR_BIT, false}});
+  EXPECT_EQ(
+      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsFatalErr, &irq_state),
+      kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public CsrngTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_csrng_irq_acknowledge(nullptr, kDifCsrngIrqCsCmdReqDone),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_csrng_irq_acknowledge(nullptr, (dif_csrng_irq_t)32),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(CSRNG_INTR_STATE_REG_OFFSET,
+                 {{CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT, true}});
+  EXPECT_EQ(dif_csrng_irq_acknowledge(&csrng_, kDifCsrngIrqCsCmdReqDone),
+            kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(CSRNG_INTR_STATE_REG_OFFSET,
+                 {{CSRNG_INTR_STATE_CS_FATAL_ERR_BIT, true}});
+  EXPECT_EQ(dif_csrng_irq_acknowledge(&csrng_, kDifCsrngIrqCsFatalErr), kDifOk);
+}
+
+class IrqGetEnabledTest : public CsrngTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_csrng_irq_get_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_csrng_irq_get_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_csrng_irq_get_enabled(&csrng_, (dif_csrng_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET,
+                {{CSRNG_INTR_ENABLE_CS_CMD_REQ_DONE_BIT, true}});
+  EXPECT_EQ(
+      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET,
+                {{CSRNG_INTR_ENABLE_CS_FATAL_ERR_BIT, false}});
+  EXPECT_EQ(
+      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsFatalErr, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public CsrngTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(
+      dif_csrng_irq_set_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_csrng_irq_set_enabled(&csrng_, (dif_csrng_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(CSRNG_INTR_ENABLE_REG_OFFSET,
+                {{CSRNG_INTR_ENABLE_CS_CMD_REQ_DONE_BIT, 0x1, true}});
+  EXPECT_EQ(
+      dif_csrng_irq_set_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, irq_state),
+      kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(CSRNG_INTR_ENABLE_REG_OFFSET,
+                {{CSRNG_INTR_ENABLE_CS_FATAL_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(
+      dif_csrng_irq_set_enabled(&csrng_, kDifCsrngIrqCsFatalErr, irq_state),
+      kDifOk);
+}
+
+class IrqForceTest : public CsrngTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_csrng_irq_force(nullptr, kDifCsrngIrqCsCmdReqDone), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_csrng_irq_force(nullptr, (dif_csrng_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(CSRNG_INTR_TEST_REG_OFFSET,
+                 {{CSRNG_INTR_TEST_CS_CMD_REQ_DONE_BIT, true}});
+  EXPECT_EQ(dif_csrng_irq_force(&csrng_, kDifCsrngIrqCsCmdReqDone), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(CSRNG_INTR_TEST_REG_OFFSET,
+                 {{CSRNG_INTR_TEST_CS_FATAL_ERR_BIT, true}});
+  EXPECT_EQ(dif_csrng_irq_force(&csrng_, kDifCsrngIrqCsFatalErr), kDifOk);
+}
+
+class IrqDisableAllTest : public CsrngTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_csrng_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_csrng_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_csrng_irq_disable_all(&csrng_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_csrng_irq_disable_all(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_csrng_irq_disable_all(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public CsrngTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_csrng_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_csrng_irq_restore_all(&csrng_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_csrng_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_csrng_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_csrng_irq_restore_all(&csrng_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_csrng_irq_restore_all(&csrng_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_csrng_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,27 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen Entropy Source DIF library
-sw_lib_dif_autogen_entropy_src = declare_dependency(
+# Autogen CSRNG DIF library
+sw_lib_dif_autogen_csrng = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_entropy_src',
+    'sw_lib_dif_autogen_csrng',
     sources: [
-      hw_ip_entropy_src_reg_h,
-      'dif_entropy_src_autogen.c',
-    ],
-    dependencies: [
-      sw_lib_mmio,
-    ],
-  )
-)
-
-# Autogen I2C Controller DIF library
-sw_lib_dif_autogen_i2c = declare_dependency(
-  link_with: static_library(
-    'sw_lib_dif_autogen_i2c',
-    sources: [
-      hw_ip_i2c_reg_h,
-      'dif_i2c_autogen.c',
+      hw_ip_csrng_reg_h,
+      'dif_csrng_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -58,6 +44,20 @@ sw_lib_dif_autogen_alert_handler = declare_dependency(
   )
 )
 
+# Autogen Entropy Source DIF library
+sw_lib_dif_autogen_entropy_src = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_entropy_src',
+    sources: [
+      hw_ip_entropy_src_reg_h,
+      'dif_entropy_src_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen GPIO DIF library
 sw_lib_dif_autogen_gpio = declare_dependency(
   link_with: static_library(
@@ -79,6 +79,20 @@ sw_lib_dif_autogen_hmac = declare_dependency(
     sources: [
       hw_ip_hmac_reg_h,
       'dif_hmac_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen I2C DIF library
+sw_lib_dif_autogen_i2c = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_i2c',
+    sources: [
+      hw_ip_i2c_reg_h,
+      'dif_i2c_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -59,10 +59,10 @@ typedef struct csrng_app_cmd {
  * Writes application command `cmd` to the CSRNG_CMD_REQ_REG register.
  * Returns the result of the operation.
  */
-static dif_csrng_result_t write_application_command(
-    const dif_csrng_t *csrng, const csrng_app_cmd_t *cmd) {
+static dif_result_t write_application_command(const dif_csrng_t *csrng,
+                                              const csrng_app_cmd_t *cmd) {
   if (csrng == NULL || cmd == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
 
   // The application command header is not specified as a register in the
@@ -77,7 +77,7 @@ static dif_csrng_result_t write_application_command(
       cmd->seed_material == NULL ? 0 : cmd->seed_material->seed_material_len;
 
   if (cmd_len & ~kAppCmdFieldCmdLen.mask) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
 
   // Build and write application command header.
@@ -85,13 +85,13 @@ static dif_csrng_result_t write_application_command(
   reg = bitfield_field32_write(reg, kAppCmdFieldCmdLen, cmd_len);
   reg = bitfield_bit32_write(reg, kAppCmdBitFlag0, cmd->entropy_src_enable);
   reg = bitfield_field32_write(reg, kAppCmdFieldGlen, cmd->generate_len);
-  mmio_region_write32(csrng->params.base_addr, CSRNG_CMD_REQ_REG_OFFSET, reg);
+  mmio_region_write32(csrng->base_addr, CSRNG_CMD_REQ_REG_OFFSET, reg);
 
   for (size_t i = 0; i < cmd_len; ++i) {
-    mmio_region_write32(csrng->params.base_addr, CSRNG_CMD_REQ_REG_OFFSET,
+    mmio_region_write32(csrng->base_addr, CSRNG_CMD_REQ_REG_OFFSET,
                         cmd->seed_material->seed_material[i]);
   }
-  return kDifCsrngOk;
+  return kDifOk;
 }
 
 /**
@@ -100,7 +100,7 @@ static dif_csrng_result_t write_application_command(
 static void get_output_status(const dif_csrng_t *csrng,
                               dif_csrng_output_status_t *status) {
   uint32_t reg =
-      mmio_region_read32(csrng->params.base_addr, CSRNG_GENBITS_VLD_REG_OFFSET);
+      mmio_region_read32(csrng->base_addr, CSRNG_GENBITS_VLD_REG_OFFSET);
   status->valid_data =
       bitfield_bit32_read(reg, CSRNG_GENBITS_VLD_GENBITS_VLD_BIT);
   status->fips_mode =
@@ -116,24 +116,25 @@ static bool is_output_ready(const dif_csrng_t *csrng) {
   return status.valid_data;
 }
 
-dif_csrng_result_t dif_csrng_init(dif_csrng_params_t params,
-                                  dif_csrng_t *csrng) {
+dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng) {
   if (csrng == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
-  *csrng = (dif_csrng_t){.params = params};
-  return kDifCsrngOk;
+
+  csrng->base_addr = base_addr;
+
+  return kDifOk;
 }
 
-dif_csrng_result_t dif_csrng_configure(const dif_csrng_t *csrng) {
+dif_result_t dif_csrng_configure(const dif_csrng_t *csrng) {
   if (csrng == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
-  mmio_region_write32(csrng->params.base_addr, CSRNG_CTRL_REG_OFFSET, 0xaaa);
-  return kDifCsrngOk;
+  mmio_region_write32(csrng->base_addr, CSRNG_CTRL_REG_OFFSET, 0xaaa);
+  return kDifOk;
 }
 
-dif_csrng_result_t dif_csrng_instantiate(
+dif_result_t dif_csrng_instantiate(
     const dif_csrng_t *csrng, dif_csrng_entropy_src_toggle_t entropy_src_enable,
     const dif_csrng_seed_material_t *seed_material) {
   const csrng_app_cmd_t app_cmd = {
@@ -145,8 +146,8 @@ dif_csrng_result_t dif_csrng_instantiate(
   return write_application_command(csrng, &app_cmd);
 }
 
-dif_csrng_result_t dif_csrng_reseed(
-    const dif_csrng_t *csrng, const dif_csrng_seed_material_t *seed_material) {
+dif_result_t dif_csrng_reseed(const dif_csrng_t *csrng,
+                              const dif_csrng_seed_material_t *seed_material) {
   const csrng_app_cmd_t app_cmd = {
       .id = kCsrngAppCmdReseed,
       .entropy_src_enable = false,
@@ -156,8 +157,8 @@ dif_csrng_result_t dif_csrng_reseed(
   return write_application_command(csrng, &app_cmd);
 }
 
-dif_csrng_result_t dif_csrng_update(
-    const dif_csrng_t *csrng, const dif_csrng_seed_material_t *seed_material) {
+dif_result_t dif_csrng_update(const dif_csrng_t *csrng,
+                              const dif_csrng_seed_material_t *seed_material) {
   const csrng_app_cmd_t app_cmd = {
       .id = kCsrngAppCmdUpdate,
       .entropy_src_enable = false,
@@ -167,10 +168,9 @@ dif_csrng_result_t dif_csrng_update(
   return write_application_command(csrng, &app_cmd);
 }
 
-dif_csrng_result_t dif_csrng_generate_start(const dif_csrng_t *csrng,
-                                            size_t len) {
+dif_result_t dif_csrng_generate_start(const dif_csrng_t *csrng, size_t len) {
   if (len == 0) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
 
   // Round up the number of 128bit blocks. Aligning with respect to uint32_t.
@@ -186,10 +186,10 @@ dif_csrng_result_t dif_csrng_generate_start(const dif_csrng_t *csrng,
   return write_application_command(csrng, &app_cmd);
 }
 
-dif_csrng_result_t dif_csrng_generate_end(const dif_csrng_t *csrng,
-                                          uint32_t *buf, size_t len) {
+dif_result_t dif_csrng_generate_end(const dif_csrng_t *csrng, uint32_t *buf,
+                                    size_t len) {
   if (csrng == NULL || buf == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
 
   // Wait until there is data ready.
@@ -203,13 +203,12 @@ dif_csrng_result_t dif_csrng_generate_end(const dif_csrng_t *csrng,
       }
       rd_cnt = 0;
     }
-    buf[i] =
-        mmio_region_read32(csrng->params.base_addr, CSRNG_GENBITS_REG_OFFSET);
+    buf[i] = mmio_region_read32(csrng->base_addr, CSRNG_GENBITS_REG_OFFSET);
   }
-  return kDifCsrngOk;
+  return kDifOk;
 }
 
-dif_csrng_result_t dif_csrng_uninstantiate(const dif_csrng_t *csrng) {
+dif_result_t dif_csrng_uninstantiate(const dif_csrng_t *csrng) {
   const csrng_app_cmd_t app_cmd = {
       .id = kCsrngAppCmdUnisntantiate,
       .entropy_src_enable = false,
@@ -219,14 +218,14 @@ dif_csrng_result_t dif_csrng_uninstantiate(const dif_csrng_t *csrng) {
   return write_application_command(csrng, &app_cmd);
 }
 
-dif_csrng_result_t dif_csrng_get_cmd_interface_status(
+dif_result_t dif_csrng_get_cmd_interface_status(
     const dif_csrng_t *csrng, dif_csrng_cmd_status_t *status) {
   if (csrng == NULL || status == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
 
   uint32_t reg =
-      mmio_region_read32(csrng->params.base_addr, CSRNG_SW_CMD_STS_REG_OFFSET);
+      mmio_region_read32(csrng->base_addr, CSRNG_SW_CMD_STS_REG_OFFSET);
   bool cmd_ready = bitfield_bit32_read(reg, CSRNG_SW_CMD_STS_CMD_RDY_BIT);
   bool cmd_error = bitfield_bit32_read(reg, CSRNG_SW_CMD_STS_CMD_STS_BIT);
 
@@ -234,63 +233,62 @@ dif_csrng_result_t dif_csrng_get_cmd_interface_status(
   // when `cmd_ready` is set to true.
   if (cmd_error) {
     *status = kDifCsrngCmdStatusError;
-    return kDifCsrngOk;
+    return kDifOk;
   }
 
   if (cmd_ready) {
     *status = kDifCsrngCmdStatusReady;
-    return kDifCsrngOk;
+    return kDifOk;
   }
 
   *status = kDifCsrngCmdStatusBusy;
-  return kDifCsrngOk;
+  return kDifOk;
 }
 
-dif_csrng_result_t dif_csrng_get_output_status(
-    const dif_csrng_t *csrng, dif_csrng_output_status_t *status) {
+dif_result_t dif_csrng_get_output_status(const dif_csrng_t *csrng,
+                                         dif_csrng_output_status_t *status) {
   if (csrng == NULL || status == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
   get_output_status(csrng, status);
-  return kDifCsrngOk;
+  return kDifOk;
 }
 
 OT_WARN_UNUSED_RESULT
-dif_csrng_result_t dif_csrng_get_internal_state(
+dif_result_t dif_csrng_get_internal_state(
     const dif_csrng_t *csrng, dif_csrng_internal_state_id_t instance_id,
     dif_csrng_internal_state_t *state) {
   if (csrng == NULL || state == NULL) {
-    return kDifCsrngBadArg;
+    return kDifBadArg;
   }
 
   // Select the instance id to read the internal state from, request a state
   // machine halt, and wait for the internal registers to be ready to be read.
   uint32_t reg = bitfield_field32_write(
       0, CSRNG_INT_STATE_NUM_INT_STATE_NUM_FIELD, instance_id);
-  mmio_region_write32(csrng->params.base_addr, CSRNG_INT_STATE_NUM_REG_OFFSET,
-                      reg);
+  mmio_region_write32(csrng->base_addr, CSRNG_INT_STATE_NUM_REG_OFFSET, reg);
 
   // Read the internal state.
-  state->reseed_counter = mmio_region_read32(csrng->params.base_addr,
-                                             CSRNG_INT_STATE_VAL_REG_OFFSET);
+  state->reseed_counter =
+      mmio_region_read32(csrng->base_addr, CSRNG_INT_STATE_VAL_REG_OFFSET);
 
   for (size_t i = 0; i < ARRAYSIZE(state->v); ++i) {
-    state->v[i] = mmio_region_read32(csrng->params.base_addr,
-                                     CSRNG_INT_STATE_VAL_REG_OFFSET);
+    state->v[i] =
+        mmio_region_read32(csrng->base_addr, CSRNG_INT_STATE_VAL_REG_OFFSET);
   }
 
   for (size_t i = 0; i < ARRAYSIZE(state->key); ++i) {
-    state->key[i] = mmio_region_read32(csrng->params.base_addr,
-                                       CSRNG_INT_STATE_VAL_REG_OFFSET);
+    state->key[i] =
+        mmio_region_read32(csrng->base_addr, CSRNG_INT_STATE_VAL_REG_OFFSET);
   }
 
-  uint32_t flags = mmio_region_read32(csrng->params.base_addr,
-                                      CSRNG_INT_STATE_VAL_REG_OFFSET);
+  uint32_t flags =
+      mmio_region_read32(csrng->base_addr, CSRNG_INT_STATE_VAL_REG_OFFSET);
 
   // The following bit indexes are defined in
   // https://docs.opentitan.org/hw/ip/csrng/doc/#working-state-values
   state->instantiated = bitfield_bit32_read(flags, /*bit_index=*/0u);
   state->fips_compliance = bitfield_bit32_read(flags, /*bit_index=*/1u);
 
-  return kDifCsrngOk;
+  return kDifOk;
 }

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -20,43 +20,38 @@ using ::testing::ElementsAreArray;
 
 class DifCsrngTest : public testing::Test, public mock_mmio::MmioTest {
  protected:
-  const dif_csrng_params_t params_ = {.base_addr = dev().region()};
-  const dif_csrng_t csrng_ = {
-      .params = {.base_addr = dev().region()},
-  };
+  const dif_csrng_t csrng_ = {.base_addr = dev().region()};
 };
 
 class InitTest : public DifCsrngTest {};
 
 TEST_F(InitTest, BadArgs) {
-  EXPECT_EQ(dif_csrng_init(params_, nullptr), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, InitOk) {
   dif_csrng_t csrng;
-  EXPECT_EQ(dif_csrng_init(params_, &csrng), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_init(dev().region(), &csrng), kDifOk);
 }
 
 class ConfigTest : public DifCsrngTest {};
 
 TEST_F(ConfigTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_configure(nullptr), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_configure(nullptr), kDifBadArg);
 }
 
 TEST_F(ConfigTest, ConfigOk) {
   EXPECT_WRITE32(CSRNG_CTRL_REG_OFFSET, 0xaaa);
-  EXPECT_EQ(dif_csrng_configure(&csrng_), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_configure(&csrng_), kDifOk);
 }
 
 class GetCmdInterfaceStatusTest : public DifCsrngTest {};
 
 TEST_F(GetCmdInterfaceStatusTest, NullArgs) {
   dif_csrng_cmd_status_t status;
-  EXPECT_EQ(dif_csrng_get_cmd_interface_status(nullptr, &status),
-            kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_get_cmd_interface_status(nullptr, &status), kDifBadArg);
 
-  EXPECT_EQ(dif_csrng_get_cmd_interface_status(&csrng_, nullptr),
-            kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_get_cmd_interface_status(&csrng_, nullptr), kDifBadArg);
 }
 
 struct GetCmdInterfaceStatusParams {
@@ -77,7 +72,7 @@ TEST_P(GetCmdInterfaceStatusTestAllParams, ValidConfigurationMode) {
                     {CSRNG_SW_CMD_STS_CMD_RDY_BIT, test_param.cmd_ready},
                     {CSRNG_SW_CMD_STS_CMD_STS_BIT, test_param.cmd_status},
                 });
-  EXPECT_EQ(dif_csrng_get_cmd_interface_status(&csrng_, &status), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_get_cmd_interface_status(&csrng_, &status), kDifOk);
   EXPECT_EQ(status, test_param.expected_status);
 }
 
@@ -93,9 +88,9 @@ class GetOutputStatusTest : public DifCsrngTest {};
 
 TEST_F(GetOutputStatusTest, NullArgs) {
   dif_csrng_output_status_t status;
-  EXPECT_EQ(dif_csrng_get_output_status(nullptr, &status), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_get_output_status(nullptr, &status), kDifBadArg);
 
-  EXPECT_EQ(dif_csrng_get_output_status(&csrng_, nullptr), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_get_output_status(&csrng_, nullptr), kDifBadArg);
 }
 
 TEST_F(GetOutputStatusTest, ValidStatus) {
@@ -108,7 +103,7 @@ TEST_F(GetOutputStatusTest, ValidStatus) {
                     {CSRNG_GENBITS_VLD_GENBITS_FIPS_BIT, false},
                 });
 
-  EXPECT_EQ(dif_csrng_get_output_status(&csrng_, &status), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_get_output_status(&csrng_, &status), kDifOk);
   EXPECT_EQ(status.valid_data, true);
   EXPECT_EQ(status.fips_mode, false);
 }
@@ -129,12 +124,12 @@ TEST_F(CommandTest, InstantiateOk) {
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000101);
   EXPECT_EQ(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleDisable,
                                   &seed_material_),
-            kDifCsrngOk);
+            kDifOk);
 
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000001);
   EXPECT_EQ(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleEnable,
                                   &seed_material_),
-            kDifCsrngOk);
+            kDifOk);
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
@@ -142,73 +137,73 @@ TEST_F(CommandTest, InstantiateOk) {
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
   EXPECT_EQ(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleEnable,
                                   &seed_material_),
-            kDifCsrngOk);
+            kDifOk);
 }
 
 TEST_F(CommandTest, InstantiateBadArgs) {
   EXPECT_EQ(dif_csrng_instantiate(nullptr, kDifCsrngEntropySrcToggleDisable,
                                   &seed_material_),
-            kDifCsrngBadArg);
+            kDifBadArg);
 
   // Failed overflow check.
   seed_material_.seed_material_len = 16;
   EXPECT_EQ(dif_csrng_instantiate(&csrng_, kDifCsrngEntropySrcToggleDisable,
                                   &seed_material_),
-            kDifCsrngBadArg);
+            kDifBadArg);
 }
 
 TEST_F(CommandTest, ReseedOk) {
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000002);
-  EXPECT_EQ(dif_csrng_reseed(&csrng_, &seed_material_), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_reseed(&csrng_, &seed_material_), kDifOk);
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000012);
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
-  EXPECT_EQ(dif_csrng_reseed(&csrng_, &seed_material_), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_reseed(&csrng_, &seed_material_), kDifOk);
 }
 
 TEST_F(CommandTest, ReseedBadArgs) {
-  EXPECT_EQ(dif_csrng_reseed(nullptr, &seed_material_), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_reseed(nullptr, &seed_material_), kDifBadArg);
 
   // Failed overflow check.
   seed_material_.seed_material_len = 16;
-  EXPECT_EQ(dif_csrng_reseed(&csrng_, &seed_material_), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_reseed(&csrng_, &seed_material_), kDifBadArg);
 }
 
 TEST_F(CommandTest, UpdateOk) {
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000004);
-  EXPECT_EQ(dif_csrng_update(&csrng_, &seed_material_), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_update(&csrng_, &seed_material_), kDifOk);
 
   seed_material_.seed_material[0] = 0x5a5a5a5a;
   seed_material_.seed_material_len = 1;
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000014);
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x5a5a5a5a);
-  EXPECT_EQ(dif_csrng_update(&csrng_, &seed_material_), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_update(&csrng_, &seed_material_), kDifOk);
 }
 
 TEST_F(CommandTest, UpdateBadArgs) {
-  EXPECT_EQ(dif_csrng_update(nullptr, &seed_material_), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_update(nullptr, &seed_material_), kDifBadArg);
 }
 
 TEST_F(CommandTest, GenerateOk) {
   // 512bits = 16 x 32bit = 4 x 128bit blocks
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00004003);
-  EXPECT_EQ(dif_csrng_generate_start(&csrng_, /*len=*/16), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_generate_start(&csrng_, /*len=*/16), kDifOk);
 
   // 576bits = 18 x 32bit = 5 x 128bit blocks (rounded up)
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00005003);
-  EXPECT_EQ(dif_csrng_generate_start(&csrng_, /*len=*/18), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_generate_start(&csrng_, /*len=*/18), kDifOk);
 }
 
 TEST_F(CommandTest, GenerateBadArgs) {
-  EXPECT_EQ(dif_csrng_generate_start(nullptr, /*len=*/1), kDifCsrngBadArg);
-  EXPECT_EQ(dif_csrng_generate_start(&csrng_, /*len=*/0), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_generate_start(nullptr, /*len=*/1), kDifBadArg);
+  EXPECT_EQ(dif_csrng_generate_start(&csrng_, /*len=*/0), kDifBadArg);
 }
 
 TEST_F(CommandTest, UninstantiateOk) {
   EXPECT_WRITE32(CSRNG_CMD_REQ_REG_OFFSET, 0x00000005);
-  EXPECT_EQ(dif_csrng_uninstantiate(&csrng_), kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_uninstantiate(&csrng_), kDifOk);
 }
 
 class GenerateEndTest : public DifCsrngTest {};
@@ -230,17 +225,15 @@ TEST_F(GenerateEndTest, ReadOk) {
   }
 
   std::vector<uint32_t> got(kExpected.size());
-  EXPECT_EQ(dif_csrng_generate_end(&csrng_, got.data(), got.size()),
-            kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_generate_end(&csrng_, got.data(), got.size()), kDifOk);
   EXPECT_THAT(got, testing::ElementsAreArray(kExpected));
 }
 
 TEST_F(GenerateEndTest, ReadBadArgs) {
-  EXPECT_EQ(dif_csrng_generate_end(&csrng_, nullptr, /*len=*/0),
-            kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_generate_end(&csrng_, nullptr, /*len=*/0), kDifBadArg);
 
   uint32_t data;
-  EXPECT_EQ(dif_csrng_generate_end(nullptr, &data, /*len=*/1), kDifCsrngBadArg);
+  EXPECT_EQ(dif_csrng_generate_end(nullptr, &data, /*len=*/1), kDifBadArg);
 }
 
 class GetInternalStateTest : public DifCsrngTest {};
@@ -271,8 +264,7 @@ TEST_F(GetInternalStateTest, GetInternalStateOk) {
   EXPECT_READ32(CSRNG_INT_STATE_VAL_REG_OFFSET, 3);
 
   dif_csrng_internal_state_t got;
-  EXPECT_EQ(dif_csrng_get_internal_state(&csrng_, instance_id, &got),
-            kDifCsrngOk);
+  EXPECT_EQ(dif_csrng_get_internal_state(&csrng_, instance_id, &got), kDifOk);
 
   EXPECT_EQ(got.reseed_counter, expected.reseed_counter);
   EXPECT_THAT(got.key, ElementsAreArray(expected.key));
@@ -284,12 +276,12 @@ TEST_F(GetInternalStateTest, GetInternalStateOk) {
 TEST_F(GetInternalStateTest, GetInternalStateBadArgs) {
   EXPECT_EQ(
       dif_csrng_get_internal_state(&csrng_, kCsrngInternalStateIdSw, nullptr),
-      kDifCsrngBadArg);
+      kDifBadArg);
 
   dif_csrng_internal_state unused;
   EXPECT_EQ(
       dif_csrng_get_internal_state(nullptr, kCsrngInternalStateIdSw, &unused),
-      kDifCsrngBadArg);
+      kDifBadArg);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -39,13 +39,14 @@ test('dif_clkmgr_unittest', executable(
 # CSRNG DIF Library (dif_csrng)
 sw_lib_dif_csrng = declare_dependency(
   link_with: static_library(
-    'csrng_ot',
+    'sw_lib_dif_csrng',
     sources: [
       hw_ip_csrng_reg_h,
       'dif_csrng.c',
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_dif_autogen_csrng,
     ],
   )
 )
@@ -53,9 +54,11 @@ sw_lib_dif_csrng = declare_dependency(
 test('dif_csrng_unittest', executable(
     'dif_csrng_unittest',
     sources: [
-      hw_ip_csrng_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_csrng.c',
       'dif_csrng_unittest.cc',
+      'autogen/dif_csrng_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_csrng.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_csrng_autogen.c',
+      hw_ip_csrng_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -40,12 +40,10 @@ static void setup_entropy_src(void) {
 }
 
 static void setup_csrng(void) {
-  const dif_csrng_params_t params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR),
-  };
   dif_csrng_t csrng;
-  CHECK(dif_csrng_init(params, &csrng) == kDifCsrngOk);
-  CHECK(dif_csrng_configure(&csrng) == kDifCsrngOk);
+  CHECK_DIF_OK(dif_csrng_init(
+      mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));
+  CHECK_DIF_OK(dif_csrng_configure(&csrng));
 }
 
 static void setup_edn(void) {


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "csrng".