### PR TITLE
[dv/alert_check] Fix tl_intg_err regression failure

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -91,7 +91,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   virtual task post_apply_reset(string reset_kind = "HARD");
     super.post_apply_reset(reset_kind);
-    if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
 
     // Wait for alert init done, then start the sequence.
     foreach (cfg.list_of_alerts[i]) begin
@@ -99,6 +98,8 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
         wait (cfg.m_alert_agent_cfg[cfg.list_of_alerts[i]].alert_init_done == 1);
       end
     end
+
+    if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();
   endtask
 
   function void pre_randomize();


### PR DESCRIPTION
Alert auto response sequence should be triggered after dut_init is done,
otherwise init process might count as signal integrity errors in
alert_receiver_driver.

Thanks @matutem for reporting this issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>