### PR TITLE
[sw/silicon_creator] Separate OTBN error codes in mask ROM.

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.h
+++ b/sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/hardened.h"
-#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,9 +82,9 @@ typedef struct ecdsa_p256_message_digest_t {
  * @param result Buffer in which to store the generated signature.
  * @return Result of the operation (OK or error).
  */
-rom_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
-                            const ecdsa_p256_private_key_t *private_key,
-                            ecdsa_p256_signature_t *result);
+otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
+                             const ecdsa_p256_private_key_t *private_key,
+                             ecdsa_p256_signature_t *result);
 
 /**
  * Verifies an ECDSA/P-256 signature.
@@ -95,10 +95,10 @@ rom_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
  * @param result Buffer in which to store output (true iff signature is valid)
  * @return Result of the operation (OK or error).
  */
-rom_error_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
-                              const ecdsa_p256_message_digest_t *digest,
-                              const ecdsa_p256_public_key_t *public_key,
-                              hardened_bool_t *result);
+otbn_error_t ecdsa_p256_verify(const ecdsa_p256_signature_t *signature,
+                               const ecdsa_p256_message_digest_t *digest,
+                               const ecdsa_p256_public_key_t *public_key,
+                               hardened_bool_t *result);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h
@@ -64,8 +64,8 @@ typedef struct rsa_3072_constants_t {
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-rom_error_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
-                                rsa_3072_int_t *result);
+otbn_error_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
+                                 rsa_3072_int_t *result);
 
 /**
  * Computes Montgomery constant m0_inv for an RSA-3072 public key.
@@ -74,8 +74,8 @@ rom_error_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-rom_error_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
-                                    uint32_t result[kOtbnWideWordNumWords]);
+otbn_error_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
+                                     uint32_t result[kOtbnWideWordNumWords]);
 
 /**
  * Computes Montgomery constants for an RSA-3072 public key.
@@ -84,8 +84,8 @@ rom_error_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-rom_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
-                                       rsa_3072_constants_t *result);
+otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
+                                        rsa_3072_constants_t *result);
 
 /**
  * Verifies an RSA-3072 signature.
@@ -96,11 +96,11 @@ rom_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
  * @param result Buffer in which to store output (true iff signature is valid)
  * @return Result of the operation (OK or error).
  */
-rom_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
-                            const rsa_3072_int_t *message,
-                            const rsa_3072_public_key_t *public_key,
-                            const rsa_3072_constants_t *constants,
-                            hardened_bool_t *result);
+otbn_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
+                             const rsa_3072_int_t *message,
+                             const rsa_3072_public_key_t *public_key,
+                             const rsa_3072_constants_t *constants,
+                             hardened_bool_t *result);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/crypto/tests/ecdsa_p256_functest.c
+++ b/sw/device/silicon_creator/lib/crypto/tests/ecdsa_p256_functest.c
@@ -5,9 +5,11 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
-#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.h"
-#include "sw/device/silicon_creator/lib/sigverify.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/otbn_util.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
 // Message
