### PR TITLE
[prim] Use logic, not bit, for show_mem_paths in prim_util_memload

### DIFF
--- a/hw/ip/prim/rtl/prim_util_memload.svh
+++ b/hw/ip/prim/rtl/prim_util_memload.svh
@@ -69,7 +69,7 @@
 `endif
 
 initial begin
-  bit show_mem_paths;
+  logic show_mem_paths;
 
   // Print the hierarchical path to the memory to help make formal connectivity checks easy.
   void'($value$plusargs("show_mem_paths=%0b", show_mem_paths));


### PR DESCRIPTION
This is a bit silly, because we know the value will never be 'x or 'z,
but the change silences a warning from AscentLint (and seems a bit
less fiddly than explicitly adding a waiver).
