### PR TITLE
[ci] Increase timeout for Verilator test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,6 +299,7 @@ jobs:
 - job: execute_verilated_tests
   displayName: Execute tests on the Verilated system (excl. slow tests)
   pool: ci-public
+  timeoutInMinutes: 120
   dependsOn:
     - chip_earlgrey_verilator
     - sw_build


### PR DESCRIPTION
We have regularly been getting timeouts in the "Execute tests
on the Verilated system (excl. slow tests)" test recently. Increase the
timeout from 1 to 2 hours.