@@ -52,11 +54,11 @@ rom_error_t sign_then_verify_test(void) {
 
   // Generate a signature for the message
   LOG_INFO("Signing...");
-  RETURN_IF_ERROR(ecdsa_p256_sign(&digest, &kPrivateKey, &signature));
+  FOLD_OTBN_ERROR(ecdsa_p256_sign(&digest, &kPrivateKey, &signature));
 
   // Verify the signature
   LOG_INFO("Verifying...");
-  RETURN_IF_ERROR(
+  FOLD_OTBN_ERROR(
       ecdsa_p256_verify(&signature, &digest, &kPublicKey, &verificationResult));
 
   // Signature verification is expected to succeed

--- a/sw/device/silicon_creator/lib/crypto/tests/rsa_3072_verify_functest.c
+++ b/sw/device/silicon_creator/lib/crypto/tests/rsa_3072_verify_functest.c
@@ -5,8 +5,8 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/entropy_testutils.h"
-#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
 static const rsa_3072_public_key_t kPublicKey = {
@@ -106,7 +106,7 @@ rom_error_t compute_constants_test(void) {
   rsa_3072_constants_t act_constants;
 
   // Precompute constants
-  RETURN_IF_ERROR(rsa_3072_compute_constants(&kPublicKey, &act_constants));
+  FOLD_OTBN_ERROR(rsa_3072_compute_constants(&kPublicKey, &act_constants));
 
   // Check that RR matches expected value
   for (int i = 0; i < kRsa3072NumWords; i++) {
@@ -128,7 +128,7 @@ rom_error_t compute_constants_test(void) {
 rom_error_t verify_test(void) {
   hardened_bool_t result;
 
-  RETURN_IF_ERROR(rsa_3072_verify(&kSignature, &kMessage, &kPublicKey,
+  FOLD_OTBN_ERROR(rsa_3072_verify(&kSignature, &kMessage, &kPublicKey,
                                   &kExpConstants, &result));
 
   CHECK(result == kHardenedBoolTrue);

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -47,19 +47,19 @@ enum { kBase = TOP_EARLGREY_OTBN_BASE_ADDR };
 /**
  * Ensures that `offset_bytes` and `len` are valid for a given `mem_size`.
  */
-static rom_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
-                                    size_t mem_size) {
+static otbn_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
+                                     size_t mem_size) {
   if (offset_bytes + num_words * sizeof(uint32_t) <
           num_words * sizeof(uint32_t) ||
       offset_bytes + num_words * sizeof(uint32_t) > mem_size) {
-    return kErrorOtbnBadOffsetLen;
+    return kOtbnErrorBadOffsetLen;
   }
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_execute(void) {
+otbn_error_t otbn_execute(void) {
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
 bool otbn_is_busy() {
@@ -71,9 +71,9 @@ void otbn_get_err_bits(otbn_err_bits_t *err_bits) {
   *err_bits = abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
 }
 
-rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
-                            size_t num_words) {
-  RETURN_IF_ERROR(
+otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t num_words) {
+  OTBN_RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
@@ -82,13 +82,13 @@ rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
         src[i]);
   }
 
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
-                            size_t num_words) {
-  RETURN_IF_ERROR(
-      check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
+otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t num_words) {
+  OTBN_RETURN_IF_ERROR(
+      check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
     abs_mmio_write32(
@@ -96,20 +96,20 @@ rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
         src[i]);
   }
 
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
-                           size_t num_words) {
-  RETURN_IF_ERROR(
-      check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
+otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
+                            size_t num_words) {
+  OTBN_RETURN_IF_ERROR(
+      check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
     dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes +
                               i * sizeof(uint32_t));
   }
 
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
 void otbn_zero_dmem(void) {
@@ -118,7 +118,7 @@ void otbn_zero_dmem(void) {
   }
 }
 
-rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
   // Only one bit in the CTRL register so no need to read current value.
   uint32_t new_ctrl;
 
@@ -130,8 +130,8 @@ rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
 
   abs_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
   if (abs_mmio_read32(kBase + OTBN_CTRL_REG_OFFSET) != new_ctrl) {
-    return kErrorOtbnUnavailable;
+    return kOtbnErrorUnavailable;
   }
 
-  return kErrorOk;
+  return kOtbnErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -9,8 +9,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/silicon_creator/lib/error.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,12 +44,41 @@ typedef enum otbn_status {
 } otbn_status_t;
 
 /**
+ * Error codes for the OTBN driver.
+ */
+typedef enum otbn_error_t {
+  /** No errors. */
+  kOtbnErrorOk = 0,
+  /** Invalid argument provided to OTBN interface function. */
+  kOtbnErrorInvalidArgument = 1,
+  /** Invalid offset provided. */
+  kOtbnErrorBadOffsetLen = 2,
+  /** OTBN internal error; use otbn_get_err_bits for specific error codes. */
+  kOtbnErrorExecutionFailed = 3,
+  /** Attempt to interact with OTBN while it was unavailable. */
+  kOtbnErrorUnavailable = 4,
+} otbn_error_t;
+
+/**
+ * Evaluate an expression and return if the result is an error.
+ *
+ * @param expr_ An expression which results in an otbn_error_t.
+ */
+#define OTBN_RETURN_IF_ERROR(expr_)     \
+  do {                                  \
+    otbn_error_t local_error_ = expr_;  \
+    if (local_error_ != kOtbnErrorOk) { \
+      return local_error_;              \
+    }                                   \
+  } while (0)
+
+/**
  * Start the execution of the application loaded into OTBN
  *
- * @return `kErrorOtbnInvalidArgument` if `start_addr` is invalid, `kErrorOk`
- *         otherwise.
+ * @return `kOtbnErrorInvalidArgument` if `start_addr` is invalid,
+ * `kOtbnErrorOk` otherwise.
  */
-rom_error_t otbn_execute(void);
+otbn_error_t otbn_execute(void);
 
 /**
  * Is OTBN busy executing an application?
@@ -61,7 +88,7 @@ rom_error_t otbn_execute(void);
 bool otbn_is_busy(void);
 
 /**
- * OTBN Errors
+ * OTBN Internal Errors
  *
  * OTBN uses a bitfield to indicate which errors have been seen. Multiple errors
  * can be seen at the same time. This enum gives the individual bits that may be
@@ -110,11 +137,11 @@ void otbn_get_err_bits(otbn_err_bits_t *err_bits);
  * @param offset_bytes the byte offset in IMEM the first word is written to
  * @param src the main memory location to start reading from.
  * @param len number of words to copy.
- * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
- * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
+ * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
+ * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
  */
-rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
-                            size_t len);
+otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t len);
 
 /**
  * Write to OTBN's data memory (DMEM)
@@ -124,11 +151,11 @@ rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
  * @param offset_bytes the byte offset in DMEM the first word is written to
  * @param src the main memory location to start reading from.
  * @param len number of words to copy.
- * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
- * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
+ * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
+ * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
  */
-rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
-                            size_t len);
+otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t len);
 
 /**
  * Read from OTBN's data memory (DMEM)
@@ -138,10 +165,10 @@ rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
  * @param offset_bytes the byte offset in DMEM the first word is read from
  * @param[out] dest the main memory location to copy the data to (preallocated)
  * @param len number of words to copy.
- * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
- * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
+ * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
+ * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
  */
-rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len);
+otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len);
 
 /**
  * Zero out the contents of OTBN's data memory (DMEM).
@@ -155,10 +182,10 @@ void otbn_zero_dmem(void);
  * changed when the OTBN status is IDLE.
  *
  * @param enable Enable or disable whether software errors are fatal.
- * @return `kErrorOtbnUnavailable` if the requested change cannot be made or
- * `kErrorOk` otherwise.
+ * @return `kOtbnErrorUnavailable` if the requested change cannot be made or
+ * `kOtbnErrorOk` otherwise.
  */
-rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
+otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -32,7 +32,7 @@ TEST_F(StartTest, Success) {
   // Send EXECUTE command.
   EXPECT_ABS_WRITE32(base_ + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
 
-  EXPECT_EQ(otbn_execute(), kErrorOk);
+  EXPECT_EQ(otbn_execute(), kOtbnErrorOk);
 }
 
 class IsBusyTest : public OtbnTest {};
@@ -60,14 +60,14 @@ TEST_F(ImemWriteTest, BadAddressBeyondMemorySize) {
   std::array<uint32_t, 2> test_data = {0};
 
   EXPECT_EQ(otbn_imem_write(OTBN_IMEM_SIZE_BYTES, test_data.data(), 1),
-            kErrorOtbnBadOffsetLen);
+            kOtbnErrorBadOffsetLen);
 }
 
 TEST_F(ImemWriteTest, BadAddressIntegerOverflow) {
   std::array<uint32_t, 4> test_data = {0};
 
   EXPECT_EQ(otbn_imem_write(0xFFFFFFFC, test_data.data(), 1),
-            kErrorOtbnBadOffsetLen);
+            kOtbnErrorBadOffsetLen);
 }
 
 TEST_F(ImemWriteTest, SuccessWithoutOffset) {
@@ -79,7 +79,7 @@ TEST_F(ImemWriteTest, SuccessWithoutOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[1]);
 
-  EXPECT_EQ(otbn_imem_write(0, test_data.data(), 2), kErrorOk);
+  EXPECT_EQ(otbn_imem_write(0, test_data.data(), 2), kOtbnErrorOk);
 }
 
 TEST_F(ImemWriteTest, SuccessWithOffset) {
@@ -91,7 +91,7 @@ TEST_F(ImemWriteTest, SuccessWithOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 8, test_data[1]);
 
-  EXPECT_EQ(otbn_imem_write(4, test_data.data(), 2), kErrorOk);
+  EXPECT_EQ(otbn_imem_write(4, test_data.data(), 2), kOtbnErrorOk);
 }
 
 class DmemWriteTest : public OtbnTest {};
@@ -105,7 +105,7 @@ TEST_F(DmemWriteTest, SuccessWithoutOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[1]);
 
-  EXPECT_EQ(otbn_dmem_write(0, test_data.data(), 2), kErrorOk);
+  EXPECT_EQ(otbn_dmem_write(0, test_data.data(), 2), kOtbnErrorOk);
 }
 
 TEST_F(DmemWriteTest, SuccessWithOffset) {
@@ -117,7 +117,7 @@ TEST_F(DmemWriteTest, SuccessWithOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 8, test_data[1]);
 
-  EXPECT_EQ(otbn_dmem_write(4, test_data.data(), 2), kErrorOk);
+  EXPECT_EQ(otbn_dmem_write(4, test_data.data(), 2), kOtbnErrorOk);
 }
 
 class DmemReadTest : public OtbnTest {};
@@ -132,7 +132,7 @@ TEST_F(DmemReadTest, SuccessWithoutOffset) {
 
   std::array<uint32_t, 2> test_data = {0};
 
-  EXPECT_EQ(otbn_dmem_read(0, test_data.data(), 2), kErrorOk);
+  EXPECT_EQ(otbn_dmem_read(0, test_data.data(), 2), kOtbnErrorOk);
   EXPECT_THAT(test_data, ElementsAre(0x12345678, 0xabcdef01));
 }
 
@@ -145,7 +145,7 @@ TEST_F(DmemReadTest, SuccessWithOffset) {
 
   std::array<uint32_t, 2> test_data = {0};
 
-  EXPECT_EQ(otbn_dmem_read(4, test_data.data(), 2), kErrorOk);
+  EXPECT_EQ(otbn_dmem_read(4, test_data.data(), 2), kOtbnErrorOk);
   EXPECT_THAT(test_data, ElementsAre(0x12345678, 0xabcdef01));
 }
 
@@ -155,14 +155,14 @@ TEST_F(ControlSoftwareErrorsFatalTest, Success) {
   EXPECT_ABS_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
   EXPECT_ABS_READ32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
 
-  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(true), kErrorOk);
+  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(true), kOtbnErrorOk);
 }  // namespace
 
 TEST_F(ControlSoftwareErrorsFatalTest, Failure) {
   EXPECT_ABS_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x0);
   EXPECT_ABS_READ32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
 
-  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(false), kErrorOtbnUnavailable);
+  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(false), kOtbnErrorUnavailable);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -91,10 +91,7 @@ enum module_ {
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
-  X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
-  X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \
-  X(kErrorOtbnExecutionFailed,        ERROR_(3, kModuleOtbn, kInternal)), \
-  X(kErrorOtbnUnavailable,            ERROR_(4, kModuleOtbn, kFailedPrecondition)), \
+  X(kErrorOtbnInternal,               ERROR_(4, kModuleOtbn, kInternal)), \
   X(kErrorFlashCtrlInvalidArgument,   ERROR_(1, kModuleFlashCtrl, kInvalidArgument)), \
   X(kErrorFlashCtrlBusy,              ERROR_(2, kModuleFlashCtrl, kUnavailable)), \
   X(kErrorFlashCtrlInternal,          ERROR_(3, kModuleFlashCtrl, kInternal)), \

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -11,7 +11,6 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
-#include "sw/device/silicon_creator/lib/error.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
@@ -23,16 +22,16 @@ void otbn_init(otbn_t *ctx) {
   };
 }
 
