### PR TITLE
[otp_ctrl] Convert HW_CFG EN chicken bits to mubi8 types

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -58,11 +58,11 @@
                 },
                 {
                     name:  "EN_CSRNG_SW_APP_READ",
-                    value: "0xA5",
+                    value: false,
                 },
                 {
                     name:  "EN_ENTROPY_SRC_FW_READ",
-                    value: "0xA5",
+                    value: false,
                 },
             ],
         }

--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -58,15 +58,15 @@
                 },
                 {
                     name:  "EN_CSRNG_SW_APP_READ",
-                    value: "0xA5",
+                    value: false,
                 },
                 {
                     name:  "EN_ENTROPY_SRC_FW_READ",
-                    value: "0xA5",
+                    value: false,
                 },
                 {
                     name: "EN_ENTROPY_SRC_FW_OVER",
-                    value: "0xA5",
+                    value: false,
                 }
             ],
         }

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -222,22 +222,26 @@
                 {
                     name:        "EN_SRAM_IFETCH",
                     size:        "1",
-                    inv_default: "0",
+                    ismubi:      true,
+                    inv_default: false
                 },
                 {
                     name:        "EN_CSRNG_SW_APP_READ",
                     size:        "1",
-                    inv_default: "0",
+                    ismubi:      true,
+                    inv_default: false
                 },
                 {
                     name:        "EN_ENTROPY_SRC_FW_READ",
                     size:        "1",
-                    inv_default: "0",
+                    ismubi:      true,
+                    inv_default: false
                 },
                 {
                     name:        "EN_ENTROPY_SRC_FW_OVER",
                     size:        "1",
-                    inv_default: "0",
+                    ismubi:      true,
+                    inv_default: false
                 },
             ],
             desc: '''

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -237,10 +237,10 @@ package otp_ctrl_part_pkg;
   typedef struct packed {
       logic [63:0] hw_cfg_digest;
       logic [31:0] unallocated;
-      logic [7:0] en_entropy_src_fw_over;
-      logic [7:0] en_entropy_src_fw_read;
-      logic [7:0] en_csrng_sw_app_read;
-      logic [7:0] en_sram_ifetch;
+      prim_mubi_pkg::mubi8_t en_entropy_src_fw_over;
+      prim_mubi_pkg::mubi8_t en_entropy_src_fw_read;
+      prim_mubi_pkg::mubi8_t en_csrng_sw_app_read;
+      prim_mubi_pkg::mubi8_t en_sram_ifetch;
       logic [255:0] manuf_state;
       logic [255:0] device_id;
   } otp_hw_cfg_data_t;
@@ -249,10 +249,10 @@ package otp_ctrl_part_pkg;
   parameter otp_hw_cfg_data_t OTP_HW_CFG_DATA_DEFAULT = '{
     hw_cfg_digest: 64'h2CD09F705F291B7A,
     unallocated: 32'h0,
-    en_entropy_src_fw_over: 8'h0,
-    en_entropy_src_fw_read: 8'h0,
-    en_csrng_sw_app_read: 8'h0,
-    en_sram_ifetch: 8'h0,
+    en_entropy_src_fw_over: 8'hA5,
+    en_entropy_src_fw_read: 8'hA5,
+    en_csrng_sw_app_read: 8'hA5,
+    en_sram_ifetch: 8'hA5,
     manuf_state: 256'h41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D523D5C06786AAC34,
     device_id: 256'hFA53B8058E157CB69F1F413E87242971B6B52A656A1CAB7FEBF21E5BF1F45EDD
   };
@@ -295,10 +295,10 @@ package otp_ctrl_part_pkg;
     640'({
       64'h2CD09F705F291B7A,
       32'h0, // unallocated space
-      8'h0,
-      8'h0,
-      8'h0,
-      8'h0,
+      8'hA5,
+      8'hA5,
+      8'hA5,
+      8'hA5,
       256'h41389646B3968A3B128F4AF0AFFC1AAC77ADEFF42376E09D523D5C06786AAC34,
       256'hFA53B8058E157CB69F1F413E87242971B6B52A656A1CAB7FEBF21E5BF1F45EDD
     }),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv.tpl
@@ -169,7 +169,11 @@ package otp_ctrl_part_pkg;
       % if offset != item['offset'] + item['size']:
       logic [${(offset - item['size'] - item['offset']) * 8 - 1}:0] unallocated;<% offset = item['offset'] + item['size'] %>
       % endif
+      % if item['ismubi']:
+      prim_mubi_pkg::mubi${item["size"]*8}_t ${item["name"].lower()};<% offset -= item['size'] %>
+      % else:
       logic [${int(item["size"])*8-1}:0] ${item["name"].lower()};<% offset -= item['size'] %>
+      % endif
     % endfor
   } otp_${part["name"].lower()}_data_t;
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -46,15 +46,6 @@ package otp_ctrl_pkg;
     DaiDigest = 3'b100
   } dai_cmd_e;
 
-  // Width of HW CFG Enable Fields
-  parameter int OtpEnWidth = 8;
-  typedef logic [OtpEnWidth-1:0] otp_en_t;
-
-  typedef enum logic [7:0] {
-    Disabled = 8'h5A,
-    Enabled = 8'hA5
-  } enable_e;
-
   parameter int DeviceIdWidth = 256;
   typedef logic [DeviceIdWidth-1:0] otp_device_id_t;
 

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -103,12 +103,12 @@
       default: "lc_ctrl_pkg::Off"
       package: "lc_ctrl_pkg"
     },
-    { struct:  "otp_en",
+    { struct:  "mubi8",
       type:    "uni",
       name:    "otp_en_sram_ifetch",
       act:     "rcv",
-      package: "otp_ctrl_pkg",
-      default: "'0"
+      package: "prim_mubi_pkg",
+      default: "prim_mubi_pkg::MuBi8False"
     },
   ]
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -61,13 +61,13 @@ class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(en_sram_ifetch,
         // 50% chance to enable
         if (is_valid) {
-          en_sram_ifetch == otp_ctrl_pkg::Enabled;
+          en_sram_ifetch == MuBi8True;
         } else {
           // 75% chance to set garbage invalid data
           if (is_off == 0) {
-            en_sram_ifetch == otp_ctrl_pkg::Disabled;
+            en_sram_ifetch == MuBi8False;
           } else {
-            !(en_sram_ifetch inside {otp_ctrl_pkg::Enabled, otp_ctrl_pkg::Disabled});
+            !(en_sram_ifetch inside {MuBi8True, MuBi8False});
           }
         }
     )

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cov.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cov.sv
@@ -70,12 +70,12 @@ class sram_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(sram_ctrl_env_cfg));
                                                 logic [2:0] csr_exec);
     // placeholder comment
     en_sram_ifetch_cp: coverpoint en_sram_ifetch {
-      bins sram_ifetch_enable = {otp_ctrl_pkg::Enabled};
-      bins sram_ifetch_valid_disable = {otp_ctrl_pkg::Disabled};
+      bins sram_ifetch_enable = {prim_mubi_pkg::MuBi8True};
+      bins sram_ifetch_valid_disable = {prim_mubi_pkg::MuBi8False};
       bins sram_ifetch_invalid_disable = {
-          [0 : otp_ctrl_pkg::Disabled-1],
-          [otp_ctrl_pkg::Disabled+1 : otp_ctrl_pkg::Enabled-1],
-          [otp_ctrl_pkg::Enabled+1 : '1]};
+          [0 : prim_mubi_pkg::MuBi8False-1],
+          [prim_mubi_pkg::MuBi8False+1 : prim_mubi_pkg::MuBi8True-1],
+          [prim_mubi_pkg::MuBi8True+1 : '1]};
     }
     lc_hw_debug_en_cp: coverpoint lc_hw_debug_en {
       bins hw_debug_en_on           = {lc_ctrl_pkg::On};

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_exec_if.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_exec_if.sv
@@ -7,12 +7,12 @@ interface sram_ctrl_exec_if;
 
   lc_ctrl_pkg::lc_tx_t lc_hw_debug_en;
 
-  otp_ctrl_pkg::otp_en_t otp_en_sram_ifetch;
+  prim_mubi_pkg::mubi8_t otp_en_sram_ifetch;
 
   // LC escalation signal must be stable before reset ends
   task automatic init();
     lc_hw_debug_en = lc_ctrl_pkg::Off;
-    otp_en_sram_ifetch = otp_ctrl_part_pkg::OTP_HW_CFG_DEFAULT;
+    otp_en_sram_ifetch = prim_mubi_pkg::MuBi8False;
   endtask
 
   task automatic drive_lc_hw_debug_en(bit [3:0] hw_debug_en);
@@ -20,7 +20,7 @@ interface sram_ctrl_exec_if;
   endtask
 
   task automatic drive_otp_en_sram_ifetch(bit [7:0] en_sram_ifetch);
-    otp_en_sram_ifetch = otp_ctrl_pkg::otp_en_t'(en_sram_ifetch);
+    otp_en_sram_ifetch = prim_mubi_pkg::mubi8_t'(en_sram_ifetch);
   endtask
 
 endinterface

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -403,7 +403,7 @@ class sram_ctrl_scoreboard extends cip_base_scoreboard #(
         valid_hw_debug_en = detected_hw_debug_en;
         valid_en_sram_ifetch = detected_en_sram_ifetch;
 
-        allow_ifetch = (valid_en_sram_ifetch == otp_ctrl_pkg::Enabled) ?
+        allow_ifetch = (valid_en_sram_ifetch == prim_mubi_pkg::MuBi8True) ?
                        (valid_csr_exec == prim_mubi_pkg::MuBi4True)           :
                        (valid_hw_debug_en == lc_ctrl_pkg::On);
 

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -42,7 +42,7 @@ module sram_ctrl
   input  lc_ctrl_pkg::lc_tx_t                        lc_escalate_en_i,
   input  lc_ctrl_pkg::lc_tx_t                        lc_hw_debug_en_i,
   // Otp configuration for sram execution
-  input  otp_ctrl_pkg::otp_en_t                      otp_en_sram_ifetch_i,
+  input  prim_mubi_pkg::mubi8_t                      otp_en_sram_ifetch_i,
   // Key request to OTP (running on clk_fixed)
   output otp_ctrl_pkg::sram_otp_key_req_t            sram_otp_key_o,
   input  otp_ctrl_pkg::sram_otp_key_rsp_t            sram_otp_key_i,
@@ -278,6 +278,7 @@ module sram_ctrl
   import prim_mubi_pkg::mubi4_e;
   import prim_mubi_pkg::MuBi4True;
   import prim_mubi_pkg::MuBi4False;
+  import prim_mubi_pkg::mubi8_test_true_strict;
 
   mubi4_e en_ifetch;
   if (InstrExec) begin : gen_instr_ctrl
@@ -286,8 +287,8 @@ module sram_ctrl
     assign lc_ifetch_en = (lc_hw_debug_en_i == lc_ctrl_pkg::On) ? MuBi4True :
                                                                   MuBi4False;
     assign reg_ifetch_en = mubi4_e'(reg2hw.exec.q);
-    assign en_ifetch = (otp_en_sram_ifetch_i == otp_ctrl_pkg::Enabled) ? reg_ifetch_en :
-                                                                         lc_ifetch_en;
+    assign en_ifetch = (mubi8_test_true_strict(otp_en_sram_ifetch_i)) ? reg_ifetch_en :
+                                                                        lc_ifetch_en;
   end else begin : gen_tieoff
     assign en_ifetch = MuBi4False;
 

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3923,12 +3923,12 @@
         }
         {
           name: otp_en_sram_ifetch
-          struct: otp_en
-          package: otp_ctrl_pkg
+          struct: mubi8
+          package: prim_mubi_pkg
           type: uni
           act: rcv
           width: 1
-          default: "'0"
+          default: prim_mubi_pkg::MuBi8False
           inst_name: sram_ctrl_ret_aon
           index: -1
         }
@@ -6217,12 +6217,12 @@
         }
         {
           name: otp_en_sram_ifetch
-          struct: otp_en
-          package: otp_ctrl_pkg
+          struct: mubi8
+          package: prim_mubi_pkg
           type: uni
           act: rcv
           width: 1
-          default: "'0"
+          default: prim_mubi_pkg::MuBi8False
           inst_name: sram_ctrl_main
           top_signame: sram_ctrl_main_otp_en_sram_ifetch
           index: -1
@@ -15948,12 +15948,12 @@
       }
       {
         name: otp_en_sram_ifetch
-        struct: otp_en
-        package: otp_ctrl_pkg
+        struct: mubi8
+        package: prim_mubi_pkg
         type: uni
         act: rcv
         width: 1
-        default: "'0"
+        default: prim_mubi_pkg::MuBi8False
         inst_name: sram_ctrl_ret_aon
         index: -1
       }
@@ -17163,12 +17163,12 @@
       }
       {
         name: otp_en_sram_ifetch
-        struct: otp_en
-        package: otp_ctrl_pkg
+        struct: mubi8
+        package: prim_mubi_pkg
         type: uni
         act: rcv
         width: 1
-        default: "'0"
+        default: prim_mubi_pkg::MuBi8False
         inst_name: sram_ctrl_main
         top_signame: sram_ctrl_main_otp_en_sram_ifetch
         index: -1
@@ -21000,13 +21000,13 @@
         default: ""
       }
       {
-        package: otp_ctrl_pkg
-        struct: otp_en
+        package: prim_mubi_pkg
+        struct: mubi8
         signame: sram_ctrl_main_otp_en_sram_ifetch
         width: 1
         type: uni
         end_idx: -1
-        default: "'0"
+        default: prim_mubi_pkg::MuBi8False
       }
     ]
   }

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -725,7 +725,7 @@ module top_earlgrey #(
   otp_ctrl_pkg::otp_device_id_t       lc_ctrl_otp_device_id;
   otp_ctrl_pkg::otp_manuf_state_t       lc_ctrl_otp_manuf_state;
   otp_ctrl_pkg::otp_device_id_t       keymgr_otp_device_id;
-  otp_ctrl_pkg::otp_en_t       sram_ctrl_main_otp_en_sram_ifetch;
+  prim_mubi_pkg::mubi8_t       sram_ctrl_main_otp_en_sram_ifetch;
 
   // define mixed connection to port
   assign edn0_edn_req[2] = ast_edn_req_i;
@@ -761,12 +761,9 @@ module top_earlgrey #(
   // OTP HW_CFG Broadcast signals.
   // TODO(#6713): The actual struct breakout and mapping currently needs to
   // be performed by hand.
-  assign csrng_otp_en_csrng_sw_app_read =
-    prim_mubi_pkg::mubi8_e'(otp_ctrl_otp_hw_cfg.data.en_csrng_sw_app_read);
-  assign entropy_src_otp_en_entropy_src_fw_read =
-    prim_mubi_pkg::mubi8_e'(otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_read);
-  assign entropy_src_otp_en_entropy_src_fw_over =
-    prim_mubi_pkg::mubi8_e'(otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_over);
+  assign csrng_otp_en_csrng_sw_app_read = otp_ctrl_otp_hw_cfg.data.en_csrng_sw_app_read;
+  assign entropy_src_otp_en_entropy_src_fw_read = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_read;
+  assign entropy_src_otp_en_entropy_src_fw_over = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_over;
   assign sram_ctrl_main_otp_en_sram_ifetch = otp_ctrl_otp_hw_cfg.data.en_sram_ifetch;
   assign lc_ctrl_otp_device_id = otp_ctrl_otp_hw_cfg.data.device_id;
   assign lc_ctrl_otp_manuf_state = otp_ctrl_otp_hw_cfg.data.manuf_state;
@@ -1973,7 +1970,7 @@ module top_earlgrey #(
       .cfg_i(ast_ram_1p_cfg),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),
-      .otp_en_sram_ifetch_i('0),
+      .otp_en_sram_ifetch_i(prim_mubi_pkg::MuBi8False),
       .regs_tl_i(sram_ctrl_ret_aon_regs_tl_req),
       .regs_tl_o(sram_ctrl_ret_aon_regs_tl_rsp),
       .ram_tl_i(sram_ctrl_ret_aon_ram_tl_req),

--- a/util/design/mubi/prim_mubi.py
+++ b/util/design/mubi/prim_mubi.py
@@ -24,7 +24,7 @@ N_MAX_NIBBLES = 4
 
 
 def is_width_valid(width):
-    return width % 4 == 0
+    return (width % 4 == 0) and (width // 4 <= N_MAX_NIBBLES) and (width > 0)
 
 
 def mubi_value_as_hexstr(sel: bool, width: int):

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -244,12 +244,9 @@ module top_${top["name"]} #(
   // OTP HW_CFG Broadcast signals.
   // TODO(#6713): The actual struct breakout and mapping currently needs to
   // be performed by hand.
-  assign csrng_otp_en_csrng_sw_app_read =
-    prim_mubi_pkg::mubi8_e'(otp_ctrl_otp_hw_cfg.data.en_csrng_sw_app_read);
-  assign entropy_src_otp_en_entropy_src_fw_read =
-    prim_mubi_pkg::mubi8_e'(otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_read);
-  assign entropy_src_otp_en_entropy_src_fw_over =
-    prim_mubi_pkg::mubi8_e'(otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_over);
+  assign csrng_otp_en_csrng_sw_app_read = otp_ctrl_otp_hw_cfg.data.en_csrng_sw_app_read;
+  assign entropy_src_otp_en_entropy_src_fw_read = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_read;
+  assign entropy_src_otp_en_entropy_src_fw_over = otp_ctrl_otp_hw_cfg.data.en_entropy_src_fw_over;
   assign sram_ctrl_main_otp_en_sram_ifetch = otp_ctrl_otp_hw_cfg.data.en_sram_ifetch;
   assign lc_ctrl_otp_device_id = otp_ctrl_otp_hw_cfg.data.device_id;
   assign lc_ctrl_otp_manuf_state = otp_ctrl_otp_hw_cfg.data.manuf_state;


### PR DESCRIPTION
This adds support for mubi types to the OTP control `HW_CFG` partition.
To that end, the `OtpMemMap` and `OtpMemImg` classes are updated accordingly so that certain fields in the OTP memory map can now be explicitly marked as a mubi type.

Signed-off-by: Michael Schaffner <msf@opentitan.org>