### PR TITLE
[aes] Improve rendering of register table in docs

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -203,6 +203,7 @@
       resval: "0",
       desc: '''
         Initial Key Registers Share 0.
+
         The actual initial key corresponds to Initial Key Registers Share 0 XORed with Initial Key Registers Share 1.
         Loaded into the internal Full Key register upon starting encryption/decryption of the next block.
         All key registers (Share 0 and Share 1) must be written at least once when the key is changed, regardless of key length (write random data for unused bits).
@@ -227,6 +228,7 @@
       resval: "0",
       desc: '''
         Initial Key Registers Share 1.
+
         The actual initial key corresponds to Initial Key Registers Share 0 XORed with Initial Key Registers Share 1.
         Loaded into the internal Full Key register upon starting encryption/decryption of the next block.
         All key registers (Share 0 and Share 1) must be written at least once when the key is changed, regardless of key length (write random data for unused bits).
@@ -253,6 +255,7 @@
       resval: "0",
       desc: '''
         Initialization Vector Registers.
+
         The initialization vector (IV) or initial counter value must be written to these registers when starting a new message in CBC or CTR mode (see Control Register), respectively.
         In CBC and CTR modes, the AES unit does not start encryption/decryption with a partially updated IV.
         Each register has to be written at least once.
@@ -281,6 +284,7 @@
       resval: "0",
       desc: '''
         Input Data Registers.
+
         If MANUAL_OPERATION=0 (see Control Register), the AES unit automatically starts encryption/decryption after all Input Data registers have been written.
         Each register has to be written at least once.
         The order in which the registers are written does not matter.
@@ -305,6 +309,7 @@
       resval: "0",
       desc: '''
         Output Data Register.
+
         Holds the output data produced by the AES unit during the last encryption/decryption operation.
         If MANUAL_OPERATION=0 (see Control Register), the AES unit is stalled when the previous output data has not yet been read and is about to be overwritten.
         Each register has to be read at least once.
@@ -331,8 +336,10 @@
 # control and status registers
   { name: "CTRL_SHADOWED",
     desc: '''
-      Control Register. Can only be updated when the AES unit is idle. If the
-      AES unit is non-idle, writes to this register are ignored.
+      Control Register.
+
+      Can only be updated when the AES unit is idle.
+      If the AES unit is non-idle, writes to this register are ignored.
       This register is shadowed, meaning two subsequent write operations are required to change its content.
       If the two write operations try to set a different value, a recoverable alert is triggered (See Status Register).
       A read operation clears the internal phase tracking: The next write operation is always considered a first write operation of an update sequence.
@@ -477,6 +484,7 @@
   { name: "TRIGGER",
     desc: '''
       Trigger Register.
+
       Each bit is individually cleared to zero when executing the corresponding trigger.
       While executing any of the triggered operations, the AES unit will set the IDLE bit in the Status Register to zero.
       The processor must check the Status Register before triggering further actions.


### PR DESCRIPTION
In the description field of a register, a newline acts as a separator
between the summary and the long description (as in a Git commit
message). Introduce a several newlines to improve the rendering.