### PR TITLE
[otbn,dv] Picks up unaligned addresses whie executing bne and be

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/configs/base.yml
+++ b/hw/ip/otbn/dv/rig/rig/configs/base.yml
@@ -13,6 +13,7 @@ gen-weights:
   SmallVal: 0.2
   StraightLineInsn: 1.0
   KnownWDR: 0.05
+  UntakenBranch: 0.05
 
   # Generators that end the program
   ECall: 1

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_branch.py
@@ -3,20 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import random
-from typing import Optional
+from typing import Optional, List, Tuple
 
-from shared.operand import ImmOperandType, RegOperandType
-from shared.insn_yaml import InsnsFile
-
-from ..config import Config
 from ..model import Model
-from ..program import ProgInsn, Program
+from ..program import Program
+from shared.insn_yaml import Insn
 
-from ..snippet import ProgSnippet
-from ..snippet_gen import GenCont, GenRet, SnippetGen
+from .branch_gen import BranchGen
 
 
-class BadBranch(SnippetGen):
+class BadBranch(BranchGen):
     '''A snippet generator that generates program ending branch instructions.
 
     This includes out of bounds branches in negative and positive extremes
@@ -25,81 +21,14 @@ class BadBranch(SnippetGen):
 
     ends_program = True
 
-    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
-        super().__init__()
-
-        self.insns = []
-        self.weights = []
-
-        self.beq = self._get_named_insn(insns_file, 'beq')
-        self.bne = self._get_named_insn(insns_file, 'bne')
-
-        # beq and bne expect operands: grs1, grs2, offset
-        for insn in [self.beq, self.bne]:
-            if not (len(insn.operands) == 3 and
-                    isinstance(insn.operands[0].op_type, RegOperandType) and
-                    insn.operands[0].op_type.reg_type == 'gpr' and
-                    not insn.operands[0].op_type.is_dest() and
-                    isinstance(insn.operands[1].op_type, RegOperandType) and
-                    insn.operands[1].op_type.reg_type == 'gpr' and
-                    not insn.operands[1].op_type.is_dest() and
-                    isinstance(insn.operands[2].op_type, ImmOperandType) and
-                    insn.operands[2].op_type.signed):
-                raise RuntimeError('{} instruction from instructions file is not '
-                                   'the shape expected by the Branch generator.'
-                                   .format(insn.mnemonic))
-
-        self.imm_op_type = self.bne.operands[2].op_type
-
-        for insn in insns_file.insns:
-            if insn.mnemonic in ['beq', 'bne']:
-                weight = cfg.insn_weights.get(insn.mnemonic)
-                if weight > 0:
-                    self.weights.append(weight)
-                    self.insns.append(insn)
-
-        # Check that at least one instruction has a positive weight.
-        assert len(self.insns) == len(self.weights)
-        if not self.weights:
-            self.disabled = True
-
-    def gen(self,
-            cont: GenCont,
-            model: Model,
-            program: Program) -> Optional[GenRet]:
-
-        # Pick maximum and minimum address range for the current PC.
-        imm_rng = self.imm_op_type.get_op_val_range(model.pc)
-        assert imm_rng is not None
-
-        min_addr, max_addr = imm_rng
-
-        # Get known registers. We always have x0.
-        # So it should never fail.
-        known_regs = model.regs_with_known_vals('gpr')
-        assert known_regs is not None
-
-        # Pick a random register among known registers.
-        idx, value = random.choice(known_regs)
-
-        equals = []
-        not_equals = []
-
-        for reg_idx, reg_val in known_regs:
-            if reg_val == value:
-                equals.append(reg_idx)
-            else:
-                not_equals.append(reg_idx)
-
-        # Get the chosen base register index as grs1 and grs2 operand. This is
-        # because we want to branch to the faulty addresses with this snippet.
-        op_val_grs1 = idx
-        assert op_val_grs1 is not None
-
+    def pick_offset(self,
+                    min_addr: int,
+                    max_addr: int,
+                    model: Model,
+                    program: Program) -> int:
         # We need to pick an out of bounds offset from all available values (A)
         # mode is a random variable to ensure that all the bins are hit
         # for offset range. It gives equal weight to all address ranges.
-
         mode = random.randint(0, 4)
         if mode == 0 and min_addr <= -4:
             tgt_addr = random.randrange(min_addr, -4, 4)
@@ -109,13 +38,17 @@ class BadBranch(SnippetGen):
             tgt_addr = min_addr
         elif mode <= 3 and program.imem_size <= max_addr:
             tgt_addr = max_addr
+        elif mode <= 4 and program.imem_size <= max_addr:
+            tgt_addr = random.randrange(0, program.imem_size, 4) + 2
         else:
-            assert mode <= 3
+            assert mode <= 4
             tgt_addr = random.randrange(min_addr + 2, max_addr, 4)
-        off_enc = self.imm_op_type.op_val_to_enc_val(tgt_addr, model.pc)
 
-        assert off_enc is not None
+        return tgt_addr
 
+    def pick_second_op(self,
+                       equals: List[int],
+                       not_equals: List[int]) -> Optional[Tuple[int, Insn]]:
         # Pick the instruction from the weighted list.
         if not_equals:
             chosen_insn = random.choices(self.insns, weights=self.weights)[0]
@@ -129,12 +62,6 @@ class BadBranch(SnippetGen):
         assert grs2_choices
 
         op_val_grs2 = random.choice(grs2_choices)
+        assert op_val_grs2 is not None
 
-        op_vals = [op_val_grs1, op_val_grs2, off_enc]
-
-        prog_insn = ProgInsn(chosen_insn, op_vals, None)
-
-        snippet = ProgSnippet(model.pc, [prog_insn])
-        snippet.insert_into_program(program)
-
-        return (snippet, True, model)
+        return (op_val_grs2, chosen_insn)

--- a/hw/ip/otbn/dv/rig/rig/gens/branch_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch_gen.py
@@ -1,0 +1,130 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional, List, Tuple
+
+from ..model import Model
+from ..program import ProgInsn, Program
+
+from shared.operand import ImmOperandType, RegOperandType
+from shared.insn_yaml import Insn, InsnsFile
+from ..snippet import ProgSnippet
+from ..snippet_gen import GenCont, GenRet, SnippetGen
+from ..config import Config
+
+
+class BranchGen(SnippetGen):
+    ''' A snippet generator base class to generate bad or unbtaken BEQ and BNE.
+
+    BadBranch and UntakenBranch inherit this class.
+
+    '''
+
+    def __init__(self, cfg: Config, insns_file: InsnsFile) -> None:
+        super().__init__()
+
+        self.insns = []
+        self.weights = []
+
+        self.beq = self._get_named_insn(insns_file, 'beq')
+        self.bne = self._get_named_insn(insns_file, 'bne')
+
+        # beq and bne expect operands: grs1, grs2, offset
+        for insn in [self.beq, self.bne]:
+            if not (len(insn.operands) == 3 and
+                    isinstance(insn.operands[0].op_type, RegOperandType) and
+                    insn.operands[0].op_type.reg_type == 'gpr' and
+                    not insn.operands[0].op_type.is_dest() and
+                    isinstance(insn.operands[1].op_type, RegOperandType) and
+                    insn.operands[1].op_type.reg_type == 'gpr' and
+                    not insn.operands[1].op_type.is_dest() and
+                    isinstance(insn.operands[2].op_type, ImmOperandType) and
+                    insn.operands[2].op_type.signed):
+                raise RuntimeError('{} instruction from instructions file is not '
+                                   'the shape expected by the Branch generator.'
+                                   .format(insn.mnemonic))
+
+        self.imm_op_type = self.bne.operands[2].op_type
+
+        for insn in insns_file.insns:
+            if insn.mnemonic in ['beq', 'bne']:
+                weight = cfg.insn_weights.get(insn.mnemonic)
+                if weight > 0:
+                    self.weights.append(weight)
+                    self.insns.append(insn)
+
+        # Disable this generator if no branch instruction has a positive weigh
+        assert len(self.insns) == len(self.weights)
+        if not self.weights:
+            self.disabled = True
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+
+        # Pick maximum and minimum address range for the current PC.
+        imm_rng = self.imm_op_type.get_op_val_range(model.pc)
+        assert imm_rng is not None
+
+        min_addr, max_addr = imm_rng
+
+        # Get known registers. We always have x0.
+        # So it should never fail.
+        known_regs = model.regs_with_known_vals('gpr')
+        assert known_regs
+
+        # Pick a random register among known registers.
+        idx, value = random.choice(known_regs)
+
+        # Get the chosen base register index as grs1 and grs2 operand. This is
+        # because we want to branch to the faulty addresses with this snippet.
+        op_val_grs1 = idx
+        assert op_val_grs1 is not None
+
+        equals = []
+        not_equals = []
+
+        for reg_idx, reg_val in known_regs:
+            if reg_val == value:
+                equals.append(reg_idx)
+            else:
+                not_equals.append(reg_idx)
+        # Pick the offset address
+        tgt_addr = self.pick_offset(min_addr, max_addr, model, program)
+        off_enc = self.imm_op_type.op_val_to_enc_val(tgt_addr, model.pc)
+        assert off_enc is not None
+
+        # Pick the instruction and second operand
+        ret = self.pick_second_op(equals, not_equals)
+        if ret is None:
+            return None
+        op_val_grs2, chosen_insn = ret
+        op_vals = [op_val_grs1, op_val_grs2, off_enc]
+
+        prog_insn = ProgInsn(chosen_insn, op_vals, None)
+        snippet = ProgSnippet(model.pc, [prog_insn])
+        snippet.insert_into_program(program)
+
+        self.update_for_insn(model, prog_insn)
+
+        return (snippet, self.ends_program, model)
+
+    def pick_offset(self,
+                    min_addr: int,
+                    max_addr: int,
+                    model: Model,
+                    program: Program) -> int:
+        raise NotImplementedError()
+
+    def pick_second_op(self,
+                       equals: List[int],
+                       not_equals: List[int]) -> Optional[Tuple[int, Insn]]:
+        raise NotImplementedError()
+
+    def update_for_insn(self,
+                        model: Model,
+                        prog_insn: ProgInsn) -> None:
+        return None

--- a/hw/ip/otbn/dv/rig/rig/gens/untaken_branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/untaken_branch.py
@@ -1,0 +1,66 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import random
+from typing import Optional, List, Tuple
+
+from ..model import Model
+from ..program import ProgInsn, Program
+
+from .branch_gen import BranchGen
+from shared.insn_yaml import Insn
+from ..snippet_gen import GenCont, GenRet
+
+
+class UntakenBranch(BranchGen):
+    '''A snippet generator for branches that are not taken.'''
+
+    def gen(self,
+            cont: GenCont,
+            model: Model,
+            program: Program) -> Optional[GenRet]:
+        # Return None if this is the last instruction in the current gap
+        # because we need to either jump or do an ECALL to avoid getting stuck.
+        if program.get_insn_space_at(model.pc) <= 1:
+            return None
+        return super().gen(cont, model, program)
+
+    def pick_offset(self,
+                    min_addr: int,
+                    max_addr: int,
+                    model: Model,
+                    program: Program) -> int:
+
+        # The below code picks up aligned and unaligned addresses randomly with
+        # 50% probability.
+        tgt_addr = random.randrange(min_addr, max_addr + 1, 2)
+
+        return tgt_addr
+
+    def pick_second_op(self,
+                       equals: List[int],
+                       not_equals: List[int]) -> Optional[Tuple[int, Insn]]:
+        if not_equals:
+            chosen_insn = random.choices(self.insns, weights=self.weights)[0]
+        else:
+            chosen_insn = self.bne
+            bne_weight = self.weights[0]
+            if not bne_weight:
+                return None
+
+        # Generates instructions having registers with unequal values for beq and
+        # registers with equal values for bne.
+        grs2_choices = not_equals if chosen_insn.mnemonic == 'beq' else equals
+        assert grs2_choices
+
+        op_val_grs2 = random.choice(grs2_choices)
+
+        return (op_val_grs2, chosen_insn)
+
+    def update_for_insn(self,
+                        model: Model,
+                        prog_insn: ProgInsn) -> None:
+        model.update_for_insn(prog_insn)
+        model.pc += 4
+

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -33,6 +33,7 @@ from .gens.bad_giant_loop import BadGiantLoop
 from .gens.bad_load_store import BadLoadStore
 from .gens.bad_zero_loop import BadZeroLoop
 from .gens.misaligned_load_store import MisalignedLoadStore
+from .gens.untaken_branch import UntakenBranch
 
 
 class SnippetGens:
@@ -47,6 +48,7 @@ class SnippetGens:
         SmallVal,
         StraightLineInsn,
         KnownWDR,
+        UntakenBranch,
 
         ECall,
         BadAtEnd,


### PR DESCRIPTION
Following additions/ modifications are made in this commit:
1. bad_branch.py: New modes are added to pick up random unaligned
addresses
2. untaken_branch.py: Generates instructions having registers with
unequal values for beq and registers with equal values for bne.

Fixes #8086

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>