### PR TITLE
[otbn,dv] Fix name of dummy instruction in otbn_env_cov

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -72,7 +72,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   `DEF_MNEM(mnem_bn_wsrr,       "bn.wsrr");
   `DEF_MNEM(mnem_bn_wsrw,       "bn.wsrw");
   // A fake mnemonic, used for bits that don't decode to a real instruction
-  `DEF_MNEM(mnem_dummy,         "dummy-insn");
+  `DEF_MNEM(mnem_dummy,         "??");
 `undef DEF_MNEM
 
   // A macro used for coverpoints for mnemonics. This expands to entries like


### PR DESCRIPTION
It seems that I had the foresight to add an entry for bad instructions
but unfortunately I guessed the wrong name :-) Switch to "??" to match
what comes out of the ISS trace interface.

We see this go wrong when running the `otbn_imem_err` sequence in nightly tests (where coverage is turned on). This is what's causing these errors in the nightly report:
```
  UVM_FATAL @  10368035 ps: (otbn_env_cov.sv:2059) [uvm_test_top.env.cov] Unknown encoding () for instruction `??'
  UVM_INFO @  10368035 ps: (uvm_report_server.svh:901) [UVM/REPORT/SERVER]
  --- UVM Report Summary ---
  
  Quit count :     0 of     1
```