### PR TITLE
[otbn,doc] Initial specification for LOAD_CHECKSUM register

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -440,6 +440,22 @@
         }
       ]
     }
+    { name: "LOAD_CHECKSUM",
+      desc: '''
+        A 32-bit CRC checksum of data written to memory
+
+        See the "Memory Load Integrity" section of the manual for full details.
+      '''
+      swaccess: "rw",
+      hwaccess: "hrw",
+      fields: [
+        { bits: "31:0",
+          name: "checksum",
+          resval: 0,
+          desc: "Checksum accumulator"
+        }
+      ]
+    }
 
     // Give IMEM and DMEM 16 KiB address space, each, to allow for easy expansion
     // of the actual IMEM and DMEM sizes without changing the address map.

--- a/hw/ip/otbn/doc/_index.md
+++ b/hw/ip/otbn/doc/_index.md
@@ -500,6 +500,9 @@ These accesses are ignored if OTBN is busy.
 A host processor can check whether OTBN is busy by reading the {{< regref "STATUS">}} register.
 All memory accesses through the register interface must be word-aligned 32b word accesses.
 
+Each memory write through the register interface updates a checksum.
+See the [Memory Load Integrity]({{< relref "#mem-load-integrity" >}}) section for more details.
+
 ### Random Numbers
 
 OTBN is connected to the [Entropy Distribution Network (EDN)]({{< relref "hw/ip/edn/doc" >}}) which can provide random numbers via the `RND` and `URND` CSRs and WSRs.
@@ -843,6 +846,31 @@ The Integrity Protection Code is checked on every memory read, even though the c
 A further check must be performed when the data is consumed.
 Detected integrity violations in the data memory raise a fatal `imem_error`.
 
+### Memory Load Integrity {#mem-load-integrity}
+
+As well as the integrity protection discussed above for the memories and bus interface, OTBN has a second layer of integrity checking to allow a host processor to ensure that a program has been loaded correctly.
+This is visible through the {{< regref "LOAD_CHECKSUM" >}} register.
+The register exposes a cumulative CRC checksum which is updated on every write to either memory.
+
+This is intended as a light-weight way to implement a more efficient "write and read back" check.
+It isn't a cryptographically secure MAC, so cannot spot an attacker who can completely control the bus.
+However, in this case the attacker would be equally able to control responses from OTBN, so any such check could be subverted.
+
+The CRC used is the 32-bit CRC-32-IEEE checksum.
+This standard choice of generating polynomial makes it compatible with other tooling, such as the POSIX cksum utility [[POSIX18]({{< relref "#ref-posix-cksum">}})].
+The stream over which the checksum is computed is the stream of writes that have been seen since the last write to {{< regref "LOAD_CHECKSUM" >}}.
+Each write is treated as a 48b value, `{imem, idx, wdata}`.
+Here, `imem` is a single bit flag which is one for writes to IMEM and zero for writes to DMEM.
+The `idx` value is the index of the word within the memory, zero extended from 10b to 15b.
+Finally, `wdata` is the 32b word that was written.
+
+The host processor can also write to the register.
+Typically, this will be to clear the value to `32'hffffffff`, the traditional starting value for a 32-bit CRC.
+
+To use this functionality, the host processor should set {{< regref "LOAD_CHECKSUM" >}} to a known value (traditionally, `32'hffffffff`).
+Next, it should write the program to be loaded to OTBN's IMEM and DMEM over the bus.
+Finally, it should read back the value of {{< regref "LOAD_CHECKSUM" >}} and compare it with an expected value.
+
 ### Secure Wipe {#design-details-secure-wipe}
 
 Applications running on OTBN may store sensitive data in the internal registers or the memory.
