### PR TITLE
[dif/pwrmgr] Autogen IRQ DIFs and integrate into test code.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+
+#include "pwrmgr_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool pwrmgr_get_irq_bit_index(dif_pwrmgr_irq_t irq,
+                                     bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifPwrmgrIrqWakeup:
+      *index_out = PWRMGR_INTR_STATE_WAKEUP_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_get_state(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_state_snapshot_t *snapshot) {
+  if (pwrmgr == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot =
+      mmio_region_read32(pwrmgr->base_addr, PWRMGR_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_is_pending(const dif_pwrmgr_t *pwrmgr,
+                                       dif_pwrmgr_irq_t irq, bool *is_pending) {
+  if (pwrmgr == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!pwrmgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(pwrmgr->base_addr, PWRMGR_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_acknowledge(const dif_pwrmgr_t *pwrmgr,
+                                        dif_pwrmgr_irq_t irq) {
+  if (pwrmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!pwrmgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(pwrmgr->base_addr, PWRMGR_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_get_enabled(const dif_pwrmgr_t *pwrmgr,
+                                        dif_pwrmgr_irq_t irq,
+                                        dif_toggle_t *state) {
+  if (pwrmgr == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!pwrmgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(pwrmgr->base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_set_enabled(const dif_pwrmgr_t *pwrmgr,
+                                        dif_pwrmgr_irq_t irq,
+                                        dif_toggle_t state) {
+  if (pwrmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!pwrmgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(pwrmgr->base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(pwrmgr->base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_force(const dif_pwrmgr_t *pwrmgr,
+                                  dif_pwrmgr_irq_t irq) {
+  if (pwrmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!pwrmgr_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(pwrmgr->base_addr, PWRMGR_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_disable_all(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_enable_snapshot_t *snapshot) {
+  if (pwrmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(pwrmgr->base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(pwrmgr->base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_restore_all(
+    const dif_pwrmgr_t *pwrmgr,
+    const dif_pwrmgr_irq_enable_snapshot_t *snapshot) {
+  if (pwrmgr == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(pwrmgr->base_addr, PWRMGR_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
@@ -1,0 +1,166 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_PWRMGR_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_PWRMGR_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/pwrmgr/doc/">PWRMGR</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to pwrmgr.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_pwrmgr {
+  /**
+   * The base address for the pwrmgr hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_pwrmgr_t;
+
+/**
+ * A pwrmgr interrupt request type.
+ */
+typedef enum dif_pwrmgr_irq {
+  /**
+   * Wake from low power state. See wake info for more details
+   */
+  kDifPwrmgrIrqWakeup = 0,
+} dif_pwrmgr_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_pwrmgr_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_pwrmgr_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_pwrmgr_irq_disable_all()` and `dif_pwrmgr_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_pwrmgr_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_get_state(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_is_pending(const dif_pwrmgr_t *pwrmgr,
+                                       dif_pwrmgr_irq_t irq, bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_acknowledge(const dif_pwrmgr_t *pwrmgr,
+                                        dif_pwrmgr_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_get_enabled(const dif_pwrmgr_t *pwrmgr,
+                                        dif_pwrmgr_irq_t irq,
+                                        dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_set_enabled(const dif_pwrmgr_t *pwrmgr,
+                                        dif_pwrmgr_irq_t irq,
+                                        dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_force(const dif_pwrmgr_t *pwrmgr,
+                                  dif_pwrmgr_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_disable_all(
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_irq_restore_all(
+    const dif_pwrmgr_t *pwrmgr,
+    const dif_pwrmgr_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_PWRMGR_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -1,0 +1,261 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "pwrmgr_regs.h"  // Generated.
+
+namespace dif_pwrmgr_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class PwrmgrTest : public Test, public MmioTest {
+ protected:
+  dif_pwrmgr_t pwrmgr_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public PwrmgrTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_pwrmgr_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_pwrmgr_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_get_state(&pwrmgr_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_pwrmgr_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_pwrmgr_irq_get_state(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_pwrmgr_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_pwrmgr_irq_get_state(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public PwrmgrTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_pwrmgr_irq_is_pending(
+                &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET,
+                {{PWRMGR_INTR_STATE_WAKEUP_BIT, true}});
+  EXPECT_EQ(
+      dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, &irq_state),
+      kDifOk);
+  EXPECT_TRUE(irq_state);
+}
+
+class IrqAcknowledgeTest : public PwrmgrTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(nullptr, kDifPwrmgrIrqWakeup),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(
+      dif_pwrmgr_irq_acknowledge(nullptr, static_cast<dif_pwrmgr_irq_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(PWRMGR_INTR_STATE_REG_OFFSET,
+                 {{PWRMGR_INTR_STATE_WAKEUP_BIT, true}});
+  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(&pwrmgr_, kDifPwrmgrIrqWakeup), kDifOk);
+}
+
+class IrqGetEnabledTest : public PwrmgrTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(
+                &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET,
+                {{PWRMGR_INTR_ENABLE_WAKEUP_BIT, true}});
+  EXPECT_EQ(
+      dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+}
+
+class IrqSetEnabledTest : public PwrmgrTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(
+                &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(PWRMGR_INTR_ENABLE_REG_OFFSET,
+                {{PWRMGR_INTR_ENABLE_WAKEUP_BIT, 0x1, true}});
+  EXPECT_EQ(
+      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, irq_state),
+      kDifOk);
+}
+
+class IrqForceTest : public PwrmgrTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, kDifPwrmgrIrqWakeup), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, static_cast<dif_pwrmgr_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(PWRMGR_INTR_TEST_REG_OFFSET,
+                 {{PWRMGR_INTR_TEST_WAKEUP_BIT, true}});
+  EXPECT_EQ(dif_pwrmgr_irq_force(&pwrmgr_, kDifPwrmgrIrqWakeup), kDifOk);
+}
+
+class IrqDisableAllTest : public PwrmgrTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public PwrmgrTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_pwrmgr_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_pwrmgr_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen OTP Controller DIF library
-sw_lib_dif_autogen_otp_ctrl = declare_dependency(
+# Autogen Power Manager DIF library
+sw_lib_dif_autogen_pwrmgr = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_otp_ctrl',
+    'sw_lib_dif_autogen_pwrmgr',
     sources: [
-      hw_ip_otp_ctrl_reg_h,
-      'dif_otp_ctrl_autogen.c',
+      hw_ip_pwrmgr_reg_h,
+      'dif_pwrmgr_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -177,6 +177,20 @@ sw_lib_dif_autogen_otbn = declare_dependency(
     sources: [
       hw_ip_otbn_reg_h,
       'dif_otbn_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen OTP Controller DIF library
+sw_lib_dif_autogen_otp_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_otp_ctrl',
+    sources: [
+      hw_ip_otp_ctrl_reg_h,
+      'dif_otp_ctrl_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
 
 #include "pwrmgr_regs.h"  // Generated
 
@@ -21,13 +22,12 @@ uint32_t AllOnesExcept(uint32_t index) { return ~(1u << index); }
 /**
  * Common constants used in tests.
  */
-static constexpr std::array<dif_pwrmgr_toggle_t, 2> kAllToggles = {
-    kDifPwrmgrToggleEnabled, kDifPwrmgrToggleDisabled};
+static constexpr std::array<dif_toggle_t, 2> kAllToggles = {
+    kDifToggleDisabled,
+    kDifToggleEnabled,
+};
 static constexpr std::array<bool, 2> kAllBools = {true, false};
-static constexpr dif_pwrmgr_toggle_t kBadToggle =
-    static_cast<dif_pwrmgr_toggle_t>(kDifPwrmgrToggleDisabled + 1);
-static constexpr dif_pwrmgr_irq_t kBadIrq =
-    static_cast<dif_pwrmgr_irq_t>(kDifPwrmgrIrqLast + 1);
+static constexpr dif_toggle_t kBadToggle = static_cast<dif_toggle_t>(2);
 static constexpr dif_pwrmgr_req_type_t kBadReqType =
     static_cast<dif_pwrmgr_req_type_t>(kDifPwrmgrReqTypeReset + 1);
 static constexpr dif_pwrmgr_domain_config_t kBadConfig =
@@ -35,23 +35,17 @@ static constexpr dif_pwrmgr_domain_config_t kBadConfig =
 static constexpr dif_pwrmgr_request_sources_t kBadSources =
     std::numeric_limits<uint32_t>::max();
 
-class DifPwrmgrTest : public testing::Test, public mock_mmio::MmioTest {
- protected:
-  /**
-   * Parameters for initializing a `dif_pwrmgr_t`.
-   */
-  const dif_pwrmgr_params_t params_ = {.base_addr = dev().region()};
-};
+class DifPwrmgrTest : public testing::Test, public mock_mmio::MmioTest {};
 
 class InitTest : public DifPwrmgrTest {};
 
 TEST_F(InitTest, BadArgs) {
-  EXPECT_EQ(dif_pwrmgr_init(params_, nullptr), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Init) {
   dif_pwrmgr_t pwrmgr;
-  EXPECT_EQ(dif_pwrmgr_init(params_, &pwrmgr), kDifPwrmgrOk);
+  EXPECT_EQ(dif_pwrmgr_init(dev().region(), &pwrmgr), kDifOk);
 }
 
 // Base class for the rest of the tests in this file, provides a
@@ -77,18 +71,16 @@ class DifPwrmgrInitialized : public DifPwrmgrTest {
   /**
    * Initialized `dif_pwrmgr_t` used in tests.
    */
-  const dif_pwrmgr_t pwrmgr_ = {.params = params_};
+  const dif_pwrmgr_t pwrmgr_ = {.base_addr = dev().region()};
 };
 
 class LowPowerTest : public DifPwrmgrInitialized {};
 
 TEST_F(LowPowerTest, SetBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(nullptr, kDifPwrmgrToggleEnabled),
-            kDifPwrmgrConfigBadArg);
-  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, kBadToggle),
-            kDifPwrmgrConfigBadArg);
-  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(nullptr, kBadToggle),
-            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(nullptr, kDifToggleEnabled),
+            kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, kBadToggle), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(nullptr, kBadToggle), kDifBadArg);
 }
 
 TEST_F(LowPowerTest, SetLocked) {
@@ -96,8 +88,7 @@ TEST_F(LowPowerTest, SetLocked) {
     EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
                   AllOnesExcept(PWRMGR_CTRL_CFG_REGWEN_EN_BIT));
 
-    EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle),
-              kDifPwrMgrConfigLocked);
+    EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle), kDifLocked);
   }
 }
 
@@ -112,37 +103,33 @@ TEST_F(LowPowerTest, Set) {
                   {{
                       .offset = PWRMGR_CONTROL_LOW_POWER_HINT_BIT,
                       .mask = 1,
-                      .value = (toggle == kDifPwrmgrToggleEnabled),
+                      .value = (toggle == kDifToggleEnabled),
                   }});
     ExpectSync();
 
-    EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle),
-              kDifPwrmgrConfigOk);
+    EXPECT_EQ(dif_pwrmgr_low_power_set_enabled(&pwrmgr_, toggle), kDifOk);
   }
 }
 
 TEST_F(LowPowerTest, GetBadArgs) {
-  dif_pwrmgr_toggle_t state;
+  dif_toggle_t state;
 
-  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(nullptr, &state),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(&pwrmgr_, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(nullptr, nullptr),
-            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(nullptr, &state), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(&pwrmgr_, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(nullptr, nullptr), kDifBadArg);
 }
 
 TEST_F(LowPowerTest, Get) {
   for (auto toggle : kAllToggles) {
-    dif_pwrmgr_toggle_t state;
+    dif_toggle_t state;
 
     EXPECT_READ32(PWRMGR_CONTROL_REG_OFFSET,
                   {{
                       .offset = PWRMGR_CONTROL_LOW_POWER_HINT_BIT,
-                      .value = (toggle == kDifPwrmgrToggleEnabled),
+                      .value = (toggle == kDifToggleEnabled),
                   }});
 
-    EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(&pwrmgr_, &state), kDifPwrmgrOk);
+    EXPECT_EQ(dif_pwrmgr_low_power_get_enabled(&pwrmgr_, &state), kDifOk);
     EXPECT_EQ(state, toggle);
   }
 }
@@ -182,18 +169,16 @@ class DomainConfig : public DifPwrmgrInitialized {
 constexpr std::array<dif_pwrmgr_domain_config_t, 4> DomainConfig::kConfigs;
 
 TEST_F(DomainConfig, SetBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_set_domain_config(nullptr, 0), kDifPwrmgrConfigBadArg);
-  EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, kBadConfig),
-            kDifPwrmgrConfigBadArg);
-  EXPECT_EQ(dif_pwrmgr_set_domain_config(nullptr, kBadConfig),
-            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(nullptr, 0), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, kBadConfig), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(nullptr, kBadConfig), kDifBadArg);
 }
 
 TEST_F(DomainConfig, SetLocked) {
   EXPECT_READ32(PWRMGR_CTRL_CFG_REGWEN_REG_OFFSET,
                 AllOnesExcept(PWRMGR_WAKEUP_EN_REGWEN_EN_BIT));
 
-  EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, 0), kDifPwrMgrConfigLocked);
+  EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, 0), kDifLocked);
 }
 
 TEST_F(DomainConfig, Set) {
@@ -211,18 +196,15 @@ TEST_F(DomainConfig, Set) {
                   }});
     ExpectSync();
 
-    EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, config), kDifPwrmgrOk);
+    EXPECT_EQ(dif_pwrmgr_set_domain_config(&pwrmgr_, config), kDifOk);
   }
 }
 
 TEST_F(DomainConfig, GetBadArgs) {
   dif_pwrmgr_domain_config_t config;
-  EXPECT_EQ(dif_pwrmgr_get_domain_config(nullptr, &config),
-            kDifPwrmgrConfigBadArg);
-  EXPECT_EQ(dif_pwrmgr_get_domain_config(&pwrmgr_, nullptr),
-            kDifPwrmgrConfigBadArg);
-  EXPECT_EQ(dif_pwrmgr_get_domain_config(nullptr, nullptr),
-            kDifPwrmgrConfigBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_domain_config(nullptr, &config), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_domain_config(&pwrmgr_, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_get_domain_config(nullptr, nullptr), kDifBadArg);
 }
 
 TEST_F(DomainConfig, Get) {
@@ -234,8 +216,7 @@ TEST_F(DomainConfig, Get) {
                   }});
 
     dif_pwrmgr_domain_config_t act_config;
-    EXPECT_EQ(dif_pwrmgr_get_domain_config(&pwrmgr_, &act_config),
-              kDifPwrmgrOk);
+    EXPECT_EQ(dif_pwrmgr_get_domain_config(&pwrmgr_, &act_config), kDifOk);
     EXPECT_EQ(act_config, exp_config);
   }
 }
@@ -268,23 +249,23 @@ constexpr std::array<dif_pwrmgr_request_sources_t, 2>
 TEST_F(RequestSources, SetBadArgs) {
   EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kDifPwrmgrReqTypeWakeup,
                                            kDifPwrmgrWakeupRequestSourceOne),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kBadReqType,
                                            kDifPwrmgrWakeupRequestSourceOne),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
                                            kBadSources),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kBadReqType,
                                            kDifPwrmgrWakeupRequestSourceOne),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kDifPwrmgrReqTypeWakeup,
                                            kBadSources),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kBadReqType, kBadSources),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_set_request_sources(nullptr, kBadReqType, kBadSources),
-            kDifPwrmgrConfigBadArg);
+            kDifBadArg);
 }
 
 TEST_F(RequestSources, SetWakeupLocked) {
@@ -293,7 +274,7 @@ TEST_F(RequestSources, SetWakeupLocked) {
 
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
                                            kDifPwrmgrWakeupRequestSourceOne),
-            kDifPwrMgrConfigLocked);
+            kDifLocked);
 }
 
 TEST_F(RequestSources, SetResetLocked) {
@@ -302,7 +283,7 @@ TEST_F(RequestSources, SetResetLocked) {
 
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
                                            kDifPwrmgrResetRequestSourceOne),
-            kDifPwrMgrConfigLocked);
+            kDifLocked);
 }
 
 TEST_F(RequestSources, SetWakeup) {
@@ -316,7 +297,7 @@ TEST_F(RequestSources, SetWakeup) {
 
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
                                            kDifPwrmgrWakeupRequestSourceOne),
-            kDifPwrmgrConfigOk);
+            kDifOk);
 }
 
 TEST_F(RequestSources, SetReset) {
@@ -330,7 +311,7 @@ TEST_F(RequestSources, SetReset) {
 
   EXPECT_EQ(dif_pwrmgr_set_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
                                            kDifPwrmgrResetRequestSourceOne),
-            kDifPwrmgrConfigOk);
+            kDifOk);
 }
 
 TEST_F(RequestSources, GetBadArgs) {
@@ -338,21 +319,21 @@ TEST_F(RequestSources, GetBadArgs) {
 
   EXPECT_EQ(dif_pwrmgr_get_request_sources(nullptr, kDifPwrmgrReqTypeWakeup,
                                            &sources),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kBadReqType, &sources),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
                                            nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_request_sources(nullptr, kBadReqType, &sources),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_get_request_sources(nullptr, kDifPwrmgrReqTypeWakeup, nullptr),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kBadReqType, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_request_sources(nullptr, kBadReqType, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
 }
 
 TEST_F(RequestSources, GetWakeup) {
@@ -362,7 +343,7 @@ TEST_F(RequestSources, GetWakeup) {
     dif_pwrmgr_request_sources_t act_sources = 0;
     EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kDifPwrmgrReqTypeWakeup,
                                              &act_sources),
-              kDifPwrmgrOk);
+              kDifOk);
     EXPECT_EQ(act_sources, exp_sources);
   }
 }
