### PR TITLE
Two small lint fixes

### DIFF
--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -31,7 +31,7 @@ module prim_packer #(
   localparam int Width = InW + OutW; // storage width
   localparam int ConcatW = Width + InW; // Input concatenated width
   localparam int PtrW = $clog2(ConcatW+1);
-  localparam int IdxW = $clog2(InW) + ~|$clog2(InW);
+  localparam int IdxW = prim_util_pkg::vbits(InW);
 
   logic valid_next, ready_next;
   logic [Width-1:0]   stored_data, stored_mask;

--- a/hw/ip/prim/rtl/prim_util_memload.svh
+++ b/hw/ip/prim/rtl/prim_util_memload.svh
@@ -69,7 +69,7 @@
 `endif
 
 initial begin
-  bit show_mem_paths;
+  logic show_mem_paths;
 
   // Print the hierarchical path to the memory to help make formal connectivity checks easy.
   void'($value$plusargs("show_mem_paths=%0b", show_mem_paths));


### PR DESCRIPTION
A fix in prim_packer, and another one in prim_util_memload to silence two warnings in the daily lint report.