### PR TITLE
[dif] Update DIF autogen templates to fix minor bugs.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
@@ -83,8 +83,7 @@ typedef uint32_t dif_alert_handler_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param alert_handler A alert_handler handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -80,7 +80,8 @@ TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
   EXPECT_EQ(dif_alert_handler_irq_is_pending(
-                &alert_handler_, (dif_alert_handler_irq_t)32, &is_pending),
+                &alert_handler_, static_cast<dif_alert_handler_irq_t>(32),
+                &is_pending),
             kDifBadArg);
 }
 
@@ -115,9 +116,9 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(
-      dif_alert_handler_irq_acknowledge(nullptr, (dif_alert_handler_irq_t)32),
-      kDifBadArg);
+  EXPECT_EQ(dif_alert_handler_irq_acknowledge(
+                nullptr, static_cast<dif_alert_handler_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -158,7 +159,8 @@ TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
   EXPECT_EQ(dif_alert_handler_irq_get_enabled(
-                &alert_handler_, (dif_alert_handler_irq_t)32, &irq_state),
+                &alert_handler_, static_cast<dif_alert_handler_irq_t>(32),
+                &irq_state),
             kDifBadArg);
 }
 
@@ -197,9 +199,10 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_alert_handler_irq_set_enabled(
-                &alert_handler_, (dif_alert_handler_irq_t)32, irq_state),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_alert_handler_irq_set_enabled(
+          &alert_handler_, static_cast<dif_alert_handler_irq_t>(32), irq_state),
+      kDifBadArg);
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -230,7 +233,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_alert_handler_irq_force(nullptr, (dif_alert_handler_irq_t)32),
+  EXPECT_EQ(dif_alert_handler_irq_force(
+                nullptr, static_cast<dif_alert_handler_irq_t>(32)),
             kDifBadArg);
 }
 

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.h
@@ -80,8 +80,7 @@ typedef uint32_t dif_csrng_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param csrng A csrng handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -75,7 +75,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_csrng_irq_is_pending(&csrng_, (dif_csrng_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_csrng_irq_is_pending(&csrng_, static_cast<dif_csrng_irq_t>(32),
+                                     &is_pending),
             kDifBadArg);
 }
 
@@ -109,8 +110,9 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_csrng_irq_acknowledge(nullptr, (dif_csrng_irq_t)32),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_csrng_irq_acknowledge(nullptr, static_cast<dif_csrng_irq_t>(32)),
+      kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -147,7 +149,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_csrng_irq_get_enabled(&csrng_, (dif_csrng_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_csrng_irq_get_enabled(&csrng_, static_cast<dif_csrng_irq_t>(32),
+                                      &irq_state),
             kDifBadArg);
 }
 
@@ -186,7 +189,8 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_csrng_irq_set_enabled(&csrng_, (dif_csrng_irq_t)32, irq_state),
+  EXPECT_EQ(dif_csrng_irq_set_enabled(&csrng_, static_cast<dif_csrng_irq_t>(32),
+                                      irq_state),
             kDifBadArg);
 }
 
