### PR TITLE
[otbn,dv] Use clocking block to spot instruction execution

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -27,6 +27,9 @@ interface otbn_model_if #(
 
   chandle                   handle;       // Handle for DPI calls to C model
 
+  clocking cb @(posedge clk_i);
+  endclocking
+
   // Wait until reset or change of status.
   task automatic wait_status();
     automatic bit [7:0] old_status = status;

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_monitor.sv
@@ -64,7 +64,14 @@ class otbn_model_monitor extends dv_base_monitor #(
 
     // Collect transactions on each clock edge when we are not in reset
     forever begin
-      @(posedge cfg.vif.clk_i);
+      // Use a clocking block to ensure we sample after the always_ff code in otbn_core_model.sv has
+      // run. This means that we'll immediately see any instructions that executed. Without it, we'd
+      // be racing against that logic, which might mean we saw the instructions a cycle later. In
+      // that case, a final instruction gets spotted after we see the status go back to idle
+      // (causing errors in the scoreboard, which doesn't expect to see instructions executing when
+      // idle).
+      @cfg.vif.cb;
+
       if (cfg.vif.rst_ni === 1'b1) begin
         // Ask the trace checker for any ISS instruction that has come in since last cycle.
         if (otbn_trace_checker_pop_iss_insn(insn_addr, insn_mnemonic)) begin


### PR DESCRIPTION
Note: This is reasonably urgent because all of our nightly tests will fail this evening if it's not merged!

This fixes a problem caused by us switching to spotting `STATUS` changes
on the negedge of the clock (in commit bfe59f0a8).

The problem was that you execute a final `ECALL` instruction or similar.
The model immediately reports that `STATUS` gets cleared, which is
spotted on the next negedge of the clock. Then (with some schedulings
from the simulator) we only see the `ECALL` instruction on the following
posedge, by which time the scoreboard thinks we've stopped execution.
This causes the check on line 290 of `otbn_scoreboard.sv` to explode.

Note that there's work afoot to flop the `STATUS` register. This problem
will go away anyway when that lands, but it seems cleaner to use a
clocking block to get rid of the race.
