### PR TITLE
Fix up metadata/doc items to get started with the CW310 FPGA

### DIFF
--- a/doc/ug/getting_started_fpga.md
+++ b/doc/ug/getting_started_fpga.md
@@ -162,7 +162,7 @@ To load `hello_world` into the FPGA on the ChipWhisperer CW310 board follow the 
 1. Run the loading tool.
    ```console
    $ cd ${REPO_TOP}
-   $ ./util/fpga/cw310_loader.py --firmware build-bin/sw/device/examples/hello_world/hello_world_fpga_cw310.bin
+   $ ./util/fpga/cw310_loader.py --firmware build-bin/sw/device/examples/hello_world/hello_world_fpga_cw310.bin --set-pll-defaults
    ```
 
    This should report how the binary is split into frames:


### PR DESCRIPTION
As I went through the "Getting Started on FPGAs" user guide, I encountered a couple bumps while using cw310_loader.py. These two little updates should smooth that out for the next user.