### PR TITLE
[dv/chip_level] Disable signal integrity check

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -23,6 +23,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   // alert checking related parameters
   bit do_alert_check = 1;
+  bit check_alert_sig_int_err = 1;
   local bit under_alert_handshake[string];
   local bit exp_alert[string];
   local bit is_fatal_alert[string];
@@ -179,8 +180,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
           if (item.alert_esc_type == AlertEscSigTrans && !item.ping_timeout &&
               item.alert_handshake_sta inside {AlertReceived, AlertAckComplete}) begin
             process_alert(alert_name, item);
-          // IP level alert protocol does not drive any sig_int_err or ping response
-          end else if (item.alert_esc_type == AlertEscIntFail) begin
+          // IP level alert protocol does not drive any sig_int_err or ping response.
+          // However, `lpg_en` or `alert_init` will trigger signal integrity error, user can
+          // disable signal integrity checking via `check_alert_sig_int_err` flag.
+          end else if (check_alert_sig_int_err && item.alert_esc_type == AlertEscIntFail) begin
             `uvm_error(`gfn, $sformatf("alert %s has unexpected signal int error", alert_name))
           end else if (item.ping_timeout) begin
             `uvm_error(`gfn, $sformatf("alert %s has unexpected timeout error", alert_name))

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -31,6 +31,9 @@ class chip_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   task run_phase(uvm_phase phase);
+    // Disable alert signal integrity check to avoid false alert on low_power_group_en or
+    // alert_init. Alert signal integrity can be checked by assertions.
+    check_alert_sig_int_err = 0;
     super.run_phase(phase);
     fork
       process_jtag_fifo();


### PR DESCRIPTION
Because of lpg and alert init are not fully supported in top-level
environment with alert_esc_agent, we will disable the alert's signal
integrity check.
This should have minimal impact because prim_receiver's assertions can
still check signal integrity error.
This also fixes issue #8715

Signed-off-by: Cindy Chen <chencindy@opentitan.org>