### PR TITLE
[sw] silicon owner bare metal example

### DIFF
--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -148,6 +148,7 @@ signing_keys = {
 subdir('boot_rom')
 subdir('otp_img')
 subdir('silicon_creator')
+subdir('silicon_owner')
 subdir('examples')
 subdir('sca')
 subdir('tests')

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -255,7 +255,7 @@ typedef struct manifest_digest_region {
 /**
  * Allowed bounds for the `length` field of a ROM_EXT manifest.
  */
-// FIXME: Update min value after we have a fairly representative ROM_EXT.
+// TODO(#9045): Move ROM_EXT size to a common location.
 #define MANIFEST_LENGTH_FIELD_ROM_EXT_MIN MANIFEST_SIZE
 #define MANIFEST_LENGTH_FIELD_ROM_EXT_MAX 0x10000
 

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -4,9 +4,9 @@
 
 /**
  * NOTE:
- * This is an incomplete common portion of ROM_EXT linker file, and should not
- * be used directly. Instead it should be included by a top level ROM_EXT slot
- * linker file.
+ * This is an incomplete common portion of the first Silicon Owner stage linker
+ * file, and should not be used directly. Instead it should be included by a
+ * top level slot linker file.
  */
 
 OUTPUT_ARCH(riscv)
@@ -20,9 +20,9 @@ __DYNAMIC = 0;
 /**
  * Marking the entry point correctly for the ELF file. The signer tool will
  * transfer this value to the `entry_point` field of the manifest, which will
- * then be used by `mask_rom_boot` to handover execution to ROM_EXT.
+ * then be used by the ROM_EXT to handover execution to ROM_EXT.
  */
-ENTRY(_rom_ext_start_boot)
+ENTRY(_start_boot)
 
 /**
  * NOTE: We have to align each section to word boundaries as our current
@@ -63,20 +63,6 @@ SECTIONS {
   } > eflash
 
   /**
-   * Shutdown text section, containing shutdown function(s).
-   *
-   * This must be the last executable section in the ROM_EXT flash image.
-   */
-  .shutdown : ALIGN(4) {
-    *(.shutdown)
-    *(.shutdown.*)
-
-    /* Ensure section end is word-aligned. */
-    . = ALIGN(4);
-    _text_end = .;
-  } > eflash
-
-  /**
    * Read-only data section, containing all large compile-time constants, like
    * strings.
    */
@@ -88,20 +74,6 @@ SECTIONS {
     *(.rodata)
     *(.rodata.*)
   } > eflash
-
-  /**
-   * Critical static data that is accessible by both the mask ROM and the ROM
-   * extension.
-   *
-   * Each variable added to .static_critical must be in its own subsection
-   * named after the variable.
-   *
-   * This data is not initialized during CRT (hence NOLOAD). Instead it will
-   * be initialized by the mask ROM.
-   */
-  .static_critical ORIGIN(ram_main) (NOLOAD) : ALIGN(4) {
-    INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
-  } > ram_main
 
   /**
    * Mutable data section, at the bottom of ram_main. This will be initialized
@@ -165,6 +137,8 @@ SECTIONS {
     _bss_end = .;
   } > ram_main
 
+  /* TODO(#9044): Switch to info_sections.ld once DV dependencies are factored
+   * out. */
   /* ELF-internal Sections. */
   .symtab 0x0 : { *(.symtab) }
   .strtab 0x0 : { *(.strtab) }

--- a/sw/device/silicon_owner/bare_metal/bare_metal_example.c
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_example.c
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/csr.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/silicon_creator/lib/drivers/pinmux.h"
+#include "sw/device/silicon_creator/lib/drivers/uart.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+void bare_metal_init(void) {
+  pinmux_init();
+  uart_init(kUartNCOValue);
+  base_set_stdout((buffer_sink_t){
+      .data = NULL,
+      .sink = uart_sink,
+  });
+}
+
+void bare_metal_main(void) {
+  bare_metal_init();
+
+  // The PASS string is scanned by system test scripts. See
+  // test/systemtest/earlgrey/test_fpga_cw310.py for more details.
+  base_printf("Bare metal PASS!\r\n");
+
+  while (true) {
+  }
+}
+
+void interrupt_handler(void) {}
+
+// We only need a single handler for all interrupts, but we want to
+// keep distinct symbols to make writing tests easier.
+void exception_handler(void) __attribute__((alias("interrupt_handler")));
+
+void nmi_handler(void) __attribute__((alias("interrupt_handler")));

--- a/sw/device/silicon_owner/bare_metal/bare_metal_example.h
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_example.h
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_OWNER_BARE_METAL_BARE_METAL_EXAMPLE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_OWNER_BARE_METAL_BARE_METAL_EXAMPLE_H_
+
+#include <stdnoreturn.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+noreturn void bare_metal_main(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_OWNER_BARE_METAL_BARE_METAL_EXAMPLE_H_

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_a.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_a.ld
@@ -1,0 +1,27 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan first Silicon Owner stage.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * The first Silicon Owner stage kept in flash, and can be loaded into either
+ * Slot A (lower half o the flash), or Slot B (upper half of flash), this
+ * linker script only targets Slot A.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/* Reserving space at the top of the RAM for the stack. */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/* Slot A starts at the start of the eFlash plus the fixed size of the first
+ * Silicon Owner stage */
+ /* TODO(#9045): Move ROM_EXT size to a common location. */
+_slot_start_address = ORIGIN(eflash) + 0x10000;
+
+INCLUDE sw/device/silicon_owner/bare_metal/bare_metal_common.ld

--- a/sw/device/silicon_owner/bare_metal/bare_metal_slot_b.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_slot_b.ld
@@ -1,0 +1,28 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Linker script for an OpenTitan first Silicon Owner stage.
+ *
+ * Portions of this file are Ibex-specific.
+ *
+ * The first Silicon Owner stage kept in flash, and can be loaded into either
+ * Slot A (lower half o the flash), or Slot B (upper half of flash), this
+ * linker script only targets Slot B.
+ */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/* Reserving space at the top of the RAM for the stack. */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/* Slot B starts at the half-size mark of the eFlash plus the fixed size of the
+ * ROM_EXT.
+ */
+ /* TODO(#9045): Move ROM_EXT size to a common location. */
+_slot_start_address = ORIGIN(eflash) + (LENGTH(eflash) / 2) + 0x10000;
+
+INCLUDE sw/device/silicon_owner/bare_metal/bare_metal_common.ld

--- a/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_start.S
@@ -1,0 +1,220 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+
+/**
+ * ROM_EXT Interrupt Vector
+ */
+  .section .vectors, "ax"
+  .option push
+
+  // Disable RISC-V instruction compression: we need all instructions to
+  // be exactly word wide in the interrupt vector.
+  .option norvc
+
+  // Disable RISC-V linker relaxation, as it can compress instructions at
+  // link-time, which we also really don't want.
+  .option norelax
+
+/**
+ * `_interrupt_vector` is an ibex-compatible interrupt vector.
+ *
+ * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts. The
+ * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
+ *
+ * Only the following will be used by Ibex:
+ * - Exception Handler (Entry 0)
+ * - Machine Software Interrupt Handler (Entry 3)
+ * - Machine Timer Interrupt Handler (Entry 7)
+ * - Machine External Interrupt Handler (Entry 11)
+ * - Vendor Interrupt Handlers (Entries 16-31)
+ *
+ * More information about Ibex's interrupts can be found here:
+ *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+ */
+  .balign 256
+  .globl _interrupt_vector
+  .type _interrupt_vector, @function
+_interrupt_vector:
+
+  // RISC-V Standard (Vectored) Interrupt Handlers:
+
+  // Exception and User Software Interrupt Handler.
+  unimp
+  // Supervisor Software Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine Software Interrupt Handler.
+  unimp
+
+  // User Timer Interrupt Handler.
+  unimp
+  // Supervisor Timer Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine Timer Interrupt Handler.
+  unimp
+
+  // User External Interrupt Handler.
+  unimp
+  // Supervisor External Interrupt Handler.
+  unimp
+  // Reserved.
+  unimp
+  // Machine External Interrupt Handler.
+  unimp
+
+  // Reserved.
+  unimp
+  unimp
+  unimp
+  unimp
+
+  // Vendor Interrupt Handlers:
+
+  // On Ibex interrupt ids 16-30 are for "fast" interrupts.
+  .rept 15
+  unimp
+  .endr
+
+  // On Ibex interrupt id 31 is for non-maskable interrupts.
+  unimp
+
+  // Set size so this vector can be disassembled.
+  .size _interrupt_vector, .-_interrupt_vector
+
+  // Re-enable compressed instructions, linker relaxation.
+  .option pop
+
+
+/**
+ * Runtime initialization code.
+ */
+
+  /**
+   * NOTE: The "ax" flag below is necessary to ensure that this section
+   * is allocated executable space by the linker.
+   */
+  .section .crt, "ax"
+
+  /**
+   * Linker Relaxation is disabled until `__global_pointer$` is setup, below,
+   * because otherwise some sequences may be turned into gp-relative sequences,
+   * which is incorrect when `gp` is not initialized.
+   */
+  .option push
+  .option norelax
+
+/**
+ * Entry point.
+ */
+  .globl _start_boot
+  .type _start_boot, @function
+_start_boot:
+
+  /**
+   * Disable Interrupts.
+   *
+   * We cannot disable exceptions, or Ibex's non-maskable interrupts (interrupt
+   * 31), so we still need to be careful.
+   */
+
+  // Clear `MIE` field of `mstatus` (disable interrupts globally).
+  csrci mstatus, 0x8
+
+  /**
+   * Clear all the machine-defined interrupts, `MEIE`, `MTIE`, and `MSIE` fields
+   * of `mie`.
+   */
+  li   t0, 0xFFFF0888
+  csrc mie, t0
+
+  /**
+   * Set up the stack pointer.
+   *
+   * In RISC-V, the stack grows downwards, so we load the address of the highest
+   * word in the stack into sp. We don't load in `_stack_end`, as that points
+   * beyond the end of RAM, and we always want it to be valid to dereference
+   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   *
+   * If an exception fires, the handler is conventionaly only allowed to clobber
+   * memory at addresses below `sp`.
+   */
+  la   sp, (_stack_end - 16)
+
+  /**
+   * Set well-defined interrupt/exception handlers
+   *
+   * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
+   */
+  la   t0, _interrupt_vector
+  andi t0, t0, -4
+  ori  t0, t0, 0b01
+  csrw mtvec, t0
+
+  /**
+   * Setup C Runtime
+   */
+
+  /**
+   * Initialize the `.data` section in RAM from RO memory.
+   */
+  la   a0, _data_start
+  la   a1, _data_end
+  la   a2, _data_init_start
+  .extern crt_section_copy
+  call crt_section_copy
+
+  /**
+   * Initialize the `.bss` section.
+   *
+   * We do this despite zeroing all of SRAM above, so that we still zero `.bss`
+   * once we've enabled SRAM scrambling.
+   */
+  la   a0, _bss_start
+  la   a1, _bss_end
+  .extern crt_section_clear
+  call crt_section_clear
+
+  // Re-clobber all of the temporary registers.
+  li t0, 0x0
+  li t1, 0x0
+  li t2, 0x0
+  li t3, 0x0
+  li t4, 0x0
+  li t5, 0x0
+  li t6, 0x0
+
+  // Re-clobber all of the argument registers.
+  li a0, 0x0
+  li a1, 0x0
+  li a2, 0x0
+  li a3, 0x0
+  li a4, 0x0
+  li a5, 0x0
+  li a6, 0x0
+  li a7, 0x0
+
+  /**
+   * Setup global pointer.
+   *
+   * This requires that we disable linker relaxations, or it will be relaxed to
+   * `mv gp, gp`, so we disabled relaxations for all of `_mask_rom_start_boot`.
+   */
+  la gp, __global_pointer$
+
+  // Re-enable linker relaxation.
+  .option pop
+
+  /**
+   * Jump to C Code
+   */
+  .extern bare_metal_main
+  tail bare_metal_main
+
+  // Set size so this function can be disassembled.
+  .size _start_boot, .-_start_boot

--- a/sw/device/silicon_owner/bare_metal/meson.build
+++ b/sw/device/silicon_owner/bare_metal/meson.build
@@ -1,0 +1,148 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mask ROM Linker Parameters
+#
+# See sw/device/exts/common/flash_link.ld for additional info about these
+# parameters.
+
+bare_metal_linkfile_slot_a = files(['bare_metal_slot_a.ld'])
+bare_metal_linkfile_slot_b = files(['bare_metal_slot_b.ld'])
+
+bare_metal_link_info = {
+  'bare_metal_slot_a' :
+  [
+    # Link arguments for slot A.
+    [
+      '-Wl,-L,@0@'.format(meson.source_root()),
+      '-Wl,-T,@0@/@1@'.format(meson.source_root(), bare_metal_linkfile_slot_a[0]),
+    ] + embedded_target_extra_link_args,
+    # Link dependency file for slot A.
+    [
+      bare_metal_linkfile_slot_a,
+    ],
+  ],
+  'bare_metal_slot_b' :
+  [
+    # Link arguments for slot B.
+    [
+      '-Wl,-L,@0@'.format(meson.source_root()),
+      '-Wl,-T,@0@/@1@'.format(meson.source_root(), bare_metal_linkfile_slot_b[0]),
+    ] + embedded_target_extra_link_args,
+    # Link dependency file for slot B.
+    [
+      bare_metal_linkfile_slot_b,
+    ],
+  ],
+}
+
+bare_metal_slot_libs = {}
+foreach slot, slot_link_args : bare_metal_link_info
+  bare_metal_slot_libs += {
+    slot: declare_dependency(
+      sources: [
+        'bare_metal_start.S',
+      ],
+      link_args: slot_link_args[0],
+      dependencies: [
+        freestanding_headers,
+        sw_silicon_creator_lib_driver_pinmux,
+        sw_silicon_creator_lib_driver_uart,
+        sw_silicon_creator_lib_fake_deps,
+        sw_silicon_creator_lib_manifest_section,
+        sw_lib_crt,
+        sw_lib_runtime_print,
+
+      ],
+      link_with: static_library(
+        slot + '_bare_metal_lib',
+        sources: [
+          'bare_metal_example.c',
+        ],
+        link_depends: [slot_link_args[1]],
+    )
+  )
+}
+endforeach
+
+foreach device_name, device_lib : sw_lib_arch_core_devices
+  foreach slot, slot_lib : bare_metal_slot_libs
+    bare_metal_elf = executable(
+      slot + '_' + device_name,
+      name_suffix: 'elf',
+      dependencies: [
+        device_lib,
+        slot_lib,
+      ],
+    )
+
+    target_name = slot + '_@0@_' + device_name
+
+    bare_metal_dis = custom_target(
+      target_name.format('dis'),
+      input: bare_metal_elf,
+      kwargs: elf_to_dis_custom_target_args,
+    )
+
+    bare_metal_bin = custom_target(
+      target_name.format('bin'),
+      input: bare_metal_elf,
+      kwargs: elf_to_bin_custom_target_args,
+    )
+
+    targets_to_export = [
+      bare_metal_elf,
+      bare_metal_dis,
+      bare_metal_bin,
+    ]
+
+    foreach key_name, key_info : signing_keys
+      signed_target_name = '_'.join(['bare_metal', slot, key_name, 'signed', '@0@', device_name])
+
+      bare_metal_signed_bin = custom_target(
+        signed_target_name.format('bin'),
+        input: bare_metal_bin,
+        output: '@BASENAME@.@0@.signed.bin'.format(key_name),
+        command: [
+          rom_ext_signer_export.full_path(),
+          'owner',
+          '@INPUT@',
+          key_info['path'],
+          bare_metal_elf.full_path(),
+          '@OUTPUT@',
+        ],
+        depends: rom_ext_signer_export,
+        build_by_default: true,
+      )
+
+      bare_metal_signed_vmem32 = custom_target(
+        signed_target_name.format('vmem32'),
+        input: bare_metal_signed_bin,
+        kwargs: bin_to_vmem32_custom_target_args,
+      )
+
+      bare_metal_signed_vmem64 = custom_target(
+        signed_target_name.format('vmem64'),
+        input: bare_metal_signed_bin,
+        kwargs: bin_to_vmem64_custom_target_args,
+      )
+
+      targets_to_export += [
+        bare_metal_signed_bin,
+        bare_metal_signed_vmem32,
+        bare_metal_signed_vmem64,
+      ]
+    endforeach
+
+    custom_target(
+      target_name.format('export'),
+      command: export_target_command,
+      depend_files: [export_target_depend_files,],
+      input: targets_to_export,
+      output: target_name.format('export'),
+      build_always_stale: true,
+      build_by_default: true,
+    )
+  endforeach
+endforeach

--- a/sw/device/silicon_owner/meson.build
+++ b/sw/device/silicon_owner/meson.build
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('bare_metal')


### PR DESCRIPTION
This commit adds the sw/device/silicon_owner folder with a bare_metal
executable which can be used to smoke test the ROM and ROM_EXT secure
boot sequence.