@@ -217,7 +221,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_csrng_irq_force(nullptr, (dif_csrng_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_csrng_irq_force(nullptr, static_cast<dif_csrng_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.h
@@ -70,8 +70,7 @@ typedef uint32_t dif_edn_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param edn A edn handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -73,7 +73,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_edn_irq_is_pending(&edn_, (dif_edn_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_edn_irq_is_pending(&edn_, static_cast<dif_edn_irq_t>(32),
+                                   &is_pending),
             kDifBadArg);
 }
 
@@ -105,7 +106,8 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_edn_irq_acknowledge(nullptr, (dif_edn_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_edn_irq_acknowledge(nullptr, static_cast<dif_edn_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -139,7 +141,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_edn_irq_get_enabled(&edn_, (dif_edn_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_edn_irq_get_enabled(&edn_, static_cast<dif_edn_irq_t>(32),
+                                    &irq_state),
             kDifBadArg);
 }
 
@@ -176,8 +179,9 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_edn_irq_set_enabled(&edn_, (dif_edn_irq_t)32, irq_state),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_edn_irq_set_enabled(&edn_, static_cast<dif_edn_irq_t>(32), irq_state),
+      kDifBadArg);
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -205,7 +209,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_edn_irq_force(nullptr, (dif_edn_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_edn_irq_force(nullptr, static_cast<dif_edn_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
@@ -80,8 +80,7 @@ typedef uint32_t dif_entropy_src_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param entropy_src A entropy_src handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -77,9 +77,10 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_entropy_src_irq_is_pending(
-                &entropy_src_, (dif_entropy_src_irq_t)32, &is_pending),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_entropy_src_irq_is_pending(
+          &entropy_src_, static_cast<dif_entropy_src_irq_t>(32), &is_pending),
+      kDifBadArg);
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -113,7 +114,8 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_entropy_src_irq_acknowledge(nullptr, (dif_entropy_src_irq_t)32),
+  EXPECT_EQ(dif_entropy_src_irq_acknowledge(
+                nullptr, static_cast<dif_entropy_src_irq_t>(32)),
             kDifBadArg);
 }
 
@@ -154,9 +156,10 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_entropy_src_irq_get_enabled(
-                &entropy_src_, (dif_entropy_src_irq_t)32, &irq_state),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_entropy_src_irq_get_enabled(
+          &entropy_src_, static_cast<dif_entropy_src_irq_t>(32), &irq_state),
+      kDifBadArg);
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -194,9 +197,10 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_entropy_src_irq_set_enabled(
-                &entropy_src_, (dif_entropy_src_irq_t)32, irq_state),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_entropy_src_irq_set_enabled(
+          &entropy_src_, static_cast<dif_entropy_src_irq_t>(32), irq_state),
+      kDifBadArg);
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -227,7 +231,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_entropy_src_irq_force(nullptr, (dif_entropy_src_irq_t)32),
+  EXPECT_EQ(dif_entropy_src_irq_force(nullptr,
+                                      static_cast<dif_entropy_src_irq_t>(32)),
             kDifBadArg);
 }
 

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.h
@@ -97,8 +97,7 @@ typedef uint32_t dif_gpio_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param gpio A gpio handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -72,7 +72,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, (dif_gpio_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, static_cast<dif_gpio_irq_t>(32),
+                                    &is_pending),
             kDifBadArg);
 }
 
@@ -101,7 +102,8 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, (dif_gpio_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, static_cast<dif_gpio_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -132,7 +134,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, (dif_gpio_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, static_cast<dif_gpio_irq_t>(32),
+                                     &irq_state),
             kDifBadArg);
 }
 
@@ -166,7 +169,8 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, (dif_gpio_irq_t)32, irq_state),
+  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, static_cast<dif_gpio_irq_t>(32),
+                                     irq_state),
             kDifBadArg);
 }
 
