### PR TITLE
[spi_device,lint] Remove double-import of parameters

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1283,9 +1283,7 @@ module spi_device
   /////////////////////
   // SPI Passthrough //
   /////////////////////
-  spi_passthrough #(
-    .NumCmdInfo(spi_device_reg_pkg::NumCmdInfo)
-  ) u_passthrough (
+  spi_passthrough u_passthrough (
     .clk_i     (clk_spi_in_buf),
     .rst_ni    (rst_spi_n),
     .clk_out_i (clk_spi_out_buf),

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -72,9 +72,7 @@
  */
 module spi_passthrough
   import spi_device_pkg::*;
-#(
-  parameter int unsigned NumCmdInfo = 16
-) (
+(
   input clk_i,   // SPI input clk
   input rst_ni,  // SPI reset
 

--- a/hw/ip/spi_device/rtl/spid_status.sv
+++ b/hw/ip/spi_device/rtl/spid_status.sv
@@ -18,8 +18,7 @@ module spid_status
     spi_device_pkg::CmdInfoReadStatus1,
     spi_device_pkg::CmdInfoReadStatus2,
     spi_device_pkg::CmdInfoReadStatus3
-  },
-  parameter int unsigned CmdInfoIdxW = spi_device_pkg::CmdInfoIdxW
+  }
 ) (
   input clk_i,
   input rst_ni,


### PR DESCRIPTION
In `spid_status`, we're already importing `spi_device_pkg::*` into the
module's scope, so this line was shadowing `CmdInfoIdxW` (with itself!)
and Verilator spat out a warning.

In `spi_passthrough`, we were importing `spi_device_pkg`, which exports
`NumCmdInfo`, shadowed by the `NumCmdInfo` parameter. We then instantiate
it (in `spi_device.sv`), setting the parameter to the thing it's
shadowing. Get rid of the parameter entirely.
