### PR TITLE
Setup verible-linter github action

### DIFF
--- a/.github/workflows/pr_lint_review.yml
+++ b/.github/workflows/pr_lint_review.yml
@@ -1,0 +1,50 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: pr-lint-review
+
+on:
+  workflow_run:
+    workflows: ["pr-trigger"]
+    types:
+      - completed
+
+jobs:
+  review_triggered:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # this workflow does not run in a PR context
+      # download 'event.json' and concatenated verible config files
+      # from a PR-tiggered workflow to mock the PR context and make
+      # a review
+      - name: 'Download artifact'
+        id: get-artifacts
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "verible_input"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/verible_input.zip', Buffer.from(download.data));
+      - run: |
+          unzip verible_input.zip
+      - name: Run Verible linter action
+        uses: chipsalliance/verible-linter-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          suggest_fixes: 'false'
+          config_file: 'verible_config'

--- a/.github/workflows/pr_trigger.yml
+++ b/.github/workflows/pr_trigger.yml
@@ -1,0 +1,30 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: pr-trigger
+
+on:
+  pull_request:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: concatenate verible configs
+        run: |
+          find . -type f -name '*.vbl' -exec cat {} \; > verible_config
+      - name: Copy event file
+        run: cp "$GITHUB_EVENT_PATH" ./event.json
+
+      # If this workflow is triggered by a PR from a fork
+      # it won't have sufficient access rights to make a review
+      # so we just save the file needed to do the review
+      # in a context with proper access rights
+      - name: Upload event file and config as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: verible_input
+          path: |
+            verible_config
+            event.json


### PR DESCRIPTION
This sets up a CI job that runs the Verible linter using github actions and posts review comments with any violation it identifies.

A similar pipeline is already used in Ibex, see this PR as an example: https://github.com/lowRISC/ibex/pull/1460

Here is an example of how it could work with opentitan: https://github.com/antmicro/opentitan/pull/3#pullrequestreview-783195641

Note that all the messages are posted as "warnings" (i.e. the violations don't mark the pipeline as failed) - this can be changed in the yml configuration.

Also note that all the Verible config files are currently concatenated and applied to the whole source code (agreed to do that in a discussion with @imphil )