### PR TITLE
[spi_host top_earlgrey rtl] Remove secondary core clock

### DIFF
--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -177,14 +177,12 @@ class rstmgr_base_vseq extends cip_base_vseq #(
                  .err_msg("Expected enabled updates in sw_rst_ctrl_n"));
     `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_spi_device_n[1], exp_ctrl_n[0])
     `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_spi_host0_n[1], exp_ctrl_n[1])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_spi_host0_core_n[1], exp_ctrl_n[2])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_spi_host1_n[1], exp_ctrl_n[3])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_spi_host1_core_n[1], exp_ctrl_n[4])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_usb_n[1], exp_ctrl_n[5])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_usbif_n[1], exp_ctrl_n[6])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_i2c0_n[1], exp_ctrl_n[7])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_i2c1_n[1], exp_ctrl_n[8])
-    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_i2c2_n[1], exp_ctrl_n[9])
+    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_spi_host1_n[1], exp_ctrl_n[2])
+    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_usb_n[1], exp_ctrl_n[3])
+    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_usbif_n[1], exp_ctrl_n[4])
+    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_i2c0_n[1], exp_ctrl_n[5])
+    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_i2c1_n[1], exp_ctrl_n[6])
+    `DV_CHECK_EQ(cfg.rstmgr_vif.resets_o.rst_i2c2_n[1], exp_ctrl_n[7])
   endtask
 
   // Stimulate and check sw_rst_ctrl_n with a given sw_rst_regen setting.

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -169,13 +169,9 @@ interface rstmgr_cascading_sva_if (
   `CASCADED_ASSERTS(CascadeSysToSpiDevice, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
                     resets_o.rst_spi_device_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
   `CASCADED_ASSERTS(CascadeSysToSpiHost0, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_host0_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
-  `CASCADED_ASSERTS(CascadeSysToSpiHost0Core, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_host0_core_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_i)
+                    resets_o.rst_spi_host0_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_i)
   `CASCADED_ASSERTS(CascadeSysToSpiHost1, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_host1_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
-  `CASCADED_ASSERTS(CascadeSysToSpiHost1Core, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_host1_core_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_i)
+                    resets_o.rst_spi_host1_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div2_i)
   `CASCADED_ASSERTS(CascadeSysToUsb, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
                     resets_o.rst_usb_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
   `CASCADED_ASSERTS(CascadeSysToUsbIf, rst_sys_src_n[rstmgr_pkg::Domain0Sel],

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -4,7 +4,6 @@
 { name: "spi_host",
   clocking: [
     {clock: "clk_i", reset: "rst_ni", primary: true},
-    {clock: "clk_core_i", reset: "rst_core_ni"}
   ]
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -131,6 +131,8 @@
           clk_io_div4_infra: io_div4
           clk_aon_infra: aon
           clk_main_infra: main
+          clk_io_infra: io
+          clk_io_div2_infra: io_div2
         }
       }
       {
@@ -401,20 +403,6 @@
         sw: true
         path: rstmgr_aon_resets.rst_spi_host0_n
         parent: sys_src
-        clock: io_div4
-      }
-      {
-        name: spi_host0_core
-        gen: true
-        type: top
-        domains:
-        [
-          "0"
-        ]
-        shadowed: false
-        sw: true
-        path: rstmgr_aon_resets.rst_spi_host0_core_n
-        parent: sys_src
         clock: io
       }
       {
@@ -428,20 +416,6 @@
         shadowed: false
         sw: true
         path: rstmgr_aon_resets.rst_spi_host1_n
-        parent: sys_src
-        clock: io_div4
-      }
-      {
-        name: spi_host1_core
-        gen: true
-        type: top
-        domains:
-        [
-          "0"
-        ]
-        shadowed: false
-        sw: true
-        path: rstmgr_aon_resets.rst_spi_host1_core_n
         parent: sys_src
         clock: io_div2
       }
@@ -856,8 +830,7 @@
       type: spi_host
       clock_srcs:
       {
-        clk_i: io_div4
-        clk_core_i: io
+        clk_i: io
       }
       clock_group: peri
       reset_connections:
@@ -867,16 +840,10 @@
           name: spi_host0
           domain: "0"
         }
-        rst_core_ni:
-        {
-          name: spi_host0_core
-          domain: "0"
-        }
       }
       clock_connections:
       {
-        clk_i: clkmgr_aon_clocks.clk_io_div4_peri
-        clk_core_i: clkmgr_aon_clocks.clk_io_peri
+        clk_i: clkmgr_aon_clocks.clk_io_peri
       }
       domain:
       [
@@ -922,8 +889,7 @@
       type: spi_host
       clock_srcs:
       {
-        clk_i: io_div4
-        clk_core_i: io_div2
+        clk_i: io_div2
       }
       clock_group: peri
       reset_connections:
@@ -933,16 +899,10 @@
           name: spi_host1
           domain: "0"
         }
-        rst_core_ni:
-        {
-          name: spi_host1_core
-          domain: "0"
-        }
       }
       clock_connections:
       {
-        clk_i: clkmgr_aon_clocks.clk_io_div4_peri
-        clk_core_i: clkmgr_aon_clocks.clk_io_div2_peri
+        clk_i: clkmgr_aon_clocks.clk_io_div2_peri
       }
       domain:
       [
@@ -8403,6 +8363,8 @@
       clock_srcs:
       {
         clk_peri_i: io_div4
+        clk_spi_host0_i: io
+        clk_spi_host1_i: io_div2
       }
       clock_group: infra
       reset: rst_peri_ni
@@ -8413,10 +8375,22 @@
           name: sys_io_div4
           domain: "0"
         }
