### PR TITLE
[clkmgr] Correctly handle measurement control CDC

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -302,6 +302,7 @@
       regwen: "MEASURE_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_${src}_i",
       fields: [
         {
           bits: "0",

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -70,6 +70,42 @@
 );
 
   ////////////////////////////////////////////////////
+  // Divided clocks
+  ////////////////////////////////////////////////////
+
+  lc_tx_t step_down_req;
+  logic [${len(clocks.derived_srcs)-1}:0] step_down_acks;
+
+% for src_name in clocks.derived_srcs:
+  logic clk_${src_name}_i;
+% endfor
+
+% for src in clocks.derived_srcs.values():
+
+  lc_tx_t ${src.name}_div_scanmode;
+  prim_lc_sync #(
+    .NumCopies(1),
+    .AsyncOn(0)
+  ) u_${src.name}_div_scanmode_sync  (
+    .clk_i(1'b0),  //unused
+    .rst_ni(1'b1), //unused
+    .lc_en_i(scanmode_i),
+    .lc_en_o(${src.name}_div_scanmode)
+  );
+
+  prim_clock_div #(
+    .Divisor(${src.div})
+  ) u_no_scan_${src.name}_div (
+    .clk_i(clk_${src.src.name}_i),
+    .rst_ni(rst_${src.src.name}_ni),
+    .step_down_req_i(step_down_req == lc_ctrl_pkg::On),
+    .step_down_ack_o(step_down_acks[${loop.index}]),
+    .test_en_i(${src.name}_div_scanmode == lc_ctrl_pkg::On),
+    .clk_o(clk_${src.name}_i)
+  );
+% endfor
+
+  ////////////////////////////////////////////////////
   // Register Interface
   ////////////////////////////////////////////////////
 
@@ -80,6 +116,10 @@
   clkmgr_reg_top u_reg (
     .clk_i,
     .rst_ni,
+% for src in typed_clocks.rg_srcs:
+    .clk_${src}_i,
+    .rst_${src}_ni,
+% endfor
     .tl_i,
     .tl_o,
     .reg2hw,
@@ -121,42 +161,6 @@
       .alert_tx_o    ( alert_tx_o[i] )
     );
   end
-
-  ////////////////////////////////////////////////////
-  // Divided clocks
-  ////////////////////////////////////////////////////
-
-  lc_tx_t step_down_req;
-  logic [${len(clocks.derived_srcs)-1}:0] step_down_acks;
-
-% for src_name in clocks.derived_srcs:
-  logic clk_${src_name}_i;
-% endfor
-
-% for src in clocks.derived_srcs.values():
-
-  lc_tx_t ${src.name}_div_scanmode;
-  prim_lc_sync #(
-    .NumCopies(1),
-    .AsyncOn(0)
-  ) u_${src.name}_div_scanmode_sync  (
-    .clk_i(1'b0),  //unused
-    .rst_ni(1'b1), //unused
-    .lc_en_i(scanmode_i),
-    .lc_en_o(${src.name}_div_scanmode)
-  );
-
-  prim_clock_div #(
-    .Divisor(${src.div})
-  ) u_no_scan_${src.name}_div (
-    .clk_i(clk_${src.src.name}_i),
-    .rst_ni(rst_${src.src.name}_ni),
-    .step_down_req_i(step_down_req == lc_ctrl_pkg::On),
-    .step_down_ack_o(step_down_acks[${loop.index}]),
-    .test_en_i(${src.name}_div_scanmode == lc_ctrl_pkg::On),
-    .clk_o(clk_${src.name}_i)
-  );
-% endfor
 
   ////////////////////////////////////////////////////
   // Clock bypass request
@@ -297,7 +301,6 @@
 
 <% aon_freq = clocks.all_srcs['aon'].freq %>\
 % for src in typed_clocks.rg_srcs:
-  logic ${src}_meas_valid;
   logic ${src}_fast_err;
   logic ${src}_slow_err;
   <%
@@ -315,15 +318,23 @@
     .en_i(clk_${src}_en & reg2hw.${src}_measure_ctrl.en.q),
     .max_cnt(reg2hw.${src}_measure_ctrl.max_thresh.q),
     .min_cnt(reg2hw.${src}_measure_ctrl.min_thresh.q),
-    .valid_o(${src}_meas_valid),
+    .valid_o(),
     .fast_o(${src}_fast_err),
     .slow_o(${src}_slow_err)
   );
 
