### PR TITLE
[dif/spi_device] Autogen IRQ DIFs and integrate into test code.

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -66,12 +66,13 @@ void demo_spi_to_log_echo(const dif_spi_device_t *spi,
                           const dif_spi_device_config_t *spi_config) {
   uint32_t spi_buf[8];
   size_t spi_len;
-  CHECK(dif_spi_device_recv(spi, spi_config, spi_buf, sizeof(spi_buf),
-                            &spi_len) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(
+      dif_spi_device_recv(spi, spi_config, spi_buf, sizeof(spi_buf), &spi_len));
   if (spi_len > 0) {
     uint32_t echo_word = spi_buf[0] ^ 0x01010101;
-    CHECK(dif_spi_device_send(spi, spi_config, &echo_word, sizeof(uint32_t),
-                              /*bytes_sent=*/NULL) == kDifSpiDeviceOk);
+    CHECK_DIF_OK(dif_spi_device_send(spi, spi_config, &echo_word,
+                                     sizeof(uint32_t),
+                                     /*bytes_sent=*/NULL));
     LOG_INFO("SPI: %z", spi_len, spi_buf);
   }
 }

--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -62,14 +62,15 @@ uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   return gpio_state;
 }
 
-void demo_spi_to_log_echo(const dif_spi_device_t *spi) {
+void demo_spi_to_log_echo(const dif_spi_device_t *spi,
+                          const dif_spi_device_config_t *spi_config) {
   uint32_t spi_buf[8];
   size_t spi_len;
-  CHECK(dif_spi_device_recv(spi, spi_buf, sizeof(spi_buf), &spi_len) ==
-        kDifSpiDeviceOk);
+  CHECK(dif_spi_device_recv(spi, spi_config, spi_buf, sizeof(spi_buf),
+                            &spi_len) == kDifSpiDeviceOk);
   if (spi_len > 0) {
     uint32_t echo_word = spi_buf[0] ^ 0x01010101;
-    CHECK(dif_spi_device_send(spi, &echo_word, sizeof(uint32_t),
+    CHECK(dif_spi_device_send(spi, spi_config, &echo_word, sizeof(uint32_t),
                               /*bytes_sent=*/NULL) == kDifSpiDeviceOk);
     LOG_INFO("SPI: %z", spi_len, spi_buf);
   }

--- a/sw/device/examples/demos.h
+++ b/sw/device/examples/demos.h
@@ -41,7 +41,8 @@ uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state);
  * Attempts to read at most 32 bytes from SPI, and echo them as printable
  * characters to LOG.
  */
-void demo_spi_to_log_echo(const dif_spi_device_t *spi);
+void demo_spi_to_log_echo(const dif_spi_device_t *spi,
+                          const dif_spi_device_config_t *spi_config);
 
 /**
  * Attempts to read characters from UART and immediately echo them back,

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -122,12 +122,8 @@ int main(int argc, char **argv) {
 
   pinmux_init();
 
-  CHECK(dif_spi_device_init(
-            (dif_spi_device_params_t){
-                .base_addr =
-                    mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR),
-            },
-            &spi) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(dif_spi_device_init(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR), &spi));
   spi_config.clock_polarity = kDifSpiDeviceEdgePositive;
   spi_config.data_phase = kDifSpiDeviceEdgeNegative;
   spi_config.tx_order = kDifSpiDeviceBitOrderMsbToLsb;
@@ -135,7 +131,7 @@ int main(int argc, char **argv) {
   spi_config.rx_fifo_timeout = 63;
   spi_config.rx_fifo_len = kDifSpiDeviceBufferLen / 2;
   spi_config.tx_fifo_len = kDifSpiDeviceBufferLen / 2;
-  CHECK(dif_spi_device_configure(&spi, &spi_config) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(dif_spi_device_configure(&spi, &spi_config));
 
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
@@ -165,8 +161,8 @@ int main(int argc, char **argv) {
   usb_simpleserial_init(&simple_serial0, &usbdev, 1, usb_receipt_callback_0);
   usb_simpleserial_init(&simple_serial1, &usbdev, 2, usb_receipt_callback_1);
 
-  CHECK(dif_spi_device_send(&spi, &spi_config, "SPI!", 4,
-                            /*bytes_sent=*/NULL) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(
+      dif_spi_device_send(&spi, &spi_config, "SPI!", 4, /*bytes_sent=*/NULL));
 
   bool say_hello = true;
   bool pass_signaled = false;

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -18,6 +18,7 @@
 
 static dif_gpio_t gpio;
 static dif_spi_device_t spi;
+static dif_spi_device_config_t spi_config;
 static dif_uart_t uart;
 
 int main(int argc, char **argv) {
@@ -40,16 +41,14 @@ int main(int argc, char **argv) {
                     mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR),
             },
             &spi) == kDifSpiDeviceOk);
