### PR TITLE
[dif/entropy_src] autogen entropy_src IRQ DIFs and integrate into src tree

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -75,7 +75,7 @@ index 5dc1286af..1e2dced96 100644
      simple_serial_process_packet();
    }
 diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
-index ef4443533..5629a15d8 100644
+index e894f1793..5629a15d8 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
 @@ -56,7 +56,6 @@ enum {
@@ -102,7 +102,7 @@ index ef4443533..5629a15d8 100644
  }
  
  /**
-@@ -148,32 +143,11 @@ void handler_irq_timer(void) {
+@@ -148,30 +143,11 @@ void handler_irq_timer(void) {
   * @param disable Set of peripherals to disable.
   */
  void sca_disable_peripherals(sca_peripherals_t disable) {
@@ -119,11 +119,9 @@ index ef4443533..5629a15d8 100644
 -                        CSRNG_CTRL_REG_OFFSET, CSRNG_CTRL_REG_RESVAL);
 -  }
 -  if (disable & kScaPeripheralEntropy) {
--    const dif_entropy_src_params_t entropy_params = {
--        .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
--    };
 -    dif_entropy_src_t entropy;
--    IGNORE_RESULT(dif_entropy_src_init(entropy_params, &entropy));
+-    IGNORE_RESULT(dif_entropy_src_init(
+-        mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy));
 -    IGNORE_RESULT(dif_entropy_src_disable(&entropy));
 -  }
 -
@@ -136,7 +134,7 @@ index ef4443533..5629a15d8 100644
    dif_clkmgr_t clkmgr;
    IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr));
  
-@@ -187,19 +161,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
+@@ -185,19 +161,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
          &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
          kDifClkmgrToggleDisabled));
    }
