### PR TITLE
[otbn] Strengthen port list asserts

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -936,10 +936,11 @@ module otbn
   `ASSERT_KNOWN(TlODValidKnown_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown_A, tl_o.a_ready)
   `ASSERT_KNOWN(IdleOKnown_A, idle_o)
-  `ASSERT_KNOWN(IdleOtpOKnown_A, idle_otp_o)
+  `ASSERT_KNOWN(IdleOtpOKnown_A, idle_otp_o, clk_otp_i, !rst_otp_ni)
   `ASSERT_KNOWN(IntrDoneOKnown_A, intr_done_o)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
-  `ASSERT_KNOWN(EdnRndOKnown_A, edn_rnd_o)
-  `ASSERT_KNOWN(EdnUrndOKnown_A, edn_urnd_o)
+  `ASSERT_KNOWN(EdnRndOKnown_A, edn_rnd_o, clk_edn_i, !rst_edn_ni)
+  `ASSERT_KNOWN(EdnUrndOKnown_A, edn_urnd_o, clk_edn_i, !rst_edn_ni)
+  `ASSERT_KNOWN(OtbnOtpKeyO_A, otbn_otp_key_o, clk_otp_i, !rst_otp_ni)
 
 endmodule

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -524,6 +524,21 @@ module otbn_core
 
   // Asserts =======================================================================================
 
-  `ASSERT(edn_req_stable, edn_rnd_req_o & ~edn_rnd_ack_i |=> edn_rnd_req_o)
+  // All outputs should be known.
   `ASSERT_KNOWN(DoneOKnown_A, done_o)
+  `ASSERT_KNOWN(ImemReqOKnown_A, imem_req_o)
+  `ASSERT_KNOWN(ImemAddrOKnown_A, imem_addr_o)
+  `ASSERT_KNOWN(ImemWdataOKnown_A, imem_wdata_o)
+  `ASSERT_KNOWN(DmemReqOKnown_A, dmem_req_o)
+  `ASSERT_KNOWN(DmemWriteOKnown_A, dmem_write_o)
+  `ASSERT_KNOWN(DmemAddrOKnown_A, dmem_addr_o)
+  `ASSERT_KNOWN(DmemWdataOKnown_A, dmem_wdata_o)
+  `ASSERT_KNOWN(DmemRmaskOKnown_A, dmem_rmask_o)
+  `ASSERT_KNOWN(EdnRndReqOKnown_A, edn_rnd_req_o)
+  `ASSERT_KNOWN(EdnUrndReqOKnown_A, edn_urnd_req_o)
+  `ASSERT_KNOWN(InsnCntOKnown_A, insn_cnt_o)
+
+  // Keep the EDN requests active until they are acknowledged.
+  `ASSERT(EdnRndReqStable_A, edn_rnd_req_o & ~edn_rnd_ack_i |=> edn_rnd_req_o)
+  `ASSERT(EdnUrndReqStable_A, edn_urnd_req_o & ~edn_urnd_ack_i |=> edn_urnd_req_o)
 endmodule

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -50,7 +50,7 @@ module otbn_start_stop_control
     ispr_init_o       = 1'b0;
     state_reset_o     = 1'b0;
 
-    unique case(state_q)
+    unique case (state_q)
       OtbnStartStopStateHalt: begin
         if (start_i) begin
           urnd_reseed_req_o = 1'b1;


### PR DESCRIPTION
Ensure we have asserts for all output ports in otbn.sv and otbn_core.sv, 
and put them into the right clock domains.

Add a matching stability assertion for the URND EDN connection, as we 
already had it for the RND one.