### PR TITLE
[pwrmgr,lint] Fix some width mismatches in pwrmgr_pkg

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -25,10 +25,10 @@ package pwrmgr_pkg;
   parameter int NumSwRstReq = 1;
 
   // position of escalation request
-  parameter int HwResetWidth = pwrmgr_reg_pkg::NumRstReqs + IntReqLastIdx;
+  parameter int HwResetWidth = pwrmgr_reg_pkg::NumRstReqs + int'(IntReqLastIdx);
   parameter int TotalResetWidth = HwResetWidth + NumSwRstReq;
-  parameter int ResetMainPwrIdx = pwrmgr_reg_pkg::NumRstReqs + IntReqMainPwr;
-  parameter int ResetEscIdx = pwrmgr_reg_pkg::NumRstReqs + IntReqEsc;
+  parameter int ResetMainPwrIdx = pwrmgr_reg_pkg::NumRstReqs + int'(IntReqMainPwr);
+  parameter int ResetEscIdx = pwrmgr_reg_pkg::NumRstReqs + int'(IntReqEsc);
   parameter int ResetSwReqIdx = TotalResetWidth - 1;
 
   // pwrmgr to ast


### PR DESCRIPTION
These are all of the form "`wide0 = wide1 + narrow`" where `wide*` are
integers and `narrow` is an enum value that's just a couple of bits
wide. Make the widening to int explicit to silence the Verilator
warning.
