### PR TITLE
[otbn] Zero insn_cnt when going into LOCKED state

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -131,6 +131,10 @@ class OTBNSim:
         if self.state.fsm_state == FsmState.POST_EXEC:
             return (None, self._on_stall(verbose, fetch_next=False))
 
+        if self.state.fsm_state == FsmState.LOCKING:
+            self.state.ext_regs.write('INSN_CNT', 0, True)
+            return (None, self._on_stall(verbose, fetch_next=False))
+
         assert self.state.fsm_state == FsmState.EXEC
 
         insn = self._next_insn

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -945,8 +945,9 @@ module otbn
   `ASSERT_KNOWN(OtbnOtpKeyO_A, otbn_otp_key_o, clk_otp_i, !rst_otp_ni)
 
   // In locked state, the readable registers INSN_CNT, IMEM, and DMEM are expected to always read 0
-  // when accessed from the bus.
-  `ASSERT(LockedInsnCntReadsZero_A, (hw2reg.status.d == StatusLocked) |-> insn_cnt == 'd0)
+  // when accessed from the bus. For INSN_CNT, we use "|=>" so that the assertion lines up with
+  // "status.q" (a signal that isn't directly accessible here).
+  `ASSERT(LockedInsnCntReadsZero_A, (hw2reg.status.d == StatusLocked) |=> insn_cnt == 'd0)
   `ASSERT(NonIdleImemReadsZero_A,
       (hw2reg.status.d != StatusIdle) & imem_rvalid_bus |-> imem_rdata_bus == 'd0)
   `ASSERT(NonIdleDmemReadsZero_A,

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -222,7 +222,6 @@ module otbn_controller
 
   logic rf_a_indirect_err, rf_b_indirect_err, rf_d_indirect_err, rf_indirect_err;
 
-  logic insn_cnt_en;
   logic [31:0] insn_cnt_d, insn_cnt_q;
 
   logic [4:0] ld_insn_bignum_wr_addr_q;
@@ -456,17 +455,25 @@ module otbn_controller
     end
   end
 
-  assign insn_cnt_d = state_reset_i ? 32'd0 : (insn_cnt_q + 32'd1);
-  assign insn_cnt_en = (insn_executing & ~stall & (insn_cnt_q != 32'hffffffff)) | state_reset_i;
-  assign insn_cnt_o = insn_cnt_q;
+  always_comb begin
+    if (state_reset_i || state_q == OtbnStateLocked) begin
+      insn_cnt_d = 32'd0;
+    end else if (insn_executing & ~stall & (insn_cnt_q != 32'hffffffff)) begin
+      insn_cnt_d = insn_cnt_q + 32'd1;
+    end else begin
+      insn_cnt_d = insn_cnt_q;
+    end
+  end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       insn_cnt_q <= 32'd0;
-    end else if (insn_cnt_en) begin
+    end else begin
       insn_cnt_q <= insn_cnt_d;
     end
   end
+
+  assign insn_cnt_o = insn_cnt_q;
 
   assign loop_reset = state_reset_i | sec_wipe_zero_i;
 


### PR DESCRIPTION
This commit consists of several parts.

1. In the RTL (otbn_controller.sv), we teach the instruction counter
    to zero itself when in a locked state.

2. At the top-level of the RTL (otbn.sv), we slightly change the
    assertion that triggered this work in the first place. It was
    checking that if the "d" of STATUS was locked then the instruction
    count should be zero. Using |=> instead means that we check
    against the (bus-visible) "q".

3. Unfortunately, the DV code didn't match either! The cleanest way
    to represent things seems to be to split the internal FSM to have
    two different "just after execution" states. That means we can put
    the "which way are we going?" logic in just one place.

   Note that there's a bit of code duplication between the POST_EXEC
   and LOCKING states in both state.py and sim.py. This is
   intentional, because I think it's a bit easier to read this way.
   The other option would be to have an if statement that applied to
   both states, but then you'd need to inspect the state again inside
   the branch to figure out the details of what you're doing.

This fixes failures in the nightly tests that look like:
```
0.otbn_imem_err.1463129800
Line 46, in log /usr/local/google/home/chencindy/nightly_openTitan/master/otbn-sim-vcs/0.otbn_imem_err/out/run.log

      Offending '(insn_cnt == 'b0)'
  UVM_ERROR @  11541746 ps: (otbn.sv:949) [ASSERT FAILED] LockedInsnCntReadsZero_A
  UVM_INFO @  11541746 ps: (uvm_report_server.svh:901) [UVM/REPORT/SERVER]
  --- UVM Report Summary ---
  
```