@@ -193,7 +197,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_gpio_irq_force(nullptr, (dif_gpio_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_gpio_irq_force(nullptr, static_cast<dif_gpio_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.h
@@ -74,8 +74,7 @@ typedef uint32_t dif_hmac_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param hmac A hmac handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -72,7 +72,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_hmac_irq_is_pending(&hmac_, (dif_hmac_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_hmac_irq_is_pending(&hmac_, static_cast<dif_hmac_irq_t>(32),
+                                    &is_pending),
             kDifBadArg);
 }
 
@@ -103,7 +104,8 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_hmac_irq_acknowledge(nullptr, (dif_hmac_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_hmac_irq_acknowledge(nullptr, static_cast<dif_hmac_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -136,7 +138,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, (dif_hmac_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_hmac_irq_get_enabled(&hmac_, static_cast<dif_hmac_irq_t>(32),
+                                     &irq_state),
             kDifBadArg);
 }
 
@@ -172,7 +175,8 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_hmac_irq_set_enabled(&hmac_, (dif_hmac_irq_t)32, irq_state),
+  EXPECT_EQ(dif_hmac_irq_set_enabled(&hmac_, static_cast<dif_hmac_irq_t>(32),
+                                     irq_state),
             kDifBadArg);
 }
 
@@ -201,7 +205,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_hmac_irq_force(nullptr, (dif_hmac_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_hmac_irq_force(nullptr, static_cast<dif_hmac_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -129,8 +129,7 @@ typedef uint32_t dif_i2c_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param i2c A i2c handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -73,7 +73,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, (dif_i2c_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_i2c_irq_is_pending(&i2c_, static_cast<dif_i2c_irq_t>(32),
+                                   &is_pending),
             kDifBadArg);
 }
 
@@ -105,7 +106,8 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_i2c_irq_acknowledge(nullptr, (dif_i2c_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_i2c_irq_acknowledge(nullptr, static_cast<dif_i2c_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -139,7 +141,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_i2c_irq_get_enabled(&i2c_, (dif_i2c_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_i2c_irq_get_enabled(&i2c_, static_cast<dif_i2c_irq_t>(32),
+                                    &irq_state),
             kDifBadArg);
 }
 
@@ -175,8 +178,9 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_i2c_irq_set_enabled(&i2c_, (dif_i2c_irq_t)32, irq_state),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_i2c_irq_set_enabled(&i2c_, static_cast<dif_i2c_irq_t>(32), irq_state),
+      kDifBadArg);
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -204,7 +208,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_i2c_irq_force(nullptr, (dif_i2c_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_i2c_irq_force(nullptr, static_cast<dif_i2c_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
@@ -66,8 +66,7 @@ typedef uint32_t dif_keymgr_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param keymgr A keymgr handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -73,9 +73,9 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(
-      dif_keymgr_irq_is_pending(&keymgr_, (dif_keymgr_irq_t)32, &is_pending),
-      kDifBadArg);
+  EXPECT_EQ(dif_keymgr_irq_is_pending(
+                &keymgr_, static_cast<dif_keymgr_irq_t>(32), &is_pending),
+            kDifBadArg);
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -89,15 +89,6 @@ TEST_F(IrqIsPendingTest, Success) {
       dif_keymgr_irq_is_pending(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
       kDifOk);
   EXPECT_TRUE(irq_state);
-
-  // Get the last IRQ state.
-  irq_state = true;
-  EXPECT_READ32(KEYMGR_INTR_STATE_REG_OFFSET,
-                {{KEYMGR_INTR_STATE_OP_DONE_BIT, false}});
-  EXPECT_EQ(
-      dif_keymgr_irq_is_pending(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
-      kDifOk);
-  EXPECT_FALSE(irq_state);
 }
 
 class IrqAcknowledgeTest : public KeymgrTest {};
@@ -108,17 +99,13 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_keymgr_irq_acknowledge(nullptr, (dif_keymgr_irq_t)32),
-            kDifBadArg);
+  EXPECT_EQ(
+      dif_keymgr_irq_acknowledge(nullptr, static_cast<dif_keymgr_irq_t>(32)),
+      kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
-  EXPECT_WRITE32(KEYMGR_INTR_STATE_REG_OFFSET,
-                 {{KEYMGR_INTR_STATE_OP_DONE_BIT, true}});
-  EXPECT_EQ(dif_keymgr_irq_acknowledge(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
-
-  // Clear the last IRQ state.
   EXPECT_WRITE32(KEYMGR_INTR_STATE_REG_OFFSET,
                  {{KEYMGR_INTR_STATE_OP_DONE_BIT, true}});
   EXPECT_EQ(dif_keymgr_irq_acknowledge(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
@@ -143,9 +130,9 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_keymgr_irq_get_enabled(&keymgr_, (dif_keymgr_irq_t)32, &irq_state),
-      kDifBadArg);
+  EXPECT_EQ(dif_keymgr_irq_get_enabled(
+                &keymgr_, static_cast<dif_keymgr_irq_t>(32), &irq_state),
+            kDifBadArg);
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -159,15 +146,6 @@ TEST_F(IrqGetEnabledTest, Success) {
       dif_keymgr_irq_get_enabled(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
       kDifOk);
   EXPECT_EQ(irq_state, kDifToggleEnabled);
-
-  // Last IRQ is disabled.
-  irq_state = kDifToggleEnabled;
-  EXPECT_READ32(KEYMGR_INTR_ENABLE_REG_OFFSET,
-                {{KEYMGR_INTR_ENABLE_OP_DONE_BIT, false}});
-  EXPECT_EQ(
-      dif_keymgr_irq_get_enabled(&keymgr_, kDifKeymgrIrqOpDone, &irq_state),
-      kDifOk);
-  EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
 class IrqSetEnabledTest : public KeymgrTest {};
@@ -182,9 +160,9 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(
-      dif_keymgr_irq_set_enabled(&keymgr_, (dif_keymgr_irq_t)32, irq_state),
-      kDifBadArg);
+  EXPECT_EQ(dif_keymgr_irq_set_enabled(
+                &keymgr_, static_cast<dif_keymgr_irq_t>(32), irq_state),
+            kDifBadArg);
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -197,14 +175,6 @@ TEST_F(IrqSetEnabledTest, Success) {
   EXPECT_EQ(
       dif_keymgr_irq_set_enabled(&keymgr_, kDifKeymgrIrqOpDone, irq_state),
       kDifOk);
-
-  // Disable last IRQ.
-  irq_state = kDifToggleDisabled;
-  EXPECT_MASK32(KEYMGR_INTR_ENABLE_REG_OFFSET,
-                {{KEYMGR_INTR_ENABLE_OP_DONE_BIT, 0x1, false}});
-  EXPECT_EQ(
-      dif_keymgr_irq_set_enabled(&keymgr_, kDifKeymgrIrqOpDone, irq_state),
-      kDifOk);
 }
 
 class IrqForceTest : public KeymgrTest {};
@@ -214,16 +184,12 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_keymgr_irq_force(nullptr, (dif_keymgr_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_keymgr_irq_force(nullptr, static_cast<dif_keymgr_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
-  EXPECT_WRITE32(KEYMGR_INTR_TEST_REG_OFFSET,
-                 {{KEYMGR_INTR_TEST_OP_DONE_BIT, true}});
-  EXPECT_EQ(dif_keymgr_irq_force(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);
-
-  // Force last IRQ.
   EXPECT_WRITE32(KEYMGR_INTR_TEST_REG_OFFSET,
                  {{KEYMGR_INTR_TEST_OP_DONE_BIT, true}});
   EXPECT_EQ(dif_keymgr_irq_force(&keymgr_, kDifKeymgrIrqOpDone), kDifOk);

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.h
@@ -66,8 +66,7 @@ typedef uint32_t dif_otbn_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param otbn A otbn handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -72,7 +72,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, (dif_otbn_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, static_cast<dif_otbn_irq_t>(32),
+                                    &is_pending),
             kDifBadArg);
 }
 
@@ -85,14 +86,6 @@ TEST_F(IrqIsPendingTest, Success) {
   EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, &irq_state),
             kDifOk);
   EXPECT_TRUE(irq_state);
-
-  // Get the last IRQ state.
-  irq_state = true;
-  EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET,
-                {{OTBN_INTR_STATE_DONE_BIT, false}});
-  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, &irq_state),
-            kDifOk);
-  EXPECT_FALSE(irq_state);
 }
 
 class IrqAcknowledgeTest : public OtbnTest {};
@@ -102,16 +95,12 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_otbn_irq_acknowledge(nullptr, (dif_otbn_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_otbn_irq_acknowledge(nullptr, static_cast<dif_otbn_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
-  EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET,
-                 {{OTBN_INTR_STATE_DONE_BIT, true}});
-  EXPECT_EQ(dif_otbn_irq_acknowledge(&otbn_, kDifOtbnIrqDone), kDifOk);
-
-  // Clear the last IRQ state.
   EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET,
                  {{OTBN_INTR_STATE_DONE_BIT, true}});
   EXPECT_EQ(dif_otbn_irq_acknowledge(&otbn_, kDifOtbnIrqDone), kDifOk);
@@ -135,7 +124,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, (dif_otbn_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, static_cast<dif_otbn_irq_t>(32),
+                                     &irq_state),
             kDifBadArg);
 }
 
@@ -149,14 +139,6 @@ TEST_F(IrqGetEnabledTest, Success) {
   EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, &irq_state),
             kDifOk);
   EXPECT_EQ(irq_state, kDifToggleEnabled);
-
-  // Last IRQ is disabled.
-  irq_state = kDifToggleEnabled;
-  EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET,
-                {{OTBN_INTR_ENABLE_DONE_BIT, false}});
-  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, &irq_state),
-            kDifOk);
-  EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
 class IrqSetEnabledTest : public OtbnTest {};
@@ -171,7 +153,8 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, (dif_otbn_irq_t)32, irq_state),
+  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, static_cast<dif_otbn_irq_t>(32),
+                                     irq_state),
             kDifBadArg);
 }
 
@@ -184,13 +167,6 @@ TEST_F(IrqSetEnabledTest, Success) {
                 {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, true}});
   EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, kDifOtbnIrqDone, irq_state),
             kDifOk);
-
-  // Disable last IRQ.
-  irq_state = kDifToggleDisabled;
-  EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
-                {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, false}});
-  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, kDifOtbnIrqDone, irq_state),
-            kDifOk);
 }
 
 class IrqForceTest : public OtbnTest {};
