### PR TITLE
[prim] use prim_buf inside prim_subreg

### DIFF
--- a/hw/ip/prim/rtl/prim_subreg.sv
+++ b/hw/ip/prim/rtl/prim_subreg.sv
@@ -53,6 +53,14 @@ module prim_subreg
     end
   end
 
+  logic wr_en_buf;
+  prim_buf #(
+    .Width(1)
+  ) u_wr_en_buf (
+    .in_i(wr_en),
+    .out_o(wr_en_buf)
+  );
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       q <= RESVAL;
@@ -61,6 +69,14 @@ module prim_subreg
     end
   end
 
-  assign qs = q;
+  logic [DW-1:0] q_buf;
+  prim_buf #(
+    .Width(DW)
+  ) u_q_buf (
+    .in_i(q),
+    .out_o(q_buf)
+  );
+
+  assign qs = q_buf;
 
 endmodule


### PR DESCRIPTION
This gives us a natual anchor point if it is ever required.
Ideally, we would directly swap the rtl code with prim_flop_en.

However, doing so creates complications for DV's backdoor loading,
as that does not work well across module hierarchies.

Instead we add anchor buffers both on the write enable and the output
of the flop, which are the two areas we would most likely be concerned
with.

This still gives us a close by anchor point and does not impact existin
DV.
