### PR TITLE
[spi_host] shift in correct bit

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_shift_register.sv
+++ b/hw/ip/spi_host/rtl/spi_host_shift_register.sv
@@ -54,7 +54,7 @@ module spi_host_shift_register (
   `ASSERT(SpeedValid, speed_i != RsvdSpd, clk_i, rst_ni)
 
   assign next_bits  = full_cyc_i ? sd_i : sd_i_q;
-  assign sr_shifted = (speed_i == Standard) ? {sr_q[6:0], next_bits[0]} :
+  assign sr_shifted = (speed_i == Standard) ? {sr_q[6:0], next_bits[1]} :
                       (speed_i == Dual)     ? {sr_q[5:0], next_bits[1:0]} :
                       (speed_i == Quad)     ? {sr_q[3:0], next_bits[3:0]} :
                       8'h00;


### PR DESCRIPTION
In Single mode, we should be shifting in sd_i[1] (nee MISO).

Signed-off-by: Chris Frantz <cfrantz@google.com>