### PR TITLE
[chip,dv] Exclude pwrmgr.ctrl[usb_clk_en_active]

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -267,6 +267,9 @@
                 '''
             },
           ]
+          tags: [// Turning off USB clock in active state impacts other CSRs
+                 // at the chip level (in other blocks, such as clkmgr).
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         { bits: "8",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -312,6 +312,9 @@
                 '''
             },
           ]
+          tags: [// Turning off USB clock in active state impacts other CSRs
+                 // at the chip level (in other blocks, such as clkmgr).
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         { bits: "8",

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -351,6 +351,9 @@
                 '''
             },
           ]
+          tags: [// Turning off USB clock in active state impacts other CSRs
+                 // at the chip level (in other blocks, such as clkmgr).
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         },
 
         { bits: "8",


### PR DESCRIPTION
Exclude this bit from writes in CSR tests since it impacts clkmgr
registers that need the USB clock to be running.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>