### PR TITLE
[otbn,util] Halve the DMEM region in OTBN's linker script

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -13,11 +13,18 @@
 MEMORY
 {
     imem (x)  : ORIGIN = 0, LENGTH = ${imem_length}
-    dmem (rw) : ORIGIN = 0, LENGTH = ${dmem_length}
+    dmem (rw) : ORIGIN = 0, LENGTH = ${dmem_length // 2}
+    dmem_scratch (rw) : ORIGIN = ${dmem_length // 2}, LENGTH = ${dmem_length // 2}
 
-    /* LMA addresses (for VMAs in imem/dmem, respectively) */
-    imem_load (rw) : ORIGIN = ${imem_lma}, LENGTH = ${imem_length}
-    dmem_load (rw) : ORIGIN = ${dmem_lma}, LENGTH = ${dmem_length}
+    /*
+      LMA addresses (for VMAs in imem/dmem, respectively)
+
+      Note that the DMEM load region is half the size of DMEM itself,
+      to model the fact that OTBN can write to the whole region but
+      only the first ${dmem_length // 2} bytes are bus-accessible.
+    */
+    imem_load (rw)    : ORIGIN = ${imem_lma}, LENGTH = ${imem_length}
+    dmem_load (rw)    : ORIGIN = ${dmem_lma}, LENGTH = ${dmem_length // 2}
 }
 
 SECTIONS
@@ -52,4 +59,9 @@ SECTIONS
 
         _dmem_end = .;
     } >dmem AT>dmem_load
+
+    .scratchpad ORIGIN(dmem_scratch) (NOLOAD) : ALIGN(32)
+    {
+        *(.scratch*)
+    } >dmem
 }

--- a/sw/device/silicon_creator/otbn/rsa.s
+++ b/sw/device/silicon_creator/otbn/rsa.s
@@ -95,16 +95,8 @@ dptr_exp:
 dptr_out:
   .word work_buf
 
+/* (End of fixed-layout section) */
 
-/* Freely available DMEM space. */
-
-m0d:
-  /* filled by modload */
-  .zero 512
-
-RR:
-  /* filled by modload */
-  .zero 512
 
 /* Modulus (n) */
 .globl modulus
@@ -116,12 +108,21 @@ modulus:
 exp:
   .zero 512
 
-/* input data */
+/* input/output data */
 .globl inout
 inout:
   .zero 512
 
-/* output data */
-.globl work_buf
+
+.section .scratchpad
+m0d:
+  /* filled by modload */
+  .zero 512
+
+RR:
+  /* filled by modload */
+  .zero 512
+
+/* working data */
 work_buf:
   .zero 512

--- a/sw/device/silicon_creator/otbn/rsa.s
+++ b/sw/device/silicon_creator/otbn/rsa.s
@@ -20,15 +20,30 @@ start:
  * RSA encryption
  */
 rsa_encrypt:
+  jal      x1, zero_work_buf
   jal      x1, modload
   jal      x1, modexp_65537
+  jal      x1, cp_work_buf
   ecall
 
 
 /**
+ * Zero the contents of work_buf
+ *
+ * clobbered registers: x3, w0
+ */
+zero_work_buf:
+  la     x3, work_buf
+  bn.xor w0, w0, w0
+  /* The buffer is 512 bytes long, which needs sixteen 256b words. */
+  loopi 16, 1
+    bn.sid x0, 0(x3++)
+  ret
+
+/**
  * Copy the contents of work_buf onto inout
  *
- * clobbered registers: x3, x4
+ * clobbered registers: x3, x4, w0
  */
 cp_work_buf:
   la  x3, work_buf

--- a/sw/otbn/crypto/rsa.s
+++ b/sw/otbn/crypto/rsa.s
@@ -23,6 +23,7 @@ start:
  * RSA encryption
  */
 rsa_encrypt:
+  jal      x1, zero_work_buf
   jal      x1, modload
   jal      x1, modexp_65537
   jal      x1, cp_work_buf
@@ -32,15 +33,29 @@ rsa_encrypt:
  * RSA decryption
  */
 rsa_decrypt:
+  jal      x1, zero_work_buf
   jal      x1, modload
   jal      x1, modexp
   jal      x1, cp_work_buf
   ecall
 
 /**
+ * Zero the contents of work_buf
+ *
+ * clobbered registers: x3, w0
+ */
+zero_work_buf:
+  la     x3, work_buf
+  bn.xor w0, w0, w0
+  /* The buffer is 512 bytes long, which needs sixteen 256b words. */
+  loopi 16, 1
+    bn.sid x0, 0(x3++)
+  ret
+
+/**
  * Copy the contents of work_buf onto inout
  *
- * clobbered registers: x3, x4
+ * clobbered registers: x3, x4, w0
  */
 cp_work_buf:
   la  x3, work_buf

--- a/sw/otbn/crypto/rsa.s
+++ b/sw/otbn/crypto/rsa.s
@@ -107,16 +107,8 @@ dptr_exp:
 dptr_out:
   .word work_buf
 
+/* (End of fixed-layout section) */
 
-/* Freely available DMEM space. */
-
-m0d:
-  /* filled by modload */
-  .zero 512
-
-RR:
-  /* filled by modload */
-  .zero 512
 
 /* Modulus (n) */
 .globl modulus
@@ -133,7 +125,16 @@ exp:
 inout:
   .zero 512
 
+
+.section .scratchpad
+m0d:
+  /* filled by modload */
+  .zero 512
+
+RR:
+  /* filled by modload */
+  .zero 512
+
 /* working data */
-.globl work_buf
 work_buf:
   .zero 512

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -188,6 +188,7 @@ def main() -> int:
         args = (['-O', 'elf32-littleriscv',
                  '--prefix-sections=.rodata.otbn',
                  '--set-section-flags=*=alloc,load,readonly',
+                 '--remove-section=.scratchpad',
                  '--prefix-symbols', sym_pfx] +
                 [out_elf,
                  out_embedded_obj])


### PR DESCRIPTION
This is to match how only the bottom half of DMEM is bus-accessible.

