### PR TITLE
[rstmgr/pwrmgr] Allow software to directly request device reset

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -22,7 +22,6 @@
     }
   ],
 
-  // Define flash_ctrl <-> flash_phy struct package
   inter_signal_list: [
     { struct:  "pwr_ast",
       type:    "req_rsp",
@@ -129,6 +128,13 @@
       name:    "fetch_en",
       act:     "req",
       package: "lc_ctrl_pkg",
+    },
+
+    { struct:  "mubi4",
+      type:    "uni",
+      name:    "sw_rst_req",
+      act:     "rcv",
+      package: "prim_mubi_pkg",
     },
   ],
 

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -88,6 +88,8 @@ module tb;
 
     .rom_ctrl_i(pwrmgr_if.rom_ctrl),
 
+    .sw_rst_req_i(prim_mubi_pkg::MuBi4False),
+
     .esc_rst_tx_i(pwrmgr_if.esc_rst_tx),
     .esc_rst_rx_o(pwrmgr_if.esc_rst_rx),
 

--- a/hw/ip/pwrmgr/pwrmgr.core
+++ b/hw/ip/pwrmgr/pwrmgr.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:prim:mubi
       - lowrisc:ip_interfaces:alert_handler_reg
     files:
       - rtl/pwrmgr.sv

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -412,7 +412,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
   assign pwr_rst_o.rst_lc_req = rst_lc_req_q;
   assign pwr_rst_o.rst_sys_req = rst_sys_req_q;
   assign pwr_rst_o.reset_cause = reset_cause_q;
-  assign pwr_rst_o.rstreqs = reset_reqs_i;
+  assign pwr_rst_o.rstreqs = reset_reqs_i[HwResetWidth-1:0];
 
   assign ips_clk_en_o = ip_clk_en_q;
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -22,10 +22,14 @@ package pwrmgr_pkg;
     IntReqLastIdx
   } pwr_int_rst_req_e;
 
+  parameter int NumSwRstReq = 1;
+
   // position of escalation request
-  parameter int TotalResetWidth = pwrmgr_reg_pkg::NumRstReqs + IntReqLastIdx;
+  parameter int HwResetWidth = pwrmgr_reg_pkg::NumRstReqs + IntReqLastIdx;
+  parameter int TotalResetWidth = HwResetWidth + NumSwRstReq;
   parameter int ResetMainPwrIdx = pwrmgr_reg_pkg::NumRstReqs + IntReqMainPwr;
   parameter int ResetEscIdx = pwrmgr_reg_pkg::NumRstReqs + IntReqEsc;
