### PR TITLE
[doc] Update TC membership list

### DIFF
--- a/doc/project/technical_committee.md
+++ b/doc/project/technical_committee.md
@@ -19,11 +19,11 @@ Expectations of Technical Committee members include the following:
 
 ## Membership
 The OpenTitan Technical Committee membership is:
-* Alex Bradbury (co-chair)
-* Scott Johnson (co-chair)
+* Alex Bradbury (chair)
 * Richard Bohn
 * Cyril Guyot
-* Garret Kelly
 * Felix Miller
 * Dominic Rizzo (observer)
+* Michael Schaffner
 * Philipp Wagner
+* Alphan Ulusoy


### PR DESCRIPTION
Remove Scott Johnson and Garret Kelly.
Add Michael Schaffner and Alphan Ulusoy.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>