### PR TITLE
Revert "[otbn,dv] Sort out timing for done/status signals in ISS"

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -35,8 +35,9 @@ module otbn_core_model
   input  logic                     rst_edn_ni,
 
   input  logic                     start_i, // start the operation
+  output bit                       done_o,  // operation done
 
-  output err_bits_t                err_bits_o, // updated when STATUS switches to idle
+  output err_bits_t                err_bits_o, // valid when done_o is asserted
 
   input  edn_pkg::edn_rsp_t        edn_rnd_i, // EDN response interface
   input  logic                     edn_rnd_cdc_done_i, // RND from EDN is valid (DUT perspective)
@@ -44,8 +45,6 @@ module otbn_core_model
 
   output bit [7:0]       status_o,   // STATUS register
   output bit [31:0]      insn_cnt_o, // INSN_CNT register
-
-  output bit             done_r_o, // A model of the core's done_o signal, delayed by 1 cycle
 
   output bit             err_o // something went wrong
 );
@@ -141,6 +140,17 @@ module otbn_core_model
   assign status_o = status_q;
   assign insn_cnt_o = insn_cnt_q;
 
+  // Track negedges of running_q and expose that as a "done" output.
+  bit running_r = 1'b0;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      running_r <= 1'b0;
+    end else begin
+      running_r <= running;
+    end
+  end
+  assign done_o = running_r & ~running;
+
   // If DesignScope is not empty, we have a design to check. Bind a copy of otbn_rf_snooper_if into
   // each register file. The otbn_model_check() function will use these to extract memory contents.
   if (DesignScope != "") begin: g_check_design
@@ -171,20 +181,6 @@ module otbn_core_model
   end
 
   assign err_o = failed_step | failed_cmp;
-
-  // Derive a "done" signal. This should trigger for a single cycle when OTBN finishes its work.
-  // It's analogous to the done_o signal on otbn_core, but this signal is delayed by a single cycle
-  // (hence its name is done_r_o).
-  bit otbn_model_busy, otbn_model_busy_r;
-  assign otbn_model_busy = (status_q != StatusIdle) && (status_q != StatusLocked);
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      otbn_model_busy_r <= 1'b0;
-    end else begin
-      otbn_model_busy_r <= otbn_model_busy;
-    end
-  end
-  assign done_r_o = otbn_model_busy_r & ~otbn_model_busy;
 
   // Make stop_pc available over DPI. This is handy for Verilator simulations (where the top-level
   // is in C++).

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
@@ -12,6 +12,7 @@ package otbn_model_agent_pkg;
     otbn_trace_checker_pop_iss_insn(output bit [31:0] insn_addr, output string mnemonic);
 
   typedef enum {
+    OtbnModelStart,
     OtbnModelStatus,
     OtbnModelInsn
   } otbn_model_item_type_e;

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -16,6 +16,7 @@ interface otbn_model_if #(
   logic                     start;        // Start the operation
 
   // Outputs from DUT
+  bit                       done;         // Operation done
   bit                       err;          // Something went wrong
   bit [31:0]                stop_pc;      // PC at end of operation
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
@@ -21,10 +21,30 @@ class otbn_model_monitor extends dv_base_monitor #(
 
   protected task collect_trans(uvm_phase phase);
     fork
+      collect_start();
       collect_status();
       // TODO: Only run when coverage is enabled.
       collect_insns();
     join
+  endtask
+
+  protected task collect_start();
+    otbn_model_item trans;
+
+    forever begin
+      // Collect transactions on each clock edge when reset is high.
+      @(posedge cfg.vif.clk_i);
+      if (cfg.vif.rst_ni === 1'b1) begin
+        if (cfg.vif.start) begin
+          trans = otbn_model_item::type_id::create("trans");
+          trans.item_type = OtbnModelStart;
+          trans.status    = 0;
+          trans.err       = 0;
+          trans.mnemonic  = "";
+          analysis_port.write(trans);
+        end
+      end
+    end
   endtask
 
   protected task collect_status();

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -157,7 +157,7 @@ module tb;
   // to grab the decoded signal from TL transactions on the cycle it happens. We have an explicit
   // check in the scoreboard to ensure that this gets asserted at the time we expect (to spot any
   // decoding errors).
-  assign model_if.start = dut.start_d;
+  assign model_if.start = dut.start_q;
 
   // Valid signals below are set when DUT finishes processing incoming 32b packages and constructs
   // 256b EDN data. Model checks if the processing of the packages are done in maximum of 5 cycles
@@ -182,6 +182,7 @@ module tb;
     .rst_edn_ni   (edn_rst_n),
 
     .start_i      (model_if.start),
+    .done_o       (model_if.done),
 
     .err_bits_o   (),
 
@@ -192,8 +193,6 @@ module tb;
 
     .status_o     (model_if.status),
     .insn_cnt_o   (model_insn_cnt),
-
-    .done_r_o     (),
 
     .err_o        (model_if.err)
   );
