### PR TITLE
[dvsim] Add a project folder name when `scratch root` environment variable is set

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -64,7 +64,10 @@ def resolve_scratch_root(arg_scratch_root, proj_root):
                                                  timeout=1,
                                                  exit_on_failure=0)
             if status == 0 and out != "":
-                arg_scratch_root = scratch_root
+                # Add a proj_root folder name in case the local workspace has different
+                # copies of the repos.
+                proj_root_folder = proj_root.split("/")[-1]
+                arg_scratch_root = os.path.join(scratch_root, proj_root_folder)
             else:
                 arg_scratch_root = default_scratch_root
                 log.warning(


### PR DESCRIPTION
This PR solves a small issue when the `SCRATCH_ROOT` environment variable is set, and the
workstation has more than one copy of the repository.
Then we add the repository name to distinguish the output.
For example: the local workstation has two repositories named
`opentitan1` and `opentitan1`, the `SCRATCH_ROOT` is set to `~/desktop`,
then the two scratch roots are: `~/desktop/opentitan1` and
`~/desktop/opentitan2`.

@tjaychen I hope this solves your issue ;)

Signed-off-by: Cindy Chen <chencindy@opentitan.org>