-  CHECK(dif_spi_device_configure(
-            &spi, (dif_spi_device_config_t){
-                      .clock_polarity = kDifSpiDeviceEdgePositive,
-                      .data_phase = kDifSpiDeviceEdgeNegative,
-                      .tx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                      .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
-                      .rx_fifo_timeout = 63,
-                      .rx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                      .tx_fifo_len = kDifSpiDeviceBufferLen / 2,
-                  }) == kDifSpiDeviceOk);
+  spi_config.clock_polarity = kDifSpiDeviceEdgePositive;
+  spi_config.data_phase = kDifSpiDeviceEdgeNegative;
+  spi_config.tx_order = kDifSpiDeviceBitOrderMsbToLsb;
+  spi_config.rx_order = kDifSpiDeviceBitOrderMsbToLsb;
+  spi_config.rx_fifo_timeout = 63;
+  spi_config.rx_fifo_len = kDifSpiDeviceBufferLen / 2;
+  spi_config.tx_fifo_len = kDifSpiDeviceBufferLen / 2;
+  CHECK(dif_spi_device_configure(&spi, &spi_config) == kDifSpiDeviceOk);
 
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
@@ -69,14 +68,14 @@ int main(int argc, char **argv) {
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");
 
-  CHECK(dif_spi_device_send(&spi, "SPI!", 4, /*bytes_sent=*/NULL) ==
-        kDifSpiDeviceOk);
+  CHECK(dif_spi_device_send(&spi, &spi_config, "SPI!", 4,
+                            /*bytes_sent=*/NULL) == kDifSpiDeviceOk);
 
   uint32_t gpio_state = 0;
   while (true) {
     usleep(10 * 1000);  // 10 ms
     gpio_state = demo_gpio_to_log_echo(&gpio, gpio_state);
-    demo_spi_to_log_echo(&spi);
+    demo_spi_to_log_echo(&spi, &spi_config);
     demo_uart_to_uart_and_gpio_echo(&uart, &gpio);
   }
 }

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -35,12 +35,8 @@ int main(int argc, char **argv) {
 
   pinmux_init();
 
-  CHECK(dif_spi_device_init(
-            (dif_spi_device_params_t){
-                .base_addr =
-                    mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR),
-            },
-            &spi) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(dif_spi_device_init(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR), &spi));
   spi_config.clock_polarity = kDifSpiDeviceEdgePositive;
   spi_config.data_phase = kDifSpiDeviceEdgeNegative;
   spi_config.tx_order = kDifSpiDeviceBitOrderMsbToLsb;
