### PR TITLE
[sw, tests] Introduce OTP controller testutil

### DIFF
--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -126,4 +126,18 @@ sw_lib_testing_sram_ctrl_testutils = declare_dependency(
   ),
 )
 
+sw_lib_testing_otp_ctrl_testutils = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_otp_ctrl_testutils',
+    sources: [
+      hw_ip_otp_ctrl_reg_h,
+      'otp_ctrl_testutils.c'
+    ],
+    dependencies: [
+      sw_lib_dif_otp_ctrl,
+      sw_lib_runtime_ibex,
+    ],
+  ),
+)
+
 subdir('test_framework')

--- a/sw/device/lib/testing/otp_ctrl_testutils.c
+++ b/sw/device/lib/testing/otp_ctrl_testutils.c
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
+
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+
+/*
+ * OTP the Direct Access Interface (DAI) operation time-out in micro seconds.
+ *
+ * It is not possible to predict the specific cycle count that a DAI operation
+ * takes, thus arbitrary value of 100us is used.
+ */
+const uint8_t kOtpDaiTimeoutUs = 100;
+
+/**
+ * Checks whether the DAI operation has finished.
+ */
+static bool dai_finished(const dif_otp_ctrl_t *otp_ctrl) {
+  dif_otp_ctrl_status_t status;
+  CHECK_DIF_OK(dif_otp_ctrl_get_status(otp_ctrl, &status));
+  return bitfield_bit32_read(status.codes, kDifOtpCtrlStatusCodeDaiIdle);
+}
+
+void otp_ctrl_testutils_wait_for_dai(const dif_otp_ctrl_t *otp_ctrl) {
+  IBEX_SPIN_FOR(dai_finished(otp_ctrl), kOtpDaiTimeoutUs);
+}

--- a/sw/device/lib/testing/otp_ctrl_testutils.h
+++ b/sw/device/lib/testing/otp_ctrl_testutils.h
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_OTP_CTRL_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_OTP_CTRL_TESTUTILS_H_
+
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+
+/**
+ * Waits for the DAI operation to finish (busy wait).
+ */
+void otp_ctrl_testutils_wait_for_dai(const dif_otp_ctrl_t *otp_ctrl);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_OTP_CTRL_TESTUTILS_H_

--- a/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
+++ b/sw/device/tests/lc_ctrl_otp_hw_cfg_test.c
@@ -12,6 +12,7 @@
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/otp_ctrl_testutils.h"
 #include "sw/device/lib/testing/test_framework/test_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -21,23 +22,6 @@ static dif_lc_ctrl_t lc;
 
 const test_config_t kTestConfig;
 const uint8_t NUM_DEVICE_ID = 8;
-const uint8_t OTP_DAI_TIMEOUT = 10;
-
-/**
- * Busy-wait until the DAI is done with whatever operation it is doing.
- */
-static void wait_for_dai(void) {
-  for (int i = 0; i < OTP_DAI_TIMEOUT; i++) {
-    dif_otp_ctrl_status_t status;
-    CHECK_DIF_OK(dif_otp_ctrl_get_status(&otp, &status));
-    if (status.codes == (1 << kDifOtpCtrlStatusCodeDaiIdle)) {
-      return;
-    }
-    LOG_INFO("Waiting for DAI...");
-    usleep(10);
-  }
-  LOG_ERROR("OTP DAI access timeout.");
-}
 
 /**
  * Read and return 32-bit OTP data via the DAI interface.
@@ -47,7 +31,7 @@ static void otp_ctrl_dai_read_32(const dif_otp_ctrl_t *otp,
                                  uint32_t address, uint32_t *buf) {
   CHECK_DIF_OK(dif_otp_ctrl_dai_read_start(otp, partition, address));
 
-  wait_for_dai();
+  otp_ctrl_testutils_wait_for_dai(otp);
 
   CHECK_DIF_OK(dif_otp_ctrl_dai_read32_end(otp, buf));
 }

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -190,6 +190,7 @@ otp_ctrl_smoketest_lib = declare_dependency(
       sw_lib_runtime_log,
       sw_lib_mmio,
       sw_lib_runtime_hart,
+      sw_lib_testing_otp_ctrl_testutils,
     ],
   ),
 )
@@ -454,6 +455,7 @@ lc_ctrl_otp_hw_cfg_test_lib = declare_dependency(
       sw_lib_runtime_log,
       sw_lib_mmio,
       sw_lib_runtime_hart,
+      sw_lib_testing_otp_ctrl_testutils,
     ],
   ),
 )


### PR DESCRIPTION
This change pulls out the common "busy wait" functionality that
was separately implemented in two different tests. Moreover, the
SRAM execution test is intending to use the same functionality.

This lead to some minor refactoring.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>