### PR TITLE
[csrng/rtl] fix for fips status on reseed command

### DIFF
--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -341,7 +341,7 @@ The actions performed by each command, as well as which flags are supported, are
     <td>Reseed</td>
     <td>0x2</td>
     <td> Reseeds an existing instance in CSRNG.
-         The flag0 and clen table in the <tt>Instance<tt> command description above also applies to the <tt>Reseed<tt> command.
+         The flag0 and clen table in the <tt>Instance</tt> command description above also applies to the <tt>Reseed</tt> command.
          Note that the last table entry (<tt>flag0</tt> is set and <tt>clen</tt> is set to non-zero) is intended for known answer testing (KAT).
          The reseed command only takes in one group (a maximum of twelve 32 bit words) of generic additional data.
          In that case that both a seed and additional data must be provided to the reseed call, the seed and additional data must be xor'ed first.

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -157,8 +157,9 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .depth_o        ()
   );
 
-  assign fips_modified = (ctr_drbg_cmd_ccmd_i == INS) ? ctr_drbg_cmd_entropy_fips_i :
-         ctr_drbg_cmd_fips_i;
+  assign fips_modified = ((ctr_drbg_cmd_ccmd_i == INS) ||
+                          (ctr_drbg_cmd_ccmd_i == RES)) ? ctr_drbg_cmd_entropy_fips_i :
+                         ctr_drbg_cmd_fips_i;
 
   assign sfifo_cmdreq_wdata = {ctr_drbg_cmd_key_i,ctr_drbg_cmd_v_i,
                                ctr_drbg_cmd_rc_i,fips_modified,

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -172,10 +172,15 @@ module csrng_main_sm import csrng_pkg::*; (
         if (!enable_i) begin
           state_d = Idle;
         end else begin
-          cmd_entropy_req_o = 1'b1;
-          // assumes all adata is present now
-          if (cmd_entropy_avail_i) begin
-            state_d = ReseedReq;
+          if (flag0_i) begin
+            // assumes all adata is present now
+            state_d = InstantReq;
+          end else begin
+            // delay one clock to fix timing issue
+            cmd_entropy_req_o = 1'b1;
+            if (cmd_entropy_avail_i) begin
+              state_d = ReseedReq;
+            end
           end
         end
       end


### PR DESCRIPTION
A bug exists where the reseed command does not handle entropy seed fetching the same way as the instantiate command, and it should.
This change makes them behave the same.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>