### PR TITLE
[util,sw] Reverse bootstrap hash word order

### DIFF
--- a/sw/host/spiflash/updater.cc
+++ b/sw/host/spiflash/updater.cc
@@ -52,7 +52,12 @@ void HashFrame(Frame *f) {
   SHA256_update(&sha256, &f->hdr.offset, sizeof(f->hdr.offset));
   SHA256_update(&sha256, f->data, f->PayloadSize());
   const uint8_t *result = SHA256_final(&sha256);
+
   memcpy(f->hdr.hash, result, SHA256_DIGEST_SIZE);
+
+  // Reverse the order of the bytes to make them little-endian and be consistent
+  // with the code signing tool.
+  std::reverse(f->hdr.hash, f->hdr.hash + SHA256_DIGEST_SIZE);
 }
 
 }  // namespace

--- a/util/fpga/cw_spiflash.py
+++ b/util/fpga/cw_spiflash.py
@@ -83,11 +83,14 @@ class _SpiFlashFrame:
         padding = self.PAYLOAD_SIZE - len(self._payload)
         if padding > 0:
             self._payload = b''.join([self._payload, b'\xFF' * padding])
+
+        # Reverse the order of the bytes to make them little-endian and be
+        # consistent with the code signing tool.
         self._digest = self.HASH_FUNCTION(b''.join([
             self._frame_number,
             self._flash_offset,
             self._payload,
-        ])).digest()
+        ])).digest()[::-1]
 
     def __bytes__(self):
         return b''.join([
@@ -109,7 +112,9 @@ class _SpiFlashFrame:
     @property
     def expected_ack(self):
         """Expected acknowledgement value for the frame."""
-        return self.HASH_FUNCTION(bytes(self)).digest()
+        # Reverse the order of the bytes to make them little-endian and be
+        # consistent with the code signing tool.
+        return self.HASH_FUNCTION(bytes(self)).digest()[::-1]
 
 
 class _Bootstrap:


### PR DESCRIPTION
Update the hash word/byte order used in the bootstrap protocol to make
it consistent with the hash produced by the code signing tool.

This commits updates:

* The test boot_rom bootstrap implementation.
* The C++ spiflash utility.
* The cw310 Python spiflash utility.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>