### PR TITLE
[sw/rom] Update sec_mmio support in alert driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -22,30 +22,38 @@ rom_error_t alert_configure(size_t index, alert_class_t cls,
   }
   index *= 4;
 
+  uint32_t reg_wr_count = 0;
+
   switch (cls) {
     case kAlertClassA:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_CLASS_A_0_VALUE_CLASSA);
+      ++reg_wr_count;
       break;
     case kAlertClassB:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_CLASS_A_0_VALUE_CLASSB);
+      ++reg_wr_count;
       break;
     case kAlertClassC:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_CLASS_A_0_VALUE_CLASSC);
+      ++reg_wr_count;
       break;
     case kAlertClassD:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_CLASS_A_0_VALUE_CLASSD);
+      ++reg_wr_count;
       break;
     case kAlertClassX:
+      sec_mmio_write_increment(reg_wr_count);
       return kErrorOk;
     default:
+      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadClass;
   }
 
@@ -58,15 +66,18 @@ rom_error_t alert_configure(size_t index, alert_class_t cls,
           kBase + ALERT_HANDLER_ALERT_EN_SHADOWED_0_REG_OFFSET + index, 1);
       sec_mmio_write32(kBase + ALERT_HANDLER_ALERT_REGWEN_0_REG_OFFSET + index,
                        0);
+      reg_wr_count += 2;
       break;
     case kAlertEnableEnabled:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_ALERT_EN_SHADOWED_0_REG_OFFSET + index, 1);
+      ++reg_wr_count;
       break;
     default:
+      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadEnable;
   }
-
+  sec_mmio_write_increment(reg_wr_count);
   return kErrorOk;
 }
 
@@ -77,30 +88,38 @@ rom_error_t alert_local_configure(size_t index, alert_class_t cls,
   }
   index *= 4;
 
+  uint32_t reg_wr_count = 0;
+
   switch (cls) {
     case kAlertClassA:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_CLASS_LA_0_VALUE_CLASSA);
+      ++reg_wr_count;
       break;
     case kAlertClassB:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_CLASS_LA_0_VALUE_CLASSB);
+      ++reg_wr_count;
       break;
     case kAlertClassC:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_CLASS_LA_0_VALUE_CLASSC);
+      ++reg_wr_count;
       break;
     case kAlertClassD:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_REG_OFFSET + index,
           ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_CLASS_LA_0_VALUE_CLASSD);
+      ++reg_wr_count;
       break;
     case kAlertClassX:
+      sec_mmio_write_increment(reg_wr_count);
       return kErrorOk;
     default:
+      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadClass;
   }
 
@@ -113,15 +132,18 @@ rom_error_t alert_local_configure(size_t index, alert_class_t cls,
           kBase + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_0_REG_OFFSET + index, 1);
       sec_mmio_write32(
           kBase + ALERT_HANDLER_LOC_ALERT_REGWEN_0_REG_OFFSET + index, 0);
+      reg_wr_count += 2;
       break;
     case kAlertEnableEnabled:
       sec_mmio_write32_shadowed(
           kBase + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_0_REG_OFFSET + index, 1);
+      ++reg_wr_count;
       break;
     default:
+      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadEnable;
   }
-
+  sec_mmio_write_increment(reg_wr_count);
   return kErrorOk;
 }
 
@@ -201,6 +223,7 @@ rom_error_t alert_class_configure(alert_class_t cls,
       return kErrorAlertBadEscalation;
   }
 
+  uint32_t reg_wr_count = 0;
   sec_mmio_write32_shadowed(
       kBase + ALERT_HANDLER_CLASSA_CTRL_SHADOWED_REG_OFFSET + offset, reg);
   sec_mmio_write32_shadowed(
@@ -215,11 +238,16 @@ rom_error_t alert_class_configure(alert_class_t cls,
             i * 4,
         config->phase_cycles[i]);
   }
+  reg_wr_count += 7;
+
   if (config->enabled == kAlertEnableLocked) {
     // Lock the alert configuration if it is configured to be locked.
     sec_mmio_write32(kBase + ALERT_HANDLER_CLASSA_REGWEN_REG_OFFSET + offset,
                      0);
+    ++reg_wr_count;
   }
+
+  sec_mmio_write_increment(reg_wr_count);
   return kErrorOk;
 }
 
