### PR TITLE
[sw/testing] Add aon_timer_testutils

### DIFF
--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/testing/check.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
+                                       uint32_t cycles) {
+  // Make sure that wake-up timer is stopped.
+  CHECK(dif_aon_timer_wakeup_stop(aon_timer) == kDifAonTimerOk);
+
+  // Make sure the wake-up IRQ is cleared to avoid false positive.
+  CHECK(dif_aon_timer_irq_acknowledge(
+            aon_timer, kDifAonTimerIrqWakeupThreshold) == kDifAonTimerOk);
+
+  bool is_pending;
+  CHECK(dif_aon_timer_irq_is_pending(aon_timer, kDifAonTimerIrqWakeupThreshold,
+                                     &is_pending) == kDifAonTimerOk);
+  CHECK(!is_pending);
+
+  CHECK(dif_aon_timer_wakeup_start(aon_timer, cycles, 0) == kDifAonTimerOk);
+}

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_AON_TIMER_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_AON_TIMER_TESTUTILS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_aon_timer.h"
+
+/**
+ * Set an aon timer for a number of AON clock cycles.
+ * @param cycles The number of AON clock cycles.
+ */
+void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
+                                       uint32_t cycles);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_AON_TIMER_TESTUTILS_H_

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -7,7 +7,22 @@ sw_lib_testing_rand_testutils = declare_dependency(
   link_with: static_library(
     'sw_lib_testing_rand_testutils',
     sources: ['rand_testutils.c'],
-  )
+  ),
+)
+
+# aon_timer test utilities.
+sw_lib_testing_aon_timer_testutils = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_aon_timer_testutils',
+    sources: [
+      'aon_timer_testutils.c'
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_aon_timer,
+      top_earlgrey,
+    ],
+  ),
 )
 
 # hardware entropy complex (entropy_src, csrng, edn) test utilities.

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -293,7 +293,7 @@ pwrmgr_smoketest_lib = declare_dependency(
     dependencies: [
       sw_lib_dif_pwrmgr,
       sw_lib_dif_rstmgr,
-      sw_lib_dif_aon_timer,
+      sw_lib_testing_aon_timer_testutils,
       sw_lib_mmio,
       sw_lib_runtime_log,
     ],


### PR DESCRIPTION
Create aon_timer_wakeup_config in aon_timer_testutils.
Change pwrmgr_smoketest to use testutils.

Signed-off-by: Guillermo Maturana <maturana@google.com>