### PR TITLE
[otbn] Separate ELF-parsing code from simulator.

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/load_elf.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/load_elf.py
@@ -1,0 +1,87 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+'''OTBN ELF file handling'''
+
+import re
+from typing import Optional, Dict
+
+from shared.elf import read_elf
+
+from .decode import decode_bytes
+from .sim import LoopWarps, OTBNSim
+
+
+def _get_exp_end_addr(symbols: Dict[str, int]) -> Optional[int]:
+    '''Get the expected end address for a run of this binary
+
+    This is the value of the ELF symbol _expected_end_addr. If the symbol
+    doesn't exist, returns None.
+
+    '''
+    if '_expected_end_addr' in symbols:
+        return symbols['_expected_end_addr']
+    return None
+
+
+def _get_loop_warps(symbols: Dict[str, int]) -> LoopWarps:
+    '''Return a list of the requested loop warps
+
+    These are read in the format described in sim.py. A warp is specified as a
+    symbol of the form
+
+      _loop_warp_FROM_TO
+
+    pointing at the address where it should take effect. If a symbol specifies
+    TO < FROM, we raise a RuntimeError. If there are multiple symbols that
+    specify warps at a particular address/count pair, we raise a RuntimeError.
+
+    '''
+    pat = re.compile(r'_loop_warp_([0-9]+)_([0-9]+)')
+
+    ret = {}  # type: LoopWarps
+
+    for sym in symbols.keys():
+        match = pat.match(sym)
+        if match is None:
+            continue
+
+        count_from = int(match.group(1))
+        count_to = int(match.group(2))
+        addr = symbols[sym]
+        assert isinstance(addr, int)
+
+        if count_to < count_from:
+            raise RuntimeError('Loop warp instruction from symbol {!r}'
+                               'implies an infinite loop (because {} < {}).'
+                               .format(sym, count_to, count_from))
+
+        at_addr = ret.setdefault(addr, {})
+        if count_from in at_addr:
+            raise RuntimeError('Multiple symbols specify a loop warp at {:#x} '
+                               'with a starting count of {}.'
+                               .format(addr, count_from))
+
+        at_addr[count_from] = count_to
+
+    return ret
+
+
+def load_elf(sim: OTBNSim, path: str) -> Optional[int]:
+    '''Load ELF file at path and inject its contents into sim
+
+    Returns the expected end address, if set, otherwise None.
+
+    '''
+    (imem_bytes, dmem_bytes, symbols) = read_elf(path)
+
+    imem_insns = decode_bytes(0, imem_bytes)
+    loop_warps = _get_loop_warps(symbols)
+    exp_end = _get_exp_end_addr(symbols)
+
+    sim.load_program(imem_insns)
+    sim.loop_warps = loop_warps
+    sim.load_data(dmem_bytes)
+
+    return exp_end

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -6,7 +6,7 @@
 import argparse
 import sys
 
-from sim.elf import load_elf
+from sim.load_elf import load_elf
 from sim.standalonesim import StandaloneSim
 from sim.stats import ExecutionStatAnalyzer
 

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -52,7 +52,7 @@ import sys
 from typing import List, Optional
 
 from sim.decode import decode_file
-from sim.elf import load_elf
+from sim.load_elf import load_elf
 from sim.sim import OTBNSim
 
 

--- a/hw/ip/otbn/dv/otbnsim/test/testutil.py
+++ b/hw/ip/otbn/dv/otbnsim/test/testutil.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 import tempfile
 
-from sim.elf import load_elf
+from sim.load_elf import load_elf
 from sim.standalonesim import StandaloneSim
 
 

--- a/hw/ip/otbn/util/shared/elf.py
+++ b/hw/ip/otbn/util/shared/elf.py
@@ -4,15 +4,11 @@
 
 '''OTBN ELF file handling'''
 
-import re
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 
 from elftools.elf.elffile import ELFFile, SymbolTableSection  # type: ignore
 
-from shared.mem_layout import get_memory_layout
-
-from .decode import decode_bytes
-from .sim import LoopWarps, OTBNSim
+from .mem_layout import get_memory_layout
 
 _SegList = List[Tuple[int, bytes]]
 
@@ -132,70 +128,9 @@ def _get_symtab(elf_file: ELFFile) -> Optional[SymbolTableSection]:
     return section
 
 
