### PR TITLE
[otbn,dv] Sort out timing for done/status signals in ISS

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -143,8 +143,9 @@ class OTBNSim:
             # Zero INSN_CNT the cycle after we are told to start (and every
             # cycle after that until we start executing instructions, but that
             # doesn't really matter)
+            changes = self._on_stall(verbose, fetch_next=False)
             self.state.ext_regs.write('INSN_CNT', 0, True)
-            return (None, self._on_stall(verbose, fetch_next=False))
+            return (None, changes)
 
         insn = self._next_insn
         if insn is None:

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -157,8 +157,9 @@ class OTBNState:
         if self.rnd_cdc_pending:
             self.rnd_cdc_counter += 1
 
+        self.ext_regs.commit()
+
         if self._urnd_stall:
-            self.ext_regs.commit()
             if self._urnd_reseed_complete:
                 self._urnd_stall = False
                 self.non_insn_stall = False

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -42,11 +42,20 @@ class otbn_scoreboard extends cip_base_scoreboard #(
   // array, mapping the transaction source ID (a_source in the TL transaction) to an expected value.
   otbn_exp_read_data_t exp_read_values [tl_source_t];
 
-  bit saw_start_tl_trans = 1'b0;
-  bit waiting_for_model = 1'b0;
+  // A flag that tracks the fact that we've seen a TL write to the CMD register that we expect to
+  // start OTBN. We track this because we derive the "start" signal in the model from an internal
+  // DUT signal, so need to make sure it stays in sync with the TL side.
+  //
+  // If false, there are no transactions pending. This gets set in process_tl_addr when we see a
+  // write to CMD. This runs on a posedge of the clock. We expect to see the model start on the
+  // following negedge. When we process a change to model status that shows things starting (in
+  // process_model_fifo), we check that the flag is set and then clear it. When setting the flag, we
+  // queue a check to run on the following posedge of the clock to make sure the flag isn't still
+  // set.
+  bit pending_start_tl_trans = 1'b0;
 
   // The mirrored STATUS register from the ISS.
-  bit [7:0] model_status = 1'b0;
+  bit [7:0] model_status = 8'd0;
 
   // The "locked" field is used to track whether OTBN is "locked". For most operational state
   // tracking, we go through the ISS, but OTBN can become locked without actually starting an
@@ -72,7 +81,6 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     fork
       process_model_fifo();
       process_trace_fifo();
-      check_start();
     join_none
   endtask
 
@@ -83,15 +91,8 @@ class otbn_scoreboard extends cip_base_scoreboard #(
     // transaction, the reset will have caused them to be forgotten.
     exp_read_values.delete();
 
-    // Clear waiting_for_model. This handles a corner case where a TL transaction comes in to start
-    // OTBN just before a reset and the reset hits after the negedge of the clock (so we have set
-    // waiting_for_model) but before the following clock cycle (which would have generated the
-    // OtbnModelStart transaction).
-    waiting_for_model = 1'b0;
-
-    // Clear saw_start_tl_trans. Any "start" TL transaction will have been discarded by the reset,
-    // so we shouldn't still be tracking it.
-    saw_start_tl_trans = 1'b0;
+    model_status = otbn_pkg::StatusIdle;
+    pending_start_tl_trans = 1'b0;
 
     // Clear the locked bit (this is modelling RTL state that should be cleared on reset)
     locked = 1'b0;
@@ -128,17 +129,22 @@ class otbn_scoreboard extends cip_base_scoreboard #(
       end
 
       case (csr.get_name())
-        // Spot writes to the "cmd" register, which tell us to start
-        // These start the processor. We don't pass those to the model through UVM, because it's
-        // difficult to get the timing right (you only recognise the transaction on the clock edge
-        // after you needed to set the signal!), so the testbench actually grabs the model's start
-        // signal from the DUT internals. Of course, we need to check this is true exactly when we
-        // expect it to be. Here, we set a flag to say that we expect the "start" signal to be high.
-        // See the check_start() task, which checks it's true at the right time.
+        // Spot writes to the "cmd" register that tell us to start
         "cmd": begin
