### PR TITLE
[dv] Fix for timing related issue in alert_esc_if

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -85,7 +85,9 @@ interface alert_esc_if(input clk, input rst_n);
   assign esc_rx   = (if_mode == dv_utils_pkg::Device && !is_alert) ? esc_rx_int   : 'z;
 
   task automatic wait_ack_complete();
+    while(alert_tx_final.alert_p === 1'b0) @(monitor_cb);
     while (alert_tx_final.alert_p === 1'b1) @(monitor_cb);
+    while(alert_rx_final.ack_p === 1'b0) @(monitor_cb);
     while (alert_rx_final.ack_p === 1'b1)   @(monitor_cb);
   endtask : wait_ack_complete
 


### PR DESCRIPTION
wait_ack_complete exited as soon as alert_p went to 0 from 1. There
could be conditions where wait_ack_complete is called before alert_p
has been asserted. This will result in immediate exit from the function.

Therefore, this fix waits for a posedge and then a negedge on alert_p.