### PR TITLE
[otbn] Added RTL for internal secure wipe

### DIFF
--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -388,10 +388,14 @@ package otbn_pkg;
     OtbnStateLocked
   } otbn_state_e;
 
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     OtbnStartStopStateHalt,
     OtbnStartStopStateUrndRefresh,
-    OtbnStartStopStateRunning
+    OtbnStartStopStateRunning,
+    OtbnStartStopSecureWipeWdrUrnd,
+    OtbnStartStopSecureWipeAccModBaseUrnd,
+    OtbnStartStopSecureWipeAllZero,
+    OtbnStartStopSecureWipeComplete
   } otbn_start_stop_state_e;
 
   // URNG PRNG default LFSR seed and permutation

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -37,6 +37,7 @@ module otbn_rf_base
   input  logic                     rst_ni,
 
   input  logic                     state_reset_i,
+  input  logic                     sec_wipe_stack_reset_i,
 
   input  logic [4:0]               wr_addr_i,
   input  logic                     wr_en_i,
@@ -87,6 +88,9 @@ module otbn_rf_base
   logic [BaseIntgWidth-1:0] stack_data_intg;
   logic                     stack_data_valid;
 
+  logic state_reset;
+
+  assign state_reset = state_reset_i | sec_wipe_stack_reset_i;
 
   assign pop_stack_a     = rd_en_a_i & (rd_addr_a_i == CallStackRegIndex[4:0]);
   assign pop_stack_b     = rd_en_b_i & (rd_addr_b_i == CallStackRegIndex[4:0]);
@@ -133,7 +137,7 @@ module otbn_rf_base
 
     .full_o        (stack_full),
 
-    .clear_i       (state_reset_i),
+    .clear_i       (state_reset),
 
     .push_i        (push_stack),
     .push_data_i   (wr_data_intg_mux_out),

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -10,13 +10,24 @@
  *
  * pre-start actions:
  *  - Seed LFSR for URND
