### PR TITLE
[dvsim] Introduce {self_dir} as variable

### DIFF
--- a/util/dvsim/CfgFactory.py
+++ b/util/dvsim/CfgFactory.py
@@ -4,6 +4,7 @@
 
 import logging as log
 import sys
+import os
 
 from CfgJson import load_hjson
 
@@ -82,7 +83,10 @@ def make_cfg(path, args, proj_root):
     of the project.
 
     '''
-    initial_values = {'proj_root': proj_root}
+    initial_values = {
+        'proj_root': proj_root,
+        'self_dir': os.path.dirname(path),
+    }
     if args.tool is not None:
         initial_values['tool'] = args.tool
 

--- a/util/dvsim/Testplan.py
+++ b/util/dvsim/Testplan.py
@@ -177,7 +177,7 @@ class Testpoint(Element):
             self.test_results = [Result(name=self.name, passing=0, total=0)]
 
 
-class Testplan():
+class Testplan:
     """The full testplan
 
     The list of Testpoints and Covergroups make up the testplan.
@@ -192,7 +192,7 @@ class Testplan():
         try:
             return hjson.load(open(filename, 'rU'))
         except IOError as e:
-            print(f"IO Error when opening fie {filename}\n{e}")
+            print(f"IO Error when opening file {filename}\n{e}")
         except hjson.scanner.HjsonDecodeError as e:
             print(f"Error: Unable to decode HJSON with file {filename}:\n{e}")
         sys.exit(1)

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -157,7 +157,7 @@ def get_proj_root():
             "But this command has failed:\n"
             "{}".format(' '.join(cmd), result.stderr.decode("utf-8")))
         sys.exit(1)
-    return (proj_root)
+    return proj_root
 
 
 def resolve_proj_root(args):


### PR DESCRIPTION
Introduce a new variable `{self_dir}` which contains the absolute path to
the Hjson file using this variable. This variable can be used in Hjson
files to produce a path to a file relative to the Hjson file the variable
is used in, making Hjson files relocateable.