+  logic synced_${src}_err;
+  prim_pulse_sync u_${src}_err_sync (
+    .clk_src_i(clk_${src}_i),
+    .rst_src_ni(rst_${src}_ni),
+    .src_pulse_i(${src}_fast_err | ${src}_slow_err),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(synced_${src}_err)
+  );
+
   assign hw2reg.recov_err_code.${src}_measure_err.d = 1'b1;
-  assign hw2reg.recov_err_code.${src}_measure_err.de =
-    ${src}_meas_valid &
-    (${src}_fast_err | ${src}_slow_err);
+  assign hw2reg.recov_err_code.${src}_measure_err.de = synced_${src}_err;
 
 % endfor
 

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -71,9 +71,11 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
 
     // Set the thresholds to get no error.
     foreach (expected_ratios[clk]) begin
-      enable_frequency_measurement(clk, expected_ratios[clk] - 1, expected_ratios[clk] + 1);
+      enable_frequency_measurement(clk, expected_ratios[clk] - 2, expected_ratios[clk] + 2);
     end
-    cfg.aon_clk_rst_vif.wait_clks(4);
+
+    // Check over a period of many clocks to ensure no errors
+    cfg.aon_clk_rst_vif.wait_clks(10);
     csr_rd_check(.ptr(ral.recov_err_code), .compare_value('0),
                  .err_msg("Expected no measurement errors"));
     // And clear errors.

--- a/hw/ip/prim/rtl/prim_clock_meas.sv
+++ b/hw/ip/prim/rtl/prim_clock_meas.sv
@@ -118,8 +118,8 @@ module prim_clock_meas #(
   end
 
   assign valid_o = en_i & valid & |cnt;
-  assign fast_o = valid & ((cnt > max_cnt) | cnt_ovfl);
-  assign slow_o = valid & (cnt < min_cnt);
+  assign fast_o = valid_o & ((cnt > max_cnt) | cnt_ovfl);
+  assign slow_o = valid_o & (cnt < min_cnt);
 
   //////////////////////////
   // Assertions

--- a/hw/ip/prim/rtl/prim_reg_cdc.sv
+++ b/hw/ip/prim/rtl/prim_reg_cdc.sv
@@ -139,16 +139,16 @@ module prim_reg_cdc #(
 
   `ifdef SIMULATION
     logic async_flag;
-    always_ff @(posedge clk_dst_i or
-      negedge rst_src_ni or negedge rst_dst_ni) begin
-      if (!rst_src_ni | !rst_dst_ni) begin
+    always_ff @(posedge clk_src_i or negedge rst_src_ni) begin
+      if (!rst_src_ni) begin
         async_flag <= '0;
       end else if (src_req) begin
         async_flag <= 1'b1;
       end else if (dst_req) begin
-        async_flag <= 1'b0;
+        async_flag <= '0;
       end
     end
+
     `ASSERT(ReqTimeout_A, $rose(async_flag) |-> strong(##[0:3] dst_req), clk_dst_i, !rst_dst_ni)
   `endif
 

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -383,6 +383,7 @@
       regwen: "MEASURE_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_io_i",
       fields: [
         {
           bits: "0",
@@ -422,6 +423,7 @@
       regwen: "MEASURE_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_io_div2_i",
       fields: [
         {
           bits: "0",
@@ -461,6 +463,7 @@
       regwen: "MEASURE_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_io_div4_i",
       fields: [
         {
           bits: "0",
@@ -500,6 +503,7 @@
       regwen: "MEASURE_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_main_i",
       fields: [
         {
           bits: "0",
@@ -539,6 +543,7 @@
       regwen: "MEASURE_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      async: "clk_usb_i",
       fields: [
         {
           bits: "0",

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -76,59 +76,6 @@
 );
 
   ////////////////////////////////////////////////////
-  // Register Interface
-  ////////////////////////////////////////////////////
-
-  logic [NumAlerts-1:0] alert_test, alerts;
-  clkmgr_reg_pkg::clkmgr_reg2hw_t reg2hw;
-  clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
-
-  clkmgr_reg_top u_reg (
-    .clk_i,
-    .rst_ni,
-    .tl_i,
-    .tl_o,
-    .reg2hw,
-    .hw2reg,
-    .intg_err_o(hw2reg.fatal_err_code.de),
-    .devmode_i(1'b1)
-  );
-  assign hw2reg.fatal_err_code.d = 1'b1;
-
-
-  ////////////////////////////////////////////////////
-  // Alerts
-  ////////////////////////////////////////////////////
-
-  assign alert_test = {
-    reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe,
-    reg2hw.alert_test.recov_fault.q & reg2hw.alert_test.recov_fault.qe
-  };
-
-  assign alerts = {
-    |reg2hw.fatal_err_code,
-    |reg2hw.recov_err_code
-  };
-
-  localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};
-
-  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
-    prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[i]),
-      .IsFatal(AlertFatal[i])
-    ) u_prim_alert_sender (
-      .clk_i,
-      .rst_ni,
-      .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[i]     ),
-      .alert_ack_o   (               ),
-      .alert_state_o (               ),
-      .alert_rx_i    ( alert_rx_i[i] ),
-      .alert_tx_o    ( alert_tx_o[i] )
-    );
-  end
-
-  ////////////////////////////////////////////////////
   // Divided clocks
   ////////////////////////////////////////////////////
 
@@ -182,6 +129,69 @@
     .test_en_i(io_div4_div_scanmode == lc_ctrl_pkg::On),
     .clk_o(clk_io_div4_i)
   );
+
+  ////////////////////////////////////////////////////
+  // Register Interface
+  ////////////////////////////////////////////////////
+
+  logic [NumAlerts-1:0] alert_test, alerts;
+  clkmgr_reg_pkg::clkmgr_reg2hw_t reg2hw;
+  clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
+
+  clkmgr_reg_top u_reg (
+    .clk_i,
+    .rst_ni,
+    .clk_io_i,
+    .rst_io_ni,
+    .clk_io_div2_i,
+    .rst_io_div2_ni,
+    .clk_io_div4_i,
+    .rst_io_div4_ni,
+    .clk_main_i,
+    .rst_main_ni,
+    .clk_usb_i,
+    .rst_usb_ni,
+    .tl_i,
+    .tl_o,
+    .reg2hw,
+    .hw2reg,
+    .intg_err_o(hw2reg.fatal_err_code.de),
+    .devmode_i(1'b1)
+  );
+  assign hw2reg.fatal_err_code.d = 1'b1;
+
+
+  ////////////////////////////////////////////////////
+  // Alerts
+  ////////////////////////////////////////////////////
+
+  assign alert_test = {
+    reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe,
+    reg2hw.alert_test.recov_fault.q & reg2hw.alert_test.recov_fault.qe
+  };
+
+  assign alerts = {
+    |reg2hw.fatal_err_code,
+    |reg2hw.recov_err_code
+  };
+
+  localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};
+
+  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
+    prim_alert_sender #(
+      .AsyncOn(AlertAsyncOn[i]),
+      .IsFatal(AlertFatal[i])
+    ) u_prim_alert_sender (
+      .clk_i,
+      .rst_ni,
+      .alert_test_i  ( alert_test[i] ),
+      .alert_req_i   ( alerts[i]     ),
+      .alert_ack_o   (               ),
+      .alert_state_o (               ),
+      .alert_rx_i    ( alert_rx_i[i] ),
+      .alert_tx_o    ( alert_tx_o[i] )
+    );
+  end
 
   ////////////////////////////////////////////////////
   // Clock bypass request
@@ -434,7 +444,6 @@
   // Clock Measurement for the roots
   ////////////////////////////////////////////////////
 
-  logic io_meas_valid;
   logic io_fast_err;
   logic io_slow_err;
     prim_clock_meas #(
@@ -448,17 +457,24 @@
     .en_i(clk_io_en & reg2hw.io_measure_ctrl.en.q),
     .max_cnt(reg2hw.io_measure_ctrl.max_thresh.q),
     .min_cnt(reg2hw.io_measure_ctrl.min_thresh.q),
-    .valid_o(io_meas_valid),
+    .valid_o(),
     .fast_o(io_fast_err),
     .slow_o(io_slow_err)
   );
 
-  assign hw2reg.recov_err_code.io_measure_err.d = 1'b1;
-  assign hw2reg.recov_err_code.io_measure_err.de =
-    io_meas_valid &
-    (io_fast_err | io_slow_err);
+  logic synced_io_err;
+  prim_pulse_sync u_io_err_sync (
+    .clk_src_i(clk_io_i),
+    .rst_src_ni(rst_io_ni),
+    .src_pulse_i(io_fast_err | io_slow_err),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(synced_io_err)
+  );
 
-  logic io_div2_meas_valid;
+  assign hw2reg.recov_err_code.io_measure_err.d = 1'b1;
+  assign hw2reg.recov_err_code.io_measure_err.de = synced_io_err;
+
   logic io_div2_fast_err;
   logic io_div2_slow_err;
     prim_clock_meas #(
@@ -472,17 +488,24 @@
     .en_i(clk_io_div2_en & reg2hw.io_div2_measure_ctrl.en.q),
     .max_cnt(reg2hw.io_div2_measure_ctrl.max_thresh.q),
     .min_cnt(reg2hw.io_div2_measure_ctrl.min_thresh.q),
-    .valid_o(io_div2_meas_valid),
+    .valid_o(),
     .fast_o(io_div2_fast_err),
     .slow_o(io_div2_slow_err)
   );
 
-  assign hw2reg.recov_err_code.io_div2_measure_err.d = 1'b1;
-  assign hw2reg.recov_err_code.io_div2_measure_err.de =
-    io_div2_meas_valid &
-    (io_div2_fast_err | io_div2_slow_err);
+  logic synced_io_div2_err;
+  prim_pulse_sync u_io_div2_err_sync (
+    .clk_src_i(clk_io_div2_i),
+    .rst_src_ni(rst_io_div2_ni),
+    .src_pulse_i(io_div2_fast_err | io_div2_slow_err),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(synced_io_div2_err)
+  );
 
-  logic io_div4_meas_valid;
+  assign hw2reg.recov_err_code.io_div2_measure_err.d = 1'b1;
+  assign hw2reg.recov_err_code.io_div2_measure_err.de = synced_io_div2_err;
+
   logic io_div4_fast_err;
   logic io_div4_slow_err;
     prim_clock_meas #(
@@ -496,17 +519,24 @@
     .en_i(clk_io_div4_en & reg2hw.io_div4_measure_ctrl.en.q),
     .max_cnt(reg2hw.io_div4_measure_ctrl.max_thresh.q),
     .min_cnt(reg2hw.io_div4_measure_ctrl.min_thresh.q),
-    .valid_o(io_div4_meas_valid),
+    .valid_o(),
     .fast_o(io_div4_fast_err),
     .slow_o(io_div4_slow_err)
   );
 
-  assign hw2reg.recov_err_code.io_div4_measure_err.d = 1'b1;
-  assign hw2reg.recov_err_code.io_div4_measure_err.de =
-    io_div4_meas_valid &
-    (io_div4_fast_err | io_div4_slow_err);
+  logic synced_io_div4_err;
+  prim_pulse_sync u_io_div4_err_sync (
+    .clk_src_i(clk_io_div4_i),
+    .rst_src_ni(rst_io_div4_ni),
+    .src_pulse_i(io_div4_fast_err | io_div4_slow_err),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(synced_io_div4_err)
+  );
 
-  logic main_meas_valid;
+  assign hw2reg.recov_err_code.io_div4_measure_err.d = 1'b1;
+  assign hw2reg.recov_err_code.io_div4_measure_err.de = synced_io_div4_err;
+
   logic main_fast_err;
   logic main_slow_err;
     prim_clock_meas #(
@@ -520,17 +550,24 @@
     .en_i(clk_main_en & reg2hw.main_measure_ctrl.en.q),
     .max_cnt(reg2hw.main_measure_ctrl.max_thresh.q),
     .min_cnt(reg2hw.main_measure_ctrl.min_thresh.q),
-    .valid_o(main_meas_valid),
+    .valid_o(),
     .fast_o(main_fast_err),
     .slow_o(main_slow_err)
   );
 
-  assign hw2reg.recov_err_code.main_measure_err.d = 1'b1;
-  assign hw2reg.recov_err_code.main_measure_err.de =
-    main_meas_valid &
-    (main_fast_err | main_slow_err);
+  logic synced_main_err;
+  prim_pulse_sync u_main_err_sync (
+    .clk_src_i(clk_main_i),
+    .rst_src_ni(rst_main_ni),
+    .src_pulse_i(main_fast_err | main_slow_err),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(synced_main_err)
+  );
 
-  logic usb_meas_valid;
+  assign hw2reg.recov_err_code.main_measure_err.d = 1'b1;
+  assign hw2reg.recov_err_code.main_measure_err.de = synced_main_err;
+
   logic usb_fast_err;
   logic usb_slow_err;
     prim_clock_meas #(
@@ -544,15 +581,23 @@
     .en_i(clk_usb_en & reg2hw.usb_measure_ctrl.en.q),
     .max_cnt(reg2hw.usb_measure_ctrl.max_thresh.q),
     .min_cnt(reg2hw.usb_measure_ctrl.min_thresh.q),
-    .valid_o(usb_meas_valid),
+    .valid_o(),
     .fast_o(usb_fast_err),
     .slow_o(usb_slow_err)
   );
 
+  logic synced_usb_err;
+  prim_pulse_sync u_usb_err_sync (
+    .clk_src_i(clk_usb_i),
+    .rst_src_ni(rst_usb_ni),
+    .src_pulse_i(usb_fast_err | usb_slow_err),
+    .clk_dst_i(clk_i),
+    .rst_dst_ni(rst_ni),
+    .dst_pulse_o(synced_usb_err)
+  );
+
   assign hw2reg.recov_err_code.usb_measure_err.d = 1'b1;
-  assign hw2reg.recov_err_code.usb_measure_err.de =
-    usb_meas_valid &
-    (usb_fast_err | usb_slow_err);
+  assign hw2reg.recov_err_code.usb_measure_err.de = synced_usb_err;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -88,6 +88,7 @@
       // the ast group is used to represent input clocks to the top
       { name: "ast",     src:"ext", sw_cg: "no"                   }
       // the powerup group is used exclusively by clk/pwr/rstmgr/pinmux
+      { name: "ast",     src:"ext", sw_cg: "no"                   }
       { name: "powerup", src:"top", sw_cg: "no"                   }
       { name: "trans",   src:"top", sw_cg: "hint", unique: "yes", }
       { name: "infra",   src:"top", sw_cg: "no",                  }


### PR DESCRIPTION
[clkmgr] Fix measurement control CDC
- Fixes #8405
- Add measurement control registers to default CDC handling
- Make sure error indications can be caught