### PR TITLE
[sparse-fsm-encode] Add alternative algorithm to generate encodings

### DIFF
--- a/util/design/sparse-fsm-encode.py
+++ b/util/design/sparse-fsm-encode.py
@@ -25,7 +25,7 @@ import math
 import random
 import sys
 
-from lib.common import get_hd, hd_histogram, wrapped_docstring
+from lib.common import hd_histogram, wrapped_docstring
 
 MAX_DRAWS = 10000
 MAX_RESTARTS = 10000
@@ -55,103 +55,44 @@ RUST_INSTRUCTIONS = """
 """
 
 
-def main():
-    log.basicConfig(level=log.INFO,
-                    format="%(levelname)s: %(message)s")
+def hw(x: int):
+    '''calculate Hamming weight'''
+    hw = 0
+    while x != 0:
+        hw += x & 1
+        x >>= 1
+    return hw
 
-    parser = argparse.ArgumentParser(
-        prog="sparse-fsm-encode",
-        description=wrapped_docstring(),
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument(
-        '-d',
-        type=int,
-        default=5,
-        metavar='<minimum HD>',
-        help='Minimum Hamming distance between encoded states.')
-    parser.add_argument('-m',
-                        type=int,
-                        default=7,
-                        metavar='<#states>',
-                        help='Number of states to encode.')
-    parser.add_argument('-n',
-                        type=int,
-                        default=10,
-                        metavar='<#nbits>',
-                        help='Encoding length [bit].')
-    parser.add_argument('-s',
-                        type=int,
-                        metavar='<seed>',
-                        help='Custom seed for RNG.')
-    parser.add_argument('--language',
-                        choices=['sv', 'c', 'rust'],
-                        default='sv',
-                        help='Choose the language of the generated enum.')
 
-    args = parser.parse_args()
+def minhd_method(bits: int, count: int, min_hd: int):
+    '''Generates `count` `bits`-bit hardended enum constants.
 
-    if args.language in ['c', 'rust']:
-        if args.n not in [8, 16, 32]:
-            log.error(
-                "When using C or Rust, widths must be a power-of-two "
-                "at least a byte (8 bits) wide. You chose %d." % (args.n, ))
-            sys.exit(1)
+    This method draws new enum candidates at random and checks whether the
+    candidate fulfills the Hamming distance constraints with respect to all
+    other enum values.
 
-    if args.m < 2:
-        log.error(
-            'Number of states %d must be at least 2.' % (args.m))
-        sys.exit(1)
+    Other solutions that use a brute-force approach would be possible as well
+    (see e.g. https://math.stackexchange.com/
+    questions/891528/generating-a-binary-code-with-maximized-hamming-distance).
+    However, due to the sparse nature of the state space, this probabilistic
+    heuristic works pretty well for most practical cases, and it scales
+    favorably to large N.
 
-    if args.m > 2**args.n:
-        log.error(
-            'Statespace 2^%d not large enough to accommodate %d states.' %
-            (args.n, args.m))
-        sys.exit(1)
-
-    if (args.d >= args.n) and not(args.d == args.n and args.m == 2):
-        log.error(
-            'State is only %d bits wide, which is not enough to fulfill a '
-            'minimum Hamming distance constraint of %d. ' % (args.n, args.d))
-        sys.exit(1)
-
-    if args.d <= 0:
-        log.error('Hamming distance must be > 0.')
-        sys.exit(1)
-
-    if args.d < 3:
-        log.warning(
-            'A value of 4-5 is recommended for the minimum Hamming distance '
-            'constraint. At a minimum, this should be set to 3.')
-
-    # If no seed has been provided, we choose a seed and print it
-    # into the generated output later on such that this run can be
-    # reproduced.
-    if args.s is None:
-        random.seed()
-        args.s = random.getrandbits(32)
-
-    random.seed(args.s)
-
-    # This is a heuristic that opportunistically draws random
-    # state encodings and check whether they fulfill the minimum
-    # Hamming distance constraint.
-    # Other solutions that use a brute-force approach would be
-    # possible as well (see e.g. https://math.stackexchange.com/
-    # questions/891528/generating-a-binary-code-with-maximized-hamming-distance).
-    # However, due to the sparse nature of the state space, this
-    # probabilistic heuristic works pretty well for most practical
-    # cases, and it scales favorably to large N.
+    This method produces an asymmetric distribution due to the one-sided
+    pruning. However, it may be a bit easier to parameterize for low
+    bitwidths that need a guaranteed minimum Hamming distance (e.g. for
+    hardware FSMs up to 16bit).
+    '''
+    max_val = (1 << bits) - 1
     num_draws = 0
     num_restarts = 0
-    rnd = random.getrandbits(args.n)
-    encodings = [format(rnd, '0' + str(args.n) + 'b')]
-    while len(encodings) < args.m:
+    enum = []
+    while len(enum) < count:
         # if we iterate for too long, start over.
         if num_draws >= MAX_DRAWS:
             num_draws = 0
             num_restarts += 1
-            rnd = random.getrandbits(args.n)
-            encodings = [format(rnd, '0' + str(args.n) + 'b')]
+            enum = []
         # if we restarted for too many times, abort.
         if num_restarts >= MAX_RESTARTS:
             log.error(
@@ -162,35 +103,205 @@ def main():
                 'increasing n, or lower the minimum Hamming distance threshold d.'
                 .format(num_restarts))
             sys.exit(1)
-        num_draws += 1
         # draw a candidate and check whether it fulfills the minimum
-        # distance requirement with respect to other encodings.
-        rnd = random.getrandbits(args.n)
-        cand = format(rnd, '0' + str(args.n) + 'b')
+        # distance requirement with respect to other enum.
+        e1 = random.getrandbits(bits)
+        num_draws += 1
         # disallow all-zero and all-one states
-        pop_cnt = cand.count('1')
-        if pop_cnt < args.n and pop_cnt > 0:
-            for k in encodings:
+        if e1 == 0 or e1 == max_val:
+            continue
+        for e2 in enum:
+            # disallow candidates that are the complement of other states
+            if e1 == ~e2:
+                break
+            # disallow candidates that are too close to other states
+            if hw(e1 ^ e2) < min_hd:
+                break
+        else:
+            enum.append(e1)
+    return enum
+
+
+def avghd_method(bits: int, count: int, avg_hd: int, max_dev: int):
+    '''Generates `count` `bits`-bit hardended enum constants.
+
+    This method constructs new candidates by drawing a random bitmask with
+    Hamming weight `avg_hd` and XOR'ing that mask onto a common seed value.
+    The constructed candidates are then tested against the Hamming distance
+    constraints.
+
+    This method is similar to the minhd method, but due to the way the
+    candidates are constructed and pruned, this method produces a symmetric
+    distribution around the average Hamming distance midpoint.
+
+    This method may be preferrable to create software constants with large
+    bitwidths (e.g. 16 or 32bit) where a symmetric distribution is desired.
+    '''
+    max_val = (1 << bits) - 1
+    num_draws = 0
+    max_draws = MAX_DRAWS * MAX_RESTARTS
+    seed = random.getrandbits(bits)
+    enum = [seed]
+    indices = list(range(0, bits))
+    for _ in range(1, count):
+        while True:
+            # if we restarted for too many times, abort.
+            if num_draws >= max_draws:
+                log.error(
+                    'Did not find a solution after drawing {} times. This is '
+                    'an indicator that not many (or even no) solutions exist for '
+                    'the current parameterization. Rerun the script and/or adjust '
+                    'the d/m/n parameters. E.g. make the state space more sparse by '
+                    'increasing n, or lower the minimum Hamming distance threshold d.'
+                    .format(num_draws))
+                sys.exit(1)
+
+            random.shuffle(indices)
+            num_draws += 1
+            mask = 0
+            for i in indices[:avg_hd]:
+                mask |= 1 << i
+            e1 = seed ^ mask
+            # disallow all-zero and all-one states
+            if e1 == 0 or e1 == max_val:
+                continue
+            for e2 in enum:
                 # disallow candidates that are the complement of other states
-                if int(cand, 2) == ~int(k, 2):
+                if e1 == ~e2:
                     break
-                # disallow candidates that are too close to other states
-                if get_hd(cand, k) < args.d:
+                # constrain HD to be within a certain range around the average
+                if max_dev and abs(hw(e1 ^ e2) - avg_hd) > max_dev:
                     break
             else:
-                encodings.append(cand)
+                enum.append(e1)
+                break
+    return enum
 
-    # Get Hamming distance statistics.
+
+def main():
+    log.basicConfig(level=log.INFO,
+                    format="%(levelname)s: %(message)s")
+
+    parser = argparse.ArgumentParser(
+        prog="sparse-fsm-encode",
+        description=wrapped_docstring(),
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--count', '-m',
+                        type=int,
+                        default=7,
+                        help='Number of states to encode.')
+    parser.add_argument('--bits', '-n',
+                        type=int,
+                        default=10,
+                        help='Encoding length [bit].')
+    parser.add_argument('--seed', '-s',
+                        type=int,
+                        help='Custom seed for PRNG.')
+    parser.add_argument('--min-hd', '-d',
+                        type=int,
+                        default=5,
+                        help='Minimum Hamming distance constraint for the minhd method.')
+    parser.add_argument('--avg-hd',
+                        type=int,
+                        help='''
+                        Average Hamming distance constraint for the avghd method.
+                        Defaults to bits/2.''')
+    parser.add_argument('--max-dev',
+                        type=int,
+                        help='''
+                        Maximum deviation from average Hamming distance for the avghd method.
+                        ''')
+    parser.add_argument('--method',
+                        choices=['minhd', 'avghd'],
+                        default='minhd',
+                        help='Choose the method to generate the enum.')
+    parser.add_argument('--language',
+                        choices=['sv', 'c', 'rust'],
+                        default='sv',
+                        help='Choose the language of the generated enum.')
+
+    args = parser.parse_args()
+
+    if args.language in ['c', 'rust']:
+        if args.bits not in [8, 16, 32]:
+            log.error(
+                "When using C or Rust, widths must be a power-of-two "
+                "at least a byte (8 bits) wide. You chose %d." % (args.bits, ))
+            sys.exit(1)
+
+    if args.count < 2:
+        log.error(
+            'Number of states %d must be at least 2.' % (args.count))
+        sys.exit(1)
+
+    if args.count > 2**args.bits:
+        log.error(
+            'Statespace 2^%d not large enough to accommodate %d states.' %
+            (args.bits, args.count))
+        sys.exit(1)
+
+    # If no seed has been provided, we choose a seed and print it
+    # into the generated output later on such that this run can be
+    # reproduced.
+    if args.seed is None:
+        random.seed()
+        args.seed = random.getrandbits(32)
+
+    random.seed(args.seed)
+
+    # Select method to use and perform some more argument checking.
+    if args.method == 'minhd':
+        if args.min_hd < 3:
+            log.warning(
+                'A value of 4-5 is recommended for the minimum Hamming distance '
+                'constraint. At a minimum, this should be set to 3.')
+        if (args.min_hd >= args.bits) and not(args.min_hd == args.bits and args.count == 2):
+            log.error(
+                'State is only %d bits wide, which is not enough to fulfill a '
+                'minimum Hamming distance constraint of %d. ' % (args.bits, args.min_hd))
+            sys.exit(1)
+        if args.min_hd <= 0:
+            log.error('Hamming distance must be > 0.')
+            sys.exit(1)
+
+        # This is used in the templates below.
+        argstring = f"--min-hd {args.min_hd}"
+
+        enum = minhd_method(args.bits, args.count, args.min_hd)
+
+    elif args.method == 'avghd':
+        args.avg_hd = args.avg_hd or (args.bits // 2)
+
+        if (args.avg_hd >= args.bits) and not(args.avg_hd == args.bits and args.count == 2):
+            log.error(
+                'State is only %d bits wide, which is not enough to fulfill a '
+                'Hamming distance constraint of %d. ' % (args.bits, args.avg_hd))
+            sys.exit(1)
+        if args.avg_hd <= 0:
+            log.error('Hamming distance must be > 0.')
+            sys.exit(1)
+
+        # This is used in the templates below.
+        argstring = f"--avg-hd {args.avg_hd}"
+        if args.max_dev is not None:
+            argstring += f" --max-dev {args.max_dev}"
+
+        enum = avghd_method(args.bits, args.count, args.avg_hd, args.max_dev)
+    else:
+        assert(False)
+
+    # Convert to binary strings and get Hamming distance statistics.
+    encodings = [f'{x:0{args.bits}b}' for x in enum]
     stats = hd_histogram(encodings)
 
     if args.language == "sv":
         print(SV_INSTRUCTIONS)
         print("// Encoding generated with:\n"
-              "// $ ./util/design/sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
-              "//      -s {} --language=sv\n"
+              "// $ ./util/design/sparse-fsm-encode.py --count {} --bits {} \\\n"
+              "//     {} --method {} --seed {} --language=sv\n"
               "//\n"
               "// Hamming distance histogram:\n"
-              "//".format(args.d, args.m, args.n, args.s))
+              "//".format(args.count, args.bits, argstring, args.method, args.seed))
         for bar in stats['bars']:
             print('// ' + bar)
         print("//\n"
@@ -202,15 +313,15 @@ def main():
               "localparam int StateWidth = {};\n"
               "typedef enum logic [StateWidth-1:0] {{".format(
                   stats['min_hd'], stats['max_hd'], stats['min_hw'],
-                  stats['max_hw'], args.n))
+                  stats['max_hw'], args.bits))
         fmt_str = "  State{} {}= {}'b{}"
         state_str = ""
         for j, k in enumerate(encodings):
             pad = ""
