### PR TITLE
[dv] Fix shadow reg backdoor path and enable csr_reset sequence

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -154,7 +154,7 @@ virtual task poke_and_check_storage_error(dv_base_reg shadowed_csr);
   string          alert_name = shadowed_csr.get_storage_err_alert_name();
 
   `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(
-      kind, kind inside {BkdrRegPathRtlCommitted, BkdrRegPathRtlShadow};)
+      kind, kind inside {BkdrRegPathRtl, BkdrRegPathRtlShadow};)
   csr_peek(.ptr(shadowed_csr), .value(origin_val), .kind(kind));
   err_val = get_shadow_reg_diff_val(shadowed_csr, origin_val);
 

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.sv
@@ -318,7 +318,7 @@ class dv_base_reg extends uvm_reg;
       if (kind == "BkdrRegPathRtlShadow") begin
         flds[i].update_shadowed_val(get_field_val(flds[i], value));
         backdoor_write_shadow_val = 1;
-      end else if (kind == "BkdrRegPathRtlCommitted") begin
+      end else if (kind == "BkdrRegPathRtl") begin
         flds[i].update_committed_val(get_field_val(flds[i], value));
         backdoor_write_shadow_val = 1;
       end

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -38,11 +38,10 @@ package dv_base_reg_pkg;
   } csr_test_type_e;
 
   typedef enum bit[2:0] {
+    // If it's a shadow reg, BkdrRegPathRtl is the path to committed reg
     BkdrRegPathRtl,          // backdoor path for reg's val in RTL
-    BkdrRegPathRtlCommitted, // backdoor path for shadow reg's committed val in RTL
     BkdrRegPathRtlShadow,    // backdoor path for shadow reg's shadow val in RTL
     BkdrRegPathGls,          // backdoor path for reg's val in GLS
-    BkdrRegPathGlsCommitted, // backdoor path for shadow reg's committed val in GLS
     BkdrRegPathGlsShdow      // backdoor path for shadow reg's shadow val in GLS
   } bkdr_reg_path_e;
 

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -133,7 +133,6 @@ ${make_ral_pkg_window_class(dv_base_prefix, esc_if_name, window)}
       end
 % if rb.flat_regs:
       set_hdl_path_root("tb.dut", "BkdrRegPathRtl");
-      set_hdl_path_root("tb.dut", "BkdrRegPathRtlCommitted");
       set_hdl_path_root("tb.dut", "BkdrRegPathRtlShadow");
       // create registers
   % for r in rb.all_regs:
@@ -535,7 +534,7 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
 %>\
       ${reg_inst}.add_hdl_path_slice(
           "${shadowed_reg_path}.committed_reg.q",
-          ${field.bits.lsb}, ${field.bits.width()}, 0, "BkdrRegPathRtlCommitted");
+          ${field.bits.lsb}, ${field.bits.width()}, 0, "BkdrRegPathRtl");
       ${reg_inst}.add_hdl_path_slice(
           "${shadowed_reg_path}.shadow_reg.q",
           ${field.bits.lsb}, ${field.bits.width()}, 0, "BkdrRegPathRtlShadow");
@@ -560,7 +559,7 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
       ${reg_inst}.add_hdl_path_slice(
           "${reg_block_path}.${reg_field_name}_qs",
           ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
-%   else:
+%   elif not reg.shadowed:
       ${reg_inst}.add_hdl_path_slice(
           "${reg_block_path}.u_${reg_field_name}.q${"s" if reg.hwext else ""}",
           ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
@@ -568,7 +567,7 @@ ${_create_reg_field(dv_base_prefix, reg_width, reg_block_path, reg.shadowed, reg
 %   if reg.shadowed and not reg.hwext:
       ${reg_inst}.add_hdl_path_slice(
           "${reg_block_path}.u_${reg_field_name}.committed_reg.q",
-          ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtlCommitted");
+          ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtl");
       ${reg_inst}.add_hdl_path_slice(
           "${reg_block_path}.u_${reg_field_name}.shadow_reg.q",
           ${field.bits.lsb}, ${field_size}, 0, "BkdrRegPathRtlShadow");


### PR DESCRIPTION
Thanks Tim Chen for finding the backdoor path issue that we deposit
backdoor value into a net rather a storage

Without this PR, we have 3 paths for shadow reg

- BkdrRegPathRtl -> point to a net connected with committed reg
- BkdrRegPathRtlCommitted -> point to committed reg
- BkdrRegPathRtlShadow -> point to shadowed reg

If we force to a net, it doesn't work. It has to be an actual storage when we force it.
Now I changed to 
- BkdrRegPathRtl ->point to committed reg
- ~~BkdrRegPathRtlCommitted -> point to committed reg~~
- BkdrRegPathRtlShadow -> point to shadowed reg

also added
1. Enhance csr_wr seq to backdoor write all the paths for csr_reset seq
2. Enhance csr_reset seq to also do backdoor read check to ensure we
don't deposit value to a net

Signed-off-by: Weicai Yang <weicai@google.com>