@@ -200,15 +176,12 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_otbn_irq_force(nullptr, (dif_otbn_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_otbn_irq_force(nullptr, static_cast<dif_otbn_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
-  EXPECT_WRITE32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_DONE_BIT, true}});
-  EXPECT_EQ(dif_otbn_irq_force(&otbn_, kDifOtbnIrqDone), kDifOk);
-
-  // Force last IRQ.
   EXPECT_WRITE32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_DONE_BIT, true}});
   EXPECT_EQ(dif_otbn_irq_force(&otbn_, kDifOtbnIrqDone), kDifOk);
 }

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.h
@@ -95,8 +95,7 @@ typedef uint32_t dif_uart_irq_enable_snapshot_t;
  * Returns whether a particular interrupt is currently pending.
  *
  * @param uart A uart handle.
- * @param irq An interrupt request.
- * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -73,7 +73,8 @@ TEST_F(IrqIsPendingTest, NullArgs) {
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_uart_irq_is_pending(&uart_, (dif_uart_irq_t)32, &is_pending),
+  EXPECT_EQ(dif_uart_irq_is_pending(&uart_, static_cast<dif_uart_irq_t>(32),
+                                    &is_pending),
             kDifBadArg);
 }
 
@@ -105,7 +106,8 @@ TEST_F(IrqAcknowledgeTest, NullArgs) {
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_uart_irq_acknowledge(nullptr, (dif_uart_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_uart_irq_acknowledge(nullptr, static_cast<dif_uart_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
@@ -139,7 +141,8 @@ TEST_F(IrqGetEnabledTest, NullArgs) {
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_uart_irq_get_enabled(&uart_, (dif_uart_irq_t)32, &irq_state),
+  EXPECT_EQ(dif_uart_irq_get_enabled(&uart_, static_cast<dif_uart_irq_t>(32),
+                                     &irq_state),
             kDifBadArg);
 }
 
@@ -178,7 +181,8 @@ TEST_F(IrqSetEnabledTest, NullArgs) {
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, (dif_uart_irq_t)32, irq_state),
+  EXPECT_EQ(dif_uart_irq_set_enabled(&uart_, static_cast<dif_uart_irq_t>(32),
+                                     irq_state),
             kDifBadArg);
 }
 
@@ -207,7 +211,8 @@ TEST_F(IrqForceTest, NullArgs) {
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_uart_irq_force(nullptr, (dif_uart_irq_t)32), kDifBadArg);
+  EXPECT_EQ(dif_uart_irq_force(nullptr, static_cast<dif_uart_irq_t>(32)),
+            kDifBadArg);
 }
 
 TEST_F(IrqForceTest, Success) {

--- a/util/make_new_dif/dif_autogen.h.tpl
+++ b/util/make_new_dif/dif_autogen.h.tpl
@@ -94,8 +94,7 @@ typedef struct dif_${ip.name_snake} {
    * Returns whether a particular interrupt is currently pending.
    *
    * @param ${ip.name_snake} A ${ip.name_snake} handle.
-   * @param irq An interrupt request.
-   * @param[out] is_pending Out-param for whether the interrupt is pending.
+   * @param[out] snapshot Out-param for interrupt state snapshot.
    * @return The result of the operation.
    */
   OT_WARN_UNUSED_RESULT

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -124,7 +124,7 @@ namespace {
     // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
     EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_, 
-        (dif_${ip.name_snake}_irq_t)32,
+        static_cast<dif_${ip.name_snake}_irq_t>(32),
         &is_pending),
       kDifBadArg);
   }
@@ -151,6 +151,7 @@ namespace {
       kDifOk);
     EXPECT_TRUE(irq_state);
 
+  % if len(irqs) > 1 or irqs[0].width > 1:
     // Get the last IRQ state.
     irq_state = true;
     EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
@@ -169,6 +170,7 @@ namespace {
         &irq_state),
       kDifOk);
     EXPECT_FALSE(irq_state);
+  % endif
   }
 
   class IrqAcknowledgeTest : public ${ip.name_camel}Test {};
