### PR TITLE
Rom keymgr sealing updates

### DIFF
--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -62,6 +62,14 @@ using MockSecMmio = testing::StrictMock<internal::MockSecMmio>;
   EXPECT_CALL(::mask_rom_test::MockSecMmio::Instance(), \
               Write32Shadowed(addr, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)));
 
+/**
+ * Expect a write counter increment with a given 32-bit increment value.
+ *
+ * @param val Increment value.
+ */
+#define EXPECT_SEC_WRITE_INCREMENT(val) \
+  EXPECT_CALL(::mask_rom_test::MockSecMmio::Instance(), WriteIncrement(val));
+
 extern "C" {
 
 void sec_mmio_init(sec_mmio_shutdown_handler callee) {

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -70,7 +70,7 @@ uint32_t sec_mmio_read32(uint32_t addr) {
   uint32_t value = abs_mmio_read32(addr);
   uint32_t masked_value = value ^ kSecMmioMaskVal;
 
-  upsert_register(addr, value);
+  upsert_register(addr, masked_value);
 
   if ((abs_mmio_read32(addr) ^ kSecMmioMaskVal) != masked_value) {
     sec_mmio_shutdown_cb(kErrorSecMmioReadFault);

--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -109,15 +109,20 @@ TEST_F(SecMmioTest, CheckValues) {
   EXPECT_ABS_READ32(8, 0);
   sec_mmio_write32(8, 0);
 
+  // Test an expected value modification which gets updated by a read.
+  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
+  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
+  EXPECT_EQ(sec_mmio_read32(8), 0xa5a5a5a5);
+
   // The expected permutation order for rnd_offset=0 is {1, 2, 0}.
   EXPECT_ABS_READ32(4, 0x87654321);
-  EXPECT_ABS_READ32(8, 0);
+  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
   EXPECT_ABS_READ32(0, 0x12345678);
   sec_mmio_check_values(/*rnd_offset=*/0);
   EXPECT_EQ(ctx_->check_count, 1);
 
   // The expected permutation order for rnd_offset=1 is {2, 0, 1}.
-  EXPECT_ABS_READ32(8, 0);
+  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
   EXPECT_ABS_READ32(0, 0x12345678);
   EXPECT_ABS_READ32(4, 0x87654321);
   sec_mmio_check_values(/*rnd_offset=*/1);
@@ -126,7 +131,7 @@ TEST_F(SecMmioTest, CheckValues) {
   // The expected permutation order for rnd_offset=32 is {0, 1, 2}.
   EXPECT_ABS_READ32(0, 0x12345678);
   EXPECT_ABS_READ32(4, 0x87654321);
-  EXPECT_ABS_READ32(8, 0);
+  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
   sec_mmio_check_values(/*rnd_offset=*/32);
   EXPECT_EQ(ctx_->check_count, 3);
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -68,15 +68,22 @@ rom_error_t keymgr_init(uint16_t entropy_reseed_interval) {
   return kErrorOk;
 }
 
-void keymgr_set_next_stage_inputs(const keymgr_binding_value_t *binding_value,
-                                  uint32_t max_key_ver) {
+void keymgr_set_next_stage_inputs(
+    const keymgr_binding_value_t *binding_value_sealing,
+    const keymgr_binding_value_t *binding_value_attestation,
+    uint32_t max_key_ver) {
   // Write and lock (rw0c) the software binding value. This register is unlocked
   // by hardware upon a successful state transition.
   // FIXME: Consider using sec_mmio module for the following register writes.
-  for (size_t i = 0; i < ARRAYSIZE(binding_value->data); ++i) {
+  for (size_t i = 0; i < ARRAYSIZE(binding_value_sealing->data); ++i) {
     abs_mmio_write32(
         kBase + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + i * sizeof(uint32_t),
-        binding_value->data[i]);
+        binding_value_sealing->data[i]);
+  }
+  for (size_t i = 0; i < ARRAYSIZE(binding_value_attestation->data); ++i) {
+    abs_mmio_write32(
+        kBase + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET + i * sizeof(uint32_t),
+        binding_value_attestation->data[i]);
   }
   abs_mmio_write32(kBase + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -65,8 +65,10 @@ typedef enum keymgr_state {
  * @param max_key_version Maximum key version from the manifest of the next
  * stage.
  */
-void keymgr_set_next_stage_inputs(const keymgr_binding_value_t *binding_value,
-                                  uint32_t max_key_version);
+void keymgr_set_next_stage_inputs(
+    const keymgr_binding_value_t *binding_value_sealing,
+    const keymgr_binding_value_t *binding_value_attestation,
+    uint32_t max_key_version);
 
 /**
  * Initializes the key manager.

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -58,17 +58,38 @@ typedef enum keymgr_state {
 } keymgr_state_t;
 
 /**
- * Sets the key manager inputs.
+ * Sets the key manager software binding inputs.
  *
- * @param binding_value Software binding value from the manifest of the next
- * stage.
- * @param max_key_version Maximum key version from the manifest of the next
- * stage.
+ * @param binding_value_sealing Software binding for sealing value.
+ * @param binding_value_attestation Software binding for attestation value.
  */
-void keymgr_set_next_stage_inputs(
+void keymgr_sw_binding_set(
     const keymgr_binding_value_t *binding_value_sealing,
-    const keymgr_binding_value_t *binding_value_attestation,
-    uint32_t max_key_version);
+    const keymgr_binding_value_t *binding_value_attestation);
+
+/**
+ * Blocks until the software binding registers are unlocked.
+ *
+ * This function can be called after `keymgr_advance_state()` to wait for the
+ * software binding registers to become available for writing.
+ */
+void keymgr_sw_binding_unlock_wait(void);
+
+/**
+ * Sets the Silicon Creator max key version.
+ *
+ * @param max_key_ver Maximum key version associated with the Silicon Creator
+ * key manager stage.
+ */
+void keymgr_creator_max_ver_set(uint32_t max_key_ver);
+
+/**
+ * Sets the Silicon Owner Intermediate max key version.
+ *
+ * @param max_key_ver Maximum key version associated with the Silicon Onwer
+ * Intermediate key manager stage.
+ */
+void keymgr_owner_int_max_ver_set(uint32_t max_key_ver);
 
 /**
  * Initializes the key manager.
@@ -88,12 +109,16 @@ rom_error_t keymgr_init(uint16_t entropy_reseed_interval);
 /**
  * Advances the state of the key manager.
  *
- * The `keymgr_check_state()` function must be called before this function to
+ * The `keymgr_state_check()` function must be called before this function to
  * ensure the key manager is in the expected state and ready to receive op
  * commands.
  *
- * The caller is responsible for calling the `keymgr_check_state()` at a later
+ * The caller is responsible for calling the `keymgr_state_check()` at a later
  * time to ensure the advance transition completed without errors.
+ *
+ * Note: It is recommended to call `keymgr_sw_binding_unlock_wait()` before the
+ * secure mmio `sec_mmio_check_values()` function to make sure the internal
+ * state of the key manager is updated in the secure mmio expectations table.
  */
 void keymgr_advance_state(void);
 
@@ -104,7 +129,7 @@ void keymgr_advance_state(void);
  * @return `kErrorOk` if the key manager is in `expected_state` and the status
  * is idle or success; otherwise returns `kErrorKeymgrInternal`.
  */
-rom_error_t keymgr_check_state(keymgr_state_t expected_state);
+rom_error_t keymgr_state_check(keymgr_state_t expected_state);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -141,7 +141,8 @@ static void init_flash(void) {
 /** Key manager configuration steps performed in mask ROM. */
 rom_error_t keymgr_rom_test(void) {
   ASSERT_OK(keymgr_check_state(kKeymgrStateReset));
-  keymgr_set_next_stage_inputs(&kBindingValueRomExt, kMaxVerRomExt);
+  keymgr_set_next_stage_inputs(&kBindingValueRomExt, &kBindingValueRomExt,
+                               kMaxVerRomExt);
   return kErrorOk;
 }
 
@@ -158,7 +159,8 @@ rom_error_t keymgr_rom_ext_test(void) {
   keymgr_advance_state();
   ASSERT_OK(keymgr_check_state(kKeymgrStateCreatorRootKey));
 
-  keymgr_set_next_stage_inputs(&kBindingValueBl0, kMaxVerBl0);
+  keymgr_set_next_stage_inputs(&kBindingValueBl0, &kBindingValueBl0,
+                               kMaxVerBl0);
 
   // FIXME: Check `kBindingValueBl0` before advancing state.
   keymgr_advance_state();

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -19,7 +19,8 @@ namespace {
 
 struct SwBindingCfg {
   uint32_t max_key_ver;
-  keymgr_binding_value_t binding_value;
+  keymgr_binding_value_t binding_value_sealing;
+  keymgr_binding_value_t binding_value_attestation;
 };
 
 class KeymgrTest : public mask_rom_test::MaskRomTest {
@@ -37,7 +38,8 @@ class KeymgrTest : public mask_rom_test::MaskRomTest {
   uint32_t base_ = TOP_EARLGREY_KEYMGR_BASE_ADDR;
   SwBindingCfg cfg_ = {
       .max_key_ver = 0xA5A5A5A5,
-      .binding_value = {0, 1, 2, 3, 4, 6, 7, 8},
+      .binding_value_sealing = {0, 1, 2, 3, 4, 6, 7, 8},
+      .binding_value_attestation = {9, 10, 11, 12, 13, 14, 15},
   };
   mask_rom_test::MockAbsMmio mmio_;
 };
@@ -55,28 +57,48 @@ TEST_F(KeymgrTest, Initialize) {
 
 TEST_F(KeymgrTest, SetNextStageInputs) {
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
-                     cfg_.binding_value.data[0]);
+                     cfg_.binding_value_sealing.data[0]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
-                     cfg_.binding_value.data[1]);
+                     cfg_.binding_value_sealing.data[1]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
-                     cfg_.binding_value.data[2]);
+                     cfg_.binding_value_sealing.data[2]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
-                     cfg_.binding_value.data[3]);
+                     cfg_.binding_value_sealing.data[3]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
-                     cfg_.binding_value.data[4]);
+                     cfg_.binding_value_sealing.data[4]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
-                     cfg_.binding_value.data[5]);
+                     cfg_.binding_value_sealing.data[5]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
-                     cfg_.binding_value.data[6]);
+                     cfg_.binding_value_sealing.data[6]);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
-                     cfg_.binding_value.data[7]);
+                     cfg_.binding_value_sealing.data[7]);
+
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[0]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[1]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[2]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[3]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[4]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[5]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[6]);
+  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
+                     cfg_.binding_value_attestation.data[7]);
+
   EXPECT_ABS_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
 
   EXPECT_ABS_WRITE32_SHADOWED(
       base_ + KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
   EXPECT_ABS_WRITE32(base_ + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
 
-  keymgr_set_next_stage_inputs(&cfg_.binding_value, cfg_.max_key_ver);
+  keymgr_set_next_stage_inputs(&cfg_.binding_value_sealing,
+                               &cfg_.binding_value_attestation,
+                               cfg_.max_key_ver);
 }
 
 TEST_F(KeymgrTest, AdvanceState) {

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -9,6 +9,7 @@
 
 #include "gtest/gtest.h"
 #include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -33,7 +34,7 @@ class KeymgrTest : public mask_rom_test::MaskRomTest {
     EXPECT_ABS_READ32(base_ + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
     EXPECT_ABS_WRITE32(base_ + KEYMGR_ERR_CODE_REG_OFFSET, err_code);
 
-    EXPECT_ABS_READ32(base_ + KEYMGR_WORKING_STATE_REG_OFFSET, km_state);
+    EXPECT_SEC_READ32(base_ + KEYMGR_WORKING_STATE_REG_OFFSET, km_state);
   }
   uint32_t base_ = TOP_EARLGREY_KEYMGR_BASE_ADDR;
   SwBindingCfg cfg_ = {
@@ -42,6 +43,7 @@ class KeymgrTest : public mask_rom_test::MaskRomTest {
       .binding_value_attestation = {9, 10, 11, 12, 13, 14, 15},
   };
   mask_rom_test::MockAbsMmio mmio_;
+  mask_rom_test::MockSecMmio sec_mmio_;
 };
 
 TEST_F(KeymgrTest, Initialize) {
@@ -49,56 +51,74 @@ TEST_F(KeymgrTest, Initialize) {
                     KEYMGR_WORKING_STATE_STATE_VALUE_RESET,
                     /*err_code=*/0u);
 
-  EXPECT_ABS_WRITE32_SHADOWED(
+  EXPECT_SEC_WRITE32_SHADOWED(
       base_ + KEYMGR_RESEED_INTERVAL_SHADOWED_REG_OFFSET, 0u);
-
+  EXPECT_SEC_WRITE_INCREMENT(1);
   EXPECT_EQ(keymgr_init(0u), kErrorOk);
 }
 
-TEST_F(KeymgrTest, SetNextStageInputs) {
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
+TEST_F(KeymgrTest, SwBindingValuesSet) {
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET,
                      cfg_.binding_value_sealing.data[0]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_1_REG_OFFSET,
                      cfg_.binding_value_sealing.data[1]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET,
                      cfg_.binding_value_sealing.data[2]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET,
                      cfg_.binding_value_sealing.data[3]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET,
                      cfg_.binding_value_sealing.data[4]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET,
                      cfg_.binding_value_sealing.data[5]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET,
                      cfg_.binding_value_sealing.data[6]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET,
                      cfg_.binding_value_sealing.data[7]);
 
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET,
                      cfg_.binding_value_attestation.data[0]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_1_REG_OFFSET,
                      cfg_.binding_value_attestation.data[1]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_2_REG_OFFSET,
                      cfg_.binding_value_attestation.data[2]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_3_REG_OFFSET,
                      cfg_.binding_value_attestation.data[3]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_4_REG_OFFSET,
                      cfg_.binding_value_attestation.data[4]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_5_REG_OFFSET,
                      cfg_.binding_value_attestation.data[5]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_6_REG_OFFSET,
                      cfg_.binding_value_attestation.data[6]);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_ATTEST_SW_BINDING_7_REG_OFFSET,
                      cfg_.binding_value_attestation.data[7]);
 
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(17);
+  keymgr_sw_binding_set(&cfg_.binding_value_sealing,
+                        &cfg_.binding_value_attestation);
+}
 
-  EXPECT_ABS_WRITE32_SHADOWED(
+TEST_F(KeymgrTest, SwBindingUnlockWait) {
+  EXPECT_ABS_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  EXPECT_SEC_READ32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 1);
+  keymgr_sw_binding_unlock_wait();
+}
+
+TEST_F(KeymgrTest, SetCreatorMaxVerKey) {
+  EXPECT_SEC_WRITE32_SHADOWED(
       base_ + KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
-  EXPECT_ABS_WRITE32(base_ + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(2);
+  keymgr_creator_max_ver_set(cfg_.max_key_ver);
+}
 
-  keymgr_set_next_stage_inputs(&cfg_.binding_value_sealing,
-                               &cfg_.binding_value_attestation,
-                               cfg_.max_key_ver);
+TEST_F(KeymgrTest, SetOwnerIntMaxVerKey) {
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET,
+      cfg_.max_key_ver);
+  EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(2);
+  keymgr_owner_int_max_ver_set(cfg_.max_key_ver);
 }
 
 TEST_F(KeymgrTest, AdvanceState) {
@@ -117,28 +137,28 @@ TEST_F(KeymgrTest, CheckState) {
   ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
                     KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
                     /*err_code=*/0u);
-  EXPECT_EQ(keymgr_check_state(kKeymgrStateCreatorRootKey), kErrorOk);
+  EXPECT_EQ(keymgr_state_check(kKeymgrStateCreatorRootKey), kErrorOk);
 }
 
 TEST_F(KeymgrTest, CheckStateInvalidResponse) {
   ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
                     KEYMGR_WORKING_STATE_STATE_VALUE_INVALID,
                     /*err_code=*/0u);
-  EXPECT_EQ(keymgr_check_state(kKeymgrStateCreatorRootKey),
+  EXPECT_EQ(keymgr_state_check(kKeymgrStateCreatorRootKey),
             kErrorKeymgrInternal);
 
   // Any non-idle status is expected to fail.
   ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_DONE_ERROR,
                     KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
                     /*err_code=*/0u);
-  EXPECT_EQ(keymgr_check_state(kKeymgrStateCreatorRootKey),
+  EXPECT_EQ(keymgr_state_check(kKeymgrStateCreatorRootKey),
             kErrorKeymgrInternal);
 
   // Any non-zero error code is expected to fail.
   ExpectStatusCheck(KEYMGR_OP_STATUS_STATUS_VALUE_IDLE,
                     KEYMGR_WORKING_STATE_STATE_VALUE_CREATOR_ROOT_KEY,
                     /*err_code=*/1u);
-  EXPECT_EQ(keymgr_check_state(kKeymgrStateCreatorRootKey),
+  EXPECT_EQ(keymgr_state_check(kKeymgrStateCreatorRootKey),
             kErrorKeymgrInternal);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -74,6 +74,7 @@ sw_silicon_creator_lib_driver_keymgr = declare_dependency(
     ],
     dependencies: [
       sw_silicon_creator_lib_base_abs_mmio,
+      sw_silicon_creator_lib_base_sec_mmio,
     ],
   ),
 )
@@ -109,6 +110,7 @@ sw_silicon_creator_lib_driver_keymgr_functest = declare_dependency(
       sw_lib_dif_pwrmgr,
       sw_lib_dif_otp_ctrl,
       sw_lib_flash_ctrl,
+      sw_silicon_creator_lib_base_sec_mmio,
       sw_silicon_creator_lib_driver_keymgr,
       sw_silicon_creator_lib_driver_lifecycle,
     ],

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -144,6 +144,7 @@ static rom_error_t mask_rom_verify(const manifest_t *manifest) {
 static rom_error_t mask_rom_boot(const manifest_t *manifest) {
   RETURN_IF_ERROR(keymgr_check_state(kKeymgrStateReset));
   keymgr_set_next_stage_inputs(&manifest->binding_value,
+                               &manifest->binding_value,
                                manifest->max_key_version);
 
   // Unlock execution of ROM_EXT executable code (text) sections.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -142,10 +142,9 @@ static rom_error_t mask_rom_verify(const manifest_t *manifest) {
  * @return rom_error_t Result of the operation.
  */
 static rom_error_t mask_rom_boot(const manifest_t *manifest) {
-  RETURN_IF_ERROR(keymgr_check_state(kKeymgrStateReset));
-  keymgr_set_next_stage_inputs(&manifest->binding_value,
-                               &manifest->binding_value,
-                               manifest->max_key_version);
+  RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateReset));
+  keymgr_sw_binding_set(&manifest->binding_value, &manifest->binding_value);
+  keymgr_creator_max_ver_set(manifest->max_key_version);
 
   // Unlock execution of ROM_EXT executable code (text) sections.
   RETURN_IF_ERROR(epmp_state_check(&epmp));


### PR DESCRIPTION
Add support for software binding configuration for both sealing and  attestation. At the moment both binding values are sourced from the manifest.


**Other changes** 

*Enable sec_mmio*

Enable sec_mmio functionality in the keymgr driver. The following values are now tracked by sec_mmio:
   
* KEYMGR_WORKING_STATE_REG_OFFSET
* KEYMGR_RESEED_INTERVAL_SHADOWED_REG_OFFSET
* KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET[0:7]
* KEYMGR_ATTEST_SW_BINDING_0_REG_OFFSET[0:7]
* KEYMGR_SW_BINDING_REGWEN_REG_OFFSET
* KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET
* KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET
* KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET
* KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET
    
The max key version register configuration was moved into a separate function to be able to lock down the creator versus owner intermediate key intermediate values.
    
The keymgr functional test was updated to enable sec_mmio expectation checks during the simulated boot sequence.

*sec_mmio fixes*

Fix issue with the `sec_mmio_read32()` function, where the expectation value was stored in unmasked form.