@@ -374,7 +355,7 @@ TEST_F(RequestSources, GetReset) {
     dif_pwrmgr_request_sources_t act_sources = 0;
     EXPECT_EQ(dif_pwrmgr_get_request_sources(&pwrmgr_, kDifPwrmgrReqTypeReset,
                                              &act_sources),
-              kDifPwrmgrOk);
+              kDifOk);
     EXPECT_EQ(act_sources, exp_sources);
   }
 }
@@ -384,25 +365,25 @@ TEST_F(RequestSources, GetCurrentBadArgs) {
 
   EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
                 nullptr, kDifPwrmgrReqTypeWakeup, &sources),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_get_current_request_sources(&pwrmgr_, kBadReqType, &sources),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
                 &pwrmgr_, kDifPwrmgrReqTypeWakeup, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_get_current_request_sources(nullptr, kBadReqType, &sources),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
                 nullptr, kDifPwrmgrReqTypeWakeup, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_get_current_request_sources(&pwrmgr_, kBadReqType, nullptr),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_get_current_request_sources(nullptr, kBadReqType, nullptr),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
 }
 
 TEST_F(RequestSources, GetCurrentWakeup) {
@@ -412,7 +393,7 @@ TEST_F(RequestSources, GetCurrentWakeup) {
     dif_pwrmgr_request_sources_t act_sources = 0;
     EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
                   &pwrmgr_, kDifPwrmgrReqTypeWakeup, &act_sources),
-              kDifPwrmgrOk);
+              kDifOk);
     EXPECT_EQ(act_sources, exp_sources);
   }
 }