@@ -912,15 +940,17 @@ The section [Writing OTBN applications]({{< ref "#writing-otbn-applications" >}}
 
 The high-level sequence by which the host processor should use OTBN is as follows.
 
+1. Optional: Initialise {{< regref "LOAD_CHECKSUM" >}}.
 1. Write the OTBN application binary to {{< regref "IMEM" >}}, starting at address 0.
-2. Optional: Write constants and input arguments, as mandated by the calling convention of the loaded application, to {{< regref "DMEM" >}}.
-3. Start the operation on OTBN by [issuing the `EXECUTE` command](#design-details-commands).
+1. Optional: Write constants and input arguments, as mandated by the calling convention of the loaded application, to {{< regref "DMEM" >}}.
+1. Optional: Read back {{< regref "LOAD_CHECKSUM" >}} and perform an integrity check.
+1. Start the operation on OTBN by [issuing the `EXECUTE` command](#design-details-commands).
    Now neither data nor instruction memory may be accessed from the host CPU.
    After it has been started the OTBN application runs to completion without further interaction with the host.
-4. Wait for the operation to complete (see below).
+1. Wait for the operation to complete (see below).
    As soon as the OTBN operation has completed the data and instruction memories can be accessed again from the host CPU.
-5. Check if the operation was successful by reading the {{< regref "ERR_BITS" >}} register.
-6. Optional: Retrieve results by reading {{< regref "DMEM" >}}, as mandated by the calling convention of the loaded application.
+1. Check if the operation was successful by reading the {{< regref "ERR_BITS" >}} register.
+1. Optional: Retrieve results by reading {{< regref "DMEM" >}}, as mandated by the calling convention of the loaded application.
 
 OTBN applications are run to completion.
 The host CPU can determine if an application has completed by either polling {{< regref "STATUS">}} or listening for an interrupt.
@@ -1270,3 +1300,5 @@ Code snippets giving examples of 256x256 and 384x384 multiplies can be found in 
 # References
 
 <a name="ref-chen08">[CHEN08]</a> L. Chen, "Hsiao-Code Check Matrices and Recursively Balanced Matrices," arXiv:0803.1217 [cs], Mar. 2008 [Online]. Available: http://arxiv.org/abs/0803.1217
+
+<a name="ref-posix-cksum">[POSIX18]</a> The Open Group, "cksum" manual. Available: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cksum.html

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -107,6 +107,11 @@ module otbn
   tlul_pkg::tl_h2d_t tl_win_h2d [2];
   tlul_pkg::tl_d2h_t tl_win_d2h [2];
 
+  // TODO: Implement LOAD_CHECKSUM register
+  logic unused_load_checksum;
+  assign unused_load_checksum = ^reg2hw.load_checksum;
+  assign hw2reg.load_checksum.d = '0;
+  assign hw2reg.load_checksum.de = 1'b0;
 
   // Inter-module signals ======================================================
 

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -51,6 +51,10 @@ package otbn_reg_pkg;
   } otbn_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+  } otbn_reg2hw_load_checksum_reg_t;
+
+  typedef struct packed {
     logic        d;
     logic        de;
   } otbn_hw2reg_intr_state_reg_t;
@@ -150,24 +154,31 @@ package otbn_reg_pkg;
     logic [31:0] d;
   } otbn_hw2reg_insn_cnt_reg_t;
 
+  typedef struct packed {
+    logic [31:0] d;
+    logic        de;
+  } otbn_hw2reg_load_checksum_reg_t;
+
   // Register -> HW type
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [18:18]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [17:17]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [16:15]
-    otbn_reg2hw_alert_test_reg_t alert_test; // [14:11]
-    otbn_reg2hw_cmd_reg_t cmd; // [10:2]
-    otbn_reg2hw_ctrl_reg_t ctrl; // [1:0]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [50:50]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [49:49]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [48:47]
+    otbn_reg2hw_alert_test_reg_t alert_test; // [46:43]
+    otbn_reg2hw_cmd_reg_t cmd; // [42:34]
+    otbn_reg2hw_ctrl_reg_t ctrl; // [33:32]
+    otbn_reg2hw_load_checksum_reg_t load_checksum; // [31:0]
   } otbn_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    otbn_hw2reg_intr_state_reg_t intr_state; // [81:80]
