### PR TITLE
[otbn] Remove unneeded assertion

### DIFF
--- a/hw/ip/otbn/rtl/otbn_rnd.sv
+++ b/hw/ip/otbn/rtl/otbn_rnd.sv
@@ -170,6 +170,5 @@ module otbn_rnd import otbn_pkg::*;
     end
   end
 
-  `ASSERT(rnd_req_stable, rnd_req_i & ~rnd_valid_o |=> rnd_req_i)
   `ASSERT(rnd_clear_on_req_complete, rnd_req_complete |=> ~rnd_valid_q)
 endmodule


### PR DESCRIPTION
The assertion checked that the rnd_req_i signal remained asserted until
the request received data. However the logic doesn't require this
constraint to work and it is violated when a fatal error during a stall
waiting for a RND read occurs.

Fixes #8528

Signed-off-by: Greg Chadwick <gac@lowrisc.org>