-            for i in range(len(str(args.m)) - len(str(j))):
+            for i in range(len(str(args.count)) - len(str(j))):
                 pad += " "
             comma = "," if j < len(encodings) - 1 else ""
-            print(fmt_str.format(j, pad, args.n, k) + comma)
+            print(fmt_str.format(j, pad, args.bits, k) + comma)
             state_str += "    State{}: ;\n".format(j)
 
         # print FSM template
@@ -246,11 +357,11 @@ prim_flop #(
         print(C_INSTRUCTIONS)
         print("/*\n"
               " * Encoding generated with\n"
-              " * $ ./util/design/sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
-              " *     -s {} --language=c\n"
+              " * $ ./util/design/sparse-fsm-encode.py --count {} --bits {} \\\n"
+              " *     {} --method {} --seed {} --language=c\n"
               " *\n"
               " * Hamming distance histogram:\n"
-              " *".format(args.d, args.m, args.n, args.s))
+              " *".format(args.count, args.bits, argstring, args.method, args.seed))
         for hist_bar in stats['bars']:
             print(" * " + hist_bar)
         print(" *\n"
@@ -264,12 +375,12 @@ prim_flop #(
                                                 stats['min_hw'],
                                                 stats['max_hw']))
         fmt_str = "  kMyState{0:} {1:}= 0x{3:0" + str(math.ceil(
-            args.n / 4)) + "x}"
+            args.bits / 4)) + "x}"
         for j, k in enumerate(encodings):
             pad = ""
