### PR TITLE
[dvsim] Modify temp_cfg_file to handle branch names with forward slash.

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -127,14 +127,16 @@ def resolve_branch(branch):
     argument is the branch name to use. Otherwise it is None and we use git to
     find the name of the current branch in the working directory.
 
+    Note, as this name will be used to generate output files any forward slashes
+    are replaced with single dashes to avoid being interpreted as directory hierarchy.
     '''
 
     if branch is not None:
-        return branch
+        return branch.replace("/", "-")
 
     result = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"],
                             stdout=subprocess.PIPE)
-    branch = result.stdout.decode("utf-8").strip()
+    branch = result.stdout.decode("utf-8").strip().replace("/", "-")
     if not branch:
         log.warning("Failed to find current git branch. "
                     "Setting it to \"default\"")


### PR DESCRIPTION
Branch names can include forward slashes (`/`).  Details of allowable
branch naming conventions can be found here:
* `man git check-ref-format`

This CL replaces `/` with `_FS_` when creating necessary temp file
names.

Signed-off-by: Todd Broch <tbroch@rivosinc.com>

TEST=manual,
```
ci/scripts/verible-lint.sh rtl
```
Passes even if branch name contains `/`