@@ -424,32 +405,30 @@ TEST_F(RequestSources, GetCurrentReset) {
     dif_pwrmgr_request_sources_t act_sources = 0;
     EXPECT_EQ(dif_pwrmgr_get_current_request_sources(
                   &pwrmgr_, kDifPwrmgrReqTypeReset, &act_sources),
-              kDifPwrmgrOk);
+              kDifOk);
     EXPECT_EQ(act_sources, exp_sources);
   }
 }
 
 TEST_F(RequestSources, LockBadArgs) {
   EXPECT_EQ(dif_pwrmgr_request_sources_lock(nullptr, kDifPwrmgrReqTypeWakeup),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kBadReqType),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_request_sources_lock(nullptr, kBadReqType),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kBadReqType), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_request_sources_lock(nullptr, kBadReqType), kDifBadArg);
 }
 
 TEST_F(RequestSources, LockWakeup) {
   EXPECT_WRITE32(PWRMGR_WAKEUP_EN_REGWEN_REG_OFFSET, 0);
 
   EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kDifPwrmgrReqTypeWakeup),
-            kDifPwrmgrOk);
+            kDifOk);
 }
 
 TEST_F(RequestSources, LockReset) {
   EXPECT_WRITE32(PWRMGR_RESET_EN_REGWEN_REG_OFFSET, 0);
 
   EXPECT_EQ(dif_pwrmgr_request_sources_lock(&pwrmgr_, kDifPwrmgrReqTypeReset),
-            kDifPwrmgrOk);
+            kDifOk);
 }
 
 TEST_F(RequestSources, IsLockedBadArgs) {
@@ -457,24 +436,24 @@ TEST_F(RequestSources, IsLockedBadArgs) {
 
   EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
                 nullptr, kDifPwrmgrReqTypeWakeup, &is_locked),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_request_sources_is_locked(&pwrmgr_, kBadReqType, &is_locked),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
                 &pwrmgr_, kDifPwrmgrReqTypeWakeup, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_request_sources_is_locked(nullptr, kBadReqType, &is_locked),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
                 nullptr, kDifPwrmgrReqTypeWakeup, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_request_sources_is_locked(&pwrmgr_, kBadReqType, nullptr),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(nullptr, kBadReqType, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
 }
 
 TEST_F(RequestSources, IsLockedWakeup) {
@@ -488,7 +467,7 @@ TEST_F(RequestSources, IsLockedWakeup) {
     bool is_locked = !exp_val;
     EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
                   &pwrmgr_, kDifPwrmgrReqTypeWakeup, &is_locked),
-              kDifPwrmgrOk);
+              kDifOk);
     EXPECT_EQ(is_locked, exp_val);
   }
 }
