### PR TITLE
[otbn,dv] Explicitly check STATUS register in tl_intg test

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -57,9 +57,10 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
 
     super.initialize(csr_base_addr);
 
-    // Tell the CIP base code the field in the FATAL_ALERT_CAUSE register that it should expect to
-    // see get set in case of a TL fault.
+    // Tell the CIP base code the fields that it should expect to see, together with their expected
+    // values, in case of a TL fault.
     tl_intg_alert_fields[ral.fatal_alert_cause.bus_intg_violation] = 1;
+    tl_intg_alert_fields[ral.status.status] = otbn_pkg::StatusLocked;
   endfunction
 
 endclass


### PR DESCRIPTION
This makes sure that we read the STATUS register after injecting the
error and that we see the value we expected. (In practice, we seem to
do that anyway with very high probability, but it can't hurt to make
absolutely sure).

(Following up on a [suggestion from Weicai](https://github.com/lowRISC/opentitan/pull/8394#discussion_r717821245))