### PR TITLE
[dif/otbn] Autogen otbn IRQ DIFs and use in tree.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -1,0 +1,172 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_otbn.h"
+
+#include "otbn_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool otbn_get_irq_bit_index(dif_otbn_irq_t irq,
+                                   bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifOtbnIrqDone:
+      *index_out = OTBN_INTR_STATE_DONE_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_get_state(const dif_otbn_t *otbn,
+                                    dif_otbn_irq_state_snapshot_t *snapshot) {
+  if (otbn == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(otbn->base_addr, OTBN_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_is_pending(const dif_otbn_t *otbn, dif_otbn_irq_t irq,
+                                     bool *is_pending) {
+  if (otbn == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otbn_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(otbn->base_addr, OTBN_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_acknowledge(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_t irq) {
+  if (otbn == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otbn_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(otbn->base_addr, OTBN_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_get_enabled(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_t irq, dif_toggle_t *state) {
+  if (otbn == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otbn_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(otbn->base_addr, OTBN_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_set_enabled(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_t irq, dif_toggle_t state) {
+  if (otbn == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otbn_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(otbn->base_addr, OTBN_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(otbn->base_addr, OTBN_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_force(const dif_otbn_t *otbn, dif_otbn_irq_t irq) {
+  if (otbn == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otbn_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(otbn->base_addr, OTBN_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_disable_all(
+    const dif_otbn_t *otbn, dif_otbn_irq_enable_snapshot_t *snapshot) {
+  if (otbn == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(otbn->base_addr, OTBN_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(otbn->base_addr, OTBN_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_restore_all(
+    const dif_otbn_t *otbn, const dif_otbn_irq_enable_snapshot_t *snapshot) {
+  if (otbn == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(otbn->base_addr, OTBN_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.h
@@ -1,0 +1,163 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_OTBN_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_OTBN_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/otbn/doc/">OTBN</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to otbn.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_otbn {
+  /**
+   * The base address for the otbn hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_otbn_t;
+
+/**
+ * A otbn interrupt request type.
+ */
+typedef enum dif_otbn_irq {
+  /**
+   * OTBN has completed the operation
+   */
+  kDifOtbnIrqDone = 0,
+} dif_otbn_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_otbn_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_otbn_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_otbn_irq_disable_all()` and `dif_otbn_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_otbn_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_get_state(const dif_otbn_t *otbn,
+                                    dif_otbn_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_is_pending(const dif_otbn_t *otbn, dif_otbn_irq_t irq,
+                                     bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_acknowledge(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_get_enabled(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_t irq, dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_set_enabled(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_t irq, dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param otbn A otbn handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_force(const dif_otbn_t *otbn, dif_otbn_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param otbn A otbn handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_disable_all(const dif_otbn_t *otbn,
+                                      dif_otbn_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param otbn A otbn handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_irq_restore_all(
+    const dif_otbn_t *otbn, const dif_otbn_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_OTBN_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -1,0 +1,279 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_otbn.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "otbn_regs.h"  // Generated.
+
+namespace dif_otbn_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class OtbnTest : public Test, public MmioTest {
+ protected:
+  dif_otbn_t otbn_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public OtbnTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_otbn_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_otbn_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_get_state(&otbn_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_otbn_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_otbn_irq_get_state(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_otbn_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otbn_irq_get_state(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public OtbnTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_otbn_irq_is_pending(nullptr, kDifOtbnIrqDone, &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_is_pending(nullptr, kDifOtbnIrqDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, (dif_otbn_irq_t)32, &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, true}});
+  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET,
+                {{OTBN_INTR_STATE_DONE_BIT, false}});
+  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public OtbnTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_otbn_irq_acknowledge(nullptr, kDifOtbnIrqDone), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_otbn_irq_acknowledge(nullptr, (dif_otbn_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET,
+                 {{OTBN_INTR_STATE_DONE_BIT, true}});
+  EXPECT_EQ(dif_otbn_irq_acknowledge(&otbn_, kDifOtbnIrqDone), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET,
+                 {{OTBN_INTR_STATE_DONE_BIT, true}});
+  EXPECT_EQ(dif_otbn_irq_acknowledge(&otbn_, kDifOtbnIrqDone), kDifOk);
+}
+
+class IrqGetEnabledTest : public OtbnTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_otbn_irq_get_enabled(nullptr, kDifOtbnIrqDone, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_get_enabled(nullptr, kDifOtbnIrqDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, (dif_otbn_irq_t)32, &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET,
+                {{OTBN_INTR_ENABLE_DONE_BIT, true}});
+  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET,
+                {{OTBN_INTR_ENABLE_DONE_BIT, false}});
+  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public OtbnTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_otbn_irq_set_enabled(nullptr, kDifOtbnIrqDone, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, (dif_otbn_irq_t)32, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
+                {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, true}});
+  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, kDifOtbnIrqDone, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
+                {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, false}});
+  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, kDifOtbnIrqDone, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public OtbnTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_otbn_irq_force(nullptr, kDifOtbnIrqDone), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_otbn_irq_force(nullptr, (dif_otbn_irq_t)32), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_DONE_BIT, true}});
+  EXPECT_EQ(dif_otbn_irq_force(&otbn_, kDifOtbnIrqDone), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_DONE_BIT, true}});
+  EXPECT_EQ(dif_otbn_irq_force(&otbn_, kDifOtbnIrqDone), kDifOk);
+}
+
+class IrqDisableAllTest : public OtbnTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_otbn_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otbn_irq_disable_all(&otbn_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otbn_irq_disable_all(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otbn_irq_disable_all(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public OtbnTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_otbn_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_restore_all(&otbn_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_otbn_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_otbn_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_otbn_irq_restore_all(&otbn_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otbn_irq_restore_all(&otbn_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_otbn_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen Key Manager DIF library
-sw_lib_dif_autogen_keymgr = declare_dependency(
+# Autogen OTBN DIF library
+sw_lib_dif_autogen_otbn = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_keymgr',
+    'sw_lib_dif_autogen_otbn',
     sources: [
-      hw_ip_keymgr_reg_h,
-      'dif_keymgr_autogen.c',
+      hw_ip_otbn_reg_h,
+      'dif_otbn_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -107,6 +107,20 @@ sw_lib_dif_autogen_i2c = declare_dependency(
     sources: [
       hw_ip_i2c_reg_h,
       'dif_i2c_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen Key Manager DIF library
+sw_lib_dif_autogen_keymgr = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_keymgr',
+    sources: [
+      hw_ip_keymgr_reg_h,
+      'dif_keymgr_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -14,56 +14,13 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sw/device/lib/dif/autogen/dif_otbn_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * Configuration for initializing an OTBN device.
- */
-typedef struct dif_otbn_config {
-  /** Base address of the OTBN device in the system. */
-  mmio_region_t base_addr;
-} dif_otbn_config_t;
-
-/**
- * Internal state of a OTBN device.
- *
- * Instances of this struct must be initialized by `dif_otbn_init()` before
- * being passed to other functions.
- */
-typedef struct dif_otbn {
-  /** Base address of the OTBN device in the system. */
-  mmio_region_t base_addr;
-} dif_otbn_t;
-
-/**
- * Generic return codes for the functions in the OTBN DIF library.
- */
-typedef enum dif_otbn_result {
-  /**
-   * The function succeeded.
-   */
-  kDifOtbnOk,
-
-  /**
-   * The function failed a non-specific assertion.
-   *
-   * This error is not recoverable.
-   */
-  kDifOtbnError,
-
-  /**
-   * There is a problem with the argument(s) to the function.
-   *
-   * This return code is only returned before the function has any side effects.
-   *
-   * This error is recoverable and the operation can be retried after correcting
-   * the problem with the argument(s).
-   */
-  kDifOtbnBadArg
-} dif_otbn_result_t;
 
 /**
  * OTBN commands
@@ -121,47 +78,17 @@ typedef enum dif_otbn_err_bits {
 } dif_otbn_err_bits_t;
 
 /**
- * OTBN interrupt configuration.
- *
- * Enumeration used to enable, disable, test and query the OTBN interrupts.
- * Please see the comportability specification for more information:
- * https://docs.opentitan.org/doc/rm/comportability_specification/
- */
-typedef enum dif_otbn_interrupt {
-  /**
-   * OTBN is done, it has run the application to completion.
-   *
-   * Associated with the `otbn.INTR_STATE.done` hardware interrupt.
-   */
-  kDifOtbnInterruptDone = 0,
-
-} dif_otbn_interrupt_t;
-
-/**
- * Generic enable/disable enumeration.
- *
- * Enumeration used to enable/disable bits, flags, ...
- */
-typedef enum dif_otbn_enable {
-  /** Enable functionality. */
-  kDifOtbnEnable = 0,
-  /** Disable functionality. */
-  kDifOtbnDisable,
-} dif_otbn_enable_t;
-
-/**
  * Initialize a OTBN device using `config` and return its internal state.
  *
  * A particular OTBN device must first be initialized by this function
  * before calling other functions of this library.
  *
- * @param config Configuration for initializing an OTBN device.
+ * @param base_addr Hardware instantiation base address.
  * @param[out] otbn OTBN instance that will store the internal state of the
  *             initialized OTBN device.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_init(const dif_otbn_config_t *config,
-                                dif_otbn_t *otbn);
+dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn);
 
 /**
  * Reset OTBN device.
@@ -170,119 +97,38 @@ dif_otbn_result_t dif_otbn_init(const dif_otbn_config_t *config,
  * reset values. Disables interrupts, output, and input filter.
  *
  * @param otbn OTBN instance
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_reset(const dif_otbn_t *otbn);
-
-/**
- * OTBN get requested IRQ state.
- *
- * Get the state of the requested IRQ in `irq_type`.
- *
- * @param otbn OTBN state data.
- * @param irq_type IRQ to get the state of.
- * @param[out] state IRQ state.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
- */
-dif_otbn_result_t dif_otbn_irq_state_get(const dif_otbn_t *otbn,
-                                         dif_otbn_interrupt_t irq_type,
-                                         dif_otbn_enable_t *state);
-
-/**
- * OTBN clear requested IRQ state.
- *
- * Clear the state of the requested IRQ in `irq_type`. Primary use of this
- * function is to de-assert the interrupt after it has been serviced.
- *
- * @param otbn OTBN state data.
- * @param irq_type IRQ to be de-asserted.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
- */
-dif_otbn_result_t dif_otbn_irq_state_clear(const dif_otbn_t *otbn,
-                                           dif_otbn_interrupt_t irq_type);
-
-/**
- * OTBN disable interrupts.
- *
- * Disable generation of all OTBN interrupts, and pass previous interrupt state
- * in `state` back to the caller. Parameter `state` is ignored if NULL.
- *
- * @param otbn OTBN state data.
- * @param[out] state IRQ state for use with `dif_otbn_irqs_restore`.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
- */
-dif_otbn_result_t dif_otbn_irqs_disable(const dif_otbn_t *otbn,
-                                        uint32_t *state);
-
-/**
- * OTBN restore IRQ state.
- *
- * Restore previous OTBN IRQ state. This function is used to restore the
- * OTBN interrupt state prior to `dif_otbn_irqs_disable` function call.
- *
- * @param otbn OTBN instance
- * @param state IRQ state to restore.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
- */
-dif_otbn_result_t dif_otbn_irqs_restore(const dif_otbn_t *otbn, uint32_t state);
-
-/**
- * OTBN interrupt control.
- *
- * Enable/disable an OTBN interrupt specified in `irq_type`.
- *
- * @param otbn OTBN instance
- * @param irq_type OTBN interrupt type.
- * @param enable enable or disable the interrupt.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
- */
-dif_otbn_result_t dif_otbn_irq_control(const dif_otbn_t *otbn,
-                                       dif_otbn_interrupt_t irq_type,
-                                       dif_otbn_enable_t enable);
-
-/**
- * OTBN interrupt force.
- *
- * Force interrupt specified in `irq_type`.
- *
- * @param otbn OTBN instance
- * @param irq_type OTBN interrupt type to be forced.
- * @return `dif_otbn_result_t`.
- */
-dif_otbn_result_t dif_otbn_irq_force(const dif_otbn_t *otbn,
-                                     dif_otbn_interrupt_t irq_type);
+dif_result_t dif_otbn_reset(const dif_otbn_t *otbn);
 
 /**
  * Start an operation by issuing a command.
  *
  * @param otbn OTBN instance.
  * @param cmd The command.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL`, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_write_cmd(const dif_otbn_t *otbn,
-                                     dif_otbn_cmd_t cmd);
+dif_result_t dif_otbn_write_cmd(const dif_otbn_t *otbn, dif_otbn_cmd_t cmd);
 
 /**
  * Gets the current status of OTBN.
  *
  * @param otbn OTBN instance
  * @param[out] status OTBN status
- * @return `kDifOtbnBadArg` if `otbn` or `status` is `NULL`,
- *         `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_get_status(const dif_otbn_t *otbn,
-                                      dif_otbn_status_t *status);
+dif_result_t dif_otbn_get_status(const dif_otbn_t *otbn,
+                                 dif_otbn_status_t *status);
 
 /**
  * Get the error bits set by the device if the operation failed.
  *
  * @param otbn OTBN instance
  * @param[out] err_bits The error bits returned by the hardware.
- * @return `kDifOtbnBadArg` if `otbn` or `err_code` is `NULL`,
- *         `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
-                                        dif_otbn_err_bits_t *err_bits);
+dif_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
+                                   dif_otbn_err_bits_t *err_bits);
 
 /**
  * Gets the number of executed OTBN instructions.
@@ -293,11 +139,9 @@ dif_otbn_result_t dif_otbn_get_err_bits(const dif_otbn_t *otbn,
  *
  * @param otbn OTBN instance
  * @param[out] insn_cnt The number of instructions executed by OTBN.
- * @return `kDifOtbnBadArg` if `otbn` or `insn_cnt` is `NULL`,
- *         `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn,
-                                        uint32_t *insn_cnt);
+dif_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn, uint32_t *insn_cnt);
 
 /**
  * Write an OTBN application into its instruction memory (IMEM)
@@ -308,12 +152,10 @@ dif_otbn_result_t dif_otbn_get_insn_cnt(const dif_otbn_t *otbn,
  * @param offset_bytes the byte offset in IMEM the first word is written to
  * @param src the main memory location to start reading from.
  * @param len_bytes number of bytes to copy.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL` or len_bytes or size are
- * invalid, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_imem_write(const dif_otbn_t *otbn,
-                                      uint32_t offset_bytes, const void *src,
-                                      size_t len_bytes);
+dif_result_t dif_otbn_imem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
+                                 const void *src, size_t len_bytes);
 
 /**
  * Read from OTBN's instruction memory (IMEM)
@@ -324,12 +166,10 @@ dif_otbn_result_t dif_otbn_imem_write(const dif_otbn_t *otbn,
  * @param offset_bytes the byte offset in IMEM the first word is read from
  * @param[out] dest the main memory location to copy the data to (preallocated)
  * @param len_bytes number of bytes to copy.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL` or len_bytes or size are
- * invalid, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_imem_read(const dif_otbn_t *otbn,
-                                     uint32_t offset_bytes, void *dest,
-                                     size_t len_bytes);
+dif_result_t dif_otbn_imem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
+                                void *dest, size_t len_bytes);
 
 /**
  * Write to OTBN's data memory (DMEM)
@@ -340,12 +180,10 @@ dif_otbn_result_t dif_otbn_imem_read(const dif_otbn_t *otbn,
  * @param offset_bytes the byte offset in DMEM the first word is written to
  * @param src the main memory location to start reading from.
  * @param len_bytes number of bytes to copy.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL` or len_bytes or size are
- * invalid, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn,
-                                      uint32_t offset_bytes, const void *src,
-                                      size_t len_bytes);
+dif_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn, uint32_t offset_bytes,
+                                 const void *src, size_t len_bytes);
 
 /**
  * Read from OTBN's data memory (DMEM)
@@ -356,12 +194,10 @@ dif_otbn_result_t dif_otbn_dmem_write(const dif_otbn_t *otbn,
  * @param offset_bytes the byte offset in DMEM the first word is read from
  * @param[out] dest the main memory location to copy the data to (preallocated)
  * @param len_bytes number of bytes to copy.
- * @return `kDifOtbnBadArg` if `otbn` is `NULL` or len_bytes or size are
- * invalid, `kDifOtbnOk` otherwise.
+ * @return The result of the operation.
  */
-dif_otbn_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn,
-                                     uint32_t offset_bytes, void *dest,
-                                     size_t len_bytes);
+dif_result_t dif_otbn_dmem_read(const dif_otbn_t *otbn, uint32_t offset_bytes,
+                                void *dest, size_t len_bytes);
 
 /**
  * Get the size of OTBN's data memory in bytes.

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -389,7 +389,9 @@ test('dif_otbn_unittest', executable(
     'dif_otbn_unittest',
     sources: [
       'dif_otbn_unittest.cc',
+      'autogen/dif_otbn_autogen_unittest.cc',
       meson.source_root() / 'sw/device/lib/dif/dif_otbn.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_otbn_autogen.c',
       hw_ip_otbn_reg_h,
     ],
     dependencies: [

--- a/sw/device/lib/runtime/otbn.c
+++ b/sw/device/lib/runtime/otbn.c
@@ -4,6 +4,8 @@
 
 #include "sw/device/lib/runtime/otbn.h"
 
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_otbn.h"
 #include "sw/device/lib/runtime/log.h"
 
@@ -30,14 +32,14 @@ otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx) {
   bool busy = true;
   while (busy) {
     dif_otbn_status_t status;
-    if (dif_otbn_get_status(&ctx->dif, &status) != kDifOtbnOk) {
+    if (dif_otbn_get_status(&ctx->dif, &status) != kDifOk) {
       return kOtbnError;
     }
     busy = status != kDifOtbnStatusIdle && status != kDifOtbnStatusLocked;
   }
 
   dif_otbn_err_bits_t err_bits;
-  if (dif_otbn_get_err_bits(&ctx->dif, &err_bits) != kDifOtbnOk) {
+  if (dif_otbn_get_err_bits(&ctx->dif, &err_bits) != kDifOk) {
     return kOtbnError;
   }
   if (err_bits != kDifOtbnErrBitsNoError) {
@@ -46,14 +48,14 @@ otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx) {
   return kOtbnOk;
 }
 
-otbn_result_t otbn_init(otbn_t *ctx, const dif_otbn_config_t dif_config) {
+otbn_result_t otbn_init(otbn_t *ctx, mmio_region_t base_addr) {
   if (ctx == NULL) {
     return kOtbnBadArg;
   }
 
   ctx->app_is_loaded = false;
 
-  if (dif_otbn_init(&dif_config, &ctx->dif) != kDifOtbnOk) {
+  if (dif_otbn_init(base_addr, &ctx->dif) != kDifOk) {
     return kOtbnError;
   }
 
@@ -77,13 +79,13 @@ otbn_result_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
   ctx->app = app;
 
   if (dif_otbn_imem_write(&ctx->dif, 0, ctx->app.imem_start, imem_size) !=
-      kDifOtbnOk) {
+      kDifOk) {
     return kOtbnError;
   }
 
   if (dmem_size > 0) {
     if (dif_otbn_dmem_write(&ctx->dif, 0, ctx->app.dmem_start, dmem_size) !=
-        kDifOtbnOk) {
+        kDifOk) {
       return kOtbnError;
     }
   }
@@ -97,7 +99,7 @@ otbn_result_t otbn_execute(otbn_t *ctx) {
     return kOtbnBadArg;
   }
 
-  if (dif_otbn_write_cmd(&ctx->dif, kDifOtbnCmdExecute) != kDifOtbnOk) {
+  if (dif_otbn_write_cmd(&ctx->dif, kDifOtbnCmdExecute) != kDifOk) {
     return kOtbnError;
   }
 
@@ -117,7 +119,7 @@ otbn_result_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len_bytes,
   }
 
   if (dif_otbn_dmem_write(&ctx->dif, dest_dmem_addr, src, len_bytes) !=
-      kDifOtbnOk) {
+      kDifOk) {
     return kOtbnError;
   }
   return kOtbnOk;
@@ -135,8 +137,7 @@ otbn_result_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
     return result;
   }
 
-  if (dif_otbn_dmem_read(&ctx->dif, src_dmem_addr, dest, len_bytes) !=
-      kDifOtbnOk) {
+  if (dif_otbn_dmem_read(&ctx->dif, src_dmem_addr, dest, len_bytes) != kDifOk) {
     return kOtbnError;
   }
   return kOtbnOk;
@@ -156,7 +157,7 @@ otbn_result_t otbn_zero_data_memory(otbn_t *ctx) {
     // Continue the process even if a single write fails to try to clear as much
     // memory as possible.
     if (dif_otbn_dmem_write(&ctx->dif, i * sizeof(uint32_t), &zero,
-                            sizeof(zero)) != kDifOtbnOk) {
+                            sizeof(zero)) != kDifOk) {
       retval = kOtbnError;
     }
   }

--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -5,6 +5,8 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_RUNTIME_OTBN_H_
 #define OPENTITAN_SW_DEVICE_LIB_RUNTIME_OTBN_H_
 
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_otbn.h"
 
 /**
@@ -160,10 +162,10 @@ typedef struct otbn {
  * Initializes the OTBN context structure.
  *
  * @param ctx The context object.
- * @param dif_config The OTBN DIF configuration (passed on to the DIF).
+ * @param base_addr The OTBN hardware base address.
  * @return The result of the operation.
  */
-otbn_result_t otbn_init(otbn_t *ctx, const dif_otbn_config_t dif_config);
+otbn_result_t otbn_init(otbn_t *ctx, mmio_region_t base_addr);
 
 /**
  * (Re-)loads the RSA application into OTBN.

--- a/sw/device/tests/otbn_ecdsa_p256_test.c
+++ b/sw/device/tests/otbn_ecdsa_p256_test.c
@@ -263,11 +263,9 @@ static void test_ecdsa_p256_roundtrip(void) {
 
   // Initialize
   otbn_t otbn_ctx;
-  dif_otbn_config_t otbn_config = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR),
-  };
   uint64_t t_start_init = profile_start();
-  CHECK(otbn_init(&otbn_ctx, otbn_config) == kOtbnOk);
+  CHECK(otbn_init(&otbn_ctx, mmio_region_from_addr(
+                                 TOP_EARLGREY_OTBN_BASE_ADDR)) == kOtbnOk);
   CHECK(otbn_load_app(&otbn_ctx, kOtbnAppP256Ecdsa) == kOtbnOk);
   profile_end(t_start_init, "Initialization");
 

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_otbn.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
@@ -42,10 +43,8 @@ bool test_main() {
 
   // Initialize
   otbn_t otbn_ctx;
-  dif_otbn_config_t otbn_config = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR),
-  };
-  CHECK(otbn_init(&otbn_ctx, otbn_config) == kOtbnOk);
+  CHECK(otbn_init(&otbn_ctx, mmio_region_from_addr(
+                                 TOP_EARLGREY_OTBN_BASE_ADDR)) == kOtbnOk);
   CHECK(otbn_load_app(&otbn_ctx, kOtbnAppCfiTest) == kOtbnOk);
 
   CHECK(otbn_execute(&otbn_ctx) == kOtbnOk);

--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -243,15 +243,12 @@ static void rsa_roundtrip(uint32_t size_bytes, const uint8_t *modulus,
                           const uint8_t *private_exponent, const uint8_t *in,
                           const uint8_t *encrypted_expected,
                           uint8_t *out_encrypted, uint8_t *out_decrypted) {
-  dif_otbn_config_t otbn_config = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR),
-  };
-
   otbn_t otbn_ctx;
 
   // Initialize
   profile_start();
-  CHECK(otbn_init(&otbn_ctx, otbn_config) == kOtbnOk);
+  CHECK(otbn_init(&otbn_ctx, mmio_region_from_addr(
+                                 TOP_EARLGREY_OTBN_BASE_ADDR)) == kOtbnOk);
   CHECK(otbn_load_app(&otbn_ctx, kOtbnAppRsa) == kOtbnOk);
   profile_end("Initialization");
 

--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -28,8 +28,7 @@ const test_config_t kTestConfig;
 static void check_otbn_err_bits(otbn_t *otbn_ctx,
                                 dif_otbn_err_bits_t expected_err_bits) {
   dif_otbn_err_bits_t otbn_err_bits;
-  dif_otbn_result_t rv = dif_otbn_get_err_bits(&otbn_ctx->dif, &otbn_err_bits);
-  CHECK(rv == kDifOtbnOk, "dif_otbn_get_err_bits() failed: %d", rv);
+  CHECK_DIF_OK(dif_otbn_get_err_bits(&otbn_ctx->dif, &otbn_err_bits));
   CHECK(otbn_err_bits == expected_err_bits,
         "dif_otbn_get_err_bits() produced unexpected error bits: %x",
         otbn_err_bits);
@@ -40,7 +39,7 @@ static void check_otbn_err_bits(otbn_t *otbn_ctx,
  */
 static void check_otbn_insn_cnt(otbn_t *otbn_ctx, uint32_t expected_insn_cnt) {
   uint32_t insn_cnt;
-  CHECK(dif_otbn_get_insn_cnt(&otbn_ctx->dif, &insn_cnt) == kDifOtbnOk);
+  CHECK_DIF_OK(dif_otbn_get_insn_cnt(&otbn_ctx->dif, &insn_cnt));
   CHECK(insn_cnt == expected_insn_cnt,
         "Expected to execute %d instructions, but got %d.", expected_insn_cnt,
         insn_cnt);
@@ -94,14 +93,14 @@ static void test_barrett384(otbn_t *otbn_ctx) {
 
   // TODO: Use symbols from the application to load these parameters once they
   // are available (#3998).
-  CHECK(dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/0, &a,
-                            sizeof(a)) == kDifOtbnOk);
-  CHECK(dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/64, &b,
-                            sizeof(b)) == kDifOtbnOk);
-  CHECK(dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/256, &m,
-                            sizeof(m)) == kDifOtbnOk);
-  CHECK(dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/320, &u,
-                            sizeof(u)) == kDifOtbnOk);
+  CHECK_DIF_OK(
+      dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/0, &a, sizeof(a)));
+  CHECK_DIF_OK(
+      dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/64, &b, sizeof(b)));
+  CHECK_DIF_OK(
+      dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/256, &m, sizeof(m)));
+  CHECK_DIF_OK(
+      dif_otbn_dmem_write(&otbn_ctx->dif, /*offset_bytes=*/320, &u, sizeof(u)));
 
   CHECK(otbn_execute(otbn_ctx) == kOtbnOk);
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
@@ -142,12 +141,9 @@ static void test_err_test(otbn_t *otbn_ctx) {
 bool test_main() {
   entropy_testutils_boot_mode_init();
 
-  dif_otbn_config_t otbn_config = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR),
-  };
-
   otbn_t otbn_ctx;
-  CHECK(otbn_init(&otbn_ctx, otbn_config) == kOtbnOk);
+  CHECK(otbn_init(&otbn_ctx, mmio_region_from_addr(
+                                 TOP_EARLGREY_OTBN_BASE_ADDR)) == kOtbnOk);
 
   test_barrett384(&otbn_ctx);
   test_err_test(&otbn_ctx);


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "otbn".