### PR TITLE
[dif] Create DIF for the spi_host

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -164,4 +164,10 @@
  */
 #define OT_UNREACHABLE() __builtin_unreachable()
 
+/**
+ * Attribute for weak alias that can be overridden, e.g., Mock overrides in
+ * DIFs.
+ */
+#define OT_ALIAS(name) __attribute__((alias(name)))
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_

--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -100,5 +100,8 @@ void *memrchr(const void *ptr, int value, size_t len) {
 // `extern` declarations to give the inline functions in the corresponding
 // header a link location.
 
+extern ptrdiff_t misalignment32_of(uintptr_t);
 extern uint32_t read_32(const void *);
 extern void write_32(uint32_t, void *);
+extern uint64_t read_64(const void *);
+extern void write_64(uint64_t, void *);

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -9,14 +9,6 @@
 #include "sw/device/lib/base/memory.h"
 
 /**
- * Computes how many bytes `addr` is ahead of the previous 32-bit word alignment
- * boundary.
- */
-static ptrdiff_t misalignment32_of(uintptr_t addr) {
-  return addr % alignof(uint32_t);
-}
-
-/**
  * Copies a block of memory between MMIO and main memory while ensuring that
  * MMIO accesses are word-aligned.
  *

--- a/sw/device/lib/base/testing/meson.build
+++ b/sw/device/lib/base/testing/meson.build
@@ -59,6 +59,7 @@ sw_lib_base_testing_mock_mmio = declare_dependency(
     dependencies: [
       sw_vendor_gtest,
       sw_lib_testing_bitfield,
+      sw_lib_testing_memory,
     ],
     native: true,
     c_args: ['-DMOCK_MMIO'],

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -322,6 +322,10 @@ cc_library(
     srcs = [
         "autogen/dif_spi_host_autogen.c",
         "autogen/dif_spi_host_autogen.h",
+        "dif_spi_host.c",
+    ],
+    hdrs = [
+        "dif_spi_host.h",
     ],
     deps = [
         ":base",
@@ -336,6 +340,9 @@ cc_test(
         "autogen/dif_spi_host_autogen.c",
         "autogen/dif_spi_host_autogen.h",
         "autogen/dif_spi_host_autogen_unittest.cc",
+        "dif_spi_host.c",
+        "dif_spi_host.h",
+        "dif_spi_host_unittest.cc",
     ],
     defines = [
         "MOCK_MMIO=1",
@@ -345,6 +352,7 @@ cc_test(
         "//hw/ip/spi_host/data:spi_host_regs",
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing",
+        "//sw/device/lib/base/testing:global_mock",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -1,0 +1,393 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_spi_host.h"
+
+#include <assert.h>
+#include <stdalign.h>
+#include <stddef.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+
+#include "spi_host_regs.h"  // Generated.
+
+// We create weak symbol aliases for the FIFO write and read functions so the
+// unit tests can provide mocks.  The mocks provide for separate testing of
+// the FIFO functions and the overall transaction management functions.
+OT_WEAK
+OT_ALIAS("dif_spi_host_fifo_write")
+void spi_host_fifo_write_alias(const dif_spi_host_t *spi_host, const void *src,
+                               uint16_t len);
+
+OT_WEAK
+OT_ALIAS("dif_spi_host_fifo_read")
+void spi_host_fifo_read_alias(const dif_spi_host_t *spi_host, void *dst,
+                              uint16_t len);
+
+static void spi_host_reset(const dif_spi_host_t *spi_host) {
+  // Set the software reset request bit.
+  mmio_region_write32(
+      spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET,
+      bitfield_bit32_write(0, SPI_HOST_CONTROL_SW_RST_BIT, true));
+
+  // Wait for the spi host to go inactive.
+  bool active;
+  do {
+    uint32_t reg =
+        mmio_region_read32(spi_host->base_addr, SPI_HOST_STATUS_REG_OFFSET);
+    active = bitfield_bit32_read(reg, SPI_HOST_STATUS_ACTIVE_BIT);
+  } while (active);
+
+  // Wait for the spi host fifos to drain.
+  uint32_t txqd, rxqd;
+  do {
+    uint32_t reg =
+        mmio_region_read32(spi_host->base_addr, SPI_HOST_STATUS_REG_OFFSET);
+    txqd = bitfield_field32_read(reg, SPI_HOST_STATUS_TXQD_FIELD);
+    rxqd = bitfield_field32_read(reg, SPI_HOST_STATUS_RXQD_FIELD);
+  } while (txqd != 0 || rxqd != 0);
+
+  // Clear the software reset request bit.
+  mmio_region_write32(
+      spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET,
+      bitfield_bit32_write(0, SPI_HOST_CONTROL_SW_RST_BIT, false));
+}
+
+static void spi_host_enable(const dif_spi_host_t *spi_host, bool enable) {
+  mmio_region_write32(
+      spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET,
+      bitfield_bit32_write(0, SPI_HOST_CONTROL_SPIEN_BIT, enable));
+}
+
+dif_result_t dif_spi_host_configure(const dif_spi_host_t *spi_host,
+                                    dif_spi_host_config_t config) {
+  if (spi_host == NULL) {
+    return kDifBadArg;
+  }
+  if (config.peripheral_clock_freq_hz == 0 || config.spi_clock == 0) {
+    return kDifBadArg;
+  }
+
+  uint32_t divider = (config.peripheral_clock_freq_hz / config.spi_clock) - 1;
+  if (divider & ~SPI_HOST_CONFIGOPTS_CLKDIV_0_MASK) {
+    return kDifBadArg;
+  }
+
+  spi_host_reset(spi_host);
+  uint32_t reg = 0;
+  reg =
+      bitfield_field32_write(reg, SPI_HOST_CONFIGOPTS_CLKDIV_0_FIELD, divider);
+  reg = bitfield_field32_write(reg, SPI_HOST_CONFIGOPTS_CSNIDLE_0_FIELD,
+                               config.chip_select.idle);
+  reg = bitfield_field32_write(reg, SPI_HOST_CONFIGOPTS_CSNTRAIL_0_FIELD,
+                               config.chip_select.trail);
+  reg = bitfield_field32_write(reg, SPI_HOST_CONFIGOPTS_CSNLEAD_0_FIELD,
+                               config.chip_select.lead);
+  reg = bitfield_bit32_write(reg, SPI_HOST_CONFIGOPTS_FULLCYC_0_BIT,
+                             config.full_cycle);
+  reg = bitfield_bit32_write(reg, SPI_HOST_CONFIGOPTS_CPHA_0_BIT, config.cpha);
+  reg = bitfield_bit32_write(reg, SPI_HOST_CONFIGOPTS_CPOL_0_BIT, config.cpol);
+  mmio_region_write32(spi_host->base_addr, SPI_HOST_CONFIGOPTS_REG_OFFSET, reg);
+  spi_host_enable(spi_host, true);
+  return kDifOk;
+}
+
+void dif_spi_host_output(const dif_spi_host_t *spi_host, bool enable) {
+  uint32_t reg =
+      mmio_region_read32(spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET);
+  mmio_region_write32(
+      spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET,
+      bitfield_bit32_write(reg, SPI_HOST_CONTROL_OUTPUT_EN_BIT, enable));
+}
+
+static void wait_ready(const dif_spi_host_t *spi_host) {
+  bool ready;
+  do {
+    uint32_t reg =
+        mmio_region_read32(spi_host->base_addr, SPI_HOST_STATUS_REG_OFFSET);
+    ready = bitfield_bit32_read(reg, SPI_HOST_STATUS_READY_BIT);
+  } while (!ready);
+}
+
+static void wait_tx_fifo(const dif_spi_host_t *spi_host) {
+  uint32_t txqd;
+  do {
+    uint32_t reg =
+        mmio_region_read32(spi_host->base_addr, SPI_HOST_STATUS_REG_OFFSET);
+    txqd = bitfield_field32_read(reg, SPI_HOST_STATUS_TXQD_FIELD);
+  } while (txqd == SPI_HOST_PARAM_TX_DEPTH);
+}
+
+static void wait_rx_fifo(const dif_spi_host_t *spi_host) {
+  uint32_t rxqd;
+  do {
+    uint32_t reg =
+        mmio_region_read32(spi_host->base_addr, SPI_HOST_STATUS_REG_OFFSET);
+    rxqd = bitfield_field32_read(reg, SPI_HOST_STATUS_RXQD_FIELD);
+  } while (rxqd == 0);
+}
+
+static inline void tx_fifo_write8(const dif_spi_host_t *spi_host,
+                                  uintptr_t srcaddr) {
+  uint8_t *src = (uint8_t *)srcaddr;
+  wait_tx_fifo(spi_host);
+  mmio_region_write8(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET, *src);
+}
+
+static inline void tx_fifo_write32(const dif_spi_host_t *spi_host,
+                                   uintptr_t srcaddr) {
+  wait_tx_fifo(spi_host);
+  uint32_t val = read_32((const void *)srcaddr);
+  mmio_region_write32(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET, val);
+}
+
+void dif_spi_host_fifo_write(const dif_spi_host_t *spi_host, const void *src,
+                             uint16_t len) {
+  uintptr_t ptr = (uintptr_t)src;
+
+  // If the pointer starts mis-aligned, write until we are aligned.
+  while (misalignment32_of(ptr) && len > 0) {
+    tx_fifo_write8(spi_host, ptr);
+    ptr += 1;
+    len -= 1;
+  }
+
+  // Write complete 32-bit words to the fifo.
+  while (len > 3) {
+    tx_fifo_write32(spi_host, ptr);
+    ptr += 4;
+    len -= 4;
+  }
+
+  // Clean up any leftover bytes.
+  while (len > 0) {
+    tx_fifo_write8(spi_host, ptr);
+    ptr += 1;
+    len -= 1;
+  }
+}
+
+typedef struct queue {
+  int32_t length;
+  uint8_t alignas(uint64_t) data[8];
+} queue_t;
+
+static void enqueue_byte(queue_t *queue, uint8_t data) {
+  queue->data[queue->length++] = data;
+}
+
+static void enqueue_word(queue_t *queue, uint32_t data) {
+  if (queue->length % sizeof(uint32_t) == 0) {
+    write_32(data, queue->data + queue->length);
+    queue->length += 4;
+  } else {
+    for (size_t i = 0; i < sizeof(uint32_t); ++i) {
+      enqueue_byte(queue, (uint8_t)data);
+      data >>= 8;
+    }
+  }
+}
+
+static uint8_t dequeue_byte(queue_t *queue) {
+  uint8_t val = queue->data[0];
+  uint64_t qword = read_64(queue->data);
+  write_64(qword >> 8, queue->data);
+  queue->length -= 1;
+  return val;
+}
+
+static uint32_t dequeue_word(queue_t *queue) {
+  uint32_t val = read_32(queue->data);
+  write_32(read_32(queue->data + sizeof(uint32_t)), queue->data);
+  queue->length -= 4;
+  return val;
+}
+
+void dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
+                            uint16_t len) {
+  uintptr_t ptr = (uintptr_t)dst;
+  // We always have to read from the RXFIFO as a 32-bit word.  We use a
+  // two-word queue to handle destination and length mis-alignments.
+  queue_t queue = {0};
+
+  // If the buffer is misaligned, write a byte at a time until we reach
+  // alignment.
+  while (misalignment32_of(ptr) && len > 0) {
+    if (queue.length < 1) {
+      wait_rx_fifo(spi_host);
+      enqueue_word(&queue, mmio_region_read32(spi_host->base_addr,
+                                              SPI_HOST_RXDATA_REG_OFFSET));
+    }
+    uint8_t *p = (uint8_t *)ptr;
+    *p = dequeue_byte(&queue);
+    ptr += 1;
+    len -= 1;
+  }
+
+  // While we can write complete words to memory, operate on 4 bytes at a time.
+  while (len > 3) {
+    if (queue.length < 4) {
+      wait_rx_fifo(spi_host);
+      enqueue_word(&queue, mmio_region_read32(spi_host->base_addr,
+                                              SPI_HOST_RXDATA_REG_OFFSET));
+    }
+    write_32(dequeue_word(&queue), (void *)ptr);
+    ptr += 4;
+    len -= 4;
+  }
+
+  // Finish up any left over buffer a byte at a time.
+  while (len > 0) {
+    if (queue.length < 1) {
+      wait_rx_fifo(spi_host);
+      enqueue_word(&queue, mmio_region_read32(spi_host->base_addr,
+                                              SPI_HOST_RXDATA_REG_OFFSET));
+    }
+    uint8_t *p = (uint8_t *)ptr;
+    *p = dequeue_byte(&queue);
+    ptr += 1;
+    len -= 1;
+  }
+}
+
+static void write_command_reg(const dif_spi_host_t *spi_host, uint16_t length,
+                              dif_spi_host_width_t speed,
+                              dif_spi_host_direction_t direction,
+                              bool last_segment) {
+  uint32_t reg = 0;
+  reg = bitfield_field32_write(reg, SPI_HOST_COMMAND_LEN_FIELD, length - 1);
+  reg = bitfield_field32_write(reg, SPI_HOST_COMMAND_SPEED_FIELD, speed);
+  reg =
+      bitfield_field32_write(reg, SPI_HOST_COMMAND_DIRECTION_FIELD, direction);
+  reg = bitfield_bit32_write(reg, SPI_HOST_COMMAND_CSAAT_BIT, !last_segment);
+  mmio_region_write32(spi_host->base_addr, SPI_HOST_COMMAND_REG_OFFSET, reg);
+}
+
+static void issue_opcode(const dif_spi_host_t *spi_host,
+                         dif_spi_host_segment_t *segment, bool last_segment) {
+  wait_tx_fifo(spi_host);
+  mmio_region_write8(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET,
+                     segment->opcode);
+  write_command_reg(spi_host, 1, kDifSpiHostWidthStandard,
+                    kDifSpiHostDirectionTx, last_segment);
+}
+
+static void issue_address(const dif_spi_host_t *spi_host,
+                          dif_spi_host_segment_t *segment, bool last_segment) {
+  wait_tx_fifo(spi_host);
+  // The address appears on the wire in big-endian order.
+  uint32_t address = bitfield_byteswap32(segment->address.address);
+  uint32_t length;
+  if (segment->address.mode == kDifSpiHostAddrMode4b) {
+    length = 4;
+    mmio_region_write32(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET,
+                        address);
+  } else {
+    length = 3;
+    address >>= 8;
+    mmio_region_write32(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET,
+                        address);
+  }
+  write_command_reg(spi_host, length, segment->address.width,
+                    kDifSpiHostDirectionTx, last_segment);
+}
+
+static void issue_dummy(const dif_spi_host_t *spi_host,
+                        dif_spi_host_segment_t *segment, bool last_segment) {
+  write_command_reg(spi_host, segment->dummy.length, segment->dummy.width,
+                    kDifSpiHostDirectionDummy, last_segment);
+}
+
+static dif_result_t issue_data_phase(const dif_spi_host_t *spi_host,
+                                     dif_spi_host_segment_t *segment,
+                                     bool last_segment) {
+  size_t length;
+  dif_spi_host_width_t width;
+  dif_spi_host_direction_t direction;
+
+  switch (segment->type) {
+    case kDifSpiHostSegmentTypeTx:
+      width = segment->tx.width;
+      length = segment->tx.length;
+      direction = kDifSpiHostDirectionTx;
+      spi_host_fifo_write_alias(spi_host, segment->tx.buf, segment->tx.length);
+      break;
+    case kDifSpiHostSegmentTypeBidirectional:
+      width = segment->bidir.width;
+      length = segment->bidir.length;
+      direction = kDifSpiHostDirectionBidirectional;
+      spi_host_fifo_write_alias(spi_host, segment->bidir.txbuf,
+                                segment->bidir.length);
+      break;
+    case kDifSpiHostSegmentTypeRx:
+      width = segment->rx.width;
+      length = segment->rx.length;
+      direction = kDifSpiHostDirectionRx;
+      break;
+    default:
+      // Programming error (within this file).  We should never get here.
+      // `issue_data_phase` should only get called for segment types which
+      // represent a data transfer.
+      return kDifBadArg;
+  }
+  write_command_reg(spi_host, length, width, direction, last_segment);
+  return kDifOk;
+}
+
+dif_result_t dif_spi_host_transaction(const dif_spi_host_t *spi_host,
+                                      uint32_t csid,
+                                      dif_spi_host_segment_t *segments,
+                                      size_t length) {
+  // Write to chip select ID.
+  mmio_region_write32(spi_host->base_addr, SPI_HOST_CSID_REG_OFFSET, csid);
+
+  // For each segment, write the segment information to the
+  // COMMAND register and transmit FIFO.
+  for (size_t i = 0; i < length; ++i) {
+    bool last_segment = i == length - 1;
+    wait_ready(spi_host);
+    dif_spi_host_segment_t *segment = &segments[i];
+    switch (segment->type) {
+      case kDifSpiHostSegmentTypeOpcode:
+        issue_opcode(spi_host, segment, last_segment);
+        break;
+      case kDifSpiHostSegmentTypeAddress:
+        issue_address(spi_host, segment, last_segment);
+        break;
+      case kDifSpiHostSegmentTypeDummy:
+        issue_dummy(spi_host, segment, last_segment);
+        break;
+      case kDifSpiHostSegmentTypeTx:
+      case kDifSpiHostSegmentTypeRx:
+      case kDifSpiHostSegmentTypeBidirectional: {
+        dif_result_t error = issue_data_phase(spi_host, segment, last_segment);
+        if (error != kDifOk) {
+          return error;
+        }
+        break;
+      }
+      default:
+        return kDifBadArg;
+    }
+  }
+
+  // For each segment which receives data, read from the receive FIFO.
+  for (size_t i = 0; i < length; ++i) {
+    dif_spi_host_segment_t *segment = &segments[i];
+    switch (segment->type) {
+      case kDifSpiHostSegmentTypeRx:
+        spi_host_fifo_read_alias(spi_host, segment->rx.buf, segment->rx.length);
+        break;
+      case kDifSpiHostSegmentTypeBidirectional:
+        spi_host_fifo_read_alias(spi_host, segment->bidir.rxbuf,
+                                 segment->bidir.length);
+        break;
+      default:
+          /* do nothing */;
+    }
+  }
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -4,12 +4,12 @@
 
 #ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_HOST_H_
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_SPI_HOST_H_
-
 /**
  * @file
- * @brief <a href="/hw/ip/spi_host/doc/">SPI Host</a> Device Interface
- * Functions
+ * @brief <a href="/hw/ip/spi_host/doc/">SPI Host</a> Device Interface Functions
  */
