### PR TITLE
[rstmgr] Add missing dependency on alert_handler_component

### DIFF
--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:clock_mux2
       - lowrisc:prim:lc_sender
       - lowrisc:prim:lc_sync
+      - lowrisc:ip:alert_handler_component
       - "fileset_ip     ? (lowrisc:ip:rstmgr_pkg)"
       - "fileset_top    ? (lowrisc:systems:rstmgr_pkg)"
       - "fileset_top    ? (lowrisc:systems:rstmgr)"


### PR DESCRIPTION
`rstmgr.sv` uses `alert_pkg`. The package containing this file needs to
be listed as dependency.