+ *
+ * post-stop actions:
+ *  - Internal Secure Wipe
+ *    -Delete WDRs
+ *    -Delete Base registers
+ *    -Delete Accumulator
+ *    -Delete Modulus
+ *    -Reset stack
  */
 
 `include "prim_assert.sv"
 
 module otbn_start_stop_control
   import otbn_pkg::*;
-(
+  #(
+  // Enable internal secure wipe
+  parameter bit                SecWipeEn  = 1'b0
+)(
   input  logic clk_i,
   input  logic rst_ni,
 
@@ -24,16 +35,31 @@ module otbn_start_stop_control
 
   output logic controller_start_o,
 
-  input  logic controller_done_i,
-
   output logic urnd_reseed_req_o,
   input  logic urnd_reseed_busy_i,
   output logic urnd_advance_o,
+
+  input   logic start_secure_wipe_i,
+  output  logic secure_wipe_running_o,
+  output  logic done_o,
+
+  output logic       sec_wipe_wdr_o,
+  output logic       sec_wipe_wdr_urnd_o,
+  output logic       sec_wipe_base_o,
+  output logic       sec_wipe_base_urnd_o,
+  output logic [4:0] sec_wipe_addr_o,
+
+  output logic sec_wipe_acc_urnd_o,
+  output logic sec_wipe_mod_urnd_o,
+  output logic sec_wipe_zero_o,
 
   output logic ispr_init_o,
   output logic state_reset_o
 );
   otbn_start_stop_state_e state_q, state_d;
+
+  logic addr_cnt_inc;
+  logic [4:0] addr_cnt_q, addr_cnt_d;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -44,11 +70,20 @@ module otbn_start_stop_control
   end
 
   always_comb begin
-    urnd_reseed_req_o = 1'b0;
-    urnd_advance_o    = 1'b0;
-    state_d           = state_q;
-    ispr_init_o       = 1'b0;
-    state_reset_o     = 1'b0;
+    urnd_reseed_req_o      = 1'b0;
+    urnd_advance_o         = 1'b0;
+    state_d                = state_q;
+    ispr_init_o            = 1'b0;
+    state_reset_o          = 1'b0;
+    sec_wipe_wdr_o         = 1'b0;
+    sec_wipe_wdr_urnd_o    = 1'b0;
+    sec_wipe_base_o        = 1'b0;
+    sec_wipe_base_urnd_o   = 1'b0;
+    sec_wipe_acc_urnd_o    = 1'b0;
+    sec_wipe_mod_urnd_o    = 1'b0;
+    sec_wipe_zero_o        = 1'b0;
+    addr_cnt_inc           = 1'b0;
+    secure_wipe_running_o  = 1'b0;
 
     unique case (state_q)
       OtbnStartStopStateHalt: begin
@@ -66,9 +101,59 @@ module otbn_start_stop_control
       end
       OtbnStartStopStateRunning: begin
         urnd_advance_o = 1'b1;
-        if (controller_done_i) begin
-          state_d = OtbnStartStopStateHalt;
+        if (start_secure_wipe_i) begin
+          if (SecWipeEn) begin
+            state_d = OtbnStartStopSecureWipeWdrUrnd;
+          end
+          else begin
+            state_d = OtbnStartStopSecureWipeComplete;
+          end
         end
+      end
+      // Writing random numbers to the wide data registers.
+       OtbnStartStopSecureWipeWdrUrnd: begin
+        urnd_advance_o        = 1'b1;
+        addr_cnt_inc          = 1'b1;
+        sec_wipe_wdr_o        = 1'b1;
+        sec_wipe_wdr_urnd_o   = 1'b1;
+        secure_wipe_running_o = 1'b1;
+        if (addr_cnt_q == 5'b11111) begin
+          state_d = OtbnStartStopSecureWipeAccModBaseUrnd;
+        end
+      end
+      // Writing random numbers to the accumulator, modulus and the base registers.
+      // addr_cnt_q wraps around to 0 when first moving to this state, and we need to
+      // supress writes to the zero register and the call stack.
+       OtbnStartStopSecureWipeAccModBaseUrnd: begin
+        secure_wipe_running_o = 1'b1;
+        urnd_advance_o        = 1'b1;
+        addr_cnt_inc          = 1'b1;
+        // The first two clock cycles are used to write random data to accumulator and modulus.
+        sec_wipe_acc_urnd_o   = (addr_cnt_q == 5'b00000);
+        sec_wipe_mod_urnd_o   = (addr_cnt_q == 5'b00001);
+        // Supress writes to the zero register and the call stack.
+        sec_wipe_base_o       = (addr_cnt_q > 5'b00001);
+        sec_wipe_base_urnd_o  = (addr_cnt_q > 5'b00001);
+        if (addr_cnt_q == 5'b11111) begin
+          state_d = OtbnStartStopSecureWipeAllZero;
+        end
+      end
+      // Writing zeros to the accumulator, modulus and the registers.
+      // Resetting stack
+       OtbnStartStopSecureWipeAllZero: begin
+        secure_wipe_running_o = 1'b1;
+        sec_wipe_zero_o       = (addr_cnt_q == 5'b00000);
+        sec_wipe_wdr_o        = 1'b1;
+        sec_wipe_base_o       = (addr_cnt_q > 5'b00001);
+        addr_cnt_inc = 1'b1;
+        if (addr_cnt_q == 5'b11111) begin
+          state_d = OtbnStartStopSecureWipeComplete;
+        end
+      end
+       OtbnStartStopSecureWipeComplete: begin
+        urnd_advance_o = 1'b1;
+        secure_wipe_running_o = 1'b1;
+        state_d = OtbnStartStopStateHalt;
       end
       default: ;
     endcase
@@ -77,9 +162,31 @@ module otbn_start_stop_control
   // Logic separate from main FSM code to avoid false combinational loop warning from verilator
   assign controller_start_o = (state_q == OtbnStartStopStateUrndRefresh) & !urnd_reseed_busy_i;
 
+  if (SecWipeEn) begin: gen_sec_wipe
+    assign done_o = (state_q == OtbnStartStopSecureWipeComplete);
+  end
+  else begin: gen_bypass_sec_wipe
+      assign done_o = start_secure_wipe_i;
+  end
+
+  assign addr_cnt_d = addr_cnt_inc ? (addr_cnt_q + 5'd1) : 5'd0;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      addr_cnt_q <= 5'd0;
+    end else
+      addr_cnt_q <= addr_cnt_d;
+  end
+
+  assign sec_wipe_addr_o = addr_cnt_q;
+
   `ASSERT(StartStopStateValid,
       state_q inside {OtbnStartStopStateHalt,
                       OtbnStartStopStateUrndRefresh,
-                      OtbnStartStopStateRunning})
+                      OtbnStartStopStateRunning,
+                      OtbnStartStopSecureWipeWdrUrnd,
+                      OtbnStartStopSecureWipeAccModBaseUrnd,
+                      OtbnStartStopSecureWipeAllZero,
+                      OtbnStartStopSecureWipeComplete})
 
 endmodule


### PR DESCRIPTION
At the end of the OTBN operation the internal state is wiped by
randomizing (using URNG data) and zeroing:
  -Wide Data registers
  -General purpose registers
  -The accumulator register
  -The modulus

Call stack pointer is reset.

This operation can be switched on/off via parameter SecWipeEn
at otbn_core.sv (default SecWipeEn = 1'b0)

Added internal secure wipe.

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>