### PR TITLE
[otbn,dv] Correct an assertion in BadBranch generator

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/bad_branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_branch.py
@@ -110,7 +110,7 @@ class BadBranch(SnippetGen):
         elif mode <= 3 and program.imem_size <= max_addr:
             tgt_addr = max_addr
         else:
-            assert mode <= 3
+            assert mode <= 4
             tgt_addr = random.randrange(min_addr + 2, max_addr, 4)
         off_enc = self.imm_op_type.op_val_to_enc_val(tgt_addr, model.pc)
 


### PR DESCRIPTION
We mis-counted the number of branches!

To all reviewers: this typo will cause quite a lot of failures in the overnight OTBN regression suite. Assuming it passes CI (which it jolly well should!), please feel free to merge if approved. I'm going to stop for the evening soon and it would be nice if it went in.

@prajwalaputtappa: I know that you've got a pending change that will re-write this anyway, but thought it might be worth trying to get the overnight test clean(er) tonight!