### PR TITLE
[opentitantool] Miscellaneous cleanups.

### DIFF
--- a/sw/host/opentitanlib/src/app/conf.rs
+++ b/sw/host/opentitanlib/src/app/conf.rs
@@ -86,7 +86,6 @@ pub enum FlashAddressMode {
     Mode4b,
 }
 
-
 /// Chip programmed via an EEPROM-like SPI protocol.
 #[derive(Deserialize, Clone, Debug)]
 pub struct SpiEeprom {
@@ -115,7 +114,7 @@ pub enum FlashDriver {
     /// Chip programmed via an EEPROM-like SPI protocol.
     SpiEeprom(SpiEeprom),
     /// Temporary measure to allow external program to implement SPI protocol.
-    SpiExternalDriver(SpiExternalDriver)
+    SpiExternalDriver(SpiExternalDriver),
 }
 
 /// Defines the way to reach and program flash storage.
@@ -151,4 +150,3 @@ pub struct ConfigurationFile {
     #[serde(default)]
     pub flash: Vec<FlashConfiguration>,
 }
-

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -45,31 +45,34 @@ impl TransportWrapper {
 
     /// Returns a SPI [`Target`] implementation.
     pub fn spi(&self, name: &str) -> Result<Rc<dyn Target>> {
-        self.transport.borrow().spi(Self::map_name(&self.spi_map, name).as_str())
+        self.transport
+            .borrow()
+            .spi(Self::map_name(&self.spi_map, name).as_str())
     }
 
     /// Returns a [`Uart`] implementation.
     pub fn uart(&self, name: &str) -> Result<Rc<dyn Uart>> {
-        self.transport.borrow().uart(Self::map_name(&self.uart_map, name).as_str())
+        self.transport
+            .borrow()
+            .uart(Self::map_name(&self.uart_map, name).as_str())
     }
 
     /// Returns a [`GpioPin`] implementation.
     pub fn gpio_pin(&self, name: &str) -> Result<Rc<dyn GpioPin>> {
-        self.transport.borrow().gpio_pin(Self::map_name(&self.pin_map, name).as_str())
+        self.transport
+            .borrow()
+            .gpio_pin(Self::map_name(&self.pin_map, name).as_str())
     }
 
     /// Programs a bitstream into an FPGA.
     pub fn fpga_program(&self, bitstream: &[u8]) -> Result<()> {
         self.transport.borrow().fpga_program(bitstream)
     }
-    
+
     /// Given an pin/uart/spi port name, if the name is a known alias,
     /// return the underlying name/number, otherwise return the string
     /// as is.
-    fn map_name(
-        map: &HashMap<String, String>,
-        name: &str
-    ) -> String {
+    fn map_name(map: &HashMap<String, String>, name: &str) -> String {
         let name = name.to_uppercase();
         // TODO(#8769): Support multi-level aliasing, either by
         // flattening after parsing all files, or by repeated lookup
@@ -89,13 +92,15 @@ impl TransportWrapper {
         }
         for uart_conf in file.uarts {
             if let Some(alias_of) = uart_conf.alias_of {
-                self.uart_map.insert(uart_conf.name.to_uppercase(), alias_of);
+                self.uart_map
+                    .insert(uart_conf.name.to_uppercase(), alias_of);
             }
             // TODO(#8769): Record baud / parity configration for later
             // use when opening uart.
         }
         for flash_conf in file.flash {
-            self.flash_map.insert(flash_conf.name.clone(), flash_conf.clone());
+            self.flash_map
+                .insert(flash_conf.name.clone(), flash_conf.clone());
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use structopt::clap::arg_enum;
 use thiserror::Error;
 
-use crate::io::gpio::{GpioPin};
+use crate::io::gpio::GpioPin;
 use crate::io::spi::Target;
 
 mod primitive;
@@ -78,7 +78,13 @@ impl Bootstrap {
 
     /// Perform the update, sending the firmware `payload` to the `spi` target,
     /// using `gpio` to sequence the reset and bootstrap pins.
-    pub fn update(&self, spi: &dyn Target, reset: &dyn GpioPin, bootstrap: &dyn GpioPin, payload: &[u8]) -> Result<()> {
+    pub fn update(
+        &self,
+        spi: &dyn Target,
+        reset: &dyn GpioPin,
+        bootstrap: &dyn GpioPin,
+        payload: &[u8],
+    ) -> Result<()> {
         log::info!("Asserting bootstrap pins...");
         bootstrap.write(true)?;
 

--- a/sw/host/opentitanlib/src/transport/cw310/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/gpio.rs
@@ -16,7 +16,10 @@ pub struct CW310GpioPin {
 
 impl CW310GpioPin {
     pub fn open(backend: Rc<RefCell<Backend>>, pinname: String) -> Result<Self> {
-        Ok(Self { device: backend, pinname })
+        Ok(Self {
+            device: backend,
+            pinname,
+        })
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/cw310/uart.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/uart.rs
@@ -43,7 +43,7 @@ impl CW310Uart {
 
         let port = ports
             .get(instance as usize)
-            .ok_or(TransportError::InvalidInstance("uart", instance.to_string()))?;
+            .ok_or_else(|| TransportError::InvalidInstance("uart", instance.to_string()))?;
         Ok(CW310Uart {
             port: RefCell::new(serialport::new(&port.port_name, 115200).open()?),
         })

--- a/sw/host/opentitanlib/src/transport/cw310/usb.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/usb.rs
@@ -441,8 +441,8 @@ impl Backend {
         self.usb
             .send_ctrl(Backend::CMD_FPGA_PROGRAM, Backend::PROGRAM_EXIT, &[])?;
 
-        if result.is_err() {
-            Err(Error::FpgaProgramFailed(result.unwrap_err().to_string()).into())
+        if let Err(e) = result {
+            Err(Error::FpgaProgramFailed(e.to_string()).into())
         } else if !status {
             Err(Error::FpgaProgramFailed("unknown error".to_string()).into())
         } else {

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::collection;
-use crate::io::gpio::{GpioPin, GpioError, PinDirection};
+use crate::io::gpio::{GpioError, GpioPin, PinDirection};
 use crate::transport::ultradebug::mpsse;
 use crate::transport::ultradebug::Ultradebug;
 use crate::util::parse_int::ParseInt;

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 use thiserror::Error;
-use std::path::{Path, PathBuf};
 
-use opentitanlib::transport::{EmptyTransport, Transport};
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::conf::ConfigurationFile;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::transport::{EmptyTransport, Transport};
 use opentitanlib::util::parse_int::ParseInt;
 
 pub mod cw310;
@@ -62,13 +62,11 @@ pub fn create_empty_transport() -> Result<Box<dyn Transport>> {
     Ok(Box::new(EmptyTransport))
 }
 
-
 fn process_config_file(env: &mut TransportWrapper, conf_file: &Path) -> Result<()> {
     log::debug!("Reading config file {:?}", conf_file);
-    let conf_data = std::fs::read_to_string(conf_file)
-        .expect("Unable to read configuration file");
-    let res: ConfigurationFile = serde_json::from_str(&conf_data)
-        .expect("Unable to parse configuration file");
+    let conf_data = std::fs::read_to_string(conf_file).expect("Unable to read configuration file");
+    let res: ConfigurationFile =
+        serde_json::from_str(&conf_data).expect("Unable to parse configuration file");
 
     let subdir = conf_file.parent().unwrap_or_else(|| Path::new(""));
     for included_conf_file in &res.includes {

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use structopt::StructOpt;
 
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 use opentitanlib::bootstrap::{Bootstrap, BootstrapOptions, BootstrapProtocol};
 use opentitanlib::io::spi::SpiParams;
 use opentitanlib::transport::Capability;

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -15,8 +15,8 @@ use std::os::unix::io::AsRawFd;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
 
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 use opentitanlib::io::uart::{Uart, UartParams};
 use opentitanlib::transport::Capability;
 use opentitanlib::util::file;

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -179,11 +179,8 @@ impl InnerConsole {
     // Maintain a buffer for the exit regexes to match against.
     fn append_buffer(&mut self, data: &[u8]) {
         self.buffer.push_str(&String::from_utf8_lossy(data));
-        if self.buffer.len() > InnerConsole::BUFFER_LEN {
-            let (_, end) = self
-                .buffer
-                .split_at(self.buffer.len() - InnerConsole::BUFFER_LEN);
-            self.buffer = end.to_string();
+        while self.buffer.len() > InnerConsole::BUFFER_LEN {
+            self.buffer.remove(0);
         }
     }
 

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -7,10 +7,10 @@ use erased_serde::Serialize;
 use std::any::Any;
 use structopt::StructOpt;
 
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 use opentitanlib::io::gpio::PinDirection;
-use opentitanlib::transport::{Capability};
+use opentitanlib::transport::Capability;
 
 #[derive(Debug, StructOpt)]
 /// Reads a GPIO pin.

--- a/sw/host/opentitantool/src/command/hello.rs
+++ b/sw/host/opentitantool/src/command/hello.rs
@@ -12,8 +12,8 @@ use erased_serde::Serialize;
 use std::any::Any;
 use structopt::StructOpt;
 
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 
 #[derive(Debug, StructOpt)]
 /// The `hello world` command accepts an command option of `--cruel`.

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -9,8 +9,8 @@ use std::fs;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 use opentitanlib::transport::Capability;
 
 /// Read data from a SPI EEPROM.

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use std::time::Instant;
 use structopt::StructOpt;
 
-use opentitanlib::app::TransportWrapper;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 use opentitanlib::io::spi::{SpiParams, Transfer};
 use opentitanlib::spiflash::SpiFlash;
 use opentitanlib::transport::Capability;


### PR DESCRIPTION
1. Maintain the regex matching buffer in the `console` in a way that respects
   unicode character boundaries.  The previous implementation could split
   the string in the middle of a unicode code point which would result in a
   panic.

   Although the `remove` function is O(n), the most likely case is going to
   be simple removal of a single character to maintain the overall buffer
   length.

2. Do some simple path manipulation when loading config files: make included
   files have paths relative to the file that included them.  Absolute paths
   will still work because Path::join does _the right thing_.

   Pass the loaded config files to the TransportWrapper so config aliasing
   works (ie: `--uart console` maps to uart zero).

3. Run `clippy` and heed its advice.

4. Run `cargo fmt` to apply standard Rust formatting.

Signed-off-by: Chris Frantz <cfrantz@google.com>