### PR TITLE
[reggen] Replace prim_pulse_sync with prim_sync_reqack

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -104,13 +104,16 @@ module adc_ctrl_reg_top (
 
   // cdc oversampling signals
     logic sync_aon_update;
-  prim_pulse_sync u_aon_tgl (
+  prim_sync_reqack u_aon_tgl (
     .clk_src_i(clk_aon_i),
     .rst_src_ni(rst_aon_ni),
-    .src_pulse_i(1'b1),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
-    .dst_pulse_o(sync_aon_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_aon_update),
+    .dst_ack_i(sync_aon_update)
   );
 
   assign reg_rdata = reg_rdata_next ;

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -104,13 +104,16 @@ module aon_timer_reg_top (
 
   // cdc oversampling signals
     logic sync_aon_update;
-  prim_pulse_sync u_aon_tgl (
+  prim_sync_reqack u_aon_tgl (
     .clk_src_i(clk_aon_i),
     .rst_src_ni(rst_aon_ni),
-    .src_pulse_i(1'b1),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
-    .dst_pulse_o(sync_aon_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_aon_update),
+    .dst_ack_i(sync_aon_update)
   );
 
   assign reg_rdata = reg_rdata_next ;

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -104,13 +104,16 @@ module pinmux_reg_top (
 
   // cdc oversampling signals
     logic sync_aon_update;
-  prim_pulse_sync u_aon_tgl (
+  prim_sync_reqack u_aon_tgl (
     .clk_src_i(clk_aon_i),
     .rst_src_ni(rst_aon_ni),
-    .src_pulse_i(1'b1),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
-    .dst_pulse_o(sync_aon_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_aon_update),
+    .dst_ack_i(sync_aon_update)
   );
 
   assign reg_rdata = reg_rdata_next ;

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -103,13 +103,16 @@ module pwm_reg_top (
 
   // cdc oversampling signals
     logic sync_core_update;
-  prim_pulse_sync u_core_tgl (
+  prim_sync_reqack u_core_tgl (
     .clk_src_i(clk_core_i),
     .rst_src_ni(rst_core_ni),
-    .src_pulse_i(1'b1),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
-    .dst_pulse_o(sync_core_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_core_update),
+    .dst_ack_i(sync_core_update)
   );
 
   assign reg_rdata = reg_rdata_next ;

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -104,13 +104,16 @@ module sysrst_ctrl_reg_top (
 
   // cdc oversampling signals
     logic sync_aon_update;
-  prim_pulse_sync u_aon_tgl (
+  prim_sync_reqack u_aon_tgl (
     .clk_src_i(clk_aon_i),
     .rst_src_ni(rst_aon_ni),
-    .src_pulse_i(1'b1),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
-    .dst_pulse_o(sync_aon_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_aon_update),
+    .dst_ack_i(sync_aon_update)
   );
 
   assign reg_rdata = reg_rdata_next ;

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -104,13 +104,16 @@ module pinmux_reg_top (
 
   // cdc oversampling signals
     logic sync_aon_update;
-  prim_pulse_sync u_aon_tgl (
+  prim_sync_reqack u_aon_tgl (
     .clk_src_i(clk_aon_i),
     .rst_src_ni(rst_aon_ni),
-    .src_pulse_i(1'b1),
     .clk_dst_i(clk_i),
     .rst_dst_ni(rst_ni),
-    .dst_pulse_o(sync_aon_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_aon_update),
+    .dst_ack_i(sync_aon_update)
   );
 
   assign reg_rdata = reg_rdata_next ;

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -295,13 +295,16 @@ module ${mod_name} (
     rname = clock.reset
   %>\
   logic sync_${clk_name}_update;
-  prim_pulse_sync u_${tgl_expr} (
+  prim_sync_reqack u_${tgl_expr} (
     .clk_src_i(${cname}),
     .rst_src_ni(${rname}),
-    .src_pulse_i(1'b1),
     .clk_dst_i(${reg_clk_expr}),
     .rst_dst_ni(${reg_rst_expr}),
-    .dst_pulse_o(sync_${clk_name}_update)
+    .req_chk_i(1'b1),
+    .src_req_i(1'b1),
+    .src_ack_o(),
+    .dst_req_o(sync_${clk_name}_update),
+    .dst_ack_i(sync_${clk_name}_update)
   );
   % endfor
 % endif


### PR DESCRIPTION
- This was an oversight, the CDC handling inside reg_top
  used to use prim_pulse_sync. This worked fine if the
  source clock is much slower than the destination clock,
  but cannot always assumed to be true.

- Switch to prim_sync_reqack which has more robust handling
  of clock ratios and is tolerant to a source faster than
  the destination.

Signed-off-by: Timothy Chen <timothytim@google.com>