-rom_error_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
-                                       uint32_t *dmem_addr_otbn) {
+otbn_error_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
+                                        uint32_t *dmem_addr_otbn) {
   if (ptr < ctx->app.dmem_start || ptr > ctx->app.dmem_end) {
-    return kErrorOtbnInvalidArgument;
+    return kOtbnErrorInvalidArgument;
   }
   *dmem_addr_otbn = (uintptr_t)ptr - (uintptr_t)ctx->app.dmem_start;
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
+otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
   while (otbn_is_busy()) {
   }
 
@@ -40,14 +39,14 @@ rom_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
   otbn_get_err_bits(&err_bits);
   if (err_bits != kOtbnErrBitsNoError) {
     ctx->error_bits = err_bits;
-    return kErrorOtbnExecutionFailed;
+    return kOtbnErrorExecutionFailed;
   }
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
+otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
   if (app.imem_end <= app.imem_start || app.dmem_end < app.dmem_start) {
-    return kErrorOtbnInvalidArgument;
+    return kOtbnErrorInvalidArgument;
   }
 
   const size_t imem_num_words = app.imem_end - app.imem_start;
@@ -55,40 +54,40 @@ rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
 
   ctx->app_is_loaded = false;
 
-  RETURN_IF_ERROR(otbn_imem_write(0, app.imem_start, imem_num_words));
+  OTBN_RETURN_IF_ERROR(otbn_imem_write(0, app.imem_start, imem_num_words));
 
   otbn_zero_dmem();
   if (dmem_num_words > 0) {
-    RETURN_IF_ERROR(otbn_dmem_write(0, app.dmem_start, dmem_num_words));
+    OTBN_RETURN_IF_ERROR(otbn_dmem_write(0, app.dmem_start, dmem_num_words));
   }
 
   ctx->app = app;
   ctx->app_is_loaded = true;
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_execute_app(otbn_t *ctx) {
+otbn_error_t otbn_execute_app(otbn_t *ctx) {
   if (!ctx->app_is_loaded) {
-    return kErrorOtbnInvalidArgument;
+    return kOtbnErrorInvalidArgument;
   }
 
   return otbn_execute();
 }
 
-rom_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len, const uint32_t *src,
-                                   otbn_ptr_t dest) {
+otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
+                                    const uint32_t *src, otbn_ptr_t dest) {
   uint32_t dest_dmem_addr;
-  RETURN_IF_ERROR(otbn_data_ptr_to_dmem_addr(ctx, dest, &dest_dmem_addr));
-  RETURN_IF_ERROR(otbn_dmem_write(dest_dmem_addr, src, len));
+  OTBN_RETURN_IF_ERROR(otbn_data_ptr_to_dmem_addr(ctx, dest, &dest_dmem_addr));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write(dest_dmem_addr, src, len));
 
-  return kErrorOk;
+  return kOtbnErrorOk;
 }
 
