### PR TITLE
[rtl,chip] Make AST suppy inputs controllable

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -828,6 +828,12 @@ module chip_earlgrey_asic (
   logic ast_init_done;
 
 
+  logic vcc_supply     = 1'b1;
+  logic vcaon_supply   = 1'b1;
+  logic vcmain_asupply = 1'b1;
+  logic vioa_supply    = 1'b1;
+  logic viob_supply    = 1'b1;
+
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
     .AdcChannels(ast_pkg::AdcChannels),
@@ -876,11 +882,11 @@ module chip_earlgrey_asic (
     .clk_ast_ext_i         ( ext_clk ),
 
     // pok test for FPGA
-    .vcc_supp_i            ( 1'b1 ),
-    .vcaon_supp_i          ( 1'b1 ),
-    .vcmain_supp_i         ( 1'b1 ),
-    .vioa_supp_i           ( 1'b1 ),
-    .viob_supp_i           ( 1'b1 ),
+    .vcc_supp_i            ( vcc_supply     ),
+    .vcaon_supp_i          ( vcaon_supply   ),
+    .vcmain_supp_i         ( vcmain_asupply ),
+    .vioa_supp_i           ( vioa_supply    ),
+    .viob_supp_i           ( viob_supply    ),
     // pok
     .ast_pwst_o            ( ast_pwst ),
     .ast_pwst_h_o          ( ast_pwst_h ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -852,6 +852,12 @@ module chip_earlgrey_cw310 #(
   };
 
 
+  logic vcc_supply     = 1'b1;
+  logic vcaon_supply   = 1'b1;
+  logic vcmain_asupply = 1'b1;
+  logic vioa_supply    = 1'b1;
+  logic viob_supply    = 1'b1;
+
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
     .AdcChannels(ast_pkg::AdcChannels),
@@ -904,11 +910,11 @@ module chip_earlgrey_cw310 #(
     .clk_ast_ext_i         ( ext_clk ),
 
     // pok test for FPGA
-    .vcc_supp_i            ( 1'b1 ),
-    .vcaon_supp_i          ( 1'b1 ),
-    .vcmain_supp_i         ( 1'b1 ),
-    .vioa_supp_i           ( 1'b1 ),
-    .viob_supp_i           ( 1'b1 ),
+    .vcc_supp_i            ( vcc_supply     ),
+    .vcaon_supp_i          ( vcaon_supply   ),
+    .vcmain_supp_i         ( vcmain_asupply ),
+    .vioa_supp_i           ( vioa_supply    ),
+    .viob_supp_i           ( viob_supply    ),
     // pok
     .ast_pwst_o            ( ast_pwst ),
     .ast_pwst_h_o          ( ast_pwst_h ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -834,6 +834,12 @@ module chip_earlgrey_nexysvideo #(
   };
 
 
+  logic vcc_supply     = 1'b1;
+  logic vcaon_supply   = 1'b1;
+  logic vcmain_asupply = 1'b1;
+  logic vioa_supply    = 1'b1;
+  logic viob_supply    = 1'b1;
+
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
     .AdcChannels(ast_pkg::AdcChannels),
@@ -886,11 +892,11 @@ module chip_earlgrey_nexysvideo #(
     .clk_ast_ext_i         ( ext_clk ),
 
     // pok test for FPGA
-    .vcc_supp_i            ( 1'b1 ),
-    .vcaon_supp_i          ( 1'b1 ),
-    .vcmain_supp_i         ( 1'b1 ),
-    .vioa_supp_i           ( 1'b1 ),
-    .viob_supp_i           ( 1'b1 ),
+    .vcc_supp_i            ( vcc_supply     ),
+    .vcaon_supp_i          ( vcaon_supply   ),
+    .vcmain_supp_i         ( vcmain_asupply ),
+    .vioa_supp_i           ( vioa_supply    ),
+    .viob_supp_i           ( viob_supply    ),
     // pok
     .ast_pwst_o            ( ast_pwst ),
     .ast_pwst_h_o          ( ast_pwst_h ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -708,6 +708,12 @@ module chip_${top["name"]}_${target["name"]} (
 
 % endif
 
+  logic vcc_supply     = 1'b1;
+  logic vcaon_supply   = 1'b1;
+  logic vcmain_asupply = 1'b1;
+  logic vioa_supply    = 1'b1;
+  logic viob_supply    = 1'b1;
+
   ast #(
     .EntropyStreams(ast_pkg::EntropyStreams),
     .AdcChannels(ast_pkg::AdcChannels),
@@ -772,11 +778,11 @@ module chip_${top["name"]}_${target["name"]} (
     .clk_ast_ext_i         ( ext_clk ),
 
     // pok test for FPGA
-    .vcc_supp_i            ( 1'b1 ),
-    .vcaon_supp_i          ( 1'b1 ),
-    .vcmain_supp_i         ( 1'b1 ),
-    .vioa_supp_i           ( 1'b1 ),
-    .viob_supp_i           ( 1'b1 ),
+    .vcc_supp_i            ( vcc_supply     ),
+    .vcaon_supp_i          ( vcaon_supply   ),
+    .vcmain_supp_i         ( vcmain_asupply ),
+    .vioa_supp_i           ( vioa_supply    ),
+    .viob_supp_i           ( viob_supply    ),
     // pok
     .ast_pwst_o            ( ast_pwst ),
     .ast_pwst_h_o          ( ast_pwst_h ),


### PR DESCRIPTION
The supply inputs to AST are tie-offs. In this commit, those now come
from variables instead, which are set to 1 by default. This makes it
easy in DV to drive those signals from the testbench to have a finer
control.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>