### PR TITLE
[prim] Minor work-around for xcelium

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_otp.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_otp.sv
@@ -25,8 +25,8 @@ module prim_generic_otp
   // VMEM file to initialize the memory with
   parameter      MemInitFile   = "",
   // Vendor test partition offset and size (both in bytes)
-  parameter  int VendorTestOffset,
-  parameter  int VendorTestSize
+  parameter  int VendorTestOffset = 0,
+  parameter  int VendorTestSize   = 0
 ) (
   input                          clk_i,
   input                          rst_ni,


### PR DESCRIPTION
- As @matutem noted, xcelium incorrectly does not allow empty parameters.
- Workaround for now by assigning a default value

Signed-off-by: Timothy Chen <timothytim@google.com>