### PR TITLE
[prim] Add option to not clear the packer FIFO upon read

### DIFF
--- a/hw/ip/aes/rtl/aes_prng_clearing.sv
+++ b/hw/ip/aes/rtl/aes_prng_clearing.sv
@@ -100,8 +100,9 @@ module aes_prng_clearing import aes_pkg::*;
     assign reseed_ack_o  = SecSkipPRNGReseeding ? reseed_req_i : seed_valid;
 
     prim_packer_fifo #(
-      .InW  ( EntropyWidth ),
-      .OutW ( Width        )
+      .InW         ( EntropyWidth ),
+      .OutW        ( Width        ),
+      .ClearOnRead ( 1'b0         )
     ) u_prim_packer_fifo (
       .clk_i    ( clk_i         ),
       .rst_ni   ( rst_ni        ),

--- a/hw/ip/aes/rtl/aes_prng_masking.sv
+++ b/hw/ip/aes/rtl/aes_prng_masking.sv
@@ -128,8 +128,9 @@ module aes_prng_masking import aes_pkg::*;
     assign reseed_ack_o  = SecSkipPRNGReseeding ? reseed_req_i : seed_valid;
 
     prim_packer_fifo #(
-      .InW  ( EntropyWidth ),
-      .OutW ( Width        )
+      .InW         ( EntropyWidth ),
+      .OutW        ( Width        ),
+      .ClearOnRead ( 1'b0         )
     ) u_prim_packer_fifo (
       .clk_i    ( clk_i         ),
       .rst_ni   ( rst_ni        ),

--- a/hw/ip/prim/rtl/prim_edn_req.sv
+++ b/hw/ip/prim/rtl/prim_edn_req.sv
@@ -71,7 +71,8 @@ module prim_edn_req
 
   prim_packer_fifo #(
     .InW(edn_pkg::ENDPOINT_BUS_WIDTH),
-    .OutW(OutWidth)
+    .OutW(OutWidth),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
There are cases where leaving around the data just read doesn't hurt but instead outputting a deterministic value after read should be avoided. For example, if the packer FIFO is used to feed pseudo-random data into an LFSR, having the packer output such a deterministic value most of the time is bad as it may simplify an attack trying to load the LFSR with
deterministic instead of random values.

For this reason, this PR adds a new parameter to the packer FIFO primitive to control this behavior on a per-case basis and disables the clearing when used to feed LFSRs or inside prim_edn_req.