### PR TITLE
[dif/rv-timer] Fix autogen DIFs dependency architecture - CI Fix.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/dif/autogen/dif_rv_timer_autogen.h"
 
 #include "rv_timer_regs.h"  // Generated.
 

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -4,7 +4,7 @@
 
 // This file is auto-generated.
 
-#include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/dif/autogen/dif_rv_timer_autogen.h"
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"


### PR DESCRIPTION
This fixes #8755 for the rv_timer, to fix a CI failure, since #8756 was
merged after #8733, without updating the rv-timer autogen DIFs. (CI
tests passed for #8756, before #8733 was merged.)

Signed-off-by: Timothy Trippel <ttrippel@google.com>