### PR TITLE
[spi_device] Upload payload mask fix

### DIFF
--- a/hw/ip/spi_device/rtl/spid_fifo2sram_adapter.sv
+++ b/hw/ip/spi_device/rtl/spid_fifo2sram_adapter.sv
@@ -74,8 +74,8 @@ module spid_fifo2sram_adapter #(
     always_comb begin
       sram_wdata_o = '0;
       sram_wmask_o = '0;
-      for(int unsigned i = 0; i < SubWordW ; i++) begin
-        if (fifoptr[0+:$clog2(SubWordW)] == i) begin
+      for(int unsigned i = 0; i < NumEntryPerWord ; i++) begin
+        if (fifoptr[0+:SubWordW] == i) begin
           sram_wdata_o[i*FifoWidth+:FifoWidth] = wdata_i;
           sram_wmask_o[i*FifoWidth+:FifoWidth] = {FifoWidth{1'b1}};
         end

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -524,7 +524,8 @@ module spid_upload
   prim_sram_arbiter #(
     .N      (NumSramIntf),
     .SramDw (SramDw),
-    .SramAw (SramAw)
+    .SramAw (SramAw),
+    .EnMask (1'b 1)
   ) u_arbiter (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
Payload arbiter inside `spid_upload` module did not enable `EnMask`
feature. It leads to update payload entries full word. Payload writes a
byte at a time.

Also, the logic calculated the byte lane incorrectly. The for loop index
Should be the number of byte per word (4).