### PR TITLE
[otbn,rig] Only generate init data for bottom 2KiB of DMEM

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/rig.py
+++ b/hw/ip/otbn/dv/rig/rig/rig.py
@@ -43,7 +43,11 @@ def gen_program(config: Config,
     # Generate some initialised data to start with. Otherwise, it takes a while
     # before we start issuing loads (because we need stores to happen first).
     # Tell the model that we've done so.
-    init_data = InitData.gen(dmem_size)
+    #
+    # Note that we only use the first half of DMEM for initialised data,
+    # because it needs to be loaded over the bus and only the first half is
+    # visible.
+    init_data = InitData.gen(dmem_size // 2)
     for addr in init_data.keys():
         model.touch_mem('dmem', addr, 4)
 


### PR DESCRIPTION
This data needs copying into memory over the bus and only the bottom
half of DMEM is going to be visible.