+  parameter int ResetSwReqIdx = TotalResetWidth - 1;
 
   // pwrmgr to ast
   typedef struct packed {
@@ -75,7 +79,7 @@ package pwrmgr_pkg;
   typedef struct packed {
     logic [PowerDomains-1:0] rst_lc_req;
     logic [PowerDomains-1:0] rst_sys_req;
-    logic [TotalResetWidth-1:0] rstreqs;
+    logic [HwResetWidth-1:0] rstreqs;
     reset_cause_e reset_cause;
   } pwr_rst_req_t;
 

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -82,7 +82,7 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     cfg.rstmgr_vif.pwr_i.rst_sys_req = {rstmgr_pkg::PowerDomains{rst_sys_req}};
   endfunction
 
-  function void set_rstreqs(logic [pwrmgr_pkg::TotalResetWidth:0] rstreqs);
+  function void set_rstreqs(logic [pwrmgr_pkg::HwResetWidth:0] rstreqs);
     cfg.rstmgr_vif.pwr_i.rstreqs = rstreqs;
   endfunction
 

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -11,7 +11,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
 
   rand ibex_pkg::crash_dump_t cpu_dump;
   rand alert_pkg::alert_crashdump_t alert_dump;
-  rand logic [pwrmgr_pkg::TotalResetWidth-1:0] rstreqs;
+  rand logic [pwrmgr_pkg::HwResetWidth-1:0] rstreqs;
   rand logic [NumSwResets-1:0] sw_rst_regwen;
   rand logic [NumSwResets-1:0] sw_rst_ctrl_n;
 
@@ -49,7 +49,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
     send_reset(pwrmgr_pkg::HwReq, rstreqs);
-    csr_rd_check(.ptr(ral.reset_info), .compare_value({rstreqs, 3'h0}),
+    csr_rd_check(.ptr(ral.reset_info), .compare_value({rstreqs, 4'h0}),
                  .err_msg("Expected reset_info to match pwrmgr_rstreqs"));
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b0);
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2583,6 +2583,18 @@
           index: -1
         }
         {
+          name: sw_rst_req
+          struct: mubi4
+          package: prim_mubi_pkg
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: pwrmgr_aon
+          default: ""
+          top_signame: rstmgr_aon_sw_rst_req
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -2737,6 +2749,20 @@
           inst_name: rstmgr_aon
           default: ""
           top_signame: rv_core_ibex_crash_dump
+          index: -1
+        }
+        {
+          name: sw_rst_req
+          struct: mubi4
+          package: prim_mubi_pkg
+          type: uni
+          act: req
+          width: 1
+          inst_name: rstmgr_aon
+          default: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: rstmgr_aon_sw_rst_req
           index: -1
         }
         {
@@ -7283,6 +7309,10 @@
       rv_dm.ndmreset_req:
       [
         rstmgr_aon.ndmreset_req
+      ]
+      rstmgr_aon.sw_rst_req:
+      [
+        pwrmgr_aon.sw_rst_req
       ]
       pwrmgr_aon.wakeups:
       [
@@ -15138,6 +15168,18 @@
         index: -1
       }
       {
+        name: sw_rst_req
+        struct: mubi4
+        package: prim_mubi_pkg
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: pwrmgr_aon
+        default: ""
+        top_signame: rstmgr_aon_sw_rst_req
+        index: -1
+      }
+      {
         name: tl
         struct: tl
         package: tlul_pkg
@@ -15245,6 +15287,20 @@
         inst_name: rstmgr_aon
         default: ""
         top_signame: rv_core_ibex_crash_dump
+        index: -1
+      }
+      {
+        name: sw_rst_req
+        struct: mubi4
+        package: prim_mubi_pkg
+        type: uni
+        act: req
+        width: 1
+        inst_name: rstmgr_aon
+        default: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: rstmgr_aon_sw_rst_req
         index: -1
       }
       {
@@ -19616,6 +19672,17 @@
         act: req
         suffix: ""
         default: "'0"
+      }
+      {
+        package: prim_mubi_pkg
+        struct: mubi4
+        signame: rstmgr_aon_sw_rst_req
+        width: 1
+        type: uni
+        end_idx: -1
+        act: req
+        suffix: ""
+        default: prim_mubi_pkg::MUBI4_DEFAULT
       }
       {
         package: ""

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -900,6 +900,18 @@
       tests: []
     }
     {
+      name: chip_sw_rstrmgr_sw_req_reset
+      desc: '''Verify software requested device reset.
+
+            Generate a reset request by directly writing the `reset_req` CSR.
+            The reset created should be identical to those caused by hardware sources.
+            After reset, the `reset_info` CSR should reflect that a software request was
+            the reset cause.
+            '''
+      milestone: V2
+      tests: ["chip_sw_rstmgr_sw_req"]
+    }
+    {
       name: chip_sw_rstrmgr_alert_info
       desc: '''Verify the expected values from the `alert_info` CSR on reset.
 

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -890,7 +890,10 @@
       'spi_device.passthrough'     : ['spi_host0.passthrough']
 
       // Debug module reset request to reset manager
-      'rv_dm.ndmreset_req' : ['rstmgr_aon.ndmreset_req']
+      'rv_dm.ndmreset_req' : ['rstmgr_aon.ndmreset_req'],
+
+      // Reset manager software reset request to pwrmgr
+      'rstmgr_aon.sw_rst_req' : ['pwrmgr_aon.sw_rst_req'],
     }
 
     // top is to connect to top net/struct.

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -240,6 +240,12 @@
       reseed: 15
     }
     {
+      name: chip_sw_rstmgr_sw_req
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/rstmgr_sw_req_test:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
+    {
       name: chip_sw_pwrmgr_usbdev_wakeup
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/pwrmgr_usbdev_smoketest:1"]

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -28,7 +28,6 @@
     }
   ],
 
-  // Define flash_ctrl <-> flash_phy struct package
   inter_signal_list: [
     { struct:  "pwr_ast",
       type:    "req_rsp",
@@ -135,6 +134,13 @@
       name:    "fetch_en",
       act:     "req",
       package: "lc_ctrl_pkg",
+    },
+
+    { struct:  "mubi4",
+      type:    "uni",
+      name:    "sw_rst_req",
+      act:     "rcv",
+      package: "prim_mubi_pkg",
     },
   ],
 

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -122,10 +122,38 @@
       package: "ibex_pkg",
     },
 
+    { struct:  "mubi4",
+      type:    "uni",
+      name:    "sw_rst_req",
+      act:     "req",
+      package: "prim_mubi_pkg",
+    },
+
     // Exported resets
   ],
 
   registers: [
+
+    { name: "RESET_REQ",
+      desc: '''
+        Software requested system reset.
+      ''',
+      swaccess: "rw",
+      hwaccess: "hrw",
+      fields: [
+        { bits: "3:0",
+          mubi: true
+          name: "VAL",
+          desc: '''
+            When set to kMultiBitBool4True, a reset to power manager is requested.
+            Upon completion of reset, this bit is automatically cleared by hardware.
+          '''
+          resval: false
+        },
+      ],
+      tags: [// This register will cause a system reset, directed test only
+        "excl:CsrAllTests:CsrExclWrite"]
+    },
 
     { name: "RESET_INFO",
       desc: '''
@@ -159,8 +187,17 @@
           resval: "0"
         },
 
+        { bits: "3",
+          hwaccess: "hrw",
+          name: "SW_RESET",
+          desc: '''
+            Indicates when a device has reset due to !!RESET_REQ.
+            '''
+          resval: "0"
+        },
+
         // reset requests include escalation reset + peripheral requests
-        { bits: "6:3",
+        { bits: "7:4",
           hwaccess: "hrw",
           name: "HW_REQ",
           desc: '''

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -16,6 +16,7 @@
 module rstmgr
   import rstmgr_pkg::*;
   import rstmgr_reg_pkg::*;
+  import prim_mubi_pkg::mubi4_t;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
@@ -43,6 +44,9 @@ module rstmgr
   // pwrmgr interface
   input pwrmgr_pkg::pwr_rst_req_t pwr_i,
   output pwrmgr_pkg::pwr_rst_rsp_t pwr_o,
+
+  // software initiated reset request
+  output mubi4_t sw_rst_req_o,
 
   // cpu related inputs
   input logic rst_cpu_n_i,
@@ -846,6 +850,14 @@ module rstmgr
   assign rst_low_power = ~first_reset & pwrmgr_rst_req &
                          (pwr_i.reset_cause == pwrmgr_pkg::LowPwrEntry);
 
+  // software initiated reset request
+  assign sw_rst_req_o = prim_mubi_pkg::mubi4_e'(reg2hw.reset_req.q);
+
+  // when pwrmgr reset request is received (reset is imminent), clear software
+  // request so we are not in an infinite reset loop.
+  assign hw2reg.reset_req.de = pwrmgr_rst_req;
+  assign hw2reg.reset_req.d  = prim_mubi_pkg::MuBi4False;
+
   prim_flop_2sync #(
     .Width(1),
     .ResetValue('0)
@@ -872,9 +884,16 @@ module rstmgr
   assign hw2reg.reset_info.ndm_reset.d  = 1'b1;
   assign hw2reg.reset_info.ndm_reset.de = rst_ndm;
 
+  // software issued request triggers the same response as hardware, although it is
+  // accounted for differently.
+  assign hw2reg.reset_info.sw_reset.d = prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_o) |
+                                        reg2hw.reset_info.sw_reset.q;
+  assign hw2reg.reset_info.sw_reset.de = rst_hw_req;
+
   // HW reset requests most likely will be multi-bit, so OR in whatever reasons
   // that are already set.
-  assign hw2reg.reset_info.hw_req.d  = pwr_i.rstreqs | reg2hw.reset_info.hw_req.q;
+  assign hw2reg.reset_info.hw_req.d  = pwr_i.rstreqs[pwrmgr_pkg::HwResetWidth-1:0] |
+                                       reg2hw.reset_info.hw_req.q;
   assign hw2reg.reset_info.hw_req.de = rst_hw_req;
 
   ////////////////////////////////////////////////////
@@ -930,7 +949,7 @@ module rstmgr
   // Assertions                                     //
   ////////////////////////////////////////////////////
 
-  `ASSERT_INIT(ParameterMatch_A, NumHwResets == pwrmgr_pkg::TotalResetWidth)
+  `ASSERT_INIT(ParameterMatch_A, NumHwResets == pwrmgr_pkg::HwResetWidth)
 
   // when upstream resets, downstream must also reset
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -26,6 +26,13 @@ package rstmgr_reg_pkg;
   } rstmgr_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
+    logic [3:0]  q;
+  } rstmgr_reg2hw_reset_req_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
+    } sw_reset;
     struct packed {
       logic [3:0]  q;
     } hw_req;
@@ -59,6 +66,11 @@ package rstmgr_reg_pkg;
   } rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t;
 
   typedef struct packed {
+    logic [3:0]  d;
+    logic        de;
+  } rstmgr_hw2reg_reset_req_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -67,6 +79,10 @@ package rstmgr_reg_pkg;
       logic        d;
       logic        de;
     } ndm_reset;
+    struct packed {
+      logic        d;
+      logic        de;
+    } sw_reset;
     struct packed {
       logic [3:0]  d;
       logic        de;
@@ -120,8 +136,9 @@ package rstmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    rstmgr_reg2hw_alert_test_reg_t alert_test; // [45:44]
-    rstmgr_reg2hw_reset_info_reg_t reset_info; // [43:40]
+    rstmgr_reg2hw_alert_test_reg_t alert_test; // [50:49]
+    rstmgr_reg2hw_reset_req_reg_t reset_req; // [48:45]
+    rstmgr_reg2hw_reset_info_reg_t reset_info; // [44:40]
     rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [39:35]
     rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [34:30]
     rstmgr_reg2hw_sw_rst_regwen_mreg_t [9:0] sw_rst_regwen; // [29:20]
@@ -130,7 +147,8 @@ package rstmgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [98:90]
+    rstmgr_hw2reg_reset_req_reg_t reset_req; // [105:101]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [100:90]
     rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [89:88]
     rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [87:84]
     rstmgr_hw2reg_alert_info_reg_t alert_info; // [83:52]
@@ -143,18 +161,19 @@ package rstmgr_reg_pkg;
 
   // Register offsets
   parameter logic [BlockAw-1:0] RSTMGR_ALERT_TEST_OFFSET = 6'h 0;
-  parameter logic [BlockAw-1:0] RSTMGR_RESET_INFO_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_REGWEN_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_REGWEN_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_CTRL_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_ATTR_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 2c;
-  parameter logic [BlockAw-1:0] RSTMGR_ERR_CODE_OFFSET = 6'h 30;
+  parameter logic [BlockAw-1:0] RSTMGR_RESET_REQ_OFFSET = 6'h 4;
+  parameter logic [BlockAw-1:0] RSTMGR_RESET_INFO_OFFSET = 6'h 8;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_REGWEN_OFFSET = 6'h c;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_CTRL_OFFSET = 6'h 10;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_ATTR_OFFSET = 6'h 14;
+  parameter logic [BlockAw-1:0] RSTMGR_ALERT_INFO_OFFSET = 6'h 18;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_REGWEN_OFFSET = 6'h 1c;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_CTRL_OFFSET = 6'h 20;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_ATTR_OFFSET = 6'h 24;
+  parameter logic [BlockAw-1:0] RSTMGR_CPU_INFO_OFFSET = 6'h 28;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_REGWEN_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] RSTMGR_SW_RST_CTRL_N_OFFSET = 6'h 30;
+  parameter logic [BlockAw-1:0] RSTMGR_ERR_CODE_OFFSET = 6'h 34;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] RSTMGR_ALERT_TEST_RESVAL = 1'h 0;
@@ -182,6 +201,7 @@ package rstmgr_reg_pkg;
   // Register index
   typedef enum int {
     RSTMGR_ALERT_TEST,
+    RSTMGR_RESET_REQ,
     RSTMGR_RESET_INFO,
     RSTMGR_ALERT_REGWEN,
     RSTMGR_ALERT_INFO_CTRL,
@@ -197,20 +217,21 @@ package rstmgr_reg_pkg;
   } rstmgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] RSTMGR_PERMIT [13] = '{
+  parameter logic [3:0] RSTMGR_PERMIT [14] = '{
     4'b 0001, // index[ 0] RSTMGR_ALERT_TEST
-    4'b 0001, // index[ 1] RSTMGR_RESET_INFO
-    4'b 0001, // index[ 2] RSTMGR_ALERT_REGWEN
-    4'b 0001, // index[ 3] RSTMGR_ALERT_INFO_CTRL
-    4'b 0001, // index[ 4] RSTMGR_ALERT_INFO_ATTR
-    4'b 1111, // index[ 5] RSTMGR_ALERT_INFO
-    4'b 0001, // index[ 6] RSTMGR_CPU_REGWEN
-    4'b 0001, // index[ 7] RSTMGR_CPU_INFO_CTRL
-    4'b 0001, // index[ 8] RSTMGR_CPU_INFO_ATTR
-    4'b 1111, // index[ 9] RSTMGR_CPU_INFO
-    4'b 0011, // index[10] RSTMGR_SW_RST_REGWEN
-    4'b 0011, // index[11] RSTMGR_SW_RST_CTRL_N
-    4'b 0001  // index[12] RSTMGR_ERR_CODE
+    4'b 0001, // index[ 1] RSTMGR_RESET_REQ
+    4'b 0001, // index[ 2] RSTMGR_RESET_INFO
+    4'b 0001, // index[ 3] RSTMGR_ALERT_REGWEN
+    4'b 0001, // index[ 4] RSTMGR_ALERT_INFO_CTRL
+    4'b 0001, // index[ 5] RSTMGR_ALERT_INFO_ATTR
+    4'b 1111, // index[ 6] RSTMGR_ALERT_INFO
+    4'b 0001, // index[ 7] RSTMGR_CPU_REGWEN
+    4'b 0001, // index[ 8] RSTMGR_CPU_INFO_CTRL
+    4'b 0001, // index[ 9] RSTMGR_CPU_INFO_ATTR
+    4'b 1111, // index[10] RSTMGR_CPU_INFO
+    4'b 0011, // index[11] RSTMGR_SW_RST_REGWEN
+    4'b 0011, // index[12] RSTMGR_SW_RST_CTRL_N
+    4'b 0001  // index[13] RSTMGR_ERR_CODE
   };
 
 endpackage

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -600,6 +600,7 @@ module top_earlgrey #(
   spi_device_pkg::passthrough_req_t       spi_device_passthrough_req;
   spi_device_pkg::passthrough_rsp_t       spi_device_passthrough_rsp;
   logic       rv_dm_ndmreset_req;
+  prim_mubi_pkg::mubi4_t       rstmgr_aon_sw_rst_req;
   logic [5:0] pwrmgr_aon_wakeups;
   logic [1:0] pwrmgr_aon_rstreqs;
   tlul_pkg::tl_h2d_t       main_tl_rv_core_ibex__corei_req;
@@ -1679,6 +1680,7 @@ module top_earlgrey #(
       .low_power_o(pwrmgr_aon_low_power),
       .rom_ctrl_i(rom_ctrl_pwrmgr_data),
       .fetch_en_o(pwrmgr_aon_fetch_en),
+      .sw_rst_req_i(rstmgr_aon_sw_rst_req),
       .tl_i(pwrmgr_aon_tl_req),
       .tl_o(pwrmgr_aon_tl_rsp),
 
@@ -1708,6 +1710,7 @@ module top_earlgrey #(
       .ndmreset_req_i(rv_dm_ndmreset_req),
       .alert_dump_i(alert_handler_crashdump),
       .cpu_dump_i(rv_core_ibex_crash_dump),
+      .sw_rst_req_o(rstmgr_aon_sw_rst_req),
       .tl_i(rstmgr_aon_tl_req),
       .tl_o(rstmgr_aon_tl_rsp),
       .scanmode_i,

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -582,6 +582,9 @@
 
       // Debug module reset request to reset manager
       'rv_dm.ndmreset_req' : ['rstmgr_aon.ndmreset_req']
+
+      // Reset manager software reset request to pwrmgr
+      'rstmgr_aon.sw_rst_req' : ['pwrmgr_aon.sw_rst_req'],
     }
 
     // top is to connect to top net/struct.

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -287,3 +287,14 @@ dif_result_t dif_rstmgr_software_reset_is_held(
 
   return kDifOk;
 }
+
+dif_result_t dif_rstmgr_software_device_reset(const dif_rstmgr_t *handle) {
+  if (handle == NULL) {
+    return kDifBadArg;
+  }
+
+  // TODO, convert to MultiBitBool when available
+  mmio_region_write32(handle->base_addr, RSTMGR_RESET_REQ_REG_OFFSET, 0xa);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -72,10 +72,14 @@ typedef enum dif_rstmgr_reset_info {
    */
   kDifRstmgrResetInfoNdm = (0x1 << 2),
   /**
+   * Device has reset due to software request.
+   */
+  kDifRstmgrResetInfoSw = (0x1 << 3),
+  /**
    * Device has reset due to a peripheral request. This can be an alert
    * escalation, watchdog or anything else.
    */
-  kDifRstmgrResetInfoHwReq = (0xf << 3),
+  kDifRstmgrResetInfoHwReq = (0xf << 4),
 } dif_rstmgr_reset_info_t;
 
 /**
@@ -265,6 +269,15 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_rstmgr_software_reset_is_held(
     const dif_rstmgr_t *handle, dif_rstmgr_peripheral_t peripheral,
     bool *asserted);
+
+/**
+ * Software request for system reset
+ *
+ * @param handle A Reset Manager handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rstmgr_software_device_reset(const dif_rstmgr_t *handle);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -50,17 +50,22 @@ typedef enum rstmgr_reason {
   kRstmgrReasonNonDebugModule = 2,
 
   /**
+   * Software issued request (SW).
+   */
+  kRstmgrReasonSoftwareRequest = 3,
+
+  /**
    * Hardware requests (HW_REQ).
    */
-  kRstmgrReasonSysrstCtrl = 3,
-  kRstmgrReasonWatchdog = 4,
-  kRstmgrReasonPowerUnstable = 5,
-  kRstmgrReasonEscalation = 6,
+  kRstmgrReasonSysrstCtrl = 4,
+  kRstmgrReasonWatchdog = 5,
+  kRstmgrReasonPowerUnstable = 6,
+  kRstmgrReasonEscalation = 7,
 
   /**
    * Last used bit index (inclusive).
    */
-  kRstmgrReasonLast = 6,
+  kRstmgrReasonLast = 7,
 } rstmgr_reason_t;
 
 /**

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -143,6 +143,23 @@ sw_tests += {
   }
 }
 
+rstmgr_sw_req_test_lib = declare_dependency(
+  link_with: static_library(
+    'rstmgr_sw_req_lib',
+    sources: ['rstmgr_sw_req_test.c'],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+    ],
+  ),
+)
+sw_tests += {
+  'rstmgr_sw_req_test': {
+    'library': rstmgr_sw_req_test_lib,
+  }
+}
+
 otbn_smoketest_lib = declare_dependency(
   link_with: static_library(
     'otbn_smoketest_lib',

--- a/sw/device/tests/rstmgr_sw_req_test.c
+++ b/sw/device/tests/rstmgr_sw_req_test.c
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_rstmgr_t rstmgr;
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  dif_rstmgr_reset_info_bitfield_t info;
+  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &info));
+
+  // If POR, clear reason and request software reset
+  if (info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("POR encountered!");
+    CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+    CHECK_DIF_OK(dif_rstmgr_software_device_reset(&rstmgr));
+
+    // wait here until device reset
+    wait_for_interrupt();
+  } else if (info == kDifRstmgrResetInfoSw) {
+    LOG_INFO("Software reset encountered!");
+    CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+  } else {
+    LOG_FATAL("Reset reason unexpected!");
+    test_status_set(kTestStatusFailed);
+  }
+
+  return true;
+}


### PR DESCRIPTION
Add a csr that allows software to directly request system reset.
Also add a simple test case (can be dropped from PR).

- Fixes #8285