### PR TITLE
Revert "[ spi_host ] Flag non-allowed write events as errors"

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -408,7 +408,6 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
-        # Bit 5 (Access Invalid) always triggers an error, so bit 5 is reserved.
         { bits: "4",
           name: "CSIDINVAL",
           desc: '''Invalid CSID: If this bit is set, the block sends an error interrupt whenever
@@ -452,12 +451,6 @@
       swaccess: "rw1c",
       hwaccess: "hrw",
       fields: [
-        { bits: "5",
-          name: "ACCESSINVAL",
-          desc: '''Indicates that TLUL attempted to write to TXDATA with no bytes enabled. Such
-                   'zero byte' writes are not supported.''',
-          resval: "0x0"
-        },
         { bits: "4",
           name: "CSIDINVAL",
           desc: '''Indicates a command was attempted with an invalid value for !!CSID.''',

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -347,35 +347,11 @@ module spi_host
   assign hw2reg.status.txfull.de  = 1'b1;
 
   logic error_overflow, error_underflow;
-  logic error_access_inval;
 
   // Since the DATA FIFOs are essentially directly connected to SW registers, it is an error if
   // there is ever a need for flow control.
-  assign error_overflow    = tx_valid & ~tx_ready;
-  assign error_underflow   = rx_ready & ~rx_valid;
-  logic access_valid;
-  assign error_access_inval = tx_valid & ~access_valid;
-
-  always_comb begin
-    unique case (tx_be)
-      4'b1000,
-      4'b0100,
-      4'b0010,
-      4'b0001,
-      4'b1100,
-      4'b0110,
-      4'b0011,
-      4'b1111: begin
-        access_valid = 1'b1;
-      end
-      default: begin
-        access_valid = 1'b0;
-      end
-    endcase
-  end
-
-  logic tx_valid_checked;
-  assign tx_valid_checked = tx_valid & ~error_overflow & ~error_access_inval;
+  assign error_overflow  = tx_valid & ~tx_ready;
+  assign error_underflow = rx_ready & ~rx_valid;
 
   // Note on ByteOrder and ByteSwapping.
   // ByteOrder == 1 is for Little-Endian transmission (i.e. LSB first), which is acheived by
@@ -391,7 +367,7 @@ module spi_host
 
     .tx_data_i         (tx_data),
     .tx_be_i           (tx_be),
-    .tx_valid_i        (tx_valid_checked),
+    .tx_valid_i        (tx_valid),
     .tx_ready_o        (tx_ready),
     .tx_watermark_i    (tx_watermark),
 
@@ -459,12 +435,11 @@ module spi_host
 
   logic event_error;
 
-  logic [5:0] error_vec;
-  logic [5:0] error_mask;
-  logic [5:0] sw_error_status;
+  logic [4:0] error_vec;
+  logic [4:0] error_mask;
+  logic [4:0] sw_error_status;
 
   assign error_vec  = {
-      error_access_inval,
       error_csid_inval,
       error_cmd_inval,
       error_underflow,
@@ -472,13 +447,7 @@ module spi_host
       error_busy
   };
 
-  // This mask dictates what classes of error events are to be escalated to error interrupts.
-  // (Assume here that error interrupts will be enabled)
-  // Software generated errors can be configured to _not_ generate error events.
-  // Bus errors (such as invalid write access) always generate error events and therefore
-  // interrupts.
   assign error_mask = {
-      1'b1, // invalid access: always an error event
       reg2hw.error_enable.csidinval.q,
       reg2hw.error_enable.cmdinval.q,
       reg2hw.error_enable.underflow.q,
@@ -486,23 +455,18 @@ module spi_host
       reg2hw.error_enable.cmdbusy.q
   };
 
-  assign hw2reg.error_status.accessinval.d  = error_access_inval;
-  assign hw2reg.error_status.csidinval.d    = error_csid_inval;
-  assign hw2reg.error_status.cmdinval.d     = error_cmd_inval;
-  assign hw2reg.error_status.underflow.d    = error_underflow;
-  assign hw2reg.error_status.overflow.d     = error_overflow;
-  assign hw2reg.error_status.cmdbusy.d      = error_busy;
+  assign hw2reg.error_status.csidinval.d = error_csid_inval;
+  assign hw2reg.error_status.cmdinval.d  = error_cmd_inval;
+  assign hw2reg.error_status.underflow.d = error_underflow;
+  assign hw2reg.error_status.overflow.d  = error_overflow;
+  assign hw2reg.error_status.cmdbusy.d   = error_busy;
 
-  // Write the status register whenever the corresponding event occurs.
-  // Only clear them from software.
-  assign hw2reg.error_status.accessinval.de = error_access_inval;
-  assign hw2reg.error_status.csidinval.de   = error_csid_inval;
-  assign hw2reg.error_status.cmdinval.de    = error_cmd_inval;
-  assign hw2reg.error_status.underflow.de   = error_underflow;
-  assign hw2reg.error_status.overflow.de    = error_overflow;
-  assign hw2reg.error_status.cmdbusy.de     = error_busy;
+  assign hw2reg.error_status.csidinval.de = 1'b1;
+  assign hw2reg.error_status.cmdinval.de  = 1'b1;
+  assign hw2reg.error_status.underflow.de = 1'b1;
+  assign hw2reg.error_status.overflow.de  = 1'b1;
+  assign hw2reg.error_status.cmdbusy.de   = 1'b1;
 
-  assign sw_error_status[5] = reg2hw.error_status.accessinval.q;
   assign sw_error_status[4] = reg2hw.error_status.csidinval.q;
   assign sw_error_status[3] = reg2hw.error_status.cmdinval.q;
   assign sw_error_status[2] = reg2hw.error_status.underflow.q;

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -150,9 +150,6 @@ package spi_host_reg_pkg;
     struct packed {
       logic        q;
     } csidinval;
-    struct packed {
-      logic        q;
-    } accessinval;
   } spi_host_reg2hw_error_status_reg_t;
 
   typedef struct packed {
@@ -263,32 +260,28 @@ package spi_host_reg_pkg;
       logic        d;
       logic        de;
     } csidinval;
-    struct packed {
-      logic        d;
-      logic        de;
-    } accessinval;
   } spi_host_hw2reg_error_status_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    spi_host_reg2hw_intr_state_reg_t intr_state; // [125:124]
-    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [123:122]
-    spi_host_reg2hw_intr_test_reg_t intr_test; // [121:118]
-    spi_host_reg2hw_alert_test_reg_t alert_test; // [117:116]
-    spi_host_reg2hw_control_reg_t control; // [115:98]
-    spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [97:67]
-    spi_host_reg2hw_csid_reg_t csid; // [66:35]
-    spi_host_reg2hw_command_reg_t command; // [34:17]
-    spi_host_reg2hw_error_enable_reg_t error_enable; // [16:12]
-    spi_host_reg2hw_error_status_reg_t error_status; // [11:6]
+    spi_host_reg2hw_intr_state_reg_t intr_state; // [124:123]
+    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [122:121]
+    spi_host_reg2hw_intr_test_reg_t intr_test; // [120:117]
+    spi_host_reg2hw_alert_test_reg_t alert_test; // [116:115]
+    spi_host_reg2hw_control_reg_t control; // [114:97]
+    spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [96:66]
+    spi_host_reg2hw_csid_reg_t csid; // [65:34]
+    spi_host_reg2hw_command_reg_t command; // [33:16]
+    spi_host_reg2hw_error_enable_reg_t error_enable; // [15:11]
+    spi_host_reg2hw_error_status_reg_t error_status; // [10:6]
     spi_host_reg2hw_event_enable_reg_t event_enable; // [5:0]
   } spi_host_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    spi_host_hw2reg_intr_state_reg_t intr_state; // [55:52]
-    spi_host_hw2reg_status_reg_t status; // [51:12]
-    spi_host_hw2reg_error_status_reg_t error_status; // [11:0]
+    spi_host_hw2reg_intr_state_reg_t intr_state; // [53:50]
+    spi_host_hw2reg_status_reg_t status; // [49:10]
+    spi_host_hw2reg_error_status_reg_t error_status; // [9:0]
   } spi_host_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -243,8 +243,6 @@ module spi_host_reg_top (
   logic error_status_cmdinval_wd;
   logic error_status_csidinval_qs;
   logic error_status_csidinval_wd;
-  logic error_status_accessinval_qs;
-  logic error_status_accessinval_wd;
   logic event_enable_we;
   logic event_enable_rxfull_qs;
   logic event_enable_rxfull_wd;
@@ -1353,31 +1351,6 @@ module spi_host_reg_top (
     .qs     (error_status_csidinval_qs)
   );
 
-  //   F[accessinval]: 5:5
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_error_status_accessinval (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (error_status_we),
-    .wd     (error_status_accessinval_wd),
-
-    // from internal hardware
-    .de     (hw2reg.error_status.accessinval.de),
-    .d      (hw2reg.error_status.accessinval.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.error_status.accessinval.q),
-
-    // to register interface (read)
-    .qs     (error_status_accessinval_qs)
-  );
-
 
   // R[event_enable]: V(False)
   //   F[rxfull]: 0:0
@@ -1643,8 +1616,6 @@ module spi_host_reg_top (
   assign error_status_cmdinval_wd = reg_wdata[3];
 
   assign error_status_csidinval_wd = reg_wdata[4];
-
-  assign error_status_accessinval_wd = reg_wdata[5];
   assign event_enable_we = addr_hit[11] & reg_we & !reg_error;
 
   assign event_enable_rxfull_wd = reg_wdata[0];
@@ -1740,7 +1711,6 @@ module spi_host_reg_top (
         reg_rdata_next[2] = error_status_underflow_qs;
         reg_rdata_next[3] = error_status_cmdinval_qs;
         reg_rdata_next[4] = error_status_csidinval_qs;
-        reg_rdata_next[5] = error_status_accessinval_qs;
       end
 
       addr_hit[11]: begin


### PR DESCRIPTION
This reverts commit 3193d73abd2f41dca02f376d70c0e070d7cfcec9.

This commit broke private CI:

```
* `UVM_ERROR (csr_utils_pkg.sv:466) [csr_utils::csr_rd_check] Check failed obs == exp (* [*] vs * [*]) Regname: chip_reg_block.spi_host*.error_status` has 1 failures:
    * Test chip_csr_rw has 1 failures.
        * 0.chip_csr_rw.1\
          Line 130, in log /azp/agent/_work/1/s/scratch/HEAD/chip_earlgrey_asic-sim-vcs/0.chip_csr_rw/out/run.log

                UVM_ERROR @ 1081370000 ps: (csr_utils_pkg.sv:466) [csr_utils::csr_rd_check] Check failed obs == exp (8 [0x8] vs 0 [0x0]) Regname: chip_reg_block.spi_host1.error_status
                UVM_INFO @ 1081370000 ps: (uvm_report_server.svh:901) [UVM/REPORT/SERVER]
                --- UVM Report Summary ---

                Quit count reached!
```

The PR itself was green, so probably a mid-air collision.