@@ -187,7 +189,7 @@ namespace {
   TEST_F(IrqAcknowledgeTest, BadIrq) {
     EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
         nullptr, 
-        (dif_${ip.name_snake}_irq_t)32),
+        static_cast<dif_${ip.name_snake}_irq_t>(32)),
       kDifBadArg);
   }
 
@@ -208,6 +210,7 @@ namespace {
       % endif
       kDifOk);
 
+  % if len(irqs) > 1 or irqs[0].width > 1:
     // Clear the last IRQ state.
     EXPECT_WRITE32(${ip.name_upper}_INTR_STATE_REG_OFFSET,
       % if irqs[0].width > 1:
@@ -223,6 +226,7 @@ namespace {
         kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
       % endif
       kDifOk);
+  % endif
   }
 
   class IrqGetEnabledTest : public ${ip.name_camel}Test {};
@@ -266,7 +270,7 @@ namespace {
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_, 
-        (dif_${ip.name_snake}_irq_t)32,
+        static_cast<dif_${ip.name_snake}_irq_t>(32),
         &irq_state),
       kDifBadArg);
   }
@@ -293,6 +297,7 @@ namespace {
       kDifOk);
     EXPECT_EQ(irq_state, kDifToggleEnabled);
 
+  % if len(irqs) > 1 or irqs[0].width > 1:
     // Last IRQ is disabled.
     irq_state = kDifToggleEnabled;
     EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
