### PR TITLE
[dv] Move alert init to post_apply_reset

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -87,6 +87,10 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
+  endtask
+
+  virtual task post_apply_reset(string reset_kind = "HARD");
+    super.post_apply_reset(reset_kind);
     if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
 
     // Wait for alert init done, then start the sequence.


### PR DESCRIPTION
This is needed for stess_all with rand reset, which invokes apply_resets_concurrently
and post_apply_reset.
This will also fix uart regression failures

Signed-off-by: Weicai Yang <weicai@google.com>