+        rst_spi_host0_ni:
+        {
+          name: spi_host0
+          domain: "0"
+        }
+        rst_spi_host1_ni:
+        {
+          name: spi_host1
+          domain: "0"
+        }
       }
       clock_connections:
       {
         clk_peri_i: clkmgr_aon_clocks.clk_io_div4_infra
+        clk_spi_host0_i: clkmgr_aon_clocks.clk_io_infra
+        clk_spi_host1_i: clkmgr_aon_clocks.clk_io_div2_infra
       }
       domain:
       [
@@ -8672,8 +8646,8 @@
         {
           name: spi_host0
           type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
+          clock: clk_spi_host0_i
+          reset: rst_spi_host0_ni
           pipeline: "false"
           inst_type: spi_host
           addr_range:
@@ -8690,8 +8664,8 @@
         {
           name: spi_host1
           type: device
-          clock: clk_peri_i
-          reset: rst_peri_ni
+          clock: clk_spi_host1_i
+          reset: rst_spi_host1_ni
           pipeline: "false"
           inst_type: spi_host
           addr_range:
@@ -13694,7 +13668,7 @@
     {
       name: peri_spi_host0_0
       clock_group: peri
-      clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
+      clock_connection: clkmgr_aon_clocks.clk_io_peri
       reset_connection:
       {
         name: spi_host0
@@ -13704,7 +13678,7 @@
     {
       name: peri_spi_host1_0
       clock_group: peri
-      clock_connection: clkmgr_aon_clocks.clk_io_div4_peri
+      clock_connection: clkmgr_aon_clocks.clk_io_div2_peri
       reset_connection:
       {
         name: spi_host1

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -151,10 +151,8 @@
       { name: "sys_io_div4",    gen: true,  type: "top", parent: "sys_src", clk: "io_div4" }
       { name: "sys_aon",        gen: true,  type: "top", parent: "sys_src", clk: "aon"     }
       { name: "spi_device",     gen: true,  type: "top", parent: "sys_src", clk: "io_div4", sw: true }
-      { name: "spi_host0",      gen: true,  type: "top", parent: "sys_src", clk: "io_div4", sw: true }
-      { name: "spi_host0_core", gen: true,  type: "top", parent: "sys_src", clk: "io",      sw: true }
-      { name: "spi_host1",      gen: true,  type: "top", parent: "sys_src", clk: "io_div4", sw: true }
-      { name: "spi_host1_core", gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true }
+      { name: "spi_host0",      gen: true,  type: "top", parent: "sys_src", clk: "io",      sw: true }
+      { name: "spi_host1",      gen: true,  type: "top", parent: "sys_src", clk: "io_div2", sw: true }
       { name: "usb",            gen: true,  type: "top", parent: "sys_src", clk: "io_div4", sw: true }
       { name: "usbif",          gen: true,  type: "top", parent: "sys_src", clk: "usb",     sw: true }
       { name: "i2c0",           gen: true,  type: "top", parent: "sys_src", clk: "io_div4", sw: true },
@@ -253,16 +251,16 @@
     },
     { name: "spi_host0",
       type: "spi_host",
-      clock_srcs: {clk_i: "io_div4", clk_core_i: "io"},
+      clock_srcs: {clk_i: "io"},
       clock_group: "peri",
-      reset_connections: {rst_ni: "spi_host0", rst_core_ni: "spi_host0_core"},
+      reset_connections: {rst_ni: "spi_host0"},
       base_addr: "0x40060000",
     },
     { name: "spi_host1",
       type: "spi_host",
-      clock_srcs: {clk_i: "io_div4", clk_core_i: "io_div2"},
+      clock_srcs: {clk_i: "io_div2"},
       clock_group: "peri",
-      reset_connections: {rst_ni: "spi_host1", rst_core_ni: "spi_host1_core"},
+      reset_connections: {rst_ni: "spi_host1"},
       base_addr: "0x40070000",
     },
     { name: "i2c0",
@@ -985,10 +983,12 @@
       reset_connections: {rst_main_ni: "sys", rst_fixed_ni: "sys_io_div4"}
     },
     { name: "peri",
-      clock_srcs: {clk_peri_i: "io_div4"},
+      clock_srcs: {clk_peri_i: "io_div4", clk_spi_host0_i: "io", clk_spi_host1_i: "io_div2"},
       clock_group: "infra",
       reset: "sys_io_div4",
-      reset_connections: {rst_peri_ni: "sys_io_div4"},
+      reset_connections: {rst_peri_ni:      "sys_io_div4",
+                          rst_spi_host0_ni: "spi_host0",
+                          rst_spi_host1_ni: "spi_host1"},
     }
   ],
 

--- a/hw/top_earlgrey/data/xbar_peri.hjson
+++ b/hw/top_earlgrey/data/xbar_peri.hjson
@@ -4,7 +4,9 @@
 { name: "peri",
   type: "xbar",
   clock_primary: "clk_peri_i", // Main clock, used in sockets
+  other_clock_list: [ "clk_spi_host0_i", "clk_spi_host1_i" ] // Secondary clocks used by specific nodes
   reset_primary: "rst_peri_ni", // Main reset, used in sockets
+  other_reset_list: [ "rst_spi_host0_ni", "rst_spi_host1_ni" ] // Secondary resets used by specific nodes
 
   nodes: [
     { name:  "main",
@@ -83,14 +85,14 @@
     },
     { name:      "spi_host0",
       type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
+      clock:     "clk_spi_host0_i",
+      reset:     "rst_spi_host0_ni",
       pipeline:  "false"
     },
     { name:      "spi_host1",
       type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
+      clock:     "clk_spi_host1_i",
+      reset:     "rst_spi_host1_ni",
       pipeline:  "false"
     },
     { name:      "rv_timer",

--- a/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/dv/autogen/tb__xbar_connect.sv
@@ -26,6 +26,10 @@
 
 wire clk_main;
 clk_rst_if clk_rst_if_main(.clk(clk_main), .rst_n(rst_n));
+wire clk_io;
+clk_rst_if clk_rst_if_io(.clk(clk_io), .rst_n(rst_n));
+wire clk_io_div2;
+clk_rst_if clk_rst_if_io_div2(.clk(clk_io_div2), .rst_n(rst_n));
 wire clk_io_div4;
 clk_rst_if clk_rst_if_io_div4(.clk(clk_io_div4), .rst_n(rst_n));
 
@@ -64,8 +68,8 @@ tl_if pattgen_tl_if(clk_io_div4, rst_n);
 tl_if pwm_aon_tl_if(clk_io_div4, rst_n);
 tl_if gpio_tl_if(clk_io_div4, rst_n);
 tl_if spi_device_tl_if(clk_io_div4, rst_n);
-tl_if spi_host0_tl_if(clk_io_div4, rst_n);
-tl_if spi_host1_tl_if(clk_io_div4, rst_n);
+tl_if spi_host0_tl_if(clk_io, rst_n);
+tl_if spi_host1_tl_if(clk_io_div2, rst_n);
 tl_if rv_timer_tl_if(clk_io_div4, rst_n);
 tl_if usbdev_tl_if(clk_io_div4, rst_n);
 tl_if pwrmgr_aon_tl_if(clk_io_div4, rst_n);
@@ -95,6 +99,10 @@ initial begin
 
     clk_rst_if_main.set_active(.drive_rst_n_val(0));
     clk_rst_if_main.set_freq_khz(100000000 / 1000);
+    clk_rst_if_io.set_active(.drive_rst_n_val(0));
+    clk_rst_if_io.set_freq_khz(96000000 / 1000);
+    clk_rst_if_io_div2.set_active(.drive_rst_n_val(0));
+    clk_rst_if_io_div2.set_freq_khz(48000000 / 1000);
     clk_rst_if_io_div4.set_active(.drive_rst_n_val(0));
     clk_rst_if_io_div4.set_freq_khz(24000000 / 1000);
 
@@ -102,11 +110,15 @@ initial begin
     force tb.dut.top_earlgrey.u_xbar_main.clk_main_i = clk_main;
     force tb.dut.top_earlgrey.u_xbar_main.clk_fixed_i = clk_io_div4;
     force tb.dut.top_earlgrey.u_xbar_peri.clk_peri_i = clk_io_div4;
+    force tb.dut.top_earlgrey.u_xbar_peri.clk_spi_host0_i = clk_io;
+    force tb.dut.top_earlgrey.u_xbar_peri.clk_spi_host1_i = clk_io_div2;
 
     // bypass rstmgr, force resets directly
     force tb.dut.top_earlgrey.u_xbar_main.rst_main_ni = rst_n;
     force tb.dut.top_earlgrey.u_xbar_main.rst_fixed_ni = rst_n;
     force tb.dut.top_earlgrey.u_xbar_peri.rst_peri_ni = rst_n;
+    force tb.dut.top_earlgrey.u_xbar_peri.rst_spi_host0_ni = rst_n;
+    force tb.dut.top_earlgrey.u_xbar_peri.rst_spi_host1_ni = rst_n;
 
     `DRIVE_CHIP_TL_HOST_IF(rv_core_ibex__corei, rv_core_ibex, corei_tl_h)
     `DRIVE_CHIP_TL_HOST_IF(rv_core_ibex__cored, rv_core_ibex, cored_tl_h)

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -669,6 +669,28 @@
     .mubi_i(((clk_main_en) ? MuBi4False : MuBi4True)),
     .mubi_o(cg_en_o.main_infra)
   );
+  assign clocks_o.clk_io_infra = clk_io_root;
+
+  // clock gated indication for alert handler
+  prim_mubi4_sender #(
+    .ResetValue(MuBi4True)
+  ) u_prim_mubi4_sender_clk_io_infra (
+    .clk_i(clk_io_i),
+    .rst_ni(rst_io_ni),
+    .mubi_i(((clk_io_en) ? MuBi4False : MuBi4True)),
+    .mubi_o(cg_en_o.io_infra)
+  );
+  assign clocks_o.clk_io_div2_infra = clk_io_div2_root;
+
+  // clock gated indication for alert handler
+  prim_mubi4_sender #(
+    .ResetValue(MuBi4True)
+  ) u_prim_mubi4_sender_clk_io_div2_infra (
+    .clk_i(clk_io_div2_i),
+    .rst_ni(rst_io_div2_ni),
+    .mubi_i(((clk_io_div2_en) ? MuBi4False : MuBi4True)),
+    .mubi_o(cg_en_o.io_div2_infra)
+  );
   assign clocks_o.clk_io_div4_secure = clk_io_div4_root;
 
   // clock gated indication for alert handler

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -39,6 +39,8 @@ package clkmgr_pkg;
     logic clk_io_div4_otbn;
     logic clk_io_div4_infra;
     logic clk_main_infra;
+    logic clk_io_infra;
+    logic clk_io_div2_infra;
     logic clk_io_div4_secure;
     logic clk_main_secure;
     logic clk_usb_secure;
@@ -68,6 +70,8 @@ package clkmgr_pkg;
     prim_mubi_pkg::mubi4_t io_div4_otbn;
     prim_mubi_pkg::mubi4_t io_div4_infra;
     prim_mubi_pkg::mubi4_t main_infra;
+    prim_mubi_pkg::mubi4_t io_infra;
+    prim_mubi_pkg::mubi4_t io_div2_infra;
     prim_mubi_pkg::mubi4_t io_div4_secure;
     prim_mubi_pkg::mubi4_t main_secure;
     prim_mubi_pkg::mubi4_t usb_secure;
@@ -78,7 +82,7 @@ package clkmgr_pkg;
     prim_mubi_pkg::mubi4_t usb_peri;
   } clkmgr_cg_en_t;
 
-  parameter int NumOutputClk = 25;
+  parameter int NumOutputClk = 27;
 
 
   typedef struct packed {

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -61,7 +61,7 @@
     { name: "NumSwResets",
       desc: "Number of software resets",
       type: "int",
-      default: "10",
+      default: "8",
       local: "true"
     },
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -169,8 +169,8 @@ module rstmgr
   ////////////////////////////////////////////////////
 
   // consistency check errors
-  logic [20:0][PowerDomains-1:0] cnsty_chk_errs;
-  logic [20:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
+  logic [18:0][PowerDomains-1:0] cnsty_chk_errs;
+  logic [18:0][PowerDomains-1:0] shadow_cnsty_chk_errs;
 
   assign hw2reg.err_code.reg_intg_err.d  = 1'b1;
   assign hw2reg.err_code.reg_intg_err.de = reg_intg_err;
@@ -308,9 +308,9 @@ module rstmgr
   // To simplify generation, each reset generates all associated power domain outputs.
   // If a reset does not support a particular power domain, that reset is always hard-wired to 0.
 
-  lc_ctrl_pkg::lc_tx_t [20:0] leaf_rst_scanmode;
+  lc_ctrl_pkg::lc_tx_t [18:0] leaf_rst_scanmode;
   prim_lc_sync #(
-    .NumCopies(21),
+    .NumCopies(19),
     .AsyncOn(0)
     ) u_leaf_rst_scanmode_sync  (
     .clk_i(1'b0),  // unused clock
@@ -655,7 +655,7 @@ module rstmgr
   rstmgr_leaf_rst u_d0_spi_host0 (
     .clk_i,
     .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
+    .leaf_clk_i(clk_io_i),
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[SPI_HOST0]),
     .scan_rst_ni,
@@ -666,71 +666,31 @@ module rstmgr
   );
   assign shadow_cnsty_chk_errs[12] = '0;
 
-  // Generating resets for spi_host0_core
-  // Power Domains: ['0']
-  // Shadowed: False
-  assign resets_o.rst_spi_host0_core_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[13][DomainAonSel] = '0;
-  assign rst_en_o.spi_host0_core[DomainAonSel] = MuBi4True;
-  rstmgr_leaf_rst u_d0_spi_host0_core (
-    .clk_i,
-    .rst_ni,
-    .leaf_clk_i(clk_io_i),
-    .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
-    .sw_rst_req_ni(sw_rst_ctrl_n[SPI_HOST0_CORE]),
-    .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[13] == lc_ctrl_pkg::On),
-    .rst_en_o(rst_en_o.spi_host0_core[Domain0Sel]),
-    .leaf_rst_o(resets_o.rst_spi_host0_core_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[13][Domain0Sel])
-  );
-  assign shadow_cnsty_chk_errs[13] = '0;
-
   // Generating resets for spi_host1
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_spi_host1_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[14][DomainAonSel] = '0;
+  assign cnsty_chk_errs[13][DomainAonSel] = '0;
   assign rst_en_o.spi_host1[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst u_d0_spi_host1 (
     .clk_i,
     .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
+    .leaf_clk_i(clk_io_div2_i),
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[SPI_HOST1]),
     .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[14] == lc_ctrl_pkg::On),
+    .scan_sel(leaf_rst_scanmode[13] == lc_ctrl_pkg::On),
     .rst_en_o(rst_en_o.spi_host1[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_spi_host1_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[14][Domain0Sel])
+    .err_o(cnsty_chk_errs[13][Domain0Sel])
   );
-  assign shadow_cnsty_chk_errs[14] = '0;
-
-  // Generating resets for spi_host1_core
-  // Power Domains: ['0']
-  // Shadowed: False
-  assign resets_o.rst_spi_host1_core_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[15][DomainAonSel] = '0;
-  assign rst_en_o.spi_host1_core[DomainAonSel] = MuBi4True;
-  rstmgr_leaf_rst u_d0_spi_host1_core (
-    .clk_i,
-    .rst_ni,
-    .leaf_clk_i(clk_io_div2_i),
-    .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
-    .sw_rst_req_ni(sw_rst_ctrl_n[SPI_HOST1_CORE]),
-    .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[15] == lc_ctrl_pkg::On),
-    .rst_en_o(rst_en_o.spi_host1_core[Domain0Sel]),
-    .leaf_rst_o(resets_o.rst_spi_host1_core_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[15][Domain0Sel])
-  );
-  assign shadow_cnsty_chk_errs[15] = '0;
+  assign shadow_cnsty_chk_errs[13] = '0;
 
   // Generating resets for usb
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_usb_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[16][DomainAonSel] = '0;
+  assign cnsty_chk_errs[14][DomainAonSel] = '0;
   assign rst_en_o.usb[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst u_d0_usb (
     .clk_i,
@@ -739,18 +699,18 @@ module rstmgr
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[USB]),
     .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[16] == lc_ctrl_pkg::On),
+    .scan_sel(leaf_rst_scanmode[14] == lc_ctrl_pkg::On),
     .rst_en_o(rst_en_o.usb[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_usb_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[16][Domain0Sel])
+    .err_o(cnsty_chk_errs[14][Domain0Sel])
   );
-  assign shadow_cnsty_chk_errs[16] = '0;
+  assign shadow_cnsty_chk_errs[14] = '0;
 
   // Generating resets for usbif
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_usbif_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[17][DomainAonSel] = '0;
+  assign cnsty_chk_errs[15][DomainAonSel] = '0;
   assign rst_en_o.usbif[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst u_d0_usbif (
     .clk_i,
@@ -759,18 +719,18 @@ module rstmgr
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[USBIF]),
     .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[17] == lc_ctrl_pkg::On),
+    .scan_sel(leaf_rst_scanmode[15] == lc_ctrl_pkg::On),
     .rst_en_o(rst_en_o.usbif[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_usbif_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[17][Domain0Sel])
+    .err_o(cnsty_chk_errs[15][Domain0Sel])
   );
-  assign shadow_cnsty_chk_errs[17] = '0;
+  assign shadow_cnsty_chk_errs[15] = '0;
 
   // Generating resets for i2c0
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c0_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[18][DomainAonSel] = '0;
+  assign cnsty_chk_errs[16][DomainAonSel] = '0;
   assign rst_en_o.i2c0[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst u_d0_i2c0 (
     .clk_i,
@@ -779,18 +739,18 @@ module rstmgr
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[I2C0]),
     .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[18] == lc_ctrl_pkg::On),
+    .scan_sel(leaf_rst_scanmode[16] == lc_ctrl_pkg::On),
     .rst_en_o(rst_en_o.i2c0[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c0_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[18][Domain0Sel])
+    .err_o(cnsty_chk_errs[16][Domain0Sel])
   );
-  assign shadow_cnsty_chk_errs[18] = '0;
+  assign shadow_cnsty_chk_errs[16] = '0;
 
   // Generating resets for i2c1
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c1_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[19][DomainAonSel] = '0;
+  assign cnsty_chk_errs[17][DomainAonSel] = '0;
   assign rst_en_o.i2c1[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst u_d0_i2c1 (
     .clk_i,
@@ -799,18 +759,18 @@ module rstmgr
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[I2C1]),
     .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[19] == lc_ctrl_pkg::On),
+    .scan_sel(leaf_rst_scanmode[17] == lc_ctrl_pkg::On),
     .rst_en_o(rst_en_o.i2c1[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c1_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[19][Domain0Sel])
+    .err_o(cnsty_chk_errs[17][Domain0Sel])
   );
-  assign shadow_cnsty_chk_errs[19] = '0;
+  assign shadow_cnsty_chk_errs[17] = '0;
 
   // Generating resets for i2c2
   // Power Domains: ['0']
   // Shadowed: False
   assign resets_o.rst_i2c2_n[DomainAonSel] = '0;
-  assign cnsty_chk_errs[20][DomainAonSel] = '0;
+  assign cnsty_chk_errs[18][DomainAonSel] = '0;
   assign rst_en_o.i2c2[DomainAonSel] = MuBi4True;
   rstmgr_leaf_rst u_d0_i2c2 (
     .clk_i,
@@ -819,12 +779,12 @@ module rstmgr
     .parent_rst_ni(rst_sys_src_n[Domain0Sel]),
     .sw_rst_req_ni(sw_rst_ctrl_n[I2C2]),
     .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[20] == lc_ctrl_pkg::On),
+    .scan_sel(leaf_rst_scanmode[18] == lc_ctrl_pkg::On),
     .rst_en_o(rst_en_o.i2c2[Domain0Sel]),
     .leaf_rst_o(resets_o.rst_i2c2_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[20][Domain0Sel])
+    .err_o(cnsty_chk_errs[18][Domain0Sel])
   );
-  assign shadow_cnsty_chk_errs[20] = '0;
+  assign shadow_cnsty_chk_errs[18] = '0;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -25,14 +25,12 @@ package rstmgr_pkg;
   // positions of software controllable reset bits
   parameter int SPI_DEVICE = 0;
   parameter int SPI_HOST0 = 1;
-  parameter int SPI_HOST0_CORE = 2;
-  parameter int SPI_HOST1 = 3;
-  parameter int SPI_HOST1_CORE = 4;
-  parameter int USB = 5;
-  parameter int USBIF = 6;
-  parameter int I2C0 = 7;
-  parameter int I2C1 = 8;
-  parameter int I2C2 = 9;
+  parameter int SPI_HOST1 = 2;
+  parameter int USB = 3;
+  parameter int USBIF = 4;
+  parameter int I2C0 = 5;
+  parameter int I2C1 = 6;
+  parameter int I2C2 = 7;
 
   // resets generated and broadcast
   typedef struct packed {
@@ -53,9 +51,7 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_sys_aon_n;
     logic [PowerDomains-1:0] rst_spi_device_n;
     logic [PowerDomains-1:0] rst_spi_host0_n;
-    logic [PowerDomains-1:0] rst_spi_host0_core_n;
     logic [PowerDomains-1:0] rst_spi_host1_n;
-    logic [PowerDomains-1:0] rst_spi_host1_core_n;
     logic [PowerDomains-1:0] rst_usb_n;
     logic [PowerDomains-1:0] rst_usbif_n;
     logic [PowerDomains-1:0] rst_i2c0_n;
@@ -82,9 +78,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] sys_aon;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_device;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host0;
-    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host0_core;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host1;
-    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] spi_host1_core;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] usb;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] usbif;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] i2c0;
@@ -92,7 +86,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] i2c2;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 25 * PowerDomains;
+  parameter int NumOutputRst = 23 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_pkg.sv
@@ -10,7 +10,7 @@ package rstmgr_reg_pkg;
   parameter int RdWidth = 32;
   parameter int IdxWidth = 4;
   parameter int NumHwResets = 4;
