### PR TITLE
[dif/usbdev] Autogen IRQ DIFs and integrate into test code.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -1,0 +1,226 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_usbdev.h"
+
+#include "usbdev_regs.h"  // Generated.
+
+/**
+ * Get the corresponding interrupt register bit offset. INTR_STATE,
+ * INTR_ENABLE and INTR_TEST registers have the same bit offsets, so this
+ * routine can be reused.
+ */
+static bool usbdev_get_irq_bit_index(dif_usbdev_irq_t irq,
+                                     bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifUsbdevIrqPktReceived:
+      *index_out = USBDEV_INTR_STATE_PKT_RECEIVED_BIT;
+      break;
+    case kDifUsbdevIrqPktSent:
+      *index_out = USBDEV_INTR_STATE_PKT_SENT_BIT;
+      break;
+    case kDifUsbdevIrqDisconnected:
+      *index_out = USBDEV_INTR_STATE_DISCONNECTED_BIT;
+      break;
+    case kDifUsbdevIrqHostLost:
+      *index_out = USBDEV_INTR_STATE_HOST_LOST_BIT;
+      break;
+    case kDifUsbdevIrqLinkReset:
+      *index_out = USBDEV_INTR_STATE_LINK_RESET_BIT;
+      break;
+    case kDifUsbdevIrqLinkSuspend:
+      *index_out = USBDEV_INTR_STATE_LINK_SUSPEND_BIT;
+      break;
+    case kDifUsbdevIrqLinkResume:
+      *index_out = USBDEV_INTR_STATE_LINK_RESUME_BIT;
+      break;
+    case kDifUsbdevIrqAvEmpty:
+      *index_out = USBDEV_INTR_STATE_AV_EMPTY_BIT;
+      break;
+    case kDifUsbdevIrqRxFull:
+      *index_out = USBDEV_INTR_STATE_RX_FULL_BIT;
+      break;
+    case kDifUsbdevIrqAvOverflow:
+      *index_out = USBDEV_INTR_STATE_AV_OVERFLOW_BIT;
+      break;
+    case kDifUsbdevIrqLinkInErr:
+      *index_out = USBDEV_INTR_STATE_LINK_IN_ERR_BIT;
+      break;
+    case kDifUsbdevIrqRxCrcErr:
+      *index_out = USBDEV_INTR_STATE_RX_CRC_ERR_BIT;
+      break;
+    case kDifUsbdevIrqRxPidErr:
+      *index_out = USBDEV_INTR_STATE_RX_PID_ERR_BIT;
+      break;
+    case kDifUsbdevIrqRxBitstuffErr:
+      *index_out = USBDEV_INTR_STATE_RX_BITSTUFF_ERR_BIT;
+      break;
+    case kDifUsbdevIrqFrame:
+      *index_out = USBDEV_INTR_STATE_FRAME_BIT;
+      break;
+    case kDifUsbdevIrqConnected:
+      *index_out = USBDEV_INTR_STATE_CONNECTED_BIT;
+      break;
+    case kDifUsbdevIrqLinkOutErr:
+      *index_out = USBDEV_INTR_STATE_LINK_OUT_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_get_state(
+    const dif_usbdev_t *usbdev, dif_usbdev_irq_state_snapshot_t *snapshot) {
+  if (usbdev == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot =
+      mmio_region_read32(usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_is_pending(const dif_usbdev_t *usbdev,
+                                       dif_usbdev_irq_t irq, bool *is_pending) {
+  if (usbdev == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!usbdev_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_acknowledge(const dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!usbdev_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_get_enabled(const dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq,
+                                        dif_toggle_t *state) {
+  if (usbdev == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!usbdev_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_set_enabled(const dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq,
+                                        dif_toggle_t state) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!usbdev_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_force(const dif_usbdev_t *usbdev,
+                                  dif_usbdev_irq_t irq) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!usbdev_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_disable_all(
+    const dif_usbdev_t *usbdev, dif_usbdev_irq_enable_snapshot_t *snapshot) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot =
+        mmio_region_read32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_restore_all(
+    const dif_usbdev_t *usbdev,
+    const dif_usbdev_irq_enable_snapshot_t *snapshot) {
+  if (usbdev == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
@@ -1,0 +1,242 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_USBDEV_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_USBDEV_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/usbdev/doc/">USBDEV</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to usbdev.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_usbdev {
+  /**
+   * The base address for the usbdev hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_usbdev_t;
+
+/**
+ * A usbdev interrupt request type.
+ */
+typedef enum dif_usbdev_irq {
+  /**
+   * Raised if a packet was received using an OUT or SETUP transaction.
+   */
+  kDifUsbdevIrqPktReceived = 0,
+  /**
+   * Raised if a packet was sent as part of an IN transaction.
+   */
+  kDifUsbdevIrqPktSent = 1,
+  /**
+   * Raised if VBUS is lost thus the link is disconnected.
+   */
+  kDifUsbdevIrqDisconnected = 2,
+  /**
+   * Raised if link is active but SOF was not received from host for 4.096 ms.
+   * The SOF should be every 1 ms.
+   */
+  kDifUsbdevIrqHostLost = 3,
+  /**
+   * Raised if the link is at SE0 longer than 3 us indicating a link reset (host
+   * asserts for min 10 ms, device can react after 2.5 us).
+   */
+  kDifUsbdevIrqLinkReset = 4,
+  /**
+   * Raised if the line has signaled J for longer than 3ms and is therefore in
+   * suspend state.
+   */
+  kDifUsbdevIrqLinkSuspend = 5,
+  /**
+   * Raised when the link becomes active again after being suspended.
+   */
+  kDifUsbdevIrqLinkResume = 6,
+  /**
+   * Raised when a transaction is NACKed because the Available Buffer FIFO for
+   * OUT or SETUP transactions is empty.
+   */
+  kDifUsbdevIrqAvEmpty = 7,
+  /**
+   * Raised when a transaction is NACKed because the Received Buffer FIFO for
+   * OUT or SETUP transactions is full.
+   */
+  kDifUsbdevIrqRxFull = 8,
+  /**
+   * Raised if a write was done to the Available Buffer FIFO when the FIFO was
+   * full.
+   */
+  kDifUsbdevIrqAvOverflow = 9,
+  /**
+   * Raised if a packet to an IN endpoint started to be received but was then
+   * dropped due to an error. After transmitting the IN payload, the USB device
+   * expects a valid ACK handshake packet. This error is raised if either the
+   * packet or CRC is invalid or a different token was received.
+   */
+  kDifUsbdevIrqLinkInErr = 10,
+  /**
+   * Raised if a CRC error occured.
+   */
+  kDifUsbdevIrqRxCrcErr = 11,
+  /**
+   * Raised if an invalid packed identifier (PID) was received.
+   */
+  kDifUsbdevIrqRxPidErr = 12,
+  /**
+   * Raised if an invalid bitstuffing was received.
+   */
+  kDifUsbdevIrqRxBitstuffErr = 13,
+  /**
+   * Raised when the USB frame number is updated with a valid SOF.
+   */
+  kDifUsbdevIrqFrame = 14,
+  /**
+   * Raised if VBUS is applied.
+   */
+  kDifUsbdevIrqConnected = 15,
+  /**
+   * Raised if a packet to an OUT endpoint started to be received but was then
+   * dropped due to an error. This error is raised if either the data toggle,
+   * token, packet or CRC is invalid or if there is no buffer available in the
+   * Received Buffer FIFO.
+   */
+  kDifUsbdevIrqLinkOutErr = 16,
+} dif_usbdev_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_usbdev_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_usbdev_irq_state_snapshot_t;
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_usbdev_irq_disable_all()` and `dif_usbdev_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_usbdev_irq_enable_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param usbdev A usbdev handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_get_state(
+    const dif_usbdev_t *usbdev, dif_usbdev_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param usbdev A usbdev handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_is_pending(const dif_usbdev_t *usbdev,
+                                       dif_usbdev_irq_t irq, bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param usbdev A usbdev handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_acknowledge(const dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq);
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param usbdev A usbdev handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_get_enabled(const dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq,
+                                        dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param usbdev A usbdev handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_set_enabled(const dif_usbdev_t *usbdev,
+                                        dif_usbdev_irq_t irq,
+                                        dif_toggle_t state);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param usbdev A usbdev handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_force(const dif_usbdev_t *usbdev,
+                                  dif_usbdev_irq_t irq);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param usbdev A usbdev handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_disable_all(
+    const dif_usbdev_t *usbdev, dif_usbdev_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param usbdev A usbdev handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_irq_restore_all(
+    const dif_usbdev_t *usbdev,
+    const dif_usbdev_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_USBDEV_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -1,0 +1,305 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_usbdev.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "usbdev_regs.h"  // Generated.
+
+namespace dif_usbdev_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class UsbdevTest : public Test, public MmioTest {
+ protected:
+  dif_usbdev_t usbdev_ = {.base_addr = dev().region()};
+};
+
+using ::testing::Eq;
+
+class IrqGetStateTest : public UsbdevTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_usbdev_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_usbdev_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_usbdev_irq_get_state(&usbdev_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_usbdev_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_usbdev_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_usbdev_irq_get_state(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_usbdev_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_usbdev_irq_get_state(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public UsbdevTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(
+      dif_usbdev_irq_is_pending(nullptr, kDifUsbdevIrqPktReceived, &is_pending),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqPktReceived, nullptr),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_usbdev_irq_is_pending(nullptr, kDifUsbdevIrqPktReceived, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_usbdev_irq_is_pending(
+                &usbdev_, static_cast<dif_usbdev_irq_t>(32), &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET,
+                {{USBDEV_INTR_STATE_PKT_RECEIVED_BIT, true}});
+  EXPECT_EQ(
+      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqPktReceived, &irq_state),
+      kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET,
+                {{USBDEV_INTR_STATE_LINK_OUT_ERR_BIT, false}});
+  EXPECT_EQ(
+      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqLinkOutErr, &irq_state),
+      kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public UsbdevTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_usbdev_irq_acknowledge(nullptr, kDifUsbdevIrqPktReceived),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(
+      dif_usbdev_irq_acknowledge(nullptr, static_cast<dif_usbdev_irq_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(USBDEV_INTR_STATE_REG_OFFSET,
+                 {{USBDEV_INTR_STATE_PKT_RECEIVED_BIT, true}});
+  EXPECT_EQ(dif_usbdev_irq_acknowledge(&usbdev_, kDifUsbdevIrqPktReceived),
+            kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(USBDEV_INTR_STATE_REG_OFFSET,
+                 {{USBDEV_INTR_STATE_LINK_OUT_ERR_BIT, true}});
+  EXPECT_EQ(dif_usbdev_irq_acknowledge(&usbdev_, kDifUsbdevIrqLinkOutErr),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public UsbdevTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_usbdev_irq_get_enabled(nullptr, kDifUsbdevIrqPktReceived, &irq_state),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqPktReceived, nullptr),
+      kDifBadArg);
+
+  EXPECT_EQ(
+      dif_usbdev_irq_get_enabled(nullptr, kDifUsbdevIrqPktReceived, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_usbdev_irq_get_enabled(
+                &usbdev_, static_cast<dif_usbdev_irq_t>(32), &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET,
+                {{USBDEV_INTR_ENABLE_PKT_RECEIVED_BIT, true}});
+  EXPECT_EQ(dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqPktReceived,
+                                       &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET,
+                {{USBDEV_INTR_ENABLE_LINK_OUT_ERR_BIT, false}});
+  EXPECT_EQ(
+      dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqLinkOutErr, &irq_state),
+      kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public UsbdevTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(
+      dif_usbdev_irq_set_enabled(nullptr, kDifUsbdevIrqPktReceived, irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_usbdev_irq_set_enabled(
+                &usbdev_, static_cast<dif_usbdev_irq_t>(32), irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(USBDEV_INTR_ENABLE_REG_OFFSET,
+                {{USBDEV_INTR_ENABLE_PKT_RECEIVED_BIT, 0x1, true}});
+  EXPECT_EQ(
+      dif_usbdev_irq_set_enabled(&usbdev_, kDifUsbdevIrqPktReceived, irq_state),
+      kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(USBDEV_INTR_ENABLE_REG_OFFSET,
+                {{USBDEV_INTR_ENABLE_LINK_OUT_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(
+      dif_usbdev_irq_set_enabled(&usbdev_, kDifUsbdevIrqLinkOutErr, irq_state),
+      kDifOk);
+}
+
+class IrqForceTest : public UsbdevTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_usbdev_irq_force(nullptr, kDifUsbdevIrqPktReceived),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(dif_usbdev_irq_force(nullptr, static_cast<dif_usbdev_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(USBDEV_INTR_TEST_REG_OFFSET,
+                 {{USBDEV_INTR_TEST_PKT_RECEIVED_BIT, true}});
+  EXPECT_EQ(dif_usbdev_irq_force(&usbdev_, kDifUsbdevIrqPktReceived), kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(USBDEV_INTR_TEST_REG_OFFSET,
+                 {{USBDEV_INTR_TEST_LINK_OUT_ERR_BIT, true}});
+  EXPECT_EQ(dif_usbdev_irq_force(&usbdev_, kDifUsbdevIrqLinkOutErr), kDifOk);
+}
+
+class IrqDisableAllTest : public UsbdevTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_usbdev_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_usbdev_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_usbdev_irq_disable_all(&usbdev_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_usbdev_irq_disable_all(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_usbdev_irq_disable_all(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public UsbdevTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_usbdev_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_usbdev_irq_restore_all(&usbdev_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_usbdev_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_usbdev_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_usbdev_irq_restore_all(&usbdev_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_usbdev_irq_restore_all(&usbdev_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_usbdev_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -268,6 +268,20 @@ sw_lib_dif_autogen_sram_ctrl = declare_dependency(
   )
 )
 
+# Autogen USB Device DIF library
+sw_lib_dif_autogen_usbdev = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_usbdev',
+    sources: [
+      hw_ip_usbdev_reg_h,
+      'dif_usbdev_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen UART DIF library
 sw_lib_dif_autogen_uart = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -58,28 +58,6 @@ static const endpoint_hw_info_t kEndpointHwInfos[USBDEV_NUM_ENDPOINTS] = {
 #undef ENDPOINT_HW_INFO_ENTRY
 
 /**
- * Mapping from `dif_usbdev_irq_t` to bit indices in interrupt registers.
- */
-static const uint8_t kIrqEnumToBitIndex[] = {
-    [kDifUsbdevIrqPktReceived] = USBDEV_INTR_COMMON_PKT_RECEIVED_BIT,
-    [kDifUsbdevIrqPktSent] = USBDEV_INTR_COMMON_PKT_SENT_BIT,
-    [kDifUsbdevIrqDisconnected] = USBDEV_INTR_COMMON_DISCONNECTED_BIT,
-    [kDifUsbdevIrqHostLost] = USBDEV_INTR_COMMON_HOST_LOST_BIT,
-    [kDifUsbdevIrqLinkReset] = USBDEV_INTR_COMMON_LINK_RESET_BIT,
-    [kDifUsbdevIrqLinkSuspend] = USBDEV_INTR_COMMON_LINK_SUSPEND_BIT,
-    [kDifUsbdevIrqLinkResume] = USBDEV_INTR_COMMON_LINK_RESUME_BIT,
-    [kDifUsbdevIrqAvEmpty] = USBDEV_INTR_COMMON_AV_EMPTY_BIT,
-    [kDifUsbdevIrqRxFull] = USBDEV_INTR_COMMON_RX_FULL_BIT,
-    [kDifUsbdevIrqAvOverflow] = USBDEV_INTR_COMMON_AV_OVERFLOW_BIT,
-    [kDifUsbdevIrqLinkInError] = USBDEV_INTR_COMMON_LINK_IN_ERR_BIT,
-    [kDifUsbdevIrqRxCrcError] = USBDEV_INTR_COMMON_RX_CRC_ERR_BIT,
-    [kDifUsbdevIrqRxPidError] = USBDEV_INTR_COMMON_RX_PID_ERR_BIT,
-    [kDifUsbdevIrqRxBitstuffError] = USBDEV_INTR_COMMON_RX_BITSTUFF_ERR_BIT,
-    [kDifUsbdevIrqFrame] = USBDEV_INTR_COMMON_FRAME_BIT,
-    [kDifUsbdevIrqConnected] = USBDEV_INTR_COMMON_CONNECTED_BIT,
-};
-
-/**
  * Static functions for the free buffer pool.
  */
 
@@ -188,11 +166,11 @@ static bool buffer_pool_init(dif_usbdev_buffer_pool_t *pool) {
  */
 
 /**
- * Checks if the given value is a valid `dif_usbdev_toggle_t` variant.
+ * Checks if the given value is a valid `dif_toggle_t` variant.
  */
 OT_WARN_UNUSED_RESULT
-static bool is_valid_toggle(dif_usbdev_toggle_t val) {
-  return val == kDifUsbdevToggleEnable || val == kDifUsbdevToggleDisable;
+static bool is_valid_toggle(dif_toggle_t val) {
+  return val == kDifToggleEnabled || val == kDifToggleDisabled;
 }
 
 /**
@@ -216,27 +194,20 @@ static bool is_valid_endpoint(uint8_t endpoint) {
 }
 
 /**
- * Checks if the given value is a valid `dif_usbdev_irq_t` variant.
- */
-OT_WARN_UNUSED_RESULT
-static bool is_valid_irq(dif_usbdev_irq_t irq) {
-  return irq >= kDifUsbdevIrqFirst && irq <= kDifUsbdevIrqLast;
-}
-
-/**
  * Enables/disables the functionality controlled by the register at `reg_offset`
  * for an endpoint.
  */
 OT_WARN_UNUSED_RESULT
-static dif_usbdev_result_t endpoint_functionality_enable(
-    const dif_usbdev_t *usbdev, uint32_t reg_offset, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state) {
+static dif_result_t endpoint_functionality_enable(const dif_usbdev_t *usbdev,
+                                                  uint32_t reg_offset,
+                                                  uint8_t endpoint,
+                                                  dif_toggle_t new_state) {
   if (usbdev == NULL || !is_valid_endpoint(endpoint) ||
       !is_valid_toggle(new_state)) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
-  if (kDifUsbdevToggleEnable) {
+  if (kDifToggleEnabled) {
     mmio_region_nonatomic_set_bit32(usbdev->base_addr, reg_offset,
                                     kEndpointHwInfos[endpoint].bit_index);
   } else {
@@ -244,7 +215,7 @@ static dif_usbdev_result_t endpoint_functionality_enable(
                                       kEndpointHwInfos[endpoint].bit_index);
   }
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
 /**
@@ -261,27 +232,26 @@ static uint32_t get_buffer_addr(uint8_t buffer_id, size_t offset) {
  * USBDEV DIF library functions.
  */
 
-dif_usbdev_result_t dif_usbdev_init(mmio_region_t base_addr,
-                                    dif_usbdev_t *usbdev) {
+dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev) {
   if (usbdev == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   usbdev->base_addr = base_addr;
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
-                                         dif_usbdev_buffer_pool_t *buffer_pool,
-                                         dif_usbdev_config_t config) {
+dif_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
+                                  dif_usbdev_buffer_pool_t *buffer_pool,
+                                  dif_usbdev_config_t config) {
   if (usbdev == NULL || buffer_pool == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Configure the free buffer pool.
   if (!buffer_pool_init(buffer_pool)) {
-    return kDifUsbdevError;
+    return kDifError;
   }
 
   // Check enum fields.
@@ -291,13 +261,13 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
       !is_valid_power_sense_override(config.power_sense_override) ||
       !is_valid_toggle(config.pin_flip) ||
       !is_valid_toggle(config.clock_sync_signals)) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Determine the value of the PHY_CONFIG register.
   uint32_t phy_config_val = 0;
 
-  if (config.differential_rx == kDifUsbdevToggleEnable) {
+  if (config.differential_rx == kDifToggleEnabled) {
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
@@ -307,7 +277,7 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
         1);
   }
 
-  if (config.differential_tx == kDifUsbdevToggleEnable) {
+  if (config.differential_tx == kDifToggleEnabled) {
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
@@ -317,7 +287,7 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
         1);
   }
 
-  if (config.single_bit_eop == kDifUsbdevToggleEnable) {
+  if (config.single_bit_eop == kDifToggleEnabled) {
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
@@ -353,7 +323,7 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
         1);
   }
 
-  if (config.pin_flip == kDifUsbdevToggleEnable) {
+  if (config.pin_flip == kDifToggleEnabled) {
     phy_config_val =
         bitfield_field32_write(phy_config_val,
                                (bitfield_field32_t){
@@ -363,7 +333,7 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
                                1);
   }
 
-  if (config.clock_sync_signals == kDifUsbdevToggleDisable) {
+  if (config.clock_sync_signals == kDifToggleDisabled) {
     phy_config_val = bitfield_field32_write(
         phy_config_val,
         (bitfield_field32_t){
@@ -377,13 +347,13 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
   mmio_region_write32(usbdev->base_addr, USBDEV_PHY_CONFIG_REG_OFFSET,
                       phy_config_val);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_fill_available_fifo(
+dif_result_t dif_usbdev_fill_available_fifo(
     const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool) {
   if (usbdev == NULL || buffer_pool == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Remove buffers from the pool and write them to the AV FIFO until it is full
@@ -392,64 +362,63 @@ dif_usbdev_result_t dif_usbdev_fill_available_fifo(
          !buffer_pool_is_empty(buffer_pool)) {
     uint8_t buffer_id;
     if (!buffer_pool_remove(buffer_pool, &buffer_id)) {
-      return kDifUsbdevError;
+      return kDifError;
     }
     mmio_region_write_only_set_field32(usbdev->base_addr,
                                        USBDEV_AVBUFFER_REG_OFFSET,
                                        USBDEV_AVBUFFER_BUFFER_FIELD, buffer_id);
   }
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_endpoint_setup_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state) {
+dif_result_t dif_usbdev_endpoint_setup_enable(const dif_usbdev_t *usbdev,
+                                              uint8_t endpoint,
+                                              dif_toggle_t new_state) {
   return endpoint_functionality_enable(usbdev, USBDEV_RXENABLE_SETUP_REG_OFFSET,
                                        endpoint, new_state);
 }
 
-dif_usbdev_result_t dif_usbdev_endpoint_out_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state) {
+dif_result_t dif_usbdev_endpoint_out_enable(const dif_usbdev_t *usbdev,
+                                            uint8_t endpoint,
+                                            dif_toggle_t new_state) {
   return endpoint_functionality_enable(usbdev, USBDEV_RXENABLE_OUT_REG_OFFSET,
                                        endpoint, new_state);
 }
 
-dif_usbdev_result_t dif_usbdev_endpoint_stall_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state) {
+dif_result_t dif_usbdev_endpoint_stall_enable(const dif_usbdev_t *usbdev,
+                                              uint8_t endpoint,
+                                              dif_toggle_t new_state) {
   return endpoint_functionality_enable(usbdev, USBDEV_STALL_REG_OFFSET,
                                        endpoint, new_state);
 }
 
-dif_usbdev_result_t dif_usbdev_endpoint_stall_get(const dif_usbdev_t *usbdev,
-                                                  uint8_t endpoint,
-                                                  bool *state) {
+dif_result_t dif_usbdev_endpoint_stall_get(const dif_usbdev_t *usbdev,
+                                           uint8_t endpoint, bool *state) {
   if (usbdev == NULL || state == NULL || !is_valid_endpoint(endpoint)) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   *state = mmio_region_get_bit32(usbdev->base_addr, USBDEV_STALL_REG_OFFSET,
                                  kEndpointHwInfos[endpoint].bit_index);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_endpoint_iso_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state) {
+dif_result_t dif_usbdev_endpoint_iso_enable(const dif_usbdev_t *usbdev,
+                                            uint8_t endpoint,
+                                            dif_toggle_t new_state) {
   return endpoint_functionality_enable(usbdev, USBDEV_ISO_REG_OFFSET, endpoint,
                                        new_state);
 }
 
-dif_usbdev_result_t dif_usbdev_interface_enable(const dif_usbdev_t *usbdev,
-                                                dif_usbdev_toggle_t new_state) {
+dif_result_t dif_usbdev_interface_enable(const dif_usbdev_t *usbdev,
+                                         dif_toggle_t new_state) {
   if (usbdev == NULL || !is_valid_toggle(new_state)) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
-  if (new_state == kDifUsbdevToggleEnable) {
+  if (new_state == kDifToggleEnabled) {
     mmio_region_nonatomic_set_bit32(usbdev->base_addr,
                                     USBDEV_USBCTRL_REG_OFFSET,
                                     USBDEV_USBCTRL_ENABLE_BIT);
@@ -459,20 +428,20 @@ dif_usbdev_result_t dif_usbdev_interface_enable(const dif_usbdev_t *usbdev,
                                       USBDEV_USBCTRL_ENABLE_BIT);
   }
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_recv_result_t dif_usbdev_recv(const dif_usbdev_t *usbdev,
-                                         dif_usbdev_rx_packet_info_t *info,
-                                         dif_usbdev_buffer_t *buffer) {
+dif_result_t dif_usbdev_recv(const dif_usbdev_t *usbdev,
+                             dif_usbdev_rx_packet_info_t *info,
+                             dif_usbdev_buffer_t *buffer) {
   if (usbdev == NULL || info == NULL || buffer == NULL) {
-    return kDifUsbdevRecvResultBadArg;
+    return kDifBadArg;
   }
 
   // Check if the RX FIFO is empty
   if (mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
                             USBDEV_USBSTAT_RX_EMPTY_BIT)) {
-    return kDifUsbdevRecvResultNoNewPacket;
+    return kDifError;
   }
 
   // Read fifo entry
@@ -492,23 +461,23 @@ dif_usbdev_recv_result_t dif_usbdev_recv(const dif_usbdev_t *usbdev,
       .type = kDifUsbdevBufferTypeRead,
   };
 
-  return kDifUsbdevRecvResultOK;
+  return kDifOk;
 }
 
-dif_usbdev_buffer_request_result_t dif_usbdev_buffer_request(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    dif_usbdev_buffer_t *buffer) {
+dif_result_t dif_usbdev_buffer_request(const dif_usbdev_t *usbdev,
+                                       dif_usbdev_buffer_pool_t *buffer_pool,
+                                       dif_usbdev_buffer_t *buffer) {
   if (usbdev == NULL || buffer_pool == NULL || buffer == NULL) {
-    return kDifUsbdevBufferRequestResultBadArg;
+    return kDifBadArg;
   }
 
   if (buffer_pool_is_empty(buffer_pool)) {
-    return kDifUsbdevBufferRequestResultNoBuffers;
+    return kDifUnavailable;
   }
 
   uint8_t buffer_id;
   if (!buffer_pool_remove(buffer_pool, &buffer_id)) {
-    return kDifUsbdevBufferRequestResultError;
+    return kDifError;
   }
 
   *buffer = (dif_usbdev_buffer_t){
@@ -518,14 +487,14 @@ dif_usbdev_buffer_request_result_t dif_usbdev_buffer_request(
       .type = kDifUsbdevBufferTypeWrite,
   };
 
-  return kDifUsbdevBufferRequestResultOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_buffer_return(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    dif_usbdev_buffer_t *buffer) {
+dif_result_t dif_usbdev_buffer_return(const dif_usbdev_t *usbdev,
+                                      dif_usbdev_buffer_pool_t *buffer_pool,
+                                      dif_usbdev_buffer_t *buffer) {
   if (usbdev == NULL || buffer_pool == NULL || buffer == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   switch (buffer->type) {
@@ -533,23 +502,23 @@ dif_usbdev_result_t dif_usbdev_buffer_return(
     case kDifUsbdevBufferTypeWrite:
       // Return the buffer to the free buffer pool
       if (!buffer_pool_add(buffer_pool, buffer->id)) {
-        return kDifUsbdevError;
+        return kDifError;
       }
       // Mark the buffer as stale
       buffer->type = kDifUsbdevBufferTypeStale;
-      return kDifUsbdevOK;
+      return kDifOk;
     default:
-      return kDifUsbdevBadArg;
+      return kDifBadArg;
   }
 }
 
-dif_usbdev_buffer_read_result_t dif_usbdev_buffer_read(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    dif_usbdev_buffer_t *buffer, uint8_t *dst, size_t dst_len,
-    size_t *bytes_written) {
+dif_result_t dif_usbdev_buffer_read(const dif_usbdev_t *usbdev,
+                                    dif_usbdev_buffer_pool_t *buffer_pool,
+                                    dif_usbdev_buffer_t *buffer, uint8_t *dst,
+                                    size_t dst_len, size_t *bytes_written) {
   if (usbdev == NULL || buffer_pool == NULL || buffer == NULL ||
       buffer->type != kDifUsbdevBufferTypeRead || dst == NULL) {
-    return kDifUsbdevBufferReadResultBadArg;
+    return kDifBadArg;
   }
 
   // bytes_to_copy is the minimum of remaining_bytes and dst_len
@@ -571,24 +540,25 @@ dif_usbdev_buffer_read_result_t dif_usbdev_buffer_read(
 
   // Check if there are any remaining bytes
   if (buffer->remaining_bytes > 0) {
-    return kDifUsbdevBufferReadResultContinue;
+    return kDifOk;
   }
 
   // Return the buffer to the free buffer pool
   if (!buffer_pool_add(buffer_pool, buffer->id)) {
-    return kDifUsbdevBufferReadResultError;
+    return kDifError;
   }
+
   // Mark the buffer as stale
   buffer->type = kDifUsbdevBufferTypeStale;
-  return kDifUsbdevBufferReadResultOK;
+  return kDifOk;
 }
 
-dif_usbdev_buffer_write_result_t dif_usbdev_buffer_write(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_t *buffer, uint8_t *src,
-    size_t src_len, size_t *bytes_written) {
+dif_result_t dif_usbdev_buffer_write(const dif_usbdev_t *usbdev,
+                                     dif_usbdev_buffer_t *buffer, uint8_t *src,
+                                     size_t src_len, size_t *bytes_written) {
   if (usbdev == NULL || buffer == NULL ||
       buffer->type != kDifUsbdevBufferTypeWrite || src == NULL) {
-    return kDifUsbdevBufferWriteResultBadArg;
+    return kDifBadArg;
   }
 
   // bytes_to_copy is the minimum of remaining_bytes and src_len.
@@ -610,18 +580,17 @@ dif_usbdev_buffer_write_result_t dif_usbdev_buffer_write(
   }
 
   if (buffer->remaining_bytes == 0 && bytes_to_copy < src_len) {
-    return kDifUsbdevBufferWriteResultFull;
+    return kDifError;
   }
 
-  return kDifUsbdevBufferWriteResultOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_send(const dif_usbdev_t *usbdev,
-                                    uint8_t endpoint,
-                                    dif_usbdev_buffer_t *buffer) {
+dif_result_t dif_usbdev_send(const dif_usbdev_t *usbdev, uint8_t endpoint,
+                             dif_usbdev_buffer_t *buffer) {
   if (usbdev == NULL || !is_valid_endpoint(endpoint) || buffer == NULL ||
       buffer->type != kDifUsbdevBufferTypeWrite) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Get the configin register offset of the endpoint.
@@ -648,15 +617,16 @@ dif_usbdev_result_t dif_usbdev_send(const dif_usbdev_t *usbdev,
   // in dif_usbdev_get_tx_status once transmission is complete.
   buffer->type = kDifUsbdevBufferTypeStale;
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_get_tx_status(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    uint8_t endpoint, dif_usbdev_tx_status_t *status) {
+dif_result_t dif_usbdev_get_tx_status(const dif_usbdev_t *usbdev,
+                                      dif_usbdev_buffer_pool_t *buffer_pool,
+                                      uint8_t endpoint,
+                                      dif_usbdev_tx_status_t *status) {
   if (usbdev == NULL || buffer_pool == NULL || status == NULL ||
       !is_valid_endpoint(endpoint)) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Get the configin register offset and bit index of the endpoint
@@ -688,7 +658,7 @@ dif_usbdev_result_t dif_usbdev_get_tx_status(
         usbdev->base_addr, USBDEV_IN_SENT_REG_OFFSET, endpoint_bit_index);
     // Return the buffer back to the free buffer pool
     if (!buffer_pool_add(buffer_pool, buffer)) {
-      return kDifUsbdevError;
+      return kDifError;
     }
     *status = kDifUsbdevTxStatusSent;
   } else if (bitfield_field32_read(config_in_val,
@@ -702,7 +672,7 @@ dif_usbdev_result_t dif_usbdev_get_tx_status(
                                      USBDEV_CONFIGIN_0_PEND_0_BIT);
     // Return the buffer back to the free buffer pool
     if (!buffer_pool_add(buffer_pool, buffer)) {
-      return kDifUsbdevError;
+      return kDifError;
     }
     *status = kDifUsbdevTxStatusCancelled;
   } else {
@@ -710,26 +680,24 @@ dif_usbdev_result_t dif_usbdev_get_tx_status(
     *status = kDifUsbdevTxStatusNoPacket;
   }
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_address_set(const dif_usbdev_t *usbdev,
-                                           uint8_t addr) {
+dif_result_t dif_usbdev_address_set(const dif_usbdev_t *usbdev, uint8_t addr) {
   if (usbdev == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   mmio_region_nonatomic_set_field32(usbdev->base_addr,
                                     USBDEV_USBCTRL_REG_OFFSET,
                                     USBDEV_USBCTRL_DEVICE_ADDRESS_FIELD, addr);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev,
-                                           uint8_t *addr) {
+dif_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev, uint8_t *addr) {
   if (usbdev == NULL || addr == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Note: Size of address is 7 bits.
@@ -737,13 +705,13 @@ dif_usbdev_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev,
                                   USBDEV_USBCTRL_DEVICE_ADDRESS_MASK,
                                   USBDEV_USBCTRL_DEVICE_ADDRESS_OFFSET);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_frame(const dif_usbdev_t *usbdev,
-                                                uint16_t *frame_index) {
+dif_result_t dif_usbdev_status_get_frame(const dif_usbdev_t *usbdev,
+                                         uint16_t *frame_index) {
   if (usbdev == NULL || frame_index == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Note: size of frame index is 11 bits.
@@ -751,26 +719,26 @@ dif_usbdev_result_t dif_usbdev_status_get_frame(const dif_usbdev_t *usbdev,
       usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET, USBDEV_USBSTAT_FRAME_MASK,
       USBDEV_USBSTAT_FRAME_OFFSET);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_host_lost(const dif_usbdev_t *usbdev,
-                                                    bool *host_lost) {
+dif_result_t dif_usbdev_status_get_host_lost(const dif_usbdev_t *usbdev,
+                                             bool *host_lost) {
   if (usbdev == NULL || host_lost == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   *host_lost =
       mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
                             USBDEV_USBSTAT_HOST_LOST_BIT);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_link_state(
+dif_result_t dif_usbdev_status_get_link_state(
     const dif_usbdev_t *usbdev, dif_usbdev_link_state_t *link_state) {
   if (usbdev == NULL || link_state == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   uint32_t val = mmio_region_read_mask32(
@@ -794,28 +762,28 @@ dif_usbdev_result_t dif_usbdev_status_get_link_state(
       *link_state = kDifUsbdevLinkStateSuspend;
       break;
     default:
-      return kDifUsbdevError;
+      return kDifError;
   }
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_sense(const dif_usbdev_t *usbdev,
-                                                bool *sense) {
+dif_result_t dif_usbdev_status_get_sense(const dif_usbdev_t *usbdev,
+                                         bool *sense) {
   if (usbdev == NULL || sense == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   *sense = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
                                  USBDEV_USBSTAT_SENSE_BIT);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_available_fifo_depth(
+dif_result_t dif_usbdev_status_get_available_fifo_depth(
     const dif_usbdev_t *usbdev, uint8_t *depth) {
   if (usbdev == NULL || depth == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Note: Size of available FIFO depth is 3 bits.
@@ -823,25 +791,25 @@ dif_usbdev_result_t dif_usbdev_status_get_available_fifo_depth(
                                    USBDEV_USBSTAT_AV_DEPTH_MASK,
                                    USBDEV_USBSTAT_AV_DEPTH_OFFSET);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_available_fifo_full(
+dif_result_t dif_usbdev_status_get_available_fifo_full(
     const dif_usbdev_t *usbdev, bool *is_full) {
   if (usbdev == NULL || is_full == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   *is_full = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
                                    USBDEV_USBSTAT_AV_FULL_BIT);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_depth(
-    const dif_usbdev_t *usbdev, uint8_t *depth) {
+dif_result_t dif_usbdev_status_get_rx_fifo_depth(const dif_usbdev_t *usbdev,
+                                                 uint8_t *depth) {
   if (usbdev == NULL || depth == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   // Note: Size of RX FIFO depth is 3 bits.
@@ -849,112 +817,17 @@ dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_depth(
                                    USBDEV_USBSTAT_RX_DEPTH_MASK,
                                    USBDEV_USBSTAT_RX_DEPTH_OFFSET);
 
-  return kDifUsbdevOK;
+  return kDifOk;
 }
 
-dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_empty(
-    const dif_usbdev_t *usbdev, bool *is_full) {
+dif_result_t dif_usbdev_status_get_rx_fifo_empty(const dif_usbdev_t *usbdev,
+                                                 bool *is_full) {
   if (usbdev == NULL || is_full == NULL) {
-    return kDifUsbdevBadArg;
+    return kDifBadArg;
   }
 
   *is_full = mmio_region_get_bit32(usbdev->base_addr, USBDEV_USBSTAT_REG_OFFSET,
                                    USBDEV_USBSTAT_RX_EMPTY_BIT);
 
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_enable(const dif_usbdev_t *usbdev,
-                                          dif_usbdev_irq_t irq,
-                                          dif_usbdev_toggle_t state) {
-  if (usbdev == NULL || !is_valid_irq(irq) || !is_valid_toggle(state)) {
-    return kDifUsbdevBadArg;
-  }
-
-  if (state == kDifUsbdevToggleEnable) {
-    mmio_region_nonatomic_set_bit32(usbdev->base_addr,
-                                    USBDEV_INTR_ENABLE_REG_OFFSET,
-                                    kIrqEnumToBitIndex[irq]);
-  } else {
-    mmio_region_nonatomic_clear_bit32(usbdev->base_addr,
-                                      USBDEV_INTR_ENABLE_REG_OFFSET,
-                                      kIrqEnumToBitIndex[irq]);
-  }
-
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_get(const dif_usbdev_t *usbdev,
-                                       dif_usbdev_irq_t irq, bool *state) {
-  if (usbdev == NULL || state == NULL || !is_valid_irq(irq)) {
-    return kDifUsbdevBadArg;
-  }
-
-  *state = mmio_region_get_bit32(
-      usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET, kIrqEnumToBitIndex[irq]);
-
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_clear(const dif_usbdev_t *usbdev,
-                                         dif_usbdev_irq_t irq) {
-  if (usbdev == NULL || !is_valid_irq(irq)) {
-    return kDifUsbdevBadArg;
-  }
-
-  mmio_region_write_only_set_bit32(
-      usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET, kIrqEnumToBitIndex[irq]);
-
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_clear_all(const dif_usbdev_t *usbdev) {
-  if (usbdev == NULL) {
-    return kDifUsbdevBadArg;
-  }
-
-  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_STATE_REG_OFFSET,
-                      UINT32_MAX);
-
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_disable_all(const dif_usbdev_t *usbdev,
-                                               uint32_t *cur_config) {
-  if (usbdev == NULL) {
-    return kDifUsbdevBadArg;
-  }
-
-  if (cur_config != NULL) {
-    *cur_config =
-        mmio_region_read32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET);
-  }
-
-  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET, 0);
-
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_restore(const dif_usbdev_t *usbdev,
-                                           uint32_t new_config) {
-  if (usbdev == NULL) {
-    return kDifUsbdevBadArg;
-  }
-
-  mmio_region_write32(usbdev->base_addr, USBDEV_INTR_ENABLE_REG_OFFSET,
-                      new_config);
-
-  return kDifUsbdevOK;
-}
-
-dif_usbdev_result_t dif_usbdev_irq_test(const dif_usbdev_t *usbdev,
-                                        dif_usbdev_irq_t irq) {
-  if (usbdev == NULL || !is_valid_irq(irq)) {
-    return kDifUsbdevBadArg;
-  }
-
-  mmio_region_write_only_set_bit32(
-      usbdev->base_addr, USBDEV_INTR_TEST_REG_OFFSET, kIrqEnumToBitIndex[irq]);
-
-  return kDifUsbdevOK;
+  return kDifOk;
 }

--- a/sw/device/lib/dif/dif_usbdev.h
+++ b/sw/device/lib/dif/dif_usbdev.h
@@ -15,6 +15,9 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sw/device/lib/dif/autogen/dif_usbdev_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,26 +100,6 @@ typedef struct dif_usbdev_buffer {
 } dif_usbdev_buffer_t;
 
 /**
- * Internal state of a USB device.
- *
- * Instances of this struct must be initialized by `dif_usbdev_init()` before
- * being passed to other functions in this library. Its fields should be
- * considered private and are only provided here so that callers can allocate
- * it.
- */
-typedef struct dif_usbdev {
-  mmio_region_t base_addr;
-} dif_usbdev_t;
-
-/**
- * Enumeration for enabling/disabling various functionality.
- */
-typedef enum dif_usbdev_toggle {
-  kDifUsbdevToggleDisable,
-  kDifUsbdevToggleEnable,
-} dif_usbdev_toggle_t;
-
-/**
  * Set of allowed configurations for USB power sense override.
  */
 typedef enum dif_usbdev_power_sense_override {
@@ -132,16 +115,16 @@ typedef struct dif_usbdev_config {
   /**
    * Use the differential rx signal instead of the single-ended signals.
    */
-  dif_usbdev_toggle_t differential_rx;
+  dif_toggle_t differential_rx;
   /**
    * Use the differential tx signal instead of the single-ended signals.
    */
-  dif_usbdev_toggle_t differential_tx;
+  dif_toggle_t differential_tx;
   /*
    * Recognize a single SE0 bit as end of packet instead of requiring
    * two bits.
    */
-  dif_usbdev_toggle_t single_bit_eop;
+  dif_toggle_t single_bit_eop;
   /**
    * Override USB power sense.
    */
@@ -149,33 +132,12 @@ typedef struct dif_usbdev_config {
   /**
    * Flip the D+/D- pins.
    */
-  dif_usbdev_toggle_t pin_flip;
+  dif_toggle_t pin_flip;
   /**
    * Reference signal generation for clock synchronization.
    */
-  dif_usbdev_toggle_t clock_sync_signals;
+  dif_toggle_t clock_sync_signals;
 } dif_usbdev_config_t;
-
-/**
- * Common return codes for the functions in this library.
- */
-typedef enum dif_usbdev_result {
-  /**
-   * Indicates that the call succeeded.
-   */
-  kDifUsbdevOK = 0,
-  /**
-   * Indicates that a non-specific error occurred and the hardware is in an
-   * invalid or irrecoverable state.
-   */
-  kDifUsbdevError = 1,
-  /**
-   * Indicates that the caller supplied invalid arguments but the call did not
-   * cause any side-effects and the hardware is in a valid and recoverable
-   * state.
-   */
-  kDifUsbdevBadArg = 2,
-} dif_usbdev_result_t;
 
 /**
  * Initialize a USB device.
@@ -188,8 +150,7 @@ typedef enum dif_usbdev_result {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_init(mmio_region_t base_addr,
-                                    dif_usbdev_t *usbdev);
+dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev);
 
 /**
  * Configures a USB device with runtime information.
@@ -202,9 +163,9 @@ dif_usbdev_result_t dif_usbdev_init(mmio_region_t base_addr,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
-                                         dif_usbdev_buffer_pool_t *buffer_pool,
-                                         dif_usbdev_config_t config);
+dif_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
+                                  dif_usbdev_buffer_pool_t *buffer_pool,
+                                  dif_usbdev_config_t config);
 
 /**
  * Fill the available buffer FIFO of a USB device.
@@ -223,7 +184,7 @@ dif_usbdev_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_fill_available_fifo(
+dif_result_t dif_usbdev_fill_available_fifo(
     const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool);
 
 /**
@@ -235,9 +196,9 @@ dif_usbdev_result_t dif_usbdev_fill_available_fifo(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_endpoint_setup_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state);
+dif_result_t dif_usbdev_endpoint_setup_enable(const dif_usbdev_t *usbdev,
+                                              uint8_t endpoint,
+                                              dif_toggle_t new_state);
 
 /**
  * Enable or disable reception of OUT packets for an endpoint.
@@ -248,9 +209,9 @@ dif_usbdev_result_t dif_usbdev_endpoint_setup_enable(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_endpoint_out_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state);
+dif_result_t dif_usbdev_endpoint_out_enable(const dif_usbdev_t *usbdev,
+                                            uint8_t endpoint,
+                                            dif_toggle_t new_state);
 
 /**
  * Enable or disable STALL for an endpoint.
@@ -261,9 +222,9 @@ dif_usbdev_result_t dif_usbdev_endpoint_out_enable(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_endpoint_stall_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state);
+dif_result_t dif_usbdev_endpoint_stall_enable(const dif_usbdev_t *usbdev,
+                                              uint8_t endpoint,
+                                              dif_toggle_t new_state);
 
 /**
  * Get STALL state of an endpoint.
@@ -274,9 +235,8 @@ dif_usbdev_result_t dif_usbdev_endpoint_stall_enable(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_endpoint_stall_get(const dif_usbdev_t *usbdev,
-                                                  uint8_t endpoint,
-                                                  bool *state);
+dif_result_t dif_usbdev_endpoint_stall_get(const dif_usbdev_t *usbdev,
+                                           uint8_t endpoint, bool *state);
 
 /**
  * Enable or disable isochronous mode for an endpoint.
@@ -291,9 +251,9 @@ dif_usbdev_result_t dif_usbdev_endpoint_stall_get(const dif_usbdev_t *usbdev,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_endpoint_iso_enable(
-    const dif_usbdev_t *usbdev, uint8_t endpoint,
-    dif_usbdev_toggle_t new_state);
+dif_result_t dif_usbdev_endpoint_iso_enable(const dif_usbdev_t *usbdev,
+                                            uint8_t endpoint,
+                                            dif_toggle_t new_state);
 
 /**
  * Enable the USB interface of a USB device.
@@ -306,8 +266,8 @@ dif_usbdev_result_t dif_usbdev_endpoint_iso_enable(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_interface_enable(const dif_usbdev_t *usbdev,
-                                                dif_usbdev_toggle_t new_state);
+dif_result_t dif_usbdev_interface_enable(const dif_usbdev_t *usbdev,
+                                         dif_toggle_t new_state);
 
 /**
  * Information about a received packet.
@@ -326,31 +286,6 @@ typedef struct dif_usbdev_rx_packet_info {
    */
   bool is_setup;
 } dif_usbdev_rx_packet_info_t;
-
-/**
- * Return codes for `dif_usbdev_recv`.
- */
-typedef enum dif_usbdev_recv_result {
-  /**
-   * Indicates that the call succeeded.
-   */
-  kDifUsbdevRecvResultOK = kDifUsbdevOK,
-  /**
-   * Indicates that a non-specific error occurred and the hardware is in an
-   * invalid or irrecoverable state.
-   */
-  kDifUsbdevRecvResultError = kDifUsbdevError,
-  /**
-   * Indicates that the caller supplied invalid arguments but the call did not
-   * cause any side-effects and the hardware is in a valid and recoverable
-   * state.
-   */
-  kDifUsbdevRecvResultBadArg = kDifUsbdevBadArg,
-  /**
-   * Indicates that RX FIFO is empty.
-   */
-  kDifUsbdevRecvResultNoNewPacket,
-} dif_usbdev_recv_result_t;
 
 /**
  * Get the packet at the front of RX FIFO.
@@ -385,35 +320,9 @@ typedef enum dif_usbdev_recv_result {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_recv_result_t dif_usbdev_recv(
-    const dif_usbdev_t *usbdev, dif_usbdev_rx_packet_info_t *packet_info,
-    dif_usbdev_buffer_t *buffer);
-
-/**
- * Return codes for `dif_usbdev_buffer_read`.
- */
-typedef enum dif_usbdev_buffer_read_result {
-  /**
-   * Indicates that the call succeeded and the entire packet payload is read.
-   */
-  kDifUsbdevBufferReadResultOK,
-  /**
-   * Indicates that a non-specific error occurred and the hardware is in an
-   * invalid or irrecoverable state.
-   */
-  kDifUsbdevBufferReadResultError,
-  /**
-   * Indicates that the caller supplied invalid arguments but the call did not
-   * cause any side-effects and the hardware is in a valid and recoverable
-   * state.
-   */
-  kDifUsbdevBufferReadResultBadArg,
-  /**
-   * Indicates that the call was successful but there are remaining bytes to be
-   * read.
-   */
-  kDifUsbdevBufferReadResultContinue,
-} dif_usbdev_buffer_read_result_t;
+dif_result_t dif_usbdev_recv(const dif_usbdev_t *usbdev,
+                             dif_usbdev_rx_packet_info_t *packet_info,
+                             dif_usbdev_buffer_t *buffer);
 
 /**
  * Read incoming packet payload.
@@ -435,10 +344,10 @@ typedef enum dif_usbdev_buffer_read_result {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_buffer_read_result_t dif_usbdev_buffer_read(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    dif_usbdev_buffer_t *buffer, uint8_t *dst, size_t dst_len,
-    size_t *bytes_written);
+dif_result_t dif_usbdev_buffer_read(const dif_usbdev_t *usbdev,
+                                    dif_usbdev_buffer_pool_t *buffer_pool,
+                                    dif_usbdev_buffer_t *buffer, uint8_t *dst,
+                                    size_t dst_len, size_t *bytes_written);
 
 /**
  * Return a buffer to the free buffer pool.
@@ -459,34 +368,9 @@ dif_usbdev_buffer_read_result_t dif_usbdev_buffer_read(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_buffer_return(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    dif_usbdev_buffer_t *buffer);
-
-/**
- * Return codes for `dif_usbdev_buffer_request`.
- */
-typedef enum dif_usbdev_buffer_request_result {
-  /**
-   * Indicates that the call succeeded.
-   */
-  kDifUsbdevBufferRequestResultOK = kDifUsbdevOK,
-  /**
-   * Indicates that a non-specific error occurred and the hardware is in an
-   * invalid or irrecoverable state.
-   */
-  kDifUsbdevBufferRequestResultError = kDifUsbdevError,
-  /**
-   * Indicates that the caller supplied invalid arguments but the call did not
-   * cause any side-effects and the hardware is in a valid and recoverable
-   * state.
-   */
-  kDifUsbdevBufferRequestResultBadArg = kDifUsbdevBadArg,
-  /**
-   * Indicates that there are no free buffers.
-   */
-  kDifUsbdevBufferRequestResultNoBuffers,
-} dif_usbdev_buffer_request_result_t;
+dif_result_t dif_usbdev_buffer_return(const dif_usbdev_t *usbdev,
+                                      dif_usbdev_buffer_pool_t *buffer_pool,
+                                      dif_usbdev_buffer_t *buffer);
 
 /**
  * Request a buffer for outgoing packet payload.
@@ -522,31 +406,9 @@ typedef enum dif_usbdev_buffer_request_result {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_buffer_request_result_t dif_usbdev_buffer_request(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    dif_usbdev_buffer_t *buffer);
-
-typedef enum dif_usbdev_buffer_write_result {
-  /**
-   * Indicates that the call succeeded.
-   */
-  kDifUsbdevBufferWriteResultOK = kDifUsbdevOK,
-  /**
-   * Indicates that a non-specific error occurred and the hardware is in an
-   * invalid or irrecoverable state.
-   */
-  kDifUsbdevBufferWriteResultError = kDifUsbdevError,
-  /**
-   * Indicates that the caller supplied invalid arguments but the call did not
-   * cause any side-effects and the hardware is in a valid and recoverable
-   * state.
-   */
-  kDifUsbdevBufferWriteResultBadArg = kDifUsbdevBadArg,
-  /**
-   * Indicates that the requested write exceeds the device buffer size.
-   */
-  kDifUsbdevBufferWriteResultFull,
-} dif_usbdev_buffer_write_result_t;
+dif_result_t dif_usbdev_buffer_request(const dif_usbdev_t *usbdev,
+                                       dif_usbdev_buffer_pool_t *buffer_pool,
+                                       dif_usbdev_buffer_t *buffer);
 
 /**
  * Write outgoing packet payload.
@@ -568,9 +430,9 @@ typedef enum dif_usbdev_buffer_write_result {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_buffer_write_result_t dif_usbdev_buffer_write(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_t *buffer, uint8_t *src,
-    size_t src_len, size_t *bytes_written);
+dif_result_t dif_usbdev_buffer_write(const dif_usbdev_t *usbdev,
+                                     dif_usbdev_buffer_t *buffer, uint8_t *src,
+                                     size_t src_len, size_t *bytes_written);
 
 /**
  * Mark a packet ready for transmission from an endpoint.
@@ -601,9 +463,8 @@ dif_usbdev_buffer_write_result_t dif_usbdev_buffer_write(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_send(const dif_usbdev_t *usbdev,
-                                    uint8_t endpoint,
-                                    dif_usbdev_buffer_t *buffer);
+dif_result_t dif_usbdev_send(const dif_usbdev_t *usbdev, uint8_t endpoint,
+                             dif_usbdev_buffer_t *buffer);
 
 /**
  * Status of an outgoing packet.
@@ -647,9 +508,10 @@ typedef enum dif_usbdev_tx_status {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_get_tx_status(
-    const dif_usbdev_t *usbdev, dif_usbdev_buffer_pool_t *buffer_pool,
-    uint8_t endpoint, dif_usbdev_tx_status_t *status);
+dif_result_t dif_usbdev_get_tx_status(const dif_usbdev_t *usbdev,
+                                      dif_usbdev_buffer_pool_t *buffer_pool,
+                                      uint8_t endpoint,
+                                      dif_usbdev_tx_status_t *status);
 
 /**
  * Set the address of a USB device.
@@ -659,8 +521,7 @@ dif_usbdev_result_t dif_usbdev_get_tx_status(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_address_set(const dif_usbdev_t *usbdev,
-                                           uint8_t addr);
+dif_result_t dif_usbdev_address_set(const dif_usbdev_t *usbdev, uint8_t addr);
 
 /**
  * Get the address of a USB device.
@@ -670,8 +531,7 @@ dif_usbdev_result_t dif_usbdev_address_set(const dif_usbdev_t *usbdev,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev,
-                                           uint8_t *addr);
+dif_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev, uint8_t *addr);
 
 /**
  * Get USB frame index.
@@ -681,8 +541,8 @@ dif_usbdev_result_t dif_usbdev_address_get(const dif_usbdev_t *usbdev,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_frame(const dif_usbdev_t *usbdev,
-                                                uint16_t *frame_index);
+dif_result_t dif_usbdev_status_get_frame(const dif_usbdev_t *usbdev,
+                                         uint16_t *frame_index);
 
 /**
  * Check if the host is lost.
@@ -696,8 +556,8 @@ dif_usbdev_result_t dif_usbdev_status_get_frame(const dif_usbdev_t *usbdev,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_host_lost(const dif_usbdev_t *usbdev,
-                                                    bool *host_lost);
+dif_result_t dif_usbdev_status_get_host_lost(const dif_usbdev_t *usbdev,
+                                             bool *host_lost);
 
 /**
  * USB link state.
@@ -718,7 +578,7 @@ typedef enum dif_usbdev_link_state {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_link_state(
+dif_result_t dif_usbdev_status_get_link_state(
     const dif_usbdev_t *usbdev, dif_usbdev_link_state_t *link_state);
 
 /**
@@ -730,8 +590,8 @@ dif_usbdev_result_t dif_usbdev_status_get_link_state(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_sense(const dif_usbdev_t *usbdev,
-                                                bool *sense);
+dif_result_t dif_usbdev_status_get_sense(const dif_usbdev_t *usbdev,
+                                         bool *sense);
 
 /**
  * Get the depth of the AV FIFO.
@@ -743,7 +603,7 @@ dif_usbdev_result_t dif_usbdev_status_get_sense(const dif_usbdev_t *usbdev,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_available_fifo_depth(
+dif_result_t dif_usbdev_status_get_available_fifo_depth(
     const dif_usbdev_t *usbdev, uint8_t *depth);
 /**
  * Check if AV FIFO is full.
@@ -755,7 +615,7 @@ dif_usbdev_result_t dif_usbdev_status_get_available_fifo_depth(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_available_fifo_full(
+dif_result_t dif_usbdev_status_get_available_fifo_full(
     const dif_usbdev_t *usbdev, bool *is_full);
 /**
  * Get the depth of the RX FIFO.
@@ -767,8 +627,8 @@ dif_usbdev_result_t dif_usbdev_status_get_available_fifo_full(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_depth(
-    const dif_usbdev_t *usbdev, uint8_t *depth);
+dif_result_t dif_usbdev_status_get_rx_fifo_depth(const dif_usbdev_t *usbdev,
+                                                 uint8_t *depth);
 
 /**
  * Check if the RX FIFO is empty.
@@ -781,167 +641,8 @@ dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_depth(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_status_get_rx_fifo_empty(
-    const dif_usbdev_t *usbdev, bool *is_empty);
-
-/**
- * USB device interrupts.
- */
-typedef enum dif_usbdev_irq {
-  /**
-   * \internal First USB device interrupt.
-   */
-  kDifUsbdevIrqFirst,
-  /**
-   * A packet was received as part of an OUT or SETUP transaction.
-   */
-  kDifUsbdevIrqPktReceived = kDifUsbdevIrqFirst,
-  /**
-   * A packet was sent as part of an IN transaction.
-   */
-  kDifUsbdevIrqPktSent,
-  /**
-   * VBUS was lost and the link was disconnected.
-   */
-  kDifUsbdevIrqDisconnected,
-  /**
-   * A Start-of-Frame (SOF) packet was not received on an active link
-   * for 4.096 ms. The host must send a SOF packet every 1 ms.
-   */
-  kDifUsbdevIrqHostLost,
-  /**
-   * Link was reset by the host.
-   */
-  kDifUsbdevIrqLinkReset,
-  /**
-   * Link was suspended by the host.
-   */
-  kDifUsbdevIrqLinkSuspend,
-  /**
-   * Link became active again after being suspended.
-   */
-  kDifUsbdevIrqLinkResume,
-  /**
-   * Available buffer FIFO was empty.
-   */
-  kDifUsbdevIrqAvEmpty,
-  /**
-   * Received buffer FIFO was full.
-   */
-  kDifUsbdevIrqRxFull,
-  /**
-   * A write was done to available buffer FIFO when it was full.
-   */
-  kDifUsbdevIrqAvOverflow,
-  /**
-   * The ACK packet expected in response to an IN transaction was
-   * not received.
-   */
-  kDifUsbdevIrqLinkInError,
-  /**
-   * A CRC error occurred.
-   */
-  kDifUsbdevIrqRxCrcError,
-  /**
-   * A packet with an invalid packet identifier (PID) was received.
-   */
-  kDifUsbdevIrqRxPidError,
-  /**
-   * A packet with invalid bitstuffing was received.
-   */
-  kDifUsbdevIrqRxBitstuffError,
-  /**
-   * USB frame number was updated with a valid SOF packet.
-   */
-  kDifUsbdevIrqFrame,
-  /**
-   * VBUS was detected.
-   */
-  kDifUsbdevIrqConnected,
-  /**
-   * \internal Last USB device interrupt.
-   */
-  kDifUsbdevIrqLast = kDifUsbdevIrqConnected
-} dif_usbdev_irq_t;
-
-/**
- * Enable or disable an interrupt.
- *
- * @param usbdev A USB device.
- * @param irq An interrupt.
- * @param state New state of the interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_enable(const dif_usbdev_t *usbdev,
-                                          dif_usbdev_irq_t irq,
-                                          dif_usbdev_toggle_t state);
-
-/**
- * Check if there is a pending request for an interrupt.
- *
- * @param usbdev A USB device.
- * @param irq An interrupt.
- * @param[out] state State of the interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_get(const dif_usbdev_t *usbdev,
-                                       dif_usbdev_irq_t irq, bool *state);
-
-/**
- * Clear an interrupt.
- *
- * @param usbdev A USB device.
- * @param irq An interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_clear(const dif_usbdev_t *usbdev,
-                                         dif_usbdev_irq_t irq);
-
-/**
- * Clear all pending interrupts.
- *
- * @param usbdev A USB device.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_clear_all(const dif_usbdev_t *usbdev);
-
-/**
- * Disable all interrupts and optionally return the current interrupt
- * configuration.
- *
- * @param usbdev A USB device.
- * @param[out] cur_config Current interrupt configuration.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_disable_all(const dif_usbdev_t *usbdev,
-                                               uint32_t *cur_config);
-
-/**
- * Restore interrupt configuration.
- *
- * @param usbdev A USB device.
- * @param new_config New interrupt configuration.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_restore(const dif_usbdev_t *usbdev,
-                                           uint32_t new_config);
-
-/**
- * Test an interrupt.
- *
- * @param usbdev A USB device.
- * @param irq An interrupt.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_usbdev_result_t dif_usbdev_irq_test(const dif_usbdev_t *usbdev,
-                                        dif_usbdev_irq_t irq);
+dif_result_t dif_usbdev_status_get_rx_fifo_empty(const dif_usbdev_t *usbdev,
+                                                 bool *is_empty);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -323,8 +323,28 @@ sw_lib_dif_usbdev = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_usbdev,
     ],
   )
+)
+
+test('dif_usbdev_unittest', executable(
+    'dif_usbdev_unittest',
+    sources: [
+      'autogen/dif_usbdev_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_usbdev.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_usbdev_autogen.c',
+      hw_ip_usbdev_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO'],
+    cpp_args: ['-DMOCK_MMIO'],
+  ),
+  suite: 'dif',
 )
 
 # HMAC device DIF library


### PR DESCRIPTION
This is PR 2/2 that partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "usbdev".

- The **fist** commit checks-in the auto-generated USBDEV IRQ DIFs and supporting typedefs/enums.
- The **second** commit integrates the auto-generated DIFs into the existing DIFs build targets.

**Note:** this depends on #8562, and thus has duplicate commits that will be removed when #8562 is merged.