### PR TITLE
[opentitantool] Refactor IO options for commonality

### DIFF
--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -3,7 +3,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::rc::Rc;
 use std::time::Duration;
+use structopt::StructOpt;
+
+use crate::transport::Transport;
+
+#[derive(Debug, StructOpt)]
+pub struct UartParams {
+    #[structopt(long, help = "UART instance", default_value = "0")]
+    uart: u32,
+
+    #[structopt(long, help = "UART baudrate")]
+    baudrate: Option<u32>,
+}
+
+impl UartParams {
+    pub fn create(&self, transport: &dyn Transport) -> Result<Rc<dyn Uart>> {
+        let uart = transport.uart(self.uart)?;
+        if let Some(baudrate) = self.baudrate {
+            uart.set_baudrate(baudrate)?;
+        }
+        Ok(uart)
+    }
+}
 
 /// A trait which represents a UART.
 pub trait Uart {

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -5,6 +5,7 @@
 pub mod bitfield;
 pub mod file;
 pub mod parse_int;
+pub mod voltage;
 
 /// The `collection` macro provides syntax for hash and set literals.
 #[macro_export]

--- a/sw/host/opentitanlib/src/util/voltage.rs
+++ b/sw/host/opentitanlib/src/util/voltage.rs
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::num::ParseFloatError;
+use std::str::FromStr;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Voltage(pub f64);
+
+impl FromStr for Voltage {
+    type Err = ParseFloatError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Allow voltages to be specified as they are in schematics: "3v3", "1v8", etc.
+        let voltage = s.to_lowercase().replace('v', ".");
+        Ok(Voltage(f64::from_str(&voltage)?))
+    }
+}
+
+impl Voltage {
+    pub fn as_volts(&self) -> f64 {
+        self.0
+    }
+    pub fn as_millivolts(&self) -> u32 {
+        (self.0 * 1000.0) as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn test_from_string() -> Result<()> {
+        assert_eq!(Voltage::from_str("3.3")?.as_volts(), 3.3);
+        assert_eq!(Voltage::from_str("3v3")?.as_volts(), 3.3);
+        assert_eq!(Voltage::from_str("1V8")?.as_volts(), 1.8);
+        assert!(Voltage::from_str("1k4").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_conversions() -> Result<()> {
+        assert_eq!(Voltage(2.5).as_volts(), 2.5);
+        assert_eq!(Voltage(2.5).as_millivolts(), 2500);
+        assert_eq!(Voltage(3.141592654).as_millivolts(), 3141);
+        Ok(())
+    }
+}

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -16,17 +16,17 @@ use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
 use opentitanlib::app::command::CommandDispatch;
-use opentitanlib::io::uart::Uart;
+use opentitanlib::io::uart::{Uart, UartParams};
 use opentitanlib::transport::{Capability, Transport};
 use opentitanlib::util::file;
 
 #[derive(Debug, StructOpt)]
 pub struct Console {
+    #[structopt(flatten)]
+    params: UartParams,
+
     #[structopt(short, long, help = "Do not print console start end exit messages.")]
     quiet: bool,
-
-    #[structopt(short, long, help = "Which UART to connect", default_value = "0")]
-    uart: u32,
 
     #[structopt(short, long, help = "Log console output to a file")]
     logfile: Option<String>,
@@ -90,7 +90,7 @@ impl CommandDispatch for Console {
             } else {
                 None
             };
-            let uart = transport.uart(self.uart)?;
+            let uart = self.params.create(transport)?;
             console.interact(&*uart, &mut stdin, &mut stdout)?;
         }
         if !self.quiet {


### PR DESCRIPTION
1. Place UART and SPI bus parameters into their own structs.  Add
`create` functions which apply the requested parameters when creating
the requested IO interface.
2. Use the Params structs in the `console` and `spi` commands.

Signed-off-by: Chris Frantz <cfrantz@google.com>