-            for i in range(len(str(args.m)) - len(str(j))):
+            for i in range(len(str(args.count)) - len(str(j))):
                 pad += " "
-            print(fmt_str.format(j, pad, args.n, int(k, 2)) + ",")
+            print(fmt_str.format(j, pad, args.bits, int(k, 2)) + ",")
 
         # print FSM template
         print("} my_state_t;")
@@ -277,11 +388,11 @@ prim_flop #(
         print(RUST_INSTRUCTIONS)
         print("///```text\n"
               "/// Encoding generated with\n"
-              "/// $ ./util/design/sparse-fsm-encode.py -d {} -m {} -n {} \\\n"
-              "///     -s {} --language=rust\n"
+              "/// $ ./util/design/sparse-fsm-encode.py --count {} --bits {} \\\n"
+              "///     {} --method {} --seed {} --language=rust\n"
               "///\n"
               "/// Hamming distance histogram:\n"
-              "///".format(args.d, args.m, args.n, args.s))
+              "///".format(args.count, args.bits, argstring, args.method, args.seed))
         for hist_bar in stats['bars']:
             print("/// " + hist_bar)
         print("///\n"
@@ -296,14 +407,14 @@ prim_flop #(
               "\n"
               "impl MyState {{".format(stats['min_hd'], stats['max_hd'],
                                        stats['min_hw'], stats['max_hw'],
-                                       args.n))
+                                       args.bits))
         fmt_str = "  const MY_STATE{0:}: MyState {1:}= MyState(0x{3:0" + str(
-            math.ceil(args.n / 4)) + "x})"
+            math.ceil(args.bits / 4)) + "x})"
         for j, k in enumerate(encodings):
             pad = ""
