### PR TITLE
[dv/alert_handler] Add regwen write in alert_handler tests

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -70,11 +70,29 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d, lock_bit[3])
   endtask
 
-  virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_CLASSES-1:0] regwen);
-    if (!regwen[0]) csr_wr(.ptr(ral.classa_clr_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[1]) csr_wr(.ptr(ral.classb_clr_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[2]) csr_wr(.ptr(ral.classc_clr_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[3]) csr_wr(.ptr(ral.classd_clr_regwen), .value($urandom_range(0, 1)));
+  virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_CLASSES-1:0] regwen = 0,
+                                            bit [NUM_ALERTS-1:0]        alert_regwen = 0,
+                                            bit [NUM_LOCAL_ALERTS-1:0]  loc_alert_regwen = 0,
+                                            bit                         ping_timer_regwen = 0,
+                                            bit [NUM_ALERT_CLASSES-1:0] class_regwen = 0);
+
+    csr_wr(.ptr(ral.classa_clr_regwen), .value(regwen[0]));
+    csr_wr(.ptr(ral.classb_clr_regwen), .value(regwen[1]));
+    csr_wr(.ptr(ral.classc_clr_regwen), .value(regwen[2]));
+    csr_wr(.ptr(ral.classd_clr_regwen), .value(regwen[3]));
+
+    foreach (alert_regwen[i]) csr_wr(.ptr(ral.alert_regwen[i]), .value(alert_regwen[i]));
+
+    foreach (loc_alert_regwen[i]) begin
+      csr_wr(.ptr(ral.loc_alert_regwen[i]), .value(loc_alert_regwen[i]));
+    end
+
+    csr_wr(.ptr(ral.ping_timer_regwen), .value(ping_timer_regwen));
+
+    csr_wr(.ptr(ral.classa_regwen), .value(class_regwen[0]));
+    csr_wr(.ptr(ral.classb_regwen), .value(class_regwen[1]));
+    csr_wr(.ptr(ral.classc_regwen), .value(class_regwen[2]));
+    csr_wr(.ptr(ral.classd_regwen), .value(class_regwen[3]));
   endtask
 
   // If do_lock_config is set, write value 1 to ping_timer_en register.

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -9,19 +9,24 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   `uvm_object_new
 
   rand bit [NUM_ALERT_CLASSES-1:0]                       intr_en;
+  rand bit [NUM_ALERT_CLASSES-1:0]                       clr_regwen;
+  rand bit [NUM_ALERT_CLASSES-1:0]                       class_regwen;
   rand bit [NUM_ALERT_CLASSES-1:0]                       clr_en;
   rand bit [NUM_ALERT_CLASSES-1:0]                       lock_bit_en;
+  rand bit [NUM_ALERTS-1:0]                              alert_regwen;
   rand bit [NUM_ALERTS-1:0]                              alert_trigger;
   rand bit [NUM_ALERTS-1:0]                              alert_int_err;
   rand bit [NUM_ALERTS-1:0]                              alert_en;
   rand bit [NUM_ALERTS-1:0]                              alert_ping_timeout;
   rand bit [NUM_ALERT_CLASSES-1:0][NUM_ALERTS-1:0]       alert_class_map;
+  rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_regwen;
   rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_en;
   rand bit [NUM_ALERT_CLASSES-1:0][NUM_LOCAL_ALERTS-1:0] local_alert_class_map;
   rand bit [NUM_ESCS-1:0]                                esc_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_standalone_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_ping_timeout;
 
+  rand bit ping_timer_regwen;
   rand bit do_clr_esc;
   rand bit do_wr_phases_cyc;
   rand bit do_esc_intr_timeout;
@@ -41,8 +46,15 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   }
 
   constraint clr_and_lock_en_c {
-    clr_en      dist {[0:'b1110] :/ 4, '1         :/ 6};
-    lock_bit_en dist {0          :/ 6, [1:'b1111] :/ 4};
+    lock_bit_en dist {0 :/ 6, [1:'b1111] :/ 4};
+  }
+
+  constraint regwen_c {
+    clr_regwen         dist {[0:'1-1] :/ 4, '1 :/ 6};
+    class_regwen       dist {[0:'1-1] :/ 4, '1 :/ 6};
+    alert_regwen       dist {[0:'1-1] :/ 4, '1 :/ 6};
+    local_alert_regwen dist {[0:'1-1] :/ 4, '1 :/ 6};
+    ping_timer_regwen  dist { 0 :/ 4      ,  1 :/ 6};
   }
 
   constraint enable_one_alert_c {
@@ -122,7 +134,8 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
       // write class_ctrl and clren_reg
       alert_handler_rand_wr_class_ctrl(lock_bit_en);
-      alert_handler_wr_regwen_regs(clr_en);
+      alert_handler_wr_regwen_regs(clr_regwen, alert_regwen, local_alert_regwen, ping_timer_regwen,
+                                   class_regwen);
 
       // randomize crashdump triggered phases
       alert_handler_crashdump_phases();

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -70,11 +70,29 @@ class alert_handler_base_vseq extends cip_base_vseq #(
     if (class_en[3]) `RAND_WRITE_CLASS_CTRL(d, lock_bit[3])
   endtask
 
-  virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_CLASSES-1:0] regwen);
-    if (!regwen[0]) csr_wr(.ptr(ral.classa_clr_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[1]) csr_wr(.ptr(ral.classb_clr_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[2]) csr_wr(.ptr(ral.classc_clr_regwen), .value($urandom_range(0, 1)));
-    if (!regwen[3]) csr_wr(.ptr(ral.classd_clr_regwen), .value($urandom_range(0, 1)));
+  virtual task alert_handler_wr_regwen_regs(bit [NUM_ALERT_CLASSES-1:0] regwen = 0,
+                                            bit [NUM_ALERTS-1:0]        alert_regwen = 0,
+                                            bit [NUM_LOCAL_ALERTS-1:0]  loc_alert_regwen = 0,
+                                            bit                         ping_timer_regwen = 0,
+                                            bit [NUM_ALERT_CLASSES-1:0] class_regwen = 0);
+
+    csr_wr(.ptr(ral.classa_clr_regwen), .value(regwen[0]));
+    csr_wr(.ptr(ral.classb_clr_regwen), .value(regwen[1]));
+    csr_wr(.ptr(ral.classc_clr_regwen), .value(regwen[2]));
+    csr_wr(.ptr(ral.classd_clr_regwen), .value(regwen[3]));
+
+    foreach (alert_regwen[i]) csr_wr(.ptr(ral.alert_regwen[i]), .value(alert_regwen[i]));
+
+    foreach (loc_alert_regwen[i]) begin
+      csr_wr(.ptr(ral.loc_alert_regwen[i]), .value(loc_alert_regwen[i]));
+    end
+
+    csr_wr(.ptr(ral.ping_timer_regwen), .value(ping_timer_regwen));
+
+    csr_wr(.ptr(ral.classa_regwen), .value(class_regwen[0]));
+    csr_wr(.ptr(ral.classb_regwen), .value(class_regwen[1]));
+    csr_wr(.ptr(ral.classc_regwen), .value(class_regwen[2]));
+    csr_wr(.ptr(ral.classd_regwen), .value(class_regwen[3]));
   endtask
 
   // If do_lock_config is set, write value 1 to ping_timer_en register.

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -9,19 +9,24 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   `uvm_object_new
 
   rand bit [NUM_ALERT_CLASSES-1:0]                       intr_en;
+  rand bit [NUM_ALERT_CLASSES-1:0]                       clr_regwen;
+  rand bit [NUM_ALERT_CLASSES-1:0]                       class_regwen;
   rand bit [NUM_ALERT_CLASSES-1:0]                       clr_en;
   rand bit [NUM_ALERT_CLASSES-1:0]                       lock_bit_en;
+  rand bit [NUM_ALERTS-1:0]                              alert_regwen;
   rand bit [NUM_ALERTS-1:0]                              alert_trigger;
   rand bit [NUM_ALERTS-1:0]                              alert_int_err;
   rand bit [NUM_ALERTS-1:0]                              alert_en;
   rand bit [NUM_ALERTS-1:0]                              alert_ping_timeout;
   rand bit [NUM_ALERT_CLASSES-1:0][NUM_ALERTS-1:0]       alert_class_map;
+  rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_regwen;
   rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_en;
   rand bit [NUM_ALERT_CLASSES-1:0][NUM_LOCAL_ALERTS-1:0] local_alert_class_map;
   rand bit [NUM_ESCS-1:0]                                esc_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_standalone_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_ping_timeout;
 
+  rand bit ping_timer_regwen;
   rand bit do_clr_esc;
   rand bit do_wr_phases_cyc;
   rand bit do_esc_intr_timeout;
@@ -41,8 +46,15 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   }
 
   constraint clr_and_lock_en_c {
-    clr_en      dist {[0:'b1110] :/ 4, '1         :/ 6};
-    lock_bit_en dist {0          :/ 6, [1:'b1111] :/ 4};
+    lock_bit_en dist {0 :/ 6, [1:'b1111] :/ 4};
+  }
+
+  constraint regwen_c {
+    clr_regwen         dist {[0:'1-1] :/ 4, '1 :/ 6};
+    class_regwen       dist {[0:'1-1] :/ 4, '1 :/ 6};
+    alert_regwen       dist {[0:'1-1] :/ 4, '1 :/ 6};
+    local_alert_regwen dist {[0:'1-1] :/ 4, '1 :/ 6};
+    ping_timer_regwen  dist { 0 :/ 4      ,  1 :/ 6};
   }
 
   constraint enable_one_alert_c {
@@ -122,7 +134,8 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
       // write class_ctrl and clren_reg
       alert_handler_rand_wr_class_ctrl(lock_bit_en);
-      alert_handler_wr_regwen_regs(clr_en);
+      alert_handler_wr_regwen_regs(clr_regwen, alert_regwen, local_alert_regwen, ping_timer_regwen,
+                                   class_regwen);
 
       // randomize crashdump triggered phases
       alert_handler_crashdump_phases();


### PR DESCRIPTION
This PR adds the newly added regwen in alert_handler to dv tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>