### PR TITLE
[hw/rom] Increase ROM size to 32kB.

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -159,7 +159,7 @@
       // two in sync.
       { window: {
           name: "ROM"
-          items: "4096" // 16 KiB
+          items: "8192" // 32 KiB
           swaccess: "ro",
           desc: '''ROM data'''
         }

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_reg_pkg.sv
@@ -11,7 +11,7 @@ package rom_ctrl_reg_pkg;
 
   // Address widths within the block
   parameter int RegsAw = 7;
-  parameter int RomAw = 14;
+  parameter int RomAw = 15;
 
   ///////////////////////////////////////////////
   // Typedefs for registers for regs interface //
@@ -134,8 +134,8 @@ package rom_ctrl_reg_pkg;
   };
 
   // Window parameters for rom interface
-  parameter logic [RomAw-1:0] ROM_CTRL_ROM_OFFSET = 14'h 0;
-  parameter int unsigned      ROM_CTRL_ROM_SIZE   = 'h 4000;
+  parameter logic [RomAw-1:0] ROM_CTRL_ROM_OFFSET = 15'h 0;
+  parameter int unsigned      ROM_CTRL_ROM_SIZE   = 'h 8000;
 
 endpackage
 

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -15,7 +15,7 @@ from Crypto.Hash import cSHAKE256
 from mem import MemChunk, MemFile
 
 ROM_BASE_WORD = 0x8000 // 4
-ROM_SIZE_WORDS = 4096
+ROM_SIZE_WORDS = 8192
 
 PRINCE_SBOX4 = [
     0xb, 0xf, 0x3, 0x2,

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6298,7 +6298,7 @@
           swaccess: ro
           exec: True
           byte_write: False
-          size: 0x4000
+          size: 0x8000
         }
       }
       param_decl:
@@ -7739,7 +7739,7 @@
           [
             {
               base_addr: 0x8000
-              size_byte: 0x4000
+              size_byte: 0x8000
             }
           ]
           xbar: false

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -644,7 +644,7 @@
           swaccess:   "ro",
           exec:       "True",
           byte_write: "False",
