### PR TITLE
[dif] Autogen all `dif_<ip>_alert_force()` DIFs.

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c
@@ -21,6 +21,28 @@ dif_result_t dif_adc_ctrl_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
+                                      dif_adc_ctrl_alert_t alert) {
+  if (adc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifAdcCtrlAlertFatalFault:
+      alert_idx = ADC_CTRL_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.h
@@ -49,6 +49,29 @@ dif_result_t dif_adc_ctrl_init(mmio_region_t base_addr,
                                dif_adc_ctrl_t *adc_ctrl);
 
 /**
+ * A adc_ctrl alert type.
+ */
+typedef enum dif_adc_ctrl_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifAdcCtrlAlertFatalFault = 0,
+} dif_adc_ctrl_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param adc_ctrl A adc_ctrl handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_adc_ctrl_alert_force(const dif_adc_ctrl_t *adc_ctrl,
+                                      dif_adc_ctrl_alert_t alert);
+
+/**
  * A adc_ctrl interrupt request type.
  */
 typedef enum dif_adc_ctrl_irq {

--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -36,6 +36,27 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public AdcCtrlTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_adc_ctrl_alert_force(nullptr, kDifAdcCtrlAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_adc_ctrl_alert_force(nullptr, static_cast<dif_adc_ctrl_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(ADC_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{ADC_CTRL_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_adc_ctrl_alert_force(&adc_ctrl_, kDifAdcCtrlAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public AdcCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_aes_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.c
@@ -19,3 +19,27 @@ dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes) {
 
   return kDifOk;
 }
+
+dif_result_t dif_aes_alert_force(const dif_aes_t *aes, dif_aes_alert_t alert) {
+  if (aes == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifAesAlertRecovCtrlUpdateErr:
+      alert_idx = AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT;
+      break;
+    case kDifAesAlertFatalFault:
+      alert_idx = AES_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(aes->base_addr, AES_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_aes_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen.h
@@ -47,6 +47,41 @@ typedef struct dif_aes {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aes_init(mmio_region_t base_addr, dif_aes_t *aes);
 
+/**
+ * A aes alert type.
+ */
+typedef enum dif_aes_alert {
+  /**
+   * This recoverable alert is triggered upon detecting an update error in the
+   * shadowed Control Register. The content of the Control Register is not
+   * modified (See Control Register). The AES unit can be recovered from such a
+   * condition by restarting the AES operation, i.e., by re-writing the Control
+   * Register. This should be monitored by the system.
+   */
+  kDifAesAlertRecovCtrlUpdateErr = 0,
+  /**
+   * This fatal alert is triggered upon detecting a fatal fault inside the AES
+   * unit. Examples for such faults include i) storage errors in the shadowed
+   * Control Register, ii) any internal FSM entering an invalid state, iii) any
+   * sparsely encoded signal taking on an invalid value, iv) errors in the
+   * internal round counter, v) escalations triggered by the life cycle
+   * controller, and vi) fatal integrity failures on the TL-UL bus. The AES unit
+   * cannot recover from such an error and needs to be reset.
+   */
+  kDifAesAlertFatalFault = 1,
+} dif_aes_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param aes A aes handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aes_alert_force(const dif_aes_t *aes, dif_aes_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
@@ -34,5 +34,29 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_aes_init({.base_addr = dev().region()}, &aes_), kDifOk);
 }
 
+class AlertForceTest : public AesTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_aes_alert_force(nullptr, kDifAesAlertRecovCtrlUpdateErr),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_aes_alert_force(nullptr, static_cast<dif_aes_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(AES_ALERT_TEST_REG_OFFSET,
+                 {{AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT, true}});
+  EXPECT_EQ(dif_aes_alert_force(&aes_, kDifAesAlertRecovCtrlUpdateErr), kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(AES_ALERT_TEST_REG_OFFSET,
+                 {{AES_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_aes_alert_force(&aes_, kDifAesAlertFatalFault), kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_aes_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.c
@@ -30,6 +30,28 @@ dif_result_t dif_aon_timer_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_aon_timer_alert_force(const dif_aon_timer_t *aon_timer,
+                                       dif_aon_timer_alert_t alert) {
+  if (aon_timer == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifAonTimerAlertFatalFault:
+      alert_idx = AON_TIMER_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(aon_timer->base_addr, AON_TIMER_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen.h
@@ -50,6 +50,29 @@ dif_result_t dif_aon_timer_init(mmio_region_t base_addr,
                                 dif_aon_timer_t *aon_timer);
 
 /**
+ * A aon_timer alert type.
+ */
+typedef enum dif_aon_timer_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifAonTimerAlertFatalFault = 0,
+} dif_aon_timer_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param aon_timer A aon_timer handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aon_timer_alert_force(const dif_aon_timer_t *aon_timer,
+                                       dif_aon_timer_alert_t alert);
+
+/**
  * A aon_timer interrupt request type.
  */
 typedef enum dif_aon_timer_irq {

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -36,6 +36,27 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public AonTimerTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_aon_timer_alert_force(nullptr, kDifAonTimerAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_aon_timer_alert_force(nullptr,
+                                      static_cast<dif_aon_timer_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(AON_TIMER_ALERT_TEST_REG_OFFSET,
+                 {{AON_TIMER_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_aon_timer_alert_force(&aon_timer_, kDifAonTimerAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public AonTimerTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.c
@@ -20,6 +20,31 @@ dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng) {
   return kDifOk;
 }
 
+dif_result_t dif_csrng_alert_force(const dif_csrng_t *csrng,
+                                   dif_csrng_alert_t alert) {
+  if (csrng == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifCsrngAlertRecovAlert:
+      alert_idx = CSRNG_ALERT_TEST_RECOV_ALERT_BIT;
+      break;
+    case kDifCsrngAlertFatalAlert:
+      alert_idx = CSRNG_ALERT_TEST_FATAL_ALERT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(csrng->base_addr, CSRNG_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen.h
@@ -48,6 +48,35 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_csrng_init(mmio_region_t base_addr, dif_csrng_t *csrng);
 
 /**
+ * A csrng alert type.
+ */
+typedef enum dif_csrng_alert {
+  /**
+   * This alert is triggered when a recoverable alert occurs.  Check the
+   * !!RECOV_ALERT_STS register to get more information.
+   */
+  kDifCsrngAlertRecovAlert = 0,
+  /**
+   * This alert triggers (i) if an illegal state machine state is reached, or
+   * (ii) if an AES fatal alert condition occurs, or (iii) if a fatal integrity
+   * failure is detected on the TL-UL bus.
+   */
+  kDifCsrngAlertFatalAlert = 1,
+} dif_csrng_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param csrng A csrng handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_csrng_alert_force(const dif_csrng_t *csrng,
+                                   dif_csrng_alert_t alert);
+
+/**
  * A csrng interrupt request type.
  */
 typedef enum dif_csrng_irq {

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -34,6 +34,30 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_csrng_init({.base_addr = dev().region()}, &csrng_), kDifOk);
 }
 
+class AlertForceTest : public CsrngTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_csrng_alert_force(nullptr, kDifCsrngAlertRecovAlert),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_csrng_alert_force(nullptr, static_cast<dif_csrng_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(CSRNG_ALERT_TEST_REG_OFFSET,
+                 {{CSRNG_ALERT_TEST_RECOV_ALERT_BIT, true}});
+  EXPECT_EQ(dif_csrng_alert_force(&csrng_, kDifCsrngAlertRecovAlert), kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(CSRNG_ALERT_TEST_REG_OFFSET,
+                 {{CSRNG_ALERT_TEST_FATAL_ALERT_BIT, true}});
+  EXPECT_EQ(dif_csrng_alert_force(&csrng_, kDifCsrngAlertFatalAlert), kDifOk);
+}
+
 class IrqGetStateTest : public CsrngTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.c
@@ -20,6 +20,30 @@ dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn) {
   return kDifOk;
 }
 
+dif_result_t dif_edn_alert_force(const dif_edn_t *edn, dif_edn_alert_t alert) {
+  if (edn == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifEdnAlertRecovAlert:
+      alert_idx = EDN_ALERT_TEST_RECOV_ALERT_BIT;
+      break;
+    case kDifEdnAlertFatalAlert:
+      alert_idx = EDN_ALERT_TEST_FATAL_ALERT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(edn->base_addr, EDN_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_edn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen.h
@@ -48,6 +48,33 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_edn_init(mmio_region_t base_addr, dif_edn_t *edn);
 
 /**
+ * A edn alert type.
+ */
+typedef enum dif_edn_alert {
+  /**
+   * This alert is triggered when entropy bus data matches on consecutive clock
+   * cycles.
+   */
+  kDifEdnAlertRecovAlert = 0,
+  /**
+   * This alert triggers (i) if an illegal state machine state is reached, or
+   * (ii) if a fatal integrity failure is detected on the TL-UL bus.
+   */
+  kDifEdnAlertFatalAlert = 1,
+} dif_edn_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param edn A edn handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_edn_alert_force(const dif_edn_t *edn, dif_edn_alert_t alert);
+
+/**
  * A edn interrupt request type.
  */
 typedef enum dif_edn_irq {

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -34,6 +34,29 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_edn_init({.base_addr = dev().region()}, &edn_), kDifOk);
 }
 
+class AlertForceTest : public EdnTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_edn_alert_force(nullptr, kDifEdnAlertRecovAlert), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_edn_alert_force(nullptr, static_cast<dif_edn_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(EDN_ALERT_TEST_REG_OFFSET,
+                 {{EDN_ALERT_TEST_RECOV_ALERT_BIT, true}});
+  EXPECT_EQ(dif_edn_alert_force(&edn_, kDifEdnAlertRecovAlert), kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(EDN_ALERT_TEST_REG_OFFSET,
+                 {{EDN_ALERT_TEST_FATAL_ALERT_BIT, true}});
+  EXPECT_EQ(dif_edn_alert_force(&edn_, kDifEdnAlertFatalAlert), kDifOk);
+}
+
 class IrqGetStateTest : public EdnTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.c
@@ -21,6 +21,31 @@ dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_entropy_src_alert_force(const dif_entropy_src_t *entropy_src,
+                                         dif_entropy_src_alert_t alert) {
+  if (entropy_src == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifEntropySrcAlertRecovAlert:
+      alert_idx = ENTROPY_SRC_ALERT_TEST_RECOV_ALERT_BIT;
+      break;
+    case kDifEntropySrcAlertFatalAlert:
+      alert_idx = ENTROPY_SRC_ALERT_TEST_FATAL_ALERT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(entropy_src->base_addr, ENTROPY_SRC_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen.h
@@ -50,6 +50,34 @@ dif_result_t dif_entropy_src_init(mmio_region_t base_addr,
                                   dif_entropy_src_t *entropy_src);
 
 /**
+ * A entropy_src alert type.
+ */
+typedef enum dif_entropy_src_alert {
+  /**
+   * This alert is triggered upon the alert health test threshold criteria not
+   * met.
+   */
+  kDifEntropySrcAlertRecovAlert = 0,
+  /**
+   * This alert triggers (i) if an illegal state machine state is reached, or
+   * (ii) if a fatal integrity failure is detected on the TL-UL bus.
+   */
+  kDifEntropySrcAlertFatalAlert = 1,
+} dif_entropy_src_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param entropy_src A entropy_src handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_entropy_src_alert_force(const dif_entropy_src_t *entropy_src,
+                                         dif_entropy_src_alert_t alert);
+
+/**
  * A entropy_src interrupt request type.
  */
 typedef enum dif_entropy_src_irq {

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -36,6 +36,35 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public EntropySrcTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_entropy_src_alert_force(nullptr, kDifEntropySrcAlertRecovAlert),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_entropy_src_alert_force(
+                nullptr, static_cast<dif_entropy_src_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(ENTROPY_SRC_ALERT_TEST_REG_OFFSET,
+                 {{ENTROPY_SRC_ALERT_TEST_RECOV_ALERT_BIT, true}});
+  EXPECT_EQ(
+      dif_entropy_src_alert_force(&entropy_src_, kDifEntropySrcAlertRecovAlert),
+      kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(ENTROPY_SRC_ALERT_TEST_REG_OFFSET,
+                 {{ENTROPY_SRC_ALERT_TEST_FATAL_ALERT_BIT, true}});
+  EXPECT_EQ(
+      dif_entropy_src_alert_force(&entropy_src_, kDifEntropySrcAlertFatalAlert),
+      kDifOk);
+}
+
 class IrqGetStateTest : public EntropySrcTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.c
@@ -21,6 +21,31 @@ dif_result_t dif_flash_ctrl_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_flash_ctrl_alert_force(const dif_flash_ctrl_t *flash_ctrl,
+                                        dif_flash_ctrl_alert_t alert) {
+  if (flash_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifFlashCtrlAlertRecovErr:
+      alert_idx = FLASH_CTRL_ALERT_TEST_RECOV_ERR_BIT;
+      break;
+    case kDifFlashCtrlAlertFatalErr:
+      alert_idx = FLASH_CTRL_ALERT_TEST_FATAL_ERR_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(flash_ctrl->base_addr, FLASH_CTRL_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen.h
@@ -50,6 +50,32 @@ dif_result_t dif_flash_ctrl_init(mmio_region_t base_addr,
                                  dif_flash_ctrl_t *flash_ctrl);
 
 /**
+ * A flash_ctrl alert type.
+ */
+typedef enum dif_flash_ctrl_alert {
+  /**
+   * Flash recoverable errors
+   */
+  kDifFlashCtrlAlertRecovErr = 0,
+  /**
+   * Flash fatal errors
+   */
+  kDifFlashCtrlAlertFatalErr = 1,
+} dif_flash_ctrl_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param flash_ctrl A flash_ctrl handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_flash_ctrl_alert_force(const dif_flash_ctrl_t *flash_ctrl,
+                                        dif_flash_ctrl_alert_t alert);
+
+/**
  * A flash_ctrl interrupt request type.
  */
 typedef enum dif_flash_ctrl_irq {

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -36,6 +36,35 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public FlashCtrlTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_flash_ctrl_alert_force(nullptr, kDifFlashCtrlAlertRecovErr),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_flash_ctrl_alert_force(nullptr,
+                                       static_cast<dif_flash_ctrl_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(FLASH_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{FLASH_CTRL_ALERT_TEST_RECOV_ERR_BIT, true}});
+  EXPECT_EQ(
+      dif_flash_ctrl_alert_force(&flash_ctrl_, kDifFlashCtrlAlertRecovErr),
+      kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(FLASH_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{FLASH_CTRL_ALERT_TEST_FATAL_ERR_BIT, true}});
+  EXPECT_EQ(
+      dif_flash_ctrl_alert_force(&flash_ctrl_, kDifFlashCtrlAlertFatalErr),
+      kDifOk);
+}
+
 class IrqGetStateTest : public FlashCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.c
@@ -20,6 +20,28 @@ dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio) {
   return kDifOk;
 }
 
+dif_result_t dif_gpio_alert_force(const dif_gpio_t *gpio,
+                                  dif_gpio_alert_t alert) {
+  if (gpio == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifGpioAlertFatalFault:
+      alert_idx = GPIO_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(gpio->base_addr, GPIO_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen.h
@@ -48,6 +48,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_gpio_init(mmio_region_t base_addr, dif_gpio_t *gpio);
 
 /**
+ * A gpio alert type.
+ */
+typedef enum dif_gpio_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifGpioAlertFatalFault = 0,
+} dif_gpio_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param gpio A gpio handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_gpio_alert_force(const dif_gpio_t *gpio,
+                                  dif_gpio_alert_t alert);
+
+/**
  * A gpio interrupt request type.
  */
 typedef enum dif_gpio_irq {

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -34,6 +34,24 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_gpio_init({.base_addr = dev().region()}, &gpio_), kDifOk);
 }
 
+class AlertForceTest : public GpioTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_gpio_alert_force(nullptr, kDifGpioAlertFatalFault), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_gpio_alert_force(nullptr, static_cast<dif_gpio_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(GPIO_ALERT_TEST_REG_OFFSET,
+                 {{GPIO_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_gpio_alert_force(&gpio_, kDifGpioAlertFatalFault), kDifOk);
+}
+
 class IrqGetStateTest : public GpioTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.c
@@ -20,6 +20,28 @@ dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac) {
   return kDifOk;
 }
 
+dif_result_t dif_hmac_alert_force(const dif_hmac_t *hmac,
+                                  dif_hmac_alert_t alert) {
+  if (hmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifHmacAlertFatalFault:
+      alert_idx = HMAC_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(hmac->base_addr, HMAC_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen.h
@@ -48,6 +48,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_hmac_init(mmio_region_t base_addr, dif_hmac_t *hmac);
 
 /**
+ * A hmac alert type.
+ */
+typedef enum dif_hmac_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifHmacAlertFatalFault = 0,
+} dif_hmac_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param hmac A hmac handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_hmac_alert_force(const dif_hmac_t *hmac,
+                                  dif_hmac_alert_t alert);
+
+/**
  * A hmac interrupt request type.
  */
 typedef enum dif_hmac_irq {

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -34,6 +34,24 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_hmac_init({.base_addr = dev().region()}, &hmac_), kDifOk);
 }
 
+class AlertForceTest : public HmacTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_hmac_alert_force(nullptr, kDifHmacAlertFatalFault), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_hmac_alert_force(nullptr, static_cast<dif_hmac_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(HMAC_ALERT_TEST_REG_OFFSET,
+                 {{HMAC_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_hmac_alert_force(&hmac_, kDifHmacAlertFatalFault), kDifOk);
+}
+
 class IrqGetStateTest : public HmacTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.c
@@ -20,6 +20,27 @@ dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c) {
   return kDifOk;
 }
 
+dif_result_t dif_i2c_alert_force(const dif_i2c_t *i2c, dif_i2c_alert_t alert) {
+  if (i2c == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifI2cAlertFatalFault:
+      alert_idx = I2C_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(i2c->base_addr, I2C_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen.h
@@ -48,6 +48,28 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_i2c_init(mmio_region_t base_addr, dif_i2c_t *i2c);
 
 /**
+ * A i2c alert type.
+ */
+typedef enum dif_i2c_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifI2cAlertFatalFault = 0,
+} dif_i2c_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param i2c A i2c handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_i2c_alert_force(const dif_i2c_t *i2c, dif_i2c_alert_t alert);
+
+/**
  * A i2c interrupt request type.
  */
 typedef enum dif_i2c_irq {

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -34,6 +34,24 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_i2c_init({.base_addr = dev().region()}, &i2c_), kDifOk);
 }
 
+class AlertForceTest : public I2cTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_i2c_alert_force(nullptr, kDifI2cAlertFatalFault), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_i2c_alert_force(nullptr, static_cast<dif_i2c_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(I2C_ALERT_TEST_REG_OFFSET,
+                 {{I2C_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_i2c_alert_force(&i2c_, kDifI2cAlertFatalFault), kDifOk);
+}
+
 class IrqGetStateTest : public I2cTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.c
@@ -20,6 +20,31 @@ dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr) {
   return kDifOk;
 }
 
+dif_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
+                                    dif_keymgr_alert_t alert) {
+  if (keymgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifKeymgrAlertFatalFaultErr:
+      alert_idx = KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_BIT;
+      break;
+    case kDifKeymgrAlertRecovOperationErr:
+      alert_idx = KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(keymgr->base_addr, KEYMGR_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen.h
@@ -48,6 +48,33 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_keymgr_init(mmio_region_t base_addr, dif_keymgr_t *keymgr);
 
 /**
+ * A keymgr alert type.
+ */
+typedef enum dif_keymgr_alert {
+  /**
+   * Alert for key manager faults.  These errors cannot be caused by software
+   */
+  kDifKeymgrAlertFatalFaultErr = 0,
+  /**
+   * Alert for key manager operation errors.  These errors could have been
+   * caused by software
+   */
+  kDifKeymgrAlertRecovOperationErr = 1,
+} dif_keymgr_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param keymgr A keymgr handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
+                                    dif_keymgr_alert_t alert);
+
+/**
  * A keymgr interrupt request type.
  */
 typedef enum dif_keymgr_irq {

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -35,6 +35,33 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_keymgr_init({.base_addr = dev().region()}, &keymgr_), kDifOk);
 }
 
+class AlertForceTest : public KeymgrTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_keymgr_alert_force(nullptr, kDifKeymgrAlertFatalFaultErr),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_keymgr_alert_force(nullptr, static_cast<dif_keymgr_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(KEYMGR_ALERT_TEST_REG_OFFSET,
+                 {{KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_BIT, true}});
+  EXPECT_EQ(dif_keymgr_alert_force(&keymgr_, kDifKeymgrAlertFatalFaultErr),
+            kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(KEYMGR_ALERT_TEST_REG_OFFSET,
+                 {{KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT, true}});
+  EXPECT_EQ(dif_keymgr_alert_force(&keymgr_, kDifKeymgrAlertRecovOperationErr),
+            kDifOk);
+}
+
 class IrqGetStateTest : public KeymgrTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.c
@@ -20,6 +20,28 @@ dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac) {
   return kDifOk;
 }
 
+dif_result_t dif_kmac_alert_force(const dif_kmac_t *kmac,
+                                  dif_kmac_alert_t alert) {
+  if (kmac == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifKmacAlertFatalFault:
+      alert_idx = KMAC_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(kmac->base_addr, KMAC_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen.h
@@ -48,6 +48,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_kmac_init(mmio_region_t base_addr, dif_kmac_t *kmac);
 
 /**
+ * A kmac alert type.
+ */
+typedef enum dif_kmac_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifKmacAlertFatalFault = 0,
+} dif_kmac_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param kmac A kmac handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_kmac_alert_force(const dif_kmac_t *kmac,
+                                  dif_kmac_alert_t alert);
+
+/**
  * A kmac interrupt request type.
  */
 typedef enum dif_kmac_irq {

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -34,6 +34,24 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_kmac_init({.base_addr = dev().region()}, &kmac_), kDifOk);
 }
 
+class AlertForceTest : public KmacTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_kmac_alert_force(nullptr, kDifKmacAlertFatalFault), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_kmac_alert_force(nullptr, static_cast<dif_kmac_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(KMAC_ALERT_TEST_REG_OFFSET,
+                 {{KMAC_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_kmac_alert_force(&kmac_, kDifKmacAlertFatalFault), kDifOk);
+}
+
 class IrqGetStateTest : public KmacTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.c
@@ -19,3 +19,31 @@ dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc_ctrl) {
 
   return kDifOk;
 }
+
+dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc_ctrl,
+                                     dif_lc_ctrl_alert_t alert) {
+  if (lc_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifLcCtrlAlertFatalProgError:
+      alert_idx = LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_BIT;
+      break;
+    case kDifLcCtrlAlertFatalStateError:
+      alert_idx = LC_CTRL_ALERT_TEST_FATAL_STATE_ERROR_BIT;
+      break;
+    case kDifLcCtrlAlertFatalBusIntegError:
+      alert_idx = LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(lc_ctrl->base_addr, LC_CTRL_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen.h
@@ -47,6 +47,39 @@ typedef struct dif_lc_ctrl {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_lc_ctrl_init(mmio_region_t base_addr, dif_lc_ctrl_t *lc_ctrl);
 
+/**
+ * A lc_ctrl alert type.
+ */
+typedef enum dif_lc_ctrl_alert {
+  /**
+   * This alert triggers if an error occurred during an OTP programming
+   * operation.
+   */
+  kDifLcCtrlAlertFatalProgError = 0,
+  /**
+   * This alert triggers if an error in the life cycle state or life cycle
+   * controller FSM is detected.
+   */
+  kDifLcCtrlAlertFatalStateError = 1,
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifLcCtrlAlertFatalBusIntegError = 2,
+} dif_lc_ctrl_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param lc_ctrl A lc_ctrl handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc_ctrl,
+                                     dif_lc_ctrl_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
@@ -35,5 +35,33 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, &lc_ctrl_), kDifOk);
 }
 
+class AlertForceTest : public LcCtrlTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_lc_ctrl_alert_force(nullptr, kDifLcCtrlAlertFatalProgError),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_lc_ctrl_alert_force(nullptr, static_cast<dif_lc_ctrl_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(LC_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_BIT, true}});
+  EXPECT_EQ(dif_lc_ctrl_alert_force(&lc_ctrl_, kDifLcCtrlAlertFatalProgError),
+            kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(LC_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT, true}});
+  EXPECT_EQ(
+      dif_lc_ctrl_alert_force(&lc_ctrl_, kDifLcCtrlAlertFatalBusIntegError),
+      kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_lc_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.c
@@ -20,6 +20,31 @@ dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn) {
   return kDifOk;
 }
 
+dif_result_t dif_otbn_alert_force(const dif_otbn_t *otbn,
+                                  dif_otbn_alert_t alert) {
+  if (otbn == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifOtbnAlertFatal:
+      alert_idx = OTBN_ALERT_TEST_FATAL_BIT;
+      break;
+    case kDifOtbnAlertRecov:
+      alert_idx = OTBN_ALERT_TEST_RECOV_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(otbn->base_addr, OTBN_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen.h
@@ -48,6 +48,33 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_otbn_init(mmio_region_t base_addr, dif_otbn_t *otbn);
 
 /**
+ * A otbn alert type.
+ */
+typedef enum dif_otbn_alert {
+  /**
+   * A fatal error. Fatal alerts are non-recoverable and will be asserted until
+   * a hard reset.
+   */
+  kDifOtbnAlertFatal = 0,
+  /**
+   * A recoverable error. Just sent once (as the processor stops).
+   */
+  kDifOtbnAlertRecov = 1,
+} dif_otbn_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param otbn A otbn handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otbn_alert_force(const dif_otbn_t *otbn,
+                                  dif_otbn_alert_t alert);
+
+/**
  * A otbn interrupt request type.
  */
 typedef enum dif_otbn_irq {

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -34,6 +34,29 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_otbn_init({.base_addr = dev().region()}, &otbn_), kDifOk);
 }
 
+class AlertForceTest : public OtbnTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_otbn_alert_force(nullptr, kDifOtbnAlertFatal), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_otbn_alert_force(nullptr, static_cast<dif_otbn_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(OTBN_ALERT_TEST_REG_OFFSET,
+                 {{OTBN_ALERT_TEST_FATAL_BIT, true}});
+  EXPECT_EQ(dif_otbn_alert_force(&otbn_, kDifOtbnAlertFatal), kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(OTBN_ALERT_TEST_REG_OFFSET,
+                 {{OTBN_ALERT_TEST_RECOV_BIT, true}});
+  EXPECT_EQ(dif_otbn_alert_force(&otbn_, kDifOtbnAlertRecov), kDifOk);
+}
+
 class IrqGetStateTest : public OtbnTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.c
@@ -21,6 +21,34 @@ dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_otp_ctrl_alert_force(const dif_otp_ctrl_t *otp_ctrl,
+                                      dif_otp_ctrl_alert_t alert) {
+  if (otp_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifOtpCtrlAlertFatalMacroError:
+      alert_idx = OTP_CTRL_ALERT_TEST_FATAL_MACRO_ERROR_BIT;
+      break;
+    case kDifOtpCtrlAlertFatalCheckError:
+      alert_idx = OTP_CTRL_ALERT_TEST_FATAL_CHECK_ERROR_BIT;
+      break;
+    case kDifOtpCtrlAlertFatalBusIntegError:
+      alert_idx = OTP_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(otp_ctrl->base_addr, OTP_CTRL_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen.h
@@ -49,6 +49,39 @@ dif_result_t dif_otp_ctrl_init(mmio_region_t base_addr,
                                dif_otp_ctrl_t *otp_ctrl);
 
 /**
+ * A otp_ctrl alert type.
+ */
+typedef enum dif_otp_ctrl_alert {
+  /**
+   * This alert triggers if hardware detects an ECC or digest error in the
+   * buffered partitions.
+   */
+  kDifOtpCtrlAlertFatalMacroError = 0,
+  /**
+   * This alert triggers if the digest over the buffered registers does not
+   * match with the digest stored in OTP.
+   */
+  kDifOtpCtrlAlertFatalCheckError = 1,
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifOtpCtrlAlertFatalBusIntegError = 2,
+} dif_otp_ctrl_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param otp_ctrl A otp_ctrl handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_alert_force(const dif_otp_ctrl_t *otp_ctrl,
+                                      dif_otp_ctrl_alert_t alert);
+
+/**
  * A otp_ctrl interrupt request type.
  */
 typedef enum dif_otp_ctrl_irq {

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -36,6 +36,35 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public OtpCtrlTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_otp_ctrl_alert_force(nullptr, kDifOtpCtrlAlertFatalMacroError),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_otp_ctrl_alert_force(nullptr, static_cast<dif_otp_ctrl_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(OTP_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{OTP_CTRL_ALERT_TEST_FATAL_MACRO_ERROR_BIT, true}});
+  EXPECT_EQ(
+      dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertFatalMacroError),
+      kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(OTP_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{OTP_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT, true}});
+  EXPECT_EQ(
+      dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertFatalBusIntegError),
+      kDifOk);
+}
+
 class IrqGetStateTest : public OtpCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.c
@@ -20,6 +20,28 @@ dif_result_t dif_pattgen_init(mmio_region_t base_addr, dif_pattgen_t *pattgen) {
   return kDifOk;
 }
 
+dif_result_t dif_pattgen_alert_force(const dif_pattgen_t *pattgen,
+                                     dif_pattgen_alert_t alert) {
+  if (pattgen == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifPattgenAlertFatalFault:
+      alert_idx = PATTGEN_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(pattgen->base_addr, PATTGEN_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen.h
@@ -48,6 +48,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_pattgen_init(mmio_region_t base_addr, dif_pattgen_t *pattgen);
 
 /**
+ * A pattgen alert type.
+ */
+typedef enum dif_pattgen_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifPattgenAlertFatalFault = 0,
+} dif_pattgen_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param pattgen A pattgen handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pattgen_alert_force(const dif_pattgen_t *pattgen,
+                                     dif_pattgen_alert_t alert);
+
+/**
  * A pattgen interrupt request type.
  */
 typedef enum dif_pattgen_irq {

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
@@ -35,6 +35,27 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_pattgen_init({.base_addr = dev().region()}, &pattgen_), kDifOk);
 }
 
+class AlertForceTest : public PattgenTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_pattgen_alert_force(nullptr, kDifPattgenAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_pattgen_alert_force(nullptr, static_cast<dif_pattgen_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(PATTGEN_ALERT_TEST_REG_OFFSET,
+                 {{PATTGEN_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_pattgen_alert_force(&pattgen_, kDifPattgenAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public PattgenTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen.c
@@ -19,3 +19,25 @@ dif_result_t dif_pinmux_init(mmio_region_t base_addr, dif_pinmux_t *pinmux) {
 
   return kDifOk;
 }
+
+dif_result_t dif_pinmux_alert_force(const dif_pinmux_t *pinmux,
+                                    dif_pinmux_alert_t alert) {
+  if (pinmux == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifPinmuxAlertFatalFault:
+      alert_idx = PINMUX_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(pinmux->base_addr, PINMUX_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen.h
@@ -47,6 +47,29 @@ typedef struct dif_pinmux {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pinmux_init(mmio_region_t base_addr, dif_pinmux_t *pinmux);
 
+/**
+ * A pinmux alert type.
+ */
+typedef enum dif_pinmux_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifPinmuxAlertFatalFault = 0,
+} dif_pinmux_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param pinmux A pinmux handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pinmux_alert_force(const dif_pinmux_t *pinmux,
+                                    dif_pinmux_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
@@ -35,5 +35,26 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_pinmux_init({.base_addr = dev().region()}, &pinmux_), kDifOk);
 }
 
+class AlertForceTest : public PinmuxTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_pinmux_alert_force(nullptr, kDifPinmuxAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_pinmux_alert_force(nullptr, static_cast<dif_pinmux_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(PINMUX_ALERT_TEST_REG_OFFSET,
+                 {{PINMUX_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_pinmux_alert_force(&pinmux_, kDifPinmuxAlertFatalFault),
+            kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_pinmux_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.c
@@ -19,3 +19,25 @@ dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *rv_plic) {
 
   return kDifOk;
 }
+
+dif_result_t dif_rv_plic_alert_force(const dif_rv_plic_t *rv_plic,
+                                     dif_rv_plic_alert_t alert) {
+  if (rv_plic == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifRvPlicAlertFatalFault:
+      alert_idx = RV_PLIC_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(rv_plic->base_addr, RV_PLIC_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen.h
@@ -47,6 +47,29 @@ typedef struct dif_rv_plic {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_rv_plic_init(mmio_region_t base_addr, dif_rv_plic_t *rv_plic);
 
+/**
+ * A rv_plic alert type.
+ */
+typedef enum dif_rv_plic_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifRvPlicAlertFatalFault = 0,
+} dif_rv_plic_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param rv_plic A rv_plic handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_plic_alert_force(const dif_rv_plic_t *rv_plic,
+                                     dif_rv_plic_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
@@ -35,5 +35,26 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, &rv_plic_), kDifOk);
 }
 
+class AlertForceTest : public RvPlicTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_rv_plic_alert_force(nullptr, kDifRvPlicAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_rv_plic_alert_force(nullptr, static_cast<dif_rv_plic_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(RV_PLIC_ALERT_TEST_REG_OFFSET,
+                 {{RV_PLIC_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_rv_plic_alert_force(&rv_plic_, kDifRvPlicAlertFatalFault),
+            kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_rv_plic_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.c
@@ -28,6 +28,28 @@ dif_result_t dif_rv_timer_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_rv_timer_alert_force(const dif_rv_timer_t *rv_timer,
+                                      dif_rv_timer_alert_t alert) {
+  if (rv_timer == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifRvTimerAlertFatalFault:
+      alert_idx = RV_TIMER_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(rv_timer->base_addr, RV_TIMER_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 typedef enum dif_rv_timer_intr_reg {
   kDifRvTimerIntrRegState = 0,
   kDifRvTimerIntrRegEnable = 1,

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen.h
@@ -49,6 +49,29 @@ dif_result_t dif_rv_timer_init(mmio_region_t base_addr,
                                dif_rv_timer_t *rv_timer);
 
 /**
+ * A rv_timer alert type.
+ */
+typedef enum dif_rv_timer_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected inside the RV_TIMER unit.
+   */
+  kDifRvTimerAlertFatalFault = 0,
+} dif_rv_timer_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param rv_timer A rv_timer handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_timer_alert_force(const dif_rv_timer_t *rv_timer,
+                                      dif_rv_timer_alert_t alert);
+
+/**
  * A rv_timer interrupt request type.
  */
 typedef enum dif_rv_timer_irq {

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -36,6 +36,27 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public RvTimerTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_rv_timer_alert_force(nullptr, kDifRvTimerAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_rv_timer_alert_force(nullptr, static_cast<dif_rv_timer_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(RV_TIMER_ALERT_TEST_REG_OFFSET,
+                 {{RV_TIMER_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_rv_timer_alert_force(&rv_timer_, kDifRvTimerAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public RvTimerTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.c
@@ -21,6 +21,28 @@ dif_result_t dif_spi_device_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_spi_device_alert_force(const dif_spi_device_t *spi_device,
+                                        dif_spi_device_alert_t alert) {
+  if (spi_device == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifSpiDeviceAlertFatalFault:
+      alert_idx = SPI_DEVICE_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(spi_device->base_addr, SPI_DEVICE_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen.h
@@ -50,6 +50,29 @@ dif_result_t dif_spi_device_init(mmio_region_t base_addr,
                                  dif_spi_device_t *spi_device);
 
 /**
+ * A spi_device alert type.
+ */
+typedef enum dif_spi_device_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifSpiDeviceAlertFatalFault = 0,
+} dif_spi_device_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param spi_device A spi_device handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_alert_force(const dif_spi_device_t *spi_device,
+                                        dif_spi_device_alert_t alert);
+
+/**
  * A spi_device interrupt request type.
  */
 typedef enum dif_spi_device_irq {

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -36,6 +36,28 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public SpiDeviceTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_spi_device_alert_force(nullptr, kDifSpiDeviceAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_spi_device_alert_force(nullptr,
+                                       static_cast<dif_spi_device_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(SPI_DEVICE_ALERT_TEST_REG_OFFSET,
+                 {{SPI_DEVICE_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(
+      dif_spi_device_alert_force(&spi_device_, kDifSpiDeviceAlertFatalFault),
+      kDifOk);
+}
+
 class IrqGetStateTest : public SpiDeviceTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.c
@@ -21,6 +21,28 @@ dif_result_t dif_spi_host_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_spi_host_alert_force(const dif_spi_host_t *spi_host,
+                                      dif_spi_host_alert_t alert) {
+  if (spi_host == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifSpiHostAlertFatalFault:
+      alert_idx = SPI_HOST_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(spi_host->base_addr, SPI_HOST_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen.h
@@ -49,6 +49,29 @@ dif_result_t dif_spi_host_init(mmio_region_t base_addr,
                                dif_spi_host_t *spi_host);
 
 /**
+ * A spi_host alert type.
+ */
+typedef enum dif_spi_host_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifSpiHostAlertFatalFault = 0,
+} dif_spi_host_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param spi_host A spi_host handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_alert_force(const dif_spi_host_t *spi_host,
+                                      dif_spi_host_alert_t alert);
+
+/**
  * A spi_host interrupt request type.
  */
 typedef enum dif_spi_host_irq {

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
@@ -36,6 +36,27 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public SpiHostTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_spi_host_alert_force(nullptr, kDifSpiHostAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_spi_host_alert_force(nullptr, static_cast<dif_spi_host_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(SPI_HOST_ALERT_TEST_REG_OFFSET,
+                 {{SPI_HOST_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_spi_host_alert_force(&spi_host_, kDifSpiHostAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public SpiHostTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.c
@@ -20,3 +20,25 @@ dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
 
   return kDifOk;
 }
+
+dif_result_t dif_sram_ctrl_alert_force(const dif_sram_ctrl_t *sram_ctrl,
+                                       dif_sram_ctrl_alert_t alert) {
+  if (sram_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifSramCtrlAlertFatalError:
+      alert_idx = SRAM_CTRL_ALERT_TEST_FATAL_ERROR_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(sram_ctrl->base_addr, SRAM_CTRL_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen.h
@@ -49,6 +49,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_sram_ctrl_init(mmio_region_t base_addr,
                                 dif_sram_ctrl_t *sram_ctrl);
 
+/**
+ * A sram_ctrl alert type.
+ */
+typedef enum dif_sram_ctrl_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected, or if the initialization mechanism has reached an invalid state.
+   */
+  kDifSramCtrlAlertFatalError = 0,
+} dif_sram_ctrl_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param sram_ctrl A sram_ctrl handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sram_ctrl_alert_force(const dif_sram_ctrl_t *sram_ctrl,
+                                       dif_sram_ctrl_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
@@ -36,5 +36,26 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public SramCtrlTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_sram_ctrl_alert_force(nullptr, kDifSramCtrlAlertFatalError),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_sram_ctrl_alert_force(nullptr,
+                                      static_cast<dif_sram_ctrl_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(SRAM_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{SRAM_CTRL_ALERT_TEST_FATAL_ERROR_BIT, true}});
+  EXPECT_EQ(dif_sram_ctrl_alert_force(&sram_ctrl_, kDifSramCtrlAlertFatalError),
+            kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_sram_ctrl_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c
@@ -21,6 +21,28 @@ dif_result_t dif_sysrst_ctrl_init(mmio_region_t base_addr,
   return kDifOk;
 }
 
+dif_result_t dif_sysrst_ctrl_alert_force(const dif_sysrst_ctrl_t *sysrst_ctrl,
+                                         dif_sysrst_ctrl_alert_t alert) {
+  if (sysrst_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifSysrstCtrlAlertFatalFault:
+      alert_idx = SYSRST_CTRL_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(sysrst_ctrl->base_addr, SYSRST_CTRL_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.h
@@ -50,6 +50,29 @@ dif_result_t dif_sysrst_ctrl_init(mmio_region_t base_addr,
                                   dif_sysrst_ctrl_t *sysrst_ctrl);
 
 /**
+ * A sysrst_ctrl alert type.
+ */
+typedef enum dif_sysrst_ctrl_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifSysrstCtrlAlertFatalFault = 0,
+} dif_sysrst_ctrl_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param sysrst_ctrl A sysrst_ctrl handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sysrst_ctrl_alert_force(const dif_sysrst_ctrl_t *sysrst_ctrl,
+                                         dif_sysrst_ctrl_alert_t alert);
+
+/**
  * A sysrst_ctrl interrupt request type.
  */
 typedef enum dif_sysrst_ctrl_irq {

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
@@ -36,6 +36,28 @@ TEST_F(InitTest, Success) {
             kDifOk);
 }
 
+class AlertForceTest : public SysrstCtrlTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_sysrst_ctrl_alert_force(nullptr, kDifSysrstCtrlAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_sysrst_ctrl_alert_force(
+                nullptr, static_cast<dif_sysrst_ctrl_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(SYSRST_CTRL_ALERT_TEST_REG_OFFSET,
+                 {{SYSRST_CTRL_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(
+      dif_sysrst_ctrl_alert_force(&sysrst_ctrl_, kDifSysrstCtrlAlertFatalFault),
+      kDifOk);
+}
+
 class IrqGetStateTest : public SysrstCtrlTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.c
@@ -20,6 +20,28 @@ dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart) {
   return kDifOk;
 }
 
+dif_result_t dif_uart_alert_force(const dif_uart_t *uart,
+                                  dif_uart_alert_t alert) {
+  if (uart == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifUartAlertFatalFault:
+      alert_idx = UART_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(uart->base_addr, UART_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_uart_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen.h
@@ -48,6 +48,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_uart_init(mmio_region_t base_addr, dif_uart_t *uart);
 
 /**
+ * A uart alert type.
+ */
+typedef enum dif_uart_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifUartAlertFatalFault = 0,
+} dif_uart_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param uart A uart handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_uart_alert_force(const dif_uart_t *uart,
+                                  dif_uart_alert_t alert);
+
+/**
  * A uart interrupt request type.
  */
 typedef enum dif_uart_irq {

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -34,6 +34,24 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_uart_init({.base_addr = dev().region()}, &uart_), kDifOk);
 }
 
+class AlertForceTest : public UartTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_uart_alert_force(nullptr, kDifUartAlertFatalFault), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_uart_alert_force(nullptr, static_cast<dif_uart_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(UART_ALERT_TEST_REG_OFFSET,
+                 {{UART_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_uart_alert_force(&uart_, kDifUartAlertFatalFault), kDifOk);
+}
+
 class IrqGetStateTest : public UartTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.c
@@ -20,6 +20,28 @@ dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev) {
   return kDifOk;
 }
 
+dif_result_t dif_usbdev_alert_force(const dif_usbdev_t *usbdev,
+                                    dif_usbdev_alert_t alert) {
+  if (usbdev == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifUsbdevAlertFatalFault:
+      alert_idx = USBDEV_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(usbdev->base_addr, USBDEV_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen.h
@@ -48,6 +48,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_usbdev_init(mmio_region_t base_addr, dif_usbdev_t *usbdev);
 
 /**
+ * A usbdev alert type.
+ */
+typedef enum dif_usbdev_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifUsbdevAlertFatalFault = 0,
+} dif_usbdev_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param usbdev A usbdev handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_usbdev_alert_force(const dif_usbdev_t *usbdev,
+                                    dif_usbdev_alert_t alert);
+
+/**
  * A usbdev interrupt request type.
  */
 typedef enum dif_usbdev_irq {

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -35,6 +35,27 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_usbdev_init({.base_addr = dev().region()}, &usbdev_), kDifOk);
 }
 
+class AlertForceTest : public UsbdevTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_usbdev_alert_force(nullptr, kDifUsbdevAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_usbdev_alert_force(nullptr, static_cast<dif_usbdev_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(USBDEV_ALERT_TEST_REG_OFFSET,
+                 {{USBDEV_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_usbdev_alert_force(&usbdev_, kDifUsbdevAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public UsbdevTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -401,27 +401,3 @@ dif_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
 
   return kDifOk;
 }
-
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_aes_alert_force(const dif_aes_t *aes, dif_aes_alert_t alert) {
-  if (aes == NULL) {
-    return kDifBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  switch (alert) {
-    case kDifAlertFatalFault:
-      index = AES_ALERT_TEST_FATAL_FAULT_BIT;
-      break;
-    case kDifAlertRecovCtrlUpdateErr:
-      index = AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT;
-      break;
-    default:
-      return kDifError;
-  }
-
-  uint32_t reg = bitfield_bit32_write(0, index, true);
-  mmio_region_write32(aes->base_addr, AES_ALERT_TEST_REG_OFFSET, reg);
-
-  return kDifOk;
-}

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -158,21 +158,6 @@ typedef struct dif_aes_transaction {
 } dif_aes_transaction_t;
 
 /**
- * An AES alert type.
- */
-typedef enum dif_aes_alert {
-  /**
-   * Fatal alert conditions include i) storage errors in the Control Register,
-   * and ii) if any internal FSM enters an invalid state.
-   */
-  kDifAlertFatalFault = 0,
-  /**
-   * Recoverable alert conditions include update errors in the Control Register.
-   */
-  kDifAlertRecovCtrlUpdateErr,
-} dif_aes_alert_t;
-
-/**
  * Resets an instance of AES.
  *
  * Clears the internal state along with the interface registers.
@@ -391,17 +376,6 @@ typedef enum dif_aes_status {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
                                 bool *set);
-
-/**
- * Forces a particular alert, causing it to be serviced as if hardware had
- * asserted it.
- *
- * @param aes AES state data.
- * @param alert An alert type.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_aes_alert_force(const dif_aes_t *aes, dif_aes_alert_t alert);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_entropy_src.h
+++ b/sw/device/lib/dif/dif_entropy_src.h
@@ -322,21 +322,6 @@ typedef struct dif_entropy_src_test_stats {
 } dif_entropy_src_test_stats_t;
 
 /**
- * An entropy source alert type.
- */
-typedef enum dif_entropy_src_alert {
-  /**
-   * Indicates that the health test criteria were not met.
-   */
-  kDifEntropySrcAlert,
-
-  /**
-   * Indicates that an internal error occurred.
-   */
-  kDifEntropySrcFatal,
-} dif_entropy_src_alert_t;
-
-/**
  * Configures entropy source with runtime information.
  *
  * This function should need to be called once for the lifetime of `handle`.
@@ -417,18 +402,6 @@ dif_result_t dif_entropy_src_avail(const dif_entropy_src_t *entropy_src);
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_entropy_src_read(const dif_entropy_src_t *entropy_src,
                                   uint32_t *word);
-
-/**
- * Forces a particular alert, causing it to be emitted as if the hardware had
- * done so.
- *
- * @param entropy An entropy source handle.
- * @param alert An alert type.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_entropy_src_alert_force(const dif_entropy_src_t *entropy_src,
-                                         dif_entropy_src_alert_t alert);
 
 /**
  * Performs an override read from the entropy pipeline.

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -560,27 +560,3 @@ dif_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
 
   return kDifOk;
 }
-
-dif_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
-                                    dif_keymgr_alert_t alert) {
-  if (keymgr == NULL) {
-    return kDifBadArg;
-  }
-
-  bitfield_bit32_index_t bit_index;
-  switch (alert) {
-    case kDifKeymgrAlertHardware:
-      bit_index = KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_BIT;
-      break;
-    case kDifKeymgrAlertSoftware:
-      bit_index = KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT;
-      break;
-    default:
-      return kDifBadArg;
-  }
-
-  mmio_region_write32(keymgr->base_addr, KEYMGR_ALERT_TEST_REG_OFFSET,
-                      bitfield_bit32_write(0, bit_index, true));
-
-  return kDifOk;
-}

--- a/sw/device/lib/dif/dif_keymgr.h
+++ b/sw/device/lib/dif/dif_keymgr.h
@@ -74,38 +74,6 @@ typedef struct dif_keymgr_config {
 } dif_keymgr_config_t;
 
 /**
- * Key manager alerts.
- *
- * Key manager generates alerts when it encounters a hardware or software
- * error. Clients can use `dif_keymgr_get_status_codes()` to determine the type
- * of error that occurred.
- */
-typedef enum dif_keymgr_alert {
-  /**
-   * A hardware error occurred.
-   *
-   * This alert is triggered when the hardware encounters an error condition
-   * that cannot be caused by the software, e.g. invalid KMAC commands, states,
-   * or outputs.
-   */
-  kDifKeymgrAlertHardware,
-  /**
-   * A software error occurred.
-   *
-   * This alert is triggered when the software attempts to start an invalid
-   * operation, e.g. attempting to generate keys when the key manager is at
-   * Initialized state, or use invalid inputs, e.g. a key with a forbidden
-   * version.
-   */
-  kDifKeymgrAlertSoftware,
-
-  /**
-   * \internal Last key manager alert.
-   */
-  kDifKeymgrAlertLast = kDifKeymgrAlertSoftware,
-} dif_keymgr_alert_t;
-
-/**
  * Key manager states.
  *
  * Key manager has seven states that control its operation. During secure boot,
@@ -476,17 +444,6 @@ typedef struct dif_keymgr_output {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_keymgr_read_output(const dif_keymgr_t *keymgr,
                                     dif_keymgr_output_t *output);
-
-/**
- * Forces a particular alert as if hardware had asserted it.
- *
- * @param keymgr A key manager handle.
- * @param alert An alert type.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_keymgr_alert_force(const dif_keymgr_t *keymgr,
-                                    dif_keymgr_alert_t alert);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_keymgr_unittest.cc
+++ b/sw/device/lib/dif/dif_keymgr_unittest.cc
@@ -813,43 +813,5 @@ TEST_F(ReadOutputTest, Read) {
   }
 }
 
-TEST_P(BadArgsTwo, AlertForce) {
-  auto keymgr = GetGoodBadPtrArg<dif_keymgr_t>(std::get<0>(GetParam()));
-  auto alert = GetGoodBadEnumArg<dif_keymgr_alert_t>(std::get<1>(GetParam()),
-                                                     kDifKeymgrAlertLast);
-
-  EXPECT_EQ(dif_keymgr_alert_force(keymgr, alert), kDifBadArg);
-}
-
-struct AlertTestCase {
-  dif_keymgr_alert_t alert;
-  bitfield_bit32_index_t bit_index;
-};
-
-class AlertForce : public DifKeymgrInitialized,
-                   public testing::WithParamInterface<AlertTestCase> {};
-
-TEST_P(AlertForce, Success) {
-  EXPECT_WRITE32(KEYMGR_ALERT_TEST_REG_OFFSET,
-                 {{
-                     .offset = GetParam().bit_index,
-                     .value = 1,
-                 }});
-
-  EXPECT_EQ(dif_keymgr_alert_force(&keymgr_, GetParam().alert), kDifOk);
-}
-
-INSTANTIATE_TEST_SUITE_P(
-    AlertForceAll, AlertForce,
-    testing::Values(
-        AlertTestCase{
-            .alert = kDifKeymgrAlertHardware,
-            .bit_index = KEYMGR_ALERT_TEST_FATAL_FAULT_ERR_BIT,
-        },
-        AlertTestCase{
-            .alert = kDifKeymgrAlertSoftware,
-            .bit_index = KEYMGR_ALERT_TEST_RECOV_OPERATION_ERR_BIT,
-        }));
-
 }  // namespace
 }  // namespace dif_keymgr_unittest

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -216,33 +216,6 @@ dif_result_t dif_lc_ctrl_get_device_id(const dif_lc_ctrl_t *lc,
   return kDifOk;
 }
 
-dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
-                                     dif_lc_ctrl_alert_t alert) {
-  if (lc == NULL) {
-    return kDifBadArg;
-  }
-
-  bitfield_bit32_index_t alert_idx;
-  switch (alert) {
-    case kDifLcCtrlAlertOtp:
-      alert_idx = LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_BIT;
-      break;
-    case kDifLcCtrlAlertCorrupt:
-      alert_idx = LC_CTRL_ALERT_TEST_FATAL_STATE_ERROR_BIT;
-      break;
-    case kDifLcCtrlAlertBus:
-      alert_idx = LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT;
-      break;
-    default:
-      return kDifBadArg;
-  }
-
-  uint32_t reg = bitfield_bit32_write(0, alert_idx, true);
-  mmio_region_write32(lc->base_addr, LC_CTRL_ALERT_TEST_REG_OFFSET, reg);
-
-  return kDifOk;
-}
-
 dif_result_t dif_lc_ctrl_mutex_try_acquire(const dif_lc_ctrl_t *lc) {
   if (lc == NULL) {
     return kDifBadArg;

--- a/sw/device/lib/dif/dif_lc_ctrl.h
+++ b/sw/device/lib/dif/dif_lc_ctrl.h
@@ -300,24 +300,6 @@ typedef struct dif_lc_ctrl_device_id {
 } dif_lc_ctrl_device_id_t;
 
 /**
- * An alert that can be raised by the hardware.
- */
-typedef enum dif_lc_ctrl_alert {
-  /**
-   * The alert triggered by a `kDifLcCtrlStatusCodeOtpError`.
-   */
-  kDifLcCtrlAlertOtp,
-  /**
-   * The alert triggered by a `kDifLcCtrlStatusCodeCorrupt`.
-   */
-  kDifLcCtrlAlertCorrupt,
-  /**
-   * The alert triggered by a `kDifLcCtrlStatusCodeBusIntegError`.
-   */
-  kDifLcCtrlAlertBus,
-} dif_lc_ctrl_alert_t;
-
-/**
  * Returns the current state of the lifecycle controller.
  *
  * @param lc A lifecycle handle.
@@ -372,18 +354,6 @@ dif_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_lc_ctrl_get_device_id(const dif_lc_ctrl_t *lc,
                                        dif_lc_ctrl_device_id_t *device_id);
-
-/**
- * Forces a particular alert, causing it to be escalated as if the hardware had
- * raised it.
- *
- * @param lc A lifecycle handle.
- * @param alert The alert to force.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_lc_ctrl_alert_force(const dif_lc_ctrl_t *lc,
-                                     dif_lc_ctrl_alert_t alert);
 
 /**
  * Attempts to acquire the lifecycle controller's HW mutex.

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -150,19 +150,6 @@ TEST_F(StateTest, NullArgs) {
   EXPECT_EQ(dif_lc_ctrl_get_id_state(&lc_, nullptr), kDifBadArg);
 }
 
-class AlertTest : public LcCtrlTest {};
-
-TEST_F(AlertTest, Force) {
-  EXPECT_WRITE32(LC_CTRL_ALERT_TEST_REG_OFFSET,
-                 {{LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_BIT, true}});
-  EXPECT_EQ(dif_lc_ctrl_alert_force(&lc_, kDifLcCtrlAlertOtp), kDifOk);
-}
-
-TEST_F(AlertTest, NullArgs) {
-  EXPECT_EQ(dif_lc_ctrl_alert_force(nullptr, kDifLcCtrlAlertCorrupt),
-            kDifBadArg);
-}
-
 class MutexTest : public LcCtrlTest {};
 
 TEST_F(MutexTest, Acquire) {

--- a/sw/device/lib/dif/dif_pwrmgr.c
+++ b/sw/device/lib/dif/dif_pwrmgr.c
@@ -479,24 +479,3 @@ dif_result_t dif_pwrmgr_wakeup_reason_clear(const dif_pwrmgr_t *pwrmgr) {
 
   return kDifOk;
 }
-
-dif_result_t dif_pwrmgr_alert_force(const dif_pwrmgr_t *pwrmgr,
-                                    dif_pwrmgr_alert_t alert) {
-  if (pwrmgr == NULL) {
-    return kDifBadArg;
-  }
-
-  bitfield_bit32_index_t index;
-  switch (alert) {
-    case kDifPwrmgrAlertFatalFault:
-      index = PWRMGR_ALERT_TEST_FATAL_FAULT_BIT;
-      break;
-    default:
-      return kDifBadArg;
-  }
-
-  uint32_t reg = bitfield_bit32_write(0, index, true);
-  mmio_region_write32(pwrmgr->base_addr, PWRMGR_ALERT_TEST_REG_OFFSET, reg);
-
-  return kDifOk;
-}

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -173,17 +173,6 @@ typedef struct dif_pwrmgr_wakeup_reason {
 } dif_pwrmgr_wakeup_reason_t;
 
 /**
- * Power manager alerts.
- */
-typedef enum dif_pwrmgr_alert {
-  /**
-   * A fatal alert is triggered when a fatal TL-UL bus integrity fault is
-   * detected.
-   */
-  kDifPwrmgrAlertFatalFault = 0,
-} dif_pwrmgr_alert_t;
-
-/**
  * Enables or disables low power state.
  *
  * When enabled, the power manager transitions to low power state on the next
@@ -369,18 +358,6 @@ dif_result_t dif_pwrmgr_wakeup_reason_get(const dif_pwrmgr_t *pwrmgr,
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_wakeup_reason_clear(const dif_pwrmgr_t *pwrmgr);
-
-/**
- * Forces a particular alert, causing it to be serviced as if hardware had
- * asserted it.
- *
- * @param pwrmgr A power manager handle.
- * @param alert A power manager alert type.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_pwrmgr_alert_force(const dif_pwrmgr_t *pwrmgr,
-                                    dif_pwrmgr_alert_t alert);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_pwrmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_pwrmgr_unittest.cc
@@ -734,22 +734,5 @@ TEST_F(WakeupRecording, ClearReason) {
   EXPECT_EQ(dif_pwrmgr_wakeup_reason_clear(&pwrmgr_), kDifOk);
 }
 
-class AlertTest : public DifPwrmgrInitialized {};
-
-TEST_F(AlertTest, ForceBadArgs) {
-  EXPECT_EQ(dif_pwrmgr_alert_force(nullptr, kDifPwrmgrAlertFatalFault),
-            kDifBadArg);
-  EXPECT_EQ(
-      dif_pwrmgr_alert_force(&pwrmgr_, static_cast<dif_pwrmgr_alert_t>(1)),
-      kDifBadArg);
-}
-
-TEST_F(AlertTest, Force) {
-  EXPECT_WRITE32(PWRMGR_ALERT_TEST_REG_OFFSET, {{0, true}});
-
-  EXPECT_EQ(dif_pwrmgr_alert_force(&pwrmgr_, kDifPwrmgrAlertFatalFault),
-            kDifOk);
-}
-
 }  // namespace
 }  // namespace dif_pwrmgr_unittest

--- a/sw/device/lib/dif/dif_sram_ctrl.h
+++ b/sw/device/lib/dif/dif_sram_ctrl.h
@@ -220,15 +220,6 @@ dif_result_t dif_sram_ctrl_get_status(const dif_sram_ctrl_t *sram_ctrl,
                                       dif_sram_ctrl_status_bitfield_t *status);
 
 /**
- * Forces a fatal error.
- *
- * @param sram_ctrl A SRAM Controller handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_sram_ctrl_alert_test(const dif_sram_ctrl_t *sram_ctrl);
-
-/**
  * Locks out requested SRAM Controller functionality.
  *
  * This function is reentrant: calling it while functionality is locked will

--- a/util/make_new_dif/dif_autogen.c.tpl
+++ b/util/make_new_dif/dif_autogen.c.tpl
@@ -66,7 +66,33 @@ dif_result_t dif_${ip.name_snake}_init(
   return kDifOk;
 }
 
-% if len(ip.irqs) > 0:
+% if ip.alerts:
+  dif_result_t dif_${ip.name_snake}_alert_force(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_alert_t alert) {
+  if (${ip.name_snake} == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+  % for alert in ip.alerts:
+    case kDif${ip.name_camel}Alert${alert.name_camel}:
+      alert_idx = ${ip.name_upper}_ALERT_TEST_${alert.name_upper}_BIT;
+      break;
+  % endfor
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  ${mmio_region_write32(ip.name_upper + "_ALERT_TEST_REG_OFFSET", "alert_test_reg")}
+
+  return kDifOk;
+}
+% endif
+
+% if ip.irqs:
   % if ip.name_snake == "rv_timer":
     typedef enum dif_${ip.name_snake}_intr_reg {
       kDif${ip.name_camel}IntrRegState = 0,

--- a/util/make_new_dif/dif_autogen.h.tpl
+++ b/util/make_new_dif/dif_autogen.h.tpl
@@ -64,7 +64,34 @@ dif_result_t dif_${ip.name_snake}_init(
   mmio_region_t base_addr,
   dif_${ip.name_snake}_t *${ip.name_snake});
 
-% if len(ip.irqs) > 0:
+% if ip.alerts:
+  /**
+   * A ${ip.name_snake} alert type.
+   */
+  typedef enum dif_${ip.name_snake}_alert {
+  % for alert in ip.alerts:
+    /**
+     * ${alert.description}
+     */
+      kDif${ip.name_camel}Alert${alert.name_camel} = ${loop.index},
+  % endfor
+  } dif_${ip.name_snake}_alert_t;
+
+  /**
+   * Forces a particular alert, causing it to be escalated as if the hardware
+   * had raised it.
+   *
+   * @param ${ip.name_snake} A ${ip.name_snake} handle.
+   * @param alert The alert to force.
+   * @return The result of the operation.
+   */
+  OT_WARN_UNUSED_RESULT
+  dif_result_t dif_${ip.name_snake}_alert_force(
+    const dif_${ip.name_snake}_t *${ip.name_snake},
+    dif_${ip.name_snake}_alert_t alert);
+% endif
+
+% if ip.irqs:
   /**
    * A ${ip.name_snake} interrupt request type.
    */

--- a/util/make_new_dif/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/dif_autogen_unittest.cc.tpl
@@ -52,7 +52,46 @@ namespace {
       kDifOk);
   }
 
-% if len(ip.irqs) > 0:
+% if ip.alerts:
+  class AlertForceTest : public ${ip.name_camel}Test {};
+
+  TEST_F(AlertForceTest, NullArgs) {
+    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+        nullptr, 
+        kDif${ip.name_camel}Alert${ip.alerts[0].name_camel}),
+      kDifBadArg);
+  }
+
+  TEST_F(AlertForceTest, BadAlert) {
+    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+        nullptr, 
+        static_cast<dif_${ip.name_snake}_alert_t>(32)),
+      kDifBadArg);
+  }
+
+  TEST_F(AlertForceTest, Success) {
+    // Force first alert.
+    EXPECT_WRITE32(${ip.name_upper}_ALERT_TEST_REG_OFFSET,
+      {{${ip.name_upper}_ALERT_TEST_${ip.alerts[0].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Alert${ip.alerts[0].name_camel}),
+      kDifOk);
+
+  % if len(ip.alerts) > 1:
+    // Force last alert.
+    EXPECT_WRITE32(${ip.name_upper}_ALERT_TEST_REG_OFFSET,
+        {{${ip.name_upper}_ALERT_TEST_${ip.alerts[-1].name_upper}_BIT, true}});
+    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+        &${ip.name_snake}_,
+        kDif${ip.name_camel}Alert${ip.alerts[-1].name_camel}),
+      kDifOk);
+  % endif
+  }
+
+% endif
+
+% if ip.irqs:
   class IrqGetStateTest : public ${ip.name_camel}Test {};
 
   TEST_F(IrqGetStateTest, NullArgs) {


### PR DESCRIPTION
This completes all tasks and fixes #8879. Specifically this commit:
1. updates the DIF autogen *.c, *.h, and *_unittest.cc templates to add
    a `dif_<ip>_alert_force()` DIF and associated unit tests,
2. re-generates all auto-generated DIFs to include the new templated
    alert force DIF, and
3. deprecates existing (manually-implemented) alert force DIFs for the
     few IPs that implemented them.

Note, due to staleness checks in CI on auto-generated DIFs, these changes had to be combined into a single commit. While the commit appears to be quite large (especially the number of files changed), this is purely due to the fact that the autogen DIF templates changed, causing all the auto-gen'd DIFs to change too.

**_Note: this PR depends on #8880, and therefore contains a duplicate commit that will be removed when the dependency is merged. Please only review the last commit._**