### PR TITLE
[otbn,dv] Disable MatchingStatus_A assertion in integrity error vseq

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -45,4 +45,14 @@ class otbn_common_vseq extends otbn_base_vseq;
     end
   endtask
 
+  // Overridden from cip_base_vseq. Disable the MatchingStatus_A assertion from the testbench for
+  // this sequence. This assertion checks that the model's STATUS register matches the DUT. Since we
+  // don't actually start the processor or model (or, indeed, tell the model about the error), this
+  // assertion will be false.
+  task run_tl_intg_err_vseq(int num_times = 1);
+    `DV_ASSERT_CTRL_REQ("otbn_status_assert_en", 1'b0)
+    super.run_tl_intg_err_vseq(num_times);
+    `DV_ASSERT_CTRL_REQ("otbn_status_assert_en", 1'b1)
+  endtask
+
 endclass

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -30,6 +30,10 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if    (interrupts);
   assign interrupts[0] = {intr_done};
 
+  // A hook to allow sequences to enable or disable the MatchingStatus_A assertion below. This is
+  // needed for sequences that trigger alerts (locking OTBN) without telling the model.
+  `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
+
   otbn_model_if #(
     .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE)
   ) model_if (


### PR DESCRIPTION
This fixes various nightly test failures that started with commit
d88e5c3 (which fixed the assertion, which was previously broken and
never fired!)