@@ -228,5 +256,6 @@ rom_error_t alert_ping_enable(void) {
   sec_mmio_write32_shadowed(
       kBase + ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET, 1);
   sec_mmio_write32(kBase + ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
+  sec_mmio_write_increment(/*value=*/2);
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
@@ -29,6 +29,7 @@ TEST_F(InitTest, AlertConfigureAlertBadIndex) {
 }
 
 TEST_F(InitTest, AlertConfigureAlertBadClass) {
+  EXPECT_SEC_WRITE_INCREMENT(0);
   EXPECT_EQ(alert_configure(0, (alert_class_t)-1, kAlertEnableNone),
             kErrorAlertBadClass);
 }
@@ -38,15 +39,18 @@ TEST_F(InitTest, AlertConfigureAlertBadEnable) {
   // experience an error when evaluating the enable parameter.
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(1);
   EXPECT_EQ(alert_configure(0, kAlertClassA, (alert_enable_t)-1),
             kErrorAlertBadEnable);
 }
 
 TEST_F(InitTest, AlertConfigureAlertClassXNoOperation) {
+  EXPECT_SEC_WRITE_INCREMENT(0);
   EXPECT_EQ(alert_configure(0, kAlertClassX, kAlertEnableNone), kErrorOk);
 }
 
 TEST_F(InitTest, LocalAlertConfigureAlertClassXNoOperation) {
+  EXPECT_SEC_WRITE_INCREMENT(0);
   EXPECT_EQ(alert_local_configure(0, kAlertClassX, kAlertEnableNone), kErrorOk);
 }
 
@@ -55,6 +59,7 @@ TEST_F(InitTest, AlertConfigure0AsClassA) {
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET, 0);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_0_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_configure(0, kAlertClassA, kAlertEnableEnabled), kErrorOk);
 }
 
@@ -63,6 +68,7 @@ TEST_F(InitTest, LocalAlertConfigure0AsClassA) {
       base_ + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_REG_OFFSET, 0);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_0_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_local_configure(0, kAlertClassA, kAlertEnableEnabled),
             kErrorOk);
 }
@@ -72,6 +78,7 @@ TEST_F(InitTest, AlertConfigure1AsClassB) {
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_1_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_1_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_configure(1, kAlertClassB, kAlertEnableEnabled), kErrorOk);
 }
 
@@ -80,6 +87,7 @@ TEST_F(InitTest, LocalAlertConfigure1AsClassB) {
       base_ + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_1_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_1_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_local_configure(1, kAlertClassB, kAlertEnableEnabled),
             kErrorOk);
 }
@@ -89,6 +97,7 @@ TEST_F(InitTest, AlertConfigure2AsClassC) {
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_2_REG_OFFSET, 2);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_2_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_configure(2, kAlertClassC, kAlertEnableEnabled), kErrorOk);
 }
 
@@ -97,6 +106,7 @@ TEST_F(InitTest, LocalAlertConfigure2AsClassC) {
       base_ + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_2_REG_OFFSET, 2);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_2_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_local_configure(2, kAlertClassC, kAlertEnableEnabled),
             kErrorOk);
 }
@@ -107,6 +117,7 @@ TEST_F(InitTest, AlertConfigure3AsClassDLocked) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_3_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32(base_ + ALERT_HANDLER_ALERT_REGWEN_3_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(3);
   EXPECT_EQ(alert_configure(3, kAlertClassD, kAlertEnableLocked), kErrorOk);
 }
 
@@ -116,6 +127,7 @@ TEST_F(InitTest, LocalAlertConfigure3AsClassDLocked) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_3_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32(base_ + ALERT_HANDLER_LOC_ALERT_REGWEN_3_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(3);
   EXPECT_EQ(alert_local_configure(3, kAlertClassD, kAlertEnableLocked),
             kErrorOk);
 }
@@ -160,6 +172,7 @@ TEST_F(InitTest, AlertConfigureClassA) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSA_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
   EXPECT_SEC_WRITE32(base_ + ALERT_HANDLER_CLASSA_REGWEN_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(8);
   EXPECT_EQ(alert_class_configure(kAlertClassA, &config), kErrorOk);
 }
 
@@ -197,6 +210,7 @@ TEST_F(InitTest, AlertConfigureClassB) {
       base_ + ALERT_HANDLER_CLASSB_PHASE2_CYC_SHADOWED_REG_OFFSET, 100);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSB_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
+  EXPECT_SEC_WRITE_INCREMENT(7);
   EXPECT_EQ(alert_class_configure(kAlertClassB, &config), kErrorOk);
 }
 
@@ -234,6 +248,7 @@ TEST_F(InitTest, AlertConfigureClassC) {
       base_ + ALERT_HANDLER_CLASSC_PHASE2_CYC_SHADOWED_REG_OFFSET, 100);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSC_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
+  EXPECT_SEC_WRITE_INCREMENT(7);
   EXPECT_EQ(alert_class_configure(kAlertClassC, &config), kErrorOk);
 }
 
@@ -271,6 +286,7 @@ TEST_F(InitTest, AlertConfigureClassD) {
       base_ + ALERT_HANDLER_CLASSD_PHASE2_CYC_SHADOWED_REG_OFFSET, 100);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSD_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
+  EXPECT_SEC_WRITE_INCREMENT(7);
   EXPECT_EQ(alert_class_configure(kAlertClassD, &config), kErrorOk);
 }
 


### PR DESCRIPTION
Updates the `sec_mmio` expected write counts. Updates the alert functest to incorporate `sec_mmio_check_values` and `sec_mmio_check_counts` calls.