### PR TITLE
[otbn,dv] Simplify the return type for snippet generators

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/bad_at_end.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_at_end.py
@@ -138,8 +138,7 @@ class BadAtEnd(Loop):
         # the "done" flag should be true (since this is supposed to cause a
         # fault) and the final PC should be 4 less, pointing just before the
         # last instruction in the loop.
-        snippet, done, model = ret
-        assert not done
+        snippet, model = ret
 
         model.pc -= 4
-        return (snippet, True, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_bnmovr.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_bnmovr.py
@@ -108,4 +108,4 @@ class BadBNMovr(SnippetGen):
         snippet = ProgSnippet(model.pc, [prog_insn])
         snippet.insert_into_program(program)
 
-        return (snippet, True, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
@@ -254,4 +254,4 @@ class BadDeepLoop(SnippetGen):
 
         # At this point, we *should* be able to make the loop unconditionally.
         snippet, model = self._gen_loop_stack(model, program)
-        return (snippet, True, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_giant_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_giant_loop.py
@@ -106,4 +106,4 @@ class BadGiantLoop(Loop):
         assert body_snippet is not None
 
         loop_snippet = LoopSnippet(hd_addr, hd_insn, body_snippet, None)
-        return (loop_snippet, True, end_model)
+        return (loop_snippet, end_model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
@@ -46,7 +46,7 @@ class BadInsn(SnippetGen):
         prog_insn = DummyProgInsn(self._get_badbits())
         snippet = ProgSnippet(model.pc, [prog_insn])
         snippet.insert_into_program(program)
-        return (snippet, True, model)
+        return (snippet, model)
 
     def pick_weight(self,
                     model: Model,

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
@@ -145,7 +145,7 @@ class BadLoadStore(SnippetGen):
         snippet = ProgSnippet(model.pc, [prog_insn])
         snippet.insert_into_program(program)
 
-        return (snippet, True, model)
+        return (snippet, model)
 
     def fill_insn(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
         '''Try to pick one of BN.XID or XW instructions

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_zero_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_zero_loop.py
@@ -79,4 +79,4 @@ class BadZeroLoop(Loop):
 
         # Return with the initial model (because the head instruction is bad,
         # we'll stop at it)
-        return (snippet, True, model_before)
+        return (snippet, model_before)

--- a/hw/ip/otbn/dv/rig/rig/gens/branch.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch.py
@@ -139,7 +139,7 @@ class Branch(SnippetGen):
             psnip.insert_into_program(program)
             model.update_for_insn(branch_insn)
             model.pc += 4
-            return (psnip, False, model)
+            return (psnip, model)
 
         # Decide how much of our remaining fuel to give the code below the
         # branch. Each side gets the same amount because only one side appears
@@ -256,4 +256,4 @@ class Branch(SnippetGen):
 
         snippet = BranchSnippet(model.pc, branch_insn, snippet0, snippet1)
         snippet.insert_into_program(program)
-        return (snippet, False, model0)
+        return (snippet, model0)

--- a/hw/ip/otbn/dv/rig/rig/gens/branch_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/branch_gen.py
@@ -110,7 +110,7 @@ class BranchGen(SnippetGen):
 
         self.update_for_insn(model, prog_insn)
 
-        return (snippet, self.ends_program, model)
+        return (snippet, model)
 
     def pick_offset(self,
                     min_addr: int,

--- a/hw/ip/otbn/dv/rig/rig/gens/call_stack_rw.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/call_stack_rw.py
@@ -150,7 +150,7 @@ class CallStackRW(SnippetGen):
         model.update_for_insn(prog_insn)
         model.pc += 4
 
-        return (snippet, False, model)
+        return (snippet, model)
 
 
 class BadCallStackRW(CallStackRW):
@@ -232,4 +232,4 @@ class BadCallStackRW(CallStackRW):
         # instruction.
         model.pc += 4 * (len(prog_insns) - 1)
 
-        return (snippet, True, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/ecall.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/ecall.py
@@ -49,7 +49,7 @@ class ECall(SnippetGen):
             cont: GenCont,
             model: Model,
             program: Program) -> Optional[GenRet]:
-        return (self.gen_at(model.pc, program), True, model)
+        return (self.gen_at(model.pc, program), model)
 
     def pick_weight(self,
                     model: Model,

--- a/hw/ip/otbn/dv/rig/rig/gens/edge_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/edge_load_store.py
@@ -97,7 +97,7 @@ class EdgeLoadStore(SnippetGen):
         snippet.insert_into_program(program)
         model.update_for_insn(prog_insn)
         model.pc += 4
-        return (snippet, False, model)
+        return (snippet, model)
 
     def fill_insn(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
         '''Try to pick one of BN.SID or SW instructions

--- a/hw/ip/otbn/dv/rig/rig/gens/jump.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/jump.py
@@ -75,7 +75,7 @@ class Jump(SnippetGen):
             return None
 
         prog_insn, snippet, model = ret
-        return (snippet, False, model)
+        return (snippet, model)
 
     def gen_tgt(self,
                 model: Model,

--- a/hw/ip/otbn/dv/rig/rig/gens/known_wdr.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/known_wdr.py
@@ -121,4 +121,4 @@ class KnownWDR(SnippetGen):
 
         model.pc += 8
 
-        return (snippet, False, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -14,7 +14,7 @@ from ..config import Config
 from ..program import ProgInsn, Program
 from ..model import LoopStack, Model
 from ..snippet import LoopSnippet, ProgSnippet, Snippet
-from ..snippet_gen import GenCont, GenRet, SimpleGenRet, SnippetGen
+from ..snippet_gen import GenCont, GenRet, SnippetGen
 
 
 class Loop(SnippetGen):
@@ -336,7 +336,7 @@ class Loop(SnippetGen):
                   bogus_insn: ProgInsn,
                   cont: GenCont,
                   model: Model,
-                  program: Program) -> Optional[SimpleGenRet]:
+                  program: Program) -> Optional[GenRet]:
         '''Generate the body of a loop
 
         The model is currently sitting at the start of the loop body.
@@ -680,4 +680,4 @@ class Loop(SnippetGen):
         snippet = LoopSnippet(hd_addr, hd_insn, body_snippet, warp)
         snippet.insert_into_program(program)
 
-        return (snippet, False, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/loop_dup_end.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop_dup_end.py
@@ -12,7 +12,7 @@ from ..config import Config
 from ..program import ProgInsn, Program
 from ..model import Model
 from ..snippet import Snippet
-from ..snippet_gen import GenCont, GenRet, SimpleGenRet
+from ..snippet_gen import GenCont, GenRet
 
 
 class LoopDupEndInner(Loop):
@@ -90,7 +90,7 @@ class LoopDupEnd(Loop):
                   bogus_insn: ProgInsn,
                   cont: GenCont,
                   model: Model,
-                  program: Program) -> Optional[SimpleGenRet]:
+                  program: Program) -> Optional[GenRet]:
         loop_end = model.pc + 4 * (bodysize - 1)
         cont = cont
         self.stack.append((loop_end, cont))
@@ -124,8 +124,7 @@ class LoopDupEnd(Loop):
         if ret is None:
             return None
 
-        snippet, done, model = ret
-        assert not done
+        snippet, model = ret
 
         # Add a bogus extra copy of the loop end address to model's loop stack
         # here. Then Loop's _gen_body implementation will pop the top one off,

--- a/hw/ip/otbn/dv/rig/rig/gens/misaligned_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/misaligned_load_store.py
@@ -141,7 +141,7 @@ class MisalignedLoadStore(SnippetGen):
         snippet = ProgSnippet(model.pc, [prog_insn])
         snippet.insert_into_program(program)
 
-        return (snippet, True, model)
+        return (snippet, model)
 
     def fill_insn(self, insn: Insn, model: Model) -> Optional[ProgInsn]:
         '''Try to pick one of BN.XID or XW instructions

--- a/hw/ip/otbn/dv/rig/rig/gens/small_val.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/small_val.py
@@ -103,4 +103,4 @@ class SmallVal(SnippetGen):
         model.update_for_insn(prog_insn)
         model.pc += 4
 
-        return (snippet, False, model)
+        return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/straight_line_insn.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/straight_line_insn.py
@@ -73,7 +73,7 @@ class StraightLineInsn(SnippetGen):
         snippet = ProgSnippet(pc, [prog_insn])
         snippet.insert_into_program(program)
 
-        return (snippet, False, model)
+        return (snippet, model)
 
     def gen_some(self,
                  count: int,

--- a/hw/ip/otbn/dv/rig/rig/snippet_gen.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gen.py
@@ -17,17 +17,12 @@ from .program import Program
 from .model import Model
 from .snippet import Snippet
 
-# The return type of a single generator. This is a tuple (snippet, done,
-# model). snippet is a generated snippet. done is true if the processor has
-# just executed an instruction that causes it to stop. model is a Model object
-# representing the state of the processor after executing the code in the
-# snippet(s). The PC of the model will be the next instruction to be executed
-# unless done is true, in which case it still points at the final instruction.
-GenRet = Tuple[Snippet, bool, Model]
-
-# An "internal" return type for generators that never cause termination.
-# (Essentially the same as GenRet, but with done = False)
-SimpleGenRet = Tuple[Snippet, Model]
+# The return type of a single generator. This is a pair: (snippet, model).
+# snippet is a generated snippet. model is a Model object representing the
+# state of the processor after executing the code in the snippet(s). The PC of
+# the model will be the next instruction to be executed unless snippet stops
+# the model, in which case it still points at the final instruction.
+GenRet = Tuple[Snippet, Model]
 
 # The return type of repeated generator calls. If the snippet is None, no
 # generators managed to generate anything.
@@ -116,11 +111,3 @@ class SnippetGen:
             raise RuntimeError('No {} instruction in instructions file.'
                                .format(mnemonic.upper()))
         return insn
-
-    @staticmethod
-    def _unsimple_genret(ret: Optional[SimpleGenRet]) -> Optional[GenRet]:
-        '''Re-pack a SimpleGenRet as a GenRet'''
-        if ret is None:
-            return None
-        snippet, model = ret
-        return (snippet, False, model)

--- a/hw/ip/otbn/dv/rig/rig/snippet_gens.py
+++ b/hw/ip/otbn/dv/rig/rig/snippet_gens.py
@@ -217,11 +217,10 @@ class SnippetGens:
                     children.append(self._gen_ecall(model.pc, program))
                 break
 
-            snippet, done, model = gen_res
+            snippet, model = gen_res
             children.append(snippet)
 
-            if done:
-                assert end
+            if end:
                 break
 
             assert model.fuel < old_fuel


### PR DESCRIPTION
There's no need to return whether or not the program has finished,
because this information is a class variable on the generator class
itself and we can pick it up from there instead.
