### PR TITLE
[sw/silicon_creator] Fix typo in bootstrap module enum name

### DIFF
--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -40,7 +40,7 @@ enum module_ {
   kModuleSecMmio =      MODULE_CODE('I', 'O'),
   kModuleBootPolicy =   MODULE_CODE('B', 'P'),
   kModuleRetSram =      MODULE_CODE('R', 'S'),
-  KModuleBootstrap =    MODULE_CODE('B', 'S'),
+  kModuleBootstrap =    MODULE_CODE('B', 'S'),
   // clang-format on
 };
 
@@ -106,13 +106,13 @@ enum module_ {
   X(kErrorBootPolicyBadIdentifier,    ERROR_(1, kModuleBootPolicy, kInternal)), \
   X(kErrorBootPolicyRollback,         ERROR_(2, kModuleBootPolicy, kInternal)), \
   X(kErrorRetSramLocked,              ERROR_(1, kModuleRetSram, kInternal)), \
-  X(kErrorBootstrapSpiDevice,         ERROR_(1, KModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapErase,             ERROR_(2, KModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapEraseCheck,        ERROR_(3, KModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapEraseExit,         ERROR_(4, KModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapWrite,             ERROR_(5, KModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapGpio,              ERROR_(6, KModuleBootstrap, kInternal)), \
-  X(kErrorBootstrapUnknown,           ERROR_(7, KModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapSpiDevice,         ERROR_(1, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapErase,             ERROR_(2, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapEraseCheck,        ERROR_(3, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapEraseExit,         ERROR_(4, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapWrite,             ERROR_(5, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapGpio,              ERROR_(6, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapUnknown,           ERROR_(7, kModuleBootstrap, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 


### PR DESCRIPTION
Should start with a lowercase `k`.

Signed-off-by: Alphan Ulusoy <alphan@google.com>