-  parameter int NumSwResets = 10;
+  parameter int NumSwResets = 8;
   parameter int NumAlerts = 1;
 
   // Address widths within the block
@@ -136,26 +136,26 @@ package rstmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    rstmgr_reg2hw_alert_test_reg_t alert_test; // [50:49]
-    rstmgr_reg2hw_reset_req_reg_t reset_req; // [48:45]
-    rstmgr_reg2hw_reset_info_reg_t reset_info; // [44:40]
-    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [39:35]
-    rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [34:30]
-    rstmgr_reg2hw_sw_rst_regwen_mreg_t [9:0] sw_rst_regwen; // [29:20]
-    rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [19:0]
+    rstmgr_reg2hw_alert_test_reg_t alert_test; // [44:43]
+    rstmgr_reg2hw_reset_req_reg_t reset_req; // [42:39]
+    rstmgr_reg2hw_reset_info_reg_t reset_info; // [38:34]
+    rstmgr_reg2hw_alert_info_ctrl_reg_t alert_info_ctrl; // [33:29]
+    rstmgr_reg2hw_cpu_info_ctrl_reg_t cpu_info_ctrl; // [28:24]
+    rstmgr_reg2hw_sw_rst_regwen_mreg_t [7:0] sw_rst_regwen; // [23:16]
+    rstmgr_reg2hw_sw_rst_ctrl_n_mreg_t [7:0] sw_rst_ctrl_n; // [15:0]
   } rstmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    rstmgr_hw2reg_reset_req_reg_t reset_req; // [105:101]
