### PR TITLE
[dif/rv_plic] Autogen DIF components and use in tree.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_rv_plic.h"
+
+#include "rv_plic_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.h
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_RV_PLIC_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_RV_PLIC_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/rv_plic/doc/">RV_PLIC</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to rv_plic.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_rv_plic {
+  /**
+   * The base address for the rv_plic hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_rv_plic_t;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_RV_PLIC_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/dif_rv_plic.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "rv_plic_regs.h"  // Generated.
+
+namespace dif_rv_plic_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Test;
+
+class RvPlicTest : public Test, public MmioTest {
+ protected:
+  dif_rv_plic_t rv_plic_ = {.base_addr = dev().region()};
+};
+
+}  // namespace
+}  // namespace dif_rv_plic_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -240,6 +240,20 @@ sw_lib_dif_autogen_rstmgr = declare_dependency(
   )
 )
 
+# Autogen RV PLIC DIF library
+sw_lib_dif_autogen_rv_plic = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_rv_plic',
+    sources: [
+      hw_top_earlgrey_rv_plic_reg_h,
+      'dif_rv_plic_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen SPI Device DIF library
 sw_lib_dif_autogen_spi_device = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/dif_rv_plic.h
+++ b/sw/device/lib/dif/dif_rv_plic.h
@@ -22,71 +22,13 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sw/device/lib/dif/autogen/dif_rv_plic_autogen.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-/**
- * A toggle state: enabled, or disabled.
- *
- * This enum may be used instead of a `bool` when describing an enabled/disabled
- * state.
- */
-typedef enum dif_rv_plic_toggle {
-  /*
-   * The "enabled" state.
-   */
-  kDifRvPlicToggleEnabled,
-  /**
-   * The "disabled" state.
-   */
-  kDifRvPlicToggleDisabled,
-} dif_rv_plic_toggle_t;
-
-/**
- * Hardware instantiation parameters for PLIC.
- *
- * This struct describes information about the underlying hardware that is
- * not determined until the hardware design is used as part of a top-level
- * design.
- */
-typedef struct dif_rv_plic_params {
-  /**
-   * The base address for the PLIC hardware registers.
-   */
-  mmio_region_t base_addr;
-} dif_rv_plic_params_t;
-
-/**
- * A handle to PLIC.
- *
- * This type should be treated as opaque by users.
- */
-typedef struct dif_rv_plic {
-  dif_rv_plic_params_t params;
-} dif_rv_plic_t;
-
-/**
- * The result of a PLIC operation.
- */
-typedef enum dif_rv_plic_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifRvPlicOk = 0,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifRvPlicError = 1,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifRvPlicBadArg = 2,
-} dif_rv_plic_result_t;
 
 /**
  * The lowest interrupt priority.
@@ -133,8 +75,7 @@ typedef uint32_t dif_rv_plic_target_t;
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_init(dif_rv_plic_params_t params,
-                                      dif_rv_plic_t *plic);
+dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *plic);
 
 /**
  * Returns whether a particular interrupt is currently pending.
@@ -145,9 +86,9 @@ dif_rv_plic_result_t dif_rv_plic_init(dif_rv_plic_params_t params,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_irq_is_pending(const dif_rv_plic_t *plic,
-                                                dif_rv_plic_irq_id_t irq,
-                                                bool *is_pending);
+dif_result_t dif_rv_plic_irq_is_pending(const dif_rv_plic_t *plic,
+                                        dif_rv_plic_irq_id_t irq,
+                                        bool *is_pending);
 
 /**
  * Checks whether a particular interrupt is currently enabled or disabled.
@@ -159,10 +100,10 @@ dif_rv_plic_result_t dif_rv_plic_irq_is_pending(const dif_rv_plic_t *plic,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_irq_get_enabled(const dif_rv_plic_t *plic,
-                                                 dif_rv_plic_irq_id_t irq,
-                                                 dif_rv_plic_target_t target,
-                                                 dif_rv_plic_toggle_t *state);
+dif_result_t dif_rv_plic_irq_get_enabled(const dif_rv_plic_t *plic,
+                                         dif_rv_plic_irq_id_t irq,
+                                         dif_rv_plic_target_t target,
+                                         dif_toggle_t *state);
 
 /**
  * Sets whether a particular interrupt is currently enabled or disabled.
@@ -177,10 +118,10 @@ dif_rv_plic_result_t dif_rv_plic_irq_get_enabled(const dif_rv_plic_t *plic,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_irq_set_enabled(const dif_rv_plic_t *plic,
-                                                 dif_rv_plic_irq_id_t irq,
-                                                 dif_rv_plic_target_t target,
-                                                 dif_rv_plic_toggle_t state);
+dif_result_t dif_rv_plic_irq_set_enabled(const dif_rv_plic_t *plic,
+                                         dif_rv_plic_irq_id_t irq,
+                                         dif_rv_plic_target_t target,
+                                         dif_toggle_t state);
 
 /**
  * Sets IRQ source priority (0-3).
@@ -195,9 +136,9 @@ dif_rv_plic_result_t dif_rv_plic_irq_set_enabled(const dif_rv_plic_t *plic,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_irq_set_priority(const dif_rv_plic_t *plic,
-                                                  dif_rv_plic_irq_id_t irq,
-                                                  uint32_t priority);
+dif_result_t dif_rv_plic_irq_set_priority(const dif_rv_plic_t *plic,
+                                          dif_rv_plic_irq_id_t irq,
+                                          uint32_t priority);
 
 /**
  * Sets the target priority threshold.
@@ -212,8 +153,9 @@ dif_rv_plic_result_t dif_rv_plic_irq_set_priority(const dif_rv_plic_t *plic,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_target_set_threshold(
-    const dif_rv_plic_t *plic, dif_rv_plic_target_t target, uint32_t threshold);
+dif_result_t dif_rv_plic_target_set_threshold(const dif_rv_plic_t *plic,
+                                              dif_rv_plic_target_t target,
+                                              uint32_t threshold);
 
 /**
  * Claims an IRQ and gets the information about the source.
@@ -240,9 +182,9 @@ dif_rv_plic_result_t dif_rv_plic_target_set_threshold(
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_irq_claim(const dif_rv_plic_t *plic,
-                                           dif_rv_plic_target_t target,
-                                           dif_rv_plic_irq_id_t *claim_data);
+dif_result_t dif_rv_plic_irq_claim(const dif_rv_plic_t *plic,
+                                   dif_rv_plic_target_t target,
+                                   dif_rv_plic_irq_id_t *claim_data);
 
 /**
  * Completes the claimed IRQ.
@@ -263,9 +205,9 @@ dif_rv_plic_result_t dif_rv_plic_irq_claim(const dif_rv_plic_t *plic,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_irq_complete(
-    const dif_rv_plic_t *plic, dif_rv_plic_target_t target,
-    dif_rv_plic_irq_id_t complete_data);
+dif_result_t dif_rv_plic_irq_complete(const dif_rv_plic_t *plic,
+                                      dif_rv_plic_target_t target,
+                                      dif_rv_plic_irq_id_t complete_data);
 
 /**
  * Forces the software interrupt for a particular target.
@@ -282,11 +224,11 @@ dif_rv_plic_result_t dif_rv_plic_irq_complete(
  *
  * @param plic PLIC state data.
  * @param target Target HART.
- * @return `dif_rv_plic_result_t`.
+ * @return `dif_result_t`.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_software_irq_force(
-    const dif_rv_plic_t *plic, dif_rv_plic_target_t target);
+dif_result_t dif_rv_plic_software_irq_force(const dif_rv_plic_t *plic,
+                                            dif_rv_plic_target_t target);
 
 /**
  * Acknowledges the software interrupt for a particular target.
@@ -297,11 +239,11 @@ dif_rv_plic_result_t dif_rv_plic_software_irq_force(
  *
  * @param plic PLIC state data.
  * @param target Target HART.
- * @return `dif_rv_plic_result_t`.
+ * @return `dif_result_t`.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_software_irq_acknowledge(
-    const dif_rv_plic_t *plic, dif_rv_plic_target_t target);
+dif_result_t dif_rv_plic_software_irq_acknowledge(const dif_rv_plic_t *plic,
+                                                  dif_rv_plic_target_t target);
 
 /**
  * Returns software interrupt pending state for a particular target.
@@ -309,11 +251,12 @@ dif_rv_plic_result_t dif_rv_plic_software_irq_acknowledge(
  * @param plic PLIC state data.
  * @param target Target HART.
  * @param[out] is_pending Flag indicating whether the interrupt is pending.
- * @return `dif_rv_plic_result_t`.
+ * @return `dif_result_t`.
  */
 OT_WARN_UNUSED_RESULT