-def _get_exp_end_addr(symtab: SymbolTableSection) -> Optional[int]:
-    '''Get the expected end address for a run of this binary
-
-    This is the value of the ELF symbol _expected_end_addr. If the symbol
-    doesn't exist, returns None.
-
-    '''
-    for sym in symtab.iter_symbols():
-        if sym.name == '_expected_end_addr':
-            assert isinstance(sym['st_value'], int)
-            return sym['st_value']
-
-    return None
-
-
-def _get_loop_warps(symtab: SymbolTableSection) -> LoopWarps:
-    '''Return a list of the requested loop warps
-
-    These are read in the format described in sim.py. A warp is specified as a
-    symbol of the form
-
-      _loop_warp_FROM_TO
-
-    pointing at the address where it should take effect. If a symbol specifies
-    TO < FROM, we raise a RuntimeError. If there are multiple symbols that
-    specify warps at a particular address/count pair, we raise a RuntimeError.
-
-    '''
-    pat = re.compile(r'_loop_warp_([0-9]+)_([0-9]+)')
-
-    ret = {}  # type: LoopWarps
-
-    for sym in symtab.iter_symbols():
-        match = pat.match(sym.name)
-        if match is None:
-            continue
-
-        count_from = int(match.group(1))
-        count_to = int(match.group(2))
-        addr = sym['st_value']
-        assert isinstance(addr, int)
-
-        if count_to < count_from:
-            raise RuntimeError('Loop warp instruction from symbol {!r}'
-                               'implies an infinite loop (because {} < {}).'
-                               .format(sym.name, count_to, count_from))
-
-        at_addr = ret.setdefault(addr, {})
-        if count_from in at_addr:
-            raise RuntimeError('Multiple symbols specify a loop warp at {:#x} '
-                               'with a starting count of {}.'
-                               .format(addr, count_from))
-
-        at_addr[count_from] = count_to
-
-    return ret
-
-
-def _read_elf(path: str,
-              imem_desc: _MemDesc,
-              dmem_desc: _MemDesc) -> Tuple[bytes,
-                                            bytes,
-                                            Optional[int],
-                                            LoopWarps]:
+def read_elf(path: str) -> Tuple[bytes,
+                                 bytes,
+                                 Dict[str, int]]:
     '''Load the ELF file at path.
 
     Returns a tuple (imem_bytes, dmem_bytes, exp_end_addr, loop_warps). The
@@ -204,17 +139,20 @@ def _read_elf(path: str,
     _get_loop_warps.
 
     '''
+    mems = get_memory_layout()
+    imem_desc = mems['IMEM']
+    dmem_desc = mems['DMEM']
+
     with open(path, 'rb') as handle:
         elf_file = ELFFile(handle)
         imem_bytes, dmem_bytes = _get_elf_mem_data(elf_file,
                                                    imem_desc, dmem_desc)
         symtab = _get_symtab(elf_file)
-        if symtab is None:
-            exp_end_addr = None
-            loop_warps = {}  # type: LoopWarps
-        else:
-            exp_end_addr = _get_exp_end_addr(symtab)
-            loop_warps = _get_loop_warps(symtab)
+        symbols = {}
+        if symtab is not None:
+            for sym in symtab.iter_symbols():
+                assert isinstance(sym['st_value'], int)
+                symbols[sym.name] = sym['st_value']
 
     assert len(imem_bytes) <= imem_desc[1]
     if len(imem_bytes) & 3:
@@ -222,26 +160,4 @@ def _read_elf(path: str,
                            'not a multiple of 4.'
                            .format(path, len(imem_bytes)))
 
-    return (imem_bytes, dmem_bytes, exp_end_addr, loop_warps)
-
-
-def load_elf(sim: OTBNSim, path: str) -> Optional[int]:
-    '''Load ELF file at path and inject its contents into sim
-
-    Returns the expected end address, if set, otherwise None.
-
-    '''
-    mems = get_memory_layout()
-    imem_desc = mems['IMEM']
-    dmem_desc = mems['DMEM']
-
-    (imem_bytes, dmem_bytes,
-     exp_end, loop_warps) = _read_elf(path, imem_desc, dmem_desc)
-
-    imem_insns = decode_bytes(0, imem_bytes)
-
-    sim.load_program(imem_insns)
-    sim.loop_warps = loop_warps
-    sim.load_data(dmem_bytes)
-
-    return exp_end
+    return (imem_bytes, dmem_bytes, symbols)


### PR DESCRIPTION
Move the OTBN simulator's ELF-parsing code into `otbn/util/shared` so it can be used by other tools. The motivation for this is that we'd like to create some static checks for OTBN based on the binaries; this PR just lays the groundwork to make it possible.