-    rstmgr_hw2reg_reset_info_reg_t reset_info; // [100:90]
-    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [89:88]
-    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [87:84]
-    rstmgr_hw2reg_alert_info_reg_t alert_info; // [83:52]
-    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [51:50]
-    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [49:46]
-    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [45:14]
-    rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t [9:0] sw_rst_ctrl_n; // [13:4]
+    rstmgr_hw2reg_reset_req_reg_t reset_req; // [103:99]
+    rstmgr_hw2reg_reset_info_reg_t reset_info; // [98:88]
+    rstmgr_hw2reg_alert_info_ctrl_reg_t alert_info_ctrl; // [87:86]
+    rstmgr_hw2reg_alert_info_attr_reg_t alert_info_attr; // [85:82]
+    rstmgr_hw2reg_alert_info_reg_t alert_info; // [81:50]
+    rstmgr_hw2reg_cpu_info_ctrl_reg_t cpu_info_ctrl; // [49:48]
+    rstmgr_hw2reg_cpu_info_attr_reg_t cpu_info_attr; // [47:44]
+    rstmgr_hw2reg_cpu_info_reg_t cpu_info; // [43:12]
+    rstmgr_hw2reg_sw_rst_ctrl_n_mreg_t [7:0] sw_rst_ctrl_n; // [11:4]
     rstmgr_hw2reg_err_code_reg_t err_code; // [3:0]
   } rstmgr_hw2reg_t;
 
