### PR TITLE
[dv,ci] Enable autogen PLIC irq test in smoke regr

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -289,7 +289,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["chip_sw_uart_tx_rx"]
+      tests: ["chip_sw_uart_tx_rx", "chip_plic_all_irqs"]
     }
   ]
 }


### PR DESCRIPTION
This is a functional autogenerated test that touches several blocks. It will be useful to run this in CI. 

If it puts a strain on CI runtime, I am ok abandoning this PR. 


Signed-off-by: Srikrishna Iyer <sriyer@google.com>