@@ -179,7 +177,7 @@ index 1a5fef16c..214e08151 100644
    CHECK_DIF_OK(
        dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index 1b1c8ae72..66635fb0a 100644
+index d9260ca0f..ff7e3ee0b 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
 @@ -207,7 +207,6 @@ aes_smoketest_lib = declare_dependency(

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -1,0 +1,191 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_entropy_src.h"
+
+#include "entropy_src_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool entropy_src_get_irq_bit_index(dif_entropy_src_irq_t irq,
+                                          bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifEntropySrcIrqEsEntropyValid:
+      *index_out = ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT;
+      break;
+    case kDifEntropySrcIrqEsHealthTestFailed:
+      *index_out = ENTROPY_SRC_INTR_STATE_ES_HEALTH_TEST_FAILED_BIT;
+      break;
+    case kDifEntropySrcIrqEsObserveFifoReady:
+      *index_out = ENTROPY_SRC_INTR_STATE_ES_OBSERVE_FIFO_READY_BIT;
+      break;
+    case kDifEntropySrcIrqEsFatalErr:
+      *index_out = ENTROPY_SRC_INTR_STATE_ES_FATAL_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_get_state(
+    const dif_entropy_src_t *entropy_src,
+    dif_entropy_src_irq_state_snapshot_t *snapshot) {
+  if (entropy_src == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(entropy_src->base_addr,
+                                 ENTROPY_SRC_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_is_pending(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq,
+    bool *is_pending) {
+  if (entropy_src == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!entropy_src_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg = mmio_region_read32(
+      entropy_src->base_addr, ENTROPY_SRC_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_acknowledge(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq) {
+  if (entropy_src == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!entropy_src_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(entropy_src->base_addr, ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_get_enabled(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq,
+    dif_toggle_t *state) {
+  if (entropy_src == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!entropy_src_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      entropy_src->base_addr, ENTROPY_SRC_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_set_enabled(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq,
+    dif_toggle_t state) {
+  if (entropy_src == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!entropy_src_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      entropy_src->base_addr, ENTROPY_SRC_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_force(const dif_entropy_src_t *entropy_src,
+                                       dif_entropy_src_irq_t irq) {
+  if (entropy_src == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!entropy_src_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(entropy_src->base_addr, ENTROPY_SRC_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_disable_all(
+    const dif_entropy_src_t *entropy_src,
+    dif_entropy_src_irq_enable_snapshot_t *snapshot) {
+  if (entropy_src == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(entropy_src->base_addr,
+                                   ENTROPY_SRC_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_restore_all(
+    const dif_entropy_src_t *entropy_src,
+    const dif_entropy_src_irq_enable_snapshot_t *snapshot) {
+  if (entropy_src == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
@@ -1,0 +1,184 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ENTROPY_SRC_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ENTROPY_SRC_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/entropy_src/doc/">ENTROPY_SRC</a> Device Interface
+ * Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to entropy_src.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_entropy_src {
+  /**
+   * The base address for the entropy_src hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_entropy_src_t;
+
+/**
+ * A entropy_src interrupt request type.
+ */
+typedef enum dif_entropy_src_irq {
+  /**
+   * Asserted when entropy source bits are available.
+   */
+  kDifEntropySrcIrqEsEntropyValid = 0,
+  /**
+   * Asserted when the alert count has been met.
+   */
+  kDifEntropySrcIrqEsHealthTestFailed = 1,
+  /**
+   * Asserted when the observe FIFO has filled to the threshold level.
+   */
+  kDifEntropySrcIrqEsObserveFifoReady = 2,
+  /**
+   * Asserted when a FIFO error occurs, or if an illegal state machine state is
+   * reached.
+   */
+  kDifEntropySrcIrqEsFatalErr = 3,
+} dif_entropy_src_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_entropy_src_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_entropy_src_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_entropy_src_irq_disable_all()` and `dif_entropy_src_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_entropy_src_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_get_state(
+    const dif_entropy_src_t *entropy_src,
+    dif_entropy_src_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_is_pending(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq,
+    bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_acknowledge(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_get_enabled(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq,
+    dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_set_enabled(
+    const dif_entropy_src_t *entropy_src, dif_entropy_src_irq_t irq,
+    dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_force(const dif_entropy_src_t *entropy_src,
+                                       dif_entropy_src_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_disable_all(
+    const dif_entropy_src_t *entropy_src,
+    dif_entropy_src_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_irq_restore_all(
+    const dif_entropy_src_t *entropy_src,
+    const dif_entropy_src_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ENTROPY_SRC_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -1,0 +1,320 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_entropy_src.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "entropy_src_regs.h"  // Generated.
+
+namespace dif_entropy_src_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class EntropySrcTest : public Test, public MmioTest {
+ protected:
+  dif_entropy_src_t entropy_src_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public EntropySrcTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_entropy_src_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_entropy_src_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_get_state(&entropy_src_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_entropy_src_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_entropy_src_irq_get_state(&entropy_src_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_entropy_src_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_entropy_src_irq_get_state(&entropy_src_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public EntropySrcTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_entropy_src_irq_is_pending(
+                nullptr, kDifEntropySrcIrqEsEntropyValid, &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_is_pending(
+                &entropy_src_, kDifEntropySrcIrqEsEntropyValid, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_is_pending(
+                nullptr, kDifEntropySrcIrqEsEntropyValid, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_entropy_src_irq_is_pending(
+                &entropy_src_, (dif_entropy_src_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT, true}});
+  EXPECT_EQ(dif_entropy_src_irq_is_pending(
+                &entropy_src_, kDifEntropySrcIrqEsEntropyValid, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_STATE_ES_FATAL_ERR_BIT, false}});
+  EXPECT_EQ(dif_entropy_src_irq_is_pending(
+                &entropy_src_, kDifEntropySrcIrqEsFatalErr, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public EntropySrcTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(
+      dif_entropy_src_irq_acknowledge(nullptr, kDifEntropySrcIrqEsEntropyValid),
+      kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_entropy_src_irq_acknowledge(nullptr, (dif_entropy_src_irq_t)32),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                 {{ENTROPY_SRC_INTR_STATE_ES_ENTROPY_VALID_BIT, true}});
+  EXPECT_EQ(dif_entropy_src_irq_acknowledge(&entropy_src_,
+                                            kDifEntropySrcIrqEsEntropyValid),
+            kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_STATE_REG_OFFSET,
+                 {{ENTROPY_SRC_INTR_STATE_ES_FATAL_ERR_BIT, true}});
+  EXPECT_EQ(dif_entropy_src_irq_acknowledge(&entropy_src_,
+                                            kDifEntropySrcIrqEsFatalErr),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public EntropySrcTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
+                nullptr, kDifEntropySrcIrqEsEntropyValid, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
+                &entropy_src_, kDifEntropySrcIrqEsEntropyValid, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
+                nullptr, kDifEntropySrcIrqEsEntropyValid, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
+                &entropy_src_, (dif_entropy_src_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_ENABLE_ES_ENTROPY_VALID_BIT, true}});
+  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
+                &entropy_src_, kDifEntropySrcIrqEsEntropyValid, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_ENABLE_ES_FATAL_ERR_BIT, false}});
+  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
+                &entropy_src_, kDifEntropySrcIrqEsFatalErr, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public EntropySrcTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_entropy_src_irq_set_enabled(
+                nullptr, kDifEntropySrcIrqEsEntropyValid, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_entropy_src_irq_set_enabled(
+                &entropy_src_, (dif_entropy_src_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_ENABLE_ES_ENTROPY_VALID_BIT, 0x1, true}});
+  EXPECT_EQ(dif_entropy_src_irq_set_enabled(
+                &entropy_src_, kDifEntropySrcIrqEsEntropyValid, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET,
+                {{ENTROPY_SRC_INTR_ENABLE_ES_FATAL_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(dif_entropy_src_irq_set_enabled(
+                &entropy_src_, kDifEntropySrcIrqEsFatalErr, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public EntropySrcTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_entropy_src_irq_force(nullptr, kDifEntropySrcIrqEsEntropyValid),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_entropy_src_irq_force(nullptr, (dif_entropy_src_irq_t)32),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_TEST_REG_OFFSET,
+                 {{ENTROPY_SRC_INTR_TEST_ES_ENTROPY_VALID_BIT, true}});
+  EXPECT_EQ(
+      dif_entropy_src_irq_force(&entropy_src_, kDifEntropySrcIrqEsEntropyValid),
+      kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_TEST_REG_OFFSET,
+                 {{ENTROPY_SRC_INTR_TEST_ES_FATAL_ERR_BIT, true}});
+  EXPECT_EQ(
+      dif_entropy_src_irq_force(&entropy_src_, kDifEntropySrcIrqEsFatalErr),
+      kDifOk);
+}
+
+class IrqDisableAllTest : public EntropySrcTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_entropy_src_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_entropy_src_irq_disable_all(nullptr, &irq_snapshot),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_entropy_src_irq_disable_all(&entropy_src_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_entropy_src_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_entropy_src_irq_disable_all(&entropy_src_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_entropy_src_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_entropy_src_irq_disable_all(&entropy_src_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public EntropySrcTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_entropy_src_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_entropy_src_irq_restore_all(nullptr, &irq_snapshot),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_restore_all(&entropy_src_, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_entropy_src_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_entropy_src_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_entropy_src_irq_restore_all(&entropy_src_, &irq_snapshot),
+            kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_entropy_src_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(ENTROPY_SRC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_entropy_src_irq_restore_all(&entropy_src_, &irq_snapshot),
+            kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_entropy_src_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,6 +2,20 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Autogen Entropy Source DIF library
+sw_lib_dif_autogen_entropy_src = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_entropy_src',
+    sources: [
+      hw_ip_entropy_src_reg_h,
+      'dif_entropy_src_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen I2C Controller DIF library
 sw_lib_dif_autogen_i2c = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -648,6 +648,7 @@ sw_lib_dif_entropy_src = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_entropy_src,
     ],
   )
 )
@@ -655,9 +656,11 @@ sw_lib_dif_entropy_src = declare_dependency(
 test('dif_entropy_src_unittest', executable(
     'dif_entropy_src_unittest',
     sources: [
-      hw_ip_entropy_src_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_entropy_src.c',
       'dif_entropy_src_unittest.cc',
+      'autogen/dif_entropy_src_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_entropy_src.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_entropy_src_autogen.c',
+      hw_ip_entropy_src_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/lib/testing/entropy_testutils.c
+++ b/sw/device/lib/testing/entropy_testutils.c
@@ -11,14 +11,12 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 static void setup_entropy_src(void) {
-  const dif_entropy_src_params_t params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
-  };
-  dif_entropy_src_t entropy;
-  CHECK(dif_entropy_src_init(params, &entropy) == kDifEntropySrcOk);
+  dif_entropy_src_t entropy_src;
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
 
   // Disable entropy for test purpose, as it has been turned on by ROM
-  CHECK(dif_entropy_src_disable(&entropy) == kDifEntropySrcOk);
+  CHECK_DIF_OK(dif_entropy_src_disable(&entropy_src));
 
   const dif_entropy_src_config_t config = {
       .mode = kDifEntropySrcModeLfsr,
@@ -38,7 +36,7 @@ static void setup_entropy_src(void) {
       .sample_rate = 2,
       .lfsr_seed = 0,
   };
-  CHECK(dif_entropy_src_configure(&entropy, config) == kDifEntropySrcOk);
+  CHECK_DIF_OK(dif_entropy_src_configure(&entropy_src, config));
 }
 
 static void setup_csrng(void) {

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -161,11 +161,9 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
                         CSRNG_CTRL_REG_OFFSET, CSRNG_CTRL_REG_RESVAL);
   }
   if (disable & kScaPeripheralEntropy) {
-    const dif_entropy_src_params_t entropy_params = {
-        .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
-    };
     dif_entropy_src_t entropy;
-    IGNORE_RESULT(dif_entropy_src_init(entropy_params, &entropy));
+    IGNORE_RESULT(dif_entropy_src_init(
+        mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy));
     IGNORE_RESULT(dif_entropy_src_disable(&entropy));
   }
 

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -21,14 +21,12 @@ const uint32_t kExpectedEntropyData[] = {
 };
 
 bool test_main() {
-  const dif_entropy_src_params_t params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR),
-  };
-  dif_entropy_src_t entropy;
-  CHECK(dif_entropy_src_init(params, &entropy) == kDifEntropySrcOk);
+  dif_entropy_src_t entropy_src;
+  CHECK_DIF_OK(dif_entropy_src_init(
+      mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));
 
   // Disable entropy for test purpose, as it has been turned on by ROM
-  CHECK(dif_entropy_src_disable(&entropy) == kDifEntropySrcOk);
+  CHECK_DIF_OK(dif_entropy_src_disable(&entropy_src));
 
   const dif_entropy_src_config_t config = {
       .mode = kDifEntropySrcModeLfsr,
@@ -48,13 +46,13 @@ bool test_main() {
       .sample_rate = 2,
       .lfsr_seed = 2,
   };
-  CHECK(dif_entropy_src_configure(&entropy, config) == kDifEntropySrcOk);
+  CHECK_DIF_OK(dif_entropy_src_configure(&entropy_src, config));
 
   uint32_t entropy_data[kEntropyDataNumWords];
   uint32_t result = 0;
   for (uint32_t i = 0; i < kEntropyDataNumWords; ++i) {
     // wait for entropy to become available
-    while (dif_entropy_src_read(&entropy, &entropy_data[i]) != kDifEntropySrcOk)
+    while (dif_entropy_src_read(&entropy_src, &entropy_data[i]) != kDifOk)
       ;
     LOG_INFO("received 0x%x, expectecd 0x%x", entropy_data[i],
              kExpectedEntropyData[i]);


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "entropy_src".