-dif_rv_plic_result_t dif_rv_plic_software_irq_is_pending(
-    const dif_rv_plic_t *plic, dif_rv_plic_target_t target, bool *is_pending);
+dif_result_t dif_rv_plic_software_irq_is_pending(const dif_rv_plic_t *plic,
+                                                 dif_rv_plic_target_t target,
+                                                 bool *is_pending);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_rv_plic_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_plic_unittest.cc
@@ -30,9 +30,7 @@ constexpr uint32_t kFirstIrq = 1;
 
 class PlicTest : public Test, public MmioTest {
  protected:
-  dif_rv_plic_t plic_ = {
-      .params = {.base_addr = dev().region()},
-  };
+  dif_rv_plic_t plic_ = {.base_addr = dev().region()};
 };
 
 class InitTest : public PlicTest {
@@ -61,15 +59,13 @@ class InitTest : public PlicTest {
 };
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, nullptr),
-            kDifRvPlicBadArg);
+  EXPECT_EQ(dif_rv_plic_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
   ExpectInitReset();
 
-  EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, &plic_),
-            kDifRvPlicOk);
+  EXPECT_EQ(dif_rv_plic_init(dev().region(), &plic_), kDifOk);
 }
 
 class IrqTest : public PlicTest {
@@ -152,8 +148,8 @@ class IrqEnableSetTest : public IrqTest {};
 
 TEST_F(IrqEnableSetTest, NullArgs) {
   EXPECT_EQ(dif_rv_plic_irq_set_enabled(nullptr, kFirstIrq, kTarget0,
-                                        kDifRvPlicToggleEnabled),
-            kDifRvPlicBadArg);
+                                        kDifToggleEnabled),
+            kDifBadArg);
 }
 
 TEST_F(IrqEnableSetTest, Target0Enable) {
@@ -161,9 +157,9 @@ TEST_F(IrqEnableSetTest, Target0Enable) {
 
   // Enable every IRQ, one at a time.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
-    EXPECT_EQ(dif_rv_plic_irq_set_enabled(&plic_, i, kTarget0,
-                                          kDifRvPlicToggleEnabled),
-              kDifRvPlicOk);
+    EXPECT_EQ(
+        dif_rv_plic_irq_set_enabled(&plic_, i, kTarget0, kDifToggleEnabled),
+        kDifOk);
   }
 }
 
