### PR TITLE
[spi_device] Default reset value for TPM_CAP

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -730,12 +730,14 @@
         { bits: "7:0"
           name: "rev"
           desc: "Revision of the TPM submodule"
+          resval: "0"
         } // f: rev
         { bits: "8"
           name: "locality"
           desc: '''If 1, the TPM submodule supports 5 Locality.
             If 0, only one Locality is provided
             '''
+          resval: "1"
         } // f: locality
         { bits: "18:16"
           name: "max_xfer_size"
@@ -753,6 +755,7 @@
             If the SW reports the transfer size more than the value described in this field,
             the SW must read the data from the write FIFO before the FIFO becomes full in order not to make FIFO overflow.
             '''
+          resval: "2"
         } // f: max_xfer_size
       ]
       tags: [

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -224,6 +224,7 @@ package spi_device_pkg;
     DualIO   = 2'h 1,
     QuadIO   = 2'h 2
   } io_mode_e;
+
   typedef enum int unsigned {
     IoModeFw       = 0,
     IoModeCmdParse = 1,

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -16056,7 +16056,7 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
+    .RESVAL  (1'h1)
   ) u_tpm_cap_locality (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -16081,7 +16081,7 @@ module spi_device_reg_top (
   prim_subreg #(
     .DW      (3),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (3'h0)
+    .RESVAL  (3'h2)
   ) u_tpm_cap_max_xfer_size (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),


### PR DESCRIPTION
SPI_DEVICE TPM_CAP is read-only register to SW. The value is assigned
from parameter values. The reset value now represents the correct
parameter values.

This PR addresses the issue #8877 