### PR TITLE
[hw/aon_timer] Make IRQ names match throughout all HJSON.

### DIFF
--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -199,7 +199,7 @@
           desc: "Raised if the wakeup timer has hit the specified threshold",
         }
         { bits: "1",
-          name: "wdog_timer_expired",
+          name: "wdog_timer_bark",
           desc: "Raised if the watchdog timer has hit the bark threshold",
         }
       ]
@@ -218,8 +218,8 @@
           desc: "Write 1 to force wkup_timer_expired interrupt",
         }
         { bits: "1",
-          name: "wdog_timer_expired",
-          desc: "Write 1 to force wdog_timer_expired (watchdog bark) interrupt",
+          name: "wdog_timer_bark",
+          desc: "Write 1 to force wdog_timer_bark interrupt",
         }
       ]
     },

--- a/hw/ip/aon_timer/doc/dv/domains.svg
+++ b/hw/ip/aon_timer/doc/dv/domains.svg
@@ -559,7 +559,7 @@
          x="-25.656269"
          y="139.95572"
          style="text-align:end;text-anchor:end;stroke:none;stroke-width:0.264583px"
-         id="tspan2985">intr_wdog_timer_expired_o</tspan></text>
+         id="tspan2985">intr_wdog_timer_bark_o</tspan></text>
     <path
        style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.529167;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker3325);stop-color:#000000;stop-opacity:1"
        d="m 150.8125,142.875 1e-5,44.97921 -29.10418,-5e-5"

--- a/hw/ip/aon_timer/rtl/aon_timer.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer.sv
@@ -193,17 +193,17 @@ module aon_timer import aon_timer_reg_pkg::*;
 
   // Registers to interrupt
   assign intr_test_qe           = reg2hw.intr_test.wkup_timer_expired.qe |
-                                  reg2hw.intr_test.wdog_timer_expired.qe;
+                                  reg2hw.intr_test.wdog_timer_bark.qe;
   assign intr_test_q [AON_WKUP] = reg2hw.intr_test.wkup_timer_expired.q;
   assign intr_state_q[AON_WKUP] = reg2hw.intr_state.wkup_timer_expired.q;
-  assign intr_test_q [AON_WDOG] = reg2hw.intr_test.wdog_timer_expired.q;
-  assign intr_state_q[AON_WDOG] = reg2hw.intr_state.wdog_timer_expired.q;
+  assign intr_test_q [AON_WDOG] = reg2hw.intr_test.wdog_timer_bark.q;
+  assign intr_state_q[AON_WDOG] = reg2hw.intr_state.wdog_timer_bark.q;
 
   // Interrupts to registers
   assign hw2reg.intr_state.wkup_timer_expired.d  = intr_state_d[AON_WKUP];
   assign hw2reg.intr_state.wkup_timer_expired.de = intr_state_de;
