### PR TITLE
[flash_ctrl/dv] Make bank erase to be selectable by default

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -142,7 +142,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
     op_readonly_on_info_partition = 0;
     op_readonly_on_info1_partition = 0;
 
-    op_erase_type_bank_pc = 0;
+    op_erase_type_bank_pc = 20;
     op_max_words = 512;
     op_allow_invalid = 1'b0;
 


### PR DESCRIPTION
Hi,
This PR is changing the default chances to randomly select bank erase (and not page erase) to be non zero (20%).
Since bank erase is one of the basic operation featured by the flash this seems more correctly.
Seems likely that in most of the tests it would best to randomly do bank erases as well as page erases only with smaller probability.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>