### PR TITLE
[otbn,dv] Move decision about stats collection to start()

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -46,8 +46,8 @@ def main() -> int:
 
     sim.state.ext_regs.commit()
 
-    sim.start()
-    sim.run(verbose=args.verbose, collect_stats=collect_stats)
+    sim.start(collect_stats)
+    sim.run(verbose=args.verbose)
 
     if exp_end_addr is not None:
         if sim.state.pc != exp_end_addr:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -85,7 +85,7 @@ def on_start(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
     print('START')
     sim.state.ext_regs.commit()
-    sim.start()
+    sim.start(collect_stats=False)
 
     return None
 
@@ -99,7 +99,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     pc = sim.state.pc
     assert 0 == pc & 3
 
-    insn, changes = sim.step(verbose=False, collect_stats=False)
+    insn, changes = sim.step(verbose=False)
 
     if insn is None:
         print('STALL')
@@ -123,7 +123,7 @@ def on_run(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
     print('RUN')
 
-    sim.run(verbose=False, collect_stats=False)
+    sim.run(verbose=False)
 
     print(' INSN_CNT = {:#x}'.format(sim.state.ext_regs.read('INSN_CNT', False)))
     print(' ERR_BITS = {:#x}'.format(sim.state.ext_regs.read('ERR_BITS', False)))

--- a/hw/ip/otbn/dv/otbnsim/test/state_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/state_test.py
@@ -18,8 +18,8 @@ def test_ext_regs_success(tmpdir: py.path.local) -> None:
     ecall
     """
 
-    sim = prepare_sim_for_asm_str(simple_asm, tmpdir)
-    sim.run(verbose=False, collect_stats=False)
+    sim = prepare_sim_for_asm_str(simple_asm, tmpdir, False)
+    sim.run(verbose=False)
 
     assert sim.state.ext_regs.read('ERR_BITS', False) == 0
     assert sim.state.ext_regs.read('FATAL_ALERT_CAUSE', False) == 0
@@ -42,8 +42,8 @@ def test_ext_regs_err_bits_bad(tmpdir: py.path.local) -> None:
     ecall
     """
 
-    sim = prepare_sim_for_asm_str(invalid_jump_asm, tmpdir)
-    sim.run(verbose=False, collect_stats=False)
+    sim = prepare_sim_for_asm_str(invalid_jump_asm, tmpdir, False)
+    sim.run(verbose=False)
 
     assert sim.state.ext_regs.read('ERR_BITS', False) == ErrBits.BAD_INSN_ADDR
 

--- a/hw/ip/otbn/dv/otbnsim/test/stats_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/stats_test.py
@@ -11,7 +11,7 @@ import testutil
 
 
 def _run_sim_for_stats(sim: OTBNSim) -> ExecutionStats:
-    sim.run(verbose=False, collect_stats=True)
+    sim.run(verbose=False)
 
     # Ensure that the execution was successful.
     assert sim.state.ext_regs.read('ERR_BITS', False) == 0
@@ -23,12 +23,12 @@ def _run_sim_for_stats(sim: OTBNSim) -> ExecutionStats:
 def _simulate_asm_file(asm_file: str, tmpdir: py.path.local) -> ExecutionStats:
     '''Run the OTBN simulator, collect statistics, and return them.'''
 
-    sim = testutil.prepare_sim_for_asm_file(asm_file, tmpdir)
+    sim = testutil.prepare_sim_for_asm_file(asm_file, tmpdir, True)
     return _run_sim_for_stats(sim)
 
 
 def _simulate_asm_str(assembly: str, tmpdir: py.path.local) -> ExecutionStats:
-    sim = testutil.prepare_sim_for_asm_str(assembly, tmpdir)
+    sim = testutil.prepare_sim_for_asm_str(assembly, tmpdir, True)
     return _run_sim_for_stats(sim)
 
 

--- a/hw/ip/otbn/dv/otbnsim/test/testutil.py
+++ b/hw/ip/otbn/dv/otbnsim/test/testutil.py
@@ -32,7 +32,9 @@ def asm_and_link_one_file(asm_path: str, work_dir: py.path.local) -> str:
     return elf_path
 
 
-def prepare_sim_for_asm_file(asm_file: str, tmpdir: py.path.local) -> OTBNSim:
+def prepare_sim_for_asm_file(asm_file: str,
+                             tmpdir: py.path.local,
+                             collect_stats: bool) -> OTBNSim:
     '''Set up the simulation of a single assembly file.
 
     The returned simulation is ready to be run through the run() method.
@@ -45,11 +47,13 @@ def prepare_sim_for_asm_file(asm_file: str, tmpdir: py.path.local) -> OTBNSim:
     load_elf(sim, elf_file)
 
     sim.state.ext_regs.commit()
-    sim.start()
+    sim.start(collect_stats)
     return sim
 
 
-def prepare_sim_for_asm_str(assembly: str, tmpdir: py.path.local) -> OTBNSim:
+def prepare_sim_for_asm_str(assembly: str,
+                            tmpdir: py.path.local,
+                            collect_stats: bool) -> OTBNSim:
     '''Set up the simulation for an assembly snippet passed as string.
 
     The returned simulation is ready to be run through the run() method.
@@ -58,4 +62,4 @@ def prepare_sim_for_asm_str(assembly: str, tmpdir: py.path.local) -> OTBNSim:
     with tempfile.NamedTemporaryFile('w', dir=tmpdir) as fp:
         fp.write(assembly)
         fp.flush()
-        return prepare_sim_for_asm_file(fp.name, tmpdir)
+        return prepare_sim_for_asm_file(fp.name, tmpdir, collect_stats)


### PR DESCRIPTION
This tidies up some downstream logic (especially with an upcoming
refactoring) because we can collect statistics iff the `self.stats`
object is not None. Much easier than wiring through a flag.