### PR TITLE
[topgen] Return a list as annotated

### DIFF
--- a/util/topgen/resets.py
+++ b/util/topgen/resets.py
@@ -111,7 +111,7 @@ class Resets:
             if reset.rst_type != 'ext':
                 clocks[reset.clock.name] = 1
 
-        return clocks.keys()
+        return list(clocks)
 
     def get_generated_resets(self) -> list:
         '''Get generated resets and return reset object


### PR DESCRIPTION
The `.keys()` method returns a dict_keys object, not a list, as
annotated in the function header. Make the function actually return a
list.