### PR TITLE
[spi_device] Fix incorrect xfer_size compare

### DIFF
--- a/hw/ip/spi_device/rtl/spi_tpm.sv
+++ b/hw/ip/spi_device/rtl/spi_tpm.sv
@@ -741,7 +741,7 @@ module spi_tpm
     end
   end
   assign xfer_bytes_d  = xfer_bytes_q + 6'h 1;
-  assign xfer_size_met = xfer_bytes_d == xfer_size;
+  assign xfer_size_met = xfer_bytes_q == xfer_size;
 
   // Output data mux
   always_comb begin


### PR DESCRIPTION
`xfer_size` in command byte is the actual bytes to be transferred minus 1.
For example, to transfer 32B, xfer_size should be 6'h 1F ('d 31).

The comparison to check if xfer_size has been transferred was wrong.