-rom_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
-                                     otbn_ptr_t src, uint32_t *dest) {
+otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
+                                      otbn_ptr_t src, uint32_t *dest) {
   uint32_t src_dmem_addr;
-  RETURN_IF_ERROR(otbn_data_ptr_to_dmem_addr(ctx, src, &src_dmem_addr));
-  RETURN_IF_ERROR(otbn_dmem_read(src_dmem_addr, dest, len_bytes));
+  OTBN_RETURN_IF_ERROR(otbn_data_ptr_to_dmem_addr(ctx, src, &src_dmem_addr));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_read(src_dmem_addr, dest, len_bytes));
 
-  return kErrorOk;
+  return kOtbnErrorOk;
 }

--- a/sw/device/silicon_creator/lib/otbn_util.h
+++ b/sw/device/silicon_creator/lib/otbn_util.h
@@ -9,7 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -159,7 +159,7 @@ void otbn_init(otbn_t *ctx);
  * @param app The application to load into OTBN.
  * @return The result of the operation.
  */
-rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
+otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
 
 /**
  * Start the OTBN application.
@@ -169,7 +169,7 @@ rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
  * @param ctx The context object.
  * @return The result of the operation.
  */
-rom_error_t otbn_execute_app(otbn_t *ctx);
+otbn_error_t otbn_execute_app(otbn_t *ctx);
 
 /**
  * Busy waits for OTBN to be done with its operation.
@@ -177,7 +177,7 @@ rom_error_t otbn_execute_app(otbn_t *ctx);
  * @param ctx The context object.
  * @return The result of the operation.
  */
