### PR TITLE
[sw] Clarify bounds for Barrett multiplication in ECDSA-P256

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/tests/ecdsa_p256_functest.c
+++ b/sw/device/silicon_creator/lib/crypto/tests/ecdsa_p256_functest.c
@@ -39,7 +39,6 @@ rom_error_t compute_digest(void) {
   RETURN_IF_ERROR(hmac_sha256_update(&kMessage, sizeof(kMessage) - 1));
   RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
 
-  // TODO: digest should be reduced modulo n
   for (i = 0; i < kP256ScalarNumWords; i++) {
     digest.h[i] = act_digest.digest[i];
   };


### PR DESCRIPTION
The Barrett implementation can accept one operand that is greater than the modulus, which allows us to not reduce the digest modulo `n` before calling `p256_sign`. (This bound for the modified Barrett reduction was formally verified for the original dcrypto implementation, with proofs [here](https://github.com/mit-plv/fiat-crypto/blob/fa0df95a7b88158232d3423a39779ad8e26586d5/src/Arithmetic/BarrettReduction/Generalized.v#L148).)

I also found and fixed two small typos in the comments tracking values through `p256_sign`.