-          size:       "0x4000"
+          size:       "0x8000"
         }
       },
       param_decl: {

--- a/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/dv/autogen/xbar_env_pkg__params.sv
@@ -14,7 +14,7 @@ tl_device_t xbar_devices[$] = '{
         '{32'h00010000, 32'h00010fff}
     }},
     '{"rom_ctrl__rom", '{
-        '{32'h00008000, 32'h0000bfff}
+        '{32'h00008000, 32'h0000ffff}
     }},
     '{"rom_ctrl__regs", '{
         '{32'h411e0000, 32'h411e0fff}

--- a/hw/top_earlgrey/dv/autogen/xbar_tgl_excl.cfg
+++ b/hw/top_earlgrey/dv/autogen/xbar_tgl_excl.cfg
@@ -29,7 +29,6 @@
 -node tb.dut*.u_rv_dm__regs *tl_i.a_address[31:31]
 -node tb.dut*.u_rv_dm__rom *tl_i.a_address[15:12]
 -node tb.dut*.u_rv_dm__rom *tl_i.a_address[31:17]
--node tb.dut*.u_rom_ctrl__rom *tl_i.a_address[14:14]
 -node tb.dut*.u_rom_ctrl__rom *tl_i.a_address[31:16]
 -node tb.dut*.u_rom_ctrl__regs *tl_i.a_address[16:12]
 -node tb.dut*.u_rom_ctrl__regs *tl_i.a_address[23:21]

--- a/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_main/data/autogen/xbar_main.gen.hjson
@@ -176,7 +176,7 @@
       [
         {
           base_addr: 0x8000
-          size_byte: 0x4000
+          size_byte: 0x8000
         }
       ]
       xbar: false

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
@@ -20,7 +20,6 @@
 -node tb.dut tl_rv_dm__regs_o.a_address[31:31]
 -node tb.dut tl_rv_dm__rom_o.a_address[15:12]
 -node tb.dut tl_rv_dm__rom_o.a_address[31:17]
--node tb.dut tl_rom_ctrl__rom_o.a_address[14:14]
 -node tb.dut tl_rom_ctrl__rom_o.a_address[31:16]
 -node tb.dut tl_rom_ctrl__regs_o.a_address[16:12]
 -node tb.dut tl_rom_ctrl__regs_o.a_address[23:21]

--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_env_pkg__params.sv
@@ -14,7 +14,7 @@ tl_device_t xbar_devices[$] = '{
         '{32'h00010000, 32'h00010fff}
     }},
     '{"rom_ctrl__rom", '{
-        '{32'h00008000, 32'h0000bfff}
+        '{32'h00008000, 32'h0000ffff}
     }},
     '{"rom_ctrl__regs", '{
         '{32'h411e0000, 32'h411e0fff}

--- a/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
+++ b/hw/top_earlgrey/ip/xbar_main/rtl/autogen/tl_main_pkg.sv
@@ -32,7 +32,7 @@ package tl_main_pkg;
 
   localparam logic [31:0] ADDR_MASK_RV_DM__REGS          = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_RV_DM__ROM           = 32'h 00000fff;
-  localparam logic [31:0] ADDR_MASK_ROM_CTRL__ROM        = 32'h 00003fff;
+  localparam logic [31:0] ADDR_MASK_ROM_CTRL__ROM        = 32'h 00007fff;
   localparam logic [31:0] ADDR_MASK_ROM_CTRL__REGS       = 32'h 00000fff;
   localparam logic [0:0][31:0] ADDR_MASK_PERI                 = {
     32'h 007fffff

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_pkg.sv
@@ -498,7 +498,7 @@ package top_earlgrey_pkg;
   /**
    * Peripheral size in bytes for rom device on rom_ctrl in top earlgrey.
    */
-  parameter int unsigned TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES = 32'h4000;
+  parameter int unsigned TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES = 32'h8000;
 
   /**
    * Peripheral base address for cfg device on rv_core_ibex in top earlgrey.
@@ -548,7 +548,7 @@ package top_earlgrey_pkg;
   /**
    * Memory size for rom in top earlgrey.
    */
-  parameter int unsigned TOP_EARLGREY_ROM_SIZE_BYTES = 32'h4000;
+  parameter int unsigned TOP_EARLGREY_ROM_SIZE_BYTES = 32'h8000;
 
 
   // Enumeration of IO power domains.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -905,7 +905,7 @@ extern "C" {
  * address between #TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR and
  * `TOP_EARLGREY_ROM_CTRL_ROM_BASE_ADDR + TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES`.
  */
-#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0x4000u
+#define TOP_EARLGREY_ROM_CTRL_ROM_SIZE_BYTES 0x8000u
 
 /**
  * Peripheral base address for cfg device on rv_core_ibex in top earlgrey.
@@ -964,7 +964,7 @@ extern "C" {
 /**
  * Memory size for rom in top earlgrey.
  */
-#define TOP_EARLGREY_ROM_SIZE_BYTES 0x4000u
+#define TOP_EARLGREY_ROM_SIZE_BYTES 0x8000u
 
 
 /**

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h
@@ -59,7 +59,7 @@
 /**
  * Memory size for rom_ctrl_rom in top earlgrey.
  */
-#define TOP_EARLGREY_ROM_SIZE_BYTES 0x4000
+#define TOP_EARLGREY_ROM_SIZE_BYTES 0x8000
 
 
 

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -11,6 +11,6 @@ MEMORY {
   ram_ret_aon(rwx) : ORIGIN = 0x40600000, LENGTH = 0x1000
   eflash(rx) : ORIGIN = 0x20000000, LENGTH = 0x100000
   ram_main(rwx) : ORIGIN = 0x10000000, LENGTH = 0x20000
-  rom(rx) : ORIGIN = 0x00008000, LENGTH = 0x4000
+  rom(rx) : ORIGIN = 0x00008000, LENGTH = 0x8000
   eflash_virtual(rx) : ORIGIN = 0x80000000, LENGTH = 0x100000
 }

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -437,7 +437,7 @@
           swaccess:   "ro",
           exec:       "True",
           byte_write: "False",
-          size:       "0x4000"
+          size:       "0x8000"
         }
       },
       param_decl: {


### PR DESCRIPTION
Increase mask ROM to 32kB to allow the mask ROM development to continue
before we start size optimizations.

Even though the mask ROM size may potentially fit within 16kB, it is
safer to preallocate additional space while we iterate over countermeasures
and final feature set.