### PR TITLE
[spi_device] Fix TPM output timing

### DIFF
--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -976,8 +976,8 @@ module spi_tpm
         // NOTE: The coding style in this state is ugly. How can we improve?
         cmdaddr_shift_en = 1'b 1;
 
-        if (cmdaddr_bitcnt >= 5'h 17) begin
-          // TODO: Add output logic here (Send WAIT or START)
+        if (cmdaddr_bitcnt >= 5'h 18) begin
+          // Send Wait byte [18h:1Fh]
           sck_p2s_valid = 1'b 1;
           sck_data_sel  = SelWait;
         end


### PR DESCRIPTION
Previously, in the Address state, TPM sent 9 beats of the WAIT byte.
It causes unwanted data shift and StartByte bypassed.

Now, TPM sends 8 beat exactly at the last byte of the address.