### PR TITLE
[rv_dm] BUFG fix

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_clock_inv.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_inv.sv
@@ -6,7 +6,8 @@
 //   Varies on the process
 
 module prim_generic_clock_inv #(
-  parameter bit HasScanMode = 1'b1
+  parameter bit HasScanMode = 1'b1,
+  parameter bit NoFpgaBufG  = 1'b0 // only used in FPGA case
 ) (
   input        clk_i,
   input        scanmode_i,
@@ -14,7 +15,9 @@ module prim_generic_clock_inv #(
 );
 
   if (HasScanMode) begin : gen_scan
-    prim_clock_mux2 i_dft_tck_mux (
+    prim_clock_mux2 #(
+      .NoFpgaBufG(NoFpgaBufG)
+    ) i_dft_tck_mux (
       .clk0_i ( ~clk_i     ),
       .clk1_i ( clk_i      ), // bypass the inverted clock for testing
       .sel_i  ( scanmode_i ),

--- a/hw/vendor/patches/pulp_riscv_dbg/0001-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,4 +1,4 @@
-From 5caf3a335f38d4cd27d9d00a1947776acebdf10a Mon Sep 17 00:00:00 2001
+From 3a39c34f70c7181b58d09f0b5fbcb992f296cd4f Mon Sep 17 00:00:00 2001
 From: Philipp Wagner <phw@lowrisc.org>
 Date: Fri, 22 Feb 2019 14:48:46 +0000
 Subject: [PATCH] Use lowrisc instead of PULP primitives
@@ -156,10 +156,10 @@ index 4665c91..1299b09 100644
  
  endmodule : dmi_cdc
 diff --git a/src/dmi_jtag_tap.sv b/src/dmi_jtag_tap.sv
-index c2e8d6e..5f10e6c 100644
+index c2e8d6e..809d4a6 100644
 --- a/src/dmi_jtag_tap.sv
 +++ b/src/dmi_jtag_tap.sv
-@@ -216,18 +216,14 @@ module dmi_jtag_tap #(
+@@ -216,18 +216,15 @@ module dmi_jtag_tap #(
    // ----------------
    // DFT
    // ----------------
@@ -178,7 +178,8 @@ index c2e8d6e..5f10e6c 100644
 +  logic tck_n;
 +
 +  prim_clock_inv #(
-+    .HasScanMode(1'b1)
++    .HasScanMode(1'b1),
++    .NoFpgaBufG(1'b1)
 +  ) i_tck_inv (
 +    .clk_i      ( tck_i      ),
 +    .clk_no     ( tck_n      ),

--- a/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dmi_jtag_tap.sv
@@ -219,7 +219,8 @@ module dmi_jtag_tap #(
   logic tck_n;
 
   prim_clock_inv #(
-    .HasScanMode(1'b1)
+    .HasScanMode(1'b1),
+    .NoFpgaBufG(1'b1)
   ) i_tck_inv (
     .clk_i      ( tck_i      ),
     .clk_no     ( tck_n      ),


### PR DESCRIPTION
We ran into a cascaded BUFG issue in https://github.com/lowRISC/opentitan/pull/8848/ which causes P&R issues on FPGA. The solution is to omit the downstream BUFG and only keep the one at the root (inside the pinmux TAP selection logic).