### PR TITLE
[docker] Remove mention of pre-built container

### DIFF
--- a/util/container/README.md
+++ b/util/container/README.md
@@ -21,13 +21,3 @@ To run container in interactive mode:
 ```shell
 $ docker run -it -v $REPO_TOP:/repo -w /repo opentitan --user $(id -u):$(id -g)
 ```
-
-## Pre-built Container
-
-There is an experimental version of the container available. To download, run:
-
-```shell
-$ docker pull gcr.io/opentitan/hw_dev
-```
-
-Use `gcr.io/opentitan/hw_dev` as the container name in any Docker commands.


### PR DESCRIPTION
The pre-built container has last been updated in 2020. Unless we start
automatically updating this container, it'll only guide users to an
outdated and unsupported configuration, which is worse than having to
build container by hand.