### PR TITLE
[aes/pre_syn] Re-enable Yosys synthesis

### DIFF
--- a/hw/ip/aes/pre_syn/syn_yosys.sh
+++ b/hw/ip/aes/pre_syn/syn_yosys.sh
@@ -104,7 +104,9 @@ for file in ${OT_DEP_SOURCES[@]}; do
     # where available.
     sed -i 's/prim_flop_2sync/prim_generic_flop_2sync/g' $LR_SYNTH_OUT_DIR/generated/${module}.v
     sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
     sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
     sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
 done
 
@@ -129,7 +131,9 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
     # where available.
     sed -i 's/prim_flop_2sync/prim_generic_flop_2sync/g' $LR_SYNTH_OUT_DIR/generated/${module}.v
     sed -i 's/prim_flop/prim_xilinx_flop/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_flop/prim_xilinx_flop/g'   $LR_SYNTH_OUT_DIR/generated/${module}.v
     sed -i 's/prim_buf/prim_xilinx_buf/g'                $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i 's/prim_sec_anchor_buf/prim_xilinx_buf/g'     $LR_SYNTH_OUT_DIR/generated/${module}.v
     sed -i 's/prim_xor2/prim_xilinx_xor2/g'              $LR_SYNTH_OUT_DIR/generated/${module}.v
 done
 


### PR DESCRIPTION
This very simple PR causes `prim_sec_anchor_*` primitives to be replaced by the corresponding Xilinx primitives before calling Yosys to re-enable Yosys synthesis of AES.