### PR TITLE
[otbn,dv] Directly signal an expected alert in IMEM error sequence

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -63,6 +63,7 @@ class otbn_env extends cip_base_env #(
     super.connect_phase(phase);
     model_agent.monitor.analysis_port.connect(scoreboard.model_fifo.analysis_export);
     trace_monitor.analysis_port.connect(scoreboard.trace_fifo.analysis_export);
+    cfg.scoreboard = scoreboard;
   endfunction
 
   function void final_phase(uvm_phase phase);

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -22,6 +22,9 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   mem_bkdr_util imem_util;
   mem_bkdr_util dmem_util;
 
+  // A handle to the scoreboard, used to flag expected errors.
+  otbn_scoreboard scoreboard;
+
   // The directory in which to look for ELF files (set by the test in build_phase; controlled by the
   // +otbn_elf_dir plusarg).
   string otbn_elf_dir;

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -91,6 +91,9 @@ package otbn_env_pkg;
     AccessSoftwareWrite
   } access_e;
 
+  // Forward declaration to allow the config to hold a scoreboard handle.
+  typedef class otbn_scoreboard;
+
   parameter int ImemIndexWidth = vbits(int'(otbn_reg_pkg::OTBN_IMEM_SIZE) / 4);
   parameter int DmemIndexWidth = vbits(int'(otbn_reg_pkg::OTBN_DMEM_SIZE) / 32);
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -276,10 +276,6 @@ class otbn_scoreboard extends cip_base_scoreboard #(
             pending_start_tl_trans = 1'b0;
           end
           model_status = item.status;
-          // If the model status is locked, the scoreboard should expect a fatal error.
-          if (model_status == otbn_pkg::StatusLocked) begin
-            set_exp_alert("fatal", .is_fatal(1));
-          end
         end
 
         OtbnModelInsn: begin

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -92,6 +92,7 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     end
 
     cfg.model_agent_cfg.vif.invalidate_imem <= 1'b1;
+    cfg.scoreboard.set_exp_alert(.alert_name("fatal"), .is_fatal(1'b1));
     @(cfg.clk_rst_vif.cb);
     cfg.model_agent_cfg.vif.invalidate_imem <= 1'b0;
 


### PR DESCRIPTION
We were picking this up from the STATUS register, but commit 6386c75
has delayed that by a cycle, so we don't spot the impending error in
time. Arguably, that wasn't really the right way to do it anyway,
since we should be setting up an expected alert when we see the bad
thing happen, not a response to it.

Copy the clkmgr DV environment and poke the scoreboard directly from
the vseq. Another way to do things would be to monitor a "fatal error
interface", but that seems a bit round-about.