-            for i in range(len(str(args.m)) - len(str(j))):
+            for i in range(len(str(args.count)) - len(str(j))):
                 pad += " "
-            print(fmt_str.format(j, pad, args.n, int(k, 2)) + ";")
+            print(fmt_str.format(j, pad, args.bits, int(k, 2)) + ";")
         print("}")
 
 


### PR DESCRIPTION
I've played around a bit with a new method for generating hardened enum encodings that was suggested by @mcy, and integrated it as an alternative way to generate enums in the `sparse-fsm-encode.py` script. I did not change the existing method and kept the old argument names so that the script is backwards compatible and produces the same encoding output when called with arguments that can be found in comments throughout our RTL codebase, e.g.:
https://github.com/lowRISC/opentitan/blob/054b24698a73be23a3695ea5f60633ed12d8e72c/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv#L54-L57

I have called the new method `avghd` and the existing one `minhd`.
A few examples for the statistics produced:

```
// Encoding generated with:
// $ ./util/design/sparse-fsm-encode.py --count 10 --bits 12 \
//     --min-hd 5 --method minhd --seed 4261180865 --language=sv
//
// Hamming distance histogram:
//
//  0: --
//  1: --
//  2: --
//  3: --
//  4: --
//  5: |||||||||||||| (24.44%)
//  6: |||||||||||||||||||| (33.33%)
//  7: ||||||||||||| (22.22%)
//  8: |||||||| (13.33%)
//  9: |||| (6.67%)
// 10: --
// 11: --
// 12: --
//
// Minimum Hamming distance: 5
// Maximum Hamming distance: 9
// Minimum Hamming weight: 3
// Maximum Hamming weight: 10
```