-    otbn_hw2reg_ctrl_reg_t ctrl; // [79:79]
-    otbn_hw2reg_status_reg_t status; // [78:70]
-    otbn_hw2reg_err_bits_reg_t err_bits; // [69:46]
-    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [45:32]
-    otbn_hw2reg_insn_cnt_reg_t insn_cnt; // [31:0]
+    otbn_hw2reg_intr_state_reg_t intr_state; // [114:113]
+    otbn_hw2reg_ctrl_reg_t ctrl; // [112:112]
+    otbn_hw2reg_status_reg_t status; // [111:103]
+    otbn_hw2reg_err_bits_reg_t err_bits; // [102:79]
+    otbn_hw2reg_fatal_alert_cause_reg_t fatal_alert_cause; // [78:65]
+    otbn_hw2reg_insn_cnt_reg_t insn_cnt; // [64:33]
+    otbn_hw2reg_load_checksum_reg_t load_checksum; // [32:0]
   } otbn_hw2reg_t;
 
   // Register offsets
@@ -181,6 +192,7 @@ package otbn_reg_pkg;
   parameter logic [BlockAw-1:0] OTBN_ERR_BITS_OFFSET = 16'h 1c;
   parameter logic [BlockAw-1:0] OTBN_FATAL_ALERT_CAUSE_OFFSET = 16'h 20;
   parameter logic [BlockAw-1:0] OTBN_INSN_CNT_OFFSET = 16'h 24;
+  parameter logic [BlockAw-1:0] OTBN_LOAD_CHECKSUM_OFFSET = 16'h 28;
 
   // Reset values for hwext registers and their fields
   parameter logic [0:0] OTBN_INTR_TEST_RESVAL = 1'h 0;
@@ -212,21 +224,23 @@ package otbn_reg_pkg;
     OTBN_STATUS,
     OTBN_ERR_BITS,
     OTBN_FATAL_ALERT_CAUSE,
-    OTBN_INSN_CNT
+    OTBN_INSN_CNT,
+    OTBN_LOAD_CHECKSUM
   } otbn_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] OTBN_PERMIT [10] = '{
-    4'b 0001, // index[0] OTBN_INTR_STATE
-    4'b 0001, // index[1] OTBN_INTR_ENABLE
-    4'b 0001, // index[2] OTBN_INTR_TEST
-    4'b 0001, // index[3] OTBN_ALERT_TEST
-    4'b 0001, // index[4] OTBN_CMD
-    4'b 0001, // index[5] OTBN_CTRL
-    4'b 0001, // index[6] OTBN_STATUS
-    4'b 0111, // index[7] OTBN_ERR_BITS
-    4'b 0001, // index[8] OTBN_FATAL_ALERT_CAUSE
-    4'b 1111  // index[9] OTBN_INSN_CNT
+  parameter logic [3:0] OTBN_PERMIT [11] = '{
+    4'b 0001, // index[ 0] OTBN_INTR_STATE
+    4'b 0001, // index[ 1] OTBN_INTR_ENABLE
+    4'b 0001, // index[ 2] OTBN_INTR_TEST
+    4'b 0001, // index[ 3] OTBN_ALERT_TEST
+    4'b 0001, // index[ 4] OTBN_CMD
+    4'b 0001, // index[ 5] OTBN_CTRL
+    4'b 0001, // index[ 6] OTBN_STATUS
+    4'b 0111, // index[ 7] OTBN_ERR_BITS
+    4'b 0001, // index[ 8] OTBN_FATAL_ALERT_CAUSE
+    4'b 1111, // index[ 9] OTBN_INSN_CNT
+    4'b 1111  // index[10] OTBN_LOAD_CHECKSUM
   };
 
 endpackage


### PR DESCRIPTION
Fixes #8503.

This initial specification is based on the existing notes in the [design doc](https://docs.google.com/document/d/1nxvpyN4qb0-tZmqkFRSD-mGotRTLbfQA48KUOMW6PVQ/edit#heading=h.hv0qtq1ls7n8). I've made slight tweaks to allow it to apply to DMEM writes as well, so that it covers initialised data. I've also specified exactly what the checksum computes. We should check that updating a 32-bit CRC with 6 bytes of data is a reasonable thing to do in a single cycle: I assume so, but don't actually know.

Please rope in any other reviewers that you think should have a look.