### PR TITLE
[otbn,dv] Avoid writing to STATUS in csr_hw_reset test

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -281,6 +281,15 @@
               </tbody>
             </table>
           '''
+          tags: [
+            // Don't write this field in the automated CSR tests. Despite this being RO for software
+            // (so you might think we couldn't write it), the csr_hw_reset test does write this by
+            // by default (using a backdoor access). The idea of that test is to write bogus values
+            // to registers, reset the block and then check that everything has its reset value.
+            // Doing this causes various assertions to fire and it isn't really necessary: we
+            // already have strong checks between this register and the output of the model.
+            "excl:CsrAllTests:CsrExclWrite"
+          ]
         }
       ]
     }


### PR DESCRIPTION
@weicaiyang, @sriyerg: I think there's a bigger question here about why we're doing backdoor accesses to force RO registers for this test. It seems kind of odd to me, and not really in keeping with how I'd imagine a CSR test ("waggle pins on the TL bus and check nothing falls off"). Is there a good reason to do it?

Anyway, this exclusion fixes a failure from last night:
```
    1.otbn_csr_hw_reset.3215972542
    Line 46, in log /usr/local/google/home/chencindy/nightly_openTitan/master/otbn-sim-vcs/1.otbn_csr_hw_reset/out/run.log

          Offending '(tb.dut.u_reg.u_status.q == tb.model_if.status)'
      UVM_ERROR @  10228607 ps: (tb.sv:253) [ASSERT FAILED] MatchingStatus_A
      UVM_INFO @  10228607 ps: (uvm_report_server.svh:901) [UVM/REPORT/SERVER]
      --- UVM Report Summary ---
```