### PR TITLE
[sw/rom_ext] Add rom_ext_epmp module.

### DIFF
--- a/sw/device/silicon_creator/rom_exts/meson.build
+++ b/sw/device/silicon_creator/rom_exts/meson.build
@@ -2,6 +2,19 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# ROM_EXT ePMP library
+sw_silicon_creator_rom_ext_epmp = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_rom_ext_epmp',
+    sources: [
+      'rom_ext_epmp.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_epmp,
+    ],
+  )
+)
+
 # Mask ROM Linker Parameters
 #
 # See sw/device/exts/common/flash_link.ld for additional info about these

--- a/sw/device/silicon_creator/rom_exts/rom_ext_epmp.c
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_epmp.c
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/rom_exts/rom_ext_epmp.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/csr.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+void rom_ext_epmp_unlock_owner_stage_rx(epmp_state_t *state,
+                                        epmp_region_t image) {
+  const int kEntry = 1;
+  epmp_state_configure_tor(state, kEntry, image, kEpmpPermLockedReadExecute);
+
+  // Update the hardware configuration (CSRs).
+  //
+  // Entry is hardcoded as 1. Make sure to modify hardcoded values if changing
+  // kEntry.
+  //
+  // The `pmp1cfg` configuration is the second field in `pmpcfg0`.
+  //
+  //            32          24          16           8           0
+  //             +-----------+-----------+-----------+-----------+
+  // `pmpcfg0` = | `pmp3cfg` | `pmp2cfg` | `pmp1cfg` | `pmp0cfg` |
+  //             +-----------+-----------+-----------+-----------+
+  CSR_WRITE(CSR_REG_PMPADDR0, image.start >> 2);
+  CSR_WRITE(CSR_REG_PMPADDR1, image.end >> 2);
+  CSR_CLEAR_BITS(CSR_REG_PMPCFG0, 0xff00);
+  CSR_SET_BITS(CSR_REG_PMPCFG0, (kEpmpModeTor | kEpmpPermLockedReadExecute)
+                                    << 8);
+}

--- a/sw/device/silicon_creator/rom_exts/rom_ext_epmp.h
+++ b/sw/device/silicon_creator/rom_exts/rom_ext_epmp.h
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_EPMP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_EPMP_H_
+
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/epmp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * ROM_EXT ROM enhanced Physical Memory Protection (ePMP) library.
+ *
+ * The ePMP configuration is managed in two parts:
+ *
+ *   1. The actual hardware configuration held in CSRs
+ *   2. The in-memory copy of register values in `epmp_state_t` that is used
+ *      to verify the CSRs
+ *
+ * Every time the hardware configuration is updated the in-memory copy
+ * must also be updated. The hardware configuration is usually interacted
+ * with directly using the CSR library or assembly whereas the in-memory
+ * copy of the state should normally be modified using configuration functions
+ * from the silicon creator ePMP library.
+ *
+ * This separation of concerns allows the hardware configuration to be
+ * updated efficiently as needed (including before the C runtime is
+ * initialized) with the in-memory copy of the state used to double check the
+ * configuration as required.
+ */
+// TODO(lowrisc/opentitan#8800): Implement ePMP initialization for ROM_EXT
+// stage.
+
+/**
+ * Unlocks the provided first Silicon Owner stage region with read-execute
+ * permissions.
+ *
+ * The provided ePMP state is also updated to reflect the changes made to the
+ * hardware configuration.
+ *
+ * @param state The ePMP state to update.
+ * @param image Region for executable sections in ROM_EXT image.
+ */
+void rom_ext_epmp_unlock_owner_stage_rx(epmp_state_t *state,
+                                        epmp_region_t image);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXTS_ROM_EXT_EPMP_H_


### PR DESCRIPTION
Add bare minimum ePMP operations to enable first stage Silicon Owner
code execution, by repacing the mask ROM rx TOR region. The module will
be later updated to include full ePMP initialization for the ROM_EXT
execution context.
