### PR TITLE
 [otbn, dv] otbn_imem_err test added along with related changes

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -80,7 +80,7 @@
             Inject ECC errors into DMEM and IMEM and expect an alert
             '''
       milestone: V2
-      tests: []
+      tests: ["otbn_imem_err"]
     }
     {
       name: back_to_back

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -36,6 +36,7 @@ filesets:
       - seq_lib/otbn_multi_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_reset_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sequential_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_imem_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -276,6 +276,10 @@ class otbn_scoreboard extends cip_base_scoreboard #(
             pending_start_tl_trans = 1'b0;
           end
           model_status = item.status;
+          // If the model status is locked, the scoreboard should expect a fatal error.
+          if (model_status == otbn_pkg::StatusLocked) begin
+            set_exp_alert("fatal", .is_fatal(1));
+          end
         end
 
         OtbnModelInsn: begin

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -107,7 +107,7 @@ class otbn_base_vseq extends cip_base_vseq #(
   // Start OTBN and then wait until done
   //
   // If the block gets reset, this task will exit early.
-  protected task run_otbn();
+  protected task run_otbn(input check_end_addr = 1);
     int exp_end_addr;
 
     // Check that we haven't been called re-entrantly. This could happen if there's a bug in the
@@ -131,7 +131,7 @@ class otbn_base_vseq extends cip_base_vseq #(
     //
     // The CSR operations above short-circuit and exit immediately if the reset line goes low. If
     // that happens, we don't want to run the checks (since the run didn't finish properly).
-    if (!cfg.under_reset) begin
+    if (!cfg.under_reset && check_end_addr) begin
       // If there was an expected end address, compare it with the model. This isn't really a test of
       // the RTL, but it's handy to make sure that the RIG really is generating the control flow that
       // it expects.
@@ -153,7 +153,9 @@ class otbn_base_vseq extends cip_base_vseq #(
 
     // Now wait until OTBN has finished
     `uvm_info(`gfn, $sformatf("\n\t ----| Waiting for OTBN to finish"), UVM_MEDIUM)
-    csr_utils_pkg::csr_spinwait(.ptr(ral.status), .exp_data(otbn_pkg::StatusIdle));
+    csr_utils_pkg::csr_spinwait(.ptr(ral.status),
+                                .exp_data(otbn_pkg::StatusBusyExecute),
+                                .compare_op(CompareOpNe));
 
     `uvm_info(`gfn, $sformatf("\n\t ----| OTBN finished"), UVM_MEDIUM)
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -1,0 +1,115 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times and corrupts the
+// imem registers while the otbn is still running.
+
+class otbn_imem_err_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_imem_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    int wait_cycles;
+    string elf_path;
+    uvm_reg_data_t act_val;
+    bit [38:0] mask;
+    bit timed_out;
+
+    logic [127:0]    key;
+    logic [63:0]     nonce;
+
+    elf_path = pick_elf_path();
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+    load_elf(elf_path, 1'b1);
+
+    wait_cycles = 1000;
+    for (int i = 0; i < 10; i++) begin
+      int cycle_counter;
+      int err_wait;
+
+      // Guess the number of cycles until error is injected. The first time around, we pick any
+      // number between 1 and 1,000. After that, we replace "1,000" with "75% of the longest we've
+      // seen the sequence run before terminating". This should avoid problems where we keep
+      // injecting errors after the sequence has finished.
+      err_wait = $urandom_range(wait_cycles * 3 / 4) + 1;
+      fork: isolation_fork
+      begin
+        fork
+          run_otbn(.check_end_addr(0));
+          begin
+            wait (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusyExecute);
+            repeat (err_wait) begin
+              @(cfg.clk_rst_vif.cbn);
+              cycle_counter++;
+            end
+          end
+        join_any
+
+        // When we get here, we know that either the OTBN sequence finished or we timed out
+        // and it's still going. We can see whether OTBN is still going by looking at the status
+        // from the model (which is also in sync with the RTL). Because we wait on the negedge
+        // when updating cycle_counter above, we know we've got the "new version" of the status at
+        // this point.
+        if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusBusyExecute) begin
+          timed_out = 1'b1;
+        end else begin
+          timed_out = 1'b0;
+          // The OTBN sequence finished so update wait_cycles. cycle_counter should always be less
+          // than wait_cycles (because of how we calculate wait cycles).
+          `DV_CHECK_FATAL(cycle_counter < wait_cycles);
+          wait_cycles = cycle_counter;
+
+          // Wait for the run_otbn thread to finish. This will usually be instant, but might take
+          // a couple of cycles if we happen to have timed out exactly at the end of the run (when
+          // the status has switched, but before run_otbn finishes)
+          wait (!running_);
+
+          // Kill the counter thread
+          disable fork;
+        end
+      end
+      join
+      if (timed_out) break;
+    end
+
+    // The below check is required to ensure that we always inject the errors while the otbn
+    // is still running. If timed_out is not asserted within 10 iterations, something has
+    // gone wrong and needs debug.
+    `DV_CHECK_FATAL(timed_out, "timed_out should be set")
+
+    key = cfg.get_imem_key();
+    nonce = cfg.get_imem_nonce();
+
+    // Mask to corrupt 1 to 2 bits of the imem memory
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
+
+    for (int i = 0; i < otbn_reg_pkg::OTBN_IMEM_SIZE / 4; i++) begin
+      bit [38:0] good_data = cfg.read_imem_word(i, key, nonce);
+      bit [38:0] bad_data = good_data ^ mask;
+      cfg.write_imem_word(i, bad_data, key, nonce);
+    end
+
+    cfg.model_agent_cfg.vif.invalidate_imem <= 1'b1;
+    @(cfg.clk_rst_vif.cb);
+    cfg.model_agent_cfg.vif.invalidate_imem <= 1'b0;
+
+    wait (cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusyExecute);
+    wait_alert_trigger("fatal", .wait_complete(1));
+    fork
+      begin
+        csr_utils_pkg::csr_rd(.ptr(ral.status), .value(act_val));
+        csr_utils_pkg::csr_rd(.ptr(ral.err_bits), .value(act_val));
+        csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
+      end
+      begin
+        wait_alert_trigger("fatal", .wait_complete(1));
+      end
+    join
+
+    dut_init("HARD");
+
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -9,3 +9,4 @@
 `include "otbn_sequential_vseq.sv"
 `include "otbn_single_vseq.sv"
 `include "otbn_smoke_vseq.sv"
+`include "otbn_imem_err_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -31,7 +31,7 @@ interface otbn_model_if #(
   task automatic wait_status();
     automatic bit [7:0] old_status = status;
     while (rst_ni === 1'b1 && status == old_status) begin
-      @(posedge clk_i or negedge rst_ni);
+      @(negedge clk_i or negedge rst_ni);
     end
   endtask
 

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -179,6 +179,12 @@ name:
       en_run_modes: ["build_otbn_multi_err_binaries_mode"]
       reseed: 1
     }
+    {
+      name: "otbn_imem_err"
+      uvm_test_seq: "otbn_imem_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This is in draft because it depends on https://github.com/lowRISC/opentitan/pull/8600 and https://github.com/lowRISC/opentitan/pull/8401. 
Once the above two PRs are merged, only the final commit will remain. 

The following changes have been made in this commit:
1. otbn_imem_err_vseq.sv: This is the sequence required to run otbn_imem_err
test. This is a new file.
2. otbn_scoreboard.sv: otbn_scoreboard is taught to expect a fatal error
when the model status goes to StatusLocked.
3. otbn_base_vseq.sv: run_otbn function is made to stall until otbn status is not
StatusBusyExecute instead of waiting for otbn to go to idle.
4. otbn_model_if.sv: wait_status now waits on negedge of the clock
instead of posedge to avoid race condition between alert arrival and
model state change. It ensures that the scoreboard sees the state change
before the fatal alert changes and knows it has to expect a fatal alert
and will not throw a fatal error.

Fixes #8505 