### PR TITLE
[chip dv] Fixes pwrmgr_smoketest

### DIFF
--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -79,7 +79,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/pwrmgr_smoketest:1"]
       en_run_modes: ["sw_test_mode"]
-      run_opts: ["+sw_test_timeout_ns=3000000"]
+      run_opts: ["+sw_test_timeout_ns=4000000"]
     }
     {
       name: chip_sw_rv_timer_smoketest


### PR DESCRIPTION
Increase test runtime due to boot rom code spending more time (likely
due to recently increased ROM size).

Signed-off-by: Srikrishna Iyer <sriyer@google.com>