### PR TITLE
[chip,dv] Fix SW GPIO smoketest failure

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -20,11 +20,6 @@ class chip_base_vseq extends cip_base_vseq #(
   // Local queue for holding received UART TX data.
   byte uart_tx_data_q[$];
 
-  // Default only iterate through SW code once.
-  constraint num_trans_c {
-    num_trans == 1;
-  }
-
   `uvm_object_new
 
   task post_start();
@@ -70,7 +65,6 @@ class chip_base_vseq extends cip_base_vseq #(
     // Do DUT init after some additional settings.
     bit do_dut_init_save = do_dut_init;
     do_dut_init = 1'b0;
-    cfg.sw_test_status_vif.set_sw_test_last_iteration(num_trans == 1);
     super.pre_start();
     do_dut_init = do_dut_init_save;
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -5,6 +5,11 @@
 class chip_sw_base_vseq extends chip_base_vseq;
   `uvm_object_utils(chip_sw_base_vseq)
 
+  // Default only iterate through SW code once.
+  constraint num_trans_c {
+    num_trans == 1;
+  }
+
   `uvm_object_new
 
   virtual task dut_init(string reset_kind = "HARD");
@@ -57,6 +62,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
   endtask
 
   virtual task body();
+    cfg.sw_test_status_vif.set_num_iterations(num_trans);
     // Initialize the CPU to kick off the sw test.
     cpu_init();
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_gpio_smoke_vseq.sv
@@ -32,7 +32,7 @@ class chip_sw_gpio_smoke_vseq extends chip_sw_base_vseq;
     super.cpu_init();
     // Need to convert integer array to byte array.
     byte_gpio_vals = new[4 * num_gpio_vals];
-    {<<byte{byte_gpio_vals}} = {<<byte{{<<int{gpio_vals}}}};
+    byte_gpio_vals = {<<byte{{<<int{gpio_vals}}}};
     sw_symbol_backdoor_overwrite(SW_SYM_GPIO_VALS, byte_gpio_vals);
   endtask
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -63,7 +63,6 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       if (trans_i > 0) begin
         apply_reset();
         backdoor_override_otp();
-        cfg.sw_test_status_vif.set_sw_test_last_iteration(trans_i == num_trans);
       end
 
       // Override the C test kLcExitToken with random data.


### PR DESCRIPTION
The test was failing in regr with a NOA error. Made the following fixes:
- Enhanced sw_test_status_if.sv to have a notion of SW test iterations
(test vseq can reboot the chip multiple times)
- Fixed accidental byte swap in gpio smoke vseq
- Other associated fixes

Signed-off-by: Srikrishna Iyer <sriyer@google.com>