-rom_error_t otbn_busy_wait_for_done(otbn_t *ctx);
+otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx);
 
 /**
  * Copies data from the CPU memory to OTBN data memory.
@@ -188,8 +188,8 @@ rom_error_t otbn_busy_wait_for_done(otbn_t *ctx);
  * @param src Source of the data to copy.
  * @return The result of the operation.
  */
-rom_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len, const uint32_t *src,
-                                   otbn_ptr_t dest);
+otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
+                                    const uint32_t *src, otbn_ptr_t dest);
 
 /**
  * Copies data from OTBN's data memory to CPU memory.
@@ -201,8 +201,8 @@ rom_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len, const uint32_t *src,
  *                  (preallocated).
  * @return The result of the operation.
  */
-rom_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
-                                     const otbn_ptr_t src, uint32_t *dest);
+otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
+                                      const otbn_ptr_t src, uint32_t *dest);
 
 /**
  * Gets the address in OTBN data memory referenced by `ptr`.
@@ -213,8 +213,22 @@ rom_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
  * @return The result of the operation; #kOtbnBadArg if `ptr` is not in the data
  *         memory space of the currently loaded application.
  */
-rom_error_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
-                                       uint32_t *dmem_addr_otbn);
+otbn_error_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
+                                        uint32_t *dmem_addr_otbn);
+
+/**
+ * Evaluate an expression and return a mask ROM error if the result is an
+ * OTBN error.
+ *
+ * @param expr_ An expression which results in an otbn_error_t.
+ */
+#define FOLD_OTBN_ERROR(expr_)          \
+  do {                                  \
+    otbn_error_t local_error_ = expr_;  \
+    if (local_error_ != kOtbnErrorOk) { \
+      return kErrorOtbnInternal;        \
+    }                                   \
+  } while (0)
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "error.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
 #include "sw/device/silicon_creator/lib/otbn_util.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
 #include "sw/device/silicon_creator/lib/sigverify_rsa_key.h"
