### PR TITLE
[otbn,dv] Wire ISS status out to the scoreboard

### DIFF
--- a/hw/ip/otbn/dv/memutil/sv_utils.h
+++ b/hw/ip/otbn/dv/memutil/sv_utils.h
@@ -6,6 +6,15 @@
 
 #include <svdpi.h>
 
+// Utility function that packs a uint8_t into a SystemVerilog bit vector that
+// represents a "bit [7:0]"
+inline void set_sv_u8(svBitVecVal *dst, uint8_t src) {
+  for (int i = 0; i < 8; ++i) {
+    svBit bit = (src >> i) & 1;
+    svPutBitselBit(dst, i, bit);
+  }
+}
+
 // Utility function that packs a uint32_t into a SystemVerilog bit vector that
 // represents a "bit [31:0]"
 inline void set_sv_u32(svBitVecVal *dst, uint32_t src) {

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -40,6 +40,7 @@ module otbn_core_model
   input logic [WLEN-1:0] edn_rnd_data_i,
   input logic            edn_urnd_data_valid_i, // URND reseed from EDN is valid
 
+  output bit [7:0]       status_o,   // STATUS register
   output bit [31:0]      insn_cnt_o, // INSN_CNT register
 
   output bit             err_o // something went wrong
@@ -67,13 +68,13 @@ module otbn_core_model
     otbn_model_destroy(model_handle);
   end
 
-  // A packed "status" value. This gets assigned by DPI function calls that need to update both
-  // whether we're running and also error flags at the same time. The contents are magic simulation
-  // values, so get initialized before reset (to avoid stopping the simulation before it even
-  // starts).
-  int unsigned status = 0;
+  // A packed set of bits representing the state of the model. This gets assigned by DPI function
+  // calls that need to update both whether we're running and also error flags at the same time. The
+  // contents are magic simulation values, so get initialized before reset (to avoid stopping the
+  // simulation before it even starts).
+  int unsigned model_state = 0;
 
-  // Extract particular bits of the status value.
+  // Extract particular bits of the model_state value.
   //
   //   [0]     running:      The ISS is currently running
   //   [1]     check_due:    The ISS just finished but still needs to check results
@@ -81,45 +82,51 @@ module otbn_core_model
   //   [3]     failed_cmp:   The consistency check at the end of run failed.
 
   bit failed_cmp, failed_step, check_due, running;
-  assign {failed_cmp, failed_step, check_due, running} = status[3:0];
+  assign {failed_cmp, failed_step, check_due, running} = model_state[3:0];
 
-  bit [31:0] raw_err_bits_d, raw_err_bits_q;
-  bit unused_raw_err_bits;
-
-  bit [31:0] stop_pc_d, stop_pc_q;
+  bit [7:0] status_d, status_q;
   bit [31:0] insn_cnt_d, insn_cnt_q;
+  bit [31:0] raw_err_bits_d, raw_err_bits_q;
+  bit [31:0] stop_pc_d, stop_pc_q;
+
+  bit unused_raw_err_bits;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      if (status != 0) begin
+      if (model_state != 0) begin
         otbn_model_reset(model_handle);
       end
-      status <= 0;
+      model_state <= 0;
+      status_q <= 0;
+      insn_cnt_q <= 0;
       raw_err_bits_q <= 0;
       stop_pc_q <= 0;
-      insn_cnt_q <= 0;
     end else begin
       if (start_i | running | check_due) begin
-        status <= otbn_model_step(model_handle,
-                                  start_i,
-                                  status,
-                                  edn_rnd_data_valid_i, edn_rnd_data_i,
-                                  edn_urnd_data_valid_i,
-                                  insn_cnt_d,
-                                  raw_err_bits_d,
-                                  stop_pc_d);
+        model_state <= otbn_model_step(model_handle,
+                                       start_i,
+                                       model_state,
+                                       edn_rnd_data_valid_i, edn_rnd_data_i,
+                                       edn_urnd_data_valid_i,
+                                       status_d,
+                                       insn_cnt_d,
+                                       raw_err_bits_d,
+                                       stop_pc_d);
+        status_q <= status_d;
+        insn_cnt_q <= insn_cnt_d;
         raw_err_bits_q <= raw_err_bits_d;
         stop_pc_q <= stop_pc_d;
-        insn_cnt_q <= insn_cnt_d;
       end else begin
         // If we're not running and we're not being told to start, there's nothing to do.
       end
     end
   end
 
-  assign err_bits_o = raw_err_bits_q[$bits(err_bits_t)-1:0];
   assign unused_raw_err_bits = ^raw_err_bits_q[31:$bits(err_bits_t)];
 
+  assign err_bits_o = raw_err_bits_q[$bits(err_bits_t)-1:0];
+
+  assign status_o = status_q;
   assign insn_cnt_o = insn_cnt_q;
 
   // Track negedges of running_q and expose that as a "done" output.

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -38,7 +38,8 @@ class OtbnModel {
   // checker. If the model has finished, writes otbn.ERR_BITS to *err_bits.
   int step(svLogic edn_rnd_data_valid,
            svLogicVecVal *edn_rnd_data, /* logic [255:0] */
-           svLogic edn_urnd_data_valid, svBitVecVal *insn_cnt /* bit [31:0] */,
+           svLogic edn_urnd_data_valid, svBitVecVal *status /* bit [7:0] */,
+           svBitVecVal *insn_cnt /* bit [31:0] */,
            svBitVecVal *err_bits /* bit [31:0] */,
            svBitVecVal *stop_pc /* bit [31:0] */);
 

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -25,7 +25,7 @@ void otbn_model_destroy(OtbnModel *model);
 // The main entry point to the OTBN model, exported from here and used in
 // otbn_core_model.sv.
 //
-// This communicates state with otbn_core_model.sv through the status
+// This communicates state with otbn_core_model.sv through the model_state
 // parameter, which has the following bits:
 //
 //    Bit 0:      running       True if the model is currently running
@@ -34,9 +34,9 @@ void otbn_model_destroy(OtbnModel *model);
 //    Bit 3:      failed_cmp    Consistency check at end of run failed
 //
 // The otbn_model_step function should only be called when either the model is
-// running (bit 0 of status), has a check due (bit 1 of status), or when start
-// is asserted. At other times, it will return immediately (but wastes a DPI
-// call).
+// running (bit 0 of model_state), has a check due (bit 1 of model_state), or
+// when start is asserted. At other times, it will return immediately (but
+// wastes a DPI call).
 //
 // If the model is running and start is false, otbn_model_step steps the ISS by
 // a single cycle. If something goes wrong, it will set failed_step to true and
@@ -54,10 +54,11 @@ void otbn_model_destroy(OtbnModel *model);
 //
 // If start is true, we start the model and then step once (as described
 // above).
-unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned status,
+unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
                          svLogic edn_rnd_data_valid,
                          svLogicVecVal *edn_rnd_data, /* logic [255:0] */
                          svLogic edn_urnd_data_valid,
+                         svBitVecVal *status /* bit [7:0] */,
                          svBitVecVal *insn_cnt /* bit [31:0] */,
                          svBitVecVal *err_bits /* bit [31:0] */,
                          svBitVecVal *stop_pc /* bit [31:0] */);

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -19,10 +19,11 @@ package otbn_model_pkg;
   import "DPI-C" context function
     int unsigned otbn_model_step(chandle          model,
                                  logic            start,
-                                 int unsigned     status,
+                                 int unsigned     model_state,
                                  logic            edn_rnd_data_valid,
                                  logic [WLEN-1:0] edn_rnd_data,
                                  logic            edn_urnd_data_valid,
+                                 inout bit [7:0]  status,
                                  inout bit [31:0] insn_cnt,
                                  inout bit [31:0] err_bits,
                                  inout bit [31:0] stop_pc);

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
@@ -13,7 +13,7 @@ package otbn_model_agent_pkg;
 
   typedef enum {
     OtbnModelStart,
-    OtbnModelDone,
+    OtbnModelStatus,
     OtbnModelInsn
   } otbn_model_item_type_e;
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -19,18 +19,16 @@ interface otbn_model_if #(
   bit                       done;         // Operation done
   bit                       err;          // Something went wrong
   bit [31:0]                stop_pc;      // PC at end of operation
+
+  // Mirrored registers
+  bit [7:0]                 status;       // STATUS register
+
   chandle                   handle;       // Handle for DPI calls to C model
 
-  // Wait until done goes high. Stops early on reset
-  task automatic wait_done();
-    while (rst_ni === 1'b1 && !done) begin
-      @(posedge clk_i or negedge rst_ni);
-    end
-  endtask
-
-  // Wait until done goes low. Stops early on reset
-  task automatic wait_not_done();
-    while (rst_ni === 1'b1 && done) begin
+  // Wait until reset or change of status.
+  task automatic wait_status();
+    bit old_status = status;
+    while (rst_ni === 1'b1 && status == old_status) begin
       @(posedge clk_i or negedge rst_ni);
     end
   endtask

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_item.sv
@@ -7,7 +7,8 @@ class otbn_model_item extends uvm_sequence_item;
   // What sort of transaction is this?
   otbn_model_item_type_e item_type;
 
-  // Only valid when item_type == OtbnModelDone.
+  // Only valid when item_type == OtbnModelStatus.
+  bit [7:0]              status;
   bit                    err;
 
   // Only valid when item_type == OtbnModelInsn
@@ -16,6 +17,7 @@ class otbn_model_item extends uvm_sequence_item;
 
   `uvm_object_utils_begin(otbn_model_item)
     `uvm_field_enum   (otbn_model_item_type_e, item_type, UVM_DEFAULT)
+    `uvm_field_int    (status, UVM_DEFAULT)
     `uvm_field_int    (err, UVM_DEFAULT)
     `uvm_field_int    (insn_addr, UVM_DEFAULT | UVM_HEX)
     `uvm_field_string (mnemonic, UVM_DEFAULT)

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -191,7 +191,7 @@ module tb;
     .edn_rnd_data_i        (dut.edn_rnd_data),
     .edn_urnd_data_valid_i (edn_urnd_data_valid),
 
-    .status_o     (),
+    .status_o     (model_if.status),
     .insn_cnt_o   (model_insn_cnt),
 
     .err_o        (model_if.err)

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -191,7 +191,9 @@ module tb;
     .edn_rnd_data_i        (dut.edn_rnd_data),
     .edn_urnd_data_valid_i (edn_urnd_data_valid),
 
+    .status_o     (),
     .insn_cnt_o   (model_insn_cnt),
+
     .err_o        (model_if.err)
   );
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -290,6 +290,7 @@ module otbn_top_sim (
     .edn_rnd_data_i        ( edn_rnd_data ),
     .edn_urnd_data_valid_i ( edn_urnd_data_valid ),
 
+    .status_o              (),
     .insn_cnt_o            ( otbn_model_insn_cnt ),
 
     .err_o                 ( otbn_model_err )


### PR DESCRIPTION
This fixes up the predictor for the STATUS register, allowing things like LOCKED states. At the moment, that won't actually happen (because we have no way for the ISS to decide to get *into* a locked state), but at least now we can report things once that's implemented.