### PR TITLE
[ci] Avoid installing/building/testing Rust in CI

### DIFF
--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -136,10 +136,5 @@ sudo chmod 777 /tools/verible
 tar -C /tools/verible -xf "$verible_tar" --strip-components=1
 export PATH=/tools/verible/bin:$PATH
 
-# Install Rust
-sw/vendor/rustup/rustup-init.sh -y \
-    --default-toolchain "${RUST_VERSION}"
-export PATH=$HOME/.cargo/bin:$PATH
-
 # Propagate PATH changes to all subsequent steps of the job
 echo "##vso[task.setvariable variable=PATH]$PATH"

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -95,10 +95,6 @@ RUN groupadd dev \
 # All subsequent steps are performed as user.
 USER dev
 
-# Install Rust plus packages.
-COPY sw/vendor/rustup/rustup-init.sh /tmp/rustup-init.sh
-RUN /tmp/rustup-init.sh -y --default-toolchain ${RUST_VERSION}
-
 # Install Python plus packages.
 #
 # Explicitly updating pip and setuptools is required to have these tools


### PR DESCRIPTION
rustup, our way to installing Rust, is currently broken, breaking all CI
jobs.

Avoid installing Rust until the issue is fixed. Software builds should
continue, but skip the Rust parts.

https://github.com/rust-lang/rustup/issues/2855