### PR TITLE
[clkmgr, pwrmgr] Add clock handshaking for usb

### DIFF
--- a/hw/ip/clkmgr/clkmgr_components.core
+++ b/hw/ip/clkmgr/clkmgr_components.core
@@ -14,6 +14,8 @@ filesets:
       - lowrisc:prim:measure
     files:
       - rtl/clkmgr_byp.sv
+      - rtl/clkmgr_clk_status.sv
+      - rtl/clkmgr_root_ctrl.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -86,8 +86,16 @@ interface clkmgr_if (
     idle_i = value;
   endfunction
 
-  function automatic void update_ip_clk_en(bit value);
-    pwr_i.ip_clk_en = value;
+  function automatic void update_io_ip_clk_en(bit value);
+    pwr_i.io_ip_clk_en = value;
+  endfunction
+
+  function automatic void update_main_ip_clk_en(bit value);
+    pwr_i.main_ip_clk_en = value;
+  endfunction
+
+  function automatic void update_usb_ip_clk_en(bit value);
+    pwr_i.usb_ip_clk_en = value;
   endfunction
 
   function automatic void update_scanmode(lc_ctrl_pkg::lc_tx_t value);
@@ -106,8 +114,9 @@ interface clkmgr_if (
     ast_clk_byp_ack = value;
   endfunction
 
+  // TODO:: this fix is not right since there are now 3 status
   function automatic logic get_clk_status();
-    return pwr_o.clk_status;
+    return pwr_o.main_status;
   endfunction
 
   function automatic void update_jitter_enable(bit value);
@@ -153,7 +162,7 @@ interface clkmgr_if (
       clk_hint_otbn_div4_ffs <= {
         clk_hint_otbn_div4_ffs[PIPELINE_DEPTH-2:0], clk_hints_csr[TransOtbnIoDiv4]
       };
-      ip_clk_en_div4_ffs <= {ip_clk_en_div4_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
+      ip_clk_en_div4_ffs <= {ip_clk_en_div4_ffs[PIPELINE_DEPTH-2:0], pwr_i.io_ip_clk_en};
     end else begin
       clk_enable_div4_ffs <= '0;
       clk_hint_otbn_div4_ffs <= '0;
@@ -174,7 +183,7 @@ interface clkmgr_if (
       clk_enable_div2_ffs <= {
         clk_enable_div2_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.io_div2_peri_en
       };
-      ip_clk_en_div2_ffs <= {ip_clk_en_div2_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
+      ip_clk_en_div2_ffs <= {ip_clk_en_div2_ffs[PIPELINE_DEPTH-2:0], pwr_i.io_ip_clk_en};
     end else begin
       clk_enable_div2_ffs <= '0;
       ip_clk_en_div2_ffs  <= '0;
@@ -190,7 +199,7 @@ interface clkmgr_if (
   always @(posedge clocks_o.clk_io_powerup or negedge rst_io_n) begin
     if (rst_io_n) begin
       clk_enable_io_ffs <= {clk_enable_io_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.io_peri_en};
-      ip_clk_en_io_ffs  <= {ip_clk_en_io_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
+      ip_clk_en_io_ffs  <= {ip_clk_en_io_ffs[PIPELINE_DEPTH-2:0], pwr_i.io_ip_clk_en};
     end else begin
       clk_enable_io_ffs <= '0;
       ip_clk_en_io_ffs  <= '0;
@@ -206,7 +215,7 @@ interface clkmgr_if (
   always @(posedge clocks_o.clk_usb_powerup or negedge rst_usb_n) begin
     if (rst_usb_n) begin
       clk_enable_usb_ffs <= {clk_enable_usb_ffs[PIPELINE_DEPTH-2:0], clk_enables_csr.usb_peri_en};
-      ip_clk_en_usb_ffs  <= {ip_clk_en_usb_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
+      ip_clk_en_usb_ffs  <= {ip_clk_en_usb_ffs[PIPELINE_DEPTH-2:0], pwr_i.usb_ip_clk_en};
     end else begin
       clk_enable_usb_ffs <= '0;
       ip_clk_en_usb_ffs  <= '0;
@@ -223,7 +232,7 @@ interface clkmgr_if (
   always @(posedge clocks_o.clk_main_powerup or negedge rst_main_n) begin
     if (rst_main_n) begin
       clk_hints_ffs <= {clk_hints_ffs[PIPELINE_DEPTH-2:0], clk_hints_csr};
-      trans_clk_en_ffs <= {trans_clk_en_ffs[PIPELINE_DEPTH-2:0], pwr_i.ip_clk_en};
+      trans_clk_en_ffs <= {trans_clk_en_ffs[PIPELINE_DEPTH-2:0], pwr_i.main_ip_clk_en};
     end else begin
       clk_hints_ffs <= '0;
       trans_clk_en_ffs <= '0;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
@@ -41,7 +41,9 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
   }
 
   // The extclk cannot be manipulated in low power mode.
-  constraint ip_clk_en_on_c {ip_clk_en == 1'b1;}
+  constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
+  constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
+  constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
 
   // This randomizes the time when the extclk_ctrl CSR write and the lc_clk_byp_req
   // input is asserted for good measure. Of course, there is a good chance only a single

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -14,7 +14,9 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
   rand logic [NUM_PERI-1:0] initial_enables;
 
   // The clk_enables CSR cannot be manipulated in low power mode.
-  constraint ip_clk_en_on_c {ip_clk_en == 1'b1;}
+  constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
+  constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
+  constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
 
   task body();
     update_csrs_with_reset_values();

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -8,7 +8,9 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-  constraint enable_ip_clk_en {ip_clk_en == 1'b1;}
+  constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
+  constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
+  constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
   constraint all_busy {idle == '0;}
 
   task body();

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -20,7 +20,9 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
   rand bit [NUM_TRANS-1:0] initial_hints;
 
   // The clk_hints CSR cannot be manipulated in low power mode.
-  constraint ip_clk_en_on_c {ip_clk_en == 1'b1;}
+  constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
+  constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
+  constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
 
   task body();
     update_csrs_with_reset_values();

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -11,13 +11,20 @@ module clkmgr_bind;
   bind clkmgr clkmgr_csr_assert_fpv clkmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
 
   bind clkmgr clkmgr_pwrmgr_sva_if clkmgr_pwrmgr_sva_if (
-    .clk_i, .rst_ni, .ip_clk_en(pwr_i.ip_clk_en), .clk_status(pwr_o.clk_status), .idle(idle_i)
+    .clk_i,
+    .rst_ni,
+    .io_clk_en(pwr_i.io_ip_clk_en),
+    .io_status(pwr_o.io_status),
+    .main_clk_en(pwr_i.main_ip_clk_en),
+    .main_status(pwr_o.main_status),
+    .usb_clk_en(pwr_i.usb_ip_clk_en),
+    .usb_status(pwr_o.usb_status)
   );
 
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_io_div4_peri_sva_if (
     .clk(clocks_o.clk_io_div4_powerup),
     .rst_n(rst_io_div4_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_io_div4_peri_en.q),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_io_div4_peri)
@@ -26,7 +33,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_io_div2_peri_sva_if (
     .clk(clocks_o.clk_io_div2_powerup),
     .rst_n(rst_io_div2_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_io_div2_peri_en.q),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_io_div2_peri)
@@ -35,7 +42,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_io_peri_sva_if (
     .clk(clocks_o.clk_io_powerup),
     .rst_n(rst_io_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_io_peri_en.q),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_io_peri)
@@ -44,7 +51,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_usb_peri_sva_if (
     .clk(clocks_o.clk_usb_powerup),
     .rst_n(rst_usb_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.usb_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_usb_peri_en.q),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_usb_peri)
@@ -53,7 +60,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_aes_hintable_sva_if (
     .clk(clocks_o.clk_main_powerup),
     .rst_n(rst_main_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_aes_hint.q || !idle_i[0]),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_main_aes)
@@ -62,7 +69,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_hmac_hintable_sva_if (
     .clk(clocks_o.clk_main_powerup),
     .rst_n(rst_main_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_hmac_hint.q || !idle_i[1]),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_main_hmac)
@@ -71,7 +78,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_kmac_hintable_sva_if (
     .clk(clocks_o.clk_main_powerup),
     .rst_n(rst_main_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_kmac_hint.q || !idle_i[2]),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_main_kmac)
@@ -80,7 +87,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_io_div4_otbn_hintable_sva_if (
     .clk(clocks_o.clk_io_div4_powerup),
     .rst_n(rst_io_div4_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_io_div4_otbn_hint.q || !idle_i[3]),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_io_div4_otbn)
@@ -89,7 +96,7 @@ module clkmgr_bind;
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_otbn_hintable_sva_if (
     .clk(clocks_o.clk_main_powerup),
     .rst_n(rst_main_ni),
-    .ip_clk_en(pwr_i.ip_clk_en),
+    .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_otbn_hint.q || !idle_i[4]),
     .scanmode(scanmode_i == lc_ctrl_pkg::On),
     .gated_clk(clocks_o.clk_main_otbn)

--- a/hw/ip/clkmgr/dv/sva/clkmgr_div_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_div_sva_if.sv
@@ -44,9 +44,9 @@ interface clkmgr_div_sva_if #(
     // tracking.
     `ASSERT(Div2Stepped_A, $rose(step_down) ##1 step_down [* WAIT_CYCLES] |-> TracksClk_S, !clk,
             !rst_n)
-  `ASSERT(Div2Whole_A,
-          $fell(step_down) ##1 !step_down [* WAIT_CYCLES] |-> WholeLeadLow_S or WholeLeadHigh_S,
-          !clk, !rst_n)
+    `ASSERT(Div2Whole_A,
+            $fell(step_down) ##1 !step_down [* WAIT_CYCLES] |-> WholeLeadLow_S or WholeLeadHigh_S,
+            !clk, !rst_n)
 
   end else begin : g_div4
 
@@ -61,9 +61,9 @@ interface clkmgr_div_sva_if #(
     `ASSERT(Div4Stepped_A,
             $rose(step_down) ##1 step_down [* WAIT_CYCLES] |-> StepLeadLow_S or StepLeadHigh_S,
             !clk, !rst_n)
-  `ASSERT(Div4Whole_A,
-          $fell(step_down) ##1 !step_down [* WAIT_CYCLES] |-> WholeLeadLow_S or WholeLeadHigh_S,
-          !clk, !rst_n)
+    `ASSERT(Div4Whole_A,
+            $fell(step_down) ##1 !step_down [* WAIT_CYCLES] |-> WholeLeadLow_S or WholeLeadHigh_S,
+            !clk, !rst_n)
 
   end
 endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_pwrmgr_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_pwrmgr_sva_if.sv
@@ -2,18 +2,21 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This contains SVA assertions to check that rising or falling edges of ip_clk_en
-// are followed by corresponding edges of clk_status.
+// This contains SVA assertions to check that rising or falling edges of the various ip_clk_en
+// are followed by corresponding edges of their clk_status.
 interface clkmgr_pwrmgr_sva_if (
   input logic clk_i,
   input logic rst_ni,
-  input logic ip_clk_en,
-  input logic clk_status,
-  input logic [4:0] idle
+  input logic io_clk_en,
+  input logic io_status,
+  input logic main_clk_en,
+  input logic main_status,
+  input logic usb_clk_en,
+  input logic usb_status
 );
 
   // The max times are longer to cover the different clock domain synchronizers.
-  // Ideally they would use the io_div4 clock, but it gets turned off when ip_clk_en
+  // Ideally they would use the io_div4 clock, but it gets turned off when io_ip_clk_en
   // goes inactive.
   localparam int FallCyclesMin = 0;
   localparam int FallCyclesMax = 16;
@@ -23,12 +26,20 @@ interface clkmgr_pwrmgr_sva_if (
 
   bit disable_sva;
 
-  // clk_status should fall if all units are idle when enable falls.
-  `ASSERT(StatusFall_A, $fell(ip_clk_en) |-> ##[FallCyclesMin:FallCyclesMax] $fell(clk_status),
+  `ASSERT(IoStatusFall_A, $fell(io_clk_en) |-> ##[FallCyclesMin:FallCyclesMax] $fell(io_status),
+          clk_i, !rst_ni || disable_sva)
+  `ASSERT(IoStatusRise_A, $rose(io_clk_en) |-> ##[RiseCyclesMin:RiseCyclesMax] $rose(io_status),
           clk_i, !rst_ni || disable_sva)
 
-  // clk_status whould rise is ip_clk_en rises.
-  `ASSERT(StatusRiseForEnable_A,
-          $rose(ip_clk_en) |-> ##[RiseCyclesMin:RiseCyclesMax] $rose(clk_status), clk_i,
+  `ASSERT(MainStatusFall_A,
+          $fell(main_clk_en) |-> ##[FallCyclesMin:FallCyclesMax] $fell(main_status), clk_i,
           !rst_ni || disable_sva)
+  `ASSERT(MainStatusRise_A,
+          $rose(main_clk_en) |-> ##[RiseCyclesMin:RiseCyclesMax] $rose(main_status), clk_i,
+          !rst_ni || disable_sva)
+
+  `ASSERT(UsbStatusFall_A, $fell(usb_clk_en) |-> ##[FallCyclesMin:FallCyclesMax] $fell(usb_status),
+          clk_i, !rst_ni || disable_sva)
+  `ASSERT(UsbStatusRise_A, $rose(usb_clk_en) |-> ##[RiseCyclesMin:RiseCyclesMax] $rose(usb_status),
+          clk_i, !rst_ni || disable_sva)
 endinterface

--- a/hw/ip/clkmgr/rtl/clkmgr_clk_status.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_clk_status.sv
@@ -1,0 +1,58 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Wrapper module for computing enable / disable status on family of clocks
+
+module clkmgr_clk_status #(
+  parameter int NumClocks = 1,
+  parameter int FilterStages = 2
+) (
+  input clk_i,
+  input rst_ni,
+  input [NumClocks-1:0] ens_i,
+  output logic status_o
+);
+
+  // The enables are coming from different clock domains,
+  // therefore after synchronization we must de-bounce the
+  // signal to ensure it is stable
+  logic [NumClocks-1:0] ens_sync;
+  prim_flop_2sync #(
+    .Width(NumClocks)
+  ) u_en_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(ens_i),
+    .q_o(ens_sync)
+  );
+
+  logic [FilterStages-1:0] en_q, dis_q, en_d, dis_d;
+
+  // enable is true when all inputs are 1
+  assign en_d = {en_q[FilterStages-2:0], &ens_sync};
+
+  // disable is true all all inputs are 0
+  assign dis_d = {dis_q[FilterStages-2:0], ~|ens_sync};
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      en_q <= '0;
+      dis_q <= '0;
+    end else begin
+      en_q <= en_d;
+      dis_q <= dis_d;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      status_o <= '0;
+    end else if (&en_q) begin
+      status_o <= 1'b1;
+    end else if (&dis_q) begin
+      status_o <= 1'b0;
+    end
+  end
+
+endmodule // clkmgr_clk_status

--- a/hw/ip/clkmgr/rtl/clkmgr_root_ctrl.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_root_ctrl.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Wrapper for scan sync and clock gating cell
+
+module clkmgr_root_ctrl
+  import clkmgr_pkg::*;
+  import lc_ctrl_pkg::lc_tx_t;
+(
+  input clk_i,
+  input rst_ni,
+
+  input lc_tx_t scanmode_i,
+  input async_en_i,
+
+  output logic en_o,
+  output logic clk_o
+);
+
+  lc_tx_t scanmode;
+  prim_lc_sync #(
+    .NumCopies(1),
+    .AsyncOn(0)
+  ) u_scanmode_sync  (
+    .clk_i(1'b0),  //unused
+    .rst_ni(1'b1), //unused
+    .lc_en_i(scanmode_i),
+    .lc_en_o(scanmode)
+  );
+
+  prim_clock_gating_sync u_cg (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .test_en_i(scanmode == lc_ctrl_pkg::On),
+    .async_en_i,
+    .en_o,
+    .clk_o
+  );
+
+endmodule // clkmgr_root_ctrl

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -71,7 +71,7 @@ interface pwrmgr_if (
 
   // Fast fsm state.
   pwrmgr_pkg::fast_pwr_state_e fast_state;
-  always_comb fast_state = `PATH_TO_DUT.i_fsm.state_q;
+  always_comb fast_state = `PATH_TO_DUT.u_fsm.state_q;
 
   // Wakeup_status ro CSR.
   logic [pwrmgr_reg_pkg::NumWkups-1:0] wake_status;
@@ -148,7 +148,7 @@ interface pwrmgr_if (
     // From AST.
     pwr_ast_rsp = '{default: '0};
     pwr_rst_rsp = '{default: '0};
-    pwr_clk_rsp.clk_status = 1'b0;
+    pwr_clk_rsp = '{default: '0};
     pwr_otp_rsp = '{default: '0};
     pwr_lc_rsp = '{default: '0};
     pwr_flash = '{default: '0};

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -26,7 +26,9 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   rand int cycles_before_pwrok;
   rand int cycles_before_clks_ok;
   rand int cycles_between_clks_ok;
-  rand int cycles_before_clk_status;
+  rand int cycles_before_io_status;
+  rand int cycles_before_main_status;
+  rand int cycles_before_usb_status;
   rand int cycles_before_rst_lc_src;
   rand int cycles_before_rst_sys_src;
   rand int cycles_before_otp_done;
@@ -45,7 +47,9 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   constraint cycles_before_pwrok_c {cycles_before_pwrok inside {[3 : 10]};}
   constraint cycles_before_clks_ok_c {cycles_before_clks_ok inside {[3 : 10]};}
   constraint cycles_between_clks_ok_c {cycles_between_clks_ok inside {[3 : 10]};}
-  constraint cycles_before_clk_status_c {cycles_before_clk_status inside {[0 : 4]};}
+  constraint cycles_before_io_status_c {cycles_before_io_status inside {[0 : 4]};}
+  constraint cycles_before_main_status_c {cycles_before_main_status inside {[0 : 4]};}
+  constraint cycles_before_usb_status_c {cycles_before_usb_status inside {[0 : 4]};}
   constraint cycles_before_rst_lc_src_base_c {cycles_before_rst_lc_src inside {[0 : 4]};}
   constraint cycles_before_rst_sys_src_base_c {cycles_before_rst_sys_src inside {[0 : 4]};}
   constraint cycles_before_otp_done_base_c {cycles_before_otp_done inside {[0 : 4]};}
@@ -180,7 +184,8 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Generates expected responses for the fast fsm.
   // - Completes the reset handshake with the rstmgr for lc and sys resets: soon after a
   //   reset is requested the corresponding active low reset src must go low.
-  // - Completes the handshake with the clkmgr: clk_status needs to track ip_clk_en.
+  // - Completes the handshake with the clkmgr for io, main, and usb clocks:
+  //   each status input needs to track the corresponding ip_clk_en output.
   // - Completes handshake with lc and otp: *_done needs to track *_init.
   // Macros for the same reason as the slow responder.
 
@@ -219,11 +224,27 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
           drop_objection();
         end
       forever
-        @cfg.pwrmgr_vif.fast_cb.pwr_clk_req.ip_clk_en begin
+        @cfg.pwrmgr_vif.fast_cb.pwr_clk_req.io_ip_clk_en begin
           raise_objection();
-          `FAST_RESPONSE_ACTION("clk_status", cfg.pwrmgr_vif.fast_cb.pwr_clk_rsp.clk_status,
-                                cfg.pwrmgr_vif.fast_cb.pwr_clk_req.ip_clk_en,
-                                cycles_before_clk_status)
+          `FAST_RESPONSE_ACTION("io_status", cfg.pwrmgr_vif.fast_cb.pwr_clk_rsp.io_status,
+                                cfg.pwrmgr_vif.fast_cb.pwr_clk_req.io_ip_clk_en,
+                                cycles_before_io_status)
+          drop_objection();
+        end
+      forever
+        @cfg.pwrmgr_vif.fast_cb.pwr_clk_req.main_ip_clk_en begin
+          raise_objection();
+          `FAST_RESPONSE_ACTION("main_status", cfg.pwrmgr_vif.fast_cb.pwr_clk_rsp.main_status,
+                                cfg.pwrmgr_vif.fast_cb.pwr_clk_req.main_ip_clk_en,
+                                cycles_before_main_status)
+          drop_objection();
+        end
+      forever
+        @cfg.pwrmgr_vif.fast_cb.pwr_clk_req.usb_ip_clk_en begin
+          raise_objection();
+          `FAST_RESPONSE_ACTION("usb_status", cfg.pwrmgr_vif.fast_cb.pwr_clk_rsp.usb_status,
+                                cfg.pwrmgr_vif.fast_cb.pwr_clk_req.usb_ip_clk_en,
+                                cycles_before_usb_status)
           drop_objection();
         end
       forever

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -68,7 +68,7 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(enabled_wakeups),
                    .err_msg("failed wake_status check"));
       `uvm_info(`gfn, $sformatf("Got wake_status=0x%x", enabled_wakeups), UVM_MEDIUM)
-      wait(cfg.pwrmgr_vif.pwr_clk_req.ip_clk_en == 1'b1);
+      wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
       cfg.pwrmgr_vif.update_wakeups('0);
 
       wait_for_fast_fsm_active();

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
@@ -35,7 +35,7 @@ interface pwrmgr_clock_enables_sva_if (
     logic prev_en;
     (1'b1,
     prev_en = usb_clk_en_active_i
-    ) ##1 usb_clk_en == prev_en;
+    ) ##[1:4] usb_clk_en == prev_en;
   endsequence
 
   `ASSERT(CoreClkPwrUp_A, transitionUp_S |=> core_clk_en == 1'b1, clk_i, reset_or_disable)

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -138,6 +138,8 @@ module pwrmgr
   logic fsm_invalid;
   logic clr_slow_req;
   logic clr_slow_ack;
+  logic usb_ip_clk_en;
+  logic usb_ip_clk_status;
   pwrup_cause_e pwrup_cause;
 
   logic low_power_fall_through;
@@ -175,6 +177,8 @@ module pwrmgr
   logic slow_usb_clk_en_lp;
   logic slow_usb_clk_en_active;
   logic slow_clr_req;
+  logic slow_usb_ip_clk_en;
+  logic slow_usb_ip_clk_status;
 
 
 
@@ -270,6 +274,8 @@ module pwrmgr
     .slow_peri_reqs_o(slow_peri_reqs),
     .slow_peri_reqs_masked_i(slow_peri_reqs_masked),
     .slow_clr_req_o(slow_clr_req),
+    .slow_usb_ip_clk_en_i(slow_usb_ip_clk_en),
+    .slow_usb_ip_clk_status_o(slow_usb_ip_clk_status),
 
     // fast domain signals
     .req_pwrdn_i(req_pwrdn),
@@ -290,6 +296,8 @@ module pwrmgr
     .peri_reqs_o(peri_reqs_masked),
     .clr_slow_req_i(clr_slow_req),
     .clr_slow_ack_o(clr_slow_ack),
+    .usb_ip_clk_en_o(usb_ip_clk_en),
+    .usb_ip_clk_status_i(usb_ip_clk_status),
 
     // AST signals
     .ast_i(pwr_ast_i),
@@ -380,6 +388,8 @@ module pwrmgr
     .rst_req_o            (slow_rst_req),
     .fsm_invalid_o        (slow_fsm_invalid),
     .clr_req_i            (slow_clr_req),
+    .usb_ip_clk_en_o      (slow_usb_ip_clk_en),
+    .usb_ip_clk_status_i  (slow_usb_ip_clk_status),
 
     .main_pd_ni           (slow_main_pd_n),
     .io_clk_en_i          (slow_io_clk_en),
@@ -399,23 +409,25 @@ module pwrmgr
 
   assign low_power_hint = reg2hw.control.low_power_hint.q == LowPower;
 
-  pwrmgr_fsm i_fsm (
+  pwrmgr_fsm u_fsm (
     .clk_i,
     .rst_ni,
     .clk_slow_i,
     .rst_slow_ni,
 
     // interface with slow_fsm
-    .req_pwrup_i       (req_pwrup),
-    .pwrup_cause_i     (pwrup_cause), // por, wake or reset request
-    .ack_pwrup_o       (ack_pwrup),
-    .req_pwrdn_o       (req_pwrdn),
-    .ack_pwrdn_i       (ack_pwrdn),
-    .low_power_entry_i (pwr_cpu_i.core_sleeping & low_power_hint),
-    .reset_reqs_i      (peri_reqs_masked.rstreqs),
-    .fsm_invalid_i     (fsm_invalid),
-    .clr_slow_req_o    (clr_slow_req),
-    .clr_slow_ack_i    (clr_slow_ack),
+    .req_pwrup_i         (req_pwrup),
+    .pwrup_cause_i       (pwrup_cause), // por, wake or reset request
+    .ack_pwrup_o         (ack_pwrup),
+    .req_pwrdn_o         (req_pwrdn),
+    .ack_pwrdn_i         (ack_pwrdn),
+    .low_power_entry_i   (pwr_cpu_i.core_sleeping & low_power_hint),
+    .reset_reqs_i        (peri_reqs_masked.rstreqs),
+    .fsm_invalid_i       (fsm_invalid),
+    .clr_slow_req_o      (clr_slow_req),
+    .clr_slow_ack_i      (clr_slow_ack),
+    .usb_ip_clk_en_i     (usb_ip_clk_en),
+    .usb_ip_clk_status_o (usb_ip_clk_status),
 
     // cfg
     .main_pd_ni        (reg2hw.control.main_pd_n.q),
@@ -432,8 +444,8 @@ module pwrmgr
     .pwr_rst_i         (pwr_rst_i),
 
     // clkmgr
-    .ips_clk_en_o      (pwr_clk_o.ip_clk_en),
-    .clk_en_status_i   (pwr_clk_i.clk_status),
+    .ips_clk_en_o      (pwr_clk_o),
+    .clk_en_status_i   (pwr_clk_i),
 
     // otp
     .otp_init_o        (pwr_otp_o.otp_init),

--- a/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_cdc.sv
@@ -34,6 +34,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   output pwr_peri_t slow_peri_reqs_o,
   input pwr_peri_t slow_peri_reqs_masked_i,
   output logic slow_clr_req_o,
+  input slow_usb_ip_clk_en_i,
+  output slow_usb_ip_clk_status_o,
 
   // fast domain signals
   input req_pwrdn_i,
@@ -54,6 +56,8 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
   output logic cdc_sync_done_o,
   input clr_slow_req_i,
   output logic clr_slow_ack_o,
+  output logic usb_ip_clk_en_o,
+  input usb_ip_clk_status_i,
 
   // peripheral inputs, mixed domains
   input pwr_peri_t peri_i,
@@ -117,6 +121,15 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .rst_ni (rst_slow_ni),
     .d_i    (peri_i),
     .q_o    (slow_peri_reqs_o)
+  );
+
+  prim_flop_2sync # (
+    .Width(1)
+  ) u_ip_clk_status_sync (
+    .clk_i  (clk_slow_i),
+    .rst_ni (rst_slow_ni),
+    .d_i    (usb_ip_clk_status_i),
+    .q_o    (slow_usb_ip_clk_status_o)
   );
 
 
@@ -215,6 +228,15 @@ module pwrmgr_cdc import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;
     .rst_ni,
     .d_i(slow_pwrup_cause_toggle_i),
     .q_o(pwrup_cause_toggle_q)
+  );
+
+  prim_flop_2sync # (
+    .Width(1)
+  ) u_ip_clk_en_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(slow_usb_ip_clk_en_i),
+    .q_o(usb_ip_clk_en_o)
   );
 
   prim_pulse_sync u_scdc_sync (

--- a/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_pkg.sv
@@ -97,12 +97,16 @@ package pwrmgr_pkg;
 
   // pwrmgr to clkmgr
   typedef struct packed {
-    logic ip_clk_en;
+    logic main_ip_clk_en;
+    logic io_ip_clk_en;
+    logic usb_ip_clk_en;
   } pwr_clk_req_t;
 
   // clkmgr to pwrmgr
   typedef struct packed {
-    logic clk_status;
+    logic main_status;
+    logic io_status;
+    logic usb_status;
   } pwr_clk_rsp_t;
 
   // pwrmgr to otp

--- a/sw/device/lib/testing/pwrmgr_testutils.c
+++ b/sw/device/lib/testing/pwrmgr_testutils.c
@@ -16,10 +16,6 @@ void pwrmgr_testutils_enable_low_power(
     dif_pwrmgr_domain_config_t domain_config) {
   // Enable low power on the next WFI with clocks and power domains configured
   // per domain_config.
-
-  // Issue #6504: USB clock in active power must be left enabled.
-  domain_config |= kDifPwrmgrDomainOptionUsbClockInActivePower;
-
   CHECK_DIF_OK(
       dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeWakeup, wakeups));
   CHECK_DIF_OK(dif_pwrmgr_set_domain_config(pwrmgr, domain_config));

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -58,9 +58,8 @@ bool test_main(void) {
         mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR),
         &aon_timer));
     aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold);
-    pwrmgr_testutils_enable_low_power(
-        &pwrmgr, kDifPwrmgrWakeupRequestSourceFive,
-        kDifPwrmgrDomainOptionUsbClockInActivePower);
+    pwrmgr_testutils_enable_low_power(&pwrmgr,
+                                      kDifPwrmgrWakeupRequestSourceFive, 0);
     // Enter low power mode.
     wait_for_interrupt();
 


### PR DESCRIPTION
Since usb clocks can be turned on/off outside of normal
low power routines, it creates some corner cases depending
on how it is used.

This PR fixes [sw, dif pwrmgr smoketest] Deadlock when disabling USB clock in active power #6504 by handshaking usb oscillator disables.
Specifically, before the usb oscillator can be disabled, it must
first request downstream gating to assert. Only when this is done,
can the usb oscillator be turned off. This ensures there is no
low power entry / exit confusion.

Note this is not the ideal fix, but this is done to minimize the amount of disruption
on the overall design and eventually dv.

Some changes in DV code are required by the clkmgr change.

RTL changes by tjaychen, DV changes by matutem.

Signed-off-by: Guillermo Maturana <maturana@google.com>