### PR TITLE
[spi, dv] Updated spi agent to support SPI_host

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_cmd_rsp_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_cmd_rsp_seq.sv
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// --------------------
+// Device sequence
+// This sequence acts as the device
+// with a DUT that acts as host.
+// the sequence will poll for read and write commands
+// for read commands it will sendback random data
+// --------------------
+
+
+class spi_device_cmd_rsp_seq extends spi_device_seq;
+  `uvm_object_utils(spi_device_cmd_rsp_seq)
+  `uvm_object_new
+
+  // read queue
+  spi_item rsp_q[$];
+  typedef enum {SPI_IDLE, SPI_ADDR, SPI_DATA } spi_fsm_e;
+  spi_fsm_e spi_state = SPI_IDLE;
+
+  virtual task body();
+
+    // wait for reset release
+    if (cfg.in_reset) wait (!cfg.in_reset);
+
+    fork
+      // get transactions from host
+      get_req();
+      // decode transactions
+      decode_cmd();
+      // transmit response
+      send_rsp(rsp_q);
+    join
+  endtask : body
+
+
+  virtual task decode_cmd();
+    spi_item item;
+    spi_item rsp = spi_item::type_id::create("rsp");
+    spi_item rsp_clone;
+    spi_cmd_e  cmd;
+    bit [31:0] addr;
+    bit [31:0] data;
+    bit [31:0] addr_cnt = 0;
+    int        byte_cnt = 0;
+
+    forever begin
+      case (spi_state)
+        SPI_IDLE: begin
+          get_nxt_req(item);
+          // find start of transaction
+          if (item.first_byte) begin
+            // decode command
+            cmd = cmd_check(item.data.pop_front);
+            spi_state = SPI_ADDR;
+          end
+        end
+
+        SPI_ADDR: begin
+          get_nxt_req(item);
+          // make sure that we did not start a new transaction
+          if (item.first_byte) begin
+            // decode command
+            cmd = cmd_check(item.data.pop_front);
+            spi_state = SPI_ADDR;
+            addr_cnt = 0;
+          end else begin
+            addr[31-8*byte_cnt -: 8] = item.data.pop_front();
+            byte_cnt += 1;
+            if (byte_cnt == cfg.spi_addr_width) begin
+              byte_cnt = 0;
+              spi_state = SPI_DATA;
+            end
+          end
+        end
+
+        SPI_DATA: begin
+          case (cmd)
+            ReadStd: begin
+              // read_until CSB low
+              data = $urandom();
+              addr_cnt += 4;
+              case (cmd)
+                ReadStd:  `DV_CHECK_RANDOMIZE_WITH_FATAL(rsp, rsp.data.size() == 8;)
+                ReadDual: `DV_CHECK_RANDOMIZE_WITH_FATAL(rsp, rsp.data.size() == 16;)
+                default:  `DV_CHECK_RANDOMIZE_WITH_FATAL(rsp, rsp.data.size() == 32;)
+              endcase // case (cmd)
+              `downcast(rsp, rsp_clone);
+              rsp_q.push_back(rsp_clone);
+              req = new();
+              // offload input queue
+              get_nxt_req(item);
+              if (item.first_byte) begin
+                // decode command
+                cmd = cmd_check(item.data.pop_front);
+                spi_state = SPI_ADDR;
+                addr_cnt = 0;
+              end
+            end
+
+            WriteStd: begin
+              get_nxt_req(item);
+              if (item.first_byte) begin
+                // decode command
+                cmd = cmd_check(item.data.pop_front);
+                spi_state = SPI_ADDR;
+                addr_cnt = 0;
+              end else begin
+                data[31-8*addr_cnt[1:0] -: 8] = item.data.pop_front();
+                addr_cnt += 1;
+              end
+              // potential TODO add associative array for read back of write data
+            end
+
+            default: begin
+              get_nxt_req(item);
+              `uvm_fatal(`gfn, $sformatf("UNSUPPORTED COMMAND"))
+            end
+          endcase
+        end // case: SPI_DATA
+        default: begin
+          `uvm_fatal(`gfn, $sformatf("BAD STATE"))
+        end
+      endcase
+    end
+  endtask // decode_cmd
+
+
+  function spi_cmd_e cmd_check(bit[7:0] data);
+    spi_cmd_e cmd;
+    `downcast(cmd, data, "Illegal Command seen")
+  endfunction
+endclass : spi_device_cmd_rsp_seq

--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_seq.sv
@@ -14,19 +14,35 @@ class spi_device_seq extends spi_base_seq;
 
   virtual task body();
     fork
-      forever begin
-        spi_item  req;
-        p_sequencer.req_analysis_fifo.get(req);
-        req_q.push_back(req);
-      end
-      forever begin
-        spi_item  rsp;
-        wait(req_q.size > 0);
-        rsp = req_q.pop_front();
-        start_item(rsp);
-        finish_item(rsp);
-      end
+      get_req();
+      send_rsp(req_q);
     join
   endtask : body
-  
+
+
+  virtual task get_req();
+    forever begin
+      spi_item req;
+      p_sequencer.req_analysis_fifo.get(req);
+      req_q.push_back(req);
+    end
+  endtask
+
+
+  virtual task send_rsp(ref spi_item item_q[$]);
+    forever begin
+      spi_item  rsp;
+      wait(item_q.size > 0);
+      rsp = item_q.pop_front();
+      start_item(rsp);
+      finish_item(rsp);
+    end
+  endtask
+
+
+  virtual task get_nxt_req(ref spi_item item);
+    wait  (req_q.size > 0);
+    item = req_q.pop_front();
+  endtask
+
 endclass : spi_device_seq

--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_dummy_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_dummy_seq.sv
@@ -10,7 +10,7 @@ class spi_host_dummy_seq extends spi_base_seq;
     req = spi_item::type_id::create("req");
     start_item(req);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
-                                   item_type inside {SpiTransSckNoCsb, SpiTransCsbNoScb};
+                                   item_type inside {SpiTransSckNoCsb, SpiTransCsbNoSck};
                                    data.size() == 1; // no used, set to 1 to simpify randomization
                                    )
     finish_item(req);

--- a/hw/dv/sv/spi_agent/seq_lib/spi_seq_list.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_seq_list.sv
@@ -6,3 +6,4 @@
 `include "spi_host_seq.sv"
 `include "spi_host_dummy_seq.sv"
 `include "spi_device_seq.sv"
