### PR TITLE
Use pycryptodome from upstream

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -22,6 +22,7 @@ mypy
 # To relax the constraint we either need to do a runtime detection, or switch all
 # users to a newer version.
 premailer < 3.9.0
+pycryptodome >= 3.11.0
 pydriller
 pyelftools
 pyftdi
@@ -53,8 +54,3 @@ git+https://github.com/lowRISC/edalize.git@ot#egg=edalize >= 0.2.4
 # (The chipwhisperer repository is rather large and uses additionally uses
 # submodules, which need to be fetched as well.)
 https://github.com/newaetech/chipwhisperer/archive/9b6825b495f14f85aae8b11007c63c59a1654584.tar.gz
-
-# Development version with OT-specific changes
-# TODO(#6694): this is temporary and should be replaced with the standard package release,
-# once the cSHAKE patches have landed upstream.
-git+https://github.com/lowRISC/pycryptodome.git@master#egg=pycryptodome >= 3.10.1


### PR DESCRIPTION
A new versin of pycryptodome has been released which includes support
for cSHAKE.

Release notes: https://www.pycryptodome.org/en/latest/src/changelog.html#october-2021

Fixes #6694