### PR TITLE
[sw/rom] sec_mmio integration at mask_rom level

### DIFF
--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -94,6 +94,10 @@ static void mask_rom_init(void) {
       .sink = uart_sink,
   });
 
+  // TODO(lowRISC/opentitan#8536): Integrate RND driver.
+  sec_mmio_check_values(/*rnd_offset=*/0);
+  sec_mmio_check_counters(/*expected_check_count=*/1);
+
   // TODO: Bootstrap.
 }
 
@@ -145,6 +149,10 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest) {
   RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateReset));
   keymgr_sw_binding_set(&manifest->binding_value, &manifest->binding_value);
   keymgr_creator_max_ver_set(manifest->max_key_version);
+
+  // TODO(lowRISC/opentitan#8536): Integrate RND driver.
+  sec_mmio_check_values(/*rnd_offset=*/0);
+  sec_mmio_check_counters(/*expected_check_count=*/3);
 
   // Unlock execution of ROM_EXT executable code (text) sections.
   RETURN_IF_ERROR(epmp_state_check(&epmp));


### PR DESCRIPTION
Integrate `sec_mmio` at the mask rom top level.