-          // We start the execution when we see a write of the EXECUTE command.
+          // We start the execution when we see a write of the EXECUTE command. See the comment
+          // above pending_start_tl_trans to see how this tracking works.
           if (item.a_data == otbn_pkg::CmdExecute) begin
-            saw_start_tl_trans = 1'b1;
+            // Set a flag: we're expecting the model to start on the next negedge. Also, spawn off a
+            // checking thread that will make sure it has been cleared again by the next posedge.
+            // Note that the reset() method is only called in the DV base class on the following
+            // posedge of rst_n, so we have to check whether we're still in reset here.
+            pending_start_tl_trans = 1'b1;
+            fork begin
+              @(cfg.clk_rst_vif.cb);
+              `DV_CHECK_FATAL(!cfg.clk_rst_vif.rst_n || !pending_start_tl_trans,
+                              "Model ignored a write of EXECUTE to the CMD register.")
+            end
+            join_none;
           end
         end
 
@@ -257,14 +263,18 @@ class otbn_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("received model transaction:\n%0s", item.sprint()), UVM_HIGH)
 
       case (item.item_type)
-        OtbnModelStart: begin
-          // We should only see the model start if it was started by a TL transaction on the
-          // previous cycle.
-          `DV_CHECK_FATAL(waiting_for_model, "model started unbidden!")
-          waiting_for_model = 1'b0;
-        end
-
         OtbnModelStatus: begin
+          // Has the status changed from idle to busy? If so, we should have seen a write to the
+          // command register on the previous posedge. See comment above pending_start_tl_trans for
+          // the details.
+          if (model_status == otbn_pkg::StatusIdle &&
+              item.status inside {otbn_pkg::StatusBusyExecute,
+                                  otbn_pkg::StatusBusySecWipeDmem,
+                                  otbn_pkg::StatusBusySecWipeImem}) begin
+            `DV_CHECK_FATAL(pending_start_tl_trans,
+                            "Saw start transaction without corresponding write to CMD")
+            pending_start_tl_trans = 1'b0;
+          end
           model_status = item.status;
         end
 
@@ -297,36 +307,6 @@ class otbn_scoreboard extends cip_base_scoreboard #(
 
       rtl_trace_queue.push_back(item);
       pop_trace_queues();
-    end
-  endtask
-
-  // We track TL writes that should start the processor and the model transaction that says it has
-  // started. There should be a single cycle delay between the two: on the negedge of each clock,
-  // convert a "there was a TL write" event (saw_start_tl_trans) to "we expect to see the model
-  // start" (waiting_for_model).
-  //
-  // If we get to a negedge where waiting_for_model is true, that means that the model didn't start
-  // when we expected it to.
-  task check_start();
-    forever begin
-      @(cfg.clk_rst_vif.cbn);
-
-      if (!cfg.clk_rst_vif.rst_n) begin
-        // We're in reset. Wait until we start again.
-        @(posedge cfg.clk_rst_vif.rst_n);
-      end else begin
-        // We're not in reset. Check that waiting_for_model is false. If not, we've had a cycle
-        // since the model should have started.
-        `DV_CHECK(!waiting_for_model, "model didn't start when we expected it to")
-
-        // If we've just seen a write to the CMD register that should start OTBN, set the
-        // waiting_for_model flag. This gives a single cycle delay (on the next cycle, we'll check
-        // it worked properly using the DV_CHECK above).
-        if (saw_start_tl_trans) begin
-          waiting_for_model = 1'b1;
-          saw_start_tl_trans = 1'b0;
-        end
-      end
     end
   endtask
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent_pkg.sv
@@ -12,7 +12,6 @@ package otbn_model_agent_pkg;
     otbn_trace_checker_pop_iss_insn(output bit [31:0] insn_addr, output string mnemonic);
 
   typedef enum {
-    OtbnModelStart,
     OtbnModelStatus,
     OtbnModelInsn
   } otbn_model_item_type_e;

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -16,7 +16,6 @@ interface otbn_model_if #(
   logic                     start;        // Start the operation
 
   // Outputs from DUT
