### PR TITLE
[doc] Add a note about PATH to OTBN software user guide

### DIFF
--- a/doc/ug/otbn_sw.md
+++ b/doc/ug/otbn_sw.md
@@ -26,6 +26,8 @@ This has the same command line interface as `riscv32-unknown-elf-as` (indeed, it
 The only difference in default flags is that `otbn-as` passes `-mno-relax`, telling the assembler not to request linker relaxation.
 This is needed because one of these relaxations generates GP-relative loads, which assume `x3` is treated as a global pointer (not true for OTBN code).
 
+You may need to add `/tools/riscv/bin` to your `PATH` to make `riscv32-unknown-elf-as` visible.
+
 To assemble some code in `foo.s` to an ELF object called `foo.o`, run:
 ```shell
 hw/ip/otbn/util/otbn-as -o foo.o foo.s


### PR DESCRIPTION
Just a quick note from my going through the user guides. The install instructions currently don't say to add `/tools/riscv/bin` to your `PATH`, so if you follow those instructions you need to add it before `otbn-as` and `otbn-ld` will work.