### PR TITLE
[otbn] Disable writing to CTRL.software_errs_fatal in CSR tests

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -213,6 +213,11 @@
             the IDLE state (see !!STATUS). Any writes to this field when OTBN
             isn't in the IDLE state are ignored.
           '''
+          tags: [
+            // Don't write this field in the automated CSR tests as it is
+            // currently unimplemented
+            "excl:CsrAllTests:CsrExclWrite",
+          ]
         }
       ],
     }


### PR DESCRIPTION
Writes don't work currently as the field is unimplemented.

Fixes #8525

Signed-off-by: Greg Chadwick <gac@lowrisc.org>