### PR TITLE
[chip,cov] Fix coverage hierarchy files

### DIFF
--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 -tree *
--module pins_if     // DV construct.
--module clk_rst_if  // DV construct.
 
 // Include port toggles of all IOs at these hierarchies.
 begin tgl(portsonly)
@@ -19,7 +17,6 @@ end
 begin line+cond+fsm+branch+assert
   +module chip_earlgrey_asic
   +module top_earlgrey
-  +module rv_core_ibex
 end
 
 // Enable full coverage collection on these modules including their
@@ -27,9 +24,30 @@ end
 begin line+cond+fsm+branch+assert
   +moduletree padring
   +moduletree pinmux
+  +moduletree rv_core_ibex
+  -tree tb.dut.top_earlgrey.u_rv_core_ibex.u_core
   +moduletree rv_plic
   +moduletree sensor_ctrl
-  +tree tb.dut.top_earlgrey.u_tl_adapter_rom
-  +tree tb.dut.top_earlgrey.u_tl_adapter_ram_main
-  +tree tb.dut.top_earlgrey.u_tl_adapter_ram_ret
+
+  // Prim_alert/esc pairs are verified in FPV and DV testbenches.
+  -moduletree prim_alert_sender
+  -moduletree prim_alert_receiver
+  -moduletree prim_esc_sender
+  -moduletree prim_esc_receiver
+  -moduletree prim_prince // prim_prince is verified in a separate DV environment.
+  -moduletree prim_lfsr // prim_lfsr is verified in FPV.
+end
+
+// TODO: Re-enable tgl(portsonly) on the the excluded prims above in the non-preverified IPs and
+// glue logic.
+begin tgl(portsonly)
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[0].u_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[1].u_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[2].u_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.gen_alert_senders[3].u_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.u_prim_esc_receiver 1
+  +tree tb.dut.top_earlgrey.u_pinmux_aon.gen_alert_tx[0].u_prim_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_rv_plic.gen_alert_tx[0].u_prim_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_sensor_ctrl.u_prim_fatal_alert_sender 1
+  +tree tb.dut.top_earlgrey.u_sensor_ctrl.u_prim_recov_alert_sender 1
 end

--- a/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg
@@ -2,18 +2,60 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Only cover the `u_reg` instance of un-pre-verified modules.
 -tree *
-+tree tb.dut.top_earlgrey.u_pinmux.u_reg
-+tree tb.dut.top_earlgrey.u_rv_plic.u_reg
-+tree tb.dut.top_earlgrey.u_sensor_ctrl_aon.u_reg
 
 // Only cover the TL interface of all sub-modules.
-+node tb.dut top_earlgrey.u_*.tl_*
++node tb.dut.top_earlgrey.u_uart0 *tl_*
++node tb.dut.top_earlgrey.u_uart1 *tl_*
++node tb.dut.top_earlgrey.u_uart2 *tl_*
++node tb.dut.top_earlgrey.u_uart3 *tl_*
++node tb.dut.top_earlgrey.u_gpio *tl_*
++node tb.dut.top_earlgrey.u_spi_device *tl_*
++node tb.dut.top_earlgrey.u_spi_host0 *tl_*
++node tb.dut.top_earlgrey.u_spi_host1 *tl_*
++node tb.dut.top_earlgrey.u_i2c0 *tl_*
++node tb.dut.top_earlgrey.u_i2c1 *tl_*
++node tb.dut.top_earlgrey.u_i2c2 *tl_*
++node tb.dut.top_earlgrey.u_pattgen *tl_*
++node tb.dut.top_earlgrey.u_rv_timer *tl_*
++node tb.dut.top_earlgrey.u_usbdev *tl_*
++node tb.dut.top_earlgrey.u_otp_ctrl *tl_*
++node tb.dut.top_earlgrey.u_lc_ctrl *tl_*
++node tb.dut.top_earlgrey.u_alert_handler *tl_*
++node tb.dut.top_earlgrey.u_pwrmgr_aon *tl_*
++node tb.dut.top_earlgrey.u_rstmgr_aon *tl_*
++node tb.dut.top_earlgrey.u_clkmgr_aon *tl_*
++node tb.dut.top_earlgrey.u_sysrst_ctrl_aon *tl_*
++node tb.dut.top_earlgrey.u_adc_ctrl_aon *tl_*
++node tb.dut.top_earlgrey.u_pwm_aon *tl_*
++node tb.dut.top_earlgrey.u_pinmux_aon *tl_*
++node tb.dut.top_earlgrey.u_aon_timer_aon *tl_*
++node tb.dut.top_earlgrey.u_sensor_ctrl *tl_*
++node tb.dut.top_earlgrey.u_sram_ctrl_ret_aon *tl_*
++node tb.dut.top_earlgrey.u_flash_ctrl *tl_*
++node tb.dut.top_earlgrey.u_rv_dm *tl_*
++node tb.dut.top_earlgrey.u_rv_plic *tl_*
++node tb.dut.top_earlgrey.u_aes *tl_*
++node tb.dut.top_earlgrey.u_hmac *tl_*
++node tb.dut.top_earlgrey.u_kmac *tl_*
++node tb.dut.top_earlgrey.u_otbn *tl_*
++node tb.dut.top_earlgrey.u_keymgr *tl_*
++node tb.dut.top_earlgrey.u_csrng *tl_*
++node tb.dut.top_earlgrey.u_entropy_src *tl_*
++node tb.dut.top_earlgrey.u_edn0 *tl_*
++node tb.dut.top_earlgrey.u_edn1 *tl_*
++node tb.dut.top_earlgrey.u_sram_ctrl_main *tl_*
++node tb.dut.top_earlgrey.u_rom_ctrl *tl_*
++node tb.dut.top_earlgrey.u_rv_core_ibex *tl_*
++node tb.dut.top_earlgrey.u_xbar_main *tl_*
++node tb.dut.top_earlgrey.u_xbar_peri *tl_*
++node tb.dut.top_earlgrey *tl_*
++node tb.dut.u_ast *tl_*
 
-// TODO: Add TL interface of top_earlgrey and AST when available.
-
-// Remove everything else from toggle coverage.
-begin tgl
-  -tree tb
+// Only cover the `u_reg` instance of un-pre-verified modules.
+begin line+cond+fsm+branch+assert
+  +tree tb.dut.top_earlgrey.u_pinmux_aon.u_reg
+  +tree tb.dut.top_earlgrey.u_rv_plic.u_reg
+  +tree tb.dut.top_earlgrey.u_sensor_ctrl.u_reg
+  +tree tb.dut.top_earlgrey.u_rv_core_ibex.u_reg_cfg
 end


### PR DESCRIPTION
The chip level coverage collection hierarchy files were slightly out of date. This PR updates both 'flavors', one used by the functional tests and the one used by the common bus-focused tests. 

The chip_cover.cfg has the following updates:
- Enable full moduletree coverage of rv_core_ibex, but remove
  - l/f/b/c/a coverage on IBEX_TOP, keep toggle cov on its port IOs
  - l/f/b/c/a coverage of pre-verified PRIMs but keep toggle coverage on their port IOs (this exclusion / inclusion applies to other non-pre-verified IPs as well
- Remove hierarchies that do not exist

The chip_cover_reg_top.cfg has the following updates:
- Cover ALL TL ports at all levels of hierarchies that we care about
- Cover the `reg_top` module within non-pre-verified IPs

The updates to the latter could be auto-generated, but it is hand-written at this point, with the hope that this will not change until we tape out. 

Signed-off-by: Srikrishna Iyer <sriyer@google.com>