### PR TITLE
[dv/alert_init] Fix regression error

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -9,9 +9,11 @@
 class alert_esc_agent_cfg extends dv_base_agent_cfg;
   virtual alert_esc_if vif;
   virtual alert_esc_probe_if probe_vif;
-  bit is_alert     = 1;
-  bit is_async     = 0;
-  bit en_ping_cov  = 1;
+  bit is_alert        = 1;
+  bit is_async        = 0;
+  bit en_ping_cov     = 1;
+  bit alert_init_done = 0;
+
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -31,6 +31,7 @@ class alert_monitor extends alert_esc_base_monitor;
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
+      cfg.alert_init_done = 0;
       @(posedge cfg.vif.rst_n);
       // Reset signals at posedge rst_n to avoid race condition at negedge rst_n
       reset_signals();
@@ -48,6 +49,7 @@ class alert_monitor extends alert_esc_base_monitor;
     wait (cfg.vif.monitor_cb.alert_tx_final.alert_p != cfg.vif.monitor_cb.alert_tx_final.alert_n);
     `uvm_info("alert_monitor", "Alert init done!", UVM_HIGH)
     under_reset = 0;
+    cfg.alert_init_done = 1;
   endtask
 
   virtual task ping_thread();

--- a/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_receiver_driver.sv
@@ -21,11 +21,13 @@ class alert_receiver_driver extends alert_esc_base_driver;
 
   virtual task reset_signals();
     do_reset();
+    do_alert_rx_init();
     forever begin
       @(negedge cfg.vif.rst_n);
       under_reset = 1;
       do_reset();
       @(posedge cfg.vif.rst_n);
+      do_alert_rx_init();
       under_reset = 0;
     end
   endtask
@@ -174,7 +176,9 @@ class alert_receiver_driver extends alert_esc_base_driver;
     cfg.vif.alert_rx_int.ping_n <= 1'b1;
     cfg.vif.alert_rx_int.ack_p <= 1'b0;
     cfg.vif.alert_rx_int.ack_n <= 1'b1;
+  endtask
 
+  virtual task do_alert_rx_init();
     // Drive alert init signal integrity error handshake.
     repeat ($urandom_range(1, 10)) @(cfg.vif.receiver_cb);
     cfg.vif.alert_rx_int.ping_n <= 1'b0;

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -88,6 +88,13 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
     if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
+
+    // Wait for alert init done, then start the sequence.
+    foreach (cfg.list_of_alerts[i]) begin
+      if (cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].is_active) begin
+        wait (cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].alert_init_done == 1);
+      end
+    end
   endtask
 
   task pre_start();

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -26,7 +26,10 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task dut_init(string reset_kind = "HARD");
     // OTP inputs `lc_state` and `lc_cnt` need to be stable before lc_ctrl's reset is deasserted
-    if (do_lc_ctrl_init) drive_otp_i();
+    if (do_lc_ctrl_init) begin
+      drive_otp_i();
+      cfg.pwr_lc_vif.drive_pin(LcPwrInitReq, 0);
+    end
     super.dut_init();
     if (do_lc_ctrl_init) lc_ctrl_init();
   endtask


### PR DESCRIPTION
This PR fixes regression error on alert_test and tl_int_error regarding
alert init sequence.
The main issue is that dut_init needs to wait for alert_init sequence to
finish before starting the sequence.

Most of the changes are from #8489. I added a small change to fix top-level test to solve the CI failure.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>