### PR TITLE
[aes/pre_syn] Added missing keymgr_pkg file for Yosys synthesis

### DIFF
--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -81,6 +81,7 @@ OT_DEP_PACKAGES=(
     "$LR_SYNTH_SRC_DIR"/../lc_ctrl/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../tlul/rtl/*_pkg.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/*_pkg.sv
+    "$LR_SYNTH_SRC_DIR"/../keymgr/rtl/*_pkg.sv
 )
 
 # Convert OpenTitan dependency sources.


### PR DESCRIPTION
Added missing keymgr_pkg.sv file to re-enable Yosys synthesis for AES.