### PR TITLE
[fpv] prim secded related updates

### DIFF
--- a/hw/ip/prim/fpv/tb/prim_secded_22_16_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_22_16_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_22_16_bind_fpv;
 
-  bind prim_secded_22_16_fpv
+  bind prim_secded_22_16_tb
     prim_secded_22_16_assert_fpv prim_secded_22_16_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_28_22_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_28_22_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_28_22_bind_fpv;
 
-  bind prim_secded_28_22_fpv
+  bind prim_secded_28_22_tb
     prim_secded_28_22_assert_fpv prim_secded_28_22_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_39_32_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_39_32_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_39_32_bind_fpv;
 
-  bind prim_secded_39_32_fpv
+  bind prim_secded_39_32_tb
     prim_secded_39_32_assert_fpv prim_secded_39_32_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_64_57_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_64_57_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_64_57_bind_fpv;
 
-  bind prim_secded_64_57_fpv
+  bind prim_secded_64_57_tb
     prim_secded_64_57_assert_fpv prim_secded_64_57_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_72_64_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_72_64_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_72_64_bind_fpv;
 
-  bind prim_secded_72_64_fpv
+  bind prim_secded_72_64_tb
     prim_secded_72_64_assert_fpv prim_secded_72_64_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_22_16_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_22_16_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_hamming_22_16_bind_fpv;
 
-  bind prim_secded_hamming_22_16_fpv
+  bind prim_secded_hamming_22_16_tb
     prim_secded_hamming_22_16_assert_fpv prim_secded_hamming_22_16_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_39_32_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_39_32_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_hamming_39_32_bind_fpv;
 
-  bind prim_secded_hamming_39_32_fpv
+  bind prim_secded_hamming_39_32_tb
     prim_secded_hamming_39_32_assert_fpv prim_secded_hamming_39_32_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/fpv/tb/prim_secded_hamming_72_64_bind_fpv.sv
+++ b/hw/ip/prim/fpv/tb/prim_secded_hamming_72_64_bind_fpv.sv
@@ -6,7 +6,7 @@
 
 module prim_secded_hamming_72_64_bind_fpv;
 
-  bind prim_secded_hamming_72_64_fpv
+  bind prim_secded_hamming_72_64_tb
     prim_secded_hamming_72_64_assert_fpv prim_secded_hamming_72_64_assert_fpv (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -147,6 +147,14 @@
                cov: true
              }
              {
+               name: prim_secded_64_57_fpv
+               dut: prim_secded_64_57_tb
+               fusesoc_core: lowrisc:fpv:prim_secded_64_57_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_64_57/{sub_flow}/{tool}"
+               cov: true
+             }
+             {
                name: prim_secded_72_64_fpv
                dut: prim_secded_72_64_tb
                fusesoc_core: lowrisc:fpv:prim_secded_72_64_fpv

--- a/hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson
+++ b/hw/top_earlgrey/lint/top_earlgrey_fpv_lint_cfgs.hjson
@@ -21,55 +21,103 @@
                name: prim_arbiter_ppc_fpv
                fusesoc_core: lowrisc:fpv:prim_arbiter_ppc_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_arbiter_ppc_fpv/lint/{tool}"
              }
              {
                name: prim_arbiter_tree_fpv
                fusesoc_core: lowrisc:fpv:prim_arbiter_tree_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_arbiter_tree_fpv/lint/{tool}"
              }
              {
                name: prim_arbiter_fixed_fpv
                fusesoc_core: lowrisc:fpv:prim_arbiter_fixed_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_arbiter_fixed_fpv/lint/{tool}"
              }
              {
                name: prim_lfsr_fpv
                fusesoc_core: lowrisc:fpv:prim_lfsr_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_lfsr_fpv/lint/{tool}"
              }
              {
                name: prim_fifo_sync_fpv
                fusesoc_core: lowrisc:fpv:prim_fifo_sync_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_fifo_sync_fpv/lint/{tool}"
              }
              {
                name: prim_alert_rxtx_fpv
                fusesoc_core: lowrisc:fpv:prim_alert_rxtx_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_alert_rxtx_fpv/lint/{tool}"
              }
              {
                name: prim_alert_rxtx_async_fpv
                fusesoc_core: lowrisc:fpv:prim_alert_rxtx_async_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_alert_rxtx_async_fpv/lint/{tool}"
              }
              {
                name: prim_esc_rxtx_fpv
                fusesoc_core: lowrisc:fpv:prim_esc_rxtx_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_esc_rxtx_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_22_16_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_22_16_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_22_16_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_28_22_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_28_22_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_28_22_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_39_32_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_39_32_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_39_32_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_64_57_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_64_57_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_64_57_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_72_64_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_72_64_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_secded_72_64_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_hamming_22_16_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_hamming_22_16_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_hamming_22_16_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_hamming_39_32_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_hamming_39_32_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_hamming_39_32_fpv/lint/{tool}"
+             }
+             {
+               name: prim_secded_hamming_72_64_fpv
+               fusesoc_core: lowrisc:fpv:prim_secded_hamming_72_64_fpv
+               import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_hamming_72_64_fpv/lint/{tool}"
              }
              {
                name: prim_packer_fpv
                fusesoc_core: lowrisc:fpv:prim_packer_fpv
                import_cfgs: ["{proj_root}/hw/lint/tools/dvsim/common_lint_cfg.hjson"]
-               rel_path: "hw/ip/prim/fpv/lint/{tool}"
+               rel_path: "hw/ip/prim/prim_packer_fpv/lint/{tool}"
              }
              {
                name: pinmux_fpv


### PR DESCRIPTION
Two commits in this PR:
1). Update the bind file module name with `_tb` postfix.
     This is related to PR #8654
2). Add prim_secded related FPV testbench to lint batch script to run CI.
     Also clean up some `rel_path` for FPV lint.