@@ -23,46 +24,63 @@ static const otbn_ptr_t kOtbnVarRsaModulus = OTBN_PTR_T_INIT(rsa, modulus);
 
 static const uint32_t kOtbnModeEncrypt = 1;
 
-rom_error_t sigverify_mod_exp_otbn(const sigverify_rsa_key_t *key,
-                                   const sigverify_rsa_buffer_t *sig,
-                                   sigverify_rsa_buffer_t *result) {
+/**
+ * Runs the OTBN RSA app for sigverify.
+ *
+ * @param key An RSA public key.
+ * @param sig Buffer that holds the signature, little-endian.
+ * @param result Buffer to write the result to, little-endian.
+ * @return The result of the operation.
+ */
+otbn_error_t sigverify_mod_exp_otbn_run_app(const sigverify_rsa_key_t *key,
+                                            const sigverify_rsa_buffer_t *sig,
+                                            sigverify_rsa_buffer_t *result) {
   static const uint32_t n_limbs = kSigVerifyRsaNumBits / 256;
 
   otbn_t otbn;
   otbn_init(&otbn);
-  RETURN_IF_ERROR(otbn_load_app(&otbn, kOtbnAppRsa));
-
-  // TODO: The OTBN routines should be consistent with ibex exponent support.
-  if (key->exponent != 65537) {
-    return kErrorSigverifyBadExponent;
-  }
+  OTBN_RETURN_IF_ERROR(otbn_load_app(&otbn, kOtbnAppRsa));
 
   // Set mode so start() will jump into rsa_encrypt().
   // NOLINTNEXTLINE(bugprone-sizeof-expression)
-  RETURN_IF_ERROR(
+  OTBN_RETURN_IF_ERROR(
       otbn_copy_data_to_otbn(&otbn, sizeof(kOtbnModeEncrypt) / sizeof(uint32_t),
                              &kOtbnModeEncrypt, kOtbnVarRsaMode));  //
 
   // Set the number of 256-bit limbs for this RSA operation.
   // NOLINTNEXTLINE(bugprone-sizeof-expression)
-  RETURN_IF_ERROR(otbn_copy_data_to_otbn(
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(
       &otbn, sizeof(n_limbs) / sizeof(uint32_t), &n_limbs, kOtbnVarRsaNLimbs));
 
   // Set the modulus.
-  RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kSigVerifyRsaNumWords,
-                                         key->n.data, kOtbnVarRsaModulus));
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kSigVerifyRsaNumWords,
+                                              key->n.data, kOtbnVarRsaModulus));
   // Set the message text.