@@ -186,7 +186,7 @@ package rstmgr_reg_pkg;
   parameter logic [3:0] RSTMGR_CPU_INFO_ATTR_CNT_AVAIL_RESVAL = 4'h 0;
   parameter logic [31:0] RSTMGR_CPU_INFO_RESVAL = 32'h 0;
   parameter logic [31:0] RSTMGR_CPU_INFO_VALUE_RESVAL = 32'h 0;
-  parameter logic [9:0] RSTMGR_SW_RST_CTRL_N_RESVAL = 10'h 3ff;
+  parameter logic [7:0] RSTMGR_SW_RST_CTRL_N_RESVAL = 8'h ff;
   parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_0_RESVAL = 1'h 1;
   parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_1_RESVAL = 1'h 1;
   parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_2_RESVAL = 1'h 1;
@@ -195,8 +195,6 @@ package rstmgr_reg_pkg;
   parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_5_RESVAL = 1'h 1;
   parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_6_RESVAL = 1'h 1;
   parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_7_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_8_RESVAL = 1'h 1;
-  parameter logic [0:0] RSTMGR_SW_RST_CTRL_N_VAL_9_RESVAL = 1'h 1;
 
   // Register index
   typedef enum int {
@@ -229,8 +227,8 @@ package rstmgr_reg_pkg;
     4'b 0001, // index[ 8] RSTMGR_CPU_INFO_CTRL
     4'b 0001, // index[ 9] RSTMGR_CPU_INFO_ATTR
     4'b 1111, // index[10] RSTMGR_CPU_INFO
-    4'b 0011, // index[11] RSTMGR_SW_RST_REGWEN
-    4'b 0011, // index[12] RSTMGR_SW_RST_CTRL_N
+    4'b 0001, // index[11] RSTMGR_SW_RST_REGWEN
+    4'b 0001, // index[12] RSTMGR_SW_RST_CTRL_N
     4'b 0001  // index[13] RSTMGR_ERR_CODE
   };
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -165,10 +165,6 @@ module rstmgr_reg_top (
   logic sw_rst_regwen_en_6_wd;
   logic sw_rst_regwen_en_7_qs;
   logic sw_rst_regwen_en_7_wd;
-  logic sw_rst_regwen_en_8_qs;
-  logic sw_rst_regwen_en_8_wd;
-  logic sw_rst_regwen_en_9_qs;
-  logic sw_rst_regwen_en_9_wd;
   logic sw_rst_ctrl_n_re;
   logic sw_rst_ctrl_n_we;
   logic sw_rst_ctrl_n_val_0_qs;
@@ -187,10 +183,6 @@ module rstmgr_reg_top (
   logic sw_rst_ctrl_n_val_6_wd;
   logic sw_rst_ctrl_n_val_7_qs;
   logic sw_rst_ctrl_n_val_7_wd;
-  logic sw_rst_ctrl_n_val_8_qs;
-  logic sw_rst_ctrl_n_val_8_wd;
-  logic sw_rst_ctrl_n_val_9_qs;
-  logic sw_rst_ctrl_n_val_9_wd;
   logic err_code_we;
   logic err_code_reg_intg_err_qs;
   logic err_code_reg_intg_err_wd;
@@ -784,56 +776,6 @@ module rstmgr_reg_top (
     .qs     (sw_rst_regwen_en_7_qs)
   );
 
-  //   F[en_8]: 8:8
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
-  ) u_sw_rst_regwen_en_8 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (sw_rst_regwen_we),
-    .wd     (sw_rst_regwen_en_8_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.sw_rst_regwen[8].q),
-
-    // to register interface (read)
-    .qs     (sw_rst_regwen_en_8_qs)
-  );
-
-  //   F[en_9]: 9:9
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
-  ) u_sw_rst_regwen_en_9 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (sw_rst_regwen_we),
-    .wd     (sw_rst_regwen_en_9_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.sw_rst_regwen[9].q),
-
-    // to register interface (read)
-    .qs     (sw_rst_regwen_en_9_qs)
-  );
-
 
   // Subregister 0 of Multireg sw_rst_ctrl_n
   // R[sw_rst_ctrl_n]: V(True)
