### PR TITLE
[util, top] Correct top level ast reset mapping

### DIFF
--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -113,12 +113,14 @@ interface rstmgr_cascading_sva_if (
   always_comb
     local_rst_n = {rstmgr_pkg::PowerDomains{resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]}};
 
-  for (genvar pd = 0; pd < rstmgr_pkg::PowerDomains; ++pd) begin : g_power_domains
-    // The AON reset triggers the various POR reset for the different clock domains through
-    // synchronizers.
-    `CASCADED_ASSERTS(CascadeEffAonToRstPorIoDiv4, effective_aon_rst[pd],
-                      resets_o.rst_por_io_div4_n[pd], SyncCycles, clk_io_div4_i)
+   // The AON reset triggers the various POR reset for the different clock domains through
+   // synchronizers.
+   // The current system doesn ot have any consumers of domain 1 por_io_div4, and thus only domain 0
+   // cascading is checked here.
+   `CASCADED_ASSERTS(CascadeEffAonToRstPorIoDiv4, effective_aon_rst[0],
+                     resets_o.rst_por_io_div4_n[0], SyncCycles, clk_io_div4_i)
 
+  for (genvar pd = 0; pd < rstmgr_pkg::PowerDomains; ++pd) begin : g_power_domains
     // The root lc reset is triggered either by the internal reset, or by the pwr_i.rst_lc_req
     // input. The latter is checked independently in pwrmgr_rstmgr_sva_if.
     `CASCADED_ASSERTS(CascadeLocalRstToLc, local_rst_n[pd] && !rst_lc_req[pd], rst_lc_src_n[pd],

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -191,8 +191,8 @@
         type: top
         domains:
         [
-          Aon
           "0"
+          Aon
         ]
         shadowed: false
         sw: false
@@ -268,7 +268,6 @@
         domains:
         [
           Aon
-          "0"
         ]
         shadowed: false
         sw: false
@@ -3586,7 +3585,7 @@
         rst_ast_adc_ni:
         {
           name: sys_aon
-          domain: "0"
+          domain: Aon
         }
         rst_ast_alert_ni:
         {
@@ -3609,6 +3608,11 @@
           domain: "0"
         }
       }
+      domain:
+      [
+        Aon
+        "0"
+      ]
       attr: reggen_only
       clock_connections:
       {
@@ -3619,10 +3623,6 @@
         clk_ast_rng_i: clkmgr_aon_clocks.clk_main_secure
         clk_ast_usb_i: clkmgr_aon_clocks.clk_usb_secure
       }
-      domain:
-      [
-        "0"
-      ]
       param_decl: {}
       param_list: []
       inter_signal_list:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -459,13 +459,32 @@
       },
       clock_group: "secure",
       reset_connections: {
-        rst_ast_tlul_ni: "lc_io_div4",
-        rst_ast_adc_ni: "sys_aon",
-        rst_ast_alert_ni: "lc_io_div4",
-        rst_ast_es_ni: "sys",
-        rst_ast_rng_ni: "sys",
-        rst_ast_usb_ni: "usbif"
+        rst_ast_tlul_ni: {
+          name: "lc_io_div4",
+          domain: "0",
+        }
+        rst_ast_adc_ni: {
+          name: "sys_aon",
+          domain: "Aon"
+        },
+        rst_ast_alert_ni: {
+          name: "lc_io_div4",
+          domain: "0",
+        },
+        rst_ast_es_ni: {
+          name: "sys",
+          domain: "0",
+        },
+        rst_ast_rng_ni: {
+          name: "sys",
+          domain: "0",
+        },
+        rst_ast_usb_ni: {
+          name: "usbif",
+          domain: "0"
+        }
       },
+      domain: ["Aon", "0"],
       base_addr: "0x40480000",
       attr: "reggen_only",
     },

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -380,7 +380,7 @@ module rstmgr
   assign shadow_cnsty_chk_errs[2] = '0;
 
   // Generating resets for por_io_div4
-  // Power Domains: ['Aon', '0']
+  // Power Domains: ['Aon']
   // Shadowed: False
   rstmgr_leaf_rst u_daon_por_io_div4 (
     .clk_i,
@@ -394,18 +394,9 @@ module rstmgr
     .leaf_rst_o(resets_o.rst_por_io_div4_n[DomainAonSel]),
     .err_o(cnsty_chk_errs[3][DomainAonSel])
   );
-  rstmgr_leaf_rst u_d0_por_io_div4 (
-    .clk_i,
-    .rst_ni,
-    .leaf_clk_i(clk_io_div4_i),
-    .parent_rst_ni(rst_por_aon_n[Domain0Sel]),
-    .sw_rst_req_ni(1'b1),
-    .scan_rst_ni,
-    .scan_sel(leaf_rst_scanmode[3] == lc_ctrl_pkg::On),
-    .rst_en_o(rst_en_o.por_io_div4[Domain0Sel]),
-    .leaf_rst_o(resets_o.rst_por_io_div4_n[Domain0Sel]),
-    .err_o(cnsty_chk_errs[3][Domain0Sel])
-  );
+  assign resets_o.rst_por_io_div4_n[Domain0Sel] = '0;
+  assign cnsty_chk_errs[3][Domain0Sel] = '0;
+  assign rst_en_o.por_io_div4[Domain0Sel] = MuBi4True;
   assign shadow_cnsty_chk_errs[3] = '0;
 
   // Generating resets for por_usb

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -868,7 +868,7 @@ module chip_earlgrey_asic (
     .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
     .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
     .rst_ast_tlul_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
-    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]),
     .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_es_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_rng_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -896,7 +896,7 @@ module chip_earlgrey_cw310 #(
     .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
     .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
     .rst_ast_tlul_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
-    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]),
     .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_es_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_rng_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -878,7 +878,7 @@ module chip_earlgrey_nexysvideo #(
     .clk_ast_rng_i (clkmgr_aon_clocks.clk_main_secure),
     .clk_ast_usb_i (clkmgr_aon_clocks.clk_usb_secure),
     .rst_ast_tlul_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
-    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::Domain0Sel]),
+    .rst_ast_adc_ni (rstmgr_aon_resets.rst_sys_aon_n[rstmgr_pkg::DomainAonSel]),
     .rst_ast_alert_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_es_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
     .rst_ast_rng_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),

--- a/util/topgen/merge.py
+++ b/util/topgen/merge.py
@@ -740,11 +740,10 @@ def amend_resets(top, name_to_block):
             top_resets.mark_reset_shadowed(primary_reset['name'])
 
         # domain determination
-        for d in module["domain"]:
-            for r in block.clocking.items:
-                if r.reset:
-                    reset = module['reset_connections'][r.reset]
-                    top_resets.add_reset_domain(reset['name'], d)
+        for r in block.clocking.items:
+            if r.reset:
+                reset = module['reset_connections'][r.reset]
+                top_resets.add_reset_domain(reset['name'], reset['domain'])
 
         # This code is here to ensure if amend_clocks/resets switched order
         # everything would still work


### PR DESCRIPTION
- Also fix a minor issue in `merge.py` that added
  unnecessary domains to resets.

Signed-off-by: Timothy Chen <timothytim@google.com>