### PR TITLE
[ci] Increase timeouts in Verilator simulation

### DIFF
--- a/test/systemtest/test_sim_verilator_opentitan.py
+++ b/test/systemtest/test_sim_verilator_opentitan.py
@@ -20,8 +20,8 @@ class VerilatorSimOpenTitan:
                  rom_vmem_path: Path,
                  otp_img_path: Path,
                  work_dir: Path,
-                 boot_timeout: int = 120,
-                 test_timeout: int = 600):
+                 boot_timeout: int = 4*60,
+                 test_timeout: int = 20*60):
         """ A verilator simulation of an OpenTitan toplevel """
         assert sim_path.is_file()
         self._sim_path = sim_path


### PR DESCRIPTION
Since several days we regularly hit the boot timeout in
`VerilatorSimOpenTitan.assert_selfchecking_test_passes`, which used to
be 120s (2 minutes). Double this timeout to 4 minutes.

To avoid the next betch of timeouts, also double the overall test
timeout to 20 minutes.