### PR TITLE
[ spi_host, dv ] Create a simple BFM for testing SPI HOST software

### DIFF
--- a/hw/dv/bfm/spi_eeprom/spi_eeprom_bfm.core
+++ b/hw/dv/bfm/spi_eeprom/spi_eeprom_bfm.core
@@ -1,0 +1,30 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:systems:spi_eeprom_bfm:0.1"
+description: "Simple SPI EPPROM BFM for testing SPI_HOST"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim_generic:rom
+    files:
+      - spi_eeprom_bfm.sv
+    file_type: systemVerilogSource
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/hw/dv/bfm/spi_eeprom/spi_eeprom_bfm.sv
+++ b/hw/dv/bfm/spi_eeprom/spi_eeprom_bfm.sv
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Simple EEPROM BFM for testing SPI Host module.
+//
+//
+
+module spi_eeprom_bfm #(
+  parameter int   Size  = 256,
+  parameter int   AddrW = $clog2(Size),
+  parameter       MemInitFile = ""
+) (
+  input  rst_ni,
+  input  sck_i,
+  input  csb_i,
+  input  sd_i,
+  output sd_o
+);
+
+  localparam logic [7:0] OpCodeSFDP = 8'h5a;
+
+  logic [7:0] sr_i_d, sr_i_q;
+  logic [7:0] sr_o_q, sr_o_d;
+
+  assign sr_i_d = { sr_i_q[6:0], sd_i };
+
+  logic [2:0] bit_cntr_q, bit_cntr_d;
+  logic [8:0] byte_cntr_q, byte_cntr_d;
+
+  assign bit_cntr_d = csb_i ? 3'h7 :
+                      (bit_cntr_q == 3'h0) ? 3'h7 :
+                      bit_cntr_q - 1;
+
+  assign sd_o = sr_o_q[bit_cntr_q];
+
+  assign byte_cntr_d = csb_i ? 1'b0 :
+                       (bit_cntr_q == 3'h0) ? byte_cntr_q + 1 :
+                       byte_cntr_q;
+
+  logic               do_process_input;
+  assign do_process_input = ~csb_i & (bit_cntr_q == 8'h0);
+
+  logic               rst_int_n;
+  assign rst_int_n = ~csb_i & rst_ni;
+
+  typedef enum logic [2:0] {
+    Init,
+    InvalidCmd,
+    Address2,
+    Address1,
+    Address0,
+    ReadEn
+  } spfd_st_e;
+
+  spfd_st_e state_q, state_d;
+
+  logic [23:0] full_address_d, full_address_q;
+
+  logic [AddrW-1:0] address;
+  assign address = full_address_d[AddrW-1:0];
+
+  logic [7:0] sfdp_data;
+
+  prim_rom_pkg::rom_cfg_t unused_cfg;
+  assign unused_cfg = '0;
+
+  prim_generic_rom #(
+    .Width(8),
+    .Depth(Size),
+    .MemInitFile(MemInitFile)
+  ) u_sfdp_rom (
+    .clk_i(~sck_i),
+    .req_i(do_process_input),
+    .addr_i(address),
+    .rdata_o(sfdp_data),
+    .cfg_i(unused_cfg)
+  );
+
+  always_comb begin
+    state_d = state_q;
+    full_address_d = full_address_q;
+    sr_o_d = sr_o_q;
+    if (do_process_input) begin
+      unique case (state_q)
+        Init: begin
+          if (sr_i_q == OpCodeSFDP) begin
+            state_d = Address2;
+          end else begin
+            state_d = InvalidCmd;
+          end
+        end
+        InvalidCmd: begin
+          state_d = InvalidCmd;
+        end
+        Address2: begin
+          full_address_d = {16'h0, sr_i_q};
+          state_d = Address1;
+        end
+        Address1: begin
+          full_address_d = {full_address_q[15:0], sr_i_q};
+          state_d = Address0;
+        end
+        Address0: begin
+          full_address_d = {full_address_q[15:0], sr_i_q};
+          state_d = ReadEn;
+        end
+        ReadEn: begin
+          full_address_d = full_address_q + 1;
+          state_d = ReadEn;
+          sr_o_d = sfdp_data;
+        end
+        default: begin
+          state_d = InvalidCmd;
+        end
+      endcase
+    end
+  end
+
+  // Armed: Support both mode 0 (CPOL=0/CPHA=0) and mode 3 (CPOL=1/CPHA=1) operation by ignoring
+  // falling edges of sck_i until at least one rising edge is detected after csb_i drops.
+  logic               armed;
+
+  // Most state processing is done on falling edge of sck_i.
+  //
+  // Exceptions:
+  // Inputs are latched in on sck_i rising edge.
+  // FSM is armed after first rising edge after csb_i drops.
+
+  always_ff @(negedge sck_i, negedge rst_int_n) begin
+    if (!rst_int_n) begin
+      bit_cntr_q     <= 3'h7;
+      byte_cntr_q    <= 8'h0;
+      state_q        <= Init;
+      full_address_q <= 24'b0;
+      sr_o_q         <= 8'h0;
+    end else begin
+      bit_cntr_q     <= armed ? bit_cntr_d  : bit_cntr_q;
+      byte_cntr_q    <= byte_cntr_d;
+      state_q        <= state_d;
+      full_address_q <= full_address_d;
+      sr_o_q         <= sr_o_d;
+    end
+  end
+
+  always_ff @(posedge sck_i, negedge rst_int_n) begin
+    if (!rst_int_n) begin
+      sr_i_q <= 8'h0;
+      armed <= 1'b0;
+    end else begin
+      sr_i_q <= sr_i_d;
+      armed <= 1'b1;
+    end
+  end
+
+endmodule

--- a/hw/top_earlgrey/chip_earlgrey_verilator.core
+++ b/hw/top_earlgrey/chip_earlgrey_verilator.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:clock_div
       - lowrisc:systems:ast
       - lowrisc:systems:scan_role_pkg
+      - lowrisc:systems:spi_eeprom_bfm
 
     files:
       - rtl/chip_earlgrey_verilator.sv: { file_type: systemVerilogSource }

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -19,6 +19,7 @@ filesets:
       - lowrisc:dv:sw_test_status
       - lowrisc:dv:dv_test_status
       - lowrisc:systems:chip_earlgrey_verilator
+      - lowrisc:systems:spi_eeprom_bfm
     files:
       - chip_sim_tb.sv: { file_type: systemVerilogSource }
       - chip_sim_tb.cc: { file_type: cppSource }

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.cc
@@ -20,6 +20,7 @@ int main(int argc, char **argv) {
   std::string ram1p_adv_scope(
       "u_prim_ram_1p_adv.u_mem."
       "gen_generic.u_impl_generic");
+  std::string eeprom_scope("TOP.chip_sim_tb.u_spi_eeprom");
 
   MemArea rom(top_scope + (".u_rom_ctrl.gen_rom_scramble_enabled.u_rom.u_rom."
                            "u_prim_rom.gen_generic.u_impl_generic"),
@@ -34,11 +35,14 @@ int main(int argc, char **argv) {
   MemArea otp(top_scope + ".u_otp_ctrl.u_otp.gen_generic.u_impl_generic." +
                   ram1p_adv_scope,
               0x4000 / 4, 4);
+  MemArea eepromsfdp(eeprom_scope + ".u_sfdp_rom", 0x100, 1);
 
   memutil.RegisterMemoryArea("rom", 0x8000, &rom);
   memutil.RegisterMemoryArea("ram", 0x10000000u, &ram);
   memutil.RegisterMemoryArea("flash", 0x20000000u, &flash);
   memutil.RegisterMemoryArea("otp", 0x40000000u /* (bogus LMA) */, &otp);
+  memutil.RegisterMemoryArea("eepromsfdp", 0x40010000u /* (bogus LMA) */,
+                             &eepromsfdp);
   simctrl.RegisterExtension(&memutil);
 
   // The initial reset delay must be long enough such that pwr/rst/clkmgr will

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -15,6 +15,10 @@ module chip_sim_tb (
   logic cio_spi_device_sdi_p2d;
   logic cio_spi_device_sdo_d2p, cio_spi_device_sdo_en_d2p;
 
+  logic cio_spi_host0_sck_d2p, cio_spi_host0_csb_d2p;
+  logic cio_spi_host0_sdi_p2d;
+  logic cio_spi_host0_sdo_d2p, cio_spi_host0_sdo_en_d2p;
+
   logic cio_usbdev_sense_p2d;
   logic cio_usbdev_se0_d2p, cio_usbdev_se0_en_d2p;
   logic cio_usbdev_dp_pullup_d2p, cio_usbdev_dp_pullup_en_d2p;
@@ -44,6 +48,13 @@ module chip_sim_tb (
     .cio_spi_device_sdi_p2d_i(cio_spi_device_sdi_p2d),
     .cio_spi_device_sdo_d2p_o(cio_spi_device_sdo_d2p),
     .cio_spi_device_sdo_en_d2p_o(cio_spi_device_sdo_en_d2p),
+
+    // SPI communication with EEPROM BFM
+    .cio_spi_host0_sck_d2p_o(cio_spi_host0_sck_d2p),
+    .cio_spi_host0_csb_d2p_o(cio_spi_host0_csb_d2p),
+    .cio_spi_host0_sdi_p2d_i(cio_spi_host0_sdi_p2d),
+    .cio_spi_host0_sdo_d2p_o(cio_spi_host0_sdo_d2p),
+    .cio_spi_host0_sdo_en_d2p_o(cio_spi_host0_sdo_en_d2p),
 
     // communication with USB
     .cio_usbdev_sense_p2d_i(cio_usbdev_sense_p2d),
@@ -133,6 +144,24 @@ module chip_sim_tb (
     .spi_device_sdi_o     (cio_spi_device_sdi_p2d),
     .spi_device_sdo_i     (cio_spi_device_sdo_d2p),
     .spi_device_sdo_en_i  (cio_spi_device_sdo_en_d2p)
+  );
+
+
+  // SPI EEPROM BFM
+  //
+  // TODO: Manage bidirectional IO
+  // For now assume that sd[0] is always host-to-EEPROM
+  // and sd[1] is always EEPROM-to-host
+
+  logic unused_spi_host0_sdo_en;
+  assign unused_spi_host0_sdo_en = cio_spi_host0_sdo_en_d2p;
+
+  spi_eeprom_bfm u_spi_eeprom (
+    .rst_ni (rst_ni),
+    .sck_i  (cio_spi_host0_sck_d2p),
+    .csb_i  (cio_spi_host0_csb_d2p),
+    .sd_i   (cio_spi_host0_sdo_d2p),
+    .sd_o   (cio_spi_host0_sdi_p2d)
   );
 
   // USB DPI

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -17,12 +17,20 @@ module chip_earlgrey_verilator (
   output logic cio_uart_tx_d2p_o,
   output logic cio_uart_tx_en_d2p_o,
 
-  // communication with SPI
+  // communication with external SPI host
   input cio_spi_device_sck_p2d_i,
   input cio_spi_device_csb_p2d_i,
   input cio_spi_device_sdi_p2d_i,
   output logic cio_spi_device_sdo_d2p_o,
   output logic cio_spi_device_sdo_en_d2p_o,
+
+  // communication with external SPI device BFM
+  // TODO: expand to quad devices
+  output logic cio_spi_host0_sck_d2p_o,
+  output logic cio_spi_host0_csb_d2p_o,
+  input cio_spi_host0_sdi_p2d_i,
+  output logic cio_spi_host0_sdo_d2p_o,
+  output logic cio_spi_host0_sdo_en_d2p_o,
 
   // communication with USB
   input cio_usbdev_sense_p2d_i,
@@ -59,11 +67,12 @@ module chip_earlgrey_verilator (
     dio_in = '0;
     dio_in[DioSpiDeviceSck] = cio_spi_device_sck_p2d_i;
     dio_in[DioSpiDeviceCsb] = cio_spi_device_csb_p2d_i;
-    dio_in[DioSpiDeviceSd0] = cio_spi_device_sdi_p2d_i;
+    dio_in[DioSpiDeviceSd1] = cio_spi_device_sdi_p2d_i;
     dio_in[DioUsbdevSense] = cio_usbdev_sense_p2d_i;
     dio_in[DioUsbdevD] = cio_usbdev_d_p2d_i;
     dio_in[DioUsbdevDp] = cio_usbdev_dp_p2d_i;
     dio_in[DioUsbdevDn] = cio_usbdev_dn_p2d_i;
+    dio_in[DioSpiHost0Sd1] = cio_spi_host0_sdi_p2d_i;
   end
 
   assign cio_usbdev_dn_d2p_o = dio_out[DioUsbdevDn];
@@ -75,6 +84,9 @@ module chip_earlgrey_verilator (
   assign cio_usbdev_dp_pullup_d2p_o = dio_out[DioUsbdevDpPullup];
   assign cio_usbdev_se0_d2p_o = dio_out[DioUsbdevSe0];
   assign cio_spi_device_sdo_d2p_o = dio_out[DioSpiDeviceSd1];
+  assign cio_spi_host0_sck_d2p_o = dio_out[DioSpiHost0Sck];
+  assign cio_spi_host0_csb_d2p_o = dio_out[DioSpiHost0Csb];
+  assign cio_spi_host0_sdo_d2p_o = dio_out[DioSpiHost0Sd0];
 
   assign cio_usbdev_dn_en_d2p_o = dio_oe[DioUsbdevDn];
   assign cio_usbdev_dp_en_d2p_o = dio_oe[DioUsbdevDp];
@@ -85,6 +97,7 @@ module chip_earlgrey_verilator (
   assign cio_usbdev_dp_pullup_en_d2p_o = dio_oe[DioUsbdevDpPullup];
   assign cio_usbdev_se0_en_d2p_o = dio_oe[DioUsbdevSe0];
   assign cio_spi_device_sdo_en_d2p_o = dio_oe[DioSpiDeviceSd1];
+  assign cio_spi_host0_sdo_en_d2p_o = dio_oe[DioSpiHost0Sd0];
 
   logic [pinmux_pkg::NMioPads-1:0] mio_in;
   logic [pinmux_pkg::NMioPads-1:0] mio_out;


### PR DESCRIPTION
- Extremely simple BFM, only supports SFDP accesses
- Connect this BFM into chip_earlgrey_verilator to help validate the SPI_HOST DIF
- Register the EEPROM's SFDP rom as a memory in chip_sim_tb

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>