### PR TITLE
option to use partner ast_pkg

### DIFF
--- a/hw/ip/prim_generic/prim_generic_otp.core
+++ b/hw/ip/prim_generic/prim_generic_otp.core
@@ -11,7 +11,8 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
-      - lowrisc:systems:ast_pkg
+      - "fileset_partner  ? (partner:systems:ast_pkg)"
+      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
       - lowrisc:prim:otp_pkg
     files:
       - rtl/prim_generic_otp.sv


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>
This is an extension to PR #8182. Added for another file the option to support the partner ast_pkg instead of the OS ast_pkg.  