### PR TITLE
[prim] Tweak prim_sync_reqack_data assertion so it can be disabled

### DIFF
--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -49,15 +49,15 @@ module tb;
   // TODO(#8758): This disables an assertion that fires if we happen to drop the edn_rst_n line
   // before rst_n when the EDN is providing data to the DUT. The proper fix is either to change the
   // design, change the assertion, or change the DV code so this doesn't happen.
+`define RND_REQ_PATH \
+    dut.u_prim_edn_rnd_req.u_prim_sync_reqack_data.gen_assert_data_dst2src
   always @(negedge edn_rst_n or posedge edn_rst_n) begin
     if (!edn_rst_n) begin
-      $assertoff(0,
-                 dut.u_prim_edn_rnd_req.u_prim_sync_reqack_data.
-                 gen_assert_data_dst2src.SyncReqAckDataHoldDst2Src);
+      $assertoff(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcA);
+      $assertoff(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcB);
     end else begin
-      $asserton(0,
-                dut.u_prim_edn_rnd_req.u_prim_sync_reqack_data.
-                gen_assert_data_dst2src.SyncReqAckDataHoldDst2Src);
+      $asserton(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcA);
+      $asserton(0, `RND_REQ_PATH.SyncReqAckDataHoldDst2SrcB);
     end
   end
 


### PR DESCRIPTION
When we run `$assertoff()`, it stops any new assertion sequences from
being started. However, this part of the previous assertion:

    $stable(data_o) [*2]

consumed time. If we inject a reset on the DST side that causes the
value to change in the last cycle of the window, an `$assertoff` won't
save us because the assertion that started on the previous cycle will
still run to completion.

Unfold the `$stable(..)` calls into comparisons between `$past()` and
present and change the assertion so that it doesn't consume time,
allowing it to be disabled at any point.
