### PR TITLE
Require a newer (still modified) version of FuseSoC

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -41,10 +41,10 @@ types-pyyaml
 types-tabulate
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.11.0
+git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.12.0
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.0
+git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.3
 
 # Development version of ChipWhisperer toolchain
 # Use a development version until support for the CW310 board works in a


### PR DESCRIPTION
We have relied for a long time on a patched/customized version of FuseSoC.
This version has now been updated to use FuseSoC 1.12 as baseline, with our
patches on top of that.

Update the (reasonably meaningless) version number in our 
python-requirements.txt to reflect that. Users still need to install 
whatever the relevant Git branch has to offer.

Even though we no longer rely on a modified version of edalize, we still 
need to use a development version if it to get a version which carries all
patches we're interested in
(https://github.com/olofk/edalize/pull/269).