### PR TITLE
[dv/pwrmgr] Add wakeup test sequence

### DIFF
--- a/hw/dv/sv/csr_utils/csr_utils_pkg.sv
+++ b/hw/dv/sv/csr_utils/csr_utils_pkg.sv
@@ -75,7 +75,7 @@ package csr_utils_pkg;
     return mem.get_access();
   endfunction
 
-  // This fucntion return mirrored value of reg/field of given RAL
+  // This function return mirrored value of reg/field of given RAL
   function automatic uvm_reg_data_t get_reg_fld_mirror_value(uvm_reg_block ral,
                                                              string        reg_name,
                                                              string        field_name  = "");

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -21,6 +21,7 @@ filesets:
       - seq_lib/pwrmgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_wakeup_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -14,9 +14,6 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
   constraint cycles_before_otp_done_c {cycles_before_otp_done inside {[1 : 2]};}
   constraint cycles_before_lc_done_c {cycles_before_lc_done inside {[1 : 2]};}
 
-  rand bit [pwrmgr_reg_pkg::NumWkups-1:0]   wakeups;
-  rand bit [pwrmgr_reg_pkg::NumRstReqs-1:0] resets;
-
   constraint wakeups_c {wakeups != 0;}
   constraint resets_c {resets != 0;}
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -4,4 +4,5 @@
 
 `include "pwrmgr_base_vseq.sv"
 `include "pwrmgr_smoke_vseq.sv"
+`include "pwrmgr_wakeup_vseq.sv"
 `include "pwrmgr_common_vseq.sv"

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The wakeup test randomly enables wakeups, info capture, and interrupts,
+// and sends wakeups at random times.
+class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_wakeup_vseq)
+
+  `uvm_object_new
+
+  rand bit                                disable_wakeup_capture;
+  constraint wakeups_c {wakeups != 0;}
+
+  rand bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeup_en;
+  constraint wakeup_en_c {
+    solve wakeups before wakeup_en;
+    |(wakeup_en & wakeups) == 1'b1;
+  }
+  rand bit core_clk_en;
+  rand bit io_clk_en;
+  rand bit usb_clk_en_lp;
+  rand bit usb_clk_en_active;
+  rand bit main_pd_n;
+
+  task body();
+    logic [TL_DW-1:0] value;
+    bit [pwrmgr_reg_pkg::NumWkups-1:0] enabled_wakeups;
+
+    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
+    csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(0));
+    for (int i = 0; i < num_trans; ++i) begin
+      `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      // Enable wakeups.
+      enabled_wakeups = wakeup_en & wakeups;
+      `DV_CHECK(enabled_wakeups, $sformatf(
+                "Some wakeup must be enabled: wkups=%b, wkup_en=%b",
+                wakeups,
+                wakeup_en
+                ))
+      `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
+      csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeup_en));
+      csr_wr(.ptr(ral.wake_info_capture_dis), .value(disable_wakeup_capture));
+      wait_for_csr_to_propagate_to_slow_domain();
+
+      // Initiate low power transition.
+      ral.control.core_clk_en.set(core_clk_en);
+      ral.control.io_clk_en.set(io_clk_en);
+      ral.control.usb_clk_en_lp.set(usb_clk_en_lp);
+      ral.control.main_pd_n.set(main_pd_n);
+      ral.control.low_power_hint.set(1'b1);
+      // Disable assertions when main power is down.
+      control_assertions(main_pd_n);
+
+      csr_update(.csr(ral.control));
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+      fast_to_low_power();
+      if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
+        wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
+      end
+
+      // Now bring it back.
+      cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+      cfg.pwrmgr_vif.update_wakeups(wakeups);
+      // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
+      cfg.slow_clk_rst_vif.wait_clks(4);
+      csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(enabled_wakeups),
+                   .err_msg("failed wake_status check"));
+      `uvm_info(`gfn, $sformatf("Got wake_status=0x%x", enabled_wakeups), UVM_MEDIUM)
+      wait(cfg.pwrmgr_vif.pwr_clk_req.ip_clk_en == 1'b1);
+      cfg.pwrmgr_vif.update_wakeups('0);
+
+      wait_for_fast_fsm_active();
+      `uvm_info(`gfn, "Back from wakeup", UVM_MEDIUM)
+
+      csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(0),
+                   .err_msg("failed reset_status check"));
+      if (disable_wakeup_capture) begin
+        csr_rd_check(.ptr(ral.wake_info.reasons),
+                     .compare_value('0));
+      end else begin
+        csr_rd_check(.ptr(ral.wake_info.reasons),
+                     .compare_value(enabled_wakeups));
+      end
+      csr_rd_check(.ptr(ral.wake_info.fall_through), .compare_value(1'b0));
+      csr_rd_check(.ptr(ral.wake_info.abort), .compare_value(1'b0));
+      // Clear wake_info.
+      csr_wr(.ptr(ral.wake_info), .value('1));
+
+      // Wait for interrupt to be generated whether or not it is enabled.
+      cfg.slow_clk_rst_vif.wait_clks(10);
+    end
+  endtask
+
+endclass : pwrmgr_wakeup_vseq

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -57,7 +57,12 @@
     {
       name: pwrmgr_smoke
       uvm_test_seq: pwrmgr_smoke_vseq
-      run_opts: ["+test_timeout_ns=100000"]
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
+    {
+      name: pwrmgr_wakeup
+      uvm_test_seq: pwrmgr_wakeup_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
     }
 
     // TODO: add more tests here


### PR DESCRIPTION
Also increase the test timeout, or the test will be killed mid-flight.
Remove redundant start_slow_fsm task, since its action is done by
slow_responder.

Signed-off-by: Guillermo Maturana <maturana@google.com>