@@ -947,34 +889,6 @@ module rstmgr_reg_top (
     .qe     (reg2hw.sw_rst_ctrl_n[7].qe),
     .q      (reg2hw.sw_rst_ctrl_n[7].q),
     .qs     (sw_rst_ctrl_n_val_7_qs)
-  );
-
-  //   F[val_8]: 8:8
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_8 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_8_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[8].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[8].qe),
-    .q      (reg2hw.sw_rst_ctrl_n[8].q),
-    .qs     (sw_rst_ctrl_n_val_8_qs)
-  );
-
-  //   F[val_9]: 9:9
-  prim_subreg_ext #(
-    .DW    (1)
-  ) u_sw_rst_ctrl_n_val_9 (
-    .re     (sw_rst_ctrl_n_re),
-    .we     (sw_rst_ctrl_n_we),
-    .wd     (sw_rst_ctrl_n_val_9_wd),
-    .d      (hw2reg.sw_rst_ctrl_n[9].d),
-    .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[9].qe),
-    .q      (reg2hw.sw_rst_ctrl_n[9].q),
-    .qs     (sw_rst_ctrl_n_val_9_qs)
   );
 
 
@@ -1124,10 +1038,6 @@ module rstmgr_reg_top (
   assign sw_rst_regwen_en_6_wd = reg_wdata[6];
 
   assign sw_rst_regwen_en_7_wd = reg_wdata[7];
-
-  assign sw_rst_regwen_en_8_wd = reg_wdata[8];
-
-  assign sw_rst_regwen_en_9_wd = reg_wdata[9];
   assign sw_rst_ctrl_n_re = addr_hit[12] & reg_re & !reg_error;
   assign sw_rst_ctrl_n_we = addr_hit[12] & reg_we & !reg_error;
 
@@ -1146,10 +1056,6 @@ module rstmgr_reg_top (
   assign sw_rst_ctrl_n_val_6_wd = reg_wdata[6];
 
   assign sw_rst_ctrl_n_val_7_wd = reg_wdata[7];
-
-  assign sw_rst_ctrl_n_val_8_wd = reg_wdata[8];
-
-  assign sw_rst_ctrl_n_val_9_wd = reg_wdata[9];
   assign err_code_we = addr_hit[13] & reg_we & !reg_error;
 
   assign err_code_reg_intg_err_wd = reg_wdata[0];
@@ -1219,8 +1125,6 @@ module rstmgr_reg_top (
         reg_rdata_next[5] = sw_rst_regwen_en_5_qs;
         reg_rdata_next[6] = sw_rst_regwen_en_6_qs;
         reg_rdata_next[7] = sw_rst_regwen_en_7_qs;
-        reg_rdata_next[8] = sw_rst_regwen_en_8_qs;
-        reg_rdata_next[9] = sw_rst_regwen_en_9_qs;
       end
 
       addr_hit[12]: begin
@@ -1232,8 +1136,6 @@ module rstmgr_reg_top (
         reg_rdata_next[5] = sw_rst_ctrl_n_val_5_qs;
         reg_rdata_next[6] = sw_rst_ctrl_n_val_6_qs;
         reg_rdata_next[7] = sw_rst_ctrl_n_val_7_qs;
-        reg_rdata_next[8] = sw_rst_ctrl_n_val_8_qs;
-        reg_rdata_next[9] = sw_rst_ctrl_n_val_9_qs;
       end
 
       addr_hit[13]: begin

--- a/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
+++ b/hw/top_earlgrey/ip/xbar_peri/data/autogen/xbar_peri.gen.hjson
@@ -11,6 +11,8 @@
   clock_srcs:
   {
     clk_peri_i: io_div4
+    clk_spi_host0_i: io
+    clk_spi_host1_i: io_div2
   }
   clock_group: infra
   reset: rst_peri_ni
@@ -21,10 +23,22 @@
       name: sys_io_div4
       domain: "0"
     }
+    rst_spi_host0_ni:
+    {
+      name: spi_host0
+      domain: "0"
+    }
+    rst_spi_host1_ni:
+    {
+      name: spi_host1
+      domain: "0"
+    }
   }
   clock_connections:
   {
     clk_peri_i: clkmgr_aon_clocks.clk_io_div4_infra
+    clk_spi_host0_i: clkmgr_aon_clocks.clk_io_infra
+    clk_spi_host1_i: clkmgr_aon_clocks.clk_io_div2_infra
   }
   domain:
   [
@@ -280,8 +294,8 @@
     {
       name: spi_host0
       type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
+      clock: clk_spi_host0_i
+      reset: rst_spi_host0_ni
       pipeline: "false"
       inst_type: spi_host
       addr_range:
@@ -298,8 +312,8 @@
     {
       name: spi_host1
       type: device
-      clock: clk_peri_i
-      reset: rst_peri_ni
+      clock: clk_spi_host1_i
+      reset: rst_spi_host1_ni
       pipeline: "false"
       inst_type: spi_host
       addr_range:

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/tb__xbar_connect.sv
@@ -7,11 +7,17 @@
 xbar_peri dut();
 
 `DRIVE_CLK(clk_peri_i)
+`DRIVE_CLK(clk_spi_host0_i)
+`DRIVE_CLK(clk_spi_host1_i)
 
 initial force dut.clk_peri_i = clk_peri_i;
+initial force dut.clk_spi_host0_i = clk_spi_host0_i;
+initial force dut.clk_spi_host1_i = clk_spi_host1_i;
 
 // TODO, all resets tie together
 initial force dut.rst_peri_ni = rst_n;
+initial force dut.rst_spi_host0_ni = rst_n;
+initial force dut.rst_spi_host1_ni = rst_n;
 
 // Host TileLink interface connections
 `CONNECT_TL_HOST_IF(main, dut, clk_peri_i, rst_n)
@@ -28,8 +34,8 @@ initial force dut.rst_peri_ni = rst_n;
 `CONNECT_TL_DEVICE_IF(pwm_aon, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(gpio, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(spi_device, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(spi_host0, dut, clk_peri_i, rst_n)
-`CONNECT_TL_DEVICE_IF(spi_host1, dut, clk_peri_i, rst_n)
+`CONNECT_TL_DEVICE_IF(spi_host0, dut, clk_spi_host0_i, rst_n)
+`CONNECT_TL_DEVICE_IF(spi_host1, dut, clk_spi_host1_i, rst_n)
 `CONNECT_TL_DEVICE_IF(rv_timer, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(usbdev, dut, clk_peri_i, rst_n)
 `CONNECT_TL_DEVICE_IF(pwrmgr_aon, dut, clk_peri_i, rst_n)

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_peri_bind.sv
@@ -81,14 +81,14 @@ module xbar_peri_bind;
     .d2h    (tl_spi_device_i)
   );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_spi_host0 (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
+    .clk_i  (clk_spi_host0_i),
+    .rst_ni (rst_spi_host0_ni),
     .h2d    (tl_spi_host0_o),
     .d2h    (tl_spi_host0_i)
   );
   bind xbar_peri tlul_assert #(.EndpointType("Host")) tlul_assert_device_spi_host1 (
-    .clk_i  (clk_peri_i),
-    .rst_ni (rst_peri_ni),
+    .clk_i  (clk_spi_host1_i),
+    .rst_ni (rst_spi_host1_ni),
     .h2d    (tl_spi_host1_o),
     .d2h    (tl_spi_host1_i)
   );

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -817,10 +817,10 @@ module top_earlgrey #(
   assign lpg_cg_en[1] = clkmgr_aon_cg_en.io_div4_peri;
   assign lpg_rst_en[1] = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::Domain0Sel];
   // peri_spi_host0_0
-  assign lpg_cg_en[2] = clkmgr_aon_cg_en.io_div4_peri;
+  assign lpg_cg_en[2] = clkmgr_aon_cg_en.io_peri;
   assign lpg_rst_en[2] = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::Domain0Sel];
   // peri_spi_host1_0
-  assign lpg_cg_en[3] = clkmgr_aon_cg_en.io_div4_peri;
+  assign lpg_cg_en[3] = clkmgr_aon_cg_en.io_div2_peri;
   assign lpg_rst_en[3] = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::Domain0Sel];
   // peri_i2c0_0
   assign lpg_cg_en[4] = clkmgr_aon_cg_en.io_div4_peri;