@@ -224,11 +223,12 @@ module tb;
   // These are the sort of checks that are easier to state at the design level than in terms of UVM
   // transactions.
 
-  // Check that the status output from the model exactly matches the register from the dut. In
-  // theory, we could see mismatches by probing the STATUS register over the TL bus, but we have to
-  // be lucky with exactly when the reads happen if we want to see off-by-one cycle errors. This
-  // assertion gives a continuous check.
-  `ASSERT(MatchingStatus_A, dut.hw2reg.status.d == model_if.status, clk, !rst_n)
+  // Check that the idle output from the DUT is the inverse of the model's "done" signal.
+  // Separately, the code in otbn_idle_checker.sv checks that the idle output from the DUT is also
+  // the inverse of the "done" signal that we expect. Combining the two tells us that the RTL and
+  // model agree about whether they are running or not.
+  `ASSERT(MatchingDone_A, idle == !model_if.done, clk, rst_n)
+
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -281,9 +281,9 @@ module otbn_top_sim (
 
   localparam string DesignScope = "..u_otbn_core";
 
+  logic      otbn_model_done;
   err_bits_t otbn_model_err_bits;
   bit [31:0] otbn_model_insn_cnt;
-  bit        otbn_model_done_r;
   bit        otbn_model_err;
 
   otbn_core_model #(
@@ -298,6 +298,7 @@ module otbn_top_sim (
     .rst_edn_ni            ( IO_RST_N ),
 
     .start_i               ( otbn_start ),
+    .done_o                ( otbn_model_done ),
 
     .err_bits_o            ( otbn_model_err_bits ),
 
@@ -305,10 +306,8 @@ module otbn_top_sim (
     .edn_rnd_cdc_done_i    ( edn_rnd_data_valid ),
     .edn_urnd_data_valid_i ( edn_urnd_data_valid ),
 
-    .status_o              ( ),
+    .status_o              (),
     .insn_cnt_o            ( otbn_model_insn_cnt ),
-
-    .done_r_o              ( otbn_model_done_r ),
 
     .err_o                 ( otbn_model_err )
   );
@@ -323,17 +322,12 @@ module otbn_top_sim (
       cnt_mismatch_latched      <= 1'b0;
       model_err_latched         <= 1'b0;
     end else begin
-      // Check that the 'done_o' output from the RTL matches the 'done_r_o' output from the model
-      // (with one cycle delay).
-      if (otbn_done_q && !otbn_model_done_r) begin
-        $display("ERROR: At time %0t, RTL done on previous cycle, but model still busy.", $time);
+      if (otbn_done_q != otbn_model_done) begin
+        $display("ERROR: At time %0t, otbn_done_q != otbn_model_done (%0d != %0d).",
+                 $time, otbn_done_q, otbn_model_done);
         done_mismatch_latched <= 1'b1;
       end
-      if (otbn_model_done_r && !otbn_done_q) begin
-        $display("ERROR: At time %0t, model finished, but RTL not done in time.", $time);
-        done_mismatch_latched <= 1'b1;
-      end
-      if (otbn_model_done_r && otbn_done_q) begin
+      if (otbn_done_q && otbn_model_done) begin
         if (otbn_err_bits_q != otbn_model_err_bits) begin
           $display("ERROR: At time %0t, otbn_err_bits != otbn_model_err_bits (0x%0x != 0x%0x).",
                    $time, otbn_err_bits_q, otbn_model_err_bits);

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -756,7 +756,7 @@ module otbn
     end
 
     // Mux between model and RTL implementation at runtime.
-    logic         done_r_model, done_rtl;
+    logic         done_model, done_rtl;
     logic         locked_model, locked_rtl;
     logic         start_model, start_rtl;
     err_bits_t    err_bits_model, err_bits_rtl;
@@ -764,9 +764,7 @@ module otbn
     logic         edn_rnd_data_valid;
     logic         edn_urnd_data_valid;
 
-    // Note that the "done" signal will come a cycle later when using the model as a core than it
-    // does when using the RTL
-    assign done = otbn_use_model ? done_r_model : done_rtl;
+    assign done = otbn_use_model ? done_model : done_rtl;
     assign locked = otbn_use_model ? locked_model : locked_rtl;
     assign err_bits = otbn_use_model ? err_bits_model : err_bits_rtl;
     assign insn_cnt = otbn_use_model ? insn_cnt_model : insn_cnt_rtl;
@@ -790,6 +788,7 @@ module otbn
       .rst_edn_ni,
 
       .start_i               (start_model),
+      .done_o                (done_model),
 
       .err_bits_o            (err_bits_model),
 
@@ -799,8 +798,6 @@ module otbn
       .edn_urnd_data_valid_i (edn_urnd_data_valid),
 
       .insn_cnt_o            (insn_cnt_model),
-
-      .done_r_o (done_r_model),
 
       .err_o ()
     );


### PR DESCRIPTION
This reverts commit aee499c3e167096c6baecf8f9e989d75e94125ff.

This commit breaks private CI:

```
2021-10-07T15:41:49.9790201Z ### Test Results
2021-10-07T15:41:49.9790752Z |  Milestone  |          Name           | Tests             |  Passing  |  Total  |  Pass Rate  |
2021-10-07T15:41:49.9792463Z |:-----------:|:-----------------------:|:------------------|:---------:|:-------:|:-----------:|
2021-10-07T15:41:49.9793370Z |     V1      |          smoke          | otbn_smoke        |     0     |    1    |   0.00 %    |
2021-10-07T15:41:49.9794048Z |     V1      |      csr_hw_reset       | otbn_csr_hw_reset |     1     |    1    |  100.00 %   |
2021-10-07T15:41:49.9794785Z |     V1      |         csr_rw          | otbn_csr_rw       |     1     |    1    |  100.00 %   |
2021-10-07T15:41:49.9795479Z |     V1      |                         | **TOTAL**         |     2     |    3    |   66.67 %   |
2021-10-07T15:41:49.9796165Z |     V2      | tl_d_outstanding_access | otbn_csr_hw_reset |     1     |    1    |  100.00 %   |
2021-10-07T15:41:49.9796889Z |             |                         | otbn_csr_rw       |     1     |    1    |  100.00 %   |
2021-10-07T15:41:49.9797568Z |     V2      |   tl_d_partial_access   | otbn_csr_hw_reset |     1     |    1    |  100.00 %   |
2021-10-07T15:41:49.9798330Z |             |                         | otbn_csr_rw       |     1     |    1    |  100.00 %   |
2021-10-07T15:41:49.9799006Z |             |                         | **TOTAL**         |     2     |    3    |   66.67 %   |
2021-10-07T15:41:49.9799366Z
2021-10-07T15:41:49.9799751Z ## Failure Buckets
2021-10-07T15:41:49.9799998Z
2021-10-07T15:41:49.9800721Z * `UVM_ERROR (otbn_scoreboard.sv:240) [scoreboard] Check failed item.d_data == exp_read_data.val (* [*] vs * [*]) value for register otbn_reg_block.status` has 1 failures:
2021-10-07T15:41:49.9801604Z     * Test otbn_smoke has 1 failures.
2021-10-07T15:41:49.9802534Z         * 0.otbn_smoke.1\
2021-10-07T15:41:49.9803525Z           Line 42, in log /azp/agent/_work/1/s/scratch/HEAD/otbn-sim-vcs/0.otbn_smoke/out/run.log
2021-10-07T15:41:49.9804259Z
2021-10-07T15:41:49.9805026Z                 UVM_ERROR @ 184377673 ps: (otbn_scoreboard.sv:240) [uvm_test_top.env.scoreboard] Check failed item.d_data == exp_read_data.val (0 [0x0] vs 1 [0x1]) value for register otbn_reg_block.status
2021-10-07T15:41:49.9806203Z                 UVM_INFO @ 184377673 ps: (uvm_report_server.svh:901) [UVM/REPORT/SERVER]
2021-10-07T15:41:49.9807126Z                 --- UVM Report Summary ---
2021-10-07T15:41:49.9807650Z
2021-10-07T15:41:49.9808110Z                 Quit count reached!
```