### PR TITLE
[dif] Fix typos in autogen'd DIF comments.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_adc_ctrl_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool adc_ctrl_get_irq_bit_index(dif_adc_ctrl_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
@@ -67,7 +67,7 @@ typedef enum dif_adc_ctrl_irq {
 typedef uint32_t dif_adc_ctrl_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param adc_ctrl A adc_ctrl handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_alert_handler_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool alert_handler_get_irq_bit_index(dif_alert_handler_irq_t irq,
                                             bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen.h
@@ -84,7 +84,7 @@ typedef enum dif_alert_handler_irq {
 typedef uint32_t dif_alert_handler_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param alert_handler A alert_handler handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
@@ -10,6 +10,7 @@
 #include "aon_timer_regs.h"  // Generated.
 
 #include <assert.h>
+
 static_assert(AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT ==
                   AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT,
               "Expected IRQ bit offsets to match across STATE/TEST regs.");
@@ -32,8 +33,8 @@ dif_result_t dif_aon_timer_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool aon_timer_get_irq_bit_index(dif_aon_timer_irq_t irq,
                                         bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
@@ -72,7 +72,7 @@ typedef enum dif_aon_timer_irq {
 typedef uint32_t dif_aon_timer_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param aon_timer A aon_timer handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool csrng_get_irq_bit_index(dif_csrng_irq_t irq,
                                     bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.h
@@ -80,7 +80,7 @@ typedef enum dif_csrng_irq {
 typedef uint32_t dif_csrng_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param csrng A csrng handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool edn_get_irq_bit_index(dif_edn_irq_t irq,
                                   bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.h
@@ -70,7 +70,7 @@ typedef enum dif_edn_irq {
 typedef uint32_t dif_edn_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param edn A edn handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool entropy_src_get_irq_bit_index(dif_entropy_src_irq_t irq,
                                           bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
@@ -81,7 +81,7 @@ typedef enum dif_entropy_src_irq {
 typedef uint32_t dif_entropy_src_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param entropy_src A entropy_src handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_flash_ctrl_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool flash_ctrl_get_irq_bit_index(dif_flash_ctrl_irq_t irq,
                                          bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
@@ -88,7 +88,7 @@ typedef enum dif_flash_ctrl_irq {
 typedef uint32_t dif_flash_ctrl_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param flash_ctrl A flash_ctrl handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool gpio_get_irq_bit_index(dif_gpio_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.h
@@ -97,7 +97,7 @@ typedef enum dif_gpio_irq {
 typedef uint32_t dif_gpio_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param gpio A gpio handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool hmac_get_irq_bit_index(dif_hmac_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.h
@@ -74,7 +74,7 @@ typedef enum dif_hmac_irq {
 typedef uint32_t dif_hmac_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param hmac A hmac handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool i2c_get_irq_bit_index(dif_i2c_irq_t irq,
                                   bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -129,7 +129,7 @@ typedef enum dif_i2c_irq {
 typedef uint32_t dif_i2c_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param i2c A i2c handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool keymgr_get_irq_bit_index(dif_keymgr_irq_t irq,
                                      bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
@@ -66,7 +66,7 @@ typedef enum dif_keymgr_irq {
 typedef uint32_t dif_keymgr_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param keymgr A keymgr handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool kmac_get_irq_bit_index(dif_kmac_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.h
@@ -74,7 +74,7 @@ typedef enum dif_kmac_irq {
 typedef uint32_t dif_kmac_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param kmac A kmac handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool otbn_get_irq_bit_index(dif_otbn_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.h
@@ -66,7 +66,7 @@ typedef enum dif_otbn_irq {
 typedef uint32_t dif_otbn_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param otbn A otbn handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool otp_ctrl_get_irq_bit_index(dif_otp_ctrl_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
@@ -72,7 +72,7 @@ typedef enum dif_otp_ctrl_irq {
 typedef uint32_t dif_otp_ctrl_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param otp_ctrl A otp_ctrl handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_pattgen_init(mmio_region_t base_addr, dif_pattgen_t *pattgen) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool pattgen_get_irq_bit_index(dif_pattgen_irq_t irq,
                                       bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.h
@@ -70,7 +70,7 @@ typedef enum dif_pattgen_irq {
 typedef uint32_t dif_pattgen_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param pattgen A pattgen handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool pwrmgr_get_irq_bit_index(dif_pwrmgr_irq_t irq,
                                      bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
@@ -66,7 +66,7 @@ typedef enum dif_pwrmgr_irq {
 typedef uint32_t dif_pwrmgr_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param pwrmgr A pwrmgr handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
@@ -10,6 +10,7 @@
 #include "rv_timer_regs.h"  // Generated.
 
 #include <assert.h>
+
 static_assert(RV_TIMER_INTR_STATE0_IS_0_BIT == RV_TIMER_INTR_ENABLE0_IE_0_BIT,
               "Expected IRQ bit offsets to match across STATE/ENABLE regs.");
 static_assert(RV_TIMER_INTR_STATE0_IS_0_BIT == RV_TIMER_INTR_TEST0_T_0_BIT,
@@ -74,8 +75,8 @@ static bool rv_timer_get_irq_reg_offset(dif_rv_timer_intr_reg_t intr_reg,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool rv_timer_get_irq_bit_index(dif_rv_timer_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
@@ -67,7 +67,7 @@ typedef enum dif_rv_timer_irq {
 typedef uint32_t dif_rv_timer_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param rv_timer A rv_timer handle.
  * @param hart_id The hart to manipulate.

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_spi_device_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool spi_device_get_irq_bit_index(dif_spi_device_irq_t irq,
                                          bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
@@ -92,7 +92,7 @@ typedef enum dif_spi_device_irq {
 typedef uint32_t dif_spi_device_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param spi_device A spi_device handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_spi_host_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool spi_host_get_irq_bit_index(dif_spi_host_irq_t irq,
                                        bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.h
@@ -71,7 +71,7 @@ typedef enum dif_spi_host_irq {
 typedef uint32_t dif_spi_host_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param spi_host A spi_host handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
@@ -24,8 +24,8 @@ dif_result_t dif_sysrst_ctrl_init(mmio_region_t base_addr,
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool sysrst_ctrl_get_irq_bit_index(dif_sysrst_ctrl_irq_t irq,
                                           bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h
@@ -68,7 +68,7 @@ typedef enum dif_sysrst_ctrl_irq {
 typedef uint32_t dif_sysrst_ctrl_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param sysrst_ctrl A sysrst_ctrl handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool uart_get_irq_bit_index(dif_uart_irq_t irq,
                                    bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.h
@@ -95,7 +95,7 @@ typedef enum dif_uart_irq {
 typedef uint32_t dif_uart_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param uart A uart handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -23,8 +23,8 @@ dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev) {
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the
- * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
- * exist, as templated below.
+ * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+ * will exist, as templated below.
  */
 static bool usbdev_get_irq_bit_index(dif_usbdev_irq_t irq,
                                      bitfield_bit32_index_t *index_out) {

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
@@ -142,7 +142,7 @@ typedef enum dif_usbdev_irq {
 typedef uint32_t dif_usbdev_irq_state_snapshot_t;
 
 /**
- * Returns whether a particular interrupt is currently pending.
+ * Returns the state of all interrupts (i.e., pending or not) for this IP.
  *
  * @param usbdev A usbdev handle.
  * @param[out] snapshot Out-param for interrupt state snapshot.

--- a/util/make_new_dif/dif_autogen.c.tpl
+++ b/util/make_new_dif/dif_autogen.c.tpl
@@ -33,6 +33,7 @@
 
 % if ip.name_snake == "aon_timer":
   #include <assert.h>
+
   % for irq in ip.irqs:
     static_assert(${ip.name_upper}_INTR_STATE_${irq.name_upper}_BIT == 
                   ${ip.name_upper}_INTR_TEST_${irq.name_upper}_BIT,
@@ -41,6 +42,7 @@
 
 % elif ip.name_snake == "rv_timer":
   #include <assert.h>
+
   % for irq in ip.irqs:
     static_assert(${ip.name_upper}_INTR_STATE0_IS_${loop.index}_BIT == 
                   ${ip.name_upper}_INTR_ENABLE0_IE_${loop.index}_BIT,
@@ -105,8 +107,8 @@ dif_result_t dif_${ip.name_snake}_init(
   /**
    * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
    * HJSON does NOT have a field "no_auto_intr_regs = true", then the
-   * "<ip>_INTR_COMMON_<irq>_BIT" macro can used. Otherwise, special cases will
-   * exist, as templated below.
+   * "<ip>_INTR_COMMON_<irq>_BIT" macro can be used. Otherwise, special cases
+   * will exist, as templated below.
    */
   static bool ${ip.name_snake}_get_irq_bit_index(
     dif_${ip.name_snake}_irq_t irq,

--- a/util/make_new_dif/dif_autogen.h.tpl
+++ b/util/make_new_dif/dif_autogen.h.tpl
@@ -98,7 +98,7 @@ dif_result_t dif_${ip.name_snake}_init(
   typedef uint32_t dif_${ip.name_snake}_irq_state_snapshot_t;
 
   /**
-   * Returns whether a particular interrupt is currently pending.
+   * Returns the state of all interrupts (i.e., pending or not) for this IP.
    *
    * @param ${ip.name_snake} A ${ip.name_snake} handle.
   % if ip.name_snake == "rv_timer":


### PR DESCRIPTION
This fixes the autogen DIF templates to remove typos in generated code comments as requested in the review comments of #8775 and #8780.