### PR TITLE
[signer] Add image type support

### DIFF
--- a/sw/device/silicon_creator/rom_exts/meson.build
+++ b/sw/device/silicon_creator/rom_exts/meson.build
@@ -156,6 +156,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
         output: '@BASENAME@.@0@.signed.bin'.format(key_name),
         command: [
           rom_ext_signer_export.full_path(),
+          'rom_ext',
           '@INPUT@',
           key_info['path'],
           rom_ext_elf.full_path(),

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -726,6 +726,7 @@ foreach sw_test_name, sw_test_info : sw_rom_ext_tests
         output: '@BASENAME@.@0@.signed.bin'.format(key_name),
         command: [
           rom_ext_signer_export.full_path(),
+          'rom_ext',
           '@INPUT@',
           key_info['path'],
           sw_test_elf.full_path(),

--- a/sw/host/rom_ext_image_tools/signer/image/src/image.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/image.rs
@@ -45,7 +45,8 @@ impl<'a> Image<'a> {
     }
 
     pub fn signed_bytes(&self) -> Vec<u8> {
-        self.bytes().split_off(self.manifest.signature.as_bytes().len())
+        self.bytes()
+            .split_off(self.manifest.signature.as_bytes().len())
     }
 }
 

--- a/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/manifest.rs
@@ -25,11 +25,16 @@ use zerocopy::FromBytes;
 //      --no-doc-comments --no-layout-tests \
 //      sw/device/silicon_creator/lib/manifest.h \
 //      -- -I./ -Isw/device/lib/base/freestanding
+// TODO: Generate some constants as hex if possible, replacing manually for now.
 
 pub const MANIFEST_SIZE: u32 = 896;
-pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xA5A5A5A5;
-pub const MANIFEST_LENGTH_FIELD_MIN: u32 = 896;
-pub const MANIFEST_LENGTH_FIELD_MAX: u32 = 65536;
+pub const MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL: u32 = 0xa5a5a5a5;
+pub const MANIFEST_IDENTIFIER_ROM_EXT: u32 = 0x4552544f;
+pub const MANIFEST_IDENTIFIER_OWNER_STAGE: u32 = 0x4f53544f;
+pub const MANIFEST_LENGTH_FIELD_ROM_EXT_MIN: u32 = 896;
+pub const MANIFEST_LENGTH_FIELD_ROM_EXT_MAX: u32 = 0x10000;
+pub const MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN: u32 = 896;
+pub const MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX: u32 = 0x70000;
 
 /// Manifest for boot stage images stored in flash.
 #[repr(C)]
@@ -88,7 +93,8 @@ impl Default for ManifestUsageConstraints {
         Self {
             selector_bits: 0,
             device_id: LifecycleDeviceId {
-                device_id: [MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL; 8usize],
+                device_id: [MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL;
+                    8usize],
             },
             manuf_state_creator: MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL,
             manuf_state_owner: MANIFEST_USAGE_CONSTRAINT_UNSELECTED_WORD_VAL,


### PR DESCRIPTION
This change adds a new CLI argument for image type (`rom_ext` or `owner`) and updates relevant `meson.build` files to unblock jumping from ROM_EXT to the first owner stage (#8697).

Signed-off-by: Alphan Ulusoy <alphan@google.com>