### PR TITLE
[dif] Autogen dif_<ip>_init() DIFs across all IPs.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_aes_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.c
@@ -7,3 +7,14 @@
 #include "sw/device/lib/dif/autogen/dif_aes_autogen.h"
 
 #include "aes_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes) {
+  if (aes == NULL) {
+    return kDifBadArg;
+  }
+
+  aes->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_aes_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.h
@@ -35,6 +35,18 @@ typedef struct dif_aes {
   mmio_region_t base_addr;
 } dif_aes_t;
 
+/**
+ * Creates a new handle for a(n) aes peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the aes peripheral.
+ * @param[out] aes Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
@@ -16,12 +16,23 @@ namespace dif_aes_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class AesTest : public Test, public MmioTest {
  protected:
   dif_aes_t aes_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public AesTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_aes_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_aes_init({.base_addr = dev().region()}, &aes_), kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_aes_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
@@ -8,6 +8,18 @@
 
 #include "alert_handler_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_init(mmio_region_t base_addr,
+                                    dif_alert_handler_t *alert_handler) {
+  if (alert_handler == NULL) {
+    return kDifBadArg;
+  }
+
+  alert_handler->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
@@ -37,6 +37,19 @@ typedef struct dif_alert_handler {
 } dif_alert_handler_t;
 
 /**
+ * Creates a new handle for a(n) alert_handler peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the alert_handler peripheral.
+ * @param[out] alert_handler Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_init(mmio_region_t base_addr,
+                                    dif_alert_handler_t *alert_handler);
+
+/**
  * A alert_handler interrupt request type.
  */
 typedef enum dif_alert_handler_irq {

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_alert_handler_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class AlertHandlerTest : public Test, public MmioTest {
@@ -23,7 +24,18 @@ class AlertHandlerTest : public Test, public MmioTest {
   dif_alert_handler_t alert_handler_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public AlertHandlerTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_alert_handler_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(
+      dif_alert_handler_init({.base_addr = dev().region()}, &alert_handler_),
+      kDifOk);
+}
 
 class IrqGetStateTest : public AlertHandlerTest {};
 

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
@@ -16,6 +16,18 @@ static_assert(AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT ==
                   AON_TIMER_INTR_TEST_WDOG_TIMER_BARK_BIT,
               "Expected IRQ bit offsets to match across STATE/TEST regs.");
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_init(mmio_region_t base_addr,
+                                dif_aon_timer_t *aon_timer) {
+  if (aon_timer == NULL) {
+    return kDifBadArg;
+  }
+
+  aon_timer->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
@@ -37,6 +37,19 @@ typedef struct dif_aon_timer {
 } dif_aon_timer_t;
 
 /**
+ * Creates a new handle for a(n) aon_timer peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the aon_timer peripheral.
+ * @param[out] aon_timer Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_init(mmio_region_t base_addr,
+                                dif_aon_timer_t *aon_timer);
+
+/**
  * A aon_timer interrupt request type.
  */
 typedef enum dif_aon_timer_irq {

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_aon_timer_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class AonTimerTest : public Test, public MmioTest {
@@ -23,7 +24,17 @@ class AonTimerTest : public Test, public MmioTest {
   dif_aon_timer_t aon_timer_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public AonTimerTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_aon_timer_init({.base_addr = dev().region()}, &aon_timer_),
+            kDifOk);
+}
 
 class IrqGetStateTest : public AonTimerTest {};
 

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
@@ -7,3 +7,14 @@
 #include "sw/device/lib/dif/autogen/dif_clkmgr_autogen.h"
 
 #include "clkmgr_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_init(mmio_region_t base_addr, dif_clkmgr_t *clkmgr) {
+  if (clkmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  clkmgr->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.h
@@ -35,6 +35,18 @@ typedef struct dif_clkmgr {
   mmio_region_t base_addr;
 } dif_clkmgr_t;
 
+/**
+ * Creates a new handle for a(n) clkmgr peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the clkmgr peripheral.
+ * @param[out] clkmgr Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_init(mmio_region_t base_addr, dif_clkmgr_t *clkmgr);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
@@ -16,12 +16,24 @@ namespace dif_clkmgr_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class ClkmgrTest : public Test, public MmioTest {
  protected:
   dif_clkmgr_t clkmgr_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public ClkmgrTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_clkmgr_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_clkmgr_init({.base_addr = dev().region()}, &clkmgr_), kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_clkmgr_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -8,6 +8,17 @@
 
 #include "csrng_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng) {
+  if (csrng == NULL) {
+    return kDifBadArg;
+  }
+
+  csrng->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_csrng {
 } dif_csrng_t;
 
 /**
+ * Creates a new handle for a(n) csrng peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the csrng peripheral.
+ * @param[out] csrng Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng);
+
+/**
  * A csrng interrupt request type.
  */
 typedef enum dif_csrng_irq {

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_csrng_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class CsrngTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class CsrngTest : public Test, public MmioTest {
   dif_csrng_t csrng_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public CsrngTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_csrng_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_csrng_init({.base_addr = dev().region()}, &csrng_), kDifOk);
+}
 
 class IrqGetStateTest : public CsrngTest {};
 

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.c
@@ -8,6 +8,17 @@
 
 #include "edn_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn) {
+  if (edn == NULL) {
+    return kDifBadArg;
+  }
+
+  edn->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_edn {
 } dif_edn_t;
 
 /**
+ * Creates a new handle for a(n) edn peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the edn peripheral.
+ * @param[out] edn Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn);
+
+/**
  * A edn interrupt request type.
  */
 typedef enum dif_edn_irq {

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_edn_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class EdnTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class EdnTest : public Test, public MmioTest {
   dif_edn_t edn_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public EdnTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_edn_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_edn_init({.base_addr = dev().region()}, &edn_), kDifOk);
+}
 
 class IrqGetStateTest : public EdnTest {};
 

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -8,6 +8,18 @@
 
 #include "entropy_src_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
+                                  dif_entropy_src_t *entropy_src) {
+  if (entropy_src == NULL) {
+    return kDifBadArg;
+  }
+
+  entropy_src->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
@@ -37,6 +37,19 @@ typedef struct dif_entropy_src {
 } dif_entropy_src_t;
 
 /**
+ * Creates a new handle for a(n) entropy_src peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the entropy_src peripheral.
+ * @param[out] entropy_src Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
+                                  dif_entropy_src_t *entropy_src);
+
+/**
  * A entropy_src interrupt request type.
  */
 typedef enum dif_entropy_src_irq {

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_entropy_src_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class EntropySrcTest : public Test, public MmioTest {
@@ -23,7 +24,17 @@ class EntropySrcTest : public Test, public MmioTest {
   dif_entropy_src_t entropy_src_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public EntropySrcTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_entropy_src_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_entropy_src_init({.base_addr = dev().region()}, &entropy_src_),
+            kDifOk);
+}
 
 class IrqGetStateTest : public EntropySrcTest {};
 

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -8,6 +8,17 @@
 
 #include "gpio_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio) {
+  if (gpio == NULL) {
+    return kDifBadArg;
+  }
+
+  gpio->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_gpio {
 } dif_gpio_t;
 
 /**
+ * Creates a new handle for a(n) gpio peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the gpio peripheral.
+ * @param[out] gpio Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio);
+
+/**
  * A gpio interrupt request type.
  */
 typedef enum dif_gpio_irq {

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_gpio_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class GpioTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class GpioTest : public Test, public MmioTest {
   dif_gpio_t gpio_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public GpioTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_gpio_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_gpio_init({.base_addr = dev().region()}, &gpio_), kDifOk);
+}
 
 class IrqGetStateTest : public GpioTest {};
 

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -8,6 +8,17 @@
 
 #include "hmac_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac) {
+  if (hmac == NULL) {
+    return kDifBadArg;
+  }
+
+  hmac->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_hmac {
 } dif_hmac_t;
 
 /**
+ * Creates a new handle for a(n) hmac peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the hmac peripheral.
+ * @param[out] hmac Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac);
+
+/**
  * A hmac interrupt request type.
  */
 typedef enum dif_hmac_irq {

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_hmac_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class HmacTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class HmacTest : public Test, public MmioTest {
   dif_hmac_t hmac_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public HmacTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_hmac_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_hmac_init({.base_addr = dev().region()}, &hmac_), kDifOk);
+}
 
 class IrqGetStateTest : public HmacTest {};
 

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.c
@@ -8,6 +8,17 @@
 
 #include "i2c_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c) {
+  if (i2c == NULL) {
+    return kDifBadArg;
+  }
+
+  i2c->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_i2c {
 } dif_i2c_t;
 
 /**
+ * Creates a new handle for a(n) i2c peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the i2c peripheral.
+ * @param[out] i2c Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c);
+
+/**
  * A i2c interrupt request type.
  */
 typedef enum dif_i2c_irq {

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_i2c_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class I2cTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class I2cTest : public Test, public MmioTest {
   dif_i2c_t i2c_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public I2cTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_i2c_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_i2c_init({.base_addr = dev().region()}, &i2c_), kDifOk);
+}
 
 class IrqGetStateTest : public I2cTest {};
 

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -8,6 +8,17 @@
 
 #include "keymgr_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr) {
+  if (keymgr == NULL) {
+    return kDifBadArg;
+  }
+
+  keymgr->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_keymgr {
 } dif_keymgr_t;
 
 /**
+ * Creates a new handle for a(n) keymgr peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the keymgr peripheral.
+ * @param[out] keymgr Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr);
+
+/**
  * A keymgr interrupt request type.
  */
 typedef enum dif_keymgr_irq {

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_keymgr_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class KeymgrTest : public Test, public MmioTest {
@@ -23,7 +24,16 @@ class KeymgrTest : public Test, public MmioTest {
   dif_keymgr_t keymgr_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public KeymgrTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_keymgr_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_keymgr_init({.base_addr = dev().region()}, &keymgr_), kDifOk);
+}
 
 class IrqGetStateTest : public KeymgrTest {};
 

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -8,6 +8,17 @@
 
 #include "kmac_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+
+  kmac->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_kmac {
 } dif_kmac_t;
 
 /**
+ * Creates a new handle for a(n) kmac peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the kmac peripheral.
+ * @param[out] kmac Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac);
+
+/**
  * A kmac interrupt request type.
  */
 typedef enum dif_kmac_irq {

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_kmac_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class KmacTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class KmacTest : public Test, public MmioTest {
   dif_kmac_t kmac_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public KmacTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_kmac_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_kmac_init({.base_addr = dev().region()}, &kmac_), kDifOk);
+}
 
 class IrqGetStateTest : public KmacTest {};
 

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
@@ -7,3 +7,14 @@
 #include "sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h"
 
 #include "lc_ctrl_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc_ctrl) {
+  if (lc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  lc_ctrl->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h
@@ -35,6 +35,18 @@ typedef struct dif_lc_ctrl {
   mmio_region_t base_addr;
 } dif_lc_ctrl_t;
 
+/**
+ * Creates a new handle for a(n) lc_ctrl peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the lc_ctrl peripheral.
+ * @param[out] lc_ctrl Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc_ctrl);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
@@ -16,12 +16,24 @@ namespace dif_lc_ctrl_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class LcCtrlTest : public Test, public MmioTest {
  protected:
   dif_lc_ctrl_t lc_ctrl_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public LcCtrlTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, &lc_ctrl_), kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_lc_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -8,6 +8,17 @@
 
 #include "otbn_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn) {
+  if (otbn == NULL) {
+    return kDifBadArg;
+  }
+
+  otbn->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_otbn {
 } dif_otbn_t;
 
 /**
+ * Creates a new handle for a(n) otbn peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the otbn peripheral.
+ * @param[out] otbn Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn);
+
+/**
  * A otbn interrupt request type.
  */
 typedef enum dif_otbn_irq {

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_otbn_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class OtbnTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class OtbnTest : public Test, public MmioTest {
   dif_otbn_t otbn_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public OtbnTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_otbn_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_otbn_init({.base_addr = dev().region()}, &otbn_), kDifOk);
+}
 
 class IrqGetStateTest : public OtbnTest {};
 

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -8,6 +8,18 @@
 
 #include "otp_ctrl_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr,
+                               dif_otp_ctrl_t *otp_ctrl) {
+  if (otp_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  otp_ctrl->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
@@ -36,6 +36,19 @@ typedef struct dif_otp_ctrl {
 } dif_otp_ctrl_t;
 
 /**
+ * Creates a new handle for a(n) otp_ctrl peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the otp_ctrl peripheral.
+ * @param[out] otp_ctrl Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr,
+                               dif_otp_ctrl_t *otp_ctrl);
+
+/**
  * A otp_ctrl interrupt request type.
  */
 typedef enum dif_otp_ctrl_irq {

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_otp_ctrl_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class OtpCtrlTest : public Test, public MmioTest {
@@ -23,7 +24,17 @@ class OtpCtrlTest : public Test, public MmioTest {
   dif_otp_ctrl_t otp_ctrl_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public OtpCtrlTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_otp_ctrl_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_otp_ctrl_init({.base_addr = dev().region()}, &otp_ctrl_),
+            kDifOk);
+}
 
 class IrqGetStateTest : public OtpCtrlTest {};
 

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
@@ -7,3 +7,14 @@
 #include "sw/device/lib/dif/autogen/dif_pinmux_autogen.h"
 
 #include "pinmux_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pinmux_init(mmio_region_t base_addr, dif_pinmux_t *pinmux) {
+  if (pinmux == NULL) {
+    return kDifBadArg;
+  }
+
+  pinmux->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen.h
@@ -35,6 +35,18 @@ typedef struct dif_pinmux {
   mmio_region_t base_addr;
 } dif_pinmux_t;
 
+/**
+ * Creates a new handle for a(n) pinmux peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the pinmux peripheral.
+ * @param[out] pinmux Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pinmux_init(mmio_region_t base_addr, dif_pinmux_t *pinmux);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
@@ -16,12 +16,24 @@ namespace dif_pinmux_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class PinmuxTest : public Test, public MmioTest {
  protected:
   dif_pinmux_t pinmux_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public PinmuxTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_pinmux_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_pinmux_init({.base_addr = dev().region()}, &pinmux_), kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_pinmux_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -8,6 +8,17 @@
 
 #include "pwrmgr_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr) {
+  if (pwrmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  pwrmgr->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_pwrmgr {
 } dif_pwrmgr_t;
 
 /**
+ * Creates a new handle for a(n) pwrmgr peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the pwrmgr peripheral.
+ * @param[out] pwrmgr Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr);
+
+/**
  * A pwrmgr interrupt request type.
  */
 typedef enum dif_pwrmgr_irq {

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_pwrmgr_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class PwrmgrTest : public Test, public MmioTest {
@@ -23,7 +24,16 @@ class PwrmgrTest : public Test, public MmioTest {
   dif_pwrmgr_t pwrmgr_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public PwrmgrTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_pwrmgr_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_pwrmgr_init({.base_addr = dev().region()}, &pwrmgr_), kDifOk);
+}
 
 class IrqGetStateTest : public PwrmgrTest {};
 

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
@@ -7,3 +7,14 @@
 #include "sw/device/lib/dif/autogen/dif_rstmgr_autogen.h"
 
 #include "rstmgr_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *rstmgr) {
+  if (rstmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  rstmgr->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen.h
@@ -35,6 +35,18 @@ typedef struct dif_rstmgr {
   mmio_region_t base_addr;
 } dif_rstmgr_t;
 
+/**
+ * Creates a new handle for a(n) rstmgr peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the rstmgr peripheral.
+ * @param[out] rstmgr Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *rstmgr);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
@@ -16,12 +16,24 @@ namespace dif_rstmgr_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class RstmgrTest : public Test, public MmioTest {
  protected:
   dif_rstmgr_t rstmgr_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public RstmgrTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_rstmgr_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_rstmgr_init({.base_addr = dev().region()}, &rstmgr_), kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_rstmgr_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
@@ -7,3 +7,14 @@
 #include "sw/device/lib/dif/autogen/dif_rv_plic_autogen.h"
 
 #include "rv_plic_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *rv_plic) {
+  if (rv_plic == NULL) {
+    return kDifBadArg;
+  }
+
+  rv_plic->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.h
@@ -35,6 +35,18 @@ typedef struct dif_rv_plic {
   mmio_region_t base_addr;
 } dif_rv_plic_t;
 
+/**
+ * Creates a new handle for a(n) rv_plic peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the rv_plic peripheral.
+ * @param[out] rv_plic Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *rv_plic);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
@@ -16,12 +16,24 @@ namespace dif_rv_plic_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class RvPlicTest : public Test, public MmioTest {
  protected:
   dif_rv_plic_t rv_plic_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public RvPlicTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, &rv_plic_), kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_rv_plic_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
@@ -14,6 +14,18 @@ static_assert(RV_TIMER_INTR_STATE0_IS_0_BIT == RV_TIMER_INTR_ENABLE0_IE_0_BIT,
 static_assert(RV_TIMER_INTR_STATE0_IS_0_BIT == RV_TIMER_INTR_TEST0_T_0_BIT,
               "Expected IRQ bit offsets to match across STATE/ENABLE regs.");
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_timer_init(mmio_region_t base_addr,
+                               dif_rv_timer_t *rv_timer) {
+  if (rv_timer == NULL) {
+    return kDifBadArg;
+  }
+
+  rv_timer->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 typedef enum dif_rv_timer_intr_reg {
   kDifRvTimerIntrRegState = 0,
   kDifRvTimerIntrRegEnable = 1,

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
@@ -36,6 +36,19 @@ typedef struct dif_rv_timer {
 } dif_rv_timer_t;
 
 /**
+ * Creates a new handle for a(n) rv_timer peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the rv_timer peripheral.
+ * @param[out] rv_timer Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_timer_init(mmio_region_t base_addr,
+                               dif_rv_timer_t *rv_timer);
+
+/**
  * A rv_timer interrupt request type.
  */
 typedef enum dif_rv_timer_irq {

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_rv_timer_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class RvTimerTest : public Test, public MmioTest {
@@ -23,7 +24,17 @@ class RvTimerTest : public Test, public MmioTest {
   dif_rv_timer_t rv_timer_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public RvTimerTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_rv_timer_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_rv_timer_init({.base_addr = dev().region()}, &rv_timer_),
+            kDifOk);
+}
 
 class IrqGetStateTest : public RvTimerTest {};
 

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -8,6 +8,18 @@
 
 #include "spi_device_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_init(mmio_region_t base_addr,
+                                 dif_spi_device_t *spi_device) {
+  if (spi_device == NULL) {
+    return kDifBadArg;
+  }
+
+  spi_device->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
@@ -37,6 +37,19 @@ typedef struct dif_spi_device {
 } dif_spi_device_t;
 
 /**
+ * Creates a new handle for a(n) spi_device peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the spi_device peripheral.
+ * @param[out] spi_device Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_init(mmio_region_t base_addr,
+                                 dif_spi_device_t *spi_device);
+
+/**
  * A spi_device interrupt request type.
  */
 typedef enum dif_spi_device_irq {

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_spi_device_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class SpiDeviceTest : public Test, public MmioTest {
@@ -23,7 +24,17 @@ class SpiDeviceTest : public Test, public MmioTest {
   dif_spi_device_t spi_device_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public SpiDeviceTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_spi_device_init({.base_addr = dev().region()}, &spi_device_),
+            kDifOk);
+}
 
 class IrqGetStateTest : public SpiDeviceTest {};
 

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
@@ -7,3 +7,15 @@
 #include "sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h"
 
 #include "sram_ctrl_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
+                                dif_sram_ctrl_t *sram_ctrl) {
+  if (sram_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  sram_ctrl->base_addr = base_addr;
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h
@@ -36,6 +36,19 @@ typedef struct dif_sram_ctrl {
   mmio_region_t base_addr;
 } dif_sram_ctrl_t;
 
+/**
+ * Creates a new handle for a(n) sram_ctrl peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the sram_ctrl peripheral.
+ * @param[out] sram_ctrl Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
+                                dif_sram_ctrl_t *sram_ctrl);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
@@ -16,12 +16,25 @@ namespace dif_sram_ctrl_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class SramCtrlTest : public Test, public MmioTest {
  protected:
   dif_sram_ctrl_t sram_ctrl_ = {.base_addr = dev().region()};
 };
+
+class InitTest : public SramCtrlTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_sram_ctrl_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_sram_ctrl_init({.base_addr = dev().region()}, &sram_ctrl_),
+            kDifOk);
+}
 
 }  // namespace
 }  // namespace dif_sram_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -8,6 +8,17 @@
 
 #include "uart_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart) {
+  if (uart == NULL) {
+    return kDifBadArg;
+  }
+
+  uart->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_uart {
 } dif_uart_t;
 
 /**
+ * Creates a new handle for a(n) uart peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the uart peripheral.
+ * @param[out] uart Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart);
+
+/**
  * A uart interrupt request type.
  */
 typedef enum dif_uart_irq {

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_uart_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class UartTest : public Test, public MmioTest {
@@ -23,7 +24,15 @@ class UartTest : public Test, public MmioTest {
   dif_uart_t uart_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public UartTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_uart_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_uart_init({.base_addr = dev().region()}, &uart_), kDifOk);
+}
 
 class IrqGetStateTest : public UartTest {};
 

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -8,6 +8,17 @@
 
 #include "usbdev_regs.h"  // Generated.
 
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  usbdev->base_addr = base_addr;
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
@@ -36,6 +36,18 @@ typedef struct dif_usbdev {
 } dif_usbdev_t;
 
 /**
+ * Creates a new handle for a(n) usbdev peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the usbdev peripheral.
+ * @param[out] usbdev Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev);
+
+/**
  * A usbdev interrupt request type.
  */
 typedef enum dif_usbdev_irq {

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -16,6 +16,7 @@ namespace dif_usbdev_autogen_unittest {
 namespace {
 using ::mock_mmio::MmioTest;
 using ::mock_mmio::MockDevice;
+using ::testing::Eq;
 using ::testing::Test;
 
 class UsbdevTest : public Test, public MmioTest {
@@ -23,7 +24,16 @@ class UsbdevTest : public Test, public MmioTest {
   dif_usbdev_t usbdev_ = {.base_addr = dev().region()};
 };
 
-using ::testing::Eq;
+class InitTest : public UsbdevTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_usbdev_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_usbdev_init({.base_addr = dev().region()}, &usbdev_), kDifOk);
+}
 
 class IrqGetStateTest : public UsbdevTest {};
 

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -190,16 +190,6 @@ static void aes_set_multireg(const dif_aes_t *aes, const uint32_t *data,
   }
 }
 
-dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes) {
-  if (aes == NULL) {
-    return kDifBadArg;
-  }
-
-  aes->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_aes_reset(const dif_aes_t *aes) {
   if (aes == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -173,18 +173,6 @@ typedef enum dif_aes_alert {
 } dif_aes_alert_t;
 
 /**
- * Creates a new handle for AES.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] aes Out param for the initialised handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes);
-
-/**
  * Resets an instance of AES.
  *
  * Clears the internal state along with the interface registers.

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -19,17 +19,6 @@ static_assert(ALERT_HANDLER_PARAM_N_PHASES == 4,
 static_assert(ALERT_HANDLER_PARAM_N_LOC_ALERT == 7,
               "Expected seven local alerts!");
 
-dif_result_t dif_alert_handler_init(mmio_region_t base_addr,
-                                    dif_alert_handler_t *alert_handler) {
-  if (alert_handler == NULL) {
-    return kDifBadArg;
-  }
-
-  alert_handler->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 /**
  * Classifies alerts for a single alert class. Returns `false` if any of the
  * provided configuration is invalid.

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -314,19 +314,6 @@ typedef struct dif_alert_handler_config {
 } dif_alert_handler_config_t;
 
 /**
- * Creates a new handle for alert handler.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param handler Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_alert_handler_init(mmio_region_t base_addr,
-                                    dif_alert_handler_t *alert_handler);
-
-/**
  * Configures alert handler with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.

--- a/sw/device/lib/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/lib/dif/dif_alert_handler_unittest.cc
@@ -30,19 +30,6 @@ class AlertHandlerTest : public testing::Test, public MmioTest {
   dif_alert_handler_t alert_handler_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public AlertHandlerTest,
-                 public testing::WithParamInterface<uint32_t> {};
-
-TEST_F(InitTest, Success) {
-  dif_alert_handler_t alert_handler;
-
-  EXPECT_EQ(dif_alert_handler_init(dev().region(), &alert_handler), kDifOk);
-}
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_alert_handler_init(dev().region(), nullptr), kDifBadArg);
-}
-
 class ConfigTest : public AlertHandlerTest {
   // We provide our own dev_ member variable in this fixture, in order to
   // support IgnoreMmioCalls().

--- a/sw/device/lib/dif/dif_aon_timer.c
+++ b/sw/device/lib/dif/dif_aon_timer.c
@@ -57,16 +57,6 @@ static bool aon_timer_watchdog_is_locked(const dif_aon_timer_t *aon) {
   return !bitfield_bit32_read(reg, AON_TIMER_WDOG_REGWEN_REGWEN_BIT);
 }
 
-dif_result_t dif_aon_timer_init(mmio_region_t base_addr, dif_aon_timer_t *aon) {
-  if (aon == NULL) {
-    return kDifBadArg;
-  }
-
-  aon->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_aon_timer_wakeup_start(const dif_aon_timer_t *aon,
                                         uint32_t threshold,
                                         uint32_t prescaler) {

--- a/sw/device/lib/dif/dif_aon_timer.h
+++ b/sw/device/lib/dif/dif_aon_timer.h
@@ -25,18 +25,6 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Creates a new handle for Always-On Timer.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] aon Out param for the initialised handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_aon_timer_init(mmio_region_t base_addr, dif_aon_timer_t *aon);
-
-/**
  * Starts Always-On Timer (wake-up timer).
  *
  * This operation starts the wake-up timer with the provided configuration.

--- a/sw/device/lib/dif/dif_aon_timer_unittest.cc
+++ b/sw/device/lib/dif/dif_aon_timer_unittest.cc
@@ -25,17 +25,6 @@ class AonTimerTest : public Test, public MmioTest {
   dif_aon_timer_t aon_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public AonTimerTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_aon_timer_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Success) {
-  dif_aon_timer_t aon;
-  EXPECT_EQ(dif_aon_timer_init(dev().region(), &aon), kDifOk);
-}
-
 class WakeupStartTest : public AonTimerTest {};
 
 TEST_F(WakeupStartTest, NullArgs) {

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -34,16 +34,6 @@ static bool clkmgr_valid_hintable_clock(dif_clkmgr_hintable_clock_t clock) {
   return clock < CLKMGR_PARAM_NUM_HINTABLE_CLOCKS;
 }
 
-dif_result_t dif_clkmgr_init(mmio_region_t base_addr, dif_clkmgr_t *clkmgr) {
-  if (clkmgr == NULL) {
-    return kDifBadArg;
-  }
-
-  clkmgr->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_clkmgr_gateable_clock_get_enabled(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_gateable_clock_t clock,
     bool *is_enabled) {

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -41,18 +41,6 @@ typedef uint32_t dif_clkmgr_gateable_clock_t;
 typedef uint32_t dif_clkmgr_hintable_clock_t;
 
 /**
- * Creates a new handle for a clock manager.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] clkmgr Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_clkmgr_init(mmio_region_t base_addr, dif_clkmgr_t *clkmgr);
-
-/**
  * Check if a Gateable Clock is Enabled or Disabled.
  *
  * @param clkmgr Clock Manager Handle.

--- a/sw/device/lib/dif/dif_clkmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_clkmgr_unittest.cc
@@ -20,15 +20,7 @@ using testing::Test;
 class ClkMgrTest : public Test, public MmioTest {
  protected:
   dif_clkmgr_t clkmgr_ = {.base_addr = dev().region()};
-  ClkMgrTest() { EXPECT_EQ(dif_clkmgr_init(dev().region(), &clkmgr_), kDifOk); }
 };
-
-class InitTest : public ClkMgrTest {};
-
-TEST_F(InitTest, NullArgs) {
-  // Null handle.
-  EXPECT_EQ(dif_clkmgr_init(dev().region(), nullptr), kDifBadArg);
-}
 
 class GateableClockTest : public ClkMgrTest {};
 

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -116,16 +116,6 @@ static bool is_output_ready(const dif_csrng_t *csrng) {
   return status.valid_data;
 }
 
-dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng) {
-  if (csrng == NULL) {
-    return kDifBadArg;
-  }
-
-  csrng->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_csrng_configure(const dif_csrng_t *csrng) {
   if (csrng == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_csrng.h
+++ b/sw/device/lib/dif/dif_csrng.h
@@ -187,18 +187,6 @@ typedef struct dif_csrng_internal_state {
 } dif_csrng_internal_state_t;
 
 /**
- * Creates a new handle for CSRNG.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] csrng Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng);
-
-/**
  * Configures CSRNG.
  *
  * This function should need to be called once for the lifetime of `csrng`.

--- a/sw/device/lib/dif/dif_csrng_unittest.cc
+++ b/sw/device/lib/dif/dif_csrng_unittest.cc
@@ -23,17 +23,6 @@ class DifCsrngTest : public testing::Test, public mock_mmio::MmioTest {
   const dif_csrng_t csrng_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public DifCsrngTest {};
-
-TEST_F(InitTest, BadArgs) {
-  EXPECT_EQ(dif_csrng_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, InitOk) {
-  dif_csrng_t csrng;
-  EXPECT_EQ(dif_csrng_init(dev().region(), &csrng), kDifOk);
-}
-
 class ConfigTest : public DifCsrngTest {};
 
 TEST_F(ConfigTest, NullArgs) {

--- a/sw/device/lib/dif/dif_edn.c
+++ b/sw/device/lib/dif/dif_edn.c
@@ -5,13 +5,3 @@
 #include "sw/device/lib/dif/dif_edn.h"
 
 #include "edn_regs.h"  // Generated
-
-dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn) {
-  if (edn == NULL) {
-    return kDifBadArg;
-  }
-
-  edn->base_addr = base_addr;
-
-  return kDifOk;
-}

--- a/sw/device/lib/dif/dif_edn.h
+++ b/sw/device/lib/dif/dif_edn.h
@@ -102,18 +102,6 @@ typedef struct dif_edn_auto_params {
 } dif_edn_auto_params_t;
 
 /**
- * Creates a new handle for Entropy Distribution Network.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] edn Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn);
-
-/**
  * Configures Entropy Distribution Network with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -87,15 +87,6 @@ static dif_result_t fw_override_set(
   return kDifOk;
 }
 
-dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
-                                  dif_entropy_src_t *entropy_src) {
-  if (entropy_src == NULL) {
-    return kDifBadArg;
-  }
-  entropy_src->base_addr = base_addr;
-  return kDifOk;
-}
-
 dif_result_t dif_entropy_src_configure(const dif_entropy_src_t *entropy_src,
                                        dif_entropy_src_config_t config) {
   if (entropy_src == NULL) {

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -337,19 +337,6 @@ typedef enum dif_entropy_src_alert {
 } dif_entropy_src_alert_t;
 
 /**
- * Creates a new handle for entropy source.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation parameters.
- * @param[out] entropy Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
-                                  dif_entropy_src_t *entropy_src);
-
-/**
  * Configures entropy source with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -20,17 +20,6 @@ class DifEntropySrcTest : public testing::Test, public mock_mmio::MmioTest {
   const dif_entropy_src_t entropy_src_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public DifEntropySrcTest {};
-
-TEST_F(InitTest, BadArgs) {
-  EXPECT_EQ(dif_entropy_src_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Init) {
-  dif_entropy_src_t entropy;
-  EXPECT_EQ(dif_entropy_src_init(dev().region(), &entropy), kDifOk);
-}
-
 class ConfigTest : public DifEntropySrcTest {
  protected:
   dif_entropy_src_config_t config_ = {

--- a/sw/device/lib/dif/dif_gpio.c
+++ b/sw/device/lib/dif/dif_gpio.c
@@ -99,16 +99,6 @@ static dif_result_t gpio_masked_bit_write(const dif_gpio_t *gpio,
   return kDifOk;
 }
 
-dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio) {
-  if (gpio == NULL) {
-    return kDifBadArg;
-  }
-
-  gpio->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_gpio_reset(const dif_gpio_t *gpio) {
   if (gpio == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_gpio.h
+++ b/sw/device/lib/dif/dif_gpio.h
@@ -89,18 +89,6 @@ typedef uint32_t dif_gpio_state_t;
 typedef uint32_t dif_gpio_mask_t;
 
 /**
- * Creates a new handle for GPIO.
- *
- * This function does not actuate the hardware.
- *
- * @param params Hardware instantiation parameters.
- * @param[out] gpio Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio);
-
-/**
  * Resets a GPIO device.
  *
  * Resets the given GPIO device by setting its configuration registers to

--- a/sw/device/lib/dif/dif_gpio_unittest.cc
+++ b/sw/device/lib/dif/dif_gpio_unittest.cc
@@ -25,18 +25,6 @@ uint32_t AllOnesExcept(uint32_t index) { return ~AllZerosExcept(index); }
 // Base class for the test fixtures in this file.
 class GpioTest : public testing::Test, public mock_mmio::MmioTest {};
 
-// Init tests
-class InitTest : public GpioTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Init) {
-  dif_gpio_t gpio;
-  EXPECT_EQ(dif_gpio_init(dev().region(), &gpio), kDifOk);
-}
-
 // Base class for the rest of the tests in this file, provides a
 // `dif_gpio_t` instance.
 class GpioTestInitialized : public GpioTest {

--- a/sw/device/lib/dif/dif_hmac.c
+++ b/sw/device/lib/dif/dif_hmac.c
@@ -39,16 +39,6 @@ static uint32_t get_fifo_available_space(const dif_hmac_t *hmac) {
   return HMAC_MSG_FIFO_SIZE_WORDS - get_fifo_entry_count(hmac);
 }
 
-dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac) {
-  if (hmac == NULL) {
-    return kDifBadArg;
-  }
-
-  hmac->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 /**
  * Sets up the CFG value for a given per-transaction configuration.
  *

--- a/sw/device/lib/dif/dif_hmac.h
+++ b/sw/device/lib/dif/dif_hmac.h
@@ -61,20 +61,6 @@ typedef struct dif_hmac_digest {
 } dif_hmac_digest_t;
 
 /**
- * Initializes the HMAC device described by `config`, writing internal state to
- * `hmac_out`.
- *
- * This function *must* be called on a particular `mmio_region_t` before calling
- * any other functions in this header with that `mmio_region_t`.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] hmac_out The location at which to write HMAC state. This location
- *                 must be valid to write to.
- * @return The result of the operation.
- */
-dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac_out);
-
-/**
  * Resets the HMAC engine and readies it to receive a new message to process an
  * HMAC digest.
  *

--- a/sw/device/lib/dif/dif_i2c.c
+++ b/sw/device/lib/dif/dif_i2c.c
@@ -129,16 +129,6 @@ dif_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
   return kDifOk;
 }
 
-dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c) {
-  if (i2c == NULL) {
-    return kDifBadArg;
-  }
-
-  i2c->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_i2c_configure(const dif_i2c_t *i2c, dif_i2c_config_t config) {
   if (i2c == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_i2c.h
+++ b/sw/device/lib/dif/dif_i2c.h
@@ -258,17 +258,6 @@ typedef enum dif_i2c_fmt {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_i2c_compute_timing(dif_i2c_timing_config_t timing_config,
                                     dif_i2c_config_t *config);
-/**
- * Creates a new handle for I2C.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] i2c Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c);
 
 /**
  * Configures I2C with runtime information.

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -256,16 +256,6 @@ static dif_toggle_t bool_to_toggle(bool val) {
   return val ? kDifToggleEnabled : kDifToggleDisabled;
 }
 
-dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr) {
-  if (keymgr == NULL) {
-    return kDifBadArg;
-  }
-
-  keymgr->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_keymgr_configure(const dif_keymgr_t *keymgr,
                                   dif_keymgr_config_t config) {
   if (keymgr == NULL) {

--- a/sw/device/lib/dif/dif_keymgr.h
+++ b/sw/device/lib/dif/dif_keymgr.h
@@ -24,6 +24,27 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * A typical usage of this library during different secure boot
+ * stages is as follows:
+ *
+ * - In Mask ROM:
+ *   - Create a new handle: `dif_keymgr_init()`.
+ *   - Configure hardware: `dif_keymgr_configure()`.
+ *   - Initialize state: `dif_keymgr_advance_state()`,
+ *   `dif_keymgr_get_status_codes()`, `dif_keymgr_get_state()`.
+ *   - Advance state: `dif_keymgr_advance_state()`,
+ *     `dif_keymgr_get_status_codes()`, `dif_keymgr_get_state()`.
+ * - In subsequent boot stages, i.e. ROM_EXT, BL0, kernel:
+ *   - Create a new handle: `dif_keymgr_init()`.
+ *   - Generate keys and/or identity seeds:
+ *     `dif_keymgr_generate_versioned_key()`,
+ *     `dif_keymgr_generate_identity_seed()`, `dif_keymgr_get_status_codes()`.
+ *   - Read output (if applicable): `dif_keymgr_read_output()`.
+ *   - Advance state: `dif_keymgr_advance_state()`,
+ *     `dif_keymgr_get_status_codes()`, `dif_keymgr_get_state()`.
+ */
+
+/**
  * Enumeration for side load slot clearing.
  */
 typedef enum dif_keymgr_sideload_clr {
@@ -159,37 +180,6 @@ typedef enum dif_keymgr_state {
    */
   kDifKeymgrStateInvalid,
 } dif_keymgr_state_t;
-
-/**
- * Creates a new handle for key manager.
- *
- * This function does not actuate the hardware and must be called to initialize
- * the handle that must be passed to other functions in this library in each
- * boot stage. A typical usage of this library during different secure boot
- * stages is as follows:
- *
- * - In Mask ROM:
- *   - Create a new handle: `dif_keymgr_init()`.
- *   - Configure hardware: `dif_keymgr_configure()`.
- *   - Initialize state: `dif_keymgr_advance_state()`,
- *   `dif_keymgr_get_status_codes()`, `dif_keymgr_get_state()`.
- *   - Advance state: `dif_keymgr_advance_state()`,
- *     `dif_keymgr_get_status_codes()`, `dif_keymgr_get_state()`.
- * - In subsequent boot stages, i.e. ROM_EXT, BL0, kernel:
- *   - Create a new handle: `dif_keymgr_init()`.
- *   - Generate keys and/or identity seeds:
- *     `dif_keymgr_generate_versioned_key()`,
- *     `dif_keymgr_generate_identity_seed()`, `dif_keymgr_get_status_codes()`.
- *   - Read output (if applicable): `dif_keymgr_read_output()`.
- *   - Advance state: `dif_keymgr_advance_state()`,
- *     `dif_keymgr_get_status_codes()`, `dif_keymgr_get_state()`.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] keymgr Out-param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr);
 
 /**
  * Configures key manager with runtime information.

--- a/sw/device/lib/dif/dif_keymgr_unittest.cc
+++ b/sw/device/lib/dif/dif_keymgr_unittest.cc
@@ -142,17 +142,6 @@ INSTANTIATE_TEST_SUITE_P(
       return ss.str();
     });
 
-class InitTest : public DifKeymgrTest {};
-
-TEST_F(InitTest, BadArgs) {
-  EXPECT_EQ(dif_keymgr_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Init) {
-  dif_keymgr_t keymgr;
-  EXPECT_EQ(dif_keymgr_init(dev().region(), &keymgr), kDifOk);
-}
-
 /**
  * Base class for the rest of the tests in this file, provides a
  * `dif_keymgr_t` instance and some methods for common expectations.

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -138,16 +138,6 @@ static bool is_state_squeeze(const dif_kmac_t *kmac) {
   return bitfield_bit32_read(reg, KMAC_STATUS_SHA3_SQUEEZE_BIT);
 }
 
-dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac) {
-  if (kmac == NULL) {
-    return kDifBadArg;
-  }
-
-  kmac->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_kmac_configure(dif_kmac_t *kmac, dif_kmac_config_t config) {
   if (kmac == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -384,18 +384,6 @@ typedef enum dif_kmac_fifo_state {
 } dif_kmac_fifo_state_t;
 
 /**
- * Creates a new handle for KMAC.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] kmac Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac);
-
-/**
  * Configures KMAC with runtime information.
  *
  * @param kmac A KMAC handle.

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -23,15 +23,6 @@ enum {
   kLcCtrlMutexRelease = 0,
 };
 
-dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc) {
-  if (lc == NULL) {
-    return kDifBadArg;
-  }
-
-  lc->base_addr = base_addr;
-  return kDifOk;
-}
-
 dif_result_t dif_lc_ctrl_get_state(const dif_lc_ctrl_t *lc,
                                    dif_lc_ctrl_state_t *state) {
   if (lc == NULL || state == NULL) {

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -318,18 +318,6 @@ typedef enum dif_lc_ctrl_alert {
 } dif_lc_ctrl_alert_t;
 
 /**
- * Creates a new handle for the lifecycle controller.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Base address of the UART peripheral.
- * @param[out] lc Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc);
-
-/**
  * Returns the current state of the lifecycle controller.
  *
  * @param lc A lifecycle handle.

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -27,17 +27,6 @@ class LcCtrlTest : public Test, public MmioTest {
   dif_lc_ctrl_t lc_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public LcCtrlTest {};
-
-TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, &lc_), kDifOk);
-}
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
-}
-
 class StateTest : public LcCtrlTest {};
 
 TEST_F(StateTest, GetState) {

--- a/sw/device/lib/dif/dif_otbn.c
+++ b/sw/device/lib/dif/dif_otbn.c
@@ -67,17 +67,6 @@ static bool check_offset_len(uint32_t offset_bytes, size_t len_bytes,
           offset_bytes + len_bytes <= mem_size);
 }
 
-dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn) {
-  if (otbn == NULL) {
-    return kDifBadArg;
-  }
-
-  otbn->base_addr = base_addr;
-  dif_otbn_reset(otbn);
-
-  return kDifOk;
-}
-
 dif_result_t dif_otbn_reset(const dif_otbn_t *otbn) {
   if (otbn == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_otbn.h
+++ b/sw/device/lib/dif/dif_otbn.h
@@ -78,19 +78,6 @@ typedef enum dif_otbn_err_bits {
 } dif_otbn_err_bits_t;
 
 /**
- * Initialize a OTBN device using `config` and return its internal state.
- *
- * A particular OTBN device must first be initialized by this function
- * before calling other functions of this library.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] otbn OTBN instance that will store the internal state of the
- *             initialized OTBN device.
- * @return The result of the operation.
- */
-dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn);
-
-/**
  * Reset OTBN device.
  *
  * Resets the given OTBN device by setting its configuration registers to

--- a/sw/device/lib/dif/dif_otbn_unittest.cc
+++ b/sw/device/lib/dif/dif_otbn_unittest.cc
@@ -27,23 +27,8 @@ class OtbnTest : public Test, public MmioTest {
                    std::numeric_limits<uint32_t>::max());
   }
 
-  mmio_region_t base_addr_ = dev().region();
-  dif_otbn_t dif_otbn_ = {
-      /* base_addr = */ base_addr_,
-  };
+  dif_otbn_t dif_otbn_ = {.base_addr = dev().region()};
 };
-
-class InitTest : public OtbnTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_init(base_addr_, nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Default) {
-  ExpectDeviceReset();
-
-  EXPECT_EQ(dif_otbn_init(base_addr_, &dif_otbn_), kDifOk);
-}
 
 class ResetTest : public OtbnTest {};
 

--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -12,16 +12,6 @@
 
 #include "otp_ctrl_regs.h"  // Generated.
 
-dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr, dif_otp_ctrl_t *otp) {
-  if (otp == NULL) {
-    return kDifBadArg;
-  }
-
-  otp->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 /**
  * Checks if integrity/consistency-check-related operations are locked.
  *

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -290,18 +290,6 @@ typedef struct dif_otp_ctrl_status {
 } dif_otp_ctrl_status_t;
 
 /**
- * Creates a new handle for OTP.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] otp Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr, dif_otp_ctrl_t *otp);
-
-/**
  * Configures OTP with runtime information.
  *
  * This function should need to be called at most once for the lifetime of

--- a/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
@@ -27,17 +27,6 @@ class OtpTest : public testing::Test, public MmioTest {
   dif_otp_ctrl_t otp_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public OtpTest {};
-
-TEST_F(InitTest, Success) {
-  dif_otp_ctrl_t handler;
-  EXPECT_EQ(dif_otp_ctrl_init(dev().region(), &handler), kDifOk);
-}
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_otp_ctrl_init(dev().region(), nullptr), kDifBadArg);
-}
-
 class ConfigTest : public OtpTest {};
 
 TEST_F(ConfigTest, Basic) {

--- a/sw/device/lib/dif/dif_pinmux.h
+++ b/sw/device/lib/dif/dif_pinmux.h
@@ -269,18 +269,6 @@ typedef struct dif_pinmux_wakeup_timed_config {
 } dif_pinmux_wakeup_timed_config_t;
 
 /**
- * Creates a new handle for a Pin Multiplexer.
- *
- * This function does not actuate the hardware.
- *
- * @param params Hardware instantiation parameters.
- * @param[out] pinmux Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_pinmux_init(mmio_region_t base_addr, dif_pinmux_t *pinmux);
-
-/**
  * Locks out Pin Multiplexer functionality based on the `target` and `index`.
  *
  * This function allows for a fine grained locking of the Pin Multiplexer

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -242,16 +242,6 @@ static bool request_sources_is_locked(const dif_pwrmgr_t *pwrmgr,
   return !bitfield_bit32_read(reg_val, reg_info.write_enable_bit_index);
 }
 
-dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr) {
-  if (pwrmgr == NULL) {
-    return kDifBadArg;
-  }
-
-  pwrmgr->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_pwrmgr_low_power_set_enabled(const dif_pwrmgr_t *pwrmgr,
                                               dif_toggle_t new_state) {
   if (pwrmgr == NULL) {

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -184,18 +184,6 @@ typedef enum dif_pwrmgr_alert {
 } dif_pwrmgr_alert_t;
 
 /**
- * Creates a new handle for power manager.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] pwrmgr Out-param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr);
-
-/**
  * Enables or disables low power state.
  *
  * When enabled, the power manager transitions to low power state on the next

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -35,22 +35,9 @@ static constexpr dif_pwrmgr_domain_config_t kBadConfig =
 static constexpr dif_pwrmgr_request_sources_t kBadSources =
     std::numeric_limits<uint32_t>::max();
 
-class DifPwrmgrTest : public testing::Test, public mock_mmio::MmioTest {};
-
-class InitTest : public DifPwrmgrTest {};
-
-TEST_F(InitTest, BadArgs) {
-  EXPECT_EQ(dif_pwrmgr_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Init) {
-  dif_pwrmgr_t pwrmgr;
-  EXPECT_EQ(dif_pwrmgr_init(dev().region(), &pwrmgr), kDifOk);
-}
-
 // Base class for the rest of the tests in this file, provides a
 // `dif_pwrmgr_t` instance.
-class DifPwrmgrInitialized : public DifPwrmgrTest {
+class DifPwrmgrInitialized : public testing::Test, public mock_mmio::MmioTest {
  protected:
   /**
    * Expectations for functions that need to sync data to slow clock domain.

--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -88,16 +88,6 @@ static void rstmgr_reset_info_clear(mmio_region_t base_addr) {
   mmio_region_write32(base_addr, RSTMGR_RESET_INFO_REG_OFFSET, UINT32_MAX);
 }
 
-dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *handle) {
-  if (handle == NULL) {
-    return kDifBadArg;
-  }
-
-  handle->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_rstmgr_reset(const dif_rstmgr_t *handle) {
   if (handle == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -88,18 +88,6 @@ typedef enum dif_rstmgr_reset_info {
 typedef uint32_t dif_rstmgr_peripheral_t;
 
 /**
- * Creates a new handle for Reset Manager.
- *
- * This function does not actuate the hardware.
- *
- * @param params Hardware instantiation parameters.
- * @param handle Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *handle);
-
-/**
  * Resets the Reset Manager registers to sane defaults.
  *
  * Note that software reset enable registers cannot be cleared once have been

--- a/sw/device/lib/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_rstmgr_unittest.cc
@@ -27,17 +27,6 @@ class RstmgrTest : public Test, public MmioTest {
   dif_rstmgr_t rstmgr_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public RstmgrTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rstmgr_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Success) {
-  dif_rstmgr_t rstmgr;
-  EXPECT_EQ(dif_rstmgr_init(dev().region(), &rstmgr), kDifOk);
-}
-
 class ResetTest : public RstmgrTest {};
 
 TEST_F(ResetTest, NullArgs) {

--- a/sw/device/lib/dif/dif_rv_plic.c
+++ b/sw/device/lib/dif/dif_rv_plic.c
@@ -149,16 +149,6 @@ dif_result_t dif_rv_plic_reset(const dif_rv_plic_t *plic) {
   return kDifOk;
 }
 
-dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *plic) {
-  if (plic == NULL) {
-    return kDifBadArg;
-  }
-
-  plic->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_rv_plic_irq_get_enabled(const dif_rv_plic_t *plic,
                                          dif_rv_plic_irq_id_t irq,
                                          dif_rv_plic_target_t target,

--- a/sw/device/lib/dif/dif_rv_plic.h
+++ b/sw/device/lib/dif/dif_rv_plic.h
@@ -66,18 +66,6 @@ typedef uint32_t dif_rv_plic_irq_id_t;
 typedef uint32_t dif_rv_plic_target_t;
 
 /**
- * Creates a new handle for PLIC.
- *
- * This function does not actuate the hardware.
- *
- * @param params Hardware instantiation parameters.
- * @param[out] plic Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *plic);
-
-/**
  * Resets the PLIC to a clean state.
  *
  *

--- a/sw/device/lib/dif/dif_rv_plic_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_plic_unittest.cc
@@ -33,16 +33,6 @@ class PlicTest : public Test, public MmioTest {
   dif_rv_plic_t plic_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public PlicTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_init(dev().region(), nullptr), kDifBadArg);
-}
-
-TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rv_plic_init(dev().region(), &plic_), kDifOk);
-}
-
 class ResetTest : public PlicTest {
  protected:
   void ExpectReset() {

--- a/sw/device/lib/dif/dif_rv_timer.c
+++ b/sw/device/lib/dif/dif_rv_timer.c
@@ -36,17 +36,6 @@ static ptrdiff_t reg_for_hart(uint32_t hart, ptrdiff_t reg_offset) {
   return kHartRegisterSpacing * hart + reg_offset;
 }
 
-dif_result_t dif_rv_timer_init(mmio_region_t base_addr,
-                               dif_rv_timer_t *timer_out) {
-  if (timer_out == NULL) {
-    return kDifBadArg;
-  }
-
-  timer_out->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 /**
  * A naive implementation of the Euclidean algorithm by repeated remainder.
  */

--- a/sw/device/lib/dif/dif_rv_timer.h
+++ b/sw/device/lib/dif/dif_rv_timer.h
@@ -85,19 +85,6 @@ dif_result_t dif_rv_timer_approximate_tick_params(
     dif_rv_timer_tick_params_t *out);
 
 /**
- * Initialize a RISC-V timer device with the given configuration.
- *
- * This function will deactivate all counters and reset all timers, which should
- * each be configured and turned on manually after this function returns.
- *
- * @param base_addr MMIO region for the device hardware registers.
- * @param[out] timer_out The timer device.
- * @return The result of the operation.
- */
-dif_result_t dif_rv_timer_init(mmio_region_t base_addr,
-                               dif_rv_timer_t *timer_out);
-
-/**
  * Completely resets a timer device, disabling all IRQs, counters, and
  * comparators.
  *

--- a/sw/device/lib/dif/dif_rv_timer_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_timer_unittest.cc
@@ -113,16 +113,6 @@ ptrdiff_t IrqRegForHart(uint32_t hart, uint32_t comparators,
 
 constexpr uint32_t kAllOnes = std::numeric_limits<uint32_t>::max();
 
-class InitTest : public TimerTest {};
-
-TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rv_timer_init(dev().region(), &rv_timer_), kDifOk);
-}
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_timer_init(dev().region(), nullptr), kDifBadArg);
-}
-
 class ResetTest : public TimerTest {};
 
 TEST_F(ResetTest, Success) {

--- a/sw/device/lib/dif/dif_spi_device.c
+++ b/sw/device/lib/dif/dif_spi_device.c
@@ -12,17 +12,6 @@
 
 const uint16_t kDifSpiDeviceBufferLen = SPI_DEVICE_BUFFER_SIZE_BYTES;
 
-dif_result_t dif_spi_device_init(mmio_region_t base_addr,
-                                 dif_spi_device_t *spi) {
-  if (spi == NULL) {
-    return kDifBadArg;
-  }
-
-  spi->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 /**
  * Computes the required value of the control register from a given
  * configuration.

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -87,19 +87,6 @@ typedef struct dif_spi_device_config {
 extern const uint16_t kDifSpiDeviceBufferLen;
 
 /**
- * Creates a new handle for SPI.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] spi Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_init(mmio_region_t base_addr,
-                                 dif_spi_device_t *spi);
-
-/**
  * Configures SPI with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.

--- a/sw/device/lib/dif/dif_sram_ctrl.c
+++ b/sw/device/lib/dif/dif_sram_ctrl.c
@@ -28,17 +28,6 @@ static uint32_t sram_ctrl_get_status(const dif_sram_ctrl_t *sram_ctrl) {
   return mmio_region_read32(sram_ctrl->base_addr, SRAM_CTRL_STATUS_REG_OFFSET);
 }
 
-dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
-                                dif_sram_ctrl_t *sram_ctrl) {
-  if (sram_ctrl == NULL) {
-    return kDifBadArg;
-  }
-
-  sram_ctrl->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_sram_ctrl_request_new_key(const dif_sram_ctrl_t *sram_ctrl) {
   if (sram_ctrl == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_sram_ctrl.h
+++ b/sw/device/lib/dif/dif_sram_ctrl.h
@@ -94,19 +94,6 @@ typedef enum dif_sram_ctrl_lock {
 } dif_sram_ctrl_lock_t;
 
 /**
- * Creates a new handle for SRAM Controller.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr The MMIO base address of the IP.
- * @param[out] sram_ctrl Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
-                                dif_sram_ctrl_t *sram_ctrl);
-
-/**
  * Performs SRAM scrambling.
  *
  * This function should only be called when the data is no longer used.

--- a/sw/device/lib/dif/dif_sram_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sram_ctrl_unittest.cc
@@ -22,12 +22,6 @@ class SramCtrlTest : public Test, public MmioTest {
   dif_sram_ctrl_t sram_ctrl_ = {.base_addr = dev().region()};
 };
 
-class InitTest : public SramCtrlTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_sram_ctrl_init(dev().region(), nullptr), kDifBadArg);
-}
-
 class RequestNewKeyTest : public SramCtrlTest {};
 
 TEST_F(RequestNewKeyTest, NullArgs) {

--- a/sw/device/lib/dif/dif_uart.c
+++ b/sw/device/lib/dif/dif_uart.c
@@ -86,15 +86,6 @@ static size_t uart_bytes_receive(const dif_uart_t *uart, size_t bytes_requested,
   return bytes_read;
 }
 
-dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart) {
-  if (uart == NULL) {
-    return kDifBadArg;
-  }
-
-  uart->base_addr = base_addr;
-  return kDifOk;
-}
-
 dif_result_t dif_uart_configure(const dif_uart_t *uart,
                                 dif_uart_config_t config) {
   if (uart == NULL) {

--- a/sw/device/lib/dif/dif_uart.h
+++ b/sw/device/lib/dif/dif_uart.h
@@ -123,18 +123,6 @@ typedef enum dif_uart_loopback {
 extern const uint32_t kDifUartFifoSizeBytes;
 
 /**
- * Creates a new handle for UART.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr Base address of the UART peripheral.
- * @param[out] uart Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart);
-
-/**
  * Configures UART with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.

--- a/sw/device/lib/dif/dif_uart_unittest.cc
+++ b/sw/device/lib/dif/dif_uart_unittest.cc
@@ -55,12 +55,6 @@ class UartTest : public Test, public MmioTest {
   };
 };
 
-class InitTest : public UartTest {};
-
-TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_uart_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
-}
-
 class ConfigTest : public UartTest {};
 
 TEST_F(ConfigTest, NullArgs) {

--- a/sw/device/lib/dif/dif_usbdev.c
+++ b/sw/device/lib/dif/dif_usbdev.c
@@ -232,16 +232,6 @@ static uint32_t get_buffer_addr(uint8_t buffer_id, size_t offset) {
  * USBDEV DIF library functions.
  */
 
-dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev) {
-  if (usbdev == NULL) {
-    return kDifBadArg;
-  }
-
-  usbdev->base_addr = base_addr;
-
-  return kDifOk;
-}
-
 dif_result_t dif_usbdev_configure(const dif_usbdev_t *usbdev,
                                   dif_usbdev_buffer_pool_t *buffer_pool,
                                   dif_usbdev_config_t config) {

--- a/sw/device/lib/dif/dif_usbdev.h
+++ b/sw/device/lib/dif/dif_usbdev.h
@@ -140,19 +140,6 @@ typedef struct dif_usbdev_config {
 } dif_usbdev_config_t;
 
 /**
- * Initialize a USB device.
- *
- * A USB device must first be initialized by this function before calling other
- * functions in this library.
- *
- * @param base_addr Hardware instantiation base address.
- * @param[out] usbdev The initialized USB device handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev);
-
-/**
  * Configures a USB device with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.

--- a/util/make_new_dif/dif_autogen.h.tpl
+++ b/util/make_new_dif/dif_autogen.h.tpl
@@ -50,8 +50,21 @@ typedef struct dif_${ip.name_snake} {
   mmio_region_t base_addr;
 } dif_${ip.name_snake}_t;
 
-% if len(ip.irqs) > 0:
+/**
+ * Creates a new handle for a(n) ${ip.name_snake} peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the ${ip.name_snake} peripheral.
+ * @param[out] ${ip.name_snake} Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_${ip.name_snake}_init(
+  mmio_region_t base_addr,
+  dif_${ip.name_snake}_t *${ip.name_snake});
 
+% if len(ip.irqs) > 0:
   /**
    * A ${ip.name_snake} interrupt request type.
    */

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -12,7 +12,6 @@
     This template requires the following Python objects to be passed:
 
     1. ip: See util/make_new_dif.py for the definition of the `ip` obj.
-    2. list[irq]: See util/make_new_dif.py for the definition of the `irq` obj.
 </%doc>
 
 // This file is auto-generated.
@@ -29,6 +28,7 @@ namespace dif_${ip.name_snake}_autogen_unittest {
 namespace {
   using ::mock_mmio::MmioTest;
   using ::mock_mmio::MockDevice;
+  using ::testing::Eq;
   using ::testing::Test;
 
   class ${ip.name_camel}Test : public Test, public MmioTest {
@@ -36,9 +36,23 @@ namespace {
     dif_${ip.name_snake}_t ${ip.name_snake}_ = {.base_addr = dev().region()};
   };
 
-% if len(ip.irqs) > 0:
-  using ::testing::Eq;
+  class InitTest : public ${ip.name_camel}Test {};
 
+  TEST_F(InitTest, NullArgs) {
+    EXPECT_EQ(dif_${ip.name_snake}_init(
+        {.base_addr = dev().region()},
+        nullptr),
+      kDifBadArg);
+  }
+
+  TEST_F(InitTest, Success) {
+    EXPECT_EQ(dif_${ip.name_snake}_init(
+        {.base_addr = dev().region()},
+        &${ip.name_snake}_),
+      kDifOk);
+  }
+
+% if len(ip.irqs) > 0:
   class IrqGetStateTest : public ${ip.name_camel}Test {};
 
   TEST_F(IrqGetStateTest, NullArgs) {

--- a/util/make_new_dif/dif_template.h.tpl
+++ b/util/make_new_dif/dif_template.h.tpl
@@ -68,20 +68,6 @@ typedef struct dif_${ip.name_snake}_output {
 } dif_${ip.name_snake}_output_t;
 
 /**
- * Creates a new handle for ${ip.name_long_lower}.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr The MMIO base address of the IP.
- * @param[out] ${ip.name_snake} Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_${ip.name_snake}_init(
-  mmio_region_t base_addr,
-  dif_${ip.name_snake}_t *${ip.name_snake});
-
-/**
  * Configures ${ip.name_long_lower} with runtime information.
  *
  * This function should only need to be called once for the lifetime of


### PR DESCRIPTION
This is the last task that fixes #8409.

Specifically, this PR:
1. updates the DIF autogen templates to auto-generate the `dif_<ip>_init()` DIF and corresponding unit tests for all IPs,
2. re-auto-generates all IP's (autogen'd) DIFs, and
3. deprecates all manually defined `dif_<ip>_init()` DIFs and unit tests.

Note, this PR appears to be quite large (it touches a lot of files) because the added code is all auto-generated from the included template changes, and the removed code is deletions of manually implemented DIFs that are now auto-generated. Unfortunately, due to CI checks for auto-generated code, this had to be contained in the same PR.