### PR TITLE
[dv/asic] Create main power glitch test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -514,7 +514,7 @@
       name: chip_sw_aon_timer_wakeup_irq
       desc: '''Verify the AON timer wake up interrupt in normal operating state.
 
-            - Program the PLIC to let the AON time wake up interrupt the CPU.
+            - Program the PLIC to let the AON timer wake up interrupt the CPU.
             - Program the AON timer to generate the wake up timeout interrupt after some time.
             - Issue a WFI to wait for the interrupt to trigger.
             - Service the interrupt when it triggers; verify that it came from AON timer.
@@ -812,13 +812,23 @@
       tests: []
     }
     {
-      name: chip_sw_pwrmgr_bad_main_pok
-      desc: '''Verify the effect of main_pok de-assertion in the middle of low power entry / exit
-            FSM transition.
+      name: chip_sw_pwrmgr_power_glitch_reset
+      desc: '''Verify the effect of a glitch in main power rail.
 
-            The main_pok from AST is randomly forced to flip while in the middle of a FSM
-            transition. This is done on all normal / deep sleep / reset request tests. The check
-            that flipping during POR results in a stretched reset is done at IP level.
+            The vcmain_supp_i AST input is forced to drop once the test is running. This triggers
+            a MainPwr reset request, which is checked reading the reset_info CSR when the test
+            restarts and the POR bit is not set.
+            '''
+      milestone: V2
+      tests: ["chip_sw_pwrmgr_power_glitch_reset"]
+    }
+    {
+      name: chip_sw_pwrmgr_sleep_power_glitch_reset
+      desc: '''Verify the effect of a glitch in main power rail in deep sleep.
+
+            The vcmain_supp_i AST input is forced to drop after putting the chip to sleep. This
+            triggers a MainPwr reset request, which is checked reading the reset_info CSR when the
+            test restarts and the POR bit is not set.
             '''
       milestone: V2
       tests: []

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -256,6 +256,13 @@
       run_opts: ["+sw_test_timeout_ns=2000000"]
     }
     {
+      name: chip_sw_pwrmgr_power_glitch_reset
+      uvm_test_seq: chip_sw_power_glitch_vseq
+      sw_images: ["sw/device/tests/pwrmgr_power_glitch_test:1"]
+      en_run_modes: ["sw_test_mode"]
+      run_opts: ["+sw_test_timeout_ns=4000000"]
+    }
+    {
       name: chip_sw_rv_timer_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/rv_timer_smoketest:1"]

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This interface is used to force the voltage supply indicators, to trigger resets due to
+// power-not-ok conditions.
+//
+// The glitches of interest are on the vcaon_supp_i and vcmain_supp_i AST inputs.
+// Forcing the values to 0 causes the AST to deassert the corresponding pok output: vcaon should
+// cause a POR reset, and vcmain a non-aon reset.
+//
+// We need to disable some pwrmgr design assertions when wiggling vcmain_supp_i.
+interface ast_supply_if (
+  input logic clk,
+  input logic trigger
+);
+
+  // The number of cycles to hold the glitch. It should be ok if it was just 1.
+  localparam int CyclesGlitching = 3;
+
+  // The number of cycles after stopping the glitch in vcmain before restarting
+  // assertions in pwrmgr.
+  localparam int CyclesBeforeReenablingAssert = 7;
+
+  function static void force_vcaon_supp_i(bit value);
+    force u_ast.vcaon_supp_i = value;
+  endfunction
+
+  // Wait some clock cycles due to various flops in the logic.
+  task automatic reenable_vcmain_assertion();
+    repeat (CyclesBeforeReenablingAssert) @(posedge clk);
+    `uvm_info("ast_supply_if", "re-enabling vcmain_supp_i related SVA", UVM_MEDIUM)
+    $assertcontrol(3, 1, 1, 1, top_earlgrey.u_pwrmgr_aon.u_slow_fsm.IntRstReq_A);
+  endtask
+
+  task static force_vcmain_supp_i(bit value);
+    `uvm_info("ast_supply_if", $sformatf("forcing vcmain_supp_i to %b", value), UVM_MEDIUM)
+    if (!value) begin
+      `uvm_info("ast_supply_if", "disabling vcmain_supp_i related SVA", UVM_MEDIUM)
+      $assertcontrol(4, 1, 1, 1, top_earlgrey.u_pwrmgr_aon.u_slow_fsm.IntRstReq_A);
+    end
+    force u_ast.vcmain_supp_i = value;
+    if (value) reenable_vcmain_assertion();
+  endtask
+
+  // Create glitch in vcmain_supp_i some cycles after a trigger transitions high.
+  task automatic glitch_vcmain_supp_i_on_next_trigger(int cycles);
+    @(posedge trigger);
+    repeat (cycles) @(posedge clk);
+    force_vcmain_supp_i(1'b0);
+    repeat (CyclesGlitching) @(posedge clk);
+    force_vcmain_supp_i(1'b1);
+  endtask
+
+endinterface

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/chip_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_stub_cpu_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_power_glitch_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
@@ -41,6 +42,7 @@ filesets:
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
+      - ast_supply_if.sv
     file_type: systemVerilogSource
 
 generate:

--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -61,6 +61,12 @@ class chip_env extends cip_base_env #(
       `uvm_fatal(`gfn, "failed to get sw_test_status_vif from uvm_config_db")
     end
 
+    // get the handle to the ast supply interface.
+    if (!uvm_config_db#(virtual ast_supply_if)::get(this, "", "ast_supply_vif",
+        cfg.ast_supply_vif)) begin
+      `uvm_fatal(`gfn, "failed to get ast_supply_vif from uvm_config_db")
+    end
+
     // create components
     foreach (m_uart_agents[i]) begin
       m_uart_agents[i] = uart_agent::type_id::create($sformatf("m_uart_agent%0d", i), this);

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -56,6 +56,7 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   uint                sw_test_timeout_ns = 5_000_000; // 5ms
   sw_logger_vif       sw_logger_vif;
   sw_test_status_vif  sw_test_status_vif;
+  ast_supply_vif      ast_supply_vif;
 
   // ext component cfgs
   rand uart_agent_cfg       m_uart_agent_cfgs[NUM_UARTS];

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -50,6 +50,7 @@ package chip_env_pkg;
   typedef virtual pins_if #(NUM_GPIOS)  gpio_vif;
   typedef virtual sw_logger_if          sw_logger_vif;
   typedef virtual sw_test_status_if     sw_test_status_vif;
+  typedef virtual ast_supply_if         ast_supply_vif;
 
   // Types of memories in the chip.
   typedef enum {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_power_glitch_vseq.sv
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_power_glitch_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_power_glitch_vseq)
+
+  `uvm_object_new
+
+  rand int cycles_after_trigger;
+  constraint cycles_after_trigger_c {cycles_after_trigger inside {[0 : 8]};}
+
+  virtual task body();
+    super.body();
+
+    // Wait until we reach the SW test state.
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+
+    cfg.ast_supply_vif.glitch_vcmain_supp_i_on_next_trigger(cycles_after_trigger);
+  endtask
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -5,7 +5,9 @@
 `include "chip_base_vseq.sv"
 `include "chip_stub_cpu_base_vseq.sv"
 `include "chip_common_vseq.sv"
+// This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
+`include "chip_sw_power_glitch_vseq.sv"
 `include "chip_sw_uart_tx_rx_vseq.sv"
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
 `include "chip_sw_gpio_smoke_vseq.sv"

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -66,6 +66,11 @@ module tb;
   uart_if uart_if[NUM_UARTS-1:0]();
   jtag_if jtag_if();
 
+  bind dut ast_supply_if ast_supply_if (
+    .clk(top_earlgrey.clk_aon_i),
+    .trigger(top_earlgrey.rv_core_ibex_pwrmgr.core_sleeping)
+  );
+
   // TODO: Replace with correct interfaces once
   // pinmux/padring and pinout have been updated.
   wire [23:0] tie_off;
@@ -263,6 +268,10 @@ module tb;
         null, "*.env", "sw_test_status_vif", `SIM_SRAM_IF.u_sw_test_status_if);
     uvm_config_db#(virtual sw_logger_if)::set(
         null, "*.env", "sw_logger_vif", `SIM_SRAM_IF.u_sw_logger_if);
+
+    // AST supply interface.
+    uvm_config_db#(virtual ast_supply_if)::set(
+        null, "*.env", "ast_supply_vif", dut.ast_supply_if);
 
     // temp disable pinmux assertion AonWkupReqKnownO_A because driving X in spi_device.sdi and
     // WkupPadSel choose IO_DPS1 in MIO will trigger this assertion

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -64,7 +64,7 @@ typedef enum dif_rstmgr_reset_info {
    */
   kDifRstmgrResetInfoPor = 0x1,
   /**
-   * Device has reset due to lowe power exit.
+   * Device has reset due to low power exit.
    */
   kDifRstmgrResetInfoLowPowerExit = (0x1 << 1),
   /**

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -342,6 +342,26 @@ sw_tests += {
   }
 }
 
+pwrmgr_power_glitch_test_lib = declare_dependency(
+  link_with: static_library(
+    'pwrmgr_power_glitch_test_lib',
+    sources: ['pwrmgr_power_glitch_test.c'],
+    dependencies: [
+      sw_lib_dif_pwrmgr,
+      sw_lib_dif_rstmgr,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+      sw_lib_testing_pwrmgr_testutils,
+      sw_lib_testing_rstmgr_testutils,
+    ],
+  ),
+)
+sw_tests += {
+  'pwrmgr_power_glitch_test': {
+    'library': pwrmgr_power_glitch_test_lib,
+  }
+}
+
 pmp_smoketest_napot_lib = declare_dependency(
   link_with: static_library(
     'pmp_smoketest_napot_lib',

--- a/sw/device/tests/pwrmgr_power_glitch_test.c
+++ b/sw/device/tests/pwrmgr_power_glitch_test.c
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/test_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+// When the test first runs the rstmgr's `reset_info` CSR should have the POR
+// bit set, the code clears reset_info and calls wait_for_interrupt(). The WFI
+// causes core_sleeping to rise, and that causes the SV side to glitch the main
+// power rail, causing a pwrmgr internally generated reset. The next time the
+// test runs is after the power glitch reset, which is confirmed reading the
+// `reset_info` CSR.
+bool test_main(void) {
+  dif_rstmgr_t rstmgr;
+  // This should be in some header file, but the number of hardware resets is
+  // a parameter. This field is after 4 well known bits, some number of bits
+  // that depend on the NumRstReqs parameter, and then there is MainPwr and
+  // Esc (alation), in increasing order.
+  //
+  // TODO(maturana) Move this to dif_pwrmgr.h somehow dealing with params.
+  const int kResetInfoMainPower = 6;
+
+  // Initialize rstmgr since this will check some registers.
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  // Notice we are clearing rstmgr's RESET_INFO, so after the power glitch there
+  // is only one bit set.
+
+  if (rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor)) {
+    LOG_INFO("Powered up for the first time, begin test");
+
+    // Clear reset_info.
+    CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+
+    // This causes core_sleeping to rise and triggers the injection of the
+    // power glitch.
+    wait_for_interrupt();
+
+  } else if (rstmgr_testutils_is_reset_info(&rstmgr,
+                                            1 << kResetInfoMainPower)) {
+    LOG_INFO("Reset received for power glitch.");
+    return true;
+
+  } else {
+    dif_rstmgr_reset_info_bitfield_t actual_info;
+    CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &actual_info));
+    LOG_INFO("Unexpected reset_info contents: 0x%x", actual_info);
+  }
+  return false;
+}


### PR DESCRIPTION
Add interface that drives some AST inputs tied to 1, including vcmain_supp_i
and vcaon_supp_i.
Create C code to handle two resets, the second being due to the power glitch
generated by the DV code in response to the `reset_info` CSR becoming 0.

Signed-off-by: Guillermo Maturana <maturana@google.com>