### PR TITLE
[doc] Add top_earlgrey-specific IP blocks to dashboard

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -37,18 +37,21 @@ Finally, we provide the same set of information for all available [top level des
   * [DV document](https://ibex-core.readthedocs.io/en/latest/03_reference/verification.html)
   * DV simulation results, with coverage (nightly) (TBD)
 
-## Top level designs
+## Earl Grey toplevel design
 
-* `top_earlgrey`
-  * [Design specification]({{< relref "hw/top_earlgrey/doc" >}})
-  * [DV document]({{< relref "hw/top_earlgrey/doc/dv" >}})
-  * [DV simulation results, with coverage (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/latest/results.html)
-  * [Connectivity results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/conn/jaspergold/latest/results.html)
-  * [AscentLint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/latest/results.html)
-  * [Verilator lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/latest/results.html)
-  * [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/results.html)
-  * [DV Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/lint/veriblelint/latest/results.html)
-  * [Synthesis results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html)
+* [Design specification]({{< relref "hw/top_earlgrey/doc" >}})
+* [DV document]({{< relref "hw/top_earlgrey/doc/dv" >}})
+* [DV simulation results, with coverage (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/latest/results.html)
+* [Connectivity results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/conn/jaspergold/latest/results.html)
+* [AscentLint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/ascentlint/latest/results.html)
+* [Verilator lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/verilator/latest/results.html)
+* [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/results.html)
+* [DV Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/lint/veriblelint/latest/results.html)
+* [Synthesis results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html)
+
+### Earl Grey-specific comportable IPs
+
+{{< dashboard "top_earlgrey" >}}
 
 ## Hardware documentation overview
 

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -93,7 +93,9 @@ config = {
     "dashboard_definitions": {
         "comportable": [
             "hw/ip",
-            "hw/top_earlgrey/ip/sensor_ctrl"
+        ],
+        "top_earlgrey": [
+            "hw/top_earlgrey/ip",
         ],
     },
 


### PR DESCRIPTION
Add a table with IP status under the top_earlgrey heading for all IP
blocks which are specific to top_earlgrey.