### PR TITLE
[spi_host] Fix signal assignment width mismatch

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -449,7 +449,7 @@ module spi_host_fsm
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       sample_en_q <= 1'b0;
-      sample_en_q2 <= 1'b00;
+      sample_en_q2 <= 1'b0;
     end else begin
       sample_en_q  <= (fsm_en && !stall) ? sample_en_d : sample_en_q;
       sample_en_q2 <= (fsm_en && !stall) ? sample_en_q : sample_en_q2;

--- a/hw/ip/spi_host/rtl/spi_host_shift_register.sv
+++ b/hw/ip/spi_host/rtl/spi_host_shift_register.sv
@@ -62,7 +62,7 @@ module spi_host_shift_register (
   assign sd_o       = (speed_i == Standard) ? {3'b000, sr_q[7]}   :
                       (speed_i == Dual)     ? {2'b00,  sr_q[7:6]} :
                       (speed_i == Quad)     ? {sr_q[7:4]} :
-                      4'h00;
+                      4'h0;
 
   // Buffer the rx_data outputs to simplify three-way flow control
   // between fsm, shift reg and byte_merge.


### PR DESCRIPTION
Reported by VCS:

```
Warning-[TMBIN] Too many bits in Based Number
../src/lowrisc_ip_spi_host_0.1/rtl/spi_host_shift_register.sv, 65
  The specified width is '4' bits, actually got '8' bits.
  The offending number is : '00'.
```

```
Warning-[TMBIN] Too many bits in Based Number
../src/lowrisc_ip_spi_host_0.1/rtl/spi_host_fsm.sv, 452
  The specified width is '1' bit, actually got '2' bits.
  The offending number is : '00'.
```