### PR TITLE
[otbn,dv] Add otbn_imem_err to the "core" regression

### DIFF
--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -196,7 +196,9 @@ name:
 
     {
       name: "core"
-      tests: ["otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset", "otbn_multi_err"]
+      tests: [
+        "otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset", "otbn_multi_err", "otbn_imem_err"
+      ]
     }
   ]
 }


### PR DESCRIPTION
These sequences are the intended to be the ones that run code and we
forgot to add `otbn_imem_err` when defining it.
