### PR TITLE
[dif/clkmgr] Autogen DIF components and use in tree.

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -75,7 +75,7 @@ index 5dc1286af..1e2dced96 100644
      simple_serial_process_packet();
    }
 diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
-index e894f1793..5629a15d8 100644
+index 4a431b9ea..fcfcee1ab 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
 @@ -56,7 +56,6 @@ enum {
@@ -102,7 +102,7 @@ index e894f1793..5629a15d8 100644
  }
  
  /**
-@@ -148,30 +143,11 @@ void handler_irq_timer(void) {
+@@ -148,29 +143,10 @@ void handler_irq_timer(void) {
   * @param disable Set of peripherals to disable.
   */
  void sca_disable_peripherals(sca_peripherals_t disable) {
@@ -127,33 +127,32 @@ index e894f1793..5629a15d8 100644
 -
    // Disable HMAC, KMAC, OTBN and USB clocks through CLKMGR DIF.
    const dif_clkmgr_params_t clkmgr_params = {
-       .base_addr = mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
        .last_gateable_clock = CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
 -      .last_hintable_clock = CLKMGR_CLK_HINTS_STATUS_CLK_MAIN_OTBN_VAL_BIT};
 +      .last_hintable_clock = CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT};
    dif_clkmgr_t clkmgr;
-   IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr));
- 
-@@ -185,19 +161,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
-         &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
-         kDifClkmgrToggleDisabled));
+   IGNORE_RESULT(
+       dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
+@@ -186,19 +162,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
+         &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
+         kDifToggleDisabled));
    }
 -  if (disable & kScaPeripheralKmac) {
 -    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT,
--        kDifClkmgrToggleDisabled));
+-        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT,
+-        kDifToggleDisabled));
 -  }
 -  if (disable & kScaPeripheralOtbn) {
 -    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--        &clkmgr, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
--        kDifClkmgrToggleDisabled));
+-        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
+-        kDifToggleDisabled));
 -    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT,
--        kDifClkmgrToggleDisabled));
+-        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT,
+-        kDifToggleDisabled));
 -  }
    if (disable & kScaPeripheralUsb) {
      IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
-         &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
+         &clkmgr, clkmgr_params, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
 diff --git a/sw/device/tests/aes_smoketest.c b/sw/device/tests/aes_smoketest.c
 index 1a5fef16c..214e08151 100644
 --- a/sw/device/tests/aes_smoketest.c
@@ -177,7 +176,7 @@ index 1a5fef16c..214e08151 100644
    CHECK_DIF_OK(
        dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index d9260ca0f..ff7e3ee0b 100644
+index 96803744e..27e3e2727 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
 @@ -207,7 +207,6 @@ aes_smoketest_lib = declare_dependency(

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_clkmgr.h"
+
+#include "clkmgr_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.h
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_CLKMGR_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_CLKMGR_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/clkmgr/doc/">CLKMGR</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to clkmgr.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_clkmgr {
+  /**
+   * The base address for the clkmgr hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_clkmgr_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_CLKMGR_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_clkmgr.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "clkmgr_regs.h"  // Generated.
+
+namespace dif_clkmgr_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class ClkmgrTest : public Test, public MmioTest {
+ protected:
+  dif_clkmgr_t clkmgr_ = {.base_addr = dev().region()};
+};
+
+}  // namespace
+}  // namespace dif_clkmgr_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen Reset Manager DIF library
-sw_lib_dif_autogen_rstmgr = declare_dependency(
+# Autogen Clock Manager DIF library
+sw_lib_dif_autogen_clkmgr = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_rstmgr',
+    'sw_lib_dif_autogen_clkmgr',
     sources: [
-      hw_ip_rstmgr_reg_h,
-      'dif_rstmgr_autogen.c',
+      hw_ip_clkmgr_reg_h,
+      'dif_clkmgr_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -163,6 +163,20 @@ sw_lib_dif_autogen_otbn = declare_dependency(
     sources: [
       hw_ip_otbn_reg_h,
       'dif_otbn_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen Reset Manager DIF library
+sw_lib_dif_autogen_rstmgr = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_rstmgr',
+    sources: [
+      hw_ip_rstmgr_reg_h,
+      'dif_rstmgr_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -14,6 +14,7 @@ sw_lib_dif_clkmgr = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_dif_autogen_clkmgr,
     ],
   )
 )
@@ -21,9 +22,10 @@ sw_lib_dif_clkmgr = declare_dependency(
 test('dif_clkmgr_unittest', executable(
     'dif_clkmgr_unittest',
     sources: [
-      hw_ip_clkmgr_reg_h,
+      'autogen/dif_clkmgr_autogen_unittest.cc',
       meson.source_root() / 'sw/device/lib/dif/dif_clkmgr.c',
-      'dif_clkmgr_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_clkmgr_autogen.c',
+      hw_ip_clkmgr_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -169,39 +169,40 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
 
   // Disable HMAC, KMAC, OTBN and USB clocks through CLKMGR DIF.
   const dif_clkmgr_params_t clkmgr_params = {
-      .base_addr = mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
       .last_gateable_clock = CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
       .last_hintable_clock = CLKMGR_CLK_HINTS_STATUS_CLK_MAIN_OTBN_VAL_BIT};
   dif_clkmgr_t clkmgr;
-  IGNORE_RESULT(dif_clkmgr_init(clkmgr_params, &clkmgr));
+  IGNORE_RESULT(
+      dif_clkmgr_init(mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR),
+                      clkmgr_params, &clkmgr));
 
   if (disable & kScaPeripheralAes) {
     IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_AES_HINT_BIT,
-        kDifClkmgrToggleDisabled));
+        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_AES_HINT_BIT,
+        kDifToggleDisabled));
   }
   if (disable & kScaPeripheralHmac) {
     IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
-        kDifClkmgrToggleDisabled));
+        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT,
+        kDifToggleDisabled));
   }
   if (disable & kScaPeripheralKmac) {
     IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT,
-        kDifClkmgrToggleDisabled));
+        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT,
+        kDifToggleDisabled));
   }
   if (disable & kScaPeripheralOtbn) {
     IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-        &clkmgr, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
-        kDifClkmgrToggleDisabled));
+        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
+        kDifToggleDisabled));
     IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT,
-        kDifClkmgrToggleDisabled));
+        &clkmgr, clkmgr_params, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT,
+        kDifToggleDisabled));
   }
   if (disable & kScaPeripheralUsb) {
     IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
-        &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
-        kDifClkmgrToggleDisabled));
+        &clkmgr, clkmgr_params, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT,
+        kDifToggleDisabled));
   }
 }
 


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "clkmgr".

Note: the clkmgr IP does not generate any interrupts, but it does generate alerts, so the changes in the PR will setup the ability to add autogenerated alert DIF(s) in the near future. Specifically, part of these changes involve migrating the clkmgr DIFs to use global (shared) DIF error codes, the autogenerated context (handle) struct, and decouple the dif_clkmgr_params_t struct from the context (handle) struct to stay consistent with the Alert Handler DIFs, as described in #8409.