### PR TITLE
Aes testutils

### DIFF
--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/aes_testutils.h"
+
+extern bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag);
+
+extern void aes_testutils_wait_for_status(dif_aes_t *aes, dif_aes_status_t flag,
+                                          bool value, uint32_t timeout_usec);

--- a/sw/device/lib/testing/aes_testutils.h
+++ b/sw/device/lib/testing/aes_testutils.h
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_AES_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_AES_TESTUTILS_H_
+
+#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/testing/check.h"
+
+/**
+ * Returns the value of the AES status flag.
+ *
+ * @param aes An aes DIF handle.
+ * @param flag Status flag to query.
+ */
+inline bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag) {
+  bool status;
+  CHECK_DIF_OK(dif_aes_get_status(aes, flag, &status));
+  return status;
+}
+
+/**
+ * Waits for the given AES status flag to be set the the given value.
+ *
+ * @param aes An aes DIF handle.
+ * @param flag Status flag to query.
+ * @param value The status flag value.
+ * @param timeout_usec Timeout in microseconds.
+ */
+inline void aes_testutils_wait_for_status(dif_aes_t *aes, dif_aes_status_t flag,
+                                          bool value, uint32_t timeout_usec) {
+  IBEX_SPIN_FOR(aes_testutils_get_status(aes, flag) == value, timeout_usec);
+}
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_AES_TESTUTILS_H_

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -10,6 +10,19 @@ sw_lib_testing_rand_testutils = declare_dependency(
   ),
 )
 
+sw_lib_testing_aes_testutils = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_aes_testutils',
+    sources: [
+      'aes_testutils.c'
+    ],
+    dependencies: [
+      sw_lib_dif_aes,
+      sw_lib_runtime_ibex,
+    ],
+  ),
+)
+
 # aon_timer test utilities.
 sw_lib_testing_aon_timer_testutils = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
Added these to make aes_idle.c test in PR #8451 a bit more
streamlined.

Ignore the first commit. 