### PR TITLE
[dif/kmac] Autogen IRQ DIFs and integrate into test code. 

### DIFF
--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -1,0 +1,178 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_kmac.h"
+
+#include "kmac_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool kmac_get_irq_bit_index(dif_kmac_irq_t irq,
+                                   bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifKmacIrqKmacDone:
+      *index_out = KMAC_INTR_STATE_KMAC_DONE_BIT;
+      break;
+    case kDifKmacIrqFifoEmpty:
+      *index_out = KMAC_INTR_STATE_FIFO_EMPTY_BIT;
+      break;
+    case kDifKmacIrqKmacErr:
+      *index_out = KMAC_INTR_STATE_KMAC_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_get_state(const dif_kmac_t *kmac,
+                                    dif_kmac_irq_state_snapshot_t *snapshot) {
+  if (kmac == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(kmac->base_addr, KMAC_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_is_pending(const dif_kmac_t *kmac, dif_kmac_irq_t irq,
+                                     bool *is_pending) {
+  if (kmac == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!kmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(kmac->base_addr, KMAC_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_acknowledge(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_t irq) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!kmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(kmac->base_addr, KMAC_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_get_enabled(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_t irq, dif_toggle_t *state) {
+  if (kmac == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!kmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(kmac->base_addr, KMAC_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_set_enabled(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_t irq, dif_toggle_t state) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!kmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(kmac->base_addr, KMAC_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(kmac->base_addr, KMAC_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_force(const dif_kmac_t *kmac, dif_kmac_irq_t irq) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!kmac_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(kmac->base_addr, KMAC_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_disable_all(
+    const dif_kmac_t *kmac, dif_kmac_irq_enable_snapshot_t *snapshot) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(kmac->base_addr, KMAC_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(kmac->base_addr, KMAC_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_restore_all(
+    const dif_kmac_t *kmac, const dif_kmac_irq_enable_snapshot_t *snapshot) {
+  if (kmac == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(kmac->base_addr, KMAC_INTR_ENABLE_REG_OFFSET, *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.h
@@ -1,0 +1,170 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_KMAC_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_KMAC_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/kmac/doc/">KMAC</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to kmac.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_kmac {
+  /**
+   * The base address for the kmac hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_kmac_t;
+
+/**
+ * A kmac interrupt request type.
+ */
+typedef enum dif_kmac_irq {
+  /**
+   * KMAC/SHA3 absorbing has been completed
+   */
+  kDifKmacIrqKmacDone = 0,
+  /**
+   * Message FIFO empty condition
+   */
+  kDifKmacIrqFifoEmpty = 1,
+  /**
+   * KMAC/SHA3 error occurred. ERR_CODE register shows the details
+   */
+  kDifKmacIrqKmacErr = 2,
+} dif_kmac_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_kmac_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_kmac_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_kmac_irq_disable_all()` and `dif_kmac_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_kmac_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param kmac A kmac handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_get_state(const dif_kmac_t *kmac,
+                                    dif_kmac_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param kmac A kmac handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_is_pending(const dif_kmac_t *kmac, dif_kmac_irq_t irq,
+                                     bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param kmac A kmac handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_acknowledge(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param kmac A kmac handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_get_enabled(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_t irq, dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param kmac A kmac handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_set_enabled(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_t irq, dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param kmac A kmac handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_force(const dif_kmac_t *kmac, dif_kmac_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param kmac A kmac handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_disable_all(const dif_kmac_t *kmac,
+                                      dif_kmac_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param kmac A kmac handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_irq_restore_all(
+    const dif_kmac_t *kmac, const dif_kmac_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_KMAC_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -1,0 +1,287 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_kmac.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "kmac_regs.h"  // Generated.
+
+namespace dif_kmac_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class KmacTest : public Test, public MmioTest {
+ protected:
+  dif_kmac_t kmac_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public KmacTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_kmac_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_kmac_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_get_state(&kmac_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_kmac_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_kmac_irq_get_state(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_kmac_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_kmac_irq_get_state(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public KmacTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_kmac_irq_is_pending(nullptr, kDifKmacIrqKmacDone, &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_is_pending(nullptr, kDifKmacIrqKmacDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, static_cast<dif_kmac_irq_t>(32),
+                                    &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
+                {{KMAC_INTR_STATE_KMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacDone, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
+                {{KMAC_INTR_STATE_KMAC_ERR_BIT, false}});
+  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacErr, &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public KmacTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_kmac_irq_acknowledge(nullptr, kDifKmacIrqKmacDone), kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_kmac_irq_acknowledge(nullptr, static_cast<dif_kmac_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(KMAC_INTR_STATE_REG_OFFSET,
+                 {{KMAC_INTR_STATE_KMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_kmac_irq_acknowledge(&kmac_, kDifKmacIrqKmacDone), kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(KMAC_INTR_STATE_REG_OFFSET,
+                 {{KMAC_INTR_STATE_KMAC_ERR_BIT, true}});
+  EXPECT_EQ(dif_kmac_irq_acknowledge(&kmac_, kDifKmacIrqKmacErr), kDifOk);
+}
+
+class IrqGetEnabledTest : public KmacTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_kmac_irq_get_enabled(nullptr, kDifKmacIrqKmacDone, &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacDone, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_get_enabled(nullptr, kDifKmacIrqKmacDone, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, static_cast<dif_kmac_irq_t>(32),
+                                     &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET,
+                {{KMAC_INTR_ENABLE_KMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacDone, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET,
+                {{KMAC_INTR_ENABLE_KMAC_ERR_BIT, false}});
+  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacErr, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public KmacTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_kmac_irq_set_enabled(nullptr, kDifKmacIrqKmacDone, irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_kmac_irq_set_enabled(&kmac_, static_cast<dif_kmac_irq_t>(32),
+                                     irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(KMAC_INTR_ENABLE_REG_OFFSET,
+                {{KMAC_INTR_ENABLE_KMAC_DONE_BIT, 0x1, true}});
+  EXPECT_EQ(dif_kmac_irq_set_enabled(&kmac_, kDifKmacIrqKmacDone, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(KMAC_INTR_ENABLE_REG_OFFSET,
+                {{KMAC_INTR_ENABLE_KMAC_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(dif_kmac_irq_set_enabled(&kmac_, kDifKmacIrqKmacErr, irq_state),
+            kDifOk);
+}
+
+class IrqForceTest : public KmacTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_kmac_irq_force(nullptr, kDifKmacIrqKmacDone), kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_kmac_irq_force(nullptr, static_cast<dif_kmac_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(KMAC_INTR_TEST_REG_OFFSET,
+                 {{KMAC_INTR_TEST_KMAC_DONE_BIT, true}});
+  EXPECT_EQ(dif_kmac_irq_force(&kmac_, kDifKmacIrqKmacDone), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(KMAC_INTR_TEST_REG_OFFSET,
+                 {{KMAC_INTR_TEST_KMAC_ERR_BIT, true}});
+  EXPECT_EQ(dif_kmac_irq_force(&kmac_, kDifKmacIrqKmacErr), kDifOk);
+}
+
+class IrqDisableAllTest : public KmacTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_kmac_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_kmac_irq_disable_all(&kmac_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_kmac_irq_disable_all(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_kmac_irq_disable_all(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public KmacTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_kmac_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_restore_all(&kmac_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_kmac_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_kmac_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_kmac_irq_restore_all(&kmac_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_kmac_irq_restore_all(&kmac_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_kmac_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,20 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Autogen Pin Multiplexer DIF library
-sw_lib_dif_autogen_pinmux = declare_dependency(
-  link_with: static_library(
-    'sw_lib_dif_autogen_pinmux',
-    sources: [
-      hw_top_earlgrey_pinmux_reg_h,
-      'dif_pinmux_autogen.c',
-    ],
-    dependencies: [
-      sw_lib_mmio,
-    ],
-  )
-)
-
 # Autogen AES DIF library
 sw_lib_dif_autogen_aes = declare_dependency(
   link_with: static_library(
@@ -156,6 +142,20 @@ sw_lib_dif_autogen_keymgr = declare_dependency(
   )
 )
 
+# Autogen KMAC DIF library
+sw_lib_dif_autogen_kmac = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_kmac',
+    sources: [
+      hw_ip_kmac_reg_h,
+      'dif_kmac_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen Lifecycle Controller DIF library
 sw_lib_dif_autogen_lc_ctrl = declare_dependency(
   link_with: static_library(
@@ -191,6 +191,20 @@ sw_lib_dif_autogen_otp_ctrl = declare_dependency(
     sources: [
       hw_ip_otp_ctrl_reg_h,
       'dif_otp_ctrl_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
+# Autogen Pin Multiplexer DIF library
+sw_lib_dif_autogen_pinmux = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_pinmux',
+    sources: [
+      hw_top_earlgrey_pinmux_reg_h,
+      'dif_pinmux_autogen.c',
     ],
     dependencies: [
       sw_lib_mmio,

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -16,23 +16,23 @@ using ::testing::ElementsAre;
 TEST(CustomizationStringTest, Encode) {
   dif_kmac_customization_string_t cs;
 
-  EXPECT_EQ(dif_kmac_customization_string_init(nullptr, 0, &cs), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_customization_string_init(nullptr, 0, &cs), kDifOk);
   EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 0));
 
-  EXPECT_EQ(dif_kmac_customization_string_init("", 0, &cs), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_customization_string_init("", 0, &cs), kDifOk);
   EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 0));
 
-  EXPECT_EQ(dif_kmac_customization_string_init("\x00\x00", 2, &cs), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_customization_string_init("\x00\x00", 2, &cs), kDifOk);
   EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 16));
   EXPECT_THAT(std::string(&cs.buffer[2], 2), ElementsAre(0, 0));
 
-  EXPECT_EQ(dif_kmac_customization_string_init("SHA-3", 5, &cs), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_customization_string_init("SHA-3", 5, &cs), kDifOk);
   EXPECT_THAT(std::string(&cs.buffer[0], 2), ElementsAre(1, 40));
   EXPECT_EQ(std::string(&cs.buffer[2], 5), "SHA-3");
 
   std::string max(kDifKmacMaxCustomizationStringLen, 0x12);
   EXPECT_EQ(dif_kmac_customization_string_init(max.data(), max.size(), &cs),
-            kDifKmacOk);
+            kDifOk);
   static_assert(kDifKmacMaxCustomizationStringLen == 32,
                 "encoding needs to be updated");
   EXPECT_THAT(std::string(&cs.buffer[0], 3), ElementsAre(2, 1, 0));
@@ -40,37 +40,35 @@ TEST(CustomizationStringTest, Encode) {
 }
 
 TEST(CustomizationStringTest, BadArg) {
-  EXPECT_EQ(dif_kmac_customization_string_init("", 0, nullptr), kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_customization_string_init("", 0, nullptr), kDifBadArg);
 
   dif_kmac_customization_string_t cs;
-  EXPECT_EQ(dif_kmac_customization_string_init(nullptr, 1, &cs),
-            kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_customization_string_init(nullptr, 1, &cs), kDifBadArg);
   EXPECT_EQ(dif_kmac_customization_string_init(
                 "", kDifKmacMaxCustomizationStringLen + 1, &cs),
-            kDifKmacBadArg);
-  EXPECT_EQ(dif_kmac_customization_string_init("", -1, &cs), kDifKmacBadArg);
+            kDifBadArg);
+  EXPECT_EQ(dif_kmac_customization_string_init("", -1, &cs), kDifBadArg);
 }
 
 TEST(FunctionNameTest, Encode) {
   dif_kmac_function_name_t fn;
 
-  EXPECT_EQ(dif_kmac_function_name_init(nullptr, 0, &fn), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_function_name_init(nullptr, 0, &fn), kDifOk);
   EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 0));
 
-  EXPECT_EQ(dif_kmac_function_name_init("", 0, &fn), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_function_name_init("", 0, &fn), kDifOk);
   EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 0));
 
-  EXPECT_EQ(dif_kmac_function_name_init("\x00\x00", 2, &fn), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_function_name_init("\x00\x00", 2, &fn), kDifOk);
   EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 16));
   EXPECT_THAT(std::string(&fn.buffer[2], 2), ElementsAre(0, 0));
 
-  EXPECT_EQ(dif_kmac_function_name_init("KMAC", 4, &fn), kDifKmacOk);
+  EXPECT_EQ(dif_kmac_function_name_init("KMAC", 4, &fn), kDifOk);
   EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 32));
   EXPECT_EQ(std::string(&fn.buffer[2], 4), "KMAC");
 
   std::string max(kDifKmacMaxFunctionNameLen, 0x34);
-  EXPECT_EQ(dif_kmac_function_name_init(max.data(), max.size(), &fn),
-            kDifKmacOk);
+  EXPECT_EQ(dif_kmac_function_name_init(max.data(), max.size(), &fn), kDifOk);
   static_assert(kDifKmacMaxFunctionNameLen == 4,
                 "encoding needs to be updated");
   EXPECT_THAT(std::string(&fn.buffer[0], 2), ElementsAre(1, 32));
@@ -78,14 +76,14 @@ TEST(FunctionNameTest, Encode) {
 }
 
 TEST(FunctionNameTest, BadArg) {
-  EXPECT_EQ(dif_kmac_function_name_init("", 0, nullptr), kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_function_name_init("", 0, nullptr), kDifBadArg);
 
   dif_kmac_function_name_t fn;
-  EXPECT_EQ(dif_kmac_function_name_init(nullptr, 1, &fn), kDifKmacBadArg);
+  EXPECT_EQ(dif_kmac_function_name_init(nullptr, 1, &fn), kDifBadArg);
   EXPECT_EQ(
       dif_kmac_function_name_init("", kDifKmacMaxFunctionNameLen + 1, &fn),
-      kDifKmacBadArg);
-  EXPECT_EQ(dif_kmac_function_name_init("", -1, &fn), kDifKmacBadArg);
+      kDifBadArg);
+  EXPECT_EQ(dif_kmac_function_name_init("", -1, &fn), kDifBadArg);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -370,6 +370,7 @@ sw_lib_dif_kmac = declare_dependency(
     dependencies: [
       sw_lib_bitfield,
       sw_lib_mmio,
+      sw_lib_dif_autogen_kmac,
     ],
   )
 )
@@ -378,7 +379,9 @@ test('dif_kmac_unittest', executable(
     'dif_kmac_unittest',
     sources: [
       'dif_kmac_unittest.cc',
+      'autogen/dif_kmac_autogen_unittest.cc',
       meson.source_root() / 'sw/device/lib/dif/dif_kmac.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_kmac_autogen.c',
       hw_ip_kmac_reg_h,
     ],
     dependencies: [

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -148,23 +148,23 @@ typedef void (*sca_callee)(void);
 void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles);
 
 /**
- * Prints an error message over UART if the given condition evaluates to false.
- * TODO: Remove once there is a CHECK version that does not require test
+ * Prints an error message over UART if the given DIF evaluates to anthing but
+ * kDifOk.
+ * TODO: Remove once there is a CHECK_DIF_OK version that does not require test
  * library dependencies.
  */
-#define CHECK(condition, ...)                             \
+#define CHECK_DIF_OK(dif_call, ...)                       \
   do {                                                    \
-    if (!(condition)) {                                   \
+    if (dif_call != kDifOk) {                             \
       /* NOTE: because the condition in this if           \
          statement can be statically determined,          \
          only one of the below string constants           \
          will be included in the final binary.*/          \
       if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("CHECK-fail: " #condition);             \
+        LOG_ERROR("DIF-fail: " #dif_call);                \
       } else {                                            \
-        LOG_ERROR("CHECK-fail: " __VA_ARGS__);            \
+        LOG_ERROR("DIF-fail: " __VA_ARGS__);              \
       }                                                   \
     }                                                     \
   } while (false)
-
 #endif  // OPENTITAN_SW_DEVICE_SCA_LIB_SCA_H_

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -206,15 +206,14 @@ static void lock_otp_secret_partition2(void) {
 /** Place kmac into sideload mode for correct keymgr operation */
 static void init_kmac_for_keymgr(void) {
   dif_kmac_t kmac;
-  CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
-                                              TOP_EARLGREY_KMAC_BASE_ADDR)},
-                      &kmac) == kDifKmacOk);
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .sideload = true,
   };
-  CHECK(dif_kmac_configure(&kmac, config) == kDifKmacOk);
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 }
 
 /** Soft reboot device */

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -93,6 +93,7 @@ bool test_main() {
 
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
+  dif_kmac_operation_state_t kmac_operation_state;
   CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
                                               TOP_EARLGREY_KMAC_BASE_ADDR)},
                       &kmac) == kDifKmacOk);
@@ -123,13 +124,15 @@ bool test_main() {
     dif_kmac_customization_string_t *sp =
         test.customization_string_len == 0 ? NULL : &s;
 
-    CHECK(dif_kmac_mode_cshake_start(&kmac, test.mode, np, sp) == kDifKmacOk);
-    CHECK(dif_kmac_absorb(&kmac, test.message, test.message_len, NULL) ==
-          kDifKmacOk);
+    CHECK(dif_kmac_mode_cshake_start(&kmac, &kmac_operation_state, test.mode,
+                                     np, sp) == kDifKmacOk);
+    CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                          test.message_len, NULL) == kDifKmacOk);
     uint32_t out[DIGEST_LEN_CSHAKE_MAX];
     CHECK(DIGEST_LEN_CSHAKE_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, out, test.digest_len, NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac) == kDifKmacOk);
+    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
+                           NULL) == kDifKmacOk);
+    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -195,17 +195,16 @@ bool test_main() {
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
   dif_kmac_operation_state_t kmac_operation_state;
-  CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
-                                              TOP_EARLGREY_KMAC_BASE_ADDR)},
-                      &kmac) == kDifKmacOk);
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
       .entropy_seed = 0xffff,
-      .entropy_fast_process = kDifKmacToggleEnabled,
+      .entropy_fast_process = kDifToggleEnabled,
   };
-  CHECK(dif_kmac_configure(&kmac, config) == kDifKmacOk);
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 
   // Run fixed length KMAC test cases using single blocking absorb/squeeze
   // operations.
@@ -213,24 +212,23 @@ bool test_main() {
     kmac_test_t test = kmac_tests[i];
 
     dif_kmac_customization_string_t s;
-    CHECK(dif_kmac_customization_string_init(test.customization_string,
-                                             test.customization_string_len,
-                                             &s) == kDifKmacOk);
+    CHECK_DIF_OK(dif_kmac_customization_string_init(
+        test.customization_string, test.customization_string_len, &s));
 
     // Use NULL for empty strings to exercise that code path.
     dif_kmac_customization_string_t *sp =
         test.customization_string_len == 0 ? NULL : &s;
 
     size_t l = test.digest_len_is_fixed ? test.digest_len : 0;
-    CHECK(dif_kmac_mode_kmac_start(&kmac, &kmac_operation_state, test.mode, l,
-                                   &test.key, sp) == kDifKmacOk);
-    CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
-                          test.message_len, NULL) == kDifKmacOk);
+    CHECK_DIF_OK(dif_kmac_mode_kmac_start(&kmac, &kmac_operation_state,
+                                          test.mode, l, &test.key, sp));
+    CHECK_DIF_OK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                                 test.message_len, NULL));
     uint32_t out[DIGEST_LEN_KMAC_MAX];
     CHECK(DIGEST_LEN_KMAC_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
-                           NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
+    CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
+                                  test.digest_len, NULL));
+    CHECK_DIF_OK(dif_kmac_end(&kmac, &kmac_operation_state));
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -194,6 +194,7 @@ bool test_main() {
 
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
+  dif_kmac_operation_state_t kmac_operation_state;
   CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
                                               TOP_EARLGREY_KMAC_BASE_ADDR)},
                       &kmac) == kDifKmacOk);
@@ -221,14 +222,15 @@ bool test_main() {
         test.customization_string_len == 0 ? NULL : &s;
 
     size_t l = test.digest_len_is_fixed ? test.digest_len : 0;
-    CHECK(dif_kmac_mode_kmac_start(&kmac, test.mode, l, &test.key, sp) ==
-          kDifKmacOk);
-    CHECK(dif_kmac_absorb(&kmac, test.message, test.message_len, NULL) ==
-          kDifKmacOk);
+    CHECK(dif_kmac_mode_kmac_start(&kmac, &kmac_operation_state, test.mode, l,
+                                   &test.key, sp) == kDifKmacOk);
+    CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                          test.message_len, NULL) == kDifKmacOk);
     uint32_t out[DIGEST_LEN_KMAC_MAX];
     CHECK(DIGEST_LEN_KMAC_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, out, test.digest_len, NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac) == kDifKmacOk);
+    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
+                           NULL) == kDifKmacOk);
+    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -160,6 +160,7 @@ bool test_main() {
 
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
+  dif_kmac_operation_state_t kmac_operation_state;
   CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
                                               TOP_EARLGREY_KMAC_BASE_ADDR)},
                       &kmac) == kDifKmacOk);
@@ -176,15 +177,17 @@ bool test_main() {
   for (int i = 0; i < ARRAYSIZE(sha3_tests); ++i) {
     sha3_test_t test = sha3_tests[i];
 
-    CHECK(dif_kmac_mode_sha3_start(&kmac, test.mode) == kDifKmacOk);
+    CHECK(dif_kmac_mode_sha3_start(&kmac, &kmac_operation_state, test.mode) ==
+          kDifKmacOk);
     if (test.message_len > 0) {
-      CHECK(dif_kmac_absorb(&kmac, test.message, test.message_len, NULL) ==
-            kDifKmacOk);
+      CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                            test.message_len, NULL) == kDifKmacOk);
     }
     uint32_t out[DIGEST_LEN_SHA3_MAX];
     CHECK(DIGEST_LEN_SHA3_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, out, test.digest_len, NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac) == kDifKmacOk);
+    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
+                           NULL) == kDifKmacOk);
+    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],
@@ -197,15 +200,17 @@ bool test_main() {
   for (int i = 0; i < ARRAYSIZE(shake_tests); ++i) {
     shake_test_t test = shake_tests[i];
 
-    CHECK(dif_kmac_mode_shake_start(&kmac, test.mode) == kDifKmacOk);
+    CHECK(dif_kmac_mode_shake_start(&kmac, &kmac_operation_state, test.mode) ==
+          kDifKmacOk);
     if (test.message_len > 0) {
-      CHECK(dif_kmac_absorb(&kmac, test.message, test.message_len, NULL) ==
-            kDifKmacOk);
+      CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                            test.message_len, NULL) == kDifKmacOk);
     }
     uint32_t out[DIGEST_LEN_SHAKE_MAX];
     CHECK(DIGEST_LEN_SHAKE_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, out, test.digest_len, NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac) == kDifKmacOk);
+    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
+                           NULL) == kDifKmacOk);
+    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -161,33 +161,32 @@ bool test_main() {
   // Intialize KMAC hardware.
   dif_kmac_t kmac;
   dif_kmac_operation_state_t kmac_operation_state;
-  CHECK(dif_kmac_init((dif_kmac_params_t){.base_addr = mmio_region_from_addr(
-                                              TOP_EARLGREY_KMAC_BASE_ADDR)},
-                      &kmac) == kDifKmacOk);
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
 
   // Configure KMAC hardware using software entropy.
   dif_kmac_config_t config = (dif_kmac_config_t){
       .entropy_mode = kDifKmacEntropyModeSoftware,
       .entropy_seed = 0xffff,
-      .entropy_fast_process = kDifKmacToggleEnabled,
+      .entropy_fast_process = kDifToggleEnabled,
   };
-  CHECK(dif_kmac_configure(&kmac, config) == kDifKmacOk);
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
 
   // Run SHA-3 test cases using single blocking absorb/squeeze operations.
   for (int i = 0; i < ARRAYSIZE(sha3_tests); ++i) {
     sha3_test_t test = sha3_tests[i];
 
-    CHECK(dif_kmac_mode_sha3_start(&kmac, &kmac_operation_state, test.mode) ==
-          kDifKmacOk);
+    CHECK_DIF_OK(
+        dif_kmac_mode_sha3_start(&kmac, &kmac_operation_state, test.mode));
     if (test.message_len > 0) {
-      CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
-                            test.message_len, NULL) == kDifKmacOk);
+      CHECK_DIF_OK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                                   test.message_len, NULL));
     }
     uint32_t out[DIGEST_LEN_SHA3_MAX];
     CHECK(DIGEST_LEN_SHA3_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
-                           NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
+    CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
+                                  test.digest_len, NULL));
+    CHECK_DIF_OK(dif_kmac_end(&kmac, &kmac_operation_state));
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],
@@ -200,17 +199,17 @@ bool test_main() {
   for (int i = 0; i < ARRAYSIZE(shake_tests); ++i) {
     shake_test_t test = shake_tests[i];
 
-    CHECK(dif_kmac_mode_shake_start(&kmac, &kmac_operation_state, test.mode) ==
-          kDifKmacOk);
+    CHECK_DIF_OK(
+        dif_kmac_mode_shake_start(&kmac, &kmac_operation_state, test.mode));
     if (test.message_len > 0) {
-      CHECK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
-                            test.message_len, NULL) == kDifKmacOk);
+      CHECK_DIF_OK(dif_kmac_absorb(&kmac, &kmac_operation_state, test.message,
+                                   test.message_len, NULL));
     }
     uint32_t out[DIGEST_LEN_SHAKE_MAX];
     CHECK(DIGEST_LEN_SHAKE_MAX >= test.digest_len);
-    CHECK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out, test.digest_len,
-                           NULL) == kDifKmacOk);
-    CHECK(dif_kmac_end(&kmac, &kmac_operation_state) == kDifKmacOk);
+    CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
+                                  test.digest_len, NULL));
+    CHECK_DIF_OK(dif_kmac_end(&kmac, &kmac_operation_state));
 
     for (int j = 0; j < test.digest_len; ++j) {
       CHECK(out[j] == test.digest[j],


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "kmac".

- The **first** commit  decouples KMAC operation state from the KMAC context/handle struct to enable the auto-generation of the  context/handle struct, and thus the IRQ DIFs too.
- The **second** commit checks-in the auto-generated KMAC IRQ DIFs and supporting typedefs/enums.
- The **third** commit integrates the auto-generated DIFs into the existing test code.