### PR TITLE
[opentitantool] Support bitstream loading on the CW310 board

### DIFF
--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -68,7 +68,9 @@ impl CW310 {
 
 impl Transport for CW310 {
     fn capabilities(&self) -> Capabilities {
-        Capabilities::new(Capability::SPI | Capability::GPIO | Capability::UART)
+        Capabilities::new(
+            Capability::SPI | Capability::GPIO | Capability::UART | Capability::FPGA_PROGRAM,
+        )
     }
 
     fn uart(&self, instance: u32) -> Result<Rc<dyn Uart>> {
@@ -104,5 +106,12 @@ impl Transport for CW310 {
             inner.spi = Some(Rc::new(spi::CW310Spi::open(Rc::clone(&self.device))?));
         }
         Ok(Rc::clone(inner.spi.as_ref().unwrap()))
+    }
+
+    fn fpga_program(&self, bitstream: &[u8]) -> Result<()> {
+        let usb = self.device.borrow();
+        usb.spi1_enable(false)?;
+        usb.pin_set_state(CW310::PIN_JTAG, true)?;
+        usb.fpga_program(bitstream)
     }
 }

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -22,6 +22,7 @@ bitflags! {
         const UART = 0x00000001;
         const SPI = 0x00000002;
         const GPIO = 0x00000004;
+        const FPGA_PROGRAM = 0x00000008;
     }
 }
 
@@ -85,6 +86,10 @@ pub trait Transport {
     }
     /// Returns a [`Gpio`] implementation.
     fn gpio(&self) -> Result<Rc<dyn Gpio>> {
+        unimplemented!();
+    }
+    /// Programs a bitstream into an FPGA.
+    fn fpga_program(&self, _bitstream: &[u8]) -> Result<()> {
         unimplemented!();
     }
 }

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use erased_serde::Serialize;
+use std::any::Any;
+use std::fs;
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::transport::{Capability, Transport};
+
+/// Read data from a SPI EEPROM.
+#[derive(Debug, StructOpt)]
+pub struct LoadBitstream {
+    #[structopt(name = "FILE")]
+    filename: PathBuf,
+}
+
+impl CommandDispatch for LoadBitstream {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &mut dyn Transport,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        transport
+            .capabilities()
+            .request(Capability::FPGA_PROGRAM)
+            .ok()?;
+
+        let bitstream = fs::read(&self.filename)?;
+        transport.fpga_program(&bitstream)?;
+        Ok(None)
+    }
+}

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -5,4 +5,5 @@
 pub mod console;
 pub mod gpio;
 pub mod hello;
+pub mod load_bitstream;
 pub mod spi;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -16,6 +16,7 @@ enum RootCommandHierarchy {
     Console(command::console::Console),
 
     Gpio(command::gpio::GpioCommand),
+    LoadBitstream(command::load_bitstream::LoadBitstream),
     Spi(command::spi::SpiCommand),
 
     // Flattened because `Greetings` is a subcommand hierarchy.


### PR DESCRIPTION
1. Add an fpga_program function to the Transport trait.
2. Add the bitstream programming procedure to the CW310 backend.
3. Add a CLI command to program the bitstream.

Signed-off-by: Chris Frantz <cfrantz@google.com>