### PR TITLE
[sw/rom] Add rom_ext sec_mmio initialization

### DIFF
--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -63,6 +63,17 @@ void sec_mmio_init(sec_mmio_shutdown_handler cb) {
   sec_mmio_ctx.expected_write_count = 0;
   for (size_t i = 0; i < ARRAYSIZE(sec_mmio_ctx.addrs); ++i) {
     sec_mmio_ctx.addrs[i] = UINT32_MAX;
+    sec_mmio_ctx.values[i] = UINT32_MAX;
+  }
+}
+
+void sec_mmio_next_stage_init(sec_mmio_shutdown_handler cb) {
+  sec_mmio_shutdown_cb = cb;
+  sec_mmio_ctx.check_count = 0;
+  for (size_t i = sec_mmio_ctx.last_index; i < ARRAYSIZE(sec_mmio_ctx.addrs);
+       ++i) {
+    sec_mmio_ctx.addrs[i] = UINT32_MAX;
+    sec_mmio_ctx.values[i] = UINT32_MAX;
   }
 }
 

--- a/sw/device/silicon_creator/lib/base/sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.h
@@ -132,6 +132,21 @@ typedef void (*sec_mmio_shutdown_handler)(rom_error_t);
 void sec_mmio_init(sec_mmio_shutdown_handler cb);
 
 /**
+ * Executes sec_mmio next boot stage initialization.
+ *
+ * Registers the `cb` callback handler, and performs the following operations to
+ * the internal `sec_mmio_ctx_t` context:
+ *
+ * - Clear the check count. This allows the caller to reset the
+ *   `sec_mmio_check_counters()` expected count argument.
+ * - Reset all expected address and values in the expectations table starting at
+ *   the last_index.
+ *
+ * @param cb Shutdown module callback handler.
+ */
+void sec_mmio_next_stage_init(sec_mmio_shutdown_handler cb);
+
+/**
  * Reads an aligned uint32_t from the MMIO region `addr`.
  *
  * This function implements a read-read-comparison operation. The first read


### PR DESCRIPTION
sec_mmio initialization for the ROM_EXT clears the current check count
expectation and resets all entries in the expectation table that were
not used by the ROM. This is to ensure that an attacker is not able to
recreate the state of the expectation table after injecting a reset
fault.
