### PR TITLE
[otbn,dv] Includes implementation of StandaloneSim class and related …

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -9,8 +9,6 @@ from .state import OTBNState
 from .stats import ExecutionStats
 from .trace import Trace
 
-_TEST_RND_DATA = \
-    0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
 
 # A dictionary that defines a function of the form "address -> from -> to". If
 # PC is the current PC and cnt is the count for the innermost loop then
@@ -48,27 +46,6 @@ class OTBNSim:
         self._execute_generator = None
         self._next_insn = None
         self.state.start()
-
-    def run(self, verbose: bool) -> int:
-        '''Run until ECALL.
-
-        Return the number of cycles taken.
-
-        '''
-        insn_count = 0
-        # ISS will stall at start until URND data is valid, immediately set it
-        # valid when in free running mode as nothing else will.
-        self.state.set_urnd_reseed_complete()
-        while self.state.running:
-            self.step(verbose)
-            insn_count += 1
-
-            if self.state.wsrs.RND.pending_request:
-                # If an instruction requests RND data, make it available
-                # immediately.
-                self.state.wsrs.RND.set_unsigned(_TEST_RND_DATA)
-
-        return insn_count
 
     def _fetch(self, pc: int) -> OTBNInsn:
         word_pc = pc >> 2

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from .sim import OTBNSim
+
+_TEST_RND_DATA = \
+    0x99999999_99999999_99999999_99999999_99999999_99999999_99999999_99999999
+
+
+class StandaloneSim(OTBNSim):
+    def run(self, verbose: bool) -> int:
+        '''Run until ECALL.
+
+        Return the number of cycles taken.
+
+        '''
+        insn_count = 0
+        # ISS will stall at start until URND data is valid; immediately set it
+        # valid when in free running mode as nothing else will.
+        self.state.set_urnd_reseed_complete()
+        while self.state.running:
+            self.step(verbose)
+            insn_count += 1
+
+            if self.state.wsrs.RND.pending_request:
+                # If an instruction requests RND data, make it available
+                # immediately.
+                self.state.wsrs.RND.set_unsigned(_TEST_RND_DATA)
+
+        return insn_count

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 
 from sim.elf import load_elf
-from sim.sim import OTBNSim
+from sim.standalonesim import StandaloneSim
 from sim.stats import ExecutionStatAnalyzer
 
 
@@ -41,7 +41,7 @@ def main() -> int:
 
     collect_stats = args.dump_stats is not None
 
-    sim = OTBNSim()
+    sim = StandaloneSim()
     exp_end_addr = load_elf(sim, args.elf)
 
     sim.state.ext_regs.commit()

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -17,9 +17,6 @@ prefixed with "0x" if they are hexadecimal.
     step                 Run one instruction. Print trace information to
                          stdout.
 
-    run                  Run instructions until ecall or error. No trace
-                         information.
-
     load_elf <path>      Load the ELF file at <path>, replacing current
                          contents of DMEM and IMEM.
 
@@ -111,22 +108,6 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
         entry = change.rtl_trace()
         if entry is not None:
             print(entry)
-
-    return None
-
-
-def on_run(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
-    '''Run until ecall or error'''
-    if len(args):
-        raise ValueError('run expects zero arguments. Got {}.'
-                         .format(args))
-
-    print('RUN')
-
-    sim.run(verbose=False)
-
-    print(' INSN_CNT = {:#x}'.format(sim.state.ext_regs.read('INSN_CNT', False)))
-    print(' ERR_BITS = {:#x}'.format(sim.state.ext_regs.read('ERR_BITS', False)))
 
     return None
 
@@ -294,7 +275,6 @@ def on_reset(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 _HANDLERS = {
     'start': on_start,
     'step': on_step,
-    'run': on_run,
     'load_elf': on_load_elf,
     'add_loop_warp': on_add_loop_warp,
     'clear_loop_warps': on_clear_loop_warps,

--- a/hw/ip/otbn/dv/otbnsim/test/stats_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/stats_test.py
@@ -5,12 +5,12 @@
 import py
 import os
 
-from sim.sim import OTBNSim
+from sim.standalonesim import StandaloneSim
 from sim.stats import ExecutionStats
 import testutil
 
 
-def _run_sim_for_stats(sim: OTBNSim) -> ExecutionStats:
+def _run_sim_for_stats(sim: StandaloneSim) -> ExecutionStats:
     sim.run(verbose=False)
 
     # Ensure that the execution was successful.

--- a/hw/ip/otbn/dv/otbnsim/test/testutil.py
+++ b/hw/ip/otbn/dv/otbnsim/test/testutil.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 
 from sim.elf import load_elf
-from sim.sim import OTBNSim
+from sim.standalonesim import StandaloneSim
 
 
 OTBN_DIR = os.path.join(os.path.dirname(__file__), '../../..')
@@ -34,7 +34,7 @@ def asm_and_link_one_file(asm_path: str, work_dir: py.path.local) -> str:
 
 def prepare_sim_for_asm_file(asm_file: str,
                              tmpdir: py.path.local,
-                             collect_stats: bool) -> OTBNSim:
+                             collect_stats: bool) -> StandaloneSim:
     '''Set up the simulation of a single assembly file.
 
     The returned simulation is ready to be run through the run() method.
@@ -43,7 +43,7 @@ def prepare_sim_for_asm_file(asm_file: str,
     assert os.path.exists(asm_file)
     elf_file = asm_and_link_one_file(asm_file, tmpdir)
 
-    sim = OTBNSim()
+    sim = StandaloneSim()
     load_elf(sim, elf_file)
 
     sim.state.ext_regs.commit()
@@ -53,7 +53,7 @@ def prepare_sim_for_asm_file(asm_file: str,
 
 def prepare_sim_for_asm_str(assembly: str,
                             tmpdir: py.path.local,
-                            collect_stats: bool) -> OTBNSim:
+                            collect_stats: bool) -> StandaloneSim:
     '''Set up the simulation for an assembly snippet passed as string.
 
     The returned simulation is ready to be run through the run() method.


### PR DESCRIPTION
The following additions/ modifications are done in this commit:
1. standalonesim.py: It is a new file added in current commit. It
includes the run function previously present in sim.py. It is required
to run the standalone otbn sims.
2. sim.py: The run function was moved from sim.py to standaloneaim.py
3. standalone.py: Type of sim class was changed from OTBNSim to
StandaloneSim.
4. simple_test.py: Following two changes are present -
   1. test_count now runs standalone instead of stepped.
   This change was done because there is no run function in OTBNSim class
   anymore.
   2. get_reg_dump function is updated to read ERR_BITS and INSN_CNT
   from the dumps generated by standalone.py

Fixes https://github.com/lowRISC/opentitan/issues/6164

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>