@@ -899,11 +899,11 @@ module top_earlgrey #(
     prim_mubi_pkg::mubi4_t unused_cg_en_12;
     assign unused_cg_en_12 = clkmgr_aon_cg_en.io_div4_otbn;
     prim_mubi_pkg::mubi4_t unused_cg_en_13;
-    assign unused_cg_en_13 = clkmgr_aon_cg_en.usb_secure;
+    assign unused_cg_en_13 = clkmgr_aon_cg_en.io_infra;
     prim_mubi_pkg::mubi4_t unused_cg_en_14;
-    assign unused_cg_en_14 = clkmgr_aon_cg_en.io_div2_peri;
+    assign unused_cg_en_14 = clkmgr_aon_cg_en.io_div2_infra;
     prim_mubi_pkg::mubi4_t unused_cg_en_15;
-    assign unused_cg_en_15 = clkmgr_aon_cg_en.io_peri;
+    assign unused_cg_en_15 = clkmgr_aon_cg_en.usb_secure;
     prim_mubi_pkg::mubi4_t unused_cg_en_16;
     assign unused_cg_en_16 = clkmgr_aon_cg_en.usb_peri;
     prim_mubi_pkg::mubi4_t unused_rst_en_0;
@@ -957,27 +957,19 @@ module top_earlgrey #(
     prim_mubi_pkg::mubi4_t unused_rst_en_24;
     assign unused_rst_en_24 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_25;
-    assign unused_rst_en_25 = rstmgr_aon_rst_en.spi_host0_core[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_25 = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_26;
-    assign unused_rst_en_26 = rstmgr_aon_rst_en.spi_host0_core[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_26 = rstmgr_aon_rst_en.usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_27;
-    assign unused_rst_en_27 = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_27 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_28;
-    assign unused_rst_en_28 = rstmgr_aon_rst_en.spi_host1_core[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_28 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_29;
-    assign unused_rst_en_29 = rstmgr_aon_rst_en.spi_host1_core[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_29 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_30;
-    assign unused_rst_en_30 = rstmgr_aon_rst_en.usb[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_30 = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_31;
-    assign unused_rst_en_31 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::DomainAonSel];
-    prim_mubi_pkg::mubi4_t unused_rst_en_32;
-    assign unused_rst_en_32 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::Domain0Sel];
-    prim_mubi_pkg::mubi4_t unused_rst_en_33;
-    assign unused_rst_en_33 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
-    prim_mubi_pkg::mubi4_t unused_rst_en_34;
-    assign unused_rst_en_34 = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::DomainAonSel];
-    prim_mubi_pkg::mubi4_t unused_rst_en_35;
-    assign unused_rst_en_35 = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_31 = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::DomainAonSel];
 
   // Peripheral Instantiation
 
@@ -1206,10 +1198,8 @@ module top_earlgrey #(
       .tl_o(spi_host0_tl_rsp),
 
       // Clock and reset connections
-      .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
-      .clk_core_i (clkmgr_aon_clocks.clk_io_peri),
-      .rst_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel]),
-      .rst_core_ni (rstmgr_aon_resets.rst_spi_host0_core_n[rstmgr_pkg::Domain0Sel])
+      .clk_i (clkmgr_aon_clocks.clk_io_peri),
+      .rst_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel])
   );
   spi_host #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[7:7])