+
+#include <stdint.h>
 
 #include "sw/device/lib/dif/autogen/dif_spi_host_autogen.h"
 
@@ -17,7 +17,199 @@
 extern "C" {
 #endif  // __cplusplus
 
-// TODO: Add DIFs.
+/**
+ * Runtime configuration for SPI Host.
+ *
+ * This struct describes (SOFTWARE) runtime information for one-time
+ * configuration of the hardware.
+ */
+typedef struct dif_spi_host_config {
+  /** Desired SPI clock frequency (SCK). */
+  uint32_t spi_clock;
+  /** Peripheral clock frequency (ie: kClockFreqPeripheralHz). */
+  uint32_t peripheral_clock_freq_hz;
+  struct {
+    /** Minimum idle time between commands in SCK half-cycles. */
+    uint8_t idle;
+    /** Chip-select trailing time in SCK half-cycles. */
+    uint8_t trail;
+    /** Chip-select leading time in SCK half-cycles. */
+    uint8_t lead;
+  } chip_select;
+  /** Full-cycle sampling mode. */
+  bool full_cycle;
+  /** SPI clock phase. */
+  bool cpha;
+  /** SPI clock polarity. */
+  bool cpol;
+} dif_spi_host_config_t;
+
+/**
+ * Width of SPI operations.
+ */
+typedef enum dif_spi_host_width {
+  /** Standard SPI mode (single lanes for send and recv). */
+  kDifSpiHostWidthStandard = 0,
+  /** Dual SPI mode (use two lanes for send and recv). */
+  kDifSpiHostWidthDual = 1,
+  /** Quad SPI mode (use four lanes for send and recv). */
+  kDifSpiHostWidthQuad = 2,
+} dif_spi_host_width_t;
+
+/**
+ * Direction of SPI operations.
+ *
+ * This describes which direction a given SPI operation will use.
+ */
+typedef enum dif_spi_host_direction {
+  /** The SPI host neither transmits or receives. */
+  kDifSpiHostDirectionDummy = 0,
+  /** The SPI host receives data. */
+  kDifSpiHostDirectionRx = 1,
+  /** The SPI host transmits data. */
+  kDifSpiHostDirectionTx = 2,
+  /** The SPI host transmits and receives data. */
+  kDifSpiHostDirectionBidirectional = 3,
+} dif_spi_host_direction_t;
+
+/**
+ * Segment types for segments in a transaction.
+ *
+ */
+typedef enum dif_spi_host_segment_type {
+  /** The segment is a SPI opcode. */
+  kDifSpiHostSegmentTypeOpcode,
+  /** The segment is a SPI address. */
+  kDifSpiHostSegmentTypeAddress,
+  /** The segment is a SPI dummy cycle. */
+  kDifSpiHostSegmentTypeDummy,
+  /** The segment is a SPI transmit (from a memory buffer). */
+  kDifSpiHostSegmentTypeTx,
+  /** The segment is a SPI receive (into a memory buffer). */
+  kDifSpiHostSegmentTypeRx,
+  /** The segment is a simultaneous transmit and receieve. */
+  kDifSpiHostSegmentTypeBidirectional,
+} dif_spi_host_segment_type_t;
+
+/**
+ * Address mode for the address segment in a transaction.
+ */
+typedef enum dif_spi_host_addr_mode {
+  /** The address is a 3-byte address. */
+  kDifSpiHostAddrMode3b,
+  /** The address is a 4-byte address. */
+  kDifSpiHostAddrMode4b,
+} dif_spi_host_addr_mode_t;
+
+/**
+ * Segment descriptor for each segment in a transaction.
+ *
+ * This struct is a tagged union: the `type` field determines
+ * which field of the union is relevant.
+ */
+typedef struct dif_spi_host_segment {
+  /** The segment type for this segment. */
+  dif_spi_host_segment_type_t type;
+  union {
+    uint8_t opcode;
+    struct {
+      dif_spi_host_width_t width;
+      dif_spi_host_addr_mode_t mode;
+      uint32_t address;
+    } address;
+    struct {
+      dif_spi_host_width_t width;
+      size_t length;
+    } dummy;
+    struct {
+      dif_spi_host_width_t width;
+      const void *buf;
+      size_t length;
+    } tx;
+    struct {
+      dif_spi_host_width_t width;
+      void *buf;
+      size_t length;
+    } rx;
+    struct {
+      dif_spi_host_width_t width;
+      const void *txbuf;
+      void *rxbuf;
+      size_t length;
+    } bidir;
+  };
+} dif_spi_host_segment_t;
+
+/**
+ * Creates a new handle for SPI Host.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the IP.
+ * @param params Hardware instantiation parameters. (optional, may remove)
+ * @param[out] spi_host Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_init(mmio_region_t base_addr,
+                               dif_spi_host_t *spi_host);
+
+/**
+ * Configures SPI Host with runtime information.
+ *
+ * This function should only need to be called once for the lifetime of
+ * `handle`.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param config Runtime configuration parameters.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_configure(const dif_spi_host_t *spi_host,
+                                    dif_spi_host_config_t config);
+
+/**
+ * Enable or disable SPI host output buffers.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param enable Enable or disable the output buffers.
+ */
+void dif_spi_host_output(const dif_spi_host_t *spi_host, bool enable);
+
+/**
+ * Write to the SPI Host transmit FIFO.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param src A pointer to the buffer to transmit.
+ * @param len The length of the transmit buffer.
+ */
+void dif_spi_host_fifo_write(const dif_spi_host_t *spi_host, const void *src,
+                             uint16_t len);
+
+/**
+ * Read from the SPI Host receive FIFO.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param dst A pointer to the buffer to receive the data.
+ * @param len The length of the receive buffer.
+ */
+void dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
+                            uint16_t len);
+
+/**
+ * Begins a SPI Host transaction.
+ *
+ * @param spi_host A SPI Host handle.
+ * @param csid The chip-select ID of the SPI target.
+ * @param segments The SPI segments to send in this transaction.
+ * @param length The number of SPI segments in this transaction.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_transaction(const dif_spi_host_t *spi_host,
+                                      uint32_t csid,
+                                      dif_spi_host_segment_t *segments,
+                                      size_t length);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -1,0 +1,460 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_spi_host.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/global_mock.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "spi_host_regs.h"  // Generated.
+
+namespace dif_spi_host_unittest {
+namespace {
+
+// Mock out the spi_host_fifo functions.
+namespace internal {
+class MockFifo : public ::global_mock::GlobalMock<MockFifo> {
+ public:
+  MOCK_METHOD(void, write, (const dif_spi_host_t *, const void *, uint16_t));
+  MOCK_METHOD(void, read, (const dif_spi_host_t *, void *, uint16_t));
+};
+}  // namespace internal
+using MockFifo = testing::StrictMock<internal::MockFifo>;
+extern "C" {
+void spi_host_fifo_write_alias(const dif_spi_host_t *spi_host, const void *src,
+                               uint16_t len) {
+  MockFifo::Instance().write(spi_host, src, len);
+}
+void spi_host_fifo_read_alias(const dif_spi_host_t *spi_host, void *dst,
+                              uint16_t len) {
+  MockFifo::Instance().read(spi_host, dst, len);
+}
+}
+
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::ElementsAre;
+using testing::Test;
+
+// Helper macros to make expectations easier to read.
+#define EXPECT_COMMAND_REG(length, width, direction, last_segment)   \
+  EXPECT_WRITE32(SPI_HOST_COMMAND_REG_OFFSET,                        \
+                 {                                                   \
+                     {SPI_HOST_COMMAND_LEN_OFFSET, (length)-1},      \
+                     {SPI_HOST_COMMAND_SPEED_OFFSET, width},         \
+                     {SPI_HOST_COMMAND_DIRECTION_OFFSET, direction}, \
+                     {SPI_HOST_COMMAND_CSAAT_BIT, !(last_segment)},  \
+                 })
+
+#define EXPECT_READY(ready)                 \
+  EXPECT_READ32(SPI_HOST_STATUS_REG_OFFSET, \
+                {{SPI_HOST_STATUS_READY_BIT, ready}})
+
+#define EXPECT_TXQD(txqd)                   \
+  EXPECT_READ32(SPI_HOST_STATUS_REG_OFFSET, \
+                {{SPI_HOST_STATUS_TXQD_OFFSET, txqd}})
+
+#define EXPECT_RXQD(rxqd)                   \
+  EXPECT_READ32(SPI_HOST_STATUS_REG_OFFSET, \
+                {{SPI_HOST_STATUS_RXQD_OFFSET, rxqd}})
+
+class SpiHostTest : public Test, public MmioTest {
+ protected:
+  void ExpectDeviceReset() {
+    // Place IP into reset.
+    EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                   {
+                       {SPI_HOST_CONTROL_SW_RST_BIT, true},
+                   });
+    // Active bit should be clear.
+    EXPECT_READ32(SPI_HOST_STATUS_REG_OFFSET, 0);
+    // TXQD and RXQD should be zeros.
+    EXPECT_READ32(SPI_HOST_STATUS_REG_OFFSET, 0);
+    // Release IP from reset.
+    EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                   {
+                       {SPI_HOST_CONTROL_SW_RST_BIT, false},
+                   });
+  }
+
+  dif_spi_host_t spi_host_ = {
+      .base_addr = dev().region(),
+  };
+
+  dif_spi_host_config config_ = {
+      .spi_clock = 1000000,
+      .peripheral_clock_freq_hz = 1000000,
+      .chip_select =
+          {
+              .idle = 0,
+              .trail = 0,
+              .lead = 0,
+          },
+      .full_cycle = false,
+      .cpha = false,
+      .cpol = false,
+  };
+};
+
+class ConfigTest : public SpiHostTest {};
+
+TEST_F(ConfigTest, NullArgs) {
+  EXPECT_EQ(dif_spi_host_configure(nullptr, config_), kDifBadArg);
+}
+
+TEST_F(ConfigTest, BadDivider) {
+  // A spi_clock faster than the peripheral clock is invalid.
+  config_.spi_clock = 1000001;
+  EXPECT_EQ(dif_spi_host_configure(&spi_host_, config_), kDifBadArg);
+
+  // A spi_clock of zero is invalid.
+  config_.spi_clock = 0;
+  EXPECT_EQ(dif_spi_host_configure(&spi_host_, config_), kDifBadArg);
+}
+
+// Checks the default configuration.
+TEST_F(ConfigTest, Default) {
+  ExpectDeviceReset();
+  EXPECT_WRITE32(SPI_HOST_CONFIGOPTS_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNIDLE_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNTRAIL_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNLEAD_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_FULLCYC_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
+                 });
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONTROL_SPIEN_BIT, true},
+                 });
+
+  EXPECT_EQ(dif_spi_host_configure(&spi_host_, config_), kDifOk);
+}
+
+// Checks manipulation of the output enable bit.
+TEST_F(ConfigTest, OutputEnable) {
+  EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONTROL_OUTPUT_EN_BIT, true},
+                 });
+  dif_spi_host_output(&spi_host_, true);
+}
+
+// Checks that the clock divider gets calculated correctly.
+TEST_F(ConfigTest, ClockRate) {
+  config_.spi_clock = 500000;
+
+  ExpectDeviceReset();
+  EXPECT_WRITE32(SPI_HOST_CONFIGOPTS_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 1},
+                     {SPI_HOST_CONFIGOPTS_CSNIDLE_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNTRAIL_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNLEAD_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_FULLCYC_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
+                 });
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONTROL_SPIEN_BIT, true},
+                 });
+
+  EXPECT_EQ(dif_spi_host_configure(&spi_host_, config_), kDifOk);
+}
+
+// Checks that the chip select options get written to the appropriate fields in
+// the config register.
+TEST_F(ConfigTest, ChipSelectOptions) {
+  config_.chip_select.idle = 1;
+  config_.chip_select.trail = 2;
+  config_.chip_select.lead = 3;
+
+  ExpectDeviceReset();
+  EXPECT_WRITE32(SPI_HOST_CONFIGOPTS_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNIDLE_0_OFFSET, 1},
+                     {SPI_HOST_CONFIGOPTS_CSNTRAIL_0_OFFSET, 2},
+                     {SPI_HOST_CONFIGOPTS_CSNLEAD_0_OFFSET, 3},
+                     {SPI_HOST_CONFIGOPTS_FULLCYC_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, false},
+                     {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, false},
+                 });
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONTROL_SPIEN_BIT, true},
+                 });
+
+  EXPECT_EQ(dif_spi_host_configure(&spi_host_, config_), kDifOk);
+}
+
+// Checks that the SPI cycle, polarity and phase options get written to the
+// appropriate fields in the config register.
+TEST_F(ConfigTest, SpiOptions) {
+  config_.full_cycle = true;
+  config_.cpol = true;
+  config_.cpha = true;
+
+  ExpectDeviceReset();
+  EXPECT_WRITE32(SPI_HOST_CONFIGOPTS_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONFIGOPTS_CLKDIV_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNIDLE_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNTRAIL_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_CSNLEAD_0_OFFSET, 0},
+                     {SPI_HOST_CONFIGOPTS_FULLCYC_0_BIT, true},
+                     {SPI_HOST_CONFIGOPTS_CPHA_0_BIT, true},
+                     {SPI_HOST_CONFIGOPTS_CPOL_0_BIT, true},
+                 });
+  EXPECT_WRITE32(SPI_HOST_CONTROL_REG_OFFSET,
+                 {
+                     {SPI_HOST_CONTROL_SPIEN_BIT, true},
+                 });
+
+  EXPECT_EQ(dif_spi_host_configure(&spi_host_, config_), kDifOk);
+}
+
+class TransactionTest : public SpiHostTest {
+ protected:
+  MockFifo fifo_;
+};
+
+// Checks that an opcode segment is sent correctly.
+TEST_F(TransactionTest, IssueOpcode) {
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeOpcode;
+  segment.opcode = 0x5a;
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_TXQD(0);
+  // Opcodes are written directly to the FIFO register.
+  EXPECT_WRITE8(SPI_HOST_TXDATA_REG_OFFSET, 0x5a);
+  EXPECT_COMMAND_REG(/*length=*/1, /*width=*/kDifSpiHostWidthStandard,
+                     /*direction=*/kDifSpiHostDirectionTx, /*last=*/true);
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that an address segment is sent correctly in 3-byte mode.
+TEST_F(TransactionTest, IssueAddressMode3b) {
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeAddress;
+  segment.address.width = kDifSpiHostWidthStandard;
+  segment.address.mode = kDifSpiHostAddrMode3b;
+  segment.address.address = 0x112233;
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_TXQD(0);
+  // SPI addresses are written directly to the FIFO register.
+  EXPECT_WRITE32(SPI_HOST_TXDATA_REG_OFFSET, 0x332211);
+  EXPECT_COMMAND_REG(/*length=*/3, /*width=*/kDifSpiHostWidthStandard,
+                     /*direction=*/kDifSpiHostDirectionTx, /*last=*/true);
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that an address segment is sent correctly in 4-byte mode.
+TEST_F(TransactionTest, IssueAddressMode4b) {
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeAddress;
+  segment.address.width = kDifSpiHostWidthStandard;
+  segment.address.mode = kDifSpiHostAddrMode4b;
+  segment.address.address = 0x11223344;
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_TXQD(0);
+  // SPI addresses are written directly to the FIFO register.
+  EXPECT_WRITE32(SPI_HOST_TXDATA_REG_OFFSET, 0x44332211);
+  EXPECT_COMMAND_REG(/*length=*/4, /*width=*/kDifSpiHostWidthStandard,
+                     /*direction=*/kDifSpiHostDirectionTx, /*last=*/true);
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that a dummy segment is sent correctly.
+TEST_F(TransactionTest, IssueDummy) {
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeDummy;
+  segment.dummy.width = kDifSpiHostWidthStandard;
+  segment.dummy.length = 8;
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_COMMAND_REG(/*length=*/8, /*width=*/kDifSpiHostWidthStandard,
+                     /*direction=*/kDifSpiHostDirectionDummy, /*last=*/true);
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that a transmit segment is sent correctly.
+TEST_F(TransactionTest, TransmitDual) {
+  uint8_t buf[32];
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeTx;
+  segment.tx.width = kDifSpiHostWidthDual;
+  segment.tx.buf = buf;
+  segment.tx.length = sizeof(buf);
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_CALL(fifo_, write(&spi_host_, buf, sizeof(buf)));
+  EXPECT_COMMAND_REG(/*length=*/sizeof(buf), /*width=*/kDifSpiHostWidthDual,
+                     /*direction=*/kDifSpiHostDirectionTx, /*last=*/true);
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that a receive segment is sent correctly.
+TEST_F(TransactionTest, ReceiveQuad) {
+  uint8_t buf[32];
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeRx;
+  segment.rx.width = kDifSpiHostWidthQuad;
+  segment.rx.buf = buf;
+  segment.rx.length = sizeof(buf);
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_COMMAND_REG(/*length=*/sizeof(buf), /*width=*/kDifSpiHostWidthQuad,
+                     /*direction=*/kDifSpiHostDirectionRx, /*last=*/true);
+  EXPECT_CALL(fifo_, read(&spi_host_, buf, sizeof(buf)));
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that a tranceive segment is sent correctly.
+TEST_F(TransactionTest, Transceive) {
+  uint8_t txbuf[32];
+  uint8_t rxbuf[32];
+  dif_spi_host_segment segment;
+  segment.type = kDifSpiHostSegmentTypeBidirectional;
+  segment.bidir.width = kDifSpiHostWidthStandard;
+  segment.bidir.txbuf = txbuf;
+  segment.bidir.rxbuf = rxbuf;
+  segment.bidir.length = sizeof(txbuf);
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_CALL(fifo_, write(&spi_host_, txbuf, sizeof(txbuf)));
+  EXPECT_COMMAND_REG(
+      /*length=*/sizeof(txbuf), /*width=*/kDifSpiHostWidthStandard,
+      /*direction=*/kDifSpiHostDirectionBidirectional, /*last=*/true);
+  EXPECT_CALL(fifo_, read(&spi_host_, rxbuf, sizeof(rxbuf)));
+
+  EXPECT_EQ(dif_spi_host_transaction(&spi_host_, 0, &segment, 1), kDifOk);
+}
+
+// Checks that multiple segments are sent correctly.
+TEST_F(TransactionTest, MultiSegmentTxRx) {
+  uint8_t txbuf[32];
+  uint8_t rxbuf[64];
+  dif_spi_host_segment segment[2];
+
+  segment[0].type = kDifSpiHostSegmentTypeTx;
+  segment[0].rx.width = kDifSpiHostWidthDual;
+  segment[0].rx.buf = txbuf;
+  segment[0].rx.length = sizeof(txbuf);
+  segment[1].type = kDifSpiHostSegmentTypeRx;
+  segment[1].rx.width = kDifSpiHostWidthDual;
+  segment[1].rx.buf = rxbuf;
+  segment[1].rx.length = sizeof(rxbuf);
+
+  EXPECT_WRITE32(SPI_HOST_CSID_REG_OFFSET, 0);
+  EXPECT_READY(true);
+  EXPECT_CALL(fifo_, write(&spi_host_, txbuf, sizeof(txbuf)));
+  EXPECT_COMMAND_REG(/*length=*/sizeof(txbuf), /*width=*/kDifSpiHostWidthDual,
+                     /*direction=*/kDifSpiHostDirectionTx, /*last=*/false);
+  EXPECT_READY(true);
+  EXPECT_COMMAND_REG(/*length=*/sizeof(rxbuf), /*width=*/kDifSpiHostWidthDual,
+                     /*direction=*/kDifSpiHostDirectionRx, /*last=*/true);
+  EXPECT_CALL(fifo_, read(&spi_host_, rxbuf, sizeof(rxbuf)));
+
+  EXPECT_EQ(
+      dif_spi_host_transaction(&spi_host_, 0, segment, ARRAYSIZE(segment)),
+      kDifOk);
+}
+
+class FifoTest : public SpiHostTest {};
+
+// Checks that an aligned source buffer is written as 32-bit words into the
+// transmit FIFO.
+TEST_F(FifoTest, AlignedWrite) {
+  uint32_t buffer[] = {1, 2};
+
+  EXPECT_TXQD(0);
+  EXPECT_WRITE32(SPI_HOST_TXDATA_REG_OFFSET, 1);
+  EXPECT_TXQD(0);
+  EXPECT_WRITE32(SPI_HOST_TXDATA_REG_OFFSET, 2);
+
+  dif_spi_host_fifo_write(&spi_host_, buffer, sizeof(buffer));
+}
+
+// Checks that a misaligned source buffer is written as bytes into the
+// transmit FIFO until alignment is reached and then written as 32-bit words.
+TEST_F(FifoTest, MisalignedWrite) {
+  // We'll intentionally mis-align the buffer by 1 when calling
+  // dif_spi_host_fifo_write.
+  uint8_t buffer[] alignas(uint32_t) = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+
+  // Because of the misalignment, expect three byte writes.
+  EXPECT_TXQD(0);
+  EXPECT_WRITE8(SPI_HOST_TXDATA_REG_OFFSET, 1);
+  EXPECT_TXQD(0);
+  EXPECT_WRITE8(SPI_HOST_TXDATA_REG_OFFSET, 2);
+  EXPECT_TXQD(0);
+  EXPECT_WRITE8(SPI_HOST_TXDATA_REG_OFFSET, 3);
+
+  // Then a word write when we reach alignment.
+  EXPECT_TXQD(0);
+  EXPECT_WRITE32(SPI_HOST_TXDATA_REG_OFFSET, 0x07060504);
+
+  // Then a byte write to finish the buffer.
+  EXPECT_TXQD(0);
+  EXPECT_WRITE8(SPI_HOST_TXDATA_REG_OFFSET, 8);
+
+  dif_spi_host_fifo_write(&spi_host_, buffer + 1, sizeof(buffer) - 1);
+}
+
+// Checks that an aligned destination buffer receives the contents of the
+// recieve FIFO.
+TEST_F(FifoTest, AlignedRead) {
+  uint32_t buffer[2];
+
+  EXPECT_RXQD(2);
+  EXPECT_READ32(SPI_HOST_RXDATA_REG_OFFSET, 1);
+  EXPECT_RXQD(1);
+  EXPECT_READ32(SPI_HOST_RXDATA_REG_OFFSET, 2);
+
+  dif_spi_host_fifo_read(&spi_host_, buffer, sizeof(buffer));
+  EXPECT_THAT(buffer, ElementsAre(1, 2));
+}
+
+// Checks that a misaligned destination buffer receives the contents of the
+// recieve FIFO.
+TEST_F(FifoTest, MisalignedRead) {
+  // We'll intentionally mis-align the buffer by 1 when calling
+  // dif_spi_host_fifo_read.
+  uint8_t buffer[9] alignas(uint32_t) = {0};
+
+  EXPECT_RXQD(2);
+  EXPECT_READ32(SPI_HOST_RXDATA_REG_OFFSET, 0x04030201);
+  EXPECT_RXQD(1);
+  EXPECT_READ32(SPI_HOST_RXDATA_REG_OFFSET, 0x08070605);
+
+  dif_spi_host_fifo_read(&spi_host_, buffer + 1, sizeof(buffer) - 1);
+  EXPECT_THAT(buffer, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7, 8));
+}
+
+}  // namespace
+}  // namespace dif_spi_host_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -298,9 +298,11 @@ sw_lib_dif_spi_host = declare_dependency(
     'sw_lib_dif_spi_host',
     sources: [
       hw_ip_spi_host_reg_h,
+      'dif_spi_host.c',
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_lib_mem,
       sw_lib_dif_autogen_spi_host,
     ],
   )
@@ -309,8 +311,10 @@ sw_lib_dif_spi_host = declare_dependency(
 test('dif_spi_host_unittest', executable(
     'dif_spi_host_unittest',
     sources: [
+      'dif_spi_host_unittest.cc',
       'autogen/dif_spi_host_autogen_unittest.cc',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_spi_host_autogen.c',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_spi_host.c',
       hw_ip_spi_host_reg_h,
     ],
     dependencies: [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -153,3 +153,12 @@ opentitan_functest(
     name = "uart_smoketest",
     srcs = ["uart_smoketest.c"],
 )
+
+opentitan_functest(
+    name = "spi_host_smoketest",
+    targets = ["cw310"],  # Can only run on CW310 board right now.
+    srcs = ["spi_host_smoketest.c"],
+    deps = [
+        "//sw/device/lib/dif:spi_host",
+    ],
+)

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -687,6 +687,7 @@ sw_tests += {
   }
 }
 
+
 # SRAM Controller scrambled access test.
 sram_ctrl_scrambled_access_test_lib = declare_dependency(
   link_with: static_library(
@@ -929,6 +930,25 @@ hmac_enc_irq_test_lib = declare_dependency(
 sw_tests += {
   'hmac_enc_irq_test': {
     'library': hmac_enc_irq_test_lib,
+  }
+}
+
+# SPI_HOST test
+spi_host_smoketest_lib = declare_dependency(
+  link_with: static_library(
+    'spi_host_smoketest_lib',
+    sources: ['spi_host_smoketest.c'],
+    dependencies: [
+      sw_lib_dif_spi_host,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'spi_host_smoketest': {
+    'library': spi_host_smoketest_lib,
   }
 }
 

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#include <assert.h>
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_spi_host.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+              "This test assumes the target platform is little endian.");
+
+#define SFDP_SIGNATURE 0x50444653
+
+const test_config_t kTestConfig;
+
+void read_sfdp(dif_spi_host_t *spi_host) {
+  uint8_t buf[256];
+  dif_spi_host_segment_t segments[] = {
+      {
+          .type = kDifSpiHostSegmentTypeOpcode,
+          .opcode = 0x5a,
+      },
+      {
+          .type = kDifSpiHostSegmentTypeAddress,
+          .address =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .mode = kDifSpiHostAddrMode3b,
+                  .address = 0x0,
+              },
+      },
+      {
+          .type = kDifSpiHostSegmentTypeDummy,
+          .dummy =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .length = 8,
+              },
+      },
+      {
+          .type = kDifSpiHostSegmentTypeRx,
+          .rx =
+              {
+                  .width = kDifSpiHostWidthStandard,
+                  .buf = buf,
+                  .length = sizeof(buf),
+              },
+      },
+  };
+  CHECK_DIF_OK(
+      dif_spi_host_transaction(spi_host, 0, segments, ARRAYSIZE(segments)));
+
+  uint32_t sfdp = read_32(buf);
+  LOG_INFO("SFDP signature is 0x%08x", sfdp);
+  CHECK(sfdp == SFDP_SIGNATURE, "Expected to find the SFDP signature!");
+}
+
+bool test_main(void) {
+  dif_spi_host_t spi_host;
+  CHECK_DIF_OK(dif_spi_host_init(
+      mmio_region_from_addr(TOP_EARLGREY_SPI_HOST0_BASE_ADDR), &spi_host));
+
+  CHECK_DIF_OK(dif_spi_host_configure(
+                   &spi_host,
+                   (dif_spi_host_config_t){
+                       .spi_clock = 1000000,
+                       .peripheral_clock_freq_hz = kClockFreqPeripheralHz,
+                   }),
+               "SPI_HOST config failed!");
+  dif_spi_host_output(&spi_host, true);
+
+  read_sfdp(&spi_host);
+  return true;
+}


### PR DESCRIPTION
1. Create spi_host DIF.
2. Add unit tests for the spi_host DIF.
3. Add a smoke test.  Currently, the smoke test only works on the CW310 board.

Signed-off-by: Chris Frantz <cfrantz@google.com>