### PR TITLE
[csrng/rtl] lint cleanup after mubi updates

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -77,15 +77,12 @@ module csrng_core import csrng_pkg::*; #(
   logic       event_cs_fatal_err;
   logic       cs_enable;
   logic       cs_enable_pfe;
-  logic       cs_enable_pfd;
   logic       cs_enable_pfa;
   logic       sw_app_enable;
   logic       sw_app_enable_pfe;
-  logic       sw_app_enable_pfd;
   logic       sw_app_enable_pfa;
   logic       read_int_state;
   logic       read_int_state_pfe;
-  logic       read_int_state_pfd;
   logic       read_int_state_pfa;
   logic       recov_alert_event;
   logic       acmd_avail;
@@ -679,14 +676,12 @@ module csrng_core import csrng_pkg::*; #(
 
   import prim_mubi_pkg::mubi4_e;
   import prim_mubi_pkg::mubi4_test_true_strict;
-  import prim_mubi_pkg::mubi4_test_false_strict;
   import prim_mubi_pkg::mubi4_test_invalid;
 
   // check for illegal enable field states, and set alert if detected
   mubi4_e mubi_cs_enable;
   assign mubi_cs_enable = mubi4_e'(reg2hw.ctrl.enable.q);
   assign cs_enable_pfe = mubi4_test_true_strict(mubi_cs_enable);
-  assign cs_enable_pfd = mubi4_test_false_strict(mubi_cs_enable);
   assign cs_enable_pfa = mubi4_test_invalid(mubi_cs_enable);
   assign hw2reg.recov_alert_sts.enable_field_alert.de = cs_enable_pfa;
   assign hw2reg.recov_alert_sts.enable_field_alert.d  = cs_enable_pfa;
@@ -694,7 +689,6 @@ module csrng_core import csrng_pkg::*; #(
   mubi4_e mubi_sw_app_enable;
   assign mubi_sw_app_enable = mubi4_e'(reg2hw.ctrl.sw_app_enable.q);
   assign sw_app_enable_pfe = mubi4_test_true_strict(mubi_sw_app_enable);
-  assign sw_app_enable_pfd = mubi4_test_false_strict(mubi_sw_app_enable);
   assign sw_app_enable_pfa = mubi4_test_invalid(mubi_sw_app_enable);
   assign hw2reg.recov_alert_sts.sw_app_enable_field_alert.de = sw_app_enable_pfa;
   assign hw2reg.recov_alert_sts.sw_app_enable_field_alert.d  = sw_app_enable_pfa;
@@ -702,7 +696,6 @@ module csrng_core import csrng_pkg::*; #(
   mubi4_e mubi_read_int_state;
   assign mubi_read_int_state = mubi4_e'(reg2hw.ctrl.read_int_state.q);
   assign read_int_state_pfe = mubi4_test_true_strict(mubi_read_int_state);
-  assign read_int_state_pfd = mubi4_test_false_strict(mubi_read_int_state);
   assign read_int_state_pfa = mubi4_test_invalid(mubi_read_int_state);
   assign hw2reg.recov_alert_sts.read_int_state_field_alert.de = read_int_state_pfa;
   assign hw2reg.recov_alert_sts.read_int_state_field_alert.d  = read_int_state_pfa;


### PR DESCRIPTION
Remove unneeded signals after MuBi updates.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>