### PR TITLE
[pwrmgr, rv_core_ibex, top] Same clks/rsts for escalate pairs

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -12,6 +12,7 @@
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {reset: "rst_main_ni"},
     {clock: "clk_slow_i", reset: "rst_slow_ni"}
+    {clock: "clk_esc_i", reset: "rst_esc_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -5,7 +5,8 @@
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {reset: "rst_main_ni"},
-    {clock: "clk_slow_i", reset: "rst_slow_ni"}
+    {clock: "clk_slow_i", reset: "rst_slow_ni"},
+    {clock: "clk_esc_i", reset: "rst_esc_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -52,6 +52,8 @@ module tb;
     .clk_slow_i (clk_slow),
     .rst_slow_ni(rst_slow_n),
     .rst_main_ni(rst_slow_n),
+    .clk_esc_i  (clk),
+    .rst_esc_ni (rst_n),
 
     .tl_i(tl_if.h2d),
     .tl_o(tl_if.d2h),

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -19,6 +19,8 @@ module pwrmgr
   input rst_slow_ni,
   input rst_ni,
   input rst_main_ni,
+  input clk_esc_i,
+  input rst_esc_ni,
 
   // Bus Interface
   input  tlul_pkg::tl_h2d_t tl_i,
@@ -84,8 +86,8 @@ module pwrmgr
     .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
     .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
   ) u_esc_rx (
-    .clk_i,
-    .rst_ni,
+    .clk_i(clk_esc_i),
+    .rst_ni(rst_esc_ni),
     .esc_req_o(esc_rst_req),
     .esc_rx_o(esc_rst_rx_o),
     .esc_tx_i(esc_rst_tx_i)

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2333,12 +2333,17 @@
     {
       name: pwrmgr_aon
       type: pwrmgr
+      clock_group: powerup
       clock_srcs:
       {
         clk_i: io_div4
         clk_slow_i: aon
+        clk_esc_i:
+        {
+          clock: io_div4
+          group: secure
+        }
       }
-      clock_group: powerup
       reset_connections:
       {
         rst_ni:
@@ -2349,6 +2354,11 @@
         rst_main_ni:
         {
           name: por_aon
+          domain: "0"
+        }
+        rst_esc_ni:
+        {
+          name: lc_io_div4
           domain: "0"
         }
         rst_slow_ni:
@@ -2367,6 +2377,7 @@
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_powerup
         clk_slow_i: clkmgr_aon_clocks.clk_aon_powerup
+        clk_esc_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       param_decl: {}
       param_list: []
@@ -6441,7 +6452,11 @@
       clock_srcs:
       {
         clk_i: main
-        clk_esc_i: io_div4
+        clk_esc_i:
+        {
+          clock: io_div4
+          group: secure
+        }
       }
       clock_group: infra
       reset_connections:
@@ -6460,7 +6475,7 @@
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
-        clk_esc_i: clkmgr_aon_clocks.clk_io_div4_infra
+        clk_esc_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain:
       [

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -329,8 +329,15 @@
     },
     { name: "pwrmgr_aon",
       type: "pwrmgr",
-      clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
       clock_group: "powerup",
+      clock_srcs: {
+        clk_i: "io_div4",
+        clk_slow_i: "aon",
+        clk_esc_i: {
+          clock: "io_div4",
+          group: "secure"
+        }
+      },
       reset_connections: {
         rst_ni: {
           name: "por_io_div4",
@@ -339,7 +346,11 @@
         rst_main_ni: {
           name: "por_aon",
           domain: "0"
-        }
+        },
+        rst_esc_ni: {
+          name: "lc_io_div4",
+          domain: "0"
+        },
         rst_slow_ni: {
           name: "por_aon",
           domain: "Aon",
@@ -659,8 +670,14 @@
                    DmHaltAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__ROM + dm::HaltAddress[31:0]",
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__ROM + dm::ExceptionAddress[31:0]",
                    PipeLine: "0"
-                  }
-      clock_srcs: {clk_i: "main", clk_esc_i: "io_div4"},
+                  },
+      clock_srcs: {
+        clk_i: "main",
+        clk_esc_i: {
+          clock: "io_div4",
+          group: "secure",
+        }
+      },
       clock_group: "infra",
       reset_connections: {rst_ni: "sys", rst_esc_ni: "lc_io_div4"},
       base_addr: "0x411F0000",

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -11,7 +11,8 @@
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
     {reset: "rst_main_ni"},
-    {clock: "clk_slow_i", reset: "rst_slow_ni"}
+    {clock: "clk_slow_i", reset: "rst_slow_ni"},
+    {clock: "clk_esc_i", reset: "rst_esc_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1522,8 +1522,10 @@ module top_earlgrey #(
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_io_div4_powerup),
       .clk_slow_i (clkmgr_aon_clocks.clk_aon_powerup),
+      .clk_esc_i (clkmgr_aon_clocks.clk_io_div4_secure),
       .rst_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
       .rst_main_ni (rstmgr_aon_resets.rst_por_aon_n[rstmgr_pkg::Domain0Sel]),
+      .rst_esc_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
       .rst_slow_ni (rstmgr_aon_resets.rst_por_aon_n[rstmgr_pkg::DomainAonSel])
   );
 
@@ -2377,7 +2379,7 @@ module top_earlgrey #(
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_main_infra),
-      .clk_esc_i (clkmgr_aon_clocks.clk_io_div4_infra),
+      .clk_esc_i (clkmgr_aon_clocks.clk_io_div4_secure),
       .rst_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
       .rst_esc_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -227,9 +227,14 @@
     },
     { name: "pwrmgr_aon",
       type: "pwrmgr",
-      clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon"},
+      clock_srcs: {clk_i: "io_div4", clk_slow_i: "aon", clk_esc_i: "io_div4"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "por_io_div4", rst_main_ni: "por_aon", rst_slow_ni: "por_aon"},
+      reset_connections: {
+        rst_ni: "por_io_div4",
+        rst_esc_ni: "lc_io_div4",
+        rst_main_ni: "por_aon",
+        rst_slow_ni: "por_aon"
+      },
       domain: ["Aon"],
       base_addr: "0x40400000",
       attr: "templated",


### PR DESCRIPTION
- Fixes #8037
- Ensures that pwrmgr / rv_core_ibex escalator clocks/resets can
  be assigned to the same clock group / power domain as the alert
  handler.  This guarantees we do not have any out of sync issues,
  and only need to handle the isolation values.

First 3 commits will be rebased away. 