### PR TITLE
[chip,dv] Fix coremark test for DV

### DIFF
--- a/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
+++ b/sw/device/benchmarks/coremark/top_earlgrey/core_portme.c
@@ -132,7 +132,9 @@ void portable_init(core_portable *p, int *argc, char *argv[]) {
     ee_printf("ERROR! Please define ee_u32 to a 32b unsigned type!\n");
   }
   p->portable_id = 1;
+  test_status_set(kTestStatusInTest);
 }
+
 /* Function : portable_fini
         Target specific final code
 */


### PR DESCRIPTION
The SW test status interface expects transition to pass or fail state
from the test state. Otherwise it throws an error. This PR fixes that.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>