+`include "spi_device_cmd_rsp_seq.sv"

--- a/hw/dv/sv/spi_agent/spi_agent.core
+++ b/hw/dv/sv/spi_agent/spi_agent.core
@@ -10,8 +10,8 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
     files:
-      - spi_if.sv
       - spi_agent_pkg.sv
+      - spi_if.sv
       - spi_item.sv: {is_include_file: true}
       - spi_agent_cfg.sv: {is_include_file: true}
       - spi_agent_cov.sv: {is_include_file: true}
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/spi_host_seq.sv: {is_include_file: true}
       - seq_lib/spi_host_dummy_seq.sv: {is_include_file: true}
       - seq_lib/spi_device_seq.sv: {is_include_file: true}
+      - seq_lib/spi_device_cmd_rsp_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -7,22 +7,36 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   // enable checkers in monitor
   bit en_monitor_checks = 1'b1;
 
+  // byte order (configured by vseq)
+  bit byte_order        = 1'b1;
+
   // host mode cfg knobs
-  time sck_period_ps = 50_000; // 20MHz
-  bit sck_polarity;       // aka CPOL
-  bit sck_phase;          // aka CPHA
-  bit host_bit_dir;       // 1 - lsb -> msb, 0 - msb -> lsb
-  bit device_bit_dir;     // 1 - lsb -> msb, 0 - msb -> lsb
-  bit sck_on;             // keep sck on
+  time sck_period_ps    = 50_000; // 20MHz
+  bit host_bit_dir;               // 0 - msb -> lsb, 1 - lsb -> msb
+  bit device_bit_dir;             // 0 - msb -> lsb, 1 - lsb -> msb
+  bit sck_on;                     // keep sck on
   bit [1:0] csb_sel;      // Select active CSB
   bit partial_byte;       // Transfering less than byte
   bit [2:0] bits_to_transfer; // Bits to transfer if using less than byte
 
-  // spi mode knob
-  spi_mode_e spi_mode;
+  //-------------------------
+  // spi_host regs
+  //-------------------------
+  // csid reg
+  bit [MAX_CS-1:0] csid;
+  // configopts register fields
+  bit              sck_polarity[MAX_CS];       // aka CPOL
+  bit              sck_phase[MAX_CS];          // aka CPHA
+  bit              full_cyc[MAX_CS];
+  bit [3:0]        csn_lead[MAX_CS];
+  bit [3:0]        csn_trail[MAX_CS];
+  bit [3:0]        csn_idle[MAX_CS];
+  // command register fields
+  spi_mode_e       spi_mode;
 
-  // spi config
-  spi_regs_t spi_agent_regs;
+
+  // address width in bytes (default is 4 bytes)
+  int spi_addr_width = 4;
 
   // how many bytes monitor samples per transaction
   int num_bytes_per_trans_in_mon = 4;
@@ -44,8 +58,6 @@ class spi_agent_cfg extends dv_base_agent_cfg;
 
   `uvm_object_utils_begin(spi_agent_cfg)
     `uvm_field_int (sck_period_ps,  UVM_DEFAULT)
-    `uvm_field_int (sck_polarity,   UVM_DEFAULT)
-    `uvm_field_int (sck_phase,      UVM_DEFAULT)
     `uvm_field_int (host_bit_dir,   UVM_DEFAULT)
     `uvm_field_int (device_bit_dir, UVM_DEFAULT)
     `uvm_field_int (csb_sel,        UVM_DEFAULT)
