### PR TITLE
[otbn,dv] Weaken trace comparison checks to allow IMEM errors

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -221,7 +221,7 @@ bool OtbnTraceChecker::MatchPair() {
   }
   rtl_pending_ = false;
   iss_pending_ = false;
-  if (!(rtl_entry_ == iss_entry_)) {
+  if (!(iss_entry_.is_model_of(rtl_entry_))) {
     std::cerr
         << ("ERROR: Mismatch between RTL and ISS trace entries.\n"
             "  RTL entry is:\n");

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -13,7 +13,6 @@ class OtbnTraceEntry {
 
   void from_rtl_trace(const std::string &trace);
 
-  bool operator==(const OtbnTraceEntry &other) const;
   void print(const std::string &indent, std::ostream &os) const;
 
   void take_writes(const OtbnTraceEntry &other);
@@ -31,6 +30,9 @@ class OtbnTraceEntry {
   // have been a stall)
   bool is_compatible(const OtbnTraceEntry &other) const;
 
+  const std::string &get_header() const { return hdr_; }
+  const std::vector<std::string> &get_writes() const { return writes_; }
+
  protected:
   std::string hdr_;
   std::vector<std::string> writes_;
@@ -39,6 +41,12 @@ class OtbnTraceEntry {
 class OtbnIssTraceEntry : public OtbnTraceEntry {
  public:
   bool from_iss_trace(const std::vector<std::string> &lines);
+
+  // Return true if this ISS trace entry is a valid model of other.
+  // This is true if the entries match exactly (of course!), but also
+  // allows a bit more wiggle room with some ISS entries that might
+  // not specify some fields exactly.
+  bool is_model_of(const OtbnTraceEntry &other) const;
 
   // Fields that are populated from the "special" line for ISS entries
   struct IssData {


### PR DESCRIPTION
We want to allow the testbench to tell the ISS that IMEM has been
corrupted. When this happens, we're going to have the ISS generate a
line like this:

    E PC: 0x00000094, insn: ??

Of course, that's not exactly equal to what the RTL spits out. But we
can't match the RTL's output exactly, because the RTL's "`insn`" field
might have been corrupted. To support this properly, this patch
weakens the check in `OtbnIssTraceEntry` to require that everything
matches up to the '??'.

You could imagine something much more general: for example, we could
interpret the output from the ISS as a glob or a regexp. But that
seems overly hard: do the stupid thing for now!
