### PR TITLE
[top/dv] Fix chip_sw_smoketest

### DIFF
--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -50,10 +50,11 @@ module tb;
   wire cpu_clk = `CPU_HIER.clk_i;
   wire cpu_rst_n = `CPU_HIER.rst_ni;
   wire alert_handler_clk = `ALERT_HANDLER_HIER.clk_i;
+  wire alert_handler_rst_n = `ALERT_HANDLER_HIER.rst_ni;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk, .rst_n);
-  alert_esc_if alert_if[NUM_ALERTS](.clk(alert_handler_clk), .rst_n(rst_n));
+  alert_esc_if alert_if[NUM_ALERTS](.clk(alert_handler_clk), .rst_n(alert_handler_rst_n));
   pins_if #(NUM_GPIOS) gpio_if(.pins(gpio_pins));
   pins_if #(1) srst_n_if(.pins(srst_n));
   pins_if #(2) tap_straps_if(.pins(tap_straps));


### PR DESCRIPTION
alert agent connects with another rst_n, it was ok before. But now we need to
do alert init sequence after every reset, so we need to use the right reset

Signed-off-by: Weicai Yang <weicai@google.com>