### PR TITLE
[clkmgr] Update measurement errors to request alerts only once

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -344,7 +344,7 @@
     { name: "RECOV_ERR_CODE",
       desc: "Recoverable Error code ",
       swaccess: "rw1c",
-      hwaccess: "hrw",
+      hwaccess: "hwo",
       fields: [
 % for src in typed_clocks.rg_srcs:
         {

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -142,9 +142,15 @@
     reg2hw.alert_test.recov_fault.q & reg2hw.alert_test.recov_fault.qe
   };
 
+  logic recov_alert;
+  assign recov_alert =
+% for src in typed_clocks.rg_srcs:
+    hw2reg.recov_err_code.${src}_measure_err.de${";" if loop.last else " |"}
+% endfor
+
   assign alerts = {
     |reg2hw.fatal_err_code,
-    |reg2hw.recov_err_code
+    recov_alert
   };
 
   localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -584,7 +584,7 @@
     { name: "RECOV_ERR_CODE",
       desc: "Recoverable Error code ",
       swaccess: "rw1c",
-      hwaccess: "hrw",
+      hwaccess: "hwo",
       fields: [
         {
           bits: "0",

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -173,9 +173,17 @@
     reg2hw.alert_test.recov_fault.q & reg2hw.alert_test.recov_fault.qe
   };
 
+  logic recov_alert;
+  assign recov_alert =
+    hw2reg.recov_err_code.io_measure_err.de |
+    hw2reg.recov_err_code.io_div2_measure_err.de |
+    hw2reg.recov_err_code.io_div4_measure_err.de |
+    hw2reg.recov_err_code.main_measure_err.de |
+    hw2reg.recov_err_code.usb_measure_err.de;
+
   assign alerts = {
     |reg2hw.fatal_err_code,
-    |reg2hw.recov_err_code
+    recov_alert
   };
 
   localparam logic [NumAlerts-1:0] AlertFatal = {1'b1, 1'b0};

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -135,24 +135,6 @@ package clkmgr_reg_pkg;
   } clkmgr_reg2hw_usb_measure_ctrl_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        q;
-    } io_measure_err;
-    struct packed {
-      logic        q;
-    } io_div2_measure_err;
-    struct packed {
-      logic        q;
-    } io_div4_measure_err;
-    struct packed {
-      logic        q;
-    } main_measure_err;
-    struct packed {
-      logic        q;
-    } usb_measure_err;
-  } clkmgr_reg2hw_recov_err_code_reg_t;
-
-  typedef struct packed {
     logic        q;
   } clkmgr_reg2hw_fatal_err_code_reg_t;
 
@@ -209,17 +191,16 @@ package clkmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_alert_test_reg_t alert_test; // [124:121]
-    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [120:113]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [112:112]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [111:108]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [107:103]
-    clkmgr_reg2hw_io_measure_ctrl_reg_t io_measure_ctrl; // [102:82]
-    clkmgr_reg2hw_io_div2_measure_ctrl_reg_t io_div2_measure_ctrl; // [81:63]
-    clkmgr_reg2hw_io_div4_measure_ctrl_reg_t io_div4_measure_ctrl; // [62:46]
-    clkmgr_reg2hw_main_measure_ctrl_reg_t main_measure_ctrl; // [45:25]
-    clkmgr_reg2hw_usb_measure_ctrl_reg_t usb_measure_ctrl; // [24:6]
-    clkmgr_reg2hw_recov_err_code_reg_t recov_err_code; // [5:1]
+    clkmgr_reg2hw_alert_test_reg_t alert_test; // [119:116]
+    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [115:108]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [107:107]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [106:103]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [102:98]
+    clkmgr_reg2hw_io_measure_ctrl_reg_t io_measure_ctrl; // [97:77]
+    clkmgr_reg2hw_io_div2_measure_ctrl_reg_t io_div2_measure_ctrl; // [76:58]
+    clkmgr_reg2hw_io_div4_measure_ctrl_reg_t io_div4_measure_ctrl; // [57:41]
+    clkmgr_reg2hw_main_measure_ctrl_reg_t main_measure_ctrl; // [40:20]
+    clkmgr_reg2hw_usb_measure_ctrl_reg_t usb_measure_ctrl; // [19:1]
     clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [0:0]
   } clkmgr_reg2hw_t;
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -1372,7 +1372,7 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.recov_err_code.io_measure_err.q),
+    .q      (),
 
     // to register interface (read)
     .qs     (recov_err_code_io_measure_err_qs)
@@ -1397,7 +1397,7 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.recov_err_code.io_div2_measure_err.q),
+    .q      (),
 
     // to register interface (read)
     .qs     (recov_err_code_io_div2_measure_err_qs)
@@ -1422,7 +1422,7 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.recov_err_code.io_div4_measure_err.q),
+    .q      (),
 
     // to register interface (read)
     .qs     (recov_err_code_io_div4_measure_err_qs)
@@ -1447,7 +1447,7 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.recov_err_code.main_measure_err.q),
+    .q      (),
 
     // to register interface (read)
     .qs     (recov_err_code_main_measure_err_qs)
@@ -1472,7 +1472,7 @@ module clkmgr_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.recov_err_code.usb_measure_err.q),
+    .q      (),
 
     // to register interface (read)
     .qs     (recov_err_code_usb_measure_err_qs)


### PR DESCRIPTION
- previously alerts were requested until software explicitly cleared, but
  this was deemed unacceptable behavior.

- Fixes #8556

Signed-off-by: Timothy Chen <timothytim@google.com>