### PR TITLE
[fpv] prim_counter_fpv

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -19,11 +19,19 @@ set_property_compile_time_limit 1000s
 #-------------------------------------------------------------------------
 
 # only one scr file exists in this folder
-analyze -sv09                 \
-  +define+FPV_ON              \
+analyze -sv09     \
+  +define+FPV_ON  \
   -f [glob *.scr]
 
-elaborate -bbox_a 4320 -top $env(DUT_TOP) -enable_sva_isunknown
+if {$env(DUT_TOP) == "prim_count_tb"} {
+  elaborate -bbox_a 4320 \
+            -top $env(DUT_TOP) \
+            -enable_sva_isunknown \
+            -param OutSelDnCnt $OutSelDnCnt \
+            -param CntStyle $CntStyle
+} else {
+  elaborate -bbox_a 4320 -top $env(DUT_TOP) -enable_sva_isunknown
+}
 
 #-------------------------------------------------------------------------
 # specify clock(s) and reset(s)
@@ -69,7 +77,7 @@ if {$env(DUT_TOP) == "rv_dm"} {
 #   clock clk_main_i -both_edges
 #   reset -expr {!rst_main_ni}
 
-} elseif {$env(DUT_TOP) == "prim_fifo_async_sram_adapter_fpv"} {
+} elseif {$env(DUT_TOP) == "prim_fifo_async_sram_adapter_tb"} {
   clock clk_wr_i -factor 2
   clock -rate {wvalid_i, wready_o, wdata_i} clk_wr_i
   clock clk_rd_i -factor 3

--- a/hw/ip/prim/fpv/prim_count_fpv.core
+++ b/hw/ip/prim/fpv/prim_count_fpv.core
@@ -1,0 +1,29 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:fpv:prim_count_fpv:0.1"
+description: "prim_count FPV target"
+filesets:
+  files_formal:
+    depend:
+      - lowrisc:prim:all
+      - lowrisc:prim:count
+    files:
+      - tb/prim_count_tb.sv
+    file_type: systemVerilogSource
+
+
+targets:
+  default: &default_target
+    # Note this setting is just used to generate a file list for jg.
+    default_tool: icarus
+    filesets:
+      - files_formal
+    toplevel: prim_count_tb
+
+  formal:
+    <<: *default_target
+
+  lint:
+    <<: *default_target

--- a/hw/ip/prim/fpv/tb/prim_count_tb.sv
+++ b/hw/ip/prim/fpv/tb/prim_count_tb.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for prim_count.
+// Intended to be used with a formal tool.
+
+module prim_count_tb
+  import prim_count_pkg::*; #(
+  parameter int Width = 2,
+  parameter bit OutSelDnCnt = 1, // 0 selects up count
+  parameter prim_count_style_e CntStyle = CrossCnt
+) (
+  input  clk_i,
+  input  rst_ni,
+  input  clr_i,
+  input  set_i,
+  input [Width-1:0] set_cnt_i,
+  input  en_i,
+  input [Width-1:0] step_i,
+  output logic[Width-1:0] cnt_o,
+  output logic err_o
+);
+
+  prim_count #(
+    .Width(Width),
+    .OutSelDnCnt(OutSelDnCnt),
+    .CntStyle(CntStyle)
+  ) u_counter (
+    .clk_i,
+    .rst_ni,
+    .clr_i,
+    .set_i,
+    .set_cnt_i,
+    .en_i,
+    .step_i,
+    .cnt_o,
+    .err_o
+  );
+
+endmodule : prim_count_tb

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -59,6 +59,36 @@
                cov: true
              }
              {
+               name: prim_dup_up_count_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 0", "-define CntStyle DupCnt"]
+               rel_path: "hw/ip/prim/prim_count/{sub_flow}/{tool}"
+               // TODO: turn on coverage once design finalizes on issue #8343.
+               cov: false
+             }
+             {
+               name: prim_cross_up_count_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 0",  "-define CntStyle CrossCnt"]
+               rel_path: "hw/ip/prim/prim_count/{sub_flow}/{tool}"
+               // TODO: turn on coverage once design finalizes on issue #8343.
+               cov: false
+             }
+             {
+               name: prim_cross_down_count_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 1", "-define CntStyle CrossCnt"]
+               rel_path: "hw/ip/prim/prim_count/{sub_flow}/{tool}"
+               // TODO: turn on coverage once design finalizes on issue #8343.
+               cov: false
+             }
+             {
                name: prim_lfsr_fpv
                dut: prim_lfsr_tb
                fusesoc_core: lowrisc:fpv:prim_lfsr_fpv


### PR DESCRIPTION
1).Set up an initial FPV testbench on prim_counter.
2).Move around some assertions in design to avoid conditional disable
assertions in FPV.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>