@@ -57,20 +69,27 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (en_extra_dly_btw_word,        UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_word,    UVM_DEFAULT)
     `uvm_field_int (extra_dly_chance_pc_btw_word, UVM_DEFAULT)
-    `uvm_field_enum(spi_mode_e, spi_mode,         UVM_DEFAULT)
+
+    `uvm_field_sarray_int(sck_polarity,   UVM_DEFAULT)
+    `uvm_field_sarray_int(sck_phase,      UVM_DEFAULT)
+    `uvm_field_sarray_int(full_cyc,        UVM_DEFAULT)
+    `uvm_field_sarray_int(csn_lead,        UVM_DEFAULT)
+    `uvm_field_sarray_int(csn_trail,       UVM_DEFAULT)
+    `uvm_field_sarray_int(csn_idle,        UVM_DEFAULT)
+    `uvm_field_enum(spi_mode_e, spi_mode, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
 
   virtual task wait_sck_edge(sck_edge_type_e sck_edge_type);
-    bit [1:0] sck_mode = {sck_polarity, sck_phase};
     bit       wait_posedge;
+    bit [1:0] sck_mode = {sck_polarity[csid], sck_phase[csid]};
 
-    // sck polarity   slk_phase       mode
-    //            0           0       0: sample at leading podedge  (drive @ prev negedge)
-    //            1           0       2: sample at leading negedge  (drive @ prev posedge)
-    //            0           1       1: sample at trailing negedge (drive @ curr posedge)
-    //            1           1       3: sample at trailing posedge (drive @ curr negedge)
+    // sck pola   sck_pha   mode
+    //        0         0      0: sample at leading  posedge_sck (drive @ prev negedge_sck)
+    //        1         0      2: sample at leading  negedge_sck (drive @ prev posedge_sck)
+    //        0         1      1: sample at trailing negedge_sck (drive @ curr posedge_sck)
+    //        1         1      3: sample at trailing posedge_sck (drive @ curr negedge_sck)
     case (sck_edge_type)
       LeadingEdge: begin
         // wait for leading edge applies to mode 1 and 3 only
@@ -80,9 +99,30 @@ class spi_agent_cfg extends dv_base_agent_cfg;
       DrivingEdge:  wait_posedge = (sck_mode inside {2'b01, 2'b10});
       SamplingEdge: wait_posedge = (sck_mode inside {2'b00, 2'b11});
     endcase
-
     if (wait_posedge) @(posedge vif.sck);
     else              @(negedge vif.sck);
+
+    `uvm_info(`gfn, $sformatf("\n  spi_agent_cfg, %s at %s clock, sck_mode %b",
+        sck_edge_type.name(), wait_posedge ? "posedge" : "negedge", sck_mode), UVM_DEBUG)
   endtask
+
+  // TODO use  dv_utils_pkg::endian_swap_byte_arr() if possible
+  virtual function void swap_byte_order(ref bit [7:0] data[$]);
+    bit [7:0] data_arr[];
+    data_arr = data;
+    `uvm_info(`gfn, $sformatf("\n  spi_agent_cfg, data_q_baseline: %p", data), UVM_DEBUG)
+    dv_utils_pkg::endian_swap_byte_arr(data_arr);
+    `uvm_info(`gfn, $sformatf("\n  spi_agent_cfg, data_q_swapped:  %p", data_arr), UVM_DEBUG)
+    data = data_arr;
+  endfunction : swap_byte_order
+
+  virtual function int get_sio_size();
+    case (spi_mode)
+      Standard: return 1;
+      Dual:     return 2;
+      Quad:     return 4;
+      default:  return 0;
+    endcase
+  endfunction : get_sio_size
 
 endclass : spi_agent_cfg

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -12,12 +12,15 @@ package spi_agent_pkg;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
-  // local types
+  // parameter
+  parameter uint MAX_CS = 4;      // set to the maximum valid value
+
   // transaction type
   typedef enum {
+    // device dut
     SpiTransNormal,    // normal SPI trans
-    SpiTransSckNoCsb,  // bad SPI trans with clk but no sb
-    SpiTransCsbNoScb   // bad SPI trans with csb but no clk
+    SpiTransSckNoCsb,  // bad SPI trans with sck but no csb
+    SpiTransCsbNoSck   // bad SPI trans with csb but no sck
   } spi_trans_type_e;
 
   // sck edge type - used by driver and monitor
@@ -29,35 +32,22 @@ package spi_agent_pkg;
   } sck_edge_type_e;
 
   // spi mode
-  typedef enum {
-    Single = 0,  // Full duplex, tx: sio[0], rx: sio[1]
-    Dual   = 1,  // Half duplex, tx and rx: sio[1:0]
-    Quad   = 2   // Half duplex, tx and rx: sio[3:0]
+  typedef enum bit [1:0] {
+    Standard = 2'b00,  // Full duplex, tx: sio[0], rx: sio[1]
+    Dual     = 2'b01,  // Half duplex, tx and rx: sio[1:0]
+    Quad     = 2'b10,  // Half duplex, tx and rx: sio[3:0]
+    RsvdSpd  = 2'b11   // RFU
   } spi_mode_e;
 
-  // spi config
-  typedef struct {
-    // CONTROL register field
-    rand bit [8:0]  tx_watermark;
-    rand bit [6:0]  rx_watermark;
-    // CONFIGOPTS register field
-    rand bit        cpol;
-    rand bit        cpha;
-    rand bit        fullcyc;
-    rand bit        csaat;
-    rand bit [3:0]  csnlead;
-    rand bit [3:0]  csntrail;
-    rand bit [3:0]  csnidle;
-    rand bit [15:0] clkdiv;
-    // COMMAND register field
-    rand bit        fulldplx;
-    rand bit        highz;
-    rand bit        speed;
-    rand bit [3:0]  tx1_cnt;
-    rand bit [8:0]  txn_cnt;
-    rand bit [8:0]  rx_cnt;
-    rand bit [3:0]  dummy_cycles;
-  } spi_regs_t;
+  typedef enum bit [7:0] {
+    ReadStd    = 8'b11001100,
+    WriteStd   = 8'b11111100,
+    ReadDual   = 8'b00000011,
+    WriteDual  = 8'b00001100,
+    ReadQuad   = 8'b00001111,
+    WriteQuad  = 8'b11110000,
+    CmdOnly    = 8'b10000001
+  } spi_cmd_e;
 
   // forward declare classes to allow typedefs below
   typedef class spi_item;

--- a/hw/dv/sv/spi_agent/spi_device_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_device_driver.sv
@@ -9,34 +9,80 @@ class spi_device_driver extends spi_driver;
   virtual task reset_signals();
     forever begin
       @(negedge cfg.vif.rst_n);
+      `uvm_info(`gfn, "\n  dev_drv: in reset progress", UVM_DEBUG)
       under_reset = 1'b1;
-      cfg.vif.sio <= 'hz;
       @(posedge cfg.vif.rst_n);
       under_reset = 1'b0;
+      `uvm_info(`gfn, "\n  dev_drv: out of reset", UVM_DEBUG)
     end
   endtask
 
   virtual task get_and_drive();
+    spi_item req, rsp;
+
     forever begin
       seq_item_port.get_next_item(req);
-      $cast(rsp, req.clone());
-      rsp.set_id_info(req);
-      `uvm_info(`gfn, $sformatf("spi_host_driver: rcvd item:\n%0s", req.sprint()), UVM_HIGH)
+      wait (!under_reset && !cfg.vif.csb[cfg.csid]);
       fork
-        drive_rx_sio();
-        drive_tx_sio();
+        begin: iso_fork
+          fork
+            send_rx_item(req);
+            drive_bus_to_highz();
+            drive_bus_for_reset();
+          join_any
+          disable fork;
+        end: iso_fork
       join
-      `uvm_info(`gfn, "spi_host_driver: item sent", UVM_HIGH)
-      seq_item_port.item_done(rsp);
+      seq_item_port.item_done();
+      `uvm_info(`gfn, "\n  dev_drv: item done", UVM_HIGH)
     end
   endtask : get_and_drive
 
-  virtual task drive_rx_sio();
-    // TODO
-  endtask : drive_rx_sio
 
-  virtual task drive_tx_sio();
-    // TODO
-  endtask : drive_tx_sio
+  virtual task send_rx_item(spi_item item);
+    logic [3:0] sio_bits;
+    bit         bits_q[$];
+    int         max_tx_bits;
 
+    if (cfg.byte_order) cfg.swap_byte_order(item.data);
+    bits_q = {>> 1 {item.data}};
+    max_tx_bits = cfg.get_sio_size();
+
+    `uvm_info(`gfn, $sformatf("\n  dev_drv: send_rx_item, return %0d bits to dut",
+                              bits_q.size()), UVM_DEBUG)
+    // pop enough bits do drive all needed sio
+    while (bits_q.size() > 0) begin
+      for (int i = 0; i < 4; i++) begin
+        sio_bits[i] = (i < max_tx_bits) ? bits_q.pop_front() : 1'bz;
+      end
+      send_data_to_sio(cfg.spi_mode, sio_bits);
+      `uvm_info(`gfn, $sformatf("\n  dev_drv: assert data bit[%0d] %b",
+                                bits_q.size(), sio_bits[0]), UVM_DEBUG)
+      if (bits_q.size() > 0) cfg.wait_sck_edge(DrivingEdge);
+    end
+  endtask : send_rx_item
+
+  virtual task send_data_to_sio(spi_mode_e mode, input logic [3:0] sio_bits);
+    unique case (mode)
+      Standard: cfg.vif.sio[1]   <= sio_bits[0];
+      Dual:     cfg.vif.sio[1:0] <= sio_bits[1:0];
+      default:  cfg.vif.sio      <= sio_bits;
+    endcase
+  endtask : send_data_to_sio
+
+  virtual task drive_bus_to_highz();
+    @(posedge cfg.vif.csb[cfg.csid]);
+    case (cfg.spi_mode)
+      Standard: cfg.vif.sio[1]   = 1'bz;
+      Dual:     cfg.vif.sio[1:0] = 2'bzz;
+      default:  cfg.vif.sio      = 4'bzzzz;   // including Quad SPI mode
+    endcase
+    `uvm_info(`gfn, "\n  dev_drv: drive_bus_to_highz is done", UVM_DEBUG)
+  endtask : drive_bus_to_highz
+
+  virtual task drive_bus_for_reset();
+    @(negedge cfg.vif.rst_n);
+    cfg.vif.sio = 4'bzzzz;
+    `uvm_info(`gfn, "\n  dev_drv: drive_bus_for_reset is done", UVM_DEBUG)
+  endtask : drive_bus_for_reset
 endclass : spi_device_driver

--- a/hw/dv/sv/spi_agent/spi_if.sv
+++ b/hw/dv/sv/spi_agent/spi_if.sv
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface spi_if (
+interface spi_if
+  import spi_agent_pkg::*;
+(
   input rst_n
 );
 
@@ -19,5 +21,21 @@ interface spi_if (
   int         sck_pulses;
   bit         sck_polarity;
   bit         sck_phase;
+
+  //---------------------------------
+  // common tasks
+  //---------------------------------
+  task automatic wait_for_clks(int clks);
+    repeat (clks) @(posedge sck);
+  endtask : wait_for_clks
+
+  task automatic get_data_from_sio(spi_agent_pkg::spi_mode_e mode, output bit sio_bits[]);
+    unique case (mode)
+      Standard: sio_bits = {>> 1 {sio[0]}};
+      Dual:     sio_bits = {>> 1 {sio[1:0]}};
+      Quad:     sio_bits = {>> 1 {sio[3:0]}};
+      default:  sio_bits = {>> 1 {sio[0]}};
+    endcase
+  endtask : get_data_from_sio
 
 endinterface : spi_if

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -4,33 +4,54 @@
 
 class spi_item extends uvm_sequence_item;
 
+  // hold transaction type
   rand spi_trans_type_e item_type;
   // byte of data sent or received
   rand bit [7:0] data[$];
+  // start of transaction
+  bit first_byte;
+
 
   rand uint dummy_clk_cnt;
   rand uint dummy_sck_length_ns;
 
   // constrain size of data sent / received to be at most 64kB
-  constraint data_size_c {
-    data.size() inside {[1:65536]};
-  }
+  constraint data_size_c { data.size() inside {[1:65536]}; }
 
-  constraint dummy_clk_cnt_c {
-    dummy_clk_cnt inside {[1:1000]};
-  }
+  constraint dummy_clk_cnt_c { dummy_clk_cnt inside {[1:1000]}; }
 
-  constraint dummy_sck_length_c {
-    dummy_sck_length_ns inside {[1:1000]};
-  }
+  constraint dummy_sck_length_c { dummy_sck_length_ns inside {[1:1000]}; }
 
   `uvm_object_utils_begin(spi_item)
     `uvm_field_enum(spi_trans_type_e, item_type, UVM_DEFAULT)
-    `uvm_field_queue_int(data,              UVM_DEFAULT)
-    `uvm_field_int(dummy_clk_cnt,           UVM_DEFAULT)
-    `uvm_field_int(dummy_sck_length_ns,     UVM_DEFAULT)
+    `uvm_field_queue_int(data,                   UVM_DEFAULT)
+    `uvm_field_int(first_byte,                   UVM_DEFAULT)
+    `uvm_field_int(dummy_clk_cnt,                UVM_DEFAULT)
+    `uvm_field_int(dummy_sck_length_ns,          UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
 
-endclass
+  function void clear_all();
+    data.delete();
+  endfunction : clear_all
+
+  function string convert2string();
+    string txt="";
+
+    txt = "\n \t ----| SPI ITEM |----";
+    txt = {txt, $sformatf("\n ----| Item Type: \t%s", item_type.name()) };
+    txt = {txt, $sformatf("\n ----| Dummy Clk Cnt: \t%0d",  dummy_clk_cnt) };
+    txt = {txt, $sformatf("\n ----| Dummy Sck Lengtht: \t%0d ns",  dummy_sck_length_ns) };
+    txt = {txt, $sformatf("\n ----| First Byte: \t%b ",  first_byte) };
+    txt = {txt, $sformatf("\n ----| Data:") };
+
+    foreach (data[i]) begin
+      if (!i[2:0]) txt = {txt, "\n"};
+      txt = {txt, $sformatf("%0h", data[i])};
+    end
+    return txt;
+  endfunction // convert2string
+
+
+endclass : spi_item

--- a/hw/dv/sv/spi_agent/spi_sequencer.sv
+++ b/hw/dv/sv/spi_agent/spi_sequencer.sv
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class spi_sequencer extends dv_base_sequencer#(spi_item, spi_agent_cfg);
+class spi_sequencer extends dv_base_sequencer#(spi_item, spi_agent_cfg, spi_item);
   `uvm_component_utils(spi_sequencer)
 
   `uvm_component_new
-
 endclass : spi_sequencer

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -125,8 +125,8 @@ class spi_device_base_vseq extends cip_base_vseq #(
       cfg.m_spi_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
     end
     // update host agent
-    cfg.m_spi_agent_cfg.sck_polarity = sck_polarity;
-    cfg.m_spi_agent_cfg.sck_phase = sck_phase;
+    cfg.m_spi_agent_cfg.sck_polarity[0] = sck_polarity;
+    cfg.m_spi_agent_cfg.sck_phase[0] = sck_phase;
     cfg.m_spi_agent_cfg.host_bit_dir = host_bit_dir;
     cfg.m_spi_agent_cfg.device_bit_dir = device_bit_dir;
     cfg.m_spi_agent_cfg.csb_sel = 0;


### PR DESCRIPTION
This Commit contains updates to the SPI agent that will make it support the spi host.
the main difference is the updated spi_device_seq and the new extended sequence.
this is needed for the Device to recognize a set of commands and respond proberly.

this could at some point in time be further developed into a spi device BFM.