@@ -1240,10 +1230,8 @@ module top_earlgrey #(
       .tl_o(spi_host1_tl_rsp),
 
       // Clock and reset connections
-      .clk_i (clkmgr_aon_clocks.clk_io_div4_peri),
-      .clk_core_i (clkmgr_aon_clocks.clk_io_div2_peri),
-      .rst_ni (rstmgr_aon_resets.rst_spi_host1_n[rstmgr_pkg::Domain0Sel]),
-      .rst_core_ni (rstmgr_aon_resets.rst_spi_host1_core_n[rstmgr_pkg::Domain0Sel])
+      .clk_i (clkmgr_aon_clocks.clk_io_div2_peri),
+      .rst_ni (rstmgr_aon_resets.rst_spi_host1_n[rstmgr_pkg::Domain0Sel])
   );
   i2c #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[8:8])
@@ -2787,7 +2775,11 @@ module top_earlgrey #(
   );
   xbar_peri u_xbar_peri (
     .clk_peri_i (clkmgr_aon_clocks.clk_io_div4_infra),
+    .clk_spi_host0_i (clkmgr_aon_clocks.clk_io_infra),
+    .clk_spi_host1_i (clkmgr_aon_clocks.clk_io_div2_infra),
     .rst_peri_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel]),
+    .rst_spi_host0_ni (rstmgr_aon_resets.rst_spi_host0_n[rstmgr_pkg::Domain0Sel]),
+    .rst_spi_host1_ni (rstmgr_aon_resets.rst_spi_host1_n[rstmgr_pkg::Domain0Sel]),
 
     // port: tl_main
     .tl_main_i(main_tl_peri_req),

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1632,15 +1632,13 @@ typedef enum top_earlgrey_power_manager_wake_ups {
 typedef enum top_earlgrey_reset_manager_sw_resets {
   kTopEarlgreyResetManagerSwResetsSpiDevice = 0, /**<  */
   kTopEarlgreyResetManagerSwResetsSpiHost0 = 1, /**<  */
-  kTopEarlgreyResetManagerSwResetsSpiHost0Core = 2, /**<  */
-  kTopEarlgreyResetManagerSwResetsSpiHost1 = 3, /**<  */
-  kTopEarlgreyResetManagerSwResetsSpiHost1Core = 4, /**<  */
-  kTopEarlgreyResetManagerSwResetsUsb = 5, /**<  */
-  kTopEarlgreyResetManagerSwResetsUsbif = 6, /**<  */
-  kTopEarlgreyResetManagerSwResetsI2c0 = 7, /**<  */
-  kTopEarlgreyResetManagerSwResetsI2c1 = 8, /**<  */
-  kTopEarlgreyResetManagerSwResetsI2c2 = 9, /**<  */
-  kTopEarlgreyResetManagerSwResetsLast = 9, /**< \internal Last valid rstmgr software reset request */
+  kTopEarlgreyResetManagerSwResetsSpiHost1 = 2, /**<  */
+  kTopEarlgreyResetManagerSwResetsUsb = 3, /**<  */
+  kTopEarlgreyResetManagerSwResetsUsbif = 4, /**<  */
+  kTopEarlgreyResetManagerSwResetsI2c0 = 5, /**<  */
+  kTopEarlgreyResetManagerSwResetsI2c1 = 6, /**<  */
+  kTopEarlgreyResetManagerSwResetsI2c2 = 7, /**<  */
+  kTopEarlgreyResetManagerSwResetsLast = 7, /**< \internal Last valid rstmgr software reset request */
 } top_earlgrey_reset_manager_sw_resets_t;
 
 /**

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -209,9 +209,9 @@
     },
     { name: "spi_host0",
       type: "spi_host",
-      clock_srcs: {clk_i: "io_div4", clk_core_i: "io"},
+      clock_srcs: {clk_i: "io"},
       clock_group: "peri",
-      reset_connections: {rst_ni: "spi_host0", rst_core_ni: "spi_host0"},
+      reset_connections: {rst_ni: "spi_host0"},
       base_addr: "0x40060000",
     },
     { name: "rv_timer",
@@ -666,10 +666,10 @@
       reset_connections: {rst_main_ni: "sys", rst_fixed_ni: "sys_io_div4"}
     },
     { name: "peri",
-      clock_srcs: {clk_peri_i: "io_div4"},
+      clock_srcs: {clk_peri_i: "io_div4", clk_spi_host0_i: "io"},
       clock_group: "infra",
       reset: "sys_io_div4",
-      reset_connections: {rst_peri_ni: "sys_io_div4"},
+      reset_connections: {rst_peri_ni: "sys_io_div4", rst_spi_host0_ni: "spi_host0"},
     }
   ],
 

--- a/hw/top_englishbreakfast/data/xbar_peri.hjson
+++ b/hw/top_englishbreakfast/data/xbar_peri.hjson
@@ -4,7 +4,9 @@
 { name: "peri",
   type: "xbar",
   clock_primary: "clk_peri_i", // Main clock, used in sockets
+  other_clock_list: [ "clk_spi_host0_i" ] // Secondary clocks used by specific nodes
   reset_primary: "rst_peri_ni", // Main reset, used in sockets
+  other_reset_list: [ "rst_spi_host0_ni" ] // Secondary resets used by specific nodes
 
   nodes: [
     { name:  "main",
@@ -35,8 +37,8 @@
     },
     { name:      "spi_host0",
       type:      "device",
-      clock:     "clk_peri_i",
-      reset:     "rst_peri_ni",
+      clock:     "clk_spi_host0_i",
+      reset:     "rst_spi_host0_ni",
       pipeline:  "false"
     },
     { name:      "rv_timer",

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -30,7 +30,7 @@ static_assert(kDifRstmgrResetInfoHwReq == (RSTMGR_RESET_INFO_HW_REQ_MASK
               "kDifRstmgrResetInfoHwReq must match the register definition!");
 
 static_assert(
-    RSTMGR_PARAM_NUM_SW_RESETS == 10,
+    RSTMGR_PARAM_NUM_SW_RESETS == 8,
     "Number of software resets has changed, please update this file!");
 
 // The Reset Manager implementation will have to be updated if the number


### PR DESCRIPTION
- Removes async tlul fifo from spi_host.sv
- Identifies all "core" clocks and resets as the same as the bus clock
- Modifies top_earlgrey xbar_peri to place the two spi_host instances on
   their appropriate clock domains

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>
