### PR TITLE
[ spi_host, dv ] Prevent Spurious CSR test errors

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -411,6 +411,7 @@
       swaccess: "rw",
       hwaccess: "hro",
       fields: [
+        # Bit 5 (Access Invalid) always triggers an error, so bit 5 is reserved.
         { bits: "4",
           name: "CSIDINVAL",
           desc: '''Invalid CSID: If this bit is set, the block sends an error interrupt whenever
@@ -454,6 +455,12 @@
       swaccess: "rw1c",
       hwaccess: "hrw",
       fields: [
+        { bits: "5",
+          name: "ACCESSINVAL",
+          desc: '''Indicates that TLUL attempted to write to TXDATA with no bytes enabled. Such
+                   'zero byte' writes are not supported.''',
+          resval: "0x0"
+        },
         { bits: "4",
           name: "CSIDINVAL",
           desc: '''Indicates a command was attempted with an invalid value for !!CSID.''',

--- a/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_pkg.sv
@@ -150,6 +150,9 @@ package spi_host_reg_pkg;
     struct packed {
       logic        q;
     } csidinval;
+    struct packed {
+      logic        q;
+    } accessinval;
   } spi_host_reg2hw_error_status_reg_t;
 
   typedef struct packed {
@@ -260,28 +263,32 @@ package spi_host_reg_pkg;
       logic        d;
       logic        de;
     } csidinval;
+    struct packed {
+      logic        d;
+      logic        de;
+    } accessinval;
   } spi_host_hw2reg_error_status_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    spi_host_reg2hw_intr_state_reg_t intr_state; // [124:123]
-    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [122:121]
-    spi_host_reg2hw_intr_test_reg_t intr_test; // [120:117]
-    spi_host_reg2hw_alert_test_reg_t alert_test; // [116:115]
-    spi_host_reg2hw_control_reg_t control; // [114:97]
-    spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [96:66]
-    spi_host_reg2hw_csid_reg_t csid; // [65:34]
-    spi_host_reg2hw_command_reg_t command; // [33:16]
-    spi_host_reg2hw_error_enable_reg_t error_enable; // [15:11]
-    spi_host_reg2hw_error_status_reg_t error_status; // [10:6]
+    spi_host_reg2hw_intr_state_reg_t intr_state; // [125:124]
+    spi_host_reg2hw_intr_enable_reg_t intr_enable; // [123:122]
+    spi_host_reg2hw_intr_test_reg_t intr_test; // [121:118]
+    spi_host_reg2hw_alert_test_reg_t alert_test; // [117:116]
+    spi_host_reg2hw_control_reg_t control; // [115:98]
+    spi_host_reg2hw_configopts_mreg_t [0:0] configopts; // [97:67]
+    spi_host_reg2hw_csid_reg_t csid; // [66:35]
+    spi_host_reg2hw_command_reg_t command; // [34:17]
+    spi_host_reg2hw_error_enable_reg_t error_enable; // [16:12]
+    spi_host_reg2hw_error_status_reg_t error_status; // [11:6]
     spi_host_reg2hw_event_enable_reg_t event_enable; // [5:0]
   } spi_host_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    spi_host_hw2reg_intr_state_reg_t intr_state; // [53:50]
-    spi_host_hw2reg_status_reg_t status; // [49:10]
-    spi_host_hw2reg_error_status_reg_t error_status; // [9:0]
+    spi_host_hw2reg_intr_state_reg_t intr_state; // [55:52]
+    spi_host_hw2reg_status_reg_t status; // [51:12]
+    spi_host_hw2reg_error_status_reg_t error_status; // [11:0]
   } spi_host_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -243,6 +243,8 @@ module spi_host_reg_top (
   logic error_status_cmdinval_wd;
   logic error_status_csidinval_qs;
   logic error_status_csidinval_wd;
+  logic error_status_accessinval_qs;
+  logic error_status_accessinval_wd;
   logic event_enable_we;
   logic event_enable_rxfull_qs;
   logic event_enable_rxfull_wd;
@@ -1351,6 +1353,31 @@ module spi_host_reg_top (
     .qs     (error_status_csidinval_qs)
   );
 
+  //   F[accessinval]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_error_status_accessinval (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (error_status_we),
+    .wd     (error_status_accessinval_wd),
+
+    // from internal hardware
+    .de     (hw2reg.error_status.accessinval.de),
+    .d      (hw2reg.error_status.accessinval.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.error_status.accessinval.q),
+
+    // to register interface (read)
+    .qs     (error_status_accessinval_qs)
+  );
+
 
   // R[event_enable]: V(False)
   //   F[rxfull]: 0:0
@@ -1616,6 +1643,8 @@ module spi_host_reg_top (
   assign error_status_cmdinval_wd = reg_wdata[3];
 
   assign error_status_csidinval_wd = reg_wdata[4];
+
+  assign error_status_accessinval_wd = reg_wdata[5];
   assign event_enable_we = addr_hit[11] & reg_we & !reg_error;
 
   assign event_enable_rxfull_wd = reg_wdata[0];
@@ -1711,6 +1740,7 @@ module spi_host_reg_top (
         reg_rdata_next[2] = error_status_underflow_qs;
         reg_rdata_next[3] = error_status_cmdinval_qs;
         reg_rdata_next[4] = error_status_csidinval_qs;
+        reg_rdata_next[5] = error_status_accessinval_qs;
       end
 
       addr_hit[11]: begin


### PR DESCRIPTION
Adds the tag: "excl:CsrNonInitTests:CsrExclWrite" to the SPI_HOST COMMAND register
This prevents the CSR test from sending bogus, nonsense commands to the IP,
which will eventually result in spurious results

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>