### PR TITLE
[sw/clkmgr_testutils] Add clkmgr testutils

### DIFF
--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+
+#include "sw/device/lib/dif/dif_clkmgr.h"
+
+extern bool clkmgr_testutils_get_trans_clock_status(
+    dif_clkmgr_t *clkmgr, dif_clkmgr_params_t params,
+    dif_clkmgr_hintable_clock_t clock);
+
+extern void clkmgr_testutils_check_trans_clock_gating(
+    dif_clkmgr_t *clkmgr, dif_clkmgr_params_t params,
+    dif_clkmgr_hintable_clock_t clock, bool exp_clock_enabled,
+    uint32_t timeout_usec);

--- a/sw/device/lib/testing/clkmgr_testutils.h
+++ b/sw/device/lib/testing/clkmgr_testutils.h
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_CLKMGR_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_CLKMGR_TESTUTILS_H_
+
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/testing/check.h"
+
+/**
+ * Returns the transactional block's clock status.
+ *
+ * @param clkmgr A clkmgr DIF handle.
+ * @param params clkmgr hardware instance parameters.
+ * @param clock The transactional clock ID.
+ * @return The transactional block's clock status.
+ */
+inline bool clkmgr_testutils_get_trans_clock_status(
+    dif_clkmgr_t *clkmgr, dif_clkmgr_params_t params,
+    dif_clkmgr_hintable_clock_t clock) {
+  bool clock_enabled;
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_get_enabled(clkmgr, params, clock,
+                                                     &clock_enabled));
+  return clock_enabled;
+}
+
+/**
+ * Verifies clock gating for transactional clocks.
+ *
+ * For a transactional block, the clock is gated only if the software enables
+ * the clock gating AND the block is idle. This function sets the clock gating
+ * hint bit to 0 and spinwaits until the clock value matches the expected. It
+ * sets the hint back to 1 afterwards. Inlined due to latency-sensitivity.
+ *
+ * @param clkmgr A clkmgr DIF handle.
+ * @param params clkmgr hardware instance parameters.
+ * @param clock The transactional clock ID.
+ * @param exp_clock_enabled Expected clock status.
+ * @param timeout_usec Timeout in microseconds.
+ */
+inline void clkmgr_testutils_check_trans_clock_gating(
+    dif_clkmgr_t *clkmgr, dif_clkmgr_params_t params,
+    dif_clkmgr_hintable_clock_t clock, bool exp_clock_enabled,
+    uint32_t timeout_usec) {
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(clkmgr, params, clock, 0x0));
+
+  IBEX_SPIN_FOR(clkmgr_testutils_get_trans_clock_status(
+                    clkmgr, params, clock) == exp_clock_enabled,
+                timeout_usec);
+
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(clkmgr, params, clock, 0x1));
+}
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CLKMGR_TESTUTILS_H_

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -25,6 +25,20 @@ sw_lib_testing_aon_timer_testutils = declare_dependency(
   ),
 )
 
+sw_lib_testing_clkmgr_testutils = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_clkmgr_testutils',
+    sources: [
+      hw_ip_clkmgr_reg_h,
+      'clkmgr_testutils.c'
+    ],
+    dependencies: [
+      sw_lib_dif_clkmgr,
+      sw_lib_runtime_ibex,
+    ],
+  ),
+)
+
 # hardware entropy complex (entropy_src, csrng, edn) test utilities.
 sw_lib_testing_entropy_testutils = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
Added these to make `aes_idle.c` test in PR #8451 a bit more
streamlined. These utils will be needed in other idle tests.

EDIT: Ignore the first commit - it will get rebased. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>