### PR TITLE
Spi stall fix2

### DIFF
--- a/hw/ip/spi_host/doc/_index.md
+++ b/hw/ip/spi_host/doc/_index.md
@@ -981,8 +981,6 @@ These *milestone signals* mark the progress of each command segment.
 The coordination of the milestone signals and the shift register controls are shown in the following waveform.
 Since the milestone signal pulses coincide with *entering* particular FSM states, they are derived from the state register *inputs* (i.e., `state_d`), as opposed to the state register outputs (`state_q`).
 
-***TODO***: Revisit the name of the `state_q` register in the following wavedrom and the previous paragraph.
-
 {{< wavejson >}}
 {signal: [
   {name: 'clk', wave: 'p........................'},
@@ -1233,9 +1231,11 @@ In the SPI_HOST FSM this is realized by disabling all flop updates whenever a st
 
 Furthermore, all control signals out of the FSM are suppressed during a stall condition.
 
-*TODO*: See if we can simplify the current scheme for "Actual" vs. "Prestall" state machine registers
+From an implementation standpoint, the presence of a stall condition has two effects on the SPI_HOST FSM:
+1. No flops or registers may be updated during a stall condition.
+Thus the FSM may not progress while stalled.
 
-#### Special consideration: State machine transactions
+2. All handshaking or control signals to other blocks must be surpressed during a stall condition, placing backpressure on the rest the blocks within the IP to also stop operations until the stall is resolved.
 
 ## Config/Command CDC
 


### PR DESCRIPTION
- Reverts changes to core state variables made in #7377
    - No more "actual" or "prestall" state
    
- Still correctly solves errors noted in #7281 with the following changes:
    - Adds signal command_ready_int to internally track non-stall-condition values for command_ready_o
    - Internal signal new_command now depends on command_ready_int, not command_ready_o
    - command_ready_o is masked to always output 0 during a stall condition.
    - All registers and output signals are now enabled only when !stall
    - The name of the state register has been renamed to simply "state_d/q"
    
- This results in a far simpler scheme for managing the FSM, with fewer coverage points to worry about.  The previous version, though functional, left some uncertainty as to how to establish coverage points for the "actual" and "prestall" states.
    
- Removes corresponding TODOs from the documentation
    
Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>

**Note to Reviewers:** In order to make the review easier this PR is currently organized into three commits:
1. Reversion of #7377 (unchanged, no real need to review)
2. Renaming `spi_host_st_d/spi_host_st_q` to `state_d/state_q`
3. Actual alternative bug fixes to handle #7281 in a more simple fashion

All three will be squashed before merging.

