### PR TITLE
[sw/silicon_creator] Add skeleton code for ROM_EXT boot policy

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -78,9 +78,8 @@ enum module_ {
   X(kErrorSigverifyBadOtpValue,       ERROR_(4, kModuleSigverify, kInternal)), \
   X(kErrorSigverifyBadLcState,        ERROR_(5, kModuleSigverify, kInternal)), \
   X(kErrorKeymgrInternal,             ERROR_(1, kModuleKeymgr, kInternal)), \
-  X(kErrorManifestBadLength,          ERROR_(1, kModuleManifest, kInternal)), \
-  X(kErrorManifestBadEntryPoint,      ERROR_(2, kModuleManifest, kInternal)), \
-  X(kErrorManifestBadCodeRegion,      ERROR_(3, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadEntryPoint,      ERROR_(1, kModuleManifest, kInternal)), \
+  X(kErrorManifestBadCodeRegion,      ERROR_(2, kModuleManifest, kInternal)), \
   X(kErrorAlertBadIndex,              ERROR_(1, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadClass,              ERROR_(2, kModuleAlertHandler, kInvalidArgument)), \
   X(kErrorAlertBadEnable,             ERROR_(3, kModuleAlertHandler, kInvalidArgument)), \
@@ -104,7 +103,8 @@ enum module_ {
   X(kErrorSecMmioWriteCountFault,     ERROR_(5, kModuleSecMmio, kInternal)), \
   X(kErrorSecMmioCheckCountFault,     ERROR_(6, kModuleSecMmio, kInternal)), \
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
-  X(kErrorBootPolicyRollback,         ERROR_(2, kModuleBootPolicy, kInternal)), \
+  X(kErrorBootPolicyBadLength,        ERROR_(2, kModuleBootPolicy, kInternal)), \
+  X(kErrorBootPolicyRollback,         ERROR_(3, kModuleBootPolicy, kInternal)), \
   X(kErrorRetSramLocked,              ERROR_(1, kModuleRetSram, kInternal)), \
   X(kErrorBootstrapSpiDevice,         ERROR_(1, KModuleBootstrap, kInternal)), \
   X(kErrorBootstrapErase,             ERROR_(2, KModuleBootstrap, kInternal)), \

--- a/sw/device/silicon_creator/lib/manifest.c
+++ b/sw/device/silicon_creator/lib/manifest.c
@@ -4,6 +4,23 @@
 
 #include "sw/device/silicon_creator/lib/manifest.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static_assert(MANIFEST_LENGTH_FIELD_ROM_EXT_MIN >= MANIFEST_SIZE,
+              "`MANIFEST_LENGTH_FIELD_ROM_EXT_MIN` is too small");
+static_assert(MANIFEST_LENGTH_FIELD_ROM_EXT_MAX >=
+                  MANIFEST_LENGTH_FIELD_ROM_EXT_MIN,
+              "`MANIFEST_LENGTH_FIELD_ROM_EXT_MAX` is too small");
+static_assert(MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN >= MANIFEST_SIZE,
+              "`MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN` is too small");
+static_assert(MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX >=
+                  MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN,
+              "`MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX` is too small");
+static_assert(MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX <=
+                  ((TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) -
+                   MANIFEST_LENGTH_FIELD_ROM_EXT_MAX),
+              "`MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX` is too large");
+
 // Extern declarations for the inline functions in the manifest header.
 extern rom_error_t manifest_check(const manifest_t *manifest);
 extern manifest_digest_region_t manifest_digest_region_get(

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -243,18 +243,33 @@ typedef struct manifest_digest_region {
 } manifest_digest_region_t;
 
 /**
- * Allowed bounds for the `length` field.
+ * ROM_EXT manifest identifier (ASCII "OTRE").
+ */
+#define MANIFEST_IDENTIFIER_ROM_EXT 0x4552544f
+
+/**
+ * First owner boot stage manifest identifier (ASCII "OTSO").
+ */
+#define MANIFEST_IDENTIFIER_OWNER_STAGE 0x4f53544f
+
+/**
+ * Allowed bounds for the `length` field of a ROM_EXT manifest.
  */
 // FIXME: Update min value after we have a fairly representative ROM_EXT.
-#define MANIFEST_LENGTH_FIELD_MIN MANIFEST_SIZE
-#define MANIFEST_LENGTH_FIELD_MAX 65536
+#define MANIFEST_LENGTH_FIELD_ROM_EXT_MIN MANIFEST_SIZE
+#define MANIFEST_LENGTH_FIELD_ROM_EXT_MAX 0x10000
+
+/**
+ * Allowed bounds for the `length` field of a first owner boot stage manifest.
+ */
+#define MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN MANIFEST_SIZE
+#define MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX 0x70000
 
 #ifndef OT_OFF_TARGET_TEST
 /**
  * Checks the fields of a manifest.
  *
  * This function performs several basic checks to ensure that
- * - Length of the image is within a reasonable range,
  * - Executable region is non-empty, inside the image, located after the
  * manifest, and word aligned, and
  * - Entry point is inside the executable region and word aligned.
@@ -263,12 +278,6 @@ typedef struct manifest_digest_region {
  * @return Result of the operation.
  */
 inline rom_error_t manifest_check(const manifest_t *manifest) {
-  // Length of the image must be within bounds.
-  if (manifest->length < MANIFEST_LENGTH_FIELD_MIN ||
-      manifest->length > MANIFEST_LENGTH_FIELD_MAX) {
-    return kErrorManifestBadLength;
-  }
-
   // Executable region must be empty, inside the image, located after the
   // manifest, and word aligned.
   if (manifest->code_start >= manifest->code_end ||

--- a/sw/device/silicon_creator/lib/manifest_unittest.cc
+++ b/sw/device/silicon_creator/lib/manifest_unittest.cc
@@ -51,14 +51,6 @@ TEST_F(ManifestTest, EntryPointGet) {
             reinterpret_cast<uintptr_t>(&manifest_) + manifest_.entry_point);
 }
 
-TEST_F(ManifestTest, BadLength) {
-  manifest_.length = MANIFEST_LENGTH_FIELD_MAX + 1;
-  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadLength);
-
-  manifest_.length = MANIFEST_LENGTH_FIELD_MIN - 1;
-  EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadLength);
-}
-
 TEST_F(ManifestTest, CodeRegionEmpty) {
   manifest_.code_start = manifest_.code_end;
   EXPECT_EQ(manifest_check(&manifest_), kErrorManifestBadCodeRegion);

--- a/sw/device/silicon_creator/mask_rom/boot_policy.c
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.c
@@ -21,10 +21,14 @@ boot_policy_manifests_t boot_policy_manifests_get(void) {
 }
 
 rom_error_t boot_policy_manifest_check(const manifest_t *manifest) {
-  RETURN_IF_ERROR(manifest_check(manifest));
-  if (manifest->identifier != kBootPolicyRomExtIdentifier) {
+  if (manifest->identifier != MANIFEST_IDENTIFIER_ROM_EXT) {
     return kErrorBootPolicyBadIdentifier;
   }
+  if (manifest->length < MANIFEST_LENGTH_FIELD_ROM_EXT_MIN ||
+      manifest->length > MANIFEST_LENGTH_FIELD_ROM_EXT_MAX) {
+    return kErrorBootPolicyBadLength;
+  }
+  RETURN_IF_ERROR(manifest_check(manifest));
   // TODO(#7879): Implement anti-rollback.
   uint32_t min_security_version = 0;
   if (manifest->security_version < min_security_version) {

--- a/sw/device/silicon_creator/mask_rom/boot_policy.h
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.h
@@ -12,13 +12,6 @@
 extern "C" {
 #endif  // __cplusplus
 
-enum {
-  /**
-   * ROM_EXT manifest identifier (ASCII "OTRE").
-   */
-  kBootPolicyRomExtIdentifier = 0x4552544f,
-};
-
 /**
  * Type alias for the ROM_EXT entry point.
  *

--- a/sw/device/silicon_creator/mask_rom/boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/boot_policy_unittest.cc
@@ -21,29 +21,37 @@ class BootPolicyTest : public mask_rom_test::MaskRomTest {
 
 TEST_F(BootPolicyTest, ManifestCheck) {
   manifest_t manifest{};
-  manifest.identifier = kBootPolicyRomExtIdentifier;
+  manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
 
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MIN;
   EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-
   EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorOk);
-}
 
-TEST_F(BootPolicyTest, ManifestCheckOutOfBounds) {
-  manifest_t manifest{};
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX >> 1;
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorOk);
 
-  EXPECT_CALL(mock_manifest_, Check(&manifest))
-      .WillOnce(Return(kErrorManifestBadLength));
-
-  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorManifestBadLength);
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX;
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorOk);
 }
 
 TEST_F(BootPolicyTest, ManifestCheckBadIdentifier) {
   manifest_t manifest{};
 
-  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-
   EXPECT_EQ(boot_policy_manifest_check(&manifest),
             kErrorBootPolicyBadIdentifier);
+}
+
+TEST_F(BootPolicyTest, ManifestCheckBadLength) {
+  manifest_t manifest{};
+  manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
+
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MIN - 1;
+  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorBootPolicyBadLength);
+
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX + 1;
+  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorBootPolicyBadLength);
 }
 
 struct ManifestOrderTestCase {

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -30,7 +30,7 @@ sw_silicon_creator_mask_rom_sigverify = declare_dependency(
   ),
 )
 
-# ROM_EXT image.
+# Mask ROM boot policy.
 sw_silicon_creator_mask_rom_boot_policy = declare_dependency(
   link_with: static_library(
     'sw_silicon_creator_mask_rom_boot_policy',

--- a/sw/device/silicon_creator/rom_exts/meson.build
+++ b/sw/device/silicon_creator/rom_exts/meson.build
@@ -7,6 +7,32 @@
 # See sw/device/exts/common/flash_link.ld for additional info about these
 # parameters.
 
+# ROM_EXT boot policy.
+sw_silicon_creator_rom_ext_boot_policy = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_rom_ext_boot_policy',
+    sources: [
+      'rom_ext_boot_policy.c',
+    ],
+  ),
+)
+
+test('sw_silicon_creator_rom_ext_boot_policy_unittest', executable(
+    'sw_silicon_creator_rom_ext_boot_policy_unittest',
+    sources: [
+      'rom_ext_boot_policy_unittest.cc',
+      'rom_ext_boot_policy.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+    ],
+    native: true,
+    c_args: ['-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DOT_OFF_TARGET_TEST'],
+  ),
+  suite: 'rom_ext',
+)
+
 rom_ext_linkfile_slot_a = files(['rom_ext_slot_a.ld'])
 rom_ext_linkfile_slot_b = files(['rom_ext_slot_b.ld'])
 
@@ -53,6 +79,7 @@ foreach slot, slot_link_args : rom_ext_link_info
         sw_lib_runtime_print,
         sw_silicon_creator_lib_base_sec_mmio,
         sw_silicon_creator_lib_manifest_section,
+        sw_silicon_creator_rom_ext_boot_policy,
 
         # TODO: ePMP test status dependency should be removed from
         # production ROM_EXT. Tests should unlock the test status

--- a/sw/device/silicon_creator/rom_exts/mock_rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_exts/mock_rom_ext_boot_policy_ptrs.h
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_MOCK_ROM_EXT_BOOT_POLICY_PTRS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_MOCK_ROM_EXT_BOOT_POLICY_PTRS_H_
+
+#include "sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_ptrs.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for rom_ext_boot_policy_ptrs.h
+ */
+class MockRomExtBootPolicyPtrs : public GlobalMock<MockRomExtBootPolicyPtrs> {
+ public:
+  MOCK_METHOD(const manifest_t *, ManifestA, ());
+  MOCK_METHOD(const manifest_t *, ManifestB, ());
+};
+
+}  // namespace internal
+
+using MockRomExtBootPolicyPtrs =
+    testing::StrictMock<internal::MockRomExtBootPolicyPtrs>;
+
+extern "C" {
+
+const manifest_t *rom_ext_boot_policy_manifest_a_get() {
+  return MockRomExtBootPolicyPtrs::Instance().ManifestA();
+}
+
+const manifest_t *rom_ext_boot_policy_manifest_b_get() {
+  return MockRomExtBootPolicyPtrs::Instance().ManifestB();
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_MOCK_ROM_EXT_BOOT_POLICY_PTRS_H_

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.c
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.h"
+
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_ptrs.h"
+
+rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(void) {
+  const manifest_t *slot_a = rom_ext_boot_policy_manifest_a_get();
+  const manifest_t *slot_b = rom_ext_boot_policy_manifest_b_get();
+  if (slot_a->security_version >= slot_b->security_version) {
+    return (rom_ext_boot_policy_manifests_t){
+        .ordered = {slot_a, slot_b},
+    };
+  }
+  return (rom_ext_boot_policy_manifests_t){
+      .ordered = {slot_b, slot_a},
+  };
+}
+
+rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest) {
+  RETURN_IF_ERROR(manifest_check(manifest));
+  if (manifest->identifier != kRomExtBootPolicyOwnerStageIdentifier) {
+    return kErrorBootPolicyBadIdentifier;
+  }
+  // TODO(#7879): Implement anti-rollback.
+  uint32_t min_security_version = 0;
+  if (manifest->security_version < min_security_version) {
+    return kErrorBootPolicyRollback;
+  }
+  return kErrorOk;
+}
+
+extern const manifest_t *rom_ext_boot_policy_manifest_a_get(void);
+extern const manifest_t *rom_ext_boot_policy_manifest_b_get(void);

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.c
@@ -21,10 +21,14 @@ rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(void) {
 }
 
 rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest) {
-  RETURN_IF_ERROR(manifest_check(manifest));
-  if (manifest->identifier != kRomExtBootPolicyOwnerStageIdentifier) {
+  if (manifest->identifier != MANIFEST_IDENTIFIER_OWNER_STAGE) {
     return kErrorBootPolicyBadIdentifier;
   }
+  if (manifest->length < MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN ||
+      manifest->length > MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX) {
+    return kErrorBootPolicyBadLength;
+  }
+  RETURN_IF_ERROR(manifest_check(manifest));
   // TODO(#7879): Implement anti-rollback.
   uint32_t min_security_version = 0;
   if (manifest->security_version < min_security_version) {

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.h
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.h
@@ -1,0 +1,71 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_BOOT_POLICY_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_BOOT_POLICY_H_
+
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/manifest.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * First owner boot stage manifest identifier (ASCII "OTSO").
+   */
+  kRomExtBootPolicyOwnerStageIdentifier = 0x4f53544f,
+};
+
+/**
+ * Type alias for the first owner boot stage entry point.
+ *
+ * The entry point address obtained from the first owner boot stage manifest
+ * must be cast to a pointer to this type before being called.
+ */
+typedef void owner_stage_entry_point(void);
+
+/**
+ * Manifests of first boot owner boot stages in descending order according to
+ * their security versions.
+ *
+ * These boot stages must be verified prior to handing over execution.
+ */
+typedef struct rom_ext_boot_policy_manifests {
+  /**
+   * First owner boot stage manifests in descending order according to
+   * their security versions.
+   */
+  const manifest_t *ordered[2];
+} rom_ext_boot_policy_manifests_t;
+
+/**
+ * Returns the manifests of first owner boot stages that should be attempted to
+ * boot in descending order according to their security versions.
+ *
+ * These boot stages must be verified prior to handing over execution.
+ *
+ * @return Manifests of first owner boot stages in descending order according to
+ * their security versions.
+ */
+rom_ext_boot_policy_manifests_t rom_ext_boot_policy_manifests_get(void);
+
+/**
+ * Checks the fields of a first owner boot stage manifest.
+ *
+ * This function performs bounds checks on the fields of the manifest, checks
+ * that its `identifier` is correct, and its `security_version` is greater than
+ * or equal to the minimum required security version.
+ *
+ * @param manifest A first boot owner boot stage manifest.
+ * @return Result of the operation.
+ */
+rom_error_t rom_ext_boot_policy_manifest_check(const manifest_t *manifest);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_BOOT_POLICY_H_

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.h
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.h
@@ -12,13 +12,6 @@
 extern "C" {
 #endif  // __cplusplus
 
-enum {
-  /**
-   * First owner boot stage manifest identifier (ASCII "OTSO").
-   */
-  kRomExtBootPolicyOwnerStageIdentifier = 0x4f53544f,
-};
-
 /**
  * Type alias for the first owner boot stage entry point.
  *

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_ptrs.h
@@ -27,7 +27,7 @@ static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
 // TODO(#7893): Should these be volatile?
 inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
   return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
-                              MANIFEST_LENGTH_FIELD_MAX);
+                              MANIFEST_LENGTH_FIELD_ROM_EXT_MAX);
 }
 
 /**
@@ -40,7 +40,7 @@ inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
 inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
   return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
                               (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) +
-                              MANIFEST_LENGTH_FIELD_MAX);
+                              MANIFEST_LENGTH_FIELD_ROM_EXT_MAX);
 }
 #else
 /**

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_ptrs.h
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_BOOT_POLICY_PTRS_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_BOOT_POLICY_PTRS_H_
+
+#include "sw/device/silicon_creator/lib/manifest.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
+              "Flash size is not divisible by 2");
+
+#ifndef OT_OFF_TARGET_TEST
+/**
+ * Returns a pointer to the manifest of the first owner boot stage image stored
+ * in flash slot A.
+ *
+ * @return Pointer to the manifest of the first owner boot stage image in slot
+ * A.
+ */
+// TODO(#7893): Should these be volatile?
+inline const manifest_t *rom_ext_boot_policy_manifest_a_get(void) {
+  return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
+                              MANIFEST_LENGTH_FIELD_MAX);
+}
+
+/**
+ * Returns a pointer to the manifest of the first owner boot stage image stored
+ * in flash slot B.
+ *
+ * @return Pointer to the manifest of the first owner boot stage image in slot
+ * B.
+ */
+inline const manifest_t *rom_ext_boot_policy_manifest_b_get(void) {
+  return (const manifest_t *)(TOP_EARLGREY_EFLASH_BASE_ADDR +
+                              (TOP_EARLGREY_EFLASH_SIZE_BYTES / 2) +
+                              MANIFEST_LENGTH_FIELD_MAX);
+}
+#else
+/**
+ * Declarations for the functions above that should be defined in tests.
+ */
+const manifest_t *rom_ext_boot_policy_manifest_a_get(void);
+const manifest_t *rom_ext_boot_policy_manifest_b_get(void);
+#endif
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_BOOT_POLICY_PTRS_H_

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_unittest.cc
@@ -21,30 +21,39 @@ class RomExtBootPolicyTest : public mask_rom_test::MaskRomTest {
 
 TEST_F(RomExtBootPolicyTest, ManifestCheck) {
   manifest_t manifest{};
-  manifest.identifier = kRomExtBootPolicyOwnerStageIdentifier;
+  manifest.identifier = MANIFEST_IDENTIFIER_OWNER_STAGE;
 
+  manifest.length = MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN;
   EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-
   EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest), kErrorOk);
-}
 
-TEST_F(RomExtBootPolicyTest, ManifestCheckOutOfBounds) {
-  manifest_t manifest{};
+  manifest.length = MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX >> 1;
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest), kErrorOk);
 
-  EXPECT_CALL(mock_manifest_, Check(&manifest))
-      .WillOnce(Return(kErrorManifestBadLength));
-
-  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest),
-            kErrorManifestBadLength);
+  manifest.length = MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX;
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest), kErrorOk);
 }
 
 TEST_F(RomExtBootPolicyTest, ManifestCheckBadIdentifier) {
   manifest_t manifest{};
 
-  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-
   EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest),
             kErrorBootPolicyBadIdentifier);
+}
+
+TEST_F(RomExtBootPolicyTest, ManifestCheckBadLength) {
+  manifest_t manifest{};
+  manifest.identifier = MANIFEST_IDENTIFIER_OWNER_STAGE;
+
+  manifest.length = MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN - 1;
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest),
+            kErrorBootPolicyBadLength);
+
+  manifest.length = MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX + 1;
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest),
+            kErrorBootPolicyBadLength);
 }
 
 struct ManifestOrderTestCase {

--- a/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_boot_policy_unittest.cc
@@ -1,0 +1,107 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_exts/rom_ext_boot_policy.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/mock_manifest.h"
+#include "sw/device/silicon_creator/rom_exts/mock_rom_ext_boot_policy_ptrs.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+namespace manifest_unittest {
+namespace {
+using ::testing::Return;
+
+class RomExtBootPolicyTest : public mask_rom_test::MaskRomTest {
+ protected:
+  mask_rom_test::MockRomExtBootPolicyPtrs rom_ext_boot_policy_ptrs_;
+  mask_rom_test::MockManifest mock_manifest_;
+};
+
+TEST_F(RomExtBootPolicyTest, ManifestCheck) {
+  manifest_t manifest{};
+  manifest.identifier = kRomExtBootPolicyOwnerStageIdentifier;
+
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest), kErrorOk);
+}
+
+TEST_F(RomExtBootPolicyTest, ManifestCheckOutOfBounds) {
+  manifest_t manifest{};
+
+  EXPECT_CALL(mock_manifest_, Check(&manifest))
+      .WillOnce(Return(kErrorManifestBadLength));
+
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest),
+            kErrorManifestBadLength);
+}
+
+TEST_F(RomExtBootPolicyTest, ManifestCheckBadIdentifier) {
+  manifest_t manifest{};
+
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+
+  EXPECT_EQ(rom_ext_boot_policy_manifest_check(&manifest),
+            kErrorBootPolicyBadIdentifier);
+}
+
+struct ManifestOrderTestCase {
+  uint32_t version_a;
+  uint32_t version_b;
+  bool is_a_first;
+};
+
+class ManifestOrderTest
+    : public RomExtBootPolicyTest,
+      public testing::WithParamInterface<ManifestOrderTestCase> {};
+
+TEST_P(ManifestOrderTest, ManifestsGet) {
+  manifest_t manifest_a{};
+  manifest_t manifest_b{};
+  manifest_a.security_version = GetParam().version_a;
+  manifest_b.security_version = GetParam().version_b;
+
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestA)
+      .WillOnce(Return(&manifest_a));
+  EXPECT_CALL(rom_ext_boot_policy_ptrs_, ManifestB)
+      .WillOnce(Return(&manifest_b));
+
+  rom_ext_boot_policy_manifests_t res = rom_ext_boot_policy_manifests_get();
+  if (GetParam().is_a_first) {
+    EXPECT_EQ(res.ordered[0], &manifest_a);
+    EXPECT_EQ(res.ordered[1], &manifest_b);
+  } else {
+    EXPECT_EQ(res.ordered[0], &manifest_b);
+    EXPECT_EQ(res.ordered[1], &manifest_a);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SecurityVersionCases, ManifestOrderTest,
+    testing::Values(
+        ManifestOrderTestCase{
+            .version_a = 0,
+            .version_b = 0,
+            .is_a_first = true,
+        },
+        ManifestOrderTestCase{
+            .version_a = 1,
+            .version_b = 0,
+            .is_a_first = true,
+        },
+        ManifestOrderTestCase{
+            .version_a = 0,
+            .version_b = 1,
+            .is_a_first = false,
+        },
+        ManifestOrderTestCase{
+            .version_a = std::numeric_limits<int32_t>::max(),
+            .version_b =
+                static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1,
+            .is_a_first = false,
+        }));
+
+}  // namespace
+}  // namespace manifest_unittest


### PR DESCRIPTION
This change adds skeleton code for ROM_EXT boot policy by mostly copying the corresponding files from `sw/device/silicon_creato/mask_rom` to unblock booting the first owner boot stage.

This is a part of the #8697 draft PR by @moidx.

The only differences from the code under the mask_rom directory are:
* Added `rom_ext_` prefix for clarity (I can do the same for the mask rom implementation if we are happy with this)
* Defined a new constant for the identifier of first owner boot stage manifests (`0x4f53544f`, ASCII "OTSO" (silicon owner))
  * Note: This will require a small change in the signer. We need to expose a CLI argument for the type of the image to set the correct identifier. I can address this in a separate PR.
* `rom_ext_boot_policy_manifest_{a,b}_get` returns pointers that are offset by `MANIFEST_LENGTH_FIELD_ROM_EXT_MAX` (`0x10000`), and
* Moved length checks from manifest.h to mask ROM and ROM_EXT boot policy implementations.

Signed-off-by: Alphan Ulusoy <alphan@google.com>