### PR TITLE
[otbn, dv] Picks signed base addresses while executing JALR

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/jump.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/jump.py
@@ -223,6 +223,10 @@ class Jump(SnippetGen):
 
         base_reg_idx, base_reg_val = random.choice(known_regs)
 
+        # Convert base_reg_val to a signed integer
+        if base_reg_val >> 31:
+            base_reg_val -= 1 << 32
+
         jmp_data = self._pick_jump(base_reg_val, offset_optype,
                                    model, program, tgt_addr)
         if jmp_data is None:


### PR DESCRIPTION
An if block is added to check if the 32nd bit of base address is 1. If
it is set, it means the base address is a negative address and it is
converted into signed integer.

Fixes https://github.com/lowRISC/opentitan/issues/8081

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>