```
// Encoding generated with:
// $ ./util/design/sparse-fsm-encode.py --count 10 --bits 12 \
//     --avg-hd 6 --method avghd --seed 2494453837 --language=sv
//
// Hamming distance histogram:
//
//  0: --
//  1: --
//  2: | (4.44%)
//  3: --
//  4: |||||| (15.56%)
//  5: --
//  6: |||||||||||||||||||| (48.89%)
//  7: --
//  8: |||||||||| (24.44%)
//  9: --
// 10: || (6.67%)
// 11: --
// 12: --
//
// Minimum Hamming distance: 2
// Maximum Hamming distance: 10
// Minimum Hamming weight: 4
// Maximum Hamming weight: 8
//
```

```
// Encoding generated with:
// $ ./util/design/sparse-fsm-encode.py --count 20 --bits 32 \
//     --min-hd 5 --method minhd --seed 3029637133 --language=sv
//
// Hamming distance histogram:
//
//  0: --
//  1: --
//  2: --
//  3: --
//  4: --
//  5: --
//  6: --
//  7: --
//  8: --
//  9:  (0.53%)
// 10: || (1.58%)
// 11: || (1.58%)
// 12: |||||| (5.26%)
// 13: |||||||||| (7.89%)
// 14: ||||||||||||||| (12.11%)
// 15: |||||||||||||||||||| (15.26%)
// 16: |||||||||||||||||| (14.21%)
// 17: |||||||||||||| (11.05%)
// 18: ||||||||||||||||| (13.68%)
// 19: ||||||||||| (8.95%)
// 20: |||| (3.68%)
// 21: || (2.11%)
// 22:  (0.53%)
// 23:  (0.53%)
// 24:  (0.53%)
// 25: --
// 26:  (0.53%)
// 27: --
// 28: --
// 29: --
// 30: --
// 31: --
// 32: --
//
// Minimum Hamming distance: 9
// Maximum Hamming distance: 26
// Minimum Hamming weight: 11
// Maximum Hamming weight: 22
```
```
// Encoding generated with:
// $ ./util/design/sparse-fsm-encode.py --count 20 --bits 32 \
//     --avg-hd 16 --method avghd --seed 1623479045 --language=sv
//
// Hamming distance histogram:
//
//  0: --
//  1: --
//  2: --
//  3: --
//  4: --
//  5: --
//  6: --
//  7: --
//  8:  (1.05%)
//  9: --
// 10: | (2.11%)
// 11: --
// 12: |||||| (11.05%)
// 13: --
// 14: |||||||| (16.32%)
// 15: --
// 16: |||||||||||||||||||| (36.84%)
// 17: --
// 18: |||||||||| (18.42%)
// 19: --
// 20: ||||| (10.53%)
// 21: --
// 22: | (3.16%)
// 23: --
// 24:  (0.53%)
// 25: --
// 26: --
// 27: --
// 28: --
// 29: --
// 30: --
// 31: --
// 32: --
//
// Minimum Hamming distance: 8
// Maximum Hamming distance: 24
// Minimum Hamming weight: 10
// Maximum Hamming weight: 20
//
```

In terms of statistics, the two methods seem to produce similar results - although it is a bit easier to create nicely symmetric HD distributions around a midpoint with `avghd`, which is due to the way new enum candidates are constructed.

The old `minhd` method on the other hand typically results in more asymmetric distributions due to the one-sided pruning of candidates. 

`minhd` does in my view feel a bit more straightforward to constrain for low-bitwidth enums, since it works with a single one-sided HD constraint instead of an average + deviation threshold. Hence I suggest we keep this one for the hardware use case.

The `avghd` method might be more suitable for generating hardened 32bit enums for SW use cases.

Signed-off-by: Michael Schaffner <msf@opentitan.org>