### PR TITLE
[dv/alert_handler] Add checking for crashdump_o output

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:cip_lib
+      - lowrisc:ip:alert_handler_component # import alert_pkg
     files:
       - alert_handler_env_pkg.sv
       - alert_handler_env_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:cip_lib
+      - lowrisc:ip:alert_handler_component # import alert_pkg
     files:
       - alert_handler_env_pkg.sv
       - alert_handler_env_cfg.sv: {is_include_file: true}


### PR DESCRIPTION
This PR supports checking in scb regarding the crashdumo_o output.
To avoid a cycle-accurate model, I left a TODO to see how to check
esc_cnt and alert_accum_count.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>