### PR TITLE
[dif/otp_ctrl] Autogen otp_ctrl IRQ DIFs and use in tree.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -1,0 +1,184 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+
+#include "otp_ctrl_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool otp_ctrl_get_irq_bit_index(dif_otp_ctrl_irq_t irq,
+                                       bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifOtpCtrlIrqOtpOperationDone:
+      *index_out = OTP_CTRL_INTR_STATE_OTP_OPERATION_DONE_BIT;
+      break;
+    case kDifOtpCtrlIrqOtpError:
+      *index_out = OTP_CTRL_INTR_STATE_OTP_ERROR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_get_state(
+    const dif_otp_ctrl_t *otp_ctrl,
+    dif_otp_ctrl_irq_state_snapshot_t *snapshot) {
+  if (otp_ctrl == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot =
+      mmio_region_read32(otp_ctrl->base_addr, OTP_CTRL_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_is_pending(const dif_otp_ctrl_t *otp_ctrl,
+                                         dif_otp_ctrl_irq_t irq,
+                                         bool *is_pending) {
+  if (otp_ctrl == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otp_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(otp_ctrl->base_addr, OTP_CTRL_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_acknowledge(const dif_otp_ctrl_t *otp_ctrl,
+                                          dif_otp_ctrl_irq_t irq) {
+  if (otp_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otp_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(otp_ctrl->base_addr, OTP_CTRL_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_get_enabled(const dif_otp_ctrl_t *otp_ctrl,
+                                          dif_otp_ctrl_irq_t irq,
+                                          dif_toggle_t *state) {
+  if (otp_ctrl == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otp_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(otp_ctrl->base_addr, OTP_CTRL_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_set_enabled(const dif_otp_ctrl_t *otp_ctrl,
+                                          dif_otp_ctrl_irq_t irq,
+                                          dif_toggle_t state) {
+  if (otp_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otp_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(otp_ctrl->base_addr, OTP_CTRL_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(otp_ctrl->base_addr, OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_force(const dif_otp_ctrl_t *otp_ctrl,
+                                    dif_otp_ctrl_irq_t irq) {
+  if (otp_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!otp_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(otp_ctrl->base_addr, OTP_CTRL_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_disable_all(
+    const dif_otp_ctrl_t *otp_ctrl,
+    dif_otp_ctrl_irq_enable_snapshot_t *snapshot) {
+  if (otp_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(otp_ctrl->base_addr,
+                                   OTP_CTRL_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(otp_ctrl->base_addr, OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_restore_all(
+    const dif_otp_ctrl_t *otp_ctrl,
+    const dif_otp_ctrl_irq_enable_snapshot_t *snapshot) {
+  if (otp_ctrl == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(otp_ctrl->base_addr, OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
@@ -1,0 +1,174 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_OTP_CTRL_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_OTP_CTRL_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/otp_ctrl/doc/">OTP_CTRL</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to otp_ctrl.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_otp_ctrl {
+  /**
+   * The base address for the otp_ctrl hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_otp_ctrl_t;
+
+/**
+ * A otp_ctrl interrupt request type.
+ */
+typedef enum dif_otp_ctrl_irq {
+  /**
+   * A direct access command or digest calculation operation has completed.
+   */
+  kDifOtpCtrlIrqOtpOperationDone = 0,
+  /**
+   * An error has occurred in the OTP controller. Check the !!ERR_CODE register
+   * to get more information.
+   */
+  kDifOtpCtrlIrqOtpError = 1,
+} dif_otp_ctrl_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_otp_ctrl_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_otp_ctrl_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_otp_ctrl_irq_disable_all()` and `dif_otp_ctrl_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_otp_ctrl_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_get_state(
+    const dif_otp_ctrl_t *otp_ctrl,
+    dif_otp_ctrl_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_is_pending(const dif_otp_ctrl_t *otp_ctrl,
+                                         dif_otp_ctrl_irq_t irq,
+                                         bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_acknowledge(const dif_otp_ctrl_t *otp_ctrl,
+                                          dif_otp_ctrl_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_get_enabled(const dif_otp_ctrl_t *otp_ctrl,
+                                          dif_otp_ctrl_irq_t irq,
+                                          dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_set_enabled(const dif_otp_ctrl_t *otp_ctrl,
+                                          dif_otp_ctrl_irq_t irq,
+                                          dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_force(const dif_otp_ctrl_t *otp_ctrl,
+                                    dif_otp_ctrl_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_disable_all(
+    const dif_otp_ctrl_t *otp_ctrl,
+    dif_otp_ctrl_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_irq_restore_all(
+    const dif_otp_ctrl_t *otp_ctrl,
+    const dif_otp_ctrl_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_OTP_CTRL_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -1,0 +1,309 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "otp_ctrl_regs.h"  // Generated.
+
+namespace dif_otp_ctrl_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class OtpCtrlTest : public Test, public MmioTest {
+ protected:
+  dif_otp_ctrl_t otp_ctrl_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public OtpCtrlTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_otp_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_state(&otp_ctrl_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_otp_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_otp_ctrl_irq_get_state(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_otp_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otp_ctrl_irq_get_state(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public OtpCtrlTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(nullptr, kDifOtpCtrlIrqOtpOperationDone,
+                                        &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(
+                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(nullptr, kDifOtpCtrlIrqOtpOperationDone,
+                                        nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(
+                &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
+                {{OTP_CTRL_INTR_STATE_OTP_OPERATION_DONE_BIT, true}});
+  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(
+                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
+                {{OTP_CTRL_INTR_STATE_OTP_ERROR_BIT, false}});
+  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
+                                        &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public OtpCtrlTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(
+      dif_otp_ctrl_irq_acknowledge(nullptr, kDifOtpCtrlIrqOtpOperationDone),
+      kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_otp_ctrl_irq_acknowledge(nullptr,
+                                         static_cast<dif_otp_ctrl_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(OTP_CTRL_INTR_STATE_REG_OFFSET,
+                 {{OTP_CTRL_INTR_STATE_OTP_OPERATION_DONE_BIT, true}});
+  EXPECT_EQ(
+      dif_otp_ctrl_irq_acknowledge(&otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone),
+      kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(OTP_CTRL_INTR_STATE_REG_OFFSET,
+                 {{OTP_CTRL_INTR_STATE_OTP_ERROR_BIT, true}});
+  EXPECT_EQ(dif_otp_ctrl_irq_acknowledge(&otp_ctrl_, kDifOtpCtrlIrqOtpError),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public OtpCtrlTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
+                nullptr, kDifOtpCtrlIrqOtpOperationDone, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
+                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
+                nullptr, kDifOtpCtrlIrqOtpOperationDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
+                &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{OTP_CTRL_INTR_ENABLE_OTP_OPERATION_DONE_BIT, true}});
+  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
+                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{OTP_CTRL_INTR_ENABLE_OTP_ERROR_BIT, false}});
+  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
+                                         &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public OtpCtrlTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(
+                nullptr, kDifOtpCtrlIrqOtpOperationDone, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(
+                &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{OTP_CTRL_INTR_ENABLE_OTP_OPERATION_DONE_BIT, 0x1, true}});
+  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(
+                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{OTP_CTRL_INTR_ENABLE_OTP_ERROR_BIT, 0x1, false}});
+  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
+                                         irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public OtpCtrlTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_otp_ctrl_irq_force(nullptr, kDifOtpCtrlIrqOtpOperationDone),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(
+      dif_otp_ctrl_irq_force(nullptr, static_cast<dif_otp_ctrl_irq_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(OTP_CTRL_INTR_TEST_REG_OFFSET,
+                 {{OTP_CTRL_INTR_TEST_OTP_OPERATION_DONE_BIT, true}});
+  EXPECT_EQ(dif_otp_ctrl_irq_force(&otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone),
+            kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(OTP_CTRL_INTR_TEST_REG_OFFSET,
+                 {{OTP_CTRL_INTR_TEST_OTP_ERROR_BIT, true}});
+  EXPECT_EQ(dif_otp_ctrl_irq_force(&otp_ctrl_, kDifOtpCtrlIrqOtpError), kDifOk);
+}
+
+class IrqDisableAllTest : public OtpCtrlTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public OtpCtrlTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_otp_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen Clock Manager DIF library
-sw_lib_dif_autogen_clkmgr = declare_dependency(
+# Autogen OTP Controller DIF library
+sw_lib_dif_autogen_otp_ctrl = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_clkmgr',
+    'sw_lib_dif_autogen_otp_ctrl',
     sources: [
-      hw_ip_clkmgr_reg_h,
-      'dif_clkmgr_autogen.c',
+      hw_ip_otp_ctrl_reg_h,
+      'dif_otp_ctrl_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -37,6 +37,20 @@ sw_lib_dif_autogen_alert_handler = declare_dependency(
     sources: [
       hw_ip_alert_handler_reg_h,
       'dif_alert_handler_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen Clock Manager DIF library
+sw_lib_dif_autogen_clkmgr = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_clkmgr',
+    sources: [
+      hw_ip_clkmgr_reg_h,
+      'dif_clkmgr_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -53,6 +53,16 @@ typedef enum dif_result {
    * Indicates that the Ip's FIFO (if it has one or more of) is full.
    */
   kDifIpFifoFull = 5,
+  /**
+   * Indicates that the attempted operation would attempt a read/write to an
+   * address that would go out of range.
+   */
+  kDifOutOfRange = 6,
+  /**
+   * Indicates that the attempted operation would attempt a read/write to an
+   * address that is not aligned.
+   */
+  kDifUnaligned = 7,
 } dif_result_t;
 
 /**

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -14,28 +14,14 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h"
 
 // Header Extern Guard (so header can be used from C and C++)
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * A toggle state: enabled, or disabled.
- *
- * This enum may be used instead of a `bool` when describing an enabled/disabled
- * state.
- */
-typedef enum dif_otp_ctrl_toggle {
-  /*
-   * The "enabled" state.
-   */
-  kDifOtpCtrlToggleEnabled,
-  /**
-   * The "disabled" state.
-   */
-  kDifOtpCtrlToggleDisabled,
-} dif_otp_ctrl_toggle_t;
 
 /**
  * A partition within OTP memory.
@@ -88,24 +74,6 @@ typedef enum dif_otp_ctrl_partition {
 } dif_otp_ctrl_partition_t;
 
 /**
- * Hardware instantiation parameters for OTP.
- *
- * This struct describes information about the underlying hardware that is
- * not determined until the hardware design is used as part of a top-level
- * design.
- */
-typedef struct dif_otp_ctrl_params {
-  /**
-   * The base address for the OTP hardware registers.
-   */
-  mmio_region_t base_addr_core;
-  /**
-   * The base address for the OTP hardware test registers.
-   */
-  mmio_region_t base_addr_prim;
-} dif_otp_ctrl_params_t;
-
-/**
  * Runtime configuration for OTP.
  *
  * This struct describes runtime information for one-time configuration of the
@@ -141,149 +109,6 @@ typedef struct dif_otp_ctrl_config {
    */
   uint32_t consistency_period_mask;
 } dif_otp_ctrl_config_t;
-
-/**
- * A handle to OTP.
- *
- * This type should be treated as opaque by users.
- */
-typedef struct dif_otp_ctrl {
-  dif_otp_ctrl_params_t params;
-} dif_otp_ctrl_t;
-
-/**
- * The result of an OTP operation.
- */
-typedef enum dif_otp_ctrl_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifOtpCtrlOk = 0,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifOtpCtrlError = 1,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifOtpCtrlBadArg = 2,
-} dif_otp_ctrl_result_t;
-
-/**
- * The result of a lockable operation.
- */
-typedef enum dif_otp_ctrl_lockable_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifOtpCtrlLockableOk = kDifOtpCtrlOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifOtpCtrlLockableError = kDifOtpCtrlError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifOtpCtrlLockableBadArg = kDifOtpCtrlBadArg,
-  /**
-   * Indicates that this operation has been locked out, and can never
-   * succeed until hardware reset.
-   */
-  kDifOtpCtrlLockableLocked,
-} dif_otp_ctrl_lockable_result_t;
-
-/**
- * The result of a Direct Access Interface (DAI) operation.
- */
-typedef enum dif_otp_ctrl_dai_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifOtpCtrlDaiOk = kDifOtpCtrlOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifOtpCtrlDaiError = kDifOtpCtrlError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifOtpCtrlDaiBadArg = kDifOtpCtrlBadArg,
-  /**
-   * Indicates that the DAI is busy and can't accept another incomming command.
-   */
-  kDifOtpCtrlDaiBusy,
-  /**
-   * Indicates that the given partition does not support this operation.
-   */
-  kDifOtpCtrlDaiBadPartition,
-  /**
-   * Indicates that the attempted DAI operation would go out of range of the
-   * requested partition.
-   */
-  kDifOtpCtrlDaiOutOfRange,
-  /**
-   * Indicates that the given address was not correctly aligned.
-   */
-  kDifOtpCtrlDaiUnaligned,
-} dif_otp_ctrl_dai_result_t;
-
-/**
- * The result of a digest operation.
- */
-typedef enum dif_otp_ctrl_digest_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifOtpCtrlDigestOk = kDifOtpCtrlOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifOtpCtrlDigestError = kDifOtpCtrlError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifOtpCtrlDigestBadArg = kDifOtpCtrlBadArg,
-  /**
-   * Indicates that a digest lookup failed because the digest had not been
-   * programmed yet.
-   */
-  kDifOtpCtrlDigestMissing,
-} dif_otp_ctrl_digest_result_t;
-
-/**
- * An OTP interrupt request type.
- */
-typedef enum dif_otp_ctrl_irq {
-  /**
-   * Indicates that an asynchronous transaction completed.
-   */
-  kDifOtpCtrlIrqDone,
-  /**
-   * Indicates that an error has occurred in the OTP controller.
-   */
-  kDifOtpCtrlIrqError,
-} dif_otp_ctrl_irq_t;
-
-/**
- * A snapshot of the enablement state of the interrupts for OTP.
- *
- * This is an opaque type, to be used with the `dif_otp_ctrl_irq_disable_all()`
- * and
- * `dif_otp_ctrl_irq_restore_all()` functions.
- */
-typedef uint32_t dif_otp_ctrl_irq_snapshot_t;
 
 /**
  * A hardware-level status code.
@@ -469,13 +294,12 @@ typedef struct dif_otp_ctrl_status {
  *
  * This function does not actuate the hardware.
  *
- * @param params Hardware instantiation parameters.
+ * @param base_addr Hardware instantiation base address.
  * @param[out] otp Out param for the initialized handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_init(dif_otp_ctrl_params_t params,
-                                        dif_otp_ctrl_t *otp);
+dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr, dif_otp_ctrl_t *otp);
 
 /**
  * Configures OTP with runtime information.
@@ -488,8 +312,8 @@ dif_otp_ctrl_result_t dif_otp_ctrl_init(dif_otp_ctrl_params_t params,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_lockable_result_t dif_otp_ctrl_configure(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_config_t config);
+dif_result_t dif_otp_ctrl_configure(const dif_otp_ctrl_t *otp,
+                                    dif_otp_ctrl_config_t config);
 
 /**
  * Runs an integrity check on the OTP hardware.
@@ -501,8 +325,7 @@ dif_otp_ctrl_lockable_result_t dif_otp_ctrl_configure(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_lockable_result_t dif_otp_ctrl_check_integrity(
-    const dif_otp_ctrl_t *otp);
+dif_result_t dif_otp_ctrl_check_integrity(const dif_otp_ctrl_t *otp);
 
 /**
  * Runs a consistency check on the OTP hardware.
@@ -514,8 +337,7 @@ dif_otp_ctrl_lockable_result_t dif_otp_ctrl_check_integrity(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_lockable_result_t dif_otp_ctrl_check_consistency(
-    const dif_otp_ctrl_t *otp);
+dif_result_t dif_otp_ctrl_check_consistency(const dif_otp_ctrl_t *otp);
 
 /**
  * Locks out `dif_otp_ctrl_configure()` and the
@@ -528,7 +350,7 @@ dif_otp_ctrl_lockable_result_t dif_otp_ctrl_check_consistency(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_lock_config(const dif_otp_ctrl_t *otp);
+dif_result_t dif_otp_ctrl_lock_config(const dif_otp_ctrl_t *otp);
 
 /**
  * Checks whether `dif_otp_ctrl_configure()` and the `dif_otp_ctrl_check_*()`
@@ -539,8 +361,8 @@ dif_otp_ctrl_result_t dif_otp_ctrl_lock_config(const dif_otp_ctrl_t *otp);
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_config_is_locked(const dif_otp_ctrl_t *otp,
-                                                    bool *is_locked);
+dif_result_t dif_otp_ctrl_config_is_locked(const dif_otp_ctrl_t *otp,
+                                           bool *is_locked);
 
 /**
  * Locks out reads to a SW partition.
@@ -560,8 +382,8 @@ dif_otp_ctrl_result_t dif_otp_ctrl_config_is_locked(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_lock_reading(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition);
+dif_result_t dif_otp_ctrl_lock_reading(const dif_otp_ctrl_t *otp,
+                                       dif_otp_ctrl_partition_t partition);
 
 /**
  * Checks whether reads to a SW partition are locked out.
@@ -575,98 +397,9 @@ dif_otp_ctrl_result_t dif_otp_ctrl_lock_reading(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_reading_is_locked(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    bool *is_locked);
-
-/**
- * Returns whether a particular interrupt is currently pending.
- *
- * @param otp An OTP handle.
- * @param irq An interrupt type.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_is_pending(const dif_otp_ctrl_t *otp,
-                                                  dif_otp_ctrl_irq_t irq,
-                                                  bool *is_pending);
-
-/**
- * Acknowledges a particular interrupt, indicating to the hardware that it has
- * been successfully serviced.
- *
- * @param otp An OTP handle.
- * @param irq An interrupt type.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_acknowledge(const dif_otp_ctrl_t *otp,
-                                                   dif_otp_ctrl_irq_t irq);
-
-/**
- * Checks whether a particular interrupt is currently enabled or disabled.
- *
- * @param otp An OTP handle.
- * @param irq An interrupt type.
- * @param[out] state Out-param toggle state of the interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_get_enabled(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_irq_t irq,
-    dif_otp_ctrl_toggle_t *state);
-
-/**
- * Sets whether a particular interrupt is currently enabled or disabled.
- *
- * @param otp An OTP handle.
- * @param irq An interrupt type.
- * @param state The new toggle state for the interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_set_enabled(const dif_otp_ctrl_t *otp,
-                                                   dif_otp_ctrl_irq_t irq,
-                                                   dif_otp_ctrl_toggle_t state);
-
-/**
- * Forces a particular interrupt, causing it to be serviced as if hardware had
- * asserted it.
- *
- * @param otp An OTP handle.
- * @param irq An interrupt type.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_force(const dif_otp_ctrl_t *otp,
-                                             dif_otp_ctrl_irq_t irq);
-
-/**
- * Disables all interrupts, optionally snapshotting all toggle state for later
- * restoration.
- *
- * @param otp An OTP handle.
- * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_disable_all(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_irq_snapshot_t *snapshot);
-
-/**
- * Restores interrupts from the given snapshot.
- *
- * This function can be used with `dif_otp_ctrl_irq_disable_all()` to temporary
- * interrupt save-and-restore.
- *
- * @param otp An OTP handle.
- * @param snapshot A snapshot to restore from.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_irq_restore_all(
-    const dif_otp_ctrl_t *otp, const dif_otp_ctrl_irq_snapshot_t *snapshot);
+dif_result_t dif_otp_ctrl_reading_is_locked(const dif_otp_ctrl_t *otp,
+                                            dif_otp_ctrl_partition_t partition,
+                                            bool *is_locked);
 
 /**
  * Gets the current status of the OTP controller.
@@ -676,8 +409,8 @@ dif_otp_ctrl_result_t dif_otp_ctrl_irq_restore_all(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
-                                              dif_otp_ctrl_status_t *status);
+dif_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
+                                     dif_otp_ctrl_status_t *status);
 
 /**
  * Schedules a read on the Direct Access Interface.
@@ -696,9 +429,9 @@ dif_otp_ctrl_result_t dif_otp_ctrl_get_status(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read_start(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    uint32_t address);
+dif_result_t dif_otp_ctrl_dai_read_start(const dif_otp_ctrl_t *otp,
+                                         dif_otp_ctrl_partition_t partition,
+                                         uint32_t address);
 
 /**
  * Gets the result of a completed 32-bit read operation on the Direct Access
@@ -712,8 +445,8 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read_start(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read32_end(const dif_otp_ctrl_t *otp,
-                                                      uint32_t *value);
+dif_result_t dif_otp_ctrl_dai_read32_end(const dif_otp_ctrl_t *otp,
+                                         uint32_t *value);
 
 /**
  * Gets the result of a completed 64-bit read operation on the Direct Access
@@ -727,8 +460,8 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read32_end(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
-                                                      uint64_t *value);
+dif_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
+                                         uint64_t *value);
 
 /**
  * Schedules a 32-bit write on the Direct Access Interface.
@@ -750,9 +483,9 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_read64_end(const dif_otp_ctrl_t *otp,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program32(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    uint32_t address, uint32_t value);
+dif_result_t dif_otp_ctrl_dai_program32(const dif_otp_ctrl_t *otp,
+                                        dif_otp_ctrl_partition_t partition,
+                                        uint32_t address, uint32_t value);
 
 /**
  * Schedules a 64-bit write on the Direct Access Interface.
@@ -771,9 +504,9 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program32(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program64(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    uint32_t address, uint64_t value);
+dif_result_t dif_otp_ctrl_dai_program64(const dif_otp_ctrl_t *otp,
+                                        dif_otp_ctrl_partition_t partition,
+                                        uint32_t address, uint64_t value);
 
 /**
  * Schedules a hardware digest operation on the Direct Access Interface.
@@ -794,9 +527,9 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_program64(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_digest(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    uint64_t digest);
+dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
+                                     dif_otp_ctrl_partition_t partition,
+                                     uint64_t digest);
 
 /**
  * Gets the buffered digest value for the given partition.
@@ -814,9 +547,9 @@ dif_otp_ctrl_dai_result_t dif_otp_ctrl_dai_digest(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_digest_result_t dif_otp_ctrl_get_digest(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    uint64_t *digest);
+dif_result_t dif_otp_ctrl_get_digest(const dif_otp_ctrl_t *otp,
+                                     dif_otp_ctrl_partition_t partition,
+                                     uint64_t *digest);
 
 /**
  * Performs a memory-mapped read of the given partition, if it supports them.
@@ -838,47 +571,10 @@ dif_otp_ctrl_digest_result_t dif_otp_ctrl_get_digest(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_dai_result_t dif_otp_ctrl_read_blocking(
-    const dif_otp_ctrl_t *otp, dif_otp_ctrl_partition_t partition,
-    uint32_t address, uint32_t *buf, size_t len);
-
-/**
- * Performs a memory-mapped read of the TEST region.
- *
- * In particular, this function will read `len` words, starting at `address`.
- *
- * The same caveats for `dif_otp_ctrl_dai_read_start()` apply to `address`; in
- * addition, `address + len` must also be in-range and must not overflow.
- *
- * @param otp An OTP handle.
- * @param address The address to read from.
- * @param[out] buf A buffer of words to write read values to.
- * @param len The number of words to read.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_read_test(const dif_otp_ctrl_t *otp,
-                                             uint32_t address, uint32_t *buf,
-                                             size_t len);
-
-/**
- * Performs a memory-mapped write of the TEST region.
- *
- * In particular, this function will write `len` words, starting at `address`.
- *
- * The same caveats for `dif_otp_ctrl_dai_program32()` apply to `address`; in
- * addition, `address + len` must also be in-range and must not overflow.
- *
- * @param otp An OTP handle.
- * @param address An absolute address to write to.
- * @param buf A buffer of words to write write values from.
- * @param len The number of words to write.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_otp_ctrl_result_t dif_otp_ctrl_write_test(const dif_otp_ctrl_t *otp,
-                                              uint32_t address,
-                                              const uint32_t *buf, size_t len);
+dif_result_t dif_otp_ctrl_read_blocking(const dif_otp_ctrl_t *otp,
+                                        dif_otp_ctrl_partition_t partition,
+                                        uint32_t address, uint32_t *buf,
+                                        size_t len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -567,7 +567,7 @@ test('dif_keymgr_unittest', executable(
   suite: 'dif',
 )
 
-# OTP controller library
+# OTP Controller library
 sw_lib_dif_otp_ctrl = declare_dependency(
   link_with: static_library(
     'sw_lib_dif_otp_ctrl',
@@ -578,6 +578,7 @@ sw_lib_dif_otp_ctrl = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_otp_ctrl,
     ],
   )
 )
@@ -585,9 +586,11 @@ sw_lib_dif_otp_ctrl = declare_dependency(
 test('dif_otp_ctrl_unittest', executable(
     'dif_otp_ctrl_unittest',
     sources: [
-      hw_ip_otp_ctrl_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_otp_ctrl.c',
       'dif_otp_ctrl_unittest.cc',
+      'autogen/dif_otp_ctrl_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_otp_ctrl.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c',
+      hw_ip_otp_ctrl_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -181,7 +181,7 @@ static dif_otp_ctrl_t otp;
 static void wait_for_dai(void) {
   while (true) {
     dif_otp_ctrl_status_t status;
-    CHECK(dif_otp_ctrl_get_status(&otp, &status) == kDifOtpCtrlOk);
+    CHECK_DIF_OK(dif_otp_ctrl_get_status(&otp, &status));
     if (bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiIdle)) {
       return;
     }
@@ -195,17 +195,10 @@ static void wait_for_dai(void) {
  */
 static void lock_otp_secret_partition2(void) {
   // initialize otp
-  mmio_region_t otp_reg_core =
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR);
-  mmio_region_t otp_reg_prim =
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_PRIM_BASE_ADDR);
-  CHECK(
-      dif_otp_ctrl_init((dif_otp_ctrl_params_t){.base_addr_core = otp_reg_core,
-                                                .base_addr_prim = otp_reg_prim},
-                        &otp) == kDifOtpCtrlOk);
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
 
-  CHECK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret2, 0) ==
-        kDifOtpCtrlDaiOk);
+  CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret2, 0));
 
   wait_for_dai();
 }

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
@@ -29,7 +29,7 @@ const uint8_t OTP_DAI_TIMEOUT = 10;
 static void wait_for_dai(void) {
   for (int i = 0; i < OTP_DAI_TIMEOUT; i++) {
     dif_otp_ctrl_status_t status;
-    CHECK(dif_otp_ctrl_get_status(&otp, &status) == kDifOtpCtrlOk);
+    CHECK_DIF_OK(dif_otp_ctrl_get_status(&otp, &status));
     if (status.codes == (1 << kDifOtpCtrlStatusCodeDaiIdle)) {
       return;
     }
@@ -45,17 +45,11 @@ static void wait_for_dai(void) {
 static void otp_ctrl_dai_read_32(const dif_otp_ctrl_t *otp,
                                  dif_otp_ctrl_partition_t partition,
                                  uint32_t address, uint32_t *buf) {
-  dif_otp_ctrl_dai_result_t read_start_err =
-      dif_otp_ctrl_dai_read_start(otp, partition, address);
-  CHECK(read_start_err == kDifOtpCtrlDaiOk,
-        "Failed to perform OTP DAI read start.");
+  CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(otp, partition, address));
 
   wait_for_dai();
 
-  dif_otp_ctrl_dai_result_t read_end_err =
-      dif_otp_ctrl_dai_read32_end(otp, buf);
-  CHECK(read_end_err == kDifOtpCtrlDaiOk,
-        "Failed to perform OTP DAI read end.");
+  CHECK_DIF_OK(dif_otp_ctrl_dai_read32_end(otp, buf));
 }
 
 /**
@@ -63,14 +57,8 @@ static void otp_ctrl_dai_read_32(const dif_otp_ctrl_t *otp,
  */
 // TODO: needs to support other recipients besides LC_CTRL.
 bool test_main(void) {
-  mmio_region_t otp_reg_core =
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR);
-  mmio_region_t otp_reg_prim =
-      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_PRIM_BASE_ADDR);
-  CHECK(
-      dif_otp_ctrl_init((dif_otp_ctrl_params_t){.base_addr_core = otp_reg_core,
-                                                .base_addr_prim = otp_reg_prim},
-                        &otp) == kDifOtpCtrlOk);
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
 
   mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
   CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
@@ -80,7 +68,7 @@ bool test_main(void) {
       .integrity_period_mask = 0x3ffff,
       .consistency_period_mask = 0x3ffffff,
   };
-  CHECK(dif_otp_ctrl_configure(&otp, config) == kDifOtpCtrlLockableOk);
+  CHECK_DIF_OK(dif_otp_ctrl_configure(&otp, config));
 
   // Read out Device ID from LC_CTRL's `device_id` registers.
   dif_lc_ctrl_device_id_t lc_device_id;


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "otp_ctrl".