@@ -48,7 +44,7 @@ int main(int argc, char **argv) {
   spi_config.rx_fifo_timeout = 63;
   spi_config.rx_fifo_len = kDifSpiDeviceBufferLen / 2;
   spi_config.tx_fifo_len = kDifSpiDeviceBufferLen / 2;
-  CHECK(dif_spi_device_configure(&spi, &spi_config) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(dif_spi_device_configure(&spi, &spi_config));
 
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
@@ -68,8 +64,8 @@ int main(int argc, char **argv) {
   LOG_INFO("or type anything into the console window.");
   LOG_INFO("The LEDs show the ASCII code of the last character.");
 
-  CHECK(dif_spi_device_send(&spi, &spi_config, "SPI!", 4,
-                            /*bytes_sent=*/NULL) == kDifSpiDeviceOk);
+  CHECK_DIF_OK(dif_spi_device_send(&spi, &spi_config, "SPI!", 4,
+                                   /*bytes_sent=*/NULL));
 
   uint32_t gpio_state = 0;
   while (true) {

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -1,0 +1,200 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_spi_device.h"
+
+#include "spi_device_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool spi_device_get_irq_bit_index(dif_spi_device_irq_t irq,
+                                         bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifSpiDeviceIrqRxf:
+      *index_out = SPI_DEVICE_INTR_STATE_RXF_BIT;
+      break;
+    case kDifSpiDeviceIrqRxlvl:
+      *index_out = SPI_DEVICE_INTR_STATE_RXLVL_BIT;
+      break;
+    case kDifSpiDeviceIrqTxlvl:
+      *index_out = SPI_DEVICE_INTR_STATE_TXLVL_BIT;
+      break;
+    case kDifSpiDeviceIrqRxerr:
+      *index_out = SPI_DEVICE_INTR_STATE_RXERR_BIT;
+      break;
+    case kDifSpiDeviceIrqRxoverflow:
+      *index_out = SPI_DEVICE_INTR_STATE_RXOVERFLOW_BIT;
+      break;
+    case kDifSpiDeviceIrqTxunderflow:
+      *index_out = SPI_DEVICE_INTR_STATE_TXUNDERFLOW_BIT;
+      break;
+    case kDifSpiDeviceIrqTpmCmdaddrNotempty:
+      *index_out = SPI_DEVICE_INTR_STATE_TPM_CMDADDR_NOTEMPTY_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_get_state(
+    const dif_spi_device_t *spi_device,
+    dif_spi_device_irq_state_snapshot_t *snapshot) {
+  if (spi_device == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(spi_device->base_addr,
+                                 SPI_DEVICE_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_is_pending(const dif_spi_device_t *spi_device,
+                                           dif_spi_device_irq_t irq,
+                                           bool *is_pending) {
+  if (spi_device == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!spi_device_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg = mmio_region_read32(
+      spi_device->base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_acknowledge(const dif_spi_device_t *spi_device,
+                                            dif_spi_device_irq_t irq) {
+  if (spi_device == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!spi_device_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(spi_device->base_addr, SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_get_enabled(const dif_spi_device_t *spi_device,
+                                            dif_spi_device_irq_t irq,
+                                            dif_toggle_t *state) {
+  if (spi_device == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!spi_device_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      spi_device->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_set_enabled(const dif_spi_device_t *spi_device,
+                                            dif_spi_device_irq_t irq,
+                                            dif_toggle_t state) {
+  if (spi_device == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!spi_device_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      spi_device->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(spi_device->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_force(const dif_spi_device_t *spi_device,
+                                      dif_spi_device_irq_t irq) {
+  if (spi_device == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!spi_device_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(spi_device->base_addr, SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_disable_all(
+    const dif_spi_device_t *spi_device,
+    dif_spi_device_irq_enable_snapshot_t *snapshot) {
+  if (spi_device == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(spi_device->base_addr,
+                                   SPI_DEVICE_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(spi_device->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                      0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_restore_all(
+    const dif_spi_device_t *spi_device,
+    const dif_spi_device_irq_enable_snapshot_t *snapshot) {
+  if (spi_device == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(spi_device->base_addr, SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
@@ -1,0 +1,194 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_SPI_DEVICE_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_SPI_DEVICE_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/spi_device/doc/">SPI_DEVICE</a> Device Interface
+ * Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to spi_device.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_spi_device {
+  /**
+   * The base address for the spi_device hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_spi_device_t;
+
+/**
+ * A spi_device interrupt request type.
+ */
+typedef enum dif_spi_device_irq {
+  /**
+   * RX SRAM FIFO Full
+   */
+  kDifSpiDeviceIrqRxf = 0,
+  /**
+   * RX SRAM FIFO is above the level
+   */
+  kDifSpiDeviceIrqRxlvl = 1,
+  /**
+   * TX SRAM FIFO is under the level
+   */
+  kDifSpiDeviceIrqTxlvl = 2,
+  /**
+   * SDI in FwMode has error
+   */
+  kDifSpiDeviceIrqRxerr = 3,
+  /**
+   * RX Async FIFO overflow
+   */
+  kDifSpiDeviceIrqRxoverflow = 4,
+  /**
+   * TX Async FIFO underflow
+   */
+  kDifSpiDeviceIrqTxunderflow = 5,
+  /**
+   * TPM Command/Address buffer available
+   */
+  kDifSpiDeviceIrqTpmCmdaddrNotempty = 6,
+} dif_spi_device_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_spi_device_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_spi_device_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_spi_device_irq_disable_all()` and `dif_spi_device_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_spi_device_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param spi_device A spi_device handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_get_state(
+    const dif_spi_device_t *spi_device,
+    dif_spi_device_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param spi_device A spi_device handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_is_pending(const dif_spi_device_t *spi_device,
+                                           dif_spi_device_irq_t irq,
+                                           bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param spi_device A spi_device handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_acknowledge(const dif_spi_device_t *spi_device,
+                                            dif_spi_device_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param spi_device A spi_device handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_get_enabled(const dif_spi_device_t *spi_device,
+                                            dif_spi_device_irq_t irq,
+                                            dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param spi_device A spi_device handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_set_enabled(const dif_spi_device_t *spi_device,
+                                            dif_spi_device_irq_t irq,
+                                            dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param spi_device A spi_device handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_force(const dif_spi_device_t *spi_device,
+                                      dif_spi_device_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param spi_device A spi_device handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_disable_all(
+    const dif_spi_device_t *spi_device,
+    dif_spi_device_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param spi_device A spi_device handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_irq_restore_all(
+    const dif_spi_device_t *spi_device,
+    const dif_spi_device_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_SPI_DEVICE_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -1,0 +1,316 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_spi_device.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "spi_device_regs.h"  // Generated.
+
+namespace dif_spi_device_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class SpiDeviceTest : public Test, public MmioTest {
+ protected:
+  dif_spi_device_t spi_device_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public SpiDeviceTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_spi_device_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_spi_device_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_spi_device_irq_get_state(&spi_device_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_spi_device_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_spi_device_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_spi_device_irq_get_state(&spi_device_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_spi_device_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_spi_device_irq_get_state(&spi_device_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public SpiDeviceTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_spi_device_irq_is_pending(nullptr, kDifSpiDeviceIrqRxf, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_spi_device_irq_is_pending(&spi_device_, kDifSpiDeviceIrqRxf, nullptr),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_spi_device_irq_is_pending(nullptr, kDifSpiDeviceIrqRxf, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(
+      dif_spi_device_irq_is_pending(
+          &spi_device_, static_cast<dif_spi_device_irq_t>(32), &is_pending),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_STATE_RXF_BIT, true}});
+  EXPECT_EQ(dif_spi_device_irq_is_pending(&spi_device_, kDifSpiDeviceIrqRxf,
+                                          &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_STATE_TPM_CMDADDR_NOTEMPTY_BIT, false}});
+  EXPECT_EQ(dif_spi_device_irq_is_pending(
+                &spi_device_, kDifSpiDeviceIrqTpmCmdaddrNotempty, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public SpiDeviceTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_irq_acknowledge(nullptr, kDifSpiDeviceIrqRxf),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_spi_device_irq_acknowledge(
+                nullptr, static_cast<dif_spi_device_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_STATE_RXF_BIT, true}});
+  EXPECT_EQ(dif_spi_device_irq_acknowledge(&spi_device_, kDifSpiDeviceIrqRxf),
+            kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_STATE_TPM_CMDADDR_NOTEMPTY_BIT, true}});
+  EXPECT_EQ(dif_spi_device_irq_acknowledge(&spi_device_,
+                                           kDifSpiDeviceIrqTpmCmdaddrNotempty),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public SpiDeviceTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_spi_device_irq_get_enabled(nullptr, kDifSpiDeviceIrqRxf, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_spi_device_irq_get_enabled(&spi_device_, kDifSpiDeviceIrqRxf,
+                                           nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(
+      dif_spi_device_irq_get_enabled(nullptr, kDifSpiDeviceIrqRxf, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_spi_device_irq_get_enabled(
+          &spi_device_, static_cast<dif_spi_device_irq_t>(32), &irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_RXF_BIT, true}});
+  EXPECT_EQ(dif_spi_device_irq_get_enabled(&spi_device_, kDifSpiDeviceIrqRxf,
+                                           &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_TPM_CMDADDR_NOTEMPTY_BIT, false}});
+  EXPECT_EQ(dif_spi_device_irq_get_enabled(
+                &spi_device_, kDifSpiDeviceIrqTpmCmdaddrNotempty, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public SpiDeviceTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(
+      dif_spi_device_irq_set_enabled(nullptr, kDifSpiDeviceIrqRxf, irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_spi_device_irq_set_enabled(
+                &spi_device_, static_cast<dif_spi_device_irq_t>(32), irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                {{SPI_DEVICE_INTR_ENABLE_RXF_BIT, 0x1, true}});
+  EXPECT_EQ(dif_spi_device_irq_set_enabled(&spi_device_, kDifSpiDeviceIrqRxf,
+                                           irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(
+      SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+      {{SPI_DEVICE_INTR_ENABLE_TPM_CMDADDR_NOTEMPTY_BIT, 0x1, false}});
+  EXPECT_EQ(dif_spi_device_irq_set_enabled(
+                &spi_device_, kDifSpiDeviceIrqTpmCmdaddrNotempty, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public SpiDeviceTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_irq_force(nullptr, kDifSpiDeviceIrqRxf), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(
+      dif_spi_device_irq_force(nullptr, static_cast<dif_spi_device_irq_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_TEST_RXF_BIT, true}});
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_device_, kDifSpiDeviceIrqRxf),
+            kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_INTR_TEST_TPM_CMDADDR_NOTEMPTY_BIT, true}});
+  EXPECT_EQ(dif_spi_device_irq_force(&spi_device_,
+                                     kDifSpiDeviceIrqTpmCmdaddrNotempty),
+            kDifOk);
+}
+
+class IrqDisableAllTest : public SpiDeviceTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_spi_device_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_spi_device_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_spi_device_irq_disable_all(&spi_device_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_spi_device_irq_disable_all(&spi_device_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_spi_device_irq_disable_all(&spi_device_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public SpiDeviceTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_spi_device_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_spi_device_irq_restore_all(&spi_device_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_spi_device_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_spi_device_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_spi_device_irq_restore_all(&spi_device_, &irq_snapshot),
+            kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_spi_device_irq_restore_all(&spi_device_, &irq_snapshot),
+            kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_spi_device_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -240,13 +240,13 @@ sw_lib_dif_autogen_rstmgr = declare_dependency(
   )
 )
 
-# Autogen UART DIF library
-sw_lib_dif_autogen_uart = declare_dependency(
+# Autogen SPI Device DIF library
+sw_lib_dif_autogen_spi_device = declare_dependency(
   link_with: static_library(
-    'sw_lib_dif_autogen_uart',
+    'sw_lib_dif_autogen_spi_device',
     sources: [
-      hw_ip_uart_reg_h,
-      'dif_uart_autogen.c',
+      hw_ip_spi_device_reg_h,
+      'dif_spi_device_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -261,6 +261,20 @@ sw_lib_dif_autogen_sram_ctrl = declare_dependency(
     sources: [
       hw_ip_sram_ctrl_reg_h,
       'dif_sram_ctrl_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen UART DIF library
+sw_lib_dif_autogen_uart = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_uart',
+    sources: [
+      hw_ip_uart_reg_h,
+      'dif_uart_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -113,8 +113,6 @@ typedef struct dif_spi_device_config {
  */
 typedef struct dif_spi_device {
   dif_spi_device_params_t params;
-  uint16_t rx_fifo_len;
-  uint16_t tx_fifo_len;
 } dif_spi_device_t;
 
 /**
@@ -209,7 +207,7 @@ dif_spi_device_result_t dif_spi_device_init(dif_spi_device_params_t params,
  */
 OT_WARN_UNUSED_RESULT
 dif_spi_device_result_t dif_spi_device_configure(
-    dif_spi_device_t *spi, dif_spi_device_config_t config);
+    const dif_spi_device_t *spi, const dif_spi_device_config_t *config);
 
 /**
  * Issues an "abort" to the given SPI device, causing all in-progress IO to
@@ -341,8 +339,9 @@ dif_spi_device_result_t dif_spi_device_set_irq_levels(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
-                                                  size_t *bytes_pending);
+dif_spi_device_result_t dif_spi_device_rx_pending(
+    const dif_spi_device_t *spi, const dif_spi_device_config_t *config,
+    size_t *bytes_pending);
 
 /**
  * Returns the number of bytes still pending transmission by hardware in the TX
@@ -353,8 +352,9 @@ dif_spi_device_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
-                                                  size_t *bytes_pending);
+dif_spi_device_result_t dif_spi_device_tx_pending(
+    const dif_spi_device_t *spi, const dif_spi_device_config_t *config,
+    size_t *bytes_pending);
 
 /**
  * Reads at most `buf_len` bytes from the RX FIFO; the number of bytes read
@@ -368,9 +368,9 @@ dif_spi_device_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
-                                            void *buf, size_t buf_len,
-                                            size_t *bytes_received);
+dif_spi_device_result_t dif_spi_device_recv(
+    const dif_spi_device_t *spi, const dif_spi_device_config_t *config,
+    void *buf, size_t buf_len, size_t *bytes_received);
 
 /**
  * Writes at most `buf_len` bytes to the TX FIFO; the number of bytes actually
@@ -383,9 +383,9 @@ dif_spi_device_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_spi_device_result_t dif_spi_device_send(const dif_spi_device_t *spi,
-                                            const void *buf, size_t buf_len,
-                                            size_t *bytes_sent);
+dif_spi_device_result_t dif_spi_device_send(
+    const dif_spi_device_t *spi, const dif_spi_device_config_t *config,
+    const void *buf, size_t buf_len, size_t *bytes_sent);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -218,16 +218,21 @@ sw_lib_dif_spi_device = declare_dependency(
       hw_ip_spi_device_reg_h,
       'dif_spi_device.c',
     ],
-    dependencies: [sw_lib_mmio],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_autogen_spi_device,
+    ],
   )
 )
 
 test('dif_spi_device_unittest', executable(
     'dif_spi_device_unittest',
     sources: [
-      hw_ip_spi_device_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_spi_device.c',
       'dif_spi_device_unittest.cc',
+      'autogen/dif_spi_device_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_spi_device.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_spi_device_autogen.c',
+      hw_ip_spi_device_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "spi_device".