@@ -172,9 +168,9 @@ TEST_F(IrqEnableSetTest, Target0Disable) {
 
   // Disable every bit, one at a time.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
-    EXPECT_EQ(dif_rv_plic_irq_set_enabled(&plic_, i, kTarget0,
-                                          kDifRvPlicToggleDisabled),
-              kDifRvPlicOk);
+    EXPECT_EQ(
+        dif_rv_plic_irq_set_enabled(&plic_, i, kTarget0, kDifToggleDisabled),
+        kDifOk);
   }
 }
 
@@ -183,13 +179,13 @@ class IrqPrioritySetTest : public PlicTest {};
 TEST_F(IrqPrioritySetTest, NullArgs) {
   EXPECT_EQ(
       dif_rv_plic_irq_set_priority(nullptr, kFirstIrq, kDifRvPlicMaxPriority),
-      kDifRvPlicBadArg);
+      kDifBadArg);
 }
 
 TEST_F(IrqPrioritySetTest, PriorityInvalid) {
   EXPECT_EQ(dif_rv_plic_irq_set_priority(nullptr, kFirstIrq,
                                          kDifRvPlicMaxPriority + 1),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(IrqPrioritySetTest, Success) {
@@ -199,7 +195,7 @@ TEST_F(IrqPrioritySetTest, Success) {
     EXPECT_WRITE32(offset, kDifRvPlicMaxPriority);
 
     EXPECT_EQ(dif_rv_plic_irq_set_priority(&plic_, i, kDifRvPlicMaxPriority),
-              kDifRvPlicOk);
+              kDifOk);
   }
 }
 
@@ -208,13 +204,13 @@ class TargetThresholdSetTest : public PlicTest {};
 TEST_F(TargetThresholdSetTest, NullArgs) {
   EXPECT_EQ(dif_rv_plic_target_set_threshold(nullptr, kTarget0,
                                              kDifRvPlicMaxPriority),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(TargetThresholdSetTest, Target0PriorityInvalid) {
   EXPECT_EQ(dif_rv_plic_target_set_threshold(&plic_, kTarget0,
                                              kDifRvPlicMaxPriority + 1),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(TargetThresholdSetTest, Target0Success) {
@@ -222,22 +218,21 @@ TEST_F(TargetThresholdSetTest, Target0Success) {
 
   EXPECT_EQ(
       dif_rv_plic_target_set_threshold(&plic_, kTarget0, kDifRvPlicMaxPriority),
-      kDifRvPlicOk);
+      kDifOk);
 }
 
 class IrqPendingStatusGetTest : public IrqTest {};
 
 TEST_F(IrqPendingStatusGetTest, NullArgs) {
   bool status;
-  dif_rv_plic_result_t result =
-      dif_rv_plic_irq_is_pending(nullptr, kFirstIrq, &status);
-  EXPECT_EQ(result, kDifRvPlicBadArg);
+  dif_result_t result = dif_rv_plic_irq_is_pending(nullptr, kFirstIrq, &status);
+  EXPECT_EQ(result, kDifBadArg);
 
   result = dif_rv_plic_irq_is_pending(&plic_, kFirstIrq, nullptr);
-  EXPECT_EQ(result, kDifRvPlicBadArg);
+  EXPECT_EQ(result, kDifBadArg);
 
   result = dif_rv_plic_irq_is_pending(nullptr, kFirstIrq, nullptr);
-  EXPECT_EQ(result, kDifRvPlicBadArg);
+  EXPECT_EQ(result, kDifBadArg);
 }
 
 TEST_F(IrqPendingStatusGetTest, Enabled) {
@@ -246,9 +241,8 @@ TEST_F(IrqPendingStatusGetTest, Enabled) {
   // Get status of every IRQ, one at a time.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     bool status;
-    dif_rv_plic_result_t result =
-        dif_rv_plic_irq_is_pending(&plic_, i, &status);
-    EXPECT_EQ(result, kDifRvPlicOk);
+    dif_result_t result = dif_rv_plic_irq_is_pending(&plic_, i, &status);
+    EXPECT_EQ(result, kDifOk);
     EXPECT_TRUE(status);
   }
 }
@@ -259,9 +253,8 @@ TEST_F(IrqPendingStatusGetTest, Disabled) {
   // Get status of every IRQ, one at a time.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     bool status;
-    dif_rv_plic_result_t result =
-        dif_rv_plic_irq_is_pending(&plic_, i, &status);
-    EXPECT_EQ(result, kDifRvPlicOk);
+    dif_result_t result = dif_rv_plic_irq_is_pending(&plic_, i, &status);
+    EXPECT_EQ(result, kDifOk);
     EXPECT_FALSE(status);
   }
 }
@@ -272,12 +265,11 @@ class IrqClaimTest : public PlicTest {
 
 TEST_F(IrqClaimTest, NullArgs) {
   dif_rv_plic_irq_id_t data;
-  EXPECT_EQ(dif_rv_plic_irq_claim(nullptr, kTarget0, &data), kDifRvPlicBadArg);
+  EXPECT_EQ(dif_rv_plic_irq_claim(nullptr, kTarget0, &data), kDifBadArg);
 
-  EXPECT_EQ(dif_rv_plic_irq_claim(&plic_, kTarget0, nullptr), kDifRvPlicBadArg);
+  EXPECT_EQ(dif_rv_plic_irq_claim(&plic_, kTarget0, nullptr), kDifBadArg);
 
-  EXPECT_EQ(dif_rv_plic_irq_claim(nullptr, kTarget0, nullptr),
-            kDifRvPlicBadArg);
+  EXPECT_EQ(dif_rv_plic_irq_claim(nullptr, kTarget0, nullptr), kDifBadArg);
 }
 
 TEST_F(IrqClaimTest, Target0Success) {
@@ -289,7 +281,7 @@ TEST_F(IrqClaimTest, Target0Success) {
   // Claim every IRQ, one per a call.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
     dif_rv_plic_irq_id_t data;
-    EXPECT_EQ(dif_rv_plic_irq_claim(&plic_, kTarget0, &data), kDifRvPlicOk);
+    EXPECT_EQ(dif_rv_plic_irq_claim(&plic_, kTarget0, &data), kDifOk);
     EXPECT_EQ(data, i);
   }
 }
@@ -299,7 +291,7 @@ class IrqCompleteTest : public PlicTest {
 };
 
 TEST_F(IrqCompleteTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_irq_complete(nullptr, kTarget0, 0), kDifRvPlicBadArg);
+  EXPECT_EQ(dif_rv_plic_irq_complete(nullptr, kTarget0, 0), kDifBadArg);
 }
 
 TEST_F(IrqCompleteTest, Target0Success) {
@@ -310,7 +302,7 @@ TEST_F(IrqCompleteTest, Target0Success) {
 
   // Complete all of the IRQs.
   for (int i = 0; i < RV_PLIC_PARAM_NUM_SRC; ++i) {
-    EXPECT_EQ(dif_rv_plic_irq_complete(&plic_, kTarget0, i), kDifRvPlicOk);
+    EXPECT_EQ(dif_rv_plic_irq_complete(&plic_, kTarget0, i), kDifOk);
   }
 }
 
@@ -319,18 +311,17 @@ class SoftwareIrqForceTest : public PlicTest {
 };
 
 TEST_F(SoftwareIrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_software_irq_force(nullptr, kTarget0),
-            kDifRvPlicBadArg);
+  EXPECT_EQ(dif_rv_plic_software_irq_force(nullptr, kTarget0), kDifBadArg);
 }
 
 TEST_F(SoftwareIrqForceTest, BadTarget) {
   EXPECT_EQ(dif_rv_plic_software_irq_force(&plic_, RV_PLIC_PARAM_NUM_TARGET),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(SoftwareIrqForceTest, Target0Success) {
   EXPECT_WRITE32(RV_PLIC_MSIP0_REG_OFFSET, 1);
-  EXPECT_EQ(dif_rv_plic_software_irq_force(&plic_, kTarget0), kDifRvPlicOk);
+  EXPECT_EQ(dif_rv_plic_software_irq_force(&plic_, kTarget0), kDifOk);
 }
 
 class SoftwareIrqAcknowledgeTest : public PlicTest {
@@ -339,19 +330,18 @@ class SoftwareIrqAcknowledgeTest : public PlicTest {
 
 TEST_F(SoftwareIrqAcknowledgeTest, NullArgs) {
   EXPECT_EQ(dif_rv_plic_software_irq_acknowledge(nullptr, kTarget0),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(SoftwareIrqAcknowledgeTest, BadTarget) {
   EXPECT_EQ(
       dif_rv_plic_software_irq_acknowledge(&plic_, RV_PLIC_PARAM_NUM_TARGET),
-      kDifRvPlicBadArg);
+      kDifBadArg);
 }
 
 TEST_F(SoftwareIrqAcknowledgeTest, Target0Success) {
   EXPECT_WRITE32(RV_PLIC_MSIP0_REG_OFFSET, 0);
-  EXPECT_EQ(dif_rv_plic_software_irq_acknowledge(&plic_, kTarget0),
-            kDifRvPlicOk);
+  EXPECT_EQ(dif_rv_plic_software_irq_acknowledge(&plic_, kTarget0), kDifOk);
 }
 
 class SoftwareIrqIsPendingTest : public PlicTest {
@@ -360,21 +350,21 @@ class SoftwareIrqIsPendingTest : public PlicTest {
 
 TEST_F(SoftwareIrqIsPendingTest, NullArgs) {
   EXPECT_EQ(dif_rv_plic_software_irq_is_pending(nullptr, kTarget0, nullptr),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 
   EXPECT_EQ(dif_rv_plic_software_irq_is_pending(&plic_, kTarget0, nullptr),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 
   bool is_pending;
   EXPECT_EQ(dif_rv_plic_software_irq_is_pending(nullptr, kTarget0, &is_pending),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(SoftwareIrqIsPendingTest, BadTarget) {
   bool is_pending;
   EXPECT_EQ(dif_rv_plic_software_irq_is_pending(
                 &plic_, RV_PLIC_PARAM_NUM_TARGET, &is_pending),
-            kDifRvPlicBadArg);
+            kDifBadArg);
 }
 
 TEST_F(SoftwareIrqIsPendingTest, Target0Success) {
@@ -382,7 +372,7 @@ TEST_F(SoftwareIrqIsPendingTest, Target0Success) {
   EXPECT_READ32(RV_PLIC_MSIP0_REG_OFFSET, 1);
 
   EXPECT_EQ(dif_rv_plic_software_irq_is_pending(&plic_, kTarget0, &is_pending),
-            kDifRvPlicOk);
+            kDifOk);
   EXPECT_TRUE(is_pending);
 
   // Cleared
@@ -390,7 +380,7 @@ TEST_F(SoftwareIrqIsPendingTest, Target0Success) {
   EXPECT_READ32(RV_PLIC_MSIP0_REG_OFFSET, 0);
 
   EXPECT_EQ(dif_rv_plic_software_irq_is_pending(&plic_, kTarget0, &is_pending),
-            kDifRvPlicOk);
+            kDifOk);
   EXPECT_FALSE(is_pending);
 }
 

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -153,6 +153,7 @@ sw_lib_dif_rv_plic = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_bitfield,
+      sw_lib_dif_autogen_rv_plic,
     ],
   )
 )
@@ -160,9 +161,11 @@ sw_lib_dif_rv_plic = declare_dependency(
 test('dif_rv_plic_unittest', executable(
     'dif_rv_plic_unittest',
     sources: [
-      hw_top_earlgrey_rv_plic_reg_h,
-      meson.source_root() / 'sw/device/lib/dif/dif_rv_plic.c',
       'dif_rv_plic_unittest.cc',
+      'autogen/dif_rv_plic_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_rv_plic.c',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_rv_plic_autogen.c',
+      hw_top_earlgrey_rv_plic_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/lib/testing/rv_plic_testutils.c
+++ b/sw/device/lib/testing/rv_plic_testutils.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 
+#include "sw/device/lib/dif/dif_base.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
@@ -17,10 +18,10 @@ void rv_plic_testutils_irq_range_enable(dif_rv_plic_t *plic,
        ++irq_id) {
     uint32_t priority = rand_testutils_gen32_range(kDifRvPlicMinPriority + 1,
                                                    kDifRvPlicMaxPriority);
-    CHECK(dif_rv_plic_irq_set_priority(plic, irq_id, priority) == kDifRvPlicOk);
-    CHECK(dif_rv_plic_irq_set_enabled(plic, irq_id, target,
-                                      kDifRvPlicToggleEnabled) == kDifRvPlicOk);
+    CHECK_DIF_OK(dif_rv_plic_irq_set_priority(plic, irq_id, priority));
+    CHECK_DIF_OK(
+        dif_rv_plic_irq_set_enabled(plic, irq_id, target, kDifToggleEnabled));
   }
-  CHECK(dif_rv_plic_target_set_threshold(plic, target, kDifRvPlicMinPriority) ==
-        kDifRvPlicOk);
+  CHECK_DIF_OK(
+      dif_rv_plic_target_set_threshold(plic, target, kDifRvPlicMinPriority));
 }

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -144,7 +144,7 @@ static volatile dif_uart_irq_t uart_irq_serviced;
 void handler_irq_external(void) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t plic_irq_id;
-  CHECK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id) == kDifRvPlicOk);
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id));
 
   // Check if it is the right peripheral.
   top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
@@ -250,7 +250,7 @@ void handler_irq_external(void) {
   }
 
   // Complete the IRQ at PLIC.
-  CHECK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id) == kDifRvPlicOk);
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id));
 }
 
 /**
@@ -299,8 +299,7 @@ static void peripherals_init(void) {
 
   mmio_region_t base_addr =
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK(dif_rv_plic_init((dif_rv_plic_params_t){.base_addr = base_addr},
-                         &plic) == kDifRvPlicOk);
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, &plic));
 }
 
 /**

--- a/sw/device/tests/sim_dv/spi_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/spi_tx_rx_test.c
@@ -70,9 +70,8 @@ static volatile bool fired_irqs[SPI_DEVICE_NUM_IRQS];
 void handler_irq_external(void) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t plic_irq_id;
-  CHECK(dif_rv_plic_irq_claim(&plic0, kTopEarlgreyPlicTargetIbex0,
-                              &plic_irq_id) == kDifRvPlicOk,
-        "dif_rv_plic_irq_claim failed");
+  CHECK_DIF_OK(
+      dif_rv_plic_irq_claim(&plic0, kTopEarlgreyPlicTargetIbex0, &plic_irq_id));
 
   // Check if it is the right peripheral.
   top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
@@ -126,9 +125,8 @@ void handler_irq_external(void) {
   CHECK_DIF_OK(dif_spi_device_irq_acknowledge(&spi_device, spi_device_irq));
 
   // Complete the IRQ at PLIC.
-  CHECK(dif_rv_plic_irq_complete(&plic0, kTopEarlgreyPlicTargetIbex0,
-                                 plic_irq_id) == kDifRvPlicOk,
-        "dif_rv_plic_irq_complete failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic0, kTopEarlgreyPlicTargetIbex0,
+                                        plic_irq_id));
 }
 
 /**
@@ -167,74 +165,50 @@ static void spi_device_init_with_irqs(
 static void plic_init_with_irqs(mmio_region_t base_addr, dif_rv_plic_t *plic) {
   LOG_INFO("Initializing the PLIC.");
 
-  CHECK(dif_rv_plic_init((dif_rv_plic_params_t){.base_addr = base_addr},
-                         plic) == kDifRvPlicOk,
-        "dif_rv_plic_init failed");
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, plic));
 
   // Set the priority of SPI DEVICE interrupts at PLIC to be >=1 (so ensure the
   // target does get interrupted).
-  CHECK(dif_rv_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxFull,
-                                     kDifRvPlicMaxPriority) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_priority failed");
-  CHECK(dif_rv_plic_irq_set_priority(plic,
-                                     kTopEarlgreyPlicIrqIdSpiDeviceRxWatermark,
-                                     kDifRvPlicMaxPriority) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_priority failed");
-  CHECK(dif_rv_plic_irq_set_priority(plic,
-                                     kTopEarlgreyPlicIrqIdSpiDeviceTxWatermark,
-                                     kDifRvPlicMaxPriority) == kDifRvPlicOk,
-        , "dif_rv_plic_irq_set_priority failed");
-  CHECK(
-      dif_rv_plic_irq_set_priority(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxError,
-                                   kDifRvPlicMaxPriority) == kDifRvPlicOk,
-      "dif_rv_plic_irq_set_priority failed");
-  CHECK(dif_rv_plic_irq_set_priority(plic,
-                                     kTopEarlgreyPlicIrqIdSpiDeviceRxOverflow,
-                                     kDifRvPlicMaxPriority) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_priority failed");
-  CHECK(dif_rv_plic_irq_set_priority(plic,
-                                     kTopEarlgreyPlicIrqIdSpiDeviceTxUnderflow,
-                                     kDifRvPlicMaxPriority) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_priority failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxFull, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxWatermark, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceTxWatermark, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxError, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxOverflow, kDifRvPlicMaxPriority));
+  CHECK_DIF_OK(dif_rv_plic_irq_set_priority(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceTxUnderflow, kDifRvPlicMaxPriority));
 
   // Set the threshold for the Ibex to 0.
-  CHECK(dif_rv_plic_target_set_threshold(plic, kTopEarlgreyPlicTargetIbex0,
-                                         0x0) == kDifRvPlicOk,
-        "dif_rv_plic_target_set_threshold failed");
+  CHECK_DIF_OK(
+      dif_rv_plic_target_set_threshold(plic, kTopEarlgreyPlicTargetIbex0, 0x0));
 
-  CHECK(dif_rv_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxFull,
-                                    kTopEarlgreyPlicTargetIbex0,
-                                    kDifRvPlicToggleEnabled) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxFull, kTopEarlgreyPlicTargetIbex0,
+      kDifToggleEnabled));
 
-  CHECK(dif_rv_plic_irq_set_enabled(plic,
-                                    kTopEarlgreyPlicIrqIdSpiDeviceRxWatermark,
-                                    kTopEarlgreyPlicTargetIbex0,
-                                    kDifRvPlicToggleEnabled) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxWatermark,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
 
-  CHECK(dif_rv_plic_irq_set_enabled(plic,
-                                    kTopEarlgreyPlicIrqIdSpiDeviceTxWatermark,
-                                    kTopEarlgreyPlicTargetIbex0,
-                                    kDifRvPlicToggleEnabled) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceTxWatermark,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
 
-  CHECK(dif_rv_plic_irq_set_enabled(plic, kTopEarlgreyPlicIrqIdSpiDeviceRxError,
-                                    kTopEarlgreyPlicTargetIbex0,
-                                    kDifRvPlicToggleEnabled) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxError, kTopEarlgreyPlicTargetIbex0,
+      kDifToggleEnabled));
 
-  CHECK(dif_rv_plic_irq_set_enabled(plic,
-                                    kTopEarlgreyPlicIrqIdSpiDeviceRxOverflow,
-                                    kTopEarlgreyPlicTargetIbex0,
-                                    kDifRvPlicToggleEnabled) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceRxOverflow,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
 
-  CHECK(dif_rv_plic_irq_set_enabled(plic,
-                                    kTopEarlgreyPlicIrqIdSpiDeviceTxUnderflow,
-                                    kTopEarlgreyPlicTargetIbex0,
-                                    kDifRvPlicToggleEnabled) == kDifRvPlicOk,
-        "dif_rv_plic_irq_set_enabled failed");
+  CHECK_DIF_OK(dif_rv_plic_irq_set_enabled(
+      plic, kTopEarlgreyPlicIrqIdSpiDeviceTxUnderflow,
+      kTopEarlgreyPlicTargetIbex0, kDifToggleEnabled));
 }
 
 static bool exp_irqs_fired(void) {

--- a/util/topgen/templates/plic_all_irqs_test.c.tpl
+++ b/util/topgen/templates/plic_all_irqs_test.c.tpl
@@ -68,7 +68,7 @@ ${comment(n)}static volatile dif_${n}_irq_t ${n}_irq_serviced;
 void handler_irq_external(void) {
   // Find which interrupt fired at PLIC by claiming it.
   dif_rv_plic_irq_id_t plic_irq_id;
-  CHECK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id) == kDifRvPlicOk);
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id));
 
   // Check if it is the right peripheral.
   top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
@@ -89,7 +89,7 @@ void handler_irq_external(void) {
   }
 
   // Complete the IRQ at PLIC.
-  CHECK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id) == kDifRvPlicOk);
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kHart, plic_irq_id));
 }
 
 /**
@@ -110,8 +110,7 @@ static void peripherals_init(void) {
 
   mmio_region_t base_addr =
       mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
-  CHECK(dif_rv_plic_init((dif_rv_plic_params_t){.base_addr = base_addr},
-                         &plic) == kDifRvPlicOk);
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, &plic));
 }
 
 /**


### PR DESCRIPTION
This partially addresses #8142, specifically, the item: "Integrate auto-generated IRQ DIFs into (existing) IP DIFs and deprecate manually implemented IRQ DIFs" --> "rv_plic".

Note: the **rv_plic** IP does not generate any interrupts, but it does generate alerts, so the changes in the PR will setup the ability to add autogenerated alert DIF(s) in the near future. Specifically, part of these changes involve migrating the rv_plic DIFs to use global (shared) DIF error codes and the autogenerated context struct.