### PR TITLE
[otbn,dv] Fix bad type in bad_ispr.py

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/bad_ispr.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_ispr.py
@@ -60,7 +60,7 @@ class BadIspr(SnippetGen):
         snippet = ProgSnippet(pc, [prog_insn])
         snippet.insert_into_program(program)
 
-        return (snippet, True, model)
+        return (snippet, model)
 
     def _gen(self,
              model: Model,


### PR DESCRIPTION
This happened because I merged two PRs that broke each other. Oops!
