### PR TITLE
[otbn] Update comment to describe generic functionality

### DIFF
--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -168,7 +168,7 @@ typedef struct otbn {
 otbn_result_t otbn_init(otbn_t *ctx, mmio_region_t base_addr);
 
 /**
- * (Re-)loads the RSA application into OTBN.
+ * (Re-)loads the application into OTBN.
  *
  * Load the application image with both instruction and data segments into OTBN.
  *


### PR DESCRIPTION
The `otbn_load_app` function appears to work for any OTBN application, not just RSA, but the comment says "loads the RSA application". This PR just updates the wording to say "loads the application".