### PR TITLE
[dif] Fix autogen DIFs dependency architecture.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_aes_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/dif/autogen/dif_aes_autogen.h"
 
 #include "aes_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/dif/autogen/dif_aes_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/autogen/dif_alert_handler_autogen.h"
 
 #include "alert_handler_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/autogen/dif_alert_handler_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/autogen/dif_aon_timer_autogen.h"
 
 #include "aon_timer_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/autogen/dif_aon_timer_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/autogen/dif_clkmgr_autogen.h"
 
 #include "clkmgr_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/autogen/dif_clkmgr_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/autogen/dif_csrng_autogen.h"
 
 #include "csrng_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_csrng.h"
+#include "sw/device/lib/dif/autogen/dif_csrng_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/autogen/dif_edn_autogen.h"
 
 #include "edn_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_edn.h"
+#include "sw/device/lib/dif/autogen/dif_edn_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/autogen/dif_entropy_src_autogen.h"
 
 #include "entropy_src_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_entropy_src.h"
+#include "sw/device/lib/dif/autogen/dif_entropy_src_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/autogen/dif_gpio_autogen.h"
 
 #include "gpio_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_gpio.h"
+#include "sw/device/lib/dif/autogen/dif_gpio_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/dif/autogen/dif_hmac_autogen.h"
 
 #include "hmac_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/dif/autogen/dif_hmac_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/dif/autogen/dif_i2c_autogen.h"
 
 #include "i2c_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_i2c.h"
+#include "sw/device/lib/dif/autogen/dif_i2c_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/autogen/dif_keymgr_autogen.h"
 
 #include "keymgr_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/autogen/dif_keymgr_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/dif/autogen/dif_kmac_autogen.h"
 
 #include "kmac_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/dif/autogen/dif_kmac_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h"
 
 #include "lc_ctrl_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/dif/autogen/dif_otbn_autogen.h"
 
 #include "otbn_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_otbn.h"
+#include "sw/device/lib/dif/autogen/dif_otbn_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/autogen/dif_pinmux_autogen.h"
 
 #include "pinmux_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_pinmux.h"
+#include "sw/device/lib/dif/autogen/dif_pinmux_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h"
 
 #include "pwrmgr_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/autogen/dif_rstmgr_autogen.h"
 
 #include "rstmgr_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/autogen/dif_rstmgr_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/autogen/dif_rv_plic_autogen.h"
 
 #include "rv_plic_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/autogen/dif_rv_plic_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/dif/autogen/dif_spi_device_autogen.h"
 
 #include "spi_device_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_spi_device.h"
+#include "sw/device/lib/dif/autogen/dif_spi_device_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
@@ -4,6 +4,6 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_sram_ctrl.h"
+#include "sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h"
 
 #include "sram_ctrl_regs.h"  // Generated.

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_sram_ctrl.h"
+#include "sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/dif/autogen/dif_uart_autogen.h"
 
 #include "uart_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/dif/autogen/dif_uart_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_usbdev.h"
+#include "sw/device/lib/dif/autogen/dif_usbdev_autogen.h"
 
 #include "usbdev_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_usbdev.h"
+#include "sw/device/lib/dif/autogen/dif_usbdev_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"

--- a/util/make_new_dif/dif_autogen.c.tpl
+++ b/util/make_new_dif/dif_autogen.c.tpl
@@ -26,7 +26,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_${ip.name_snake}.h"
+#include "sw/device/lib/dif/autogen/dif_${ip.name_snake}_autogen.h"
 
 #include "${ip.name_snake}_regs.h"  // Generated.
 

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -17,7 +17,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_${ip.name_snake}.h"
+#include "sw/device/lib/dif/autogen/dif_${ip.name_snake}_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"


### PR DESCRIPTION
This fixes #8755.

The dependency architecture of the auto-genenerated DIFs does not match that described in #8142. Specifically, auto-generated C/C++ files,
`dif_<ip>_autogen.c` and `dif_<ip>_autogen_unittest.cc`, should #include
auto-generated header files, `dif_<ip>_autogen.h`, **_not_** the manually
implemented header files.

Signed-off-by: Timothy Trippel <ttrippel@google.com>