### PR TITLE
[dif] Fix dif_sram_ctrl dependencies

### DIFF
--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -892,7 +892,10 @@ sw_lib_dif_sram_ctrl = declare_dependency(
       hw_ip_sram_ctrl_reg_h,
       'dif_sram_ctrl.c',
     ],
-    dependencies: [sw_lib_mmio],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_autogen_sram_ctrl,
+    ],
   )
 )
 


### PR DESCRIPTION
Autogenerated component of DIF was missing from dependencies which meant that the sram_ctrl test utilities failed to link correctly.