### PR TITLE
[docker] Copy files into container as user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,16 @@
 .git/
+
 *~
 *.bak
+tags
 __pycache__
+/.vscode
 opentitan-docs
 
-# fusesoc results and build directories with special suffixes
+# fusesoc result
+build/
+
+# build directories with special suffixes
 build*/
 
 # Generated register headers
@@ -15,6 +21,9 @@ jgproject/
 
 # FPGA splice intermediate files
 *.jou
+
+# Environment configuration (produced by Meson)
+.env
 
 # Simulation Results
 *.log
@@ -38,3 +47,23 @@ ascentlint.rpt
 # verilator/gtkwave waveforms and wave lists
 *.fst
 *.gtkw
+
+# Foundry library
+hw/foundry/
+
+# ROM_EXT signer vendored in dependencies
+sw/host/rom_ext_image_signer/vendored_dependencies
+
+# Autogen files for non-Earlgrey tops
+hw/top_englishbreakfast/**/autogen/
+hw/top_englishbreakfast/ip/alert_handler/dv/alert_handler_env_pkg__params.sv
+hw/top_englishbreakfast/ip/sensor_ctrl/rtl/*
+hw/top_englishbreakfast/ip/xbar_main/xbar_main.core
+hw/top_englishbreakfast/ip/xbar_peri/xbar_peri.core
+
+# Rust Cargo build system files.
+Cargo.lock
+sw/host/**/target
+
+# Bazel-related cache and output directories
+bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@ build/
 # build directories with special suffixes
 build*/
 
-# Sphinx result
-_build/
-
 # Generated register headers
 hw/ip/*/sw
 

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -102,11 +102,12 @@ RUN groupadd dev \
     && passwd -u dev
 
 # All subsequent steps are performed as user.
-USER dev
+USER dev:dev
 
 # Install Rust plus packages.
-COPY sw/vendor/rustup/rustup-init.sh /tmp/rustup-init.sh
-RUN /tmp/rustup-init.sh -y --default-toolchain ${RUST_VERSION}
+COPY --chown=dev:dev sw/vendor/rustup/rustup-init.sh /tmp/rustup-init.sh
+RUN /tmp/rustup-init.sh -y --default-toolchain ${RUST_VERSION} \
+    && rm -f /tmp/rustup-init.sh
 
 # Install Python plus packages.
 #
@@ -116,11 +117,12 @@ RUN /tmp/rustup-init.sh -y --default-toolchain ${RUST_VERSION}
 # Python version. If that information is not read, pip installs the latest
 # version, which then fails to run.
 ENV PATH "/home/dev/.local/bin:${PATH}"
-COPY python-requirements.txt /tmp/python-requirements.txt
+COPY --chown=dev:dev python-requirements.txt /tmp/python-requirements.txt
 RUN python3 -m pip install --user -U pip setuptools \
     && python3 -m pip install --user -r /tmp/python-requirements.txt \
-        --no-warn-script-location
+        --no-warn-script-location \
+    && rm -f /tmp/python-requirements.txt
 
-USER root
+USER root:root
 
 ENTRYPOINT [ "/start.sh" ]


### PR DESCRIPTION
We use some scripts within the container as dev user. Explicitly copy them
as this user to ensure the user executing the script has permissions on
them later on.

(`COPY` always uses root:root as target user/group. On some machines, the
files ended up executable as docker ran, while on others it didn't. Making
things explicit should give us a consistent build experience.)

See #8569