### PR TITLE
[dif_sram_ctrl] Introduce API for chip_sram_scrambled_access testing

### DIFF
--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -169,3 +169,17 @@ sw_lib_dif_autogen_uart = declare_dependency(
     ],
   )
 )
+
+# Autogen SRAM Controller DIF library
+sw_lib_dif_autogen_sram_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_sram_ctrl',
+    sources: [
+      hw_ip_sram_ctrl_reg_h,
+      'dif_sram_ctrl_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)

--- a/sw/device/lib/dif/dif_sram_ctrl.c
+++ b/sw/device/lib/dif/dif_sram_ctrl.c
@@ -4,4 +4,68 @@
 
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
 
-// TODO: implement!
+#include "sram_ctrl_regs.h"  // Generated.
+
+/**
+ * Obtains the lock state of the "Control" register.
+ *
+ * When locked - new scrambling key and SRAM pseudo-random data overwriting
+ * requests are not available.
+ */
+static dif_toggle_t sram_ctrl_lock_state(const dif_sram_ctrl_t *sram_ctrl) {
+  return mmio_region_read32(sram_ctrl->base_addr,
+                            SRAM_CTRL_CTRL_REGWEN_REG_OFFSET)
+             ? kDifToggleDisabled
+             : kDifToggleEnabled;
+}
+
+/**
+ * Obtains the SRAM Controller statues.
+ *
+ * `dif_sram_ctrl_status_t` can be used to query individual flags.
+ */
+static uint32_t sram_ctrl_get_status(const dif_sram_ctrl_t *sram_ctrl) {
+  return mmio_region_read32(sram_ctrl->base_addr, SRAM_CTRL_STATUS_REG_OFFSET);
+}
+
+dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
+                                dif_sram_ctrl_t *sram_ctrl) {
+  if (sram_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  sram_ctrl->base_addr = base_addr;
+
+  return kDifOk;
+}
+
+dif_result_t dif_sram_ctrl_request_new_key(const dif_sram_ctrl_t *sram_ctrl) {
+  if (sram_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  if (sram_ctrl_lock_state(sram_ctrl) == kDifToggleEnabled) {
+    return kDifLocked;
+  }
+
+  uint32_t reg =
+      bitfield_bit32_write(0, SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, true);
+  mmio_region_write32(sram_ctrl->base_addr, SRAM_CTRL_CTRL_REG_OFFSET, reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sram_ctrl_get_status(const dif_sram_ctrl_t *sram_ctrl,
+                                      dif_sram_ctrl_status_bitfield_t *status) {
+  if (sram_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  if (status == NULL) {
+    return kDifBadArg;
+  }
+
+  *status = sram_ctrl_get_status(sram_ctrl);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_sram_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sram_ctrl_unittest.cc
@@ -1,0 +1,85 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_sram_ctrl.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sram_ctrl_regs.h"  // Generated.
+
+namespace dif_sram_ctrl_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class SramCtrlTest : public Test, public MmioTest {
+ protected:
+  dif_sram_ctrl_t sram_ctrl_ = {.base_addr = dev().region()};
+};
+
+class InitTest : public SramCtrlTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_sram_ctrl_init(dev().region(), nullptr), kDifBadArg);
+}
+
+class RequestNewKeyTest : public SramCtrlTest {};
+
+TEST_F(RequestNewKeyTest, NullArgs) {
+  EXPECT_EQ(dif_sram_ctrl_request_new_key(nullptr), kDifBadArg);
+}
+
+TEST_F(RequestNewKeyTest, Locked) {
+  EXPECT_READ32(SRAM_CTRL_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_sram_ctrl_request_new_key(&sram_ctrl_), kDifLocked);
+}
+
+TEST_F(RequestNewKeyTest, Success) {
+  EXPECT_READ32(SRAM_CTRL_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(SRAM_CTRL_CTRL_REG_OFFSET,
+                 {{SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, true},
+                  {SRAM_CTRL_CTRL_INIT_BIT, false}});
+  EXPECT_EQ(dif_sram_ctrl_request_new_key(&sram_ctrl_), kDifOk);
+}
+
+class GetStatusTest : public SramCtrlTest {};
+
+TEST_F(GetStatusTest, NullArgs) {
+  dif_sram_ctrl_status_bitfield_t status;
+  EXPECT_EQ(dif_sram_ctrl_get_status(&sram_ctrl_, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_sram_ctrl_get_status(nullptr, &status), kDifBadArg);
+  EXPECT_EQ(dif_sram_ctrl_get_status(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(GetStatusTest, SuccessSome) {
+  EXPECT_READ32(SRAM_CTRL_STATUS_REG_OFFSET, 0xA5A5A5A5);
+
+  dif_sram_ctrl_status_bitfield_t status = 0;
+  EXPECT_EQ(dif_sram_ctrl_get_status(&sram_ctrl_, &status), kDifOk);
+  EXPECT_EQ(status, 0xA5A5A5A5);
+}
+
+TEST_F(GetStatusTest, SuccessAll) {
+  EXPECT_READ32(SRAM_CTRL_STATUS_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+
+  dif_sram_ctrl_status_bitfield_t status = 0;
+  EXPECT_EQ(dif_sram_ctrl_get_status(&sram_ctrl_, &status), kDifOk);
+  EXPECT_EQ(status, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(GetStatusTest, SuccessNone) {
+  EXPECT_READ32(SRAM_CTRL_STATUS_REG_OFFSET, 0);
+
+  dif_sram_ctrl_status_bitfield_t status = std::numeric_limits<uint32_t>::max();
+  EXPECT_EQ(dif_sram_ctrl_get_status(&sram_ctrl_, &status), kDifOk);
+  EXPECT_EQ(status, 0);
+}
+
+}  // namespace
+}  // namespace dif_sram_ctrl_autogen_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -755,6 +755,7 @@ sw_lib_dif_sram_ctrl = declare_dependency(
   link_with: static_library(
     'sw_lib_dif_sram_ctrl',
     sources: [
+      hw_ip_sram_ctrl_reg_h,
       'dif_sram_ctrl.c',
     ],
     dependencies: [sw_lib_mmio],

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -761,3 +761,23 @@ sw_lib_dif_sram_ctrl = declare_dependency(
     dependencies: [sw_lib_mmio],
   )
 )
+
+test('dif_sram_ctrl_unittest', executable(
+    'dif_sram_ctrl_unittest',
+    sources: [
+      'dif_sram_ctrl_unittest.cc',
+      'autogen/dif_sram_ctrl_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_sram_ctrl.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c',
+      hw_ip_sram_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO'],
+    cpp_args: ['-DMOCK_MMIO'],
+  ),
+  suite: 'dif',
+)


### PR DESCRIPTION
# Introduction

This PR aims to implement all API required for the `chip_sram_scrambled_access` chip level test.

# Future work

It is expected that the rest of the API described in the header will come in follow-up PRs, and will be prioritized for the chip level test use-cases.