### PR TITLE
[dif/keymgr] Autogen keymgr IRQ DIFs and integrate into src tree.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_keymgr.h"
+
+#include "keymgr_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool keymgr_get_irq_bit_index(dif_keymgr_irq_t irq,
+                                     bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifKeymgrIrqOpDone:
+      *index_out = KEYMGR_INTR_STATE_OP_DONE_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_get_state(
+    const dif_keymgr_t *keymgr, dif_keymgr_irq_state_snapshot_t *snapshot) {
+  if (keymgr == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_is_pending(const dif_keymgr_t *keymgr,
+                                       dif_keymgr_irq_t irq, bool *is_pending) {
+  if (keymgr == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!keymgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_acknowledge(const dif_keymgr_t *keymgr,
+                                        dif_keymgr_irq_t irq) {
+  if (keymgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!keymgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(keymgr->base_addr, KEYMGR_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_get_enabled(const dif_keymgr_t *keymgr,
+                                        dif_keymgr_irq_t irq,
+                                        dif_toggle_t *state) {
+  if (keymgr == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!keymgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_set_enabled(const dif_keymgr_t *keymgr,
+                                        dif_keymgr_irq_t irq,
+                                        dif_toggle_t state) {
+  if (keymgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!keymgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(keymgr->base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_force(const dif_keymgr_t *keymgr,
+                                  dif_keymgr_irq_t irq) {
+  if (keymgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!keymgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(keymgr->base_addr, KEYMGR_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_disable_all(
+    const dif_keymgr_t *keymgr, dif_keymgr_irq_enable_snapshot_t *snapshot) {
+  if (keymgr == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(keymgr->base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(keymgr->base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_restore_all(
+    const dif_keymgr_t *keymgr,
+    const dif_keymgr_irq_enable_snapshot_t *snapshot) {
+  if (keymgr == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(keymgr->base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
@@ -1,0 +1,167 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_KEYMGR_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_KEYMGR_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/keymgr/doc/">KEYMGR</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to keymgr.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_keymgr {
+  /**
+   * The base address for the keymgr hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_keymgr_t;
+
+/**
+ * A keymgr interrupt request type.
+ */
+typedef enum dif_keymgr_irq {
+  /**
+   * Operation complete
+   */
+  kDifKeymgrIrqOpDone = 0,
+} dif_keymgr_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_keymgr_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_keymgr_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_keymgr_irq_disable_all()` and `dif_keymgr_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_keymgr_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_get_state(
+    const dif_keymgr_t *keymgr, dif_keymgr_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_is_pending(const dif_keymgr_t *keymgr,
+                                       dif_keymgr_irq_t irq, bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_acknowledge(const dif_keymgr_t *keymgr,
+                                        dif_keymgr_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_get_enabled(const dif_keymgr_t *keymgr,
+                                        dif_keymgr_irq_t irq,
+                                        dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_set_enabled(const dif_keymgr_t *keymgr,
+                                        dif_keymgr_irq_t irq,
+                                        dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param keymgr A keymgr handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_force(const dif_keymgr_t *keymgr,
+                                  dif_keymgr_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param keymgr A keymgr handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_disable_all(
+    const dif_keymgr_t *keymgr, dif_keymgr_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param keymgr A keymgr handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_irq_restore_all(
+    const dif_keymgr_t *keymgr,
+    const dif_keymgr_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_KEYMGR_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -1,0 +1,295 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_keymgr.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "keymgr_regs.h"  // Generated.
+
+namespace dif_keymgr_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class KeymgrTest : public Test, public MmioTest {
+ protected:
+  dif_keymgr_t keymgr_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public KeymgrTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_keymgr_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_keymgr_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_get_state(&keymgr_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_keymgr_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KEYMGR_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_keymgr_irq_get_state(&keymgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_keymgr_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KEYMGR_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_keymgr_irq_get_state(&keymgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public KeymgrTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_keymgr_irq_is_pending(nullptr, kDifKeymgrIrqOpDone, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_is_pending(&keymgr_, kDifKeymgrIrqOpDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_is_pending(nullptr, kDifKeymgrIrqOpDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(
+      dif_keymgr_irq_is_pending(&keymgr_, (dif_keymgr_irq_t)32, &is_pending),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(KEYMGR_INTR_STATE_REG_OFFSET,
+                {{KEYMGR_INTR_STATE_OP_DONE_BIT, true}});
+  EXPECT_EQ(
+      dif_keymgr_irq_is_pending(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
+      kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(KEYMGR_INTR_STATE_REG_OFFSET,
+                {{KEYMGR_INTR_STATE_OP_DONE_BIT, false}});
+  EXPECT_EQ(
+      dif_keymgr_irq_is_pending(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
+      kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public KeymgrTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_keymgr_irq_acknowledge(nullptr, kDifKeymgrIrqOpDone),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_keymgr_irq_acknowledge(nullptr, (dif_keymgr_irq_t)32),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(KEYMGR_INTR_STATE_REG_OFFSET,
+                 {{KEYMGR_INTR_STATE_OP_DONE_BIT, true}});
+  EXPECT_EQ(dif_keymgr_irq_acknowledge(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(KEYMGR_INTR_STATE_REG_OFFSET,
+                 {{KEYMGR_INTR_STATE_OP_DONE_BIT, true}});
+  EXPECT_EQ(dif_keymgr_irq_acknowledge(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
+}
+
+class IrqGetEnabledTest : public KeymgrTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_keymgr_irq_get_enabled(nullptr, kDifKeymgrIrqOpDone, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_get_enabled(&keymgr_, kDifKeymgrIrqOpDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_get_enabled(nullptr, kDifKeymgrIrqOpDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_keymgr_irq_get_enabled(&keymgr_, (dif_keymgr_irq_t)32, &irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                {{KEYMGR_INTR_ENABLE_OP_DONE_BIT, true}});
+  EXPECT_EQ(
+      dif_keymgr_irq_get_enabled(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                {{KEYMGR_INTR_ENABLE_OP_DONE_BIT, false}});
+  EXPECT_EQ(
+      dif_keymgr_irq_get_enabled(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public KeymgrTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_keymgr_irq_set_enabled(nullptr, kDifKeymgrIrqOpDone, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(
+      dif_keymgr_irq_set_enabled(&keymgr_, (dif_keymgr_irq_t)32, irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                {{KEYMGR_INTR_ENABLE_OP_DONE_BIT, 0x1, true}});
+  EXPECT_EQ(
+      dif_keymgr_irq_set_enabled(&keymgr_, kDifKeymgrIrqOpDone, irq_state),
+      kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                {{KEYMGR_INTR_ENABLE_OP_DONE_BIT, 0x1, false}});
+  EXPECT_EQ(
+      dif_keymgr_irq_set_enabled(&keymgr_, kDifKeymgrIrqOpDone, irq_state),
+      kDifOk);
+}
+
+class IrqForceTest : public KeymgrTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_keymgr_irq_force(nullptr, kDifKeymgrIrqOpDone), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_keymgr_irq_force(nullptr, (dif_keymgr_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(KEYMGR_INTR_TEST_REG_OFFSET,
+                 {{KEYMGR_INTR_TEST_OP_DONE_BIT, true}});
+  EXPECT_EQ(dif_keymgr_irq_force(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(KEYMGR_INTR_TEST_REG_OFFSET,
+                 {{KEYMGR_INTR_TEST_OP_DONE_BIT, true}});
+  EXPECT_EQ(dif_keymgr_irq_force(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
+}
+
+class IrqDisableAllTest : public KeymgrTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_keymgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_keymgr_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_keymgr_irq_disable_all(&keymgr_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_keymgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_keymgr_irq_disable_all(&keymgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_keymgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_keymgr_irq_disable_all(&keymgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public KeymgrTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_keymgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_keymgr_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_restore_all(&keymgr_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_keymgr_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_keymgr_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_keymgr_irq_restore_all(&keymgr_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_keymgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(KEYMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_keymgr_irq_restore_all(&keymgr_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_keymgr_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen CSRNG DIF library
-sw_lib_dif_autogen_csrng = declare_dependency(
+# Autogen Key Manager DIF library
+sw_lib_dif_autogen_keymgr = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_csrng',
+    'sw_lib_dif_autogen_keymgr',
     sources: [
-      hw_ip_csrng_reg_h,
-      'dif_csrng_autogen.c',
+      hw_ip_keymgr_reg_h,
+      'dif_keymgr_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -37,6 +37,20 @@ sw_lib_dif_autogen_alert_handler = declare_dependency(
     sources: [
       hw_ip_alert_handler_reg_h,
       'dif_alert_handler_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen CSRNG DIF library
+sw_lib_dif_autogen_csrng = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_csrng',
+    sources: [
+      hw_ip_csrng_reg_h,
+      'dif_csrng_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -6,7 +6,10 @@
 
 #include <assert.h>
 
+#include "sw/device/lib/dif/dif_base.h"
+
 #include "keymgr_regs.h"  // Generated.
+#include "sw/device/lib/dif/autogen/dif_keymgr_autogen.h"
 
 /**
  * Address spaces of SEALING_SW_BINDING_N, SALT_N, SW_SHARE0_OUTPUT_N, and
@@ -120,13 +123,13 @@ OT_WARN_UNUSED_RESULT
 static bool is_ready(const dif_keymgr_t *keymgr) {
   // Keymgr must be idle and the CONTROL register must be writable.
   uint32_t reg_op_status =
-      mmio_region_read32(keymgr->params.base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
+      mmio_region_read32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
   if (bitfield_field32_read(reg_op_status, KEYMGR_OP_STATUS_STATUS_FIELD) !=
       KEYMGR_OP_STATUS_STATUS_VALUE_IDLE) {
     return false;
   }
-  uint32_t reg_cfg_regwen = mmio_region_read32(keymgr->params.base_addr,
-                                               KEYMGR_CFG_REGWEN_REG_OFFSET);
+  uint32_t reg_cfg_regwen =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_CFG_REGWEN_REG_OFFSET);
   return bitfield_bit32_read(reg_cfg_regwen, KEYMGR_CFG_REGWEN_EN_BIT);
 }
 
@@ -224,35 +227,20 @@ static void start_operation(const dif_keymgr_t *keymgr,
       reg_control, KEYMGR_CONTROL_OPERATION_FIELD, params.op);
   reg_control =
       bitfield_bit32_write(reg_control, KEYMGR_CONTROL_START_BIT, true);
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_CONTROL_REG_OFFSET,
+  mmio_region_write32(keymgr->base_addr, KEYMGR_CONTROL_REG_OFFSET,
                       reg_control);
 }
 
 /**
- * Returns the bit index for a given IRQ.
+ * Checks if a value is a valid `dif_toggle_t` and converts it to `bool`.
  */
 OT_WARN_UNUSED_RESULT
-static bool get_irq_bit_index(dif_keymgr_irq_t irq,
-                              bitfield_bit32_index_t *bit_index) {
-  switch (irq) {
-    case kDifKeymgrIrqDone:
-      *bit_index = KEYMGR_INTR_COMMON_OP_DONE_BIT;
-      return true;
-    default:
-      return false;
-  }
-}
-
-/**
- * Checks if a value is a valid `dif_keymgr_toggle_t` and converts it to `bool`.
- */
-OT_WARN_UNUSED_RESULT
-static bool toggle_to_bool(dif_keymgr_toggle_t val, bool *val_bool) {
+static bool toggle_to_bool(dif_toggle_t val, bool *val_bool) {
   switch (val) {
-    case kDifKeymgrToggleEnabled:
+    case kDifToggleEnabled:
       *val_bool = true;
       break;
-    case kDifKeymgrToggleDisabled:
+    case kDifToggleDisabled:
       *val_bool = false;
       break;
     default:
@@ -262,100 +250,98 @@ static bool toggle_to_bool(dif_keymgr_toggle_t val, bool *val_bool) {
 }
 
 /**
- * Converts a `bool` to `dif_keymgr_toggle_t`.
+ * Converts a `bool` to `dif_toggle_t`.
  */
-static dif_keymgr_toggle_t bool_to_toggle(bool val) {
-  return val ? kDifKeymgrToggleEnabled : kDifKeymgrToggleDisabled;
+static dif_toggle_t bool_to_toggle(bool val) {
+  return val ? kDifToggleEnabled : kDifToggleDisabled;
 }
 
-dif_keymgr_result_t dif_keymgr_init(dif_keymgr_params_t params,
-                                    dif_keymgr_t *keymgr) {
+dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr) {
   if (keymgr == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
-  *keymgr = (dif_keymgr_t){.params = params};
+  keymgr->base_addr = base_addr;
 
-  return kDifKeymgrOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_configure(const dif_keymgr_t *keymgr,
-                                         dif_keymgr_config_t config) {
+dif_result_t dif_keymgr_configure(const dif_keymgr_t *keymgr,
+                                  dif_keymgr_config_t config) {
   if (keymgr == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
   uint32_t reg_val =
       bitfield_field32_write(0, KEYMGR_RESEED_INTERVAL_SHADOWED_VAL_FIELD,
                              config.entropy_reseed_interval);
-  mmio_region_write32_shadowed(keymgr->params.base_addr,
-                               KEYMGR_RESEED_INTERVAL_SHADOWED_REG_OFFSET,
-                               reg_val);
+  mmio_region_write32_shadowed(
+      keymgr->base_addr, KEYMGR_RESEED_INTERVAL_SHADOWED_REG_OFFSET, reg_val);
 
-  return kDifKeymgrOk;
+  return kDifOk;
 }
 
-dif_keymgr_lockable_result_t dif_keymgr_advance_state(
-    const dif_keymgr_t *keymgr, const dif_keymgr_state_params_t *params) {
+dif_result_t dif_keymgr_advance_state(const dif_keymgr_t *keymgr,
+                                      const dif_keymgr_state_params_t *params) {
   if (keymgr == NULL) {
-    return kDifKeymgrLockableBadArg;
+    return kDifBadArg;
   }
 
   if (!is_ready(keymgr)) {
-    return kDifKeymgrLockableLocked;
+    return kDifLocked;
   }
 
   // Get current state and determine if we need to set the max key version and
   // sw binding value.
   max_key_version_reg_info_t max_key_ver_reg_info;
-  uint32_t reg_working_state = mmio_region_read32(
-      keymgr->params.base_addr, KEYMGR_WORKING_STATE_REG_OFFSET);
+  uint32_t reg_working_state =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_WORKING_STATE_REG_OFFSET);
   if (!get_max_key_version_reg_info_for_next_state(
           (bitfield_field32_read(reg_working_state,
                                  KEYMGR_WORKING_STATE_STATE_FIELD)),
           &max_key_ver_reg_info)) {
-    return kDifKeymgrLockableError;
+    return kDifError;
   }
 
   // Set the binding value and max key version if keymgr is going to
   // transition to an operational state.
   if (max_key_ver_reg_info.is_required) {
     if (params == NULL) {
-      return kDifKeymgrLockableBadArg;
+      return kDifBadArg;
     }
 
     // Check if SEALING_SW_BINDING_N registers are locked
     uint32_t reg_sw_binding_wen = mmio_region_read32(
-        keymgr->params.base_addr, KEYMGR_SW_BINDING_REGWEN_REG_OFFSET);
+        keymgr->base_addr, KEYMGR_SW_BINDING_REGWEN_REG_OFFSET);
     if (!bitfield_bit32_read(reg_sw_binding_wen,
                              KEYMGR_SW_BINDING_REGWEN_EN_BIT)) {
-      return kDifKeymgrLockableLocked;
+      return kDifLocked;
     }
 
     // Check if MAX_*_KEY_VER register is locked.
     uint32_t reg_max_key_ver_wen = mmio_region_read32(
-        keymgr->params.base_addr, max_key_ver_reg_info.wen_reg_offset);
+        keymgr->base_addr, max_key_ver_reg_info.wen_reg_offset);
     if (!bitfield_bit32_read(reg_max_key_ver_wen,
                              max_key_ver_reg_info.wen_bit_index)) {
-      return kDifKeymgrLockableLocked;
+      return kDifLocked;
     }
 
     // Write and lock (rw0c) the software binding value. This register is
     // unlocked by hardware upon a successful state transition.
     mmio_region_memcpy_to_mmio32(
-        keymgr->params.base_addr, KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
+        keymgr->base_addr, KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
         params->binding_value, sizeof(params->binding_value));
-    mmio_region_write32(keymgr->params.base_addr,
-                        KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+    mmio_region_write32(keymgr->base_addr, KEYMGR_SW_BINDING_REGWEN_REG_OFFSET,
+                        0);
 
     // Write and lock (rw0c) the max key version.
-    mmio_region_write32_shadowed(keymgr->params.base_addr,
+    mmio_region_write32_shadowed(keymgr->base_addr,
                                  max_key_ver_reg_info.reg_offset,
                                  params->max_key_version);
-    mmio_region_write32(keymgr->params.base_addr,
-                        max_key_ver_reg_info.wen_reg_offset, 0);
+    mmio_region_write32(keymgr->base_addr, max_key_ver_reg_info.wen_reg_offset,
+                        0);
   } else if (params != NULL) {
-    return kDifKeymgrLockableBadArg;
+    return kDifBadArg;
   }
 
   // Advance state.
@@ -364,16 +350,16 @@ dif_keymgr_lockable_result_t dif_keymgr_advance_state(
                               .op = KEYMGR_CONTROL_OPERATION_VALUE_ADVANCE,
                           });
 
-  return kDifKeymgrLockableOk;
+  return kDifOk;
 }
 
-dif_keymgr_lockable_result_t dif_keymgr_disable(const dif_keymgr_t *keymgr) {
+dif_result_t dif_keymgr_disable(const dif_keymgr_t *keymgr) {
   if (keymgr == NULL) {
-    return kDifKeymgrLockableBadArg;
+    return kDifBadArg;
   }
 
   if (!is_ready(keymgr)) {
-    return kDifKeymgrLockableLocked;
+    return kDifLocked;
   }
 
   // Disable key manager.
@@ -382,19 +368,19 @@ dif_keymgr_lockable_result_t dif_keymgr_disable(const dif_keymgr_t *keymgr) {
                               .op = KEYMGR_CONTROL_OPERATION_VALUE_DISABLE,
                           });
 
-  return kDifKeymgrLockableOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_get_status_codes(
+dif_result_t dif_keymgr_get_status_codes(
     const dif_keymgr_t *keymgr, dif_keymgr_status_codes_t *status_codes) {
   if (keymgr == NULL || status_codes == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
   // Read and clear OP_STATUS register (rw1c).
   uint32_t reg_op_status =
-      mmio_region_read32(keymgr->params.base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_OP_STATUS_REG_OFFSET,
+      mmio_region_read32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET);
+  mmio_region_write32(keymgr->base_addr, KEYMGR_OP_STATUS_REG_OFFSET,
                       reg_op_status);
 
   bool is_idle = false;
@@ -413,7 +399,7 @@ dif_keymgr_result_t dif_keymgr_get_status_codes(
     case KEYMGR_OP_STATUS_STATUS_VALUE_WIP:
       break;
     default:
-      return kDifKeymgrError;
+      return kDifError;
   }
 
   // Bit 0 of `dif_keymgr_status_codes_t` indicates whether the key manager is
@@ -422,9 +408,9 @@ dif_keymgr_result_t dif_keymgr_get_status_codes(
 
   if (has_error) {
     // Read and clear ERR_CODE register (rw1c).
-    uint32_t reg_err_code = mmio_region_read32(keymgr->params.base_addr,
-                                               KEYMGR_ERR_CODE_REG_OFFSET);
-    mmio_region_write32(keymgr->params.base_addr, KEYMGR_ERR_CODE_REG_OFFSET,
+    uint32_t reg_err_code =
+        mmio_region_read32(keymgr->base_addr, KEYMGR_ERR_CODE_REG_OFFSET);
+    mmio_region_write32(keymgr->base_addr, KEYMGR_ERR_CODE_REG_OFFSET,
                         reg_err_code);
     // Error bits start from bit 1 in `dif_keymgr_status_codes_t`.
     // Note: The mask is hardcoded since it is not auto generated yet.
@@ -433,59 +419,58 @@ dif_keymgr_result_t dif_keymgr_get_status_codes(
         .index = 1,
     };
     if (reg_err_code > kErrorBitfield.mask || reg_err_code == 0) {
-      return kDifKeymgrError;
+      return kDifError;
     }
     *status_codes =
         bitfield_field32_write(*status_codes, kErrorBitfield, reg_err_code);
   }
 
-  return kDifKeymgrOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_get_state(const dif_keymgr_t *keymgr,
-                                         dif_keymgr_state_t *state) {
+dif_result_t dif_keymgr_get_state(const dif_keymgr_t *keymgr,
+                                  dif_keymgr_state_t *state) {
   if (keymgr == NULL || state == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t reg_state = mmio_region_read32(keymgr->params.base_addr,
-                                          KEYMGR_WORKING_STATE_REG_OFFSET);
+  uint32_t reg_state =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_WORKING_STATE_REG_OFFSET);
 
   switch (bitfield_field32_read(reg_state, KEYMGR_WORKING_STATE_STATE_FIELD)) {
     case KEYMGR_WORKING_STATE_STATE_VALUE_RESET:
       *state = kDifKeymgrStateReset;
-      return kDifKeymgrOk;
+      return kDifOk;
     case KEYMGR_WORKING_STATE_STATE_VALUE_INIT:
       *state = kDifKeymgrStateInitialized;
-      return kDifKeymgrOk;
+      return kDifOk;
     case KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY:
       *state = kDifKeymgrStateCreatorRootKey;
-      return kDifKeymgrOk;
+      return kDifOk;
     case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_INTERMEDIATE_KEY:
       *state = kDifKeymgrStateOwnerIntermediateKey;
-      return kDifKeymgrOk;
+      return kDifOk;
     case KEYMGR_WORKING_STATE_STATE_VALUE_OWNER_KEY:
       *state = kDifKeymgrStateOwnerRootKey;
-      return kDifKeymgrOk;
+      return kDifOk;
     case KEYMGR_WORKING_STATE_STATE_VALUE_DISABLED:
       *state = kDifKeymgrStateDisabled;
-      return kDifKeymgrOk;
+      return kDifOk;
     case KEYMGR_WORKING_STATE_STATE_VALUE_INVALID:
       *state = kDifKeymgrStateInvalid;
-      return kDifKeymgrOk;
+      return kDifOk;
     default:
-      return kDifKeymgrError;
+      return kDifError;
   }
 }
 
-dif_keymgr_lockable_result_t dif_keymgr_generate_identity_seed(
-    const dif_keymgr_t *keymgr) {
+dif_result_t dif_keymgr_generate_identity_seed(const dif_keymgr_t *keymgr) {
   if (keymgr == NULL) {
-    return kDifKeymgrLockableBadArg;
+    return kDifBadArg;
   }
 
   if (!is_ready(keymgr)) {
-    return kDifKeymgrLockableLocked;
+    return kDifLocked;
   }
 
   start_operation(keymgr, (start_operation_params_t){
@@ -493,13 +478,13 @@ dif_keymgr_lockable_result_t dif_keymgr_generate_identity_seed(
                               .op = KEYMGR_CONTROL_OPERATION_VALUE_GENERATE_ID,
                           });
 
-  return kDifKeymgrLockableOk;
+  return kDifOk;
 }
 
-dif_keymgr_lockable_result_t dif_keymgr_generate_versioned_key(
+dif_result_t dif_keymgr_generate_versioned_key(
     const dif_keymgr_t *keymgr, dif_keymgr_versioned_key_params_t params) {
   if (keymgr == NULL) {
-    return kDifKeymgrLockableBadArg;
+    return kDifBadArg;
   }
 
   start_operation_params_t hw_op_params;
@@ -523,75 +508,73 @@ dif_keymgr_lockable_result_t dif_keymgr_generate_versioned_key(
       };
       break;
     default:
-      return kDifKeymgrLockableBadArg;
+      return kDifBadArg;
   }
 
   if (!is_ready(keymgr)) {
-    return kDifKeymgrLockableLocked;
+    return kDifLocked;
   }
 
   // Set salt and version
-  mmio_region_memcpy_to_mmio32(keymgr->params.base_addr,
-                               KEYMGR_SALT_0_REG_OFFSET, params.salt,
-                               sizeof(params.salt));
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_KEY_VERSION_REG_OFFSET,
+  mmio_region_memcpy_to_mmio32(keymgr->base_addr, KEYMGR_SALT_0_REG_OFFSET,
+                               params.salt, sizeof(params.salt));
+  mmio_region_write32(keymgr->base_addr, KEYMGR_KEY_VERSION_REG_OFFSET,
                       params.version);
 
   start_operation(keymgr, hw_op_params);
 
-  return kDifKeymgrLockableOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_sideload_clear_set_enabled(
-    const dif_keymgr_t *keymgr, dif_keymgr_toggle_t state) {
+dif_result_t dif_keymgr_sideload_clear_set_enabled(const dif_keymgr_t *keymgr,
+                                                   dif_toggle_t state) {
   bool enable = false;
   if (keymgr == NULL || !toggle_to_bool(state, &enable)) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
-  dif_keymgr_sideload_clr_t val = state == kDifKeymgrToggleEnabled
+  dif_keymgr_sideload_clr_t val = state == kDifToggleEnabled
                                       ? kDifKeyMgrSideLoadClearAll
                                       : kDifKeyMgrSideLoadClearNone;
 
-  mmio_region_write32(keymgr->params.base_addr,
-                      KEYMGR_SIDELOAD_CLEAR_REG_OFFSET, val);
+  mmio_region_write32(keymgr->base_addr, KEYMGR_SIDELOAD_CLEAR_REG_OFFSET, val);
 
-  return kDifKeymgrOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_sideload_clear_get_enabled(
-    const dif_keymgr_t *keymgr, dif_keymgr_toggle_t *state) {
+dif_result_t dif_keymgr_sideload_clear_get_enabled(const dif_keymgr_t *keymgr,
+                                                   dif_toggle_t *state) {
   if (keymgr == NULL || state == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
-  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
-                                        KEYMGR_SIDELOAD_CLEAR_REG_OFFSET);
+  uint32_t reg_val =
+      mmio_region_read32(keymgr->base_addr, KEYMGR_SIDELOAD_CLEAR_REG_OFFSET);
   *state = bool_to_toggle(reg_val == kDifKeyMgrSideLoadClearAll);
 
-  return kDifKeymgrOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
-                                           dif_keymgr_output_t *output) {
+dif_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
+                                    dif_keymgr_output_t *output) {
   if (keymgr == NULL || output == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
-  mmio_region_memcpy_from_mmio32(keymgr->params.base_addr,
+  mmio_region_memcpy_from_mmio32(keymgr->base_addr,
                                  KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET,
                                  output->value[0], sizeof(output->value[0]));
-  mmio_region_memcpy_from_mmio32(keymgr->params.base_addr,
+  mmio_region_memcpy_from_mmio32(keymgr->base_addr,
                                  KEYMGR_SW_SHARE1_OUTPUT_0_REG_OFFSET,
                                  output->value[1], sizeof(output->value[1]));
 
-  return kDifKeymgrOk;
+  return kDifOk;
 }
 
-dif_keymgr_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
-                                           dif_keymgr_alert_t alert) {
+dif_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
+                                    dif_keymgr_alert_t alert) {
   if (keymgr == NULL) {
-    return kDifKeymgrBadArg;
+    return kDifBadArg;
   }
 
   bitfield_bit32_index_t bit_index;
@@ -603,117 +586,11 @@ dif_keymgr_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
       bit_index = KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT;
       break;
     default:
-      return kDifKeymgrBadArg;
+      return kDifBadArg;
   }
 
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_ALERT_TEST_REG_OFFSET,
+  mmio_region_write32(keymgr->base_addr, KEYMGR_ALERT_TEST_REG_OFFSET,
                       bitfield_bit32_write(0, bit_index, true));
 
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_is_pending(const dif_keymgr_t *keymgr,
-                                              dif_keymgr_irq_t irq,
-                                              bool *is_pending) {
-  bitfield_bit32_index_t bit_index;
-  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index) ||
-      is_pending == NULL) {
-    return kDifKeymgrBadArg;
-  }
-
-  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
-                                        KEYMGR_INTR_STATE_REG_OFFSET);
-  *is_pending = bitfield_bit32_read(reg_val, bit_index);
-
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_acknowledge(const dif_keymgr_t *keymgr,
-                                               dif_keymgr_irq_t irq) {
-  bitfield_bit32_index_t bit_index;
-  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index)) {
-    return kDifKeymgrBadArg;
-  }
-
-  uint32_t reg_val = bitfield_bit32_write(0, bit_index, true);
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_STATE_REG_OFFSET,
-                      reg_val);
-
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_get_enabled(const dif_keymgr_t *keymgr,
-                                               dif_keymgr_irq_t irq,
-                                               dif_keymgr_toggle_t *state) {
-  bitfield_bit32_index_t bit_index;
-  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index) || state == NULL) {
-    return kDifKeymgrBadArg;
-  }
-
-  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
-                                        KEYMGR_INTR_ENABLE_REG_OFFSET);
-  *state = bool_to_toggle(bitfield_bit32_read(reg_val, bit_index));
-
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_set_enabled(const dif_keymgr_t *keymgr,
-                                               dif_keymgr_irq_t irq,
-                                               dif_keymgr_toggle_t state) {
-  bitfield_bit32_index_t bit_index;
-  bool enable = false;
-  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index) ||
-      !toggle_to_bool(state, &enable)) {
-    return kDifKeymgrBadArg;
-  }
-
-  uint32_t reg_val = mmio_region_read32(keymgr->params.base_addr,
-                                        KEYMGR_INTR_ENABLE_REG_OFFSET);
-  reg_val = bitfield_bit32_write(reg_val, bit_index, enable);
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
-                      reg_val);
-
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_force(const dif_keymgr_t *keymgr,
-                                         dif_keymgr_irq_t irq) {
-  bitfield_bit32_index_t bit_index;
-  if (keymgr == NULL || !get_irq_bit_index(irq, &bit_index)) {
-    return kDifKeymgrBadArg;
-  }
-
-  uint32_t reg_val = bitfield_bit32_write(0, bit_index, true);
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_TEST_REG_OFFSET,
-                      reg_val);
-
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_disable_all(
-    const dif_keymgr_t *keymgr, dif_keymgr_irq_snapshot_t *snapshot) {
-  if (keymgr == NULL) {
-    return kDifKeymgrBadArg;
-  }
-
-  if (snapshot != NULL) {
-    *snapshot = mmio_region_read32(keymgr->params.base_addr,
-                                   KEYMGR_INTR_ENABLE_REG_OFFSET);
-  }
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
-                      0);
-
-  return kDifKeymgrOk;
-}
-
-dif_keymgr_result_t dif_keymgr_irq_restore_all(
-    const dif_keymgr_t *keymgr, const dif_keymgr_irq_snapshot_t *snapshot) {
-  if (keymgr == NULL || snapshot == NULL) {
-    return kDifKeymgrBadArg;
-  }
-
-  mmio_region_write32(keymgr->params.base_addr, KEYMGR_INTR_ENABLE_REG_OFFSET,
-                      *snapshot);
-
-  return kDifKeymgrOk;
+  return kDifOk;
 }

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -516,6 +516,7 @@ sw_lib_dif_keymgr = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_keymgr,
     ],
   )
 )
@@ -523,9 +524,11 @@ sw_lib_dif_keymgr = declare_dependency(
 test('dif_keymgr_unittest', executable(
     'dif_keymgr_unittest',
     sources: [
-      hw_ip_keymgr_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_keymgr.c',
       'dif_keymgr_unittest.cc',
+      'autogen/dif_keymgr_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_keymgr.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_keymgr_autogen.c',
+      hw_ip_keymgr_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "keymgr".