### PR TITLE
[dvsim] Correctly set self_dir for included Hjson files

### DIFF
--- a/util/dvsim/CfgFactory.py
+++ b/util/dvsim/CfgFactory.py
@@ -23,6 +23,11 @@ def _load_cfg(path, initial_values):
     failure.
 
     '''
+    # Set the `self_dir` template variable to the path of the currently
+    # processed Hjson file.
+    assert 'self_dir' in initial_values
+    initial_values['self_dir'] = os.path.dirname(path)
+
     # Start by loading up the hjson file and any included files
     hjson_data = load_hjson(path, initial_values)
 


### PR DESCRIPTION
The `self_dir` variable (used as `{self_dir}`) in dvsim-processed Hjson
files is intended to contain the absolute path to the Hjson file it
appears in. This was the case for top-level Hjson files (i.e. a Hjson
config file which was directly passed to dvsim.py), but not for included
files. Fix that.