### PR TITLE
[otbn,dv] Zero mirrored STATUS register on reset

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -397,6 +397,10 @@ void ISSWrapper::reset(bool gen_trace) {
   // the ISS one cycle *after* start, but clearing it here avoids a glitch
   // before that.
   mirrored_.insn_cnt = 0;
+
+  // Zero our mirror of STATUS: the initial zero value for the next run doesn't
+  // get reported by the ISS.
+  mirrored_.status = 0;
 }
 
 void ISSWrapper::get_regs(std::array<uint32_t, 32> *gprs,


### PR DESCRIPTION
Without this change, the `otbn_reset` test fails. What happens is that a
running operation gets killed by a reset (leaving `STATUS` equal to `0x1`)
and the mirrored `STATUS` value in the C++ code doesn't get zeroed,
which means a `STATUS` of 1 appears as soon as the model gets
re-started... one cycle too early.

(I don't think this is a new bug, but it became newly visible once we fixed the assertion in d88e5c3da).