### PR TITLE
[edn/csrng/hjson] recov_alert_sts description cleanup

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -294,7 +294,7 @@
           desc: '''
                 This bit is set when the ENABLE field in the !!CTRL register is set to
                 a value other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
         { bits: "1",
@@ -302,7 +302,7 @@
           desc: '''
                 This bit is set when the SW_APP_ENABLE field in the !!CTRL register is set to
                 a value other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
         { bits: "2",
@@ -310,7 +310,7 @@
           desc: '''
                 This bit is set when the READ_INT_STATE field in the !!CTRL register is set to
                 a value other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
       ]

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -264,7 +264,7 @@
           desc: '''
                 This bit is set when the EDN_ENABLE field is set to an illegal value,
                 something other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
         { bits: "1",
@@ -272,7 +272,7 @@
           desc: '''
                 This bit is set when the BOOT_REQ_MODE field is set to an illegal value,
                 something other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
         { bits: "2",
@@ -280,7 +280,7 @@
           desc: '''
                 This bit is set when the AUTO_REQ_MODE field is set to an illegal value,
                 something other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
         { bits: "3",
@@ -288,7 +288,7 @@
           desc: '''
                 This bit is set when the CMD_FIFO_RST field is set to an illegal value,
                 something other than 0x5 or 0xA.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
         { bits: "12",
@@ -296,7 +296,7 @@
           desc: '''
                 This bit is set when the interal entropy bus value is equal to the prior
                 valid value on the bus, indicating a possible attack.
-                Writing a zero to this register resets the status bits.
+                Writing a zero resets this status bit.
                 '''
         }
       ]


### PR DESCRIPTION
Changes made to be consistent in the language used for the alert status register.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>