### PR TITLE
[dif/adc_ctrl] Auto-generate portion of DIFs.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -210,6 +210,7 @@ gen_hw_hdr = generator(
 
 # TODO: Considering moving these into hw/ip directories.
 TOPNAME='top_earlgrey'
+hw_ip_adc_ctrl_reg_h = gen_hw_hdr.process('hw/ip/adc_ctrl/data/adc_ctrl.hjson')
 hw_ip_aes_reg_h = gen_hw_hdr.process('hw/ip/aes/data/aes.hjson')
 hw_ip_alert_handler_reg_h = gen_hw_hdr.process('hw/' + TOPNAME + '/ip_autogen/alert_handler/data/alert_handler.hjson')
 hw_ip_aon_timer_reg_h = gen_hw_hdr.process('hw/ip/aon_timer/data/aon_timer.hjson')

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -1,0 +1,194 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h"
+
+#include "adc_ctrl_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_init(mmio_region_t base_addr,
+                               dif_adc_ctrl_t *adc_ctrl) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  adc_ctrl->base_addr = base_addr;
+
+  return kDifOk;
+}
+
+/**
+ * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
+ * HJSON does NOT have a field "no_auto_intr_regs = true", then the
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
+ * exist, as templated below.
+ */
+static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
+                                       bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifAdcCtrlIrqDebugCable:
+      *index_out = ADC_CTRL_INTR_COMMON_DEBUG_CABLE_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_get_state(
+    const dif_adc_ctrl_t *adc_ctrl,
+    dif_adc_ctrl_irq_state_snapshot_t *snapshot) {
+  if (adc_ctrl == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot =
+      mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_is_pending(const dif_adc_ctrl_t *adc_ctrl,
+                                         dif_adc_ctrl_irq_t irq,
+                                         bool *is_pending) {
+  if (adc_ctrl == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!adc_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg =
+      mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_acknowledge(const dif_adc_ctrl_t *adc_ctrl,
+                                          dif_adc_ctrl_irq_t irq) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!adc_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_force(const dif_adc_ctrl_t *adc_ctrl,
+                                    dif_adc_ctrl_irq_t irq) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!adc_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_get_enabled(const dif_adc_ctrl_t *adc_ctrl,
+                                          dif_adc_ctrl_irq_t irq,
+                                          dif_toggle_t *state) {
+  if (adc_ctrl == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!adc_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_set_enabled(const dif_adc_ctrl_t *adc_ctrl,
+                                          dif_adc_ctrl_irq_t irq,
+                                          dif_toggle_t state) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!adc_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg =
+      mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_disable_all(
+    const dif_adc_ctrl_t *adc_ctrl,
+    dif_adc_ctrl_irq_enable_snapshot_t *snapshot) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(adc_ctrl->base_addr,
+                                   ADC_CTRL_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_restore_all(
+    const dif_adc_ctrl_t *adc_ctrl,
+    const dif_adc_ctrl_irq_enable_snapshot_t *snapshot) {
+  if (adc_ctrl == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
@@ -1,0 +1,182 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ADC_CTRL_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ADC_CTRL_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/adc_ctrl/doc/">ADC_CTRL</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to adc_ctrl.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_adc_ctrl {
+  /**
+   * The base address for the adc_ctrl hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_adc_ctrl_t;
+
+/**
+ * Creates a new handle for a(n) adc_ctrl peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the adc_ctrl peripheral.
+ * @param[out] adc_ctrl Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_init(mmio_region_t base_addr,
+                               dif_adc_ctrl_t *adc_ctrl);
+
+/**
+ * A adc_ctrl interrupt request type.
+ */
+typedef enum dif_adc_ctrl_irq {
+  /**
+   * USB-C debug cable is attached or disconnected
+   */
+  kDifAdcCtrlIrqDebugCable = 0,
+} dif_adc_ctrl_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_adc_ctrl_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_adc_ctrl_irq_state_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_get_state(
+    const dif_adc_ctrl_t *adc_ctrl,
+    dif_adc_ctrl_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_is_pending(const dif_adc_ctrl_t *adc_ctrl,
+                                         dif_adc_ctrl_irq_t irq,
+                                         bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_acknowledge(const dif_adc_ctrl_t *adc_ctrl,
+                                          dif_adc_ctrl_irq_t irq);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_force(const dif_adc_ctrl_t *adc_ctrl,
+                                    dif_adc_ctrl_irq_t irq);
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_adc_ctrl_irq_disable_all()` and `dif_adc_ctrl_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_adc_ctrl_irq_enable_snapshot_t;
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_get_enabled(const dif_adc_ctrl_t *adc_ctrl,
+                                          dif_adc_ctrl_irq_t irq,
+                                          dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_set_enabled(const dif_adc_ctrl_t *adc_ctrl,
+                                          dif_adc_ctrl_irq_t irq,
+                                          dif_toggle_t state);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_disable_all(
+    const dif_adc_ctrl_t *adc_ctrl,
+    dif_adc_ctrl_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_irq_restore_all(
+    const dif_adc_ctrl_t *adc_ctrl,
+    const dif_adc_ctrl_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_ADC_CTRL_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -1,0 +1,281 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "adc_ctrl_regs.h"  // Generated.
+
+namespace dif_adc_ctrl_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Eq;
+using ::testing::Test;
+
+class AdcCtrlTest : public Test, public MmioTest {
+ protected:
+  dif_adc_ctrl_t adc_ctrl_ = {.base_addr = dev().region()};
+};
+
+class InitTest : public AdcCtrlTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_adc_ctrl_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_adc_ctrl_init({.base_addr = dev().region()}, &adc_ctrl_),
+            kDifOk);
+}
+
+class IrqGetStateTest : public AdcCtrlTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_adc_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_get_state(&adc_ctrl_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_adc_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_adc_ctrl_irq_get_state(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_adc_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_adc_ctrl_irq_get_state(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public AdcCtrlTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqDebugCable,
+                                        &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
+                                        nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(
+      dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqDebugCable, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(
+                &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), &is_pending),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET,
+                {{ADC_CTRL_INTR_STATE_DEBUG_CABLE_BIT, true}});
+  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
+                                        &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+}
+
+class IrqAcknowledgeTest : public AdcCtrlTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqDebugCable),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge(nullptr,
+                                         static_cast<dif_adc_ctrl_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(ADC_CTRL_INTR_STATE_REG_OFFSET,
+                 {{ADC_CTRL_INTR_STATE_DEBUG_CABLE_BIT, true}});
+  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqDebugCable),
+            kDifOk);
+}
+
+class IrqForceTest : public AdcCtrlTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqDebugCable),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(
+      dif_adc_ctrl_irq_force(nullptr, static_cast<dif_adc_ctrl_irq_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(ADC_CTRL_INTR_TEST_REG_OFFSET,
+                 {{ADC_CTRL_INTR_TEST_DEBUG_CABLE_BIT, true}});
+  EXPECT_EQ(dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqDebugCable),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public AdcCtrlTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqDebugCable,
+                                         &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
+                                         nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(
+      dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqDebugCable, nullptr),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(
+                &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), &irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{ADC_CTRL_INTR_ENABLE_DEBUG_CABLE_BIT, true}});
+  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
+                                         &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+}
+
+class IrqSetEnabledTest : public AdcCtrlTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_set_enabled(nullptr, kDifAdcCtrlIrqDebugCable,
+                                         irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_set_enabled(
+                &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{ADC_CTRL_INTR_ENABLE_DEBUG_CABLE_BIT, 0x1, true}});
+  EXPECT_EQ(dif_adc_ctrl_irq_set_enabled(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
+                                         irq_state),
+            kDifOk);
+}
+
+class IrqDisableAllTest : public AdcCtrlTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public AdcCtrlTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_adc_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -2,6 +2,20 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Autogen ADC Control Interface DIF library
+sw_lib_dif_autogen_adc_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_adc_ctrl',
+    sources: [
+      hw_ip_adc_ctrl_reg_h,
+      'dif_adc_ctrl_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen AES DIF library
 sw_lib_dif_autogen_aes = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -4,6 +4,38 @@
 
 subdir('autogen')
 
+# ADC Control Interface DIF Library (dif_adc_ctrl)
+sw_lib_dif_adc_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_adc_ctrl',
+    sources: [
+      hw_ip_adc_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_autogen_adc_ctrl,
+    ],
+  )
+)
+
+test('dif_adc_ctrl_unittest', executable(
+    'dif_adc_ctrl_unittest',
+    sources: [
+      'autogen/dif_adc_ctrl_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c',
+      hw_ip_adc_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO'],
+    cpp_args: ['-DMOCK_MMIO'],
+  ),
+  suite: 'dif',
+)
+
 # Clock Manager DIF Library (dif_clkmgr)
 sw_lib_dif_clkmgr = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
Currently, the DIF library for the ADC Control Interface is unimplemented. This begins the implementation of this DIF library by first checking in the auto-generated DIFs (init and IRQ DIFs).

This partially addresses a task in #8142: _Auto-generate IRQ DIFs for IPs without an existing DIF library --> adc_ctrl._

**Note:** this PR depends on #8753, so only refer to the last commit (the first commit will be dropped when #8753 merges).