### PR TITLE
[chip,dv,sw] Add a spinwait API

### DIFF
--- a/sw/device/lib/runtime/ibex.c
+++ b/sw/device/lib/runtime/ibex.c
@@ -19,3 +19,6 @@ uint32_t ibex_mtval_read(void) {
   CSR_READ(CSR_REG_MTVAL, &mtval);
   return mtval;
 }
+
+extern ibex_timeout_t ibex_timeout_init(uint32_t timeout_usec);
+extern bool ibex_timeout_check(const ibex_timeout_t *timeout);


### PR DESCRIPTION
This commit introduces a SPIWAIT macro that accepts an expression, a
timeout value in microseconds and boolean output indicating the timeout
occurred.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>