@@ -504,7 +483,7 @@ TEST_F(RequestSources, IsLockedReset) {
     bool is_locked = !exp_val;
     EXPECT_EQ(dif_pwrmgr_request_sources_is_locked(
                   &pwrmgr_, kDifPwrmgrReqTypeReset, &is_locked),
-              kDifPwrmgrOk);
+              kDifOk);
     EXPECT_EQ(is_locked, exp_val);
   }
 }
@@ -512,15 +491,15 @@ TEST_F(RequestSources, IsLockedReset) {
 class WakeupRecording : public DifPwrmgrInitialized {};
 
 TEST_F(WakeupRecording, SetEnabledBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_set_enabled(
-                nullptr, kDifPwrmgrToggleEnabled),
-            kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_set_enabled(nullptr,
+                                                            kDifToggleEnabled),
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_wakeup_request_recording_set_enabled(&pwrmgr_, kBadToggle),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_wakeup_request_recording_set_enabled(nullptr, kBadToggle),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
 }
 
 TEST_F(WakeupRecording, SetEnabled) {
@@ -528,25 +507,25 @@ TEST_F(WakeupRecording, SetEnabled) {
     EXPECT_WRITE32(PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET,
                    {{
                        .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL_BIT,
-                       .value = (new_state == kDifPwrmgrToggleDisabled),
+                       .value = (new_state == kDifToggleDisabled),
                    }});
 
     EXPECT_EQ(
         dif_pwrmgr_wakeup_request_recording_set_enabled(&pwrmgr_, new_state),
-        kDifPwrmgrOk);
+        kDifOk);
   }
 }
 
 TEST_F(WakeupRecording, GetEnabledBadArgs) {
-  dif_pwrmgr_toggle_t is_enabled;
+  dif_toggle_t is_enabled;
 
   EXPECT_EQ(
       dif_pwrmgr_wakeup_request_recording_get_enabled(nullptr, &is_enabled),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_get_enabled(&pwrmgr_, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(dif_pwrmgr_wakeup_request_recording_get_enabled(nullptr, nullptr),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
 }
 
 TEST_F(WakeupRecording, GetEnabled) {
@@ -554,15 +533,14 @@ TEST_F(WakeupRecording, GetEnabled) {
     EXPECT_READ32(PWRMGR_WAKE_INFO_CAPTURE_DIS_REG_OFFSET,
                   {{
                       .offset = PWRMGR_WAKE_INFO_CAPTURE_DIS_VAL_BIT,
-                      .value = (exp_val == kDifPwrmgrToggleDisabled),
+                      .value = (exp_val == kDifToggleDisabled),
                   }});
 
-    dif_pwrmgr_toggle_t is_enabled = (exp_val == kDifPwrmgrToggleEnabled)
-                                         ? kDifPwrmgrToggleDisabled
-                                         : kDifPwrmgrToggleEnabled;
+    dif_toggle_t is_enabled =
+        (exp_val == kDifToggleEnabled) ? kDifToggleDisabled : kDifToggleEnabled;
     EXPECT_EQ(
         dif_pwrmgr_wakeup_request_recording_get_enabled(&pwrmgr_, &is_enabled),
-        kDifPwrmgrOk);
+        kDifOk);
     EXPECT_EQ(is_enabled, exp_val);
   }
 }
@@ -570,10 +548,9 @@ TEST_F(WakeupRecording, GetEnabled) {
 TEST_F(WakeupRecording, GetReasonBadArgs) {
   dif_pwrmgr_wakeup_reason_t wakeup_reason;
 
-  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(nullptr, &wakeup_reason),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(&pwrmgr_, nullptr), kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(nullptr, nullptr), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(nullptr, &wakeup_reason), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(&pwrmgr_, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(nullptr, nullptr), kDifBadArg);
 }
 
 /**
@@ -754,233 +731,37 @@ TEST_F(WakeupRecording, GetReason) {
     EXPECT_READ32(PWRMGR_WAKE_INFO_REG_OFFSET, test_case.read_val);
 
     dif_pwrmgr_wakeup_reason_t wakeup_reason;
-    EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(&pwrmgr_, &wakeup_reason),
-              kDifPwrmgrOk);
+    EXPECT_EQ(dif_pwrmgr_wakeup_reason_get(&pwrmgr_, &wakeup_reason), kDifOk);
     EXPECT_THAT(wakeup_reason, Eq(test_case.exp_output));
   }
 }
 
 TEST_F(WakeupRecording, ClearReasonBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(nullptr), kDifPwrmgrBadArg);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(nullptr), kDifBadArg);
 }
 
 TEST_F(WakeupRecording, ClearReason) {
   EXPECT_WRITE32(PWRMGR_WAKE_INFO_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(&pwrmgr_), kDifPwrmgrOk);
-}
-
-class IrqTest : public DifPwrmgrInitialized {};
-
-TEST_F(IrqTest, IsPendingBadArgs) {
-  bool is_pending;
-
-  EXPECT_EQ(
-      dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, &is_pending),
-      kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kBadIrq, &is_pending),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kBadIrq, &is_pending),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kBadIrq, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kBadIrq, nullptr),
-            kDifPwrmgrBadArg);
-}
-
-TEST_F(IrqTest, IsPending) {
-  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
-       irq <= kDifPwrmgrIrqLast; ++irq) {
-    for (auto exp_val : kAllBools) {
-      EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET, {{
-                                                      .offset = irq,
-                                                      .value = exp_val,
-                                                  }});
-
-      bool is_pending = !exp_val;
-      EXPECT_EQ(dif_pwrmgr_irq_is_pending(
-                    &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq), &is_pending),
-                kDifPwrmgrOk);
-      EXPECT_EQ(is_pending, exp_val);
-    }
-  }
-}
-
-TEST_F(IrqTest, AckBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(nullptr, kDifPwrmgrIrqWakeup),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(&pwrmgr_, kBadIrq), kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(nullptr, kBadIrq), kDifPwrmgrBadArg);
-}
-
-TEST_F(IrqTest, Ack) {
-  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
-       irq <= kDifPwrmgrIrqLast; ++irq) {
-    EXPECT_WRITE32(PWRMGR_INTR_STATE_REG_OFFSET, (1u << irq));
-
-    EXPECT_EQ(dif_pwrmgr_irq_acknowledge(&pwrmgr_,
-                                         static_cast<dif_pwrmgr_irq_t>(irq)),
-              kDifPwrmgrOk);
-  }
-}
-
-TEST_F(IrqTest, GetEnabledBadArgs) {
-  dif_pwrmgr_toggle_t is_enabled;
-
-  EXPECT_EQ(
-      dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, &is_enabled),
-      kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kBadIrq, &is_enabled),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kBadIrq, &is_enabled),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kBadIrq, nullptr),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kBadIrq, nullptr),
-            kDifPwrmgrBadArg);
-}
-
-TEST_F(IrqTest, GetEnabled) {
-  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
-       irq <= kDifPwrmgrIrqLast; ++irq) {
-    for (auto exp_val : kAllToggles) {
-      EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET,
-                    {{
-                        .offset = irq,
-                        .value = (exp_val == kDifPwrmgrToggleEnabled),
-                    }});
-
-      dif_pwrmgr_toggle_t is_enabled = (exp_val == kDifPwrmgrToggleEnabled)
-                                           ? kDifPwrmgrToggleDisabled
-                                           : kDifPwrmgrToggleEnabled;
-      EXPECT_EQ(dif_pwrmgr_irq_get_enabled(
-                    &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq), &is_enabled),
-                kDifPwrmgrOk);
-      EXPECT_EQ(is_enabled, exp_val);
-    }
-  }
-}
-
-TEST_F(IrqTest, SetEnabledBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup,
-                                       kDifPwrmgrToggleEnabled),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(
-      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kBadIrq, kDifPwrmgrToggleEnabled),
-      kDifPwrmgrBadArg);
-  EXPECT_EQ(
-      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, kBadToggle),
-      kDifPwrmgrBadArg);
-  EXPECT_EQ(
-      dif_pwrmgr_irq_set_enabled(nullptr, kBadIrq, kDifPwrmgrToggleEnabled),
-      kDifPwrmgrBadArg);
-  EXPECT_EQ(
-      dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup, kBadToggle),
-      kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(&pwrmgr_, kBadIrq, kBadToggle),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(nullptr, kBadIrq, kBadToggle),
-            kDifPwrmgrBadArg);
-}
-
-TEST_F(IrqTest, SetEnabled) {
-  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
-       irq <= kDifPwrmgrIrqLast; ++irq) {
-    for (auto new_state : kAllToggles) {
-      EXPECT_MASK32(PWRMGR_INTR_ENABLE_REG_OFFSET,
-                    {{
-                        .offset = irq,
-                        .mask = 1,
-                        .value = (new_state == kDifPwrmgrToggleEnabled),
-                    }});
-
-      EXPECT_EQ(dif_pwrmgr_irq_set_enabled(
-                    &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq), new_state),
-                kDifPwrmgrOk);
-    }
-  }
-}
-
-TEST_F(IrqTest, ForceBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, kDifPwrmgrIrqWakeup),
-            kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_force(&pwrmgr_, kBadIrq), kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, kBadIrq), kDifPwrmgrBadArg);
-}
-
-TEST_F(IrqTest, Force) {
-  for (std::underlying_type<dif_pwrmgr_irq_t>::type irq = 0;
-       irq <= kDifPwrmgrIrqLast; ++irq) {
-    EXPECT_WRITE32(PWRMGR_INTR_TEST_REG_OFFSET, {{
-                                                    .offset = irq,
-                                                    .value = 1,
-                                                }});
-
-    EXPECT_EQ(
-        dif_pwrmgr_irq_force(&pwrmgr_, static_cast<dif_pwrmgr_irq_t>(irq)),
-        kDifPwrmgrOk);
-  }
-}
-
-TEST_F(IrqTest, DisableAllBadArgs) {
-  dif_pwrmgr_irq_snapshot_t snapshot;
-
-  // `snapshot` is optional.
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, &snapshot), kDifPwrmgrBadArg);
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, nullptr), kDifPwrmgrBadArg);
-}
-TEST_F(IrqTest, DisableAll) {
-  uint32_t exp_snapshot = 0xA5A5A5A5;
-
-  // With `snapshot`.
-  EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET, exp_snapshot);
-  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
-
-  dif_pwrmgr_irq_snapshot_t act_snapshot = 0;
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, &act_snapshot), kDifPwrmgrOk);
-  EXPECT_EQ(act_snapshot, exp_snapshot);
-
-  // Without `snapshot`.
-  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, nullptr), kDifPwrmgrOk);
-}
-
-TEST_F(IrqTest, RestoreAllBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, 0), kDifPwrmgrBadArg);
-}
-
-TEST_F(IrqTest, RestoreAll) {
-  dif_pwrmgr_irq_snapshot_t snapshot = 0xA5A5A5A5;
-
-  EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, snapshot);
-
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, snapshot), kDifPwrmgrOk);
+  EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(&pwrmgr_), kDifOk);
 }
 
 class AlertTest : public DifPwrmgrInitialized {};
 
 TEST_F(AlertTest, ForceBadArgs) {
   EXPECT_EQ(dif_pwrmgr_alert_force(nullptr, kDifPwrmgrAlertFatalFault),
-            kDifPwrmgrBadArg);
+            kDifBadArg);
   EXPECT_EQ(
       dif_pwrmgr_alert_force(&pwrmgr_, static_cast<dif_pwrmgr_alert_t>(1)),
-      kDifPwrmgrBadArg);
+      kDifBadArg);
 }
 
 TEST_F(AlertTest, Force) {
   EXPECT_WRITE32(PWRMGR_ALERT_TEST_REG_OFFSET, {{0, true}});
 
   EXPECT_EQ(dif_pwrmgr_alert_force(&pwrmgr_, kDifPwrmgrAlertFatalFault),
-            kDifPwrmgrOk);
+            kDifOk);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -509,6 +509,7 @@ sw_lib_dif_pwrmgr = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_pwrmgr,
     ],
   )
 )
@@ -516,9 +517,11 @@ sw_lib_dif_pwrmgr = declare_dependency(
 test('dif_pwrmgr_unittest', executable(
     'dif_pwrmgr_unittest',
     sources: [
-      hw_ip_pwrmgr_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_pwrmgr.c',
       'dif_pwrmgr_unittest.cc',
+      'autogen/dif_pwrmgr_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_pwrmgr.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c',
+      hw_ip_pwrmgr_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -225,12 +225,10 @@ static void soft_reboot(dif_pwrmgr_t *pwrmgr, dif_aon_timer_t *aon_timer) {
   dif_pwrmgr_domain_config_t config;
   config = kDifPwrmgrDomainOptionUsbClockInActivePower;
 
-  CHECK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeWakeup,
-                                       kDifPwrmgrWakeupRequestSourceFive) ==
-        kDifPwrmgrConfigOk);
-  CHECK(dif_pwrmgr_set_domain_config(pwrmgr, config) == kDifPwrmgrConfigOk);
-  CHECK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifPwrmgrToggleEnabled) ==
-        kDifPwrmgrConfigOk);
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeWakeup, kDifPwrmgrWakeupRequestSourceFive));
+  CHECK_DIF_OK(dif_pwrmgr_set_domain_config(pwrmgr, config));
+  CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifToggleEnabled));
 
   // Enter low power mode.
   LOG_INFO("Entering low power");
@@ -287,12 +285,8 @@ bool test_main(void) {
 
   // Initialize pwrmgr
   dif_pwrmgr_t pwrmgr;
-  CHECK(dif_pwrmgr_init(
-            (dif_pwrmgr_params_t){
-                .base_addr =
-                    mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR),
-            },
-            &pwrmgr) == kDifPwrmgrOk);
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
 
   // Initialize aon_timer
   dif_aon_timer_t aon_timer;
@@ -303,7 +297,7 @@ bool test_main(void) {
 
   // Get wakeup reason
   dif_pwrmgr_wakeup_reason_t wakeup_reason;
-  CHECK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason) == kDifPwrmgrOk);
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));
 
   if (compare_wakeup_reasons(&wakeup_reason, &kWakeUpReasonPor)) {
     LOG_INFO("Powered up for the first time, program flash");

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -54,12 +54,8 @@ bool test_main(void) {
   dif_aon_timer_t aon_timer;
 
   // Initialize pwrmgr
-  CHECK(dif_pwrmgr_init(
-            (dif_pwrmgr_params_t){
-                .base_addr =
-                    mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR),
-            },
-            &pwrmgr) == kDifPwrmgrOk);
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
 
   // Initialize rstmgr since this will check some registers.
   CHECK_DIF_OK(dif_rstmgr_init(
@@ -69,7 +65,7 @@ bool test_main(void) {
   // Notice we are clear rstmgr's RESET_INFO, so after the aon wakeup there
   // is only one bit set.
   dif_pwrmgr_wakeup_reason_t wakeup_reason;
-  CHECK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason) == kDifPwrmgrOk);
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));
 
   if (compare_wakeup_reasons(&wakeup_reason, &kWakeUpReasonPor)) {
     LOG_INFO("Powered up for the first time, begin test");
@@ -110,12 +106,10 @@ bool test_main(void) {
     // Issue #6504: USB clock in active power must be left enabled.
     config = kDifPwrmgrDomainOptionUsbClockInActivePower;
 
-    CHECK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeWakeup,
-                                         kDifPwrmgrWakeupRequestSourceFive) ==
-          kDifPwrmgrConfigOk);
-    CHECK(dif_pwrmgr_set_domain_config(&pwrmgr, config) == kDifPwrmgrConfigOk);
-    CHECK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifPwrmgrToggleEnabled) ==
-          kDifPwrmgrConfigOk);
+    CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+        &pwrmgr, kDifPwrmgrReqTypeWakeup, kDifPwrmgrWakeupRequestSourceFive));
+    CHECK_DIF_OK(dif_pwrmgr_set_domain_config(&pwrmgr, config));
+    CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifToggleEnabled));
 
     // Enter low power mode.
     wait_for_interrupt();

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -31,16 +31,12 @@ static bool compare_wakeup_reasons(dif_pwrmgr_wakeup_reason_t lhs,
 }
 
 bool test_main(void) {
-  CHECK(dif_pwrmgr_init(
-            (dif_pwrmgr_params_t){
-                .base_addr =
-                    mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR),
-            },
-            &pwrmgr) == kDifPwrmgrOk);
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
 
   // Assuming the chip hasn't slept yet, wakeup reason should be empty.
   dif_pwrmgr_wakeup_reason_t wakeup_reason;
-  CHECK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason) == kDifPwrmgrOk);
+  CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));
 
   const dif_pwrmgr_wakeup_reason_t exp_por_wakeup_reason = {
       .types = 0,
@@ -73,14 +69,11 @@ bool test_main(void) {
     usbdev_force_dx_pullup(kDnSel, true);
 
     // Enable low power on the next WFI with default settings.
-    CHECK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeWakeup,
-                                         kDifPwrmgrWakeupRequestSourceThree) ==
-          kDifPwrmgrConfigOk);
-    CHECK(dif_pwrmgr_set_domain_config(
-              &pwrmgr, kDifPwrmgrDomainOptionUsbClockInActivePower) ==
-          kDifPwrmgrConfigOk);
-    CHECK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifPwrmgrToggleEnabled) ==
-          kDifPwrmgrConfigOk);
+    CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+        &pwrmgr, kDifPwrmgrReqTypeWakeup, kDifPwrmgrWakeupRequestSourceThree));
+    CHECK_DIF_OK(dif_pwrmgr_set_domain_config(
+        &pwrmgr, kDifPwrmgrDomainOptionUsbClockInActivePower));
+    CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifToggleEnabled));
 
     // Enter low power mode.
     wait_for_interrupt();


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "pwrmgr".