### PR TITLE
[otbn,dv] Run Python model with -u

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -265,7 +265,8 @@ ISSWrapper::ISSWrapper() : tmpdir(new TmpDir()) {
       abort();
     }
     // Finally, exec the ISS
-    execl(model_path.c_str(), model_path.c_str(), NULL);
+    execl("/usr/bin/env", "/usr/bin/env", "python3", "-u", model_path.c_str(),
+          NULL);
   }
 
   // We are the parent process and pid is the PID of the child. Close the pipe


### PR DESCRIPTION
This disables buffering at the block level for stdout and stderr in
the Python subprocess. Without this argument, it seems that Python
3.6, at least, buffers sys.stderr at the block level if it doesn't
point at a console. When run under dvsim, it points at the run.log
file.

With this fixed, you can add debug prints to the model with something
like

    print('my message', file=sys.stderr)

and have it appear in the log output. Without the flag, you need to
follow with a sys.stderr.flush() to be sure to see the result.

This isn't a problem with recent versions of Python: it seems that
they changed the default behaviour at some point.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>