### PR TITLE
[otbn,dv] Allow trace entries from stalls in ISS wrapper

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -87,6 +87,7 @@ class OtbnTraceChecker : public OtbnTraceListener {
   OtbnTraceEntry rtl_entry_;
   OtbnTraceEntry rtl_stalled_entry_;
 
+  bool iss_started_;
   bool iss_pending_;
   OtbnIssTraceEntry iss_entry_;
 

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -24,6 +24,8 @@ void OtbnTraceEntry::from_rtl_trace(const std::string &trace) {
       writes_.push_back(line);
   }
   std::sort(writes_.begin(), writes_.end());
+  auto last = std::unique(writes_.begin(), writes_.end());
+  writes_.erase(last, writes_.end());
 }
 
 bool OtbnTraceEntry::operator==(const OtbnTraceEntry &other) const {
@@ -43,6 +45,8 @@ void OtbnTraceEntry::take_writes(const OtbnTraceEntry &other) {
       writes_.push_back(write);
     }
     std::sort(writes_.begin(), writes_.end());
+    auto last = std::unique(writes_.begin(), writes_.end());
+    writes_.erase(last, writes_.end());
   }
 }
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -158,10 +158,10 @@ class OTBNState:
             self.rnd_cdc_counter += 1
 
         if self._urnd_stall:
+            self.ext_regs.commit()
             if self._urnd_reseed_complete:
                 self._urnd_stall = False
                 self.non_insn_stall = False
-                self.ext_regs.commit()
 
             return
 
@@ -194,7 +194,6 @@ class OTBNState:
     def start(self) -> None:
         '''Set the running flag and the ext_reg busy flag; perform state init'''
         self.ext_regs.write('STATUS', Status.BUSY_EXECUTE, True)
-        self.ext_regs.write('INSN_CNT', 0, True)
         self.running = True
         self._urnd_stall = True
         self.non_insn_stall = True


### PR DESCRIPTION
This lets us gets rid of some hacks in `ISSWrapper::start()`. Now, STALL
lines can have some associated updates (in practice, these are always
to external registers), which get reflected in the model immediately
but are merged together with the next execute line to be checked
against the RTL.
