### PR TITLE
[otbn,dv] Maybe use IRQ to detect end instead of polling STATUS

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -36,6 +36,15 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   // than generating memory transactions?
   int unsigned backdoor_load_pct = 50;
 
+  // How often should sequences enable interrupts?
+  int unsigned enable_interrupts_pct = 50;
+
+  // If a previous sequence triggered an interrupt, should we clear it again before we start?
+  int unsigned clear_irq_pct = 90;
+
+  // How often should we poll STATUS to detect completion, even though interrupts are enabled?
+  int unsigned poll_despite_interrupts_pct = 10;
+
   // The hierarchical scope of the DUT instance in the testbench. This is used when constructing the
   // DPI wrapper (in otbn_env::build_phase) to tell it where to find the DUT for backdoor loading
   // memories. The default value matches the block-level testbench, but it can be overridden in a

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_multi_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_multi_vseq.sv
@@ -26,14 +26,25 @@ class otbn_multi_vseq extends otbn_base_vseq;
 
     for (int i = 0; i < 10; i++) begin
       bit rerun = (i == 0) ? 1'b0 : ($urandom_range(100) <= rerun_pct);
+      bit enable_interrupts = $urandom_range(100) < cfg.enable_interrupts_pct;
+      bit irq_pin_high = cfg.intr_vif.sample_pin(0);
+      bit clear_status = irq_pin_high ? ($urandom_range(100) < cfg.clear_irq_pct) : 1'b0;
 
-      if (rerun) begin
-        `uvm_info(`gfn, $sformatf("Re-using OTBN binary at `%0s'", elf_path), UVM_LOW)
-      end else begin
-        elf_path = pick_elf_path();
-        `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
-        load_elf(elf_path, 1'b0);
-      end
+      fork
+        cfg_interrupts(enable_interrupts);
+        if (clear_status) begin
+          csr_utils_pkg::csr_wr(.ptr(ral.intr_state), .value(32'h1));
+        end
+        begin
+          if (rerun) begin
+            `uvm_info(`gfn, $sformatf("Re-using OTBN binary at `%0s'", elf_path), UVM_LOW)
+          end else begin
+            elf_path = pick_elf_path();
+            `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+            load_elf(elf_path, 1'b0);
+          end
+        end
+      join
 
       run_otbn();      
     end

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -19,10 +19,14 @@ class otbn_single_vseq extends otbn_base_vseq;
 
   task body();
     string elf_path = pick_elf_path();
+    bit    enable_interrupts = $urandom_range(100) < cfg.enable_interrupts_pct;
 
-    // Actually load the binary
+    // Load the binary and (if required) enable interrupts. These run in parallel
     `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
-    load_elf(elf_path, do_backdoor_load);
+    fork
+      load_elf(elf_path, do_backdoor_load);
+      cfg_interrupts(enable_interrupts);
+    join
 
     // We've loaded the binary. Run the processor to see what happens!
     run_otbn();


### PR DESCRIPTION
Configuring this goes in two steps: firstly, you have to write to the
enable register. There's an `enable_interrupts_pct` knob that sequences
that care can get from the environment config to spot that it is
needed.

Then the `run_otbn()` task in the base class chooses whether to use
interrupts or polling, based on whether interrupts are enabled (if
not, it will poll!) and `poll_despite_interrupts_pct`.

This is the "UVM side" of https://github.com/lowRISC/opentitan/issues/4839.