### PR TITLE
Update edalize requirement to 0.2.4

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -44,7 +44,7 @@ types-tabulate
 git+https://github.com/lowRISC/fusesoc.git@ot#egg=fusesoc >= 1.12.0
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.3
+git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.4
 
 # Development version of ChipWhisperer toolchain
 # Use a development version until support for the CW310 board works in a


### PR DESCRIPTION
Edalize 0.2.3 has a bug which prevents more than one script to run,
which is fixed in later versions.

~(The switch to the ot-dev branch will go away before merging, only the version number update will stay.)~