-  bit                       done;         // Operation done
   bit                       err;          // Something went wrong
   bit [31:0]                stop_pc;      // PC at end of operation
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
@@ -21,30 +21,10 @@ class otbn_model_monitor extends dv_base_monitor #(
 
   protected task collect_trans(uvm_phase phase);
     fork
-      collect_start();
       collect_status();
       // TODO: Only run when coverage is enabled.
       collect_insns();
     join
-  endtask
-
-  protected task collect_start();
-    otbn_model_item trans;
-
-    forever begin
-      // Collect transactions on each clock edge when reset is high.
-      @(posedge cfg.vif.clk_i);
-      if (cfg.vif.rst_ni === 1'b1) begin
-        if (cfg.vif.start) begin
-          trans = otbn_model_item::type_id::create("trans");
-          trans.item_type = OtbnModelStart;
-          trans.status    = 0;
-          trans.err       = 0;
-          trans.mnemonic  = "";
-          analysis_port.write(trans);
-        end
-      end
-    end
   endtask
 
   protected task collect_status();

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -281,9 +281,9 @@ module otbn_top_sim (
 
   localparam string DesignScope = "..u_otbn_core";
 
-  logic      otbn_model_done;
   err_bits_t otbn_model_err_bits;
   bit [31:0] otbn_model_insn_cnt;
+  bit        otbn_model_done_r;
   bit        otbn_model_err;
 
   otbn_core_model #(
@@ -298,7 +298,6 @@ module otbn_top_sim (
     .rst_edn_ni            ( IO_RST_N ),
 
     .start_i               ( otbn_start ),
-    .done_o                ( otbn_model_done ),
 
     .err_bits_o            ( otbn_model_err_bits ),
 
@@ -306,8 +305,10 @@ module otbn_top_sim (
     .edn_rnd_cdc_done_i    ( edn_rnd_data_valid ),
     .edn_urnd_data_valid_i ( edn_urnd_data_valid ),
 
-    .status_o              (),
+    .status_o              ( ),
     .insn_cnt_o            ( otbn_model_insn_cnt ),
+
+    .done_r_o              ( otbn_model_done_r ),
 
     .err_o                 ( otbn_model_err )
   );
@@ -322,12 +323,17 @@ module otbn_top_sim (
       cnt_mismatch_latched      <= 1'b0;
       model_err_latched         <= 1'b0;
     end else begin
-      if (otbn_done_q != otbn_model_done) begin
-        $display("ERROR: At time %0t, otbn_done_q != otbn_model_done (%0d != %0d).",
-                 $time, otbn_done_q, otbn_model_done);
+      // Check that the 'done_o' output from the RTL matches the 'done_r_o' output from the model
+      // (with one cycle delay).
+      if (otbn_done_q && !otbn_model_done_r) begin
+        $display("ERROR: At time %0t, RTL done on previous cycle, but model still busy.", $time);
         done_mismatch_latched <= 1'b1;
       end
-      if (otbn_done_q && otbn_model_done) begin
+      if (otbn_model_done_r && !otbn_done_q) begin
+        $display("ERROR: At time %0t, model finished, but RTL not done in time.", $time);
+        done_mismatch_latched <= 1'b1;
+      end
+      if (otbn_model_done_r && otbn_done_q) begin
         if (otbn_err_bits_q != otbn_model_err_bits) begin
           $display("ERROR: At time %0t, otbn_err_bits != otbn_model_err_bits (0x%0x != 0x%0x).",
                    $time, otbn_err_bits_q, otbn_model_err_bits);

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -363,16 +363,26 @@ module otbn_top_sim (
   end
 
   // Defined in otbn_top_sim.cc
-  import "DPI-C" context function int OtbnTopApplyLoopWarp();
+  import "DPI-C" context function int OtbnTopInstallLoopWarps();
+  import "DPI-C" context function void OtbnTopApplyLoopWarp();
+  bit warps_installed;
 
   always_ff @(negedge IO_CLK or negedge IO_RST_N) begin
     if (!IO_RST_N) begin
-      loop_warp_model_err <= 1'b0;
+      warps_installed <= 1'b0;
     end else begin
-      if (OtbnTopApplyLoopWarp() != 0) begin
-        $display("ERROR: At time %0t, OtbnTopApplyLoopWarp() failed.", $time);
-        loop_warp_model_err <= 1'b1;
+      if (!warps_installed) begin
+        if (OtbnTopInstallLoopWarps() != 0) begin
+          $display("ERROR: At time %0t, OtbnTopInstallLoopWarps() failed.", $time);
+          loop_warp_model_err <= 1'b1;
+        end
       end
+      warps_installed <= 1'b1;
+    end
+  end
+  always_ff @(posedge IO_CLK or negedge IO_RST_N) begin
+    if (IO_RST_N) begin
+      OtbnTopApplyLoopWarp();
     end
   end
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -756,7 +756,7 @@ module otbn
     end
 
     // Mux between model and RTL implementation at runtime.
-    logic         done_model, done_rtl;
+    logic         done_r_model, done_rtl;
     logic         locked_model, locked_rtl;
     logic         start_model, start_rtl;
     err_bits_t    err_bits_model, err_bits_rtl;
@@ -764,7 +764,9 @@ module otbn
     logic         edn_rnd_data_valid;
     logic         edn_urnd_data_valid;
 
-    assign done = otbn_use_model ? done_model : done_rtl;
+    // Note that the "done" signal will come a cycle later when using the model as a core than it
+    // does when using the RTL
+    assign done = otbn_use_model ? done_r_model : done_rtl;
     assign locked = otbn_use_model ? locked_model : locked_rtl;
     assign err_bits = otbn_use_model ? err_bits_model : err_bits_rtl;
     assign insn_cnt = otbn_use_model ? insn_cnt_model : insn_cnt_rtl;
@@ -788,7 +790,6 @@ module otbn
       .rst_edn_ni,
 
       .start_i               (start_model),
-      .done_o                (done_model),
 
       .err_bits_o            (err_bits_model),
 
@@ -798,6 +799,8 @@ module otbn
       .edn_urnd_data_valid_i (edn_urnd_data_valid),
 
       .insn_cnt_o            (insn_cnt_model),
+
+      .done_r_o (done_r_model),
 
       .err_o ()
     );


### PR DESCRIPTION
This PR has two commits. The first is a cleanup/tidyup in how we backdoor load "loop warp" information in the Verilator top-level. The second is the real point of this PR; commit message below:

Now that `otbn_core_model` exposes a STATUS register, we can use it to
derive the "`done`" signal. Using the status register directly, rather
than reconstructing it from the done signal, models the OTBN block
more closely and actually simplifies a load of tracking DV
code (mainly because the two things that we're comparing Just Match,
so we don't need to convert between the two views of the world).

Unfortunately, we can't get rid of the "`done`" signal entirely, because
`otbn.sv` can choose to instantiate the model instead of the RTL to
represent the core. The timing isn't *quite* right here, because the
core flops STATUS but not its done_o output. But this shouldn't matter
for the chip-level sims where we use the model like this.

We *do* check that the RTL's done signal is as predicted in the UVM
and verilator testbenches.

This patch also sorts out the timing of the start of execution in the
UVM testbench: the ISS was probing the wrong start signal, so started
a cycle late. This didn't matter too much, because it and the design
were both waiting on the EDN, which took more than one cycle.

Finally, we fix the assertion that checks the model and RTL have
matching STATUS. This was broken before (using "`rst_n`", rather than
"`!rst_n`"), which is why we didn't notice the off-by-one at the start.
