### PR TITLE
[dv] Fix wait_alert_trigger

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -97,6 +97,10 @@ interface alert_esc_if(input clk, input rst_n);
     get_alert = (alert_tx_final.alert_p === 1'b1 && alert_tx_final.alert_n === 1'b0);
   endfunction : get_alert
 
+  function automatic bit is_alert_handshaking();
+    return alert_tx_final.alert_p === 1'b1 || alert_rx_final.ack_p === 1'b1;
+  endfunction : is_alert_handshaking
+
   // this task wait for alert_ping request.
   // alert_ping request is detected by level triggered "alert_rx.ping_p/n" signals pairs
   // and no sig_int_err


### PR DESCRIPTION
A few update on waiting for an alert
1. `DV_SPINWAIT_EXIT doesn't report uvm_error. It creates 2 threads and any
of them finish, it kills the other. Added uvm_error if alert doesn't
occur.
2. the alert may be triggered earlier than we call this task, change to
wait for either alert_p or ack_p.
3. increase default max_wait_time to 7 cycles

Signed-off-by: Weicai Yang <weicai@google.com>