### PR TITLE
[otbn,dv] Properly handle unknown instructions in coverage

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -72,7 +72,9 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   `DEF_MNEM(mnem_bn_wsrr,       "bn.wsrr");
   `DEF_MNEM(mnem_bn_wsrw,       "bn.wsrw");
   // A fake mnemonic, used for bits that don't decode to a real instruction
-  `DEF_MNEM(mnem_dummy,         "??");
+  `DEF_MNEM(mnem_dummy,         "dummy-insn");
+  // A fake mnemonic, used for invalid IMEM data (after a failed integrity check)
+  `DEF_MNEM(mnem_question_mark, "??");
 `undef DEF_MNEM
 
   // A macro used for coverpoints for mnemonics. This expands to entries like
@@ -1904,6 +1906,7 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     insn_encodings[mnem_bn_wsrr]       = "wcsr";
     insn_encodings[mnem_bn_wsrw]       = "wcsr";
     insn_encodings[mnem_dummy]         = "dummy";
+    insn_encodings[mnem_question_mark] = "dummy";
   endfunction
 
   // Handle coverage for external (bus-accessible) CSRs


### PR DESCRIPTION
In 38a36b5, I switched from "`dummy-insn`" to "`??`" to match the trace
output when we try to fetch invalid data from IMEM. What I didn't
realise is that we do actually generate "`dummy-insn`" as well. That
happens when we have valid data from IMEM that doesn't decode to a
valid word.

Renaming that situation from "`dummy-insn`" to "`??`" doesn't seem right:
it's probably better to have a name that makes it clear what's going
on. But an IMEM integrity error probably shouldn't talk about "dummy
instructions" either.

This patch allows both names.