-  RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kSigVerifyRsaNumWords,
-                                         sig->data, kOtbnVarRsaIn));
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kSigVerifyRsaNumWords,
+                                              sig->data, kOtbnVarRsaIn));
 
   // Start the OTBN routine.
-  RETURN_IF_ERROR(otbn_execute_app(&otbn));
+  OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
 
   // Spin here waiting for OTBN to complete.
-  RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
 
   // Read digest out of OTBN dmem.
-  RETURN_IF_ERROR(otbn_copy_data_from_otbn(&otbn, kSigVerifyRsaNumWords,
-                                           kOtbnVarRsaOut, result->data));
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(&otbn, kSigVerifyRsaNumWords,
+                                                kOtbnVarRsaOut, result->data));
+  return kOtbnErrorOk;
+}
+
+rom_error_t sigverify_mod_exp_otbn(const sigverify_rsa_key_t *key,
+                                   const sigverify_rsa_buffer_t *sig,
+                                   sigverify_rsa_buffer_t *result) {
+  // TODO: The OTBN routines should be consistent with ibex exponent support.
+  if (key->exponent != 65537) {
+    return kErrorSigverifyBadExponent;
+  }
+
+  // Run OTBN application, and convert the OTBN error to a ROM error if needed.
+  FOLD_OTBN_ERROR(sigverify_mod_exp_otbn_run_app(key, sig, result));
+
   return kErrorOk;
 }


### PR DESCRIPTION
Resolves #8937 

In order to make the crypto library more portable, we change the error types in the mask ROM OTBN driver to be OTBN-specific errors instead of generic ROM errors, and then use those error codes in the crypto library as well.

For now, I've defined `OTBN_RETURN_IF_ERROR` (analogous to `rom_error_t`'s `RETURN_IF_ERROR`) to make the porting simpler. This might change later, especially if we can reduce the number of points in the OTBN DMEM interface that are capable of returning errors (e.g. by returning 0s for a DMEM read past the end of the address space instead of erroring). Note that tests still use `rom_error_t` so that they can run with the machinery in `EXECUTE_TEST`.