### PR TITLE
[util] Add tooling support for V2S milestone

### DIFF
--- a/hw/dv/tools/dvsim/testplans/sec_cm_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/sec_cm_testplan.hjson
@@ -17,7 +17,7 @@
             - Check that fatal alert is triggered.
             - Check that err_code/fault_status is updated correctly and preserved until reset.
             - Check the following operation should be failed if applicable.'''
-      milestone: V2
+      milestone: V2S
       tests: ["{name}_sec_cm"]
     }
     {
@@ -30,7 +30,7 @@
                won't go away until reset.
 
             Same checks as `one_hot_check`'''
-      milestone: V2
+      milestone: V2S
       tests: ["{name}_sec_cm"]
     }
     {
@@ -44,7 +44,7 @@
               won't go away until reset.
 
             Same checks as `one_hot_check`'''
-      milestone: V2
+      milestone: V2S
       tests: ["{name}_sec_cm"]
     }
   ]

--- a/hw/ip/keymgr/data/keymgr_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_testplan.hjson
@@ -181,7 +181,7 @@
     {
       name: sec_cm_check
       desc: '''
-            Verify the outcome after injecting faults to security countermeasures.
+            Verify the outcome after injecting faults into security countermeasures.
 
             Stimulus:
             As mentioned in `sec_cm_testplan`.
@@ -190,7 +190,7 @@
             - Besides checking alert and `fault_status`, issue an operation after injecting faults,
               then ensure that `op_status` is failed and design enters `StInvalid`.
             '''
-      milestone: V2
+      milestone: V2S
       tests: ["keymgr_sec_cm"]
     }
     {

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -37,6 +37,7 @@ STAGE_STRINGS = {
     'V0': 'Initial Work',
     'V1': 'Under Test',
     'V2': 'Testing Complete',
+    'V2S': 'Testing Complete, With Security Countermeasures Verified',
     'V3': 'Verification Complete',
     # DIF Stages (S for Software)
     'S0': 'Initial Work',

--- a/util/dvsim/Testplan.py
+++ b/util/dvsim/Testplan.py
@@ -99,7 +99,7 @@ class Testpoint(Element):
     fields = Element.fields + ("milestone", "tests")
 
     # Verification milestones.
-    milestones = ("N.A.", "V1", "V2", "V3")
+    milestones = ("N.A.", "V1", "V2", "V2S", "V3")
 
     def __init__(self, raw_dict):
         super().__init__(raw_dict)

--- a/util/dvsim/doc/testplanner.md
+++ b/util/dvsim/doc/testplanner.md
@@ -30,7 +30,7 @@ The following attributes are used to define each testpoint, at minimum:
 
 * **milestone: targeted verification milestone**
 
-    This is either `V1`, `V2` or `V3`.
+    This is either `V1`, `V2`, `V2S` or `V3`.
     It helps us track whether all of the testing requirements of a milestone have been achieved.
 
 * **desc: testpoint description**


### PR DESCRIPTION
Enhance dvsim testplan, dashboard gen tools to support V2S as an
intermediate milestone.
The documentation of what V2S entails will come in subsequent PRs.

The security countermeasure testpoints are updated to track V2S milestone. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>