### PR TITLE
[conn] Update tb name

### DIFF
--- a/hw/formal/tools/dvsim/common_conn_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_conn_cfg.hjson
@@ -4,6 +4,7 @@
 {
   sub_flow:    conn
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
+  dut:         "{name}"
 
   // Vars that need to exported to the env
   exports: [


### PR DESCRIPTION
With PR #8654 merged, Connectivity test does not have a default dut name
anymore. This PR adds a default tb name for connectivity test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>