-  assign hw2reg.intr_state.wdog_timer_expired.d  = intr_state_d[AON_WDOG];
-  assign hw2reg.intr_state.wdog_timer_expired.de = intr_state_de;
+  assign hw2reg.intr_state.wdog_timer_bark.d  = intr_state_d[AON_WDOG];
+  assign hw2reg.intr_state.wdog_timer_bark.de = intr_state_de;
 
   prim_intr_hw #(
     .Width (2)

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv
@@ -65,7 +65,7 @@ package aon_timer_reg_pkg;
     } wkup_timer_expired;
     struct packed {
       logic        q;
-    } wdog_timer_expired;
+    } wdog_timer_bark;
   } aon_timer_reg2hw_intr_state_reg_t;
 
   typedef struct packed {
@@ -76,7 +76,7 @@ package aon_timer_reg_pkg;
     struct packed {
       logic        q;
       logic        qe;
-    } wdog_timer_expired;
+    } wdog_timer_bark;
   } aon_timer_reg2hw_intr_test_reg_t;
 
   typedef struct packed {
@@ -101,7 +101,7 @@ package aon_timer_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } wdog_timer_expired;
+    } wdog_timer_bark;
   } aon_timer_hw2reg_intr_state_reg_t;
 
   typedef struct packed {

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -151,11 +151,11 @@ module aon_timer_reg_top (
   logic intr_state_we;
   logic intr_state_wkup_timer_expired_qs;
   logic intr_state_wkup_timer_expired_wd;
-  logic intr_state_wdog_timer_expired_qs;
-  logic intr_state_wdog_timer_expired_wd;
+  logic intr_state_wdog_timer_bark_qs;
+  logic intr_state_wdog_timer_bark_wd;
   logic intr_test_we;
   logic intr_test_wkup_timer_expired_wd;
-  logic intr_test_wdog_timer_expired_wd;
+  logic intr_test_wdog_timer_bark_wd;
   logic wkup_cause_we;
   logic [0:0] wkup_cause_qs;
   logic wkup_cause_busy;
@@ -751,29 +751,29 @@ module aon_timer_reg_top (
     .qs     (intr_state_wkup_timer_expired_qs)
   );
 
-  //   F[wdog_timer_expired]: 1:1
+  //   F[wdog_timer_bark]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW1C),
     .RESVAL  (1'h0)
-  ) u_intr_state_wdog_timer_expired (
+  ) u_intr_state_wdog_timer_bark (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (intr_state_we),
-    .wd     (intr_state_wdog_timer_expired_wd),
+    .wd     (intr_state_wdog_timer_bark_wd),
 
     // from internal hardware
-    .de     (hw2reg.intr_state.wdog_timer_expired.de),
-    .d      (hw2reg.intr_state.wdog_timer_expired.d),
+    .de     (hw2reg.intr_state.wdog_timer_bark.de),
+    .d      (hw2reg.intr_state.wdog_timer_bark.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.intr_state.wdog_timer_expired.q),
+    .q      (reg2hw.intr_state.wdog_timer_bark.q),
 
     // to register interface (read)
-    .qs     (intr_state_wdog_timer_expired_qs)
+    .qs     (intr_state_wdog_timer_bark_qs)
   );
 
 
@@ -792,17 +792,17 @@ module aon_timer_reg_top (
     .qs     ()
   );
 
-  //   F[wdog_timer_expired]: 1:1
+  //   F[wdog_timer_bark]: 1:1
   prim_subreg_ext #(
     .DW    (1)
-  ) u_intr_test_wdog_timer_expired (
+  ) u_intr_test_wdog_timer_bark (
     .re     (1'b0),
     .we     (intr_test_we),
-    .wd     (intr_test_wdog_timer_expired_wd),
+    .wd     (intr_test_wdog_timer_bark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.wdog_timer_expired.qe),
-    .q      (reg2hw.intr_test.wdog_timer_expired.q),
+    .qe     (reg2hw.intr_test.wdog_timer_bark.qe),
+    .q      (reg2hw.intr_test.wdog_timer_bark.q),
     .qs     ()
   );
 
@@ -895,12 +895,12 @@ module aon_timer_reg_top (
 
   assign intr_state_wkup_timer_expired_wd = reg_wdata[0];
 
-  assign intr_state_wdog_timer_expired_wd = reg_wdata[1];
+  assign intr_state_wdog_timer_bark_wd = reg_wdata[1];
   assign intr_test_we = addr_hit[10] & reg_we & !reg_error;
 
   assign intr_test_wkup_timer_expired_wd = reg_wdata[0];
 
-  assign intr_test_wdog_timer_expired_wd = reg_wdata[1];
+  assign intr_test_wdog_timer_bark_wd = reg_wdata[1];
   assign wkup_cause_we = addr_hit[11] & reg_we & !reg_error;
 
 
@@ -939,7 +939,7 @@ module aon_timer_reg_top (
       end
       addr_hit[9]: begin
         reg_rdata_next[0] = intr_state_wkup_timer_expired_qs;
-        reg_rdata_next[1] = intr_state_wdog_timer_expired_qs;
+        reg_rdata_next[1] = intr_state_wdog_timer_bark_qs;
       end
 
       addr_hit[10]: begin

--- a/sw/device/lib/dif/dif_aon_timer.c
+++ b/sw/device/lib/dif/dif_aon_timer.c
@@ -15,15 +15,15 @@
 static_assert(AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT ==
                   AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT,
               "Wake-up IRQ have different indexes in different registers!");
-static_assert(AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT ==
-                  AON_TIMER_INTR_TEST_WDOG_TIMER_EXPIRED_BIT,
+static_assert(AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT ==
+                  AON_TIMER_INTR_TEST_WDOG_TIMER_BARK_BIT,
               "Watchdog IRQ have different indexes in different registers!");
 
 const size_t kAonTimerWakeupIrqIndex =
     AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT;
 
 const size_t kAonTimerWatchdogIrqIndex =
-    AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT;
+    AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT;
 
 static void aon_timer_wakeup_clear_counter(const dif_aon_timer_t *aon) {
   mmio_region_write32(aon->params.base_addr, AON_TIMER_WKUP_COUNT_REG_OFFSET,

--- a/sw/device/lib/dif/dif_aon_timer_unittest.cc
+++ b/sw/device/lib/dif/dif_aon_timer_unittest.cc
@@ -403,8 +403,7 @@ TEST_F(IrqIsPendingTest, SuccessPending) {
             kDifAonTimerOk);
   EXPECT_EQ(is_pending, true);
 
-  reg = bitfield_bit32_write(0, AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT,
-                             true);
+  reg = bitfield_bit32_write(0, AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT, true);
   EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET, reg);
 
   is_pending = false;
@@ -438,8 +437,7 @@ TEST_F(IrqAcknowledgeTest, Success) {
       dif_aon_timer_irq_acknowledge(&aon_, kDifAonTimerIrqWakeupThreshold),
       kDifAonTimerOk);
 
-  reg = bitfield_bit32_write(0, AON_TIMER_INTR_STATE_WDOG_TIMER_EXPIRED_BIT,
-                             true);
+  reg = bitfield_bit32_write(0, AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT, true);
   EXPECT_WRITE32(AON_TIMER_INTR_STATE_REG_OFFSET, reg);
 
   EXPECT_EQ(dif_aon_timer_irq_acknowledge(&aon_,
@@ -469,8 +467,7 @@ TEST_F(IrqForceTest, Success) {
   EXPECT_EQ(dif_aon_timer_irq_force(&aon_, kDifAonTimerIrqWakeupThreshold),
             kDifAonTimerOk);
 
-  reg =
-      bitfield_bit32_write(0, AON_TIMER_INTR_TEST_WDOG_TIMER_EXPIRED_BIT, true);
+  reg = bitfield_bit32_write(0, AON_TIMER_INTR_TEST_WDOG_TIMER_BARK_BIT, true);
   EXPECT_WRITE32(AON_TIMER_INTR_TEST_REG_OFFSET, reg);
 
   EXPECT_EQ(


### PR DESCRIPTION
This fixes #8533.

Every IP that can raise IRQs has an `interrupt_list` field in its HJSON
file that lists the names (in snake case) and brief descriptions (in a
full sentence/phrase) of each interrupt it produces.

Additionally, for IPs that raise IRQs, their HJSON usually defines the
following three registers: INTR_STATE, INTR_ENABLE, and INTR_TEST.
Typically, the bit fields within each of those three registers map 1:1
with the interrupts listed above in the `interrupt_list` field, and
**_therefore their names match_**.

However, in the aon_timer, the `wdog_timer_bark` interrupt was also
referred to as `wdog_timer_expired`. This fixes this naming
irregularity.

Signed-off-by: Timothy Trippel <ttrippel@google.com>