### PR TITLE
[otbn,dv] Add a simple predictor for the STATUS register

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -19,7 +19,7 @@ package otbn_env_pkg;
   import otbn_ral_pkg::*;
 
   import otbn_pkg::flags_t;
-  import bus_params_pkg::BUS_DW;
+  import bus_params_pkg::BUS_AW, bus_params_pkg::BUS_DW, bus_params_pkg::BUS_DBW;
   import top_pkg::TL_AIW;
 
   // macro includes

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -14,4 +14,35 @@ class otbn_common_vseq extends otbn_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  // Overriding a method from cip_base_vseq. This is only necessary when running the common
+  // sequences (where we might turn off the scoreboard and its predictor, but still check register
+  // values are as expected).
+  task tl_access_w_abort(input bit [BUS_AW-1:0]    addr,
+                         input bit                 write,
+                         inout bit [BUS_DW-1:0]    data,
+                         output bit                completed,
+                         output bit                saw_err,
+                         input bit [BUS_DBW-1:0]   mask = '1,
+                         input bit                 check_rsp = 1'b1,
+                         input bit                 exp_err_rsp = 1'b0,
+                         input bit [BUS_DW-1:0]    exp_data = 0,
+                         input bit [BUS_DW-1:0]    compare_mask = '1,
+                         input bit                 check_exp_data = 1'b0,
+                         input bit                 blocking = csr_utils_pkg::default_csr_blocking,
+                         input tlul_pkg::tl_type_e tl_type = tlul_pkg::DataType,
+                         tl_sequencer              tl_sequencer_h = p_sequencer.tl_sequencer_h,
+                         input tl_intg_err_e       tl_intg_err_type = TlIntgErrNone,
+                         input int                 req_abort_pct = 0);
+    super.tl_access_w_abort(addr, write, data, completed, saw_err, mask, check_rsp, exp_err_rsp,
+                            exp_data, compare_mask, check_exp_data, blocking, tl_type,
+                            tl_sequencer_h, tl_intg_err_type, req_abort_pct);
+
+    // If we see a write which causes an integrity error AND we've disabled the scoreboard (which
+    // has its own predictor), we update the predicted value of the STATUS register to be LOCKED.
+    if (completed && saw_err && !cfg.en_scb) begin
+      `DV_CHECK_FATAL(ral.status.status.predict(otbn_pkg::StatusLocked, .kind(UVM_PREDICT_READ)),
+                      "Failed to update STATUS register")
+    end
+  endtask
+
 endclass

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_base_vseq.sv
@@ -41,7 +41,6 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
 
   // Task to perform `num_ops` fully randomized memory transactions.
   virtual task do_rand_ops(int num_ops);
-    uvm_status_e status;
     addr_range_t loc_mem_range[$] = cfg.ral_models["rom_ctrl_rom_reg_block"].mem_ranges;
 
     bit [TL_DW-1:0] data;
@@ -50,6 +49,8 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
     int             mem_idx;
 
     repeat (num_ops) begin
+      bit completed, saw_err;
+
       int mem_idx = $urandom_range(0, loc_mem_range.size - 1);
       `DV_CHECK_STD_RANDOMIZE_FATAL(data)
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr,
@@ -59,7 +60,8 @@ class rom_ctrl_base_vseq extends cip_base_vseq #(
 
       tl_access_w_abort(.addr(addr),
                         .data(data),
-                        .status(status),
+                        .completed(completed),
+                        .saw_err(saw_err),
                         .mask(get_rand_contiguous_mask('1)),
                         .write(write),
                         .blocking(1'b0),

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -133,12 +133,12 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
                            bit blocking  = $urandom_range(0, 1),
                            bit abort     = 0,
                            bit en_ifetch = 0);
-    uvm_status_e status;
-
     bit [TL_DW-1:0] data;
     bit [TL_AW-1:0] addr;
     tlul_pkg::tl_type_e tl_type;
     repeat (num_ops) begin
+      bit completed, saw_err;
+
       // full randomize addr and data
       `DV_CHECK_STD_RANDOMIZE_FATAL(data)
       `DV_CHECK_STD_RANDOMIZE_FATAL(addr)
@@ -148,7 +148,8 @@ class sram_ctrl_base_vseq extends cip_base_vseq #(
 
       tl_access_w_abort(.addr(addr),
                         .data(data),
-                        .status(status),
+                        .completed(completed),
+                        .saw_err(saw_err),
                         .mask(get_rand_contiguous_mask()),
                         .write($urandom_range(0, 1)),
                         .blocking(blocking),


### PR DESCRIPTION
This register jumps to "LOCKED" when we see a write with an integrity
error. Ideally, we'd track this sort of thing with the predictor in
the scoreboard but the automated CSR tests disable the scoreboard and
its predictor (but still check for expected values of CSRs!).

Hack in the update logic that we need.

Fixes #8376.