### PR TITLE
[dif/flash_ctrl] Auto-generate portion of DIFs.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
@@ -1,0 +1,210 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_init(mmio_region_t base_addr,
+                                 dif_flash_ctrl_t *flash_ctrl) {
+  if (flash_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  flash_ctrl->base_addr = base_addr;
+
+  return kDifOk;
+}
+
+/**
+ * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
+ * HJSON does NOT have a field "no_auto_intr_regs = true", then the
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
+ * exist, as templated below.
+ */
+static bool flash_ctrl_get_irq_bit_index(dif_flash_ctrl_irq_t irq,
+                                         bitfield_bit32_index_t *index_out) {
+  switch (irq) {
+    case kDifFlashCtrlIrqProgEmpty:
+      *index_out = FLASH_CTRL_INTR_COMMON_PROG_EMPTY_BIT;
+      break;
+    case kDifFlashCtrlIrqProgLvl:
+      *index_out = FLASH_CTRL_INTR_COMMON_PROG_LVL_BIT;
+      break;
+    case kDifFlashCtrlIrqRdFull:
+      *index_out = FLASH_CTRL_INTR_COMMON_RD_FULL_BIT;
+      break;
+    case kDifFlashCtrlIrqRdLvl:
+      *index_out = FLASH_CTRL_INTR_COMMON_RD_LVL_BIT;
+      break;
+    case kDifFlashCtrlIrqOpDone:
+      *index_out = FLASH_CTRL_INTR_COMMON_OP_DONE_BIT;
+      break;
+    case kDifFlashCtrlIrqCorrErr:
+      *index_out = FLASH_CTRL_INTR_COMMON_CORR_ERR_BIT;
+      break;
+    default:
+      return false;
+  }
+
+  return true;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_get_state(
+    const dif_flash_ctrl_t *flash_ctrl,
+    dif_flash_ctrl_irq_state_snapshot_t *snapshot) {
+  if (flash_ctrl == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  *snapshot = mmio_region_read32(flash_ctrl->base_addr,
+                                 FLASH_CTRL_INTR_STATE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_is_pending(const dif_flash_ctrl_t *flash_ctrl,
+                                           dif_flash_ctrl_irq_t irq,
+                                           bool *is_pending) {
+  if (flash_ctrl == NULL || is_pending == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!flash_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_state_reg = mmio_region_read32(
+      flash_ctrl->base_addr, FLASH_CTRL_INTR_STATE_REG_OFFSET);
+
+  *is_pending = bitfield_bit32_read(intr_state_reg, index);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_acknowledge(const dif_flash_ctrl_t *flash_ctrl,
+                                            dif_flash_ctrl_irq_t irq) {
+  if (flash_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!flash_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  // Writing to the register clears the corresponding bits (Write-one clear).
+  uint32_t intr_state_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(flash_ctrl->base_addr, FLASH_CTRL_INTR_STATE_REG_OFFSET,
+                      intr_state_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_force(const dif_flash_ctrl_t *flash_ctrl,
+                                      dif_flash_ctrl_irq_t irq) {
+  if (flash_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!flash_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_test_reg = bitfield_bit32_write(0, index, true);
+  mmio_region_write32(flash_ctrl->base_addr, FLASH_CTRL_INTR_TEST_REG_OFFSET,
+                      intr_test_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_get_enabled(const dif_flash_ctrl_t *flash_ctrl,
+                                            dif_flash_ctrl_irq_t irq,
+                                            dif_toggle_t *state) {
+  if (flash_ctrl == NULL || state == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!flash_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      flash_ctrl->base_addr, FLASH_CTRL_INTR_ENABLE_REG_OFFSET);
+
+  bool is_enabled = bitfield_bit32_read(intr_enable_reg, index);
+  *state = is_enabled ? kDifToggleEnabled : kDifToggleDisabled;
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_set_enabled(const dif_flash_ctrl_t *flash_ctrl,
+                                            dif_flash_ctrl_irq_t irq,
+                                            dif_toggle_t state) {
+  if (flash_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t index;
+  if (!flash_ctrl_get_irq_bit_index(irq, &index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t intr_enable_reg = mmio_region_read32(
+      flash_ctrl->base_addr, FLASH_CTRL_INTR_ENABLE_REG_OFFSET);
+
+  bool enable_bit = (state == kDifToggleEnabled) ? true : false;
+  intr_enable_reg = bitfield_bit32_write(intr_enable_reg, index, enable_bit);
+  mmio_region_write32(flash_ctrl->base_addr, FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                      intr_enable_reg);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_disable_all(
+    const dif_flash_ctrl_t *flash_ctrl,
+    dif_flash_ctrl_irq_enable_snapshot_t *snapshot) {
+  if (flash_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  // Pass the current interrupt state to the caller, if requested.
+  if (snapshot != NULL) {
+    *snapshot = mmio_region_read32(flash_ctrl->base_addr,
+                                   FLASH_CTRL_INTR_ENABLE_REG_OFFSET);
+  }
+
+  // Disable all interrupts.
+  mmio_region_write32(flash_ctrl->base_addr, FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                      0u);
+
+  return kDifOk;
+}
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_restore_all(
+    const dif_flash_ctrl_t *flash_ctrl,
+    const dif_flash_ctrl_irq_enable_snapshot_t *snapshot) {
+  if (flash_ctrl == NULL || snapshot == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(flash_ctrl->base_addr, FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                      *snapshot);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
@@ -1,0 +1,203 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_FLASH_CTRL_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_FLASH_CTRL_AUTOGEN_H_
+
+// This file is auto-generated.
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/flash_ctrl/doc/">FLASH_CTRL</a> Device Interface
+ * Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to flash_ctrl.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_flash_ctrl {
+  /**
+   * The base address for the flash_ctrl hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_flash_ctrl_t;
+
+/**
+ * Creates a new handle for a(n) flash_ctrl peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the flash_ctrl peripheral.
+ * @param[out] flash_ctrl Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_init(mmio_region_t base_addr,
+                                 dif_flash_ctrl_t *flash_ctrl);
+
+/**
+ * A flash_ctrl interrupt request type.
+ */
+typedef enum dif_flash_ctrl_irq {
+  /**
+   * Program FIFO empty
+   */
+  kDifFlashCtrlIrqProgEmpty = 0,
+  /**
+   * Program FIFO drained to level
+   */
+  kDifFlashCtrlIrqProgLvl = 1,
+  /**
+   * Read FIFO full
+   */
+  kDifFlashCtrlIrqRdFull = 2,
+  /**
+   * Read FIFO filled to level
+   */
+  kDifFlashCtrlIrqRdLvl = 3,
+  /**
+   * Operation complete
+   */
+  kDifFlashCtrlIrqOpDone = 4,
+  /**
+   * Correctable error encountered
+   */
+  kDifFlashCtrlIrqCorrErr = 5,
+} dif_flash_ctrl_irq_t;
+
+/**
+ * A snapshot of the state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the `dif_flash_ctrl_irq_get_state()`
+ * function.
+ */
+typedef uint32_t dif_flash_ctrl_irq_state_snapshot_t;
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param[out] snapshot Out-param for interrupt state snapshot.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_get_state(
+    const dif_flash_ctrl_t *flash_ctrl,
+    dif_flash_ctrl_irq_state_snapshot_t *snapshot);
+
+/**
+ * Returns whether a particular interrupt is currently pending.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] is_pending Out-param for whether the interrupt is pending.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_is_pending(const dif_flash_ctrl_t *flash_ctrl,
+                                           dif_flash_ctrl_irq_t irq,
+                                           bool *is_pending);
+
+/**
+ * Acknowledges a particular interrupt, indicating to the hardware that it has
+ * been successfully serviced.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_acknowledge(const dif_flash_ctrl_t *flash_ctrl,
+                                            dif_flash_ctrl_irq_t irq);
+
+/**
+ * Forces a particular interrupt, causing it to be serviced as if hardware had
+ * asserted it.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param irq An interrupt request.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_force(const dif_flash_ctrl_t *flash_ctrl,
+                                      dif_flash_ctrl_irq_t irq);
+
+/**
+ * A snapshot of the enablement state of the interrupts for this IP.
+ *
+ * This is an opaque type, to be used with the
+ * `dif_flash_ctrl_irq_disable_all()` and `dif_flash_ctrl_irq_restore_all()`
+ * functions.
+ */
+typedef uint32_t dif_flash_ctrl_irq_enable_snapshot_t;
+
+/**
+ * Checks whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param irq An interrupt request.
+ * @param[out] state Out-param toggle state of the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_get_enabled(const dif_flash_ctrl_t *flash_ctrl,
+                                            dif_flash_ctrl_irq_t irq,
+                                            dif_toggle_t *state);
+
+/**
+ * Sets whether a particular interrupt is currently enabled or disabled.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param irq An interrupt request.
+ * @param state The new toggle state for the interrupt.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_set_enabled(const dif_flash_ctrl_t *flash_ctrl,
+                                            dif_flash_ctrl_irq_t irq,
+                                            dif_toggle_t state);
+
+/**
+ * Disables all interrupts, optionally snapshotting all enable states for later
+ * restoration.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param[out] snapshot Out-param for the snapshot; may be `NULL`.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_disable_all(
+    const dif_flash_ctrl_t *flash_ctrl,
+    dif_flash_ctrl_irq_enable_snapshot_t *snapshot);
+
+/**
+ * Restores interrupts from the given (enable) snapshot.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param snapshot A snapshot to restore from.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_irq_restore_all(
+    const dif_flash_ctrl_t *flash_ctrl,
+    const dif_flash_ctrl_irq_enable_snapshot_t *snapshot);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_FLASH_CTRL_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -1,0 +1,327 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is auto-generated.
+
+#include "sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "flash_ctrl_regs.h"  // Generated.
+
+namespace dif_flash_ctrl_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Eq;
+using ::testing::Test;
+
+class FlashCtrlTest : public Test, public MmioTest {
+ protected:
+  dif_flash_ctrl_t flash_ctrl_ = {.base_addr = dev().region()};
+};
+
+class InitTest : public FlashCtrlTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_flash_ctrl_init({.base_addr = dev().region()}, nullptr),
+            kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_flash_ctrl_init({.base_addr = dev().region()}, &flash_ctrl_),
+            kDifOk);
+}
+
+class IrqGetStateTest : public FlashCtrlTest {};
+
+TEST_F(IrqGetStateTest, NullArgs) {
+  dif_flash_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_get_state(&flash_ctrl_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_get_state(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqGetStateTest, SuccessAllRaised) {
+  dif_flash_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(FLASH_CTRL_INTR_STATE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_flash_ctrl_irq_get_state(&flash_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(IrqGetStateTest, SuccessNoneRaised) {
+  dif_flash_ctrl_irq_state_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(FLASH_CTRL_INTR_STATE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_flash_ctrl_irq_get_state(&flash_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+class IrqIsPendingTest : public FlashCtrlTest {};
+
+TEST_F(IrqIsPendingTest, NullArgs) {
+  bool is_pending;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_is_pending(nullptr, kDifFlashCtrlIrqProgEmpty,
+                                          &is_pending),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_is_pending(&flash_ctrl_,
+                                          kDifFlashCtrlIrqProgEmpty, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_is_pending(nullptr, kDifFlashCtrlIrqProgEmpty,
+                                          nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, BadIrq) {
+  bool is_pending;
+  // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
+  EXPECT_EQ(
+      dif_flash_ctrl_irq_is_pending(
+          &flash_ctrl_, static_cast<dif_flash_ctrl_irq_t>(32), &is_pending),
+      kDifBadArg);
+}
+
+TEST_F(IrqIsPendingTest, Success) {
+  bool irq_state;
+
+  // Get the first IRQ state.
+  irq_state = false;
+  EXPECT_READ32(FLASH_CTRL_INTR_STATE_REG_OFFSET,
+                {{FLASH_CTRL_INTR_STATE_PROG_EMPTY_BIT, true}});
+  EXPECT_EQ(dif_flash_ctrl_irq_is_pending(
+                &flash_ctrl_, kDifFlashCtrlIrqProgEmpty, &irq_state),
+            kDifOk);
+  EXPECT_TRUE(irq_state);
+
+  // Get the last IRQ state.
+  irq_state = true;
+  EXPECT_READ32(FLASH_CTRL_INTR_STATE_REG_OFFSET,
+                {{FLASH_CTRL_INTR_STATE_CORR_ERR_BIT, false}});
+  EXPECT_EQ(dif_flash_ctrl_irq_is_pending(&flash_ctrl_, kDifFlashCtrlIrqCorrErr,
+                                          &irq_state),
+            kDifOk);
+  EXPECT_FALSE(irq_state);
+}
+
+class IrqAcknowledgeTest : public FlashCtrlTest {};
+
+TEST_F(IrqAcknowledgeTest, NullArgs) {
+  EXPECT_EQ(dif_flash_ctrl_irq_acknowledge(nullptr, kDifFlashCtrlIrqProgEmpty),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, BadIrq) {
+  EXPECT_EQ(dif_flash_ctrl_irq_acknowledge(
+                nullptr, static_cast<dif_flash_ctrl_irq_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(IrqAcknowledgeTest, Success) {
+  // Clear the first IRQ state.
+  EXPECT_WRITE32(FLASH_CTRL_INTR_STATE_REG_OFFSET,
+                 {{FLASH_CTRL_INTR_STATE_PROG_EMPTY_BIT, true}});
+  EXPECT_EQ(
+      dif_flash_ctrl_irq_acknowledge(&flash_ctrl_, kDifFlashCtrlIrqProgEmpty),
+      kDifOk);
+
+  // Clear the last IRQ state.
+  EXPECT_WRITE32(FLASH_CTRL_INTR_STATE_REG_OFFSET,
+                 {{FLASH_CTRL_INTR_STATE_CORR_ERR_BIT, true}});
+  EXPECT_EQ(
+      dif_flash_ctrl_irq_acknowledge(&flash_ctrl_, kDifFlashCtrlIrqCorrErr),
+      kDifOk);
+}
+
+class IrqForceTest : public FlashCtrlTest {};
+
+TEST_F(IrqForceTest, NullArgs) {
+  EXPECT_EQ(dif_flash_ctrl_irq_force(nullptr, kDifFlashCtrlIrqProgEmpty),
+            kDifBadArg);
+}
+
+TEST_F(IrqForceTest, BadIrq) {
+  EXPECT_EQ(
+      dif_flash_ctrl_irq_force(nullptr, static_cast<dif_flash_ctrl_irq_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(IrqForceTest, Success) {
+  // Force first IRQ.
+  EXPECT_WRITE32(FLASH_CTRL_INTR_TEST_REG_OFFSET,
+                 {{FLASH_CTRL_INTR_TEST_PROG_EMPTY_BIT, true}});
+  EXPECT_EQ(dif_flash_ctrl_irq_force(&flash_ctrl_, kDifFlashCtrlIrqProgEmpty),
+            kDifOk);
+
+  // Force last IRQ.
+  EXPECT_WRITE32(FLASH_CTRL_INTR_TEST_REG_OFFSET,
+                 {{FLASH_CTRL_INTR_TEST_CORR_ERR_BIT, true}});
+  EXPECT_EQ(dif_flash_ctrl_irq_force(&flash_ctrl_, kDifFlashCtrlIrqCorrErr),
+            kDifOk);
+}
+
+class IrqGetEnabledTest : public FlashCtrlTest {};
+
+TEST_F(IrqGetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_get_enabled(nullptr, kDifFlashCtrlIrqProgEmpty,
+                                           &irq_state),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_get_enabled(&flash_ctrl_,
+                                           kDifFlashCtrlIrqProgEmpty, nullptr),
+            kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_get_enabled(nullptr, kDifFlashCtrlIrqProgEmpty,
+                                           nullptr),
+            kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state;
+
+  EXPECT_EQ(
+      dif_flash_ctrl_irq_get_enabled(
+          &flash_ctrl_, static_cast<dif_flash_ctrl_irq_t>(32), &irq_state),
+      kDifBadArg);
+}
+
+TEST_F(IrqGetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // First IRQ is enabled.
+  irq_state = kDifToggleDisabled;
+  EXPECT_READ32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{FLASH_CTRL_INTR_ENABLE_PROG_EMPTY_BIT, true}});
+  EXPECT_EQ(dif_flash_ctrl_irq_get_enabled(
+                &flash_ctrl_, kDifFlashCtrlIrqProgEmpty, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleEnabled);
+
+  // Last IRQ is disabled.
+  irq_state = kDifToggleEnabled;
+  EXPECT_READ32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{FLASH_CTRL_INTR_ENABLE_CORR_ERR_BIT, false}});
+  EXPECT_EQ(dif_flash_ctrl_irq_get_enabled(&flash_ctrl_,
+                                           kDifFlashCtrlIrqCorrErr, &irq_state),
+            kDifOk);
+  EXPECT_EQ(irq_state, kDifToggleDisabled);
+}
+
+class IrqSetEnabledTest : public FlashCtrlTest {};
+
+TEST_F(IrqSetEnabledTest, NullArgs) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_set_enabled(nullptr, kDifFlashCtrlIrqProgEmpty,
+                                           irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, BadIrq) {
+  dif_toggle_t irq_state = kDifToggleEnabled;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_set_enabled(
+                &flash_ctrl_, static_cast<dif_flash_ctrl_irq_t>(32), irq_state),
+            kDifBadArg);
+}
+
+TEST_F(IrqSetEnabledTest, Success) {
+  dif_toggle_t irq_state;
+
+  // Enable first IRQ.
+  irq_state = kDifToggleEnabled;
+  EXPECT_MASK32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{FLASH_CTRL_INTR_ENABLE_PROG_EMPTY_BIT, 0x1, true}});
+  EXPECT_EQ(dif_flash_ctrl_irq_set_enabled(
+                &flash_ctrl_, kDifFlashCtrlIrqProgEmpty, irq_state),
+            kDifOk);
+
+  // Disable last IRQ.
+  irq_state = kDifToggleDisabled;
+  EXPECT_MASK32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                {{FLASH_CTRL_INTR_ENABLE_CORR_ERR_BIT, 0x1, false}});
+  EXPECT_EQ(dif_flash_ctrl_irq_set_enabled(&flash_ctrl_,
+                                           kDifFlashCtrlIrqCorrErr, irq_state),
+            kDifOk);
+}
+
+class IrqDisableAllTest : public FlashCtrlTest {};
+
+TEST_F(IrqDisableAllTest, NullArgs) {
+  dif_flash_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_disable_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
+  EXPECT_WRITE32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_flash_ctrl_irq_disable_all(&flash_ctrl_, nullptr), kDifOk);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
+  dif_flash_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_WRITE32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_flash_ctrl_irq_disable_all(&flash_ctrl_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, 0);
+}
+
+TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
+  dif_flash_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_READ32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                std::numeric_limits<uint32_t>::max());
+  EXPECT_WRITE32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_flash_ctrl_irq_disable_all(&flash_ctrl_, &irq_snapshot),
+            kDifOk);
+  EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
+}
+
+class IrqRestoreAllTest : public FlashCtrlTest {};
+
+TEST_F(IrqRestoreAllTest, NullArgs) {
+  dif_flash_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_EQ(dif_flash_ctrl_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_restore_all(&flash_ctrl_, nullptr), kDifBadArg);
+
+  EXPECT_EQ(dif_flash_ctrl_irq_restore_all(nullptr, nullptr), kDifBadArg);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
+  dif_flash_ctrl_irq_enable_snapshot_t irq_snapshot =
+      std::numeric_limits<uint32_t>::max();
+
+  EXPECT_WRITE32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET,
+                 std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(dif_flash_ctrl_irq_restore_all(&flash_ctrl_, &irq_snapshot),
+            kDifOk);
+}
+
+TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
+  dif_flash_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
+
+  EXPECT_WRITE32(FLASH_CTRL_INTR_ENABLE_REG_OFFSET, 0);
+  EXPECT_EQ(dif_flash_ctrl_irq_restore_all(&flash_ctrl_, &irq_snapshot),
+            kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_flash_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -100,6 +100,20 @@ sw_lib_dif_autogen_entropy_src = declare_dependency(
   )
 )
 
+# Autogen Flash Controller DIF library
+sw_lib_dif_autogen_flash_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_autogen_flash_ctrl',
+    sources: [
+      hw_ip_flash_ctrl_reg_h,
+      'dif_flash_ctrl_autogen.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+    ],
+  )
+)
+
 # Autogen GPIO DIF library
 sw_lib_dif_autogen_gpio = declare_dependency(
   link_with: static_library(

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -882,3 +882,35 @@ test('dif_sysrst_ctrl_unittest', executable(
   ),
   suite: 'dif',
 )
+
+# Flash Controller library
+sw_lib_dif_flash_ctrl = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_flash_ctrl',
+    sources: [
+      hw_ip_flash_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_autogen_flash_ctrl,
+    ],
+  )
+)
+
+test('dif_flash_ctrl_unittest', executable(
+    'dif_flash_ctrl_unittest',
+    sources: [
+      'autogen/dif_flash_ctrl_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c',
+      hw_ip_flash_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_base_testing_mock_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_MMIO'],
+    cpp_args: ['-DMOCK_MMIO'],
+  ),
+  suite: 'dif',
+)


### PR DESCRIPTION
Currently, the DIF library for the Flash Controller is unimplemented. This begins the implementation of this DIF library by first checking in the auto-generated DIFs (init and IRQ DIFs).

This partially addresses a task in #8142: _Auto-generate IRQ DIFs for IPs without an existing DIF library --> flash_ctrl._

**Note:** this PR depends on #8753, so only refer to the last commit (the first commit will be dropped when #8753 merges).