### PR TITLE
[dv/dsim] Remove dsim's system_lib from library path

### DIFF
--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -82,7 +82,7 @@
   // Vars that need to exported to the env.
   exports: [
     { PATH: "{DSIM_HOME}:{PATH}" }
-    { LD_LIBRARY_PATH: "{DSIM_HOME}/lib:{DSIM_HOME}/system_lib:{LD_LIBRARY_PATH}" }
+    { LD_LIBRARY_PATH: "{DSIM_HOME}/lib:{LD_LIBRARY_PATH}" }
   ]
 
   // Defaults for DSim


### PR DESCRIPTION
We found this was causing crashes that prevented dsim from even starting.

Signed-off-by: Guillermo Maturana <maturana@google.com>