### PR TITLE
[dv/full_chip] Expand aon_timer testutils

### DIFF
--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -27,5 +27,23 @@ void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
       aon_timer, kDifAonTimerIrqWkupTimerExpired, &is_pending));
   CHECK(!is_pending);
 
+  // Set prescaler to zero.
   CHECK_DIF_OK(dif_aon_timer_wakeup_start(aon_timer, cycles, 0));
+}
+
+void aon_timer_testutils_watchdog_config(dif_aon_timer_t *aon_timer,
+                                         uint32_t bark_cycles,
+                                         uint32_t bite_cycles) {
+  // Make sure that watchdog timer is stopped.
+  CHECK_DIF_OK(dif_aon_timer_watchdog_stop(aon_timer));
+
+  // Make sure the watchdog IRQ is cleared to avoid false positive.
+  CHECK_DIF_OK(
+      dif_aon_timer_irq_acknowledge(aon_timer, kDifAonTimerIrqWdogTimerBark));
+  bool is_pending;
+  CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
+      aon_timer, kDifAonTimerIrqWdogTimerBark, &is_pending));
+  CHECK(!is_pending);
+  CHECK_DIF_OK(dif_aon_timer_watchdog_start(aon_timer, bark_cycles, bite_cycles,
+                                            false, false));
 }

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -10,10 +10,22 @@
 #include "sw/device/lib/dif/dif_aon_timer.h"
 
 /**
- * Set an aon timer for a number of AON clock cycles.
+ * Configure wakeup counter for a number of AON clock cycles.
  * @param cycles The number of AON clock cycles.
  */
 void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
                                        uint32_t cycles);
+
+/**
+ * Configure watchdog counter in number of AON clock cycles.
+ *
+ * The watchdog counter is set without locking it, and configured so it doesn't
+ * pause for low power.
+ * @param bark_cycles The number of AON clock cycles till barking.
+ * @param bite_cycles The number of AON clock cycles till biting.
+ */
+void aon_timer_testutils_watchdog_config(dif_aon_timer_t *aon_timer,
+                                         uint32_t bark_cycles,
+                                         uint32_t bite_cycles);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_AON_TIMER_TESTUTILS_H_

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -309,6 +309,7 @@ aon_timer_smoketest_lib = declare_dependency(
     sources: ['aon_timer_smoketest.c'],
     dependencies: [
       sw_lib_dif_aon_timer,
+      sw_lib_testing_aon_timer_testutils,
       sw_lib_mmio,
       sw_lib_runtime_log,
     ],


### PR DESCRIPTION
Add utility function to set a watchdog.
Change aon_timer smoketest to use the testutils.

Signed-off-by: Guillermo Maturana <maturana@google.com>