@@ -311,6 +316,7 @@ namespace {
         &irq_state),
       kDifOk);
     EXPECT_EQ(irq_state, kDifToggleDisabled);
+  % endif
   }
 
   class IrqSetEnabledTest : public ${ip.name_camel}Test {};
@@ -334,7 +340,7 @@ namespace {
 
     EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
         &${ip.name_snake}_, 
-        (dif_${ip.name_snake}_irq_t)32,
+        static_cast<dif_${ip.name_snake}_irq_t>(32),
         irq_state),
       kDifBadArg);
   }
@@ -360,6 +366,7 @@ namespace {
         irq_state),
       kDifOk);
 
+  % if len(irqs) > 1 or irqs[0].width > 1:
     // Disable last IRQ.
     irq_state = kDifToggleDisabled;
     EXPECT_MASK32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET,
@@ -377,6 +384,7 @@ namespace {
       % endif
         irq_state),
       kDifOk);
+  % endif
   }
 
   class IrqForceTest : public ${ip.name_camel}Test {};
@@ -395,7 +403,7 @@ namespace {
   TEST_F(IrqForceTest, BadIrq) {
     EXPECT_EQ(dif_${ip.name_snake}_irq_force(
         nullptr, 
-        (dif_${ip.name_snake}_irq_t)32),
+        static_cast<dif_${ip.name_snake}_irq_t>(32)),
       kDifBadArg);
   }
 
@@ -416,6 +424,7 @@ namespace {
       % endif
       kDifOk);
 
+  % if len(irqs) > 1 or irqs[0].width > 1:
     // Force last IRQ.
     EXPECT_WRITE32(${ip.name_upper}_INTR_TEST_REG_OFFSET,
       % if irqs[0].width > 1:
@@ -431,6 +440,7 @@ namespace {
         kDif${ip.name_camel}Irq${irqs[-1].name_camel}),
       % endif
       kDifOk);
+  % endif
   }
 
   class IrqDisableAllTest : public ${ip.name_camel}Test {};


### PR DESCRIPTION
This updates the DIF autogen templates and regenerates all
auto-generated DIFs to address review comments made in #8435.
Specifically:
  1. a comment block for the `dif_keymgr_irq_get_state(...)` was fixed,
  2. static_casts were used throughout auto-gen'd DIF unit tests, and
  3. redundant unit tests are removed for IP's that only have raise a
     single IRQ.

Signed-off-by: Timothy Trippel <ttrippel@google.com>