### PR TITLE
[spi_device] Upload to push entries into Addr FIFO

### DIFF
--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -327,6 +327,8 @@ module spid_upload
 
         if (addrcnt == '0) begin
           st_d = StPayload;
+
+          addrfifo_wvalid = 1'b 1;
         end
       end
 


### PR DESCRIPTION
In previous design, the state machine didnot push the address to the
FIFO. State machine has a checker to move to Payload stage, but did not
assert `addrfifo_wvalid`.

This commit adds the behavior.