### PR TITLE
[dv] Slightly generalise run_stress_all_with_rand_reset_vseq

### DIFF
--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -221,8 +221,8 @@ Some examples:
   response (with `d_error` = 1), but also triggers a fatal alert and updates status CSRs
   such as `ERR_CODE`. The list of CSRs that are impacted by this alert event, maintained
   in `cfg.tl_intg_alert_fields`, are also checked for correctness.
-* **task run_stress_all_with_rand_reset_vseq**: This task runs 3 parallel threads,
-  which are ip_stress_all_vseq, run_tl_errors_vseq and reset sequence. After
+* **task run_seq_with_rand_reset_vseq**: This task runs 3 parallel threads,
+  which are a sequence provided, run_tl_errors_vseq and reset sequence. After
   reset occurs, the other threads will be killed and then all the CSRs will be read
   for check. This task runs multiple iterations to ensure DUT won't be broken after
   reset and TL errors.

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -140,7 +140,7 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
   endtask
 
   // This is called after apply_reset in this class and after apply_resets_concurrently
-  // in cip_base_vseq::run_stress_all_with_rand_reset_vseq.
+  // in cip_base_vseq::run_seq_with_rand_reset_vseq.
   virtual task post_apply_reset(string reset_kind = "HARD");
   endtask
 


### PR DESCRIPTION
*This depends on https://github.com/lowRISC/opentitan/pull/8837. Merge that first, which will leave just the last commit in the PR*

This task was originally designed for running stress sequences,
selected by plusarg. More recently, we taught it to take an optional
sequence argument, which would be used instead of the stress sequence.

Tidy things up a bit, moving the generic stuff that takes a sequence
to a new task (run_seq_with_rand_reset_vseq) and putting the plusargs
handling in a wrapper task.
