### PR TITLE
[ spi_host, rtl ] Fix CSAAT behavior

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -252,7 +252,8 @@ module spi_host_fsm
           // and of CSAAT is asserted, the details of the subsequent command.
           if (!last_bit || !last_byte) begin
             state_d = InternalClkLow;
-          end else if (!command_i.segment.csaat) begin
+          // Check value of csaat for the previously submitted segment
+          end else if (!csaat_q) begin
             state_d = WaitTrail;
           end else begin
             state_d = next_state_after_idle_csb_active;


### PR DESCRIPTION
When ending a segment forces SPI HOST FSM to look at CSAAT for the
currently running segment, not one that is potentially pending at
the FSM inputs.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>