### PR TITLE
[hw/ip] Updated lc_ctrl testplan

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "lc_ctrl"
+  // We have two interfaces to the registers TLUL (default) & JTAG TAP
+  intf: ["", "_jtag"]
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
@@ -42,7 +44,7 @@
             and check state count.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_state_post_trans"]
     }
     {
       name: regwen_during_op
@@ -55,7 +57,7 @@
             - Check that accessing its locked CSRs is gated during the transition operation.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_regwen_during_op"]
     }
     {
       name: lc_prog_failure
@@ -85,7 +87,7 @@
             - Check if lc_state moves to escalation state.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_state_failure"]
     }
     {
       name: lc_errors
@@ -116,17 +118,7 @@
                upon next power cycle
             '''
       milestone: V2
-      tests: []
-    }
-    {
-      name: jtag_access
-      desc: '''
-            This test checks jtag debug interface in lc_ctrl.
-            This test will use both JTAG TAP and TLUL to access the CSR space.
-            All above CSR sequences should be accessible via both interfaces.
-            '''
-      milestone: V2
-      tests: []
+      tests: ["lc_ctrl_security_escalation"]
     }
     {
       name: jtag_priority
@@ -143,7 +135,18 @@
               interfaces.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_jtag_priority"]
+    }
+    {
+      name: jtag_combined_access
+      desc: '''
+            This test checks JTAG TAP and TLUL interfaces can run concurrently without blocking.
+            - The standard CSR RW sequence will test the registers using the TLUL interface - but with some registers skipped
+            - A concurrent sequence, similar to the CSR RW sequence, will access the skipped registers via
+            the JTAG TAP interface.
+            '''
+      milestone: V3
+      tests: ["lc_ctrl_jtag_combined_access"]
     }
     {
       name: stress_all
@@ -151,8 +154,16 @@
             - Combine above sequences in one test to run sequentially, except csr sequence.
             - Randomly add reset between each sequence.
             '''
-      milestone: V2
-      tests: []
+      milestone: V3
+      tests: ["lc_ctrl_stress_all"]
+    }
+    {
+      name: random_parameters
+      desc: '''
+            Smoke test but with RTL parameters randomized
+            '''
+      milestone: V3
+      tests: ["lc_ctrl_random_parameters"]
     }
   ]
 }

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -50,15 +50,106 @@
       name: lc_ctrl_smoke
       uvm_test_seq: lc_ctrl_smoke_vseq
     }
-
     {
       name: lc_ctrl_prog_failure
       uvm_test_seq: lc_ctrl_prog_failure_vseq
     }
-
     {
       name: lc_ctrl_errors
       uvm_test_seq: lc_ctrl_errors_vseq
+    }
+    {
+      name: lc_ctrl_regwen_during_op
+      uvm_test_seq: lc_ctrl_regwen_during_op_vseq
+    }
+    {
+      name: lc_ctrl_state_failure
+      uvm_test_seq: lc_ctrl_state_failure_vseq
+    }
+    {
+      name: lc_ctrl_state_post_trans
+      uvm_test_seq: lc_ctrl_regwen_during_op_vseq
+    }
+    {
+      name: lc_ctrl_security_escalation
+      uvm_test_seq: lc_ctrl_security_escalation_vseq
+    }
+    {
+      name: lc_ctrl_jtag_priority
+      uvm_test_seq: lc_ctrl_jtag_priority_vseq
+    }
+    {
+      name: lc_ctrl_jtag_combined_access
+      uvm_test_seq: lc_ctrl_jtag_combined_access_vseq
+    }
+    {
+      name: lc_ctrl_stress_all
+      uvm_test_seq: lc_ctrl_stress_all_vseq
+    }
+    {
+      name: lc_ctrl_random_parameters
+      uvm_test_seq: lc_ctrl_smoke_vseq
+    }
+    {
+      name: "lc_ctrl_jtag_csr_hw_reset"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_hw_reset", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_rw"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_rw", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 20
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_bit_bash"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_bit_bash", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_aliasing"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_aliasing", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "lc_ctrl_jtag_same_csr_outstanding"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+run_same_csr_outstanding", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 20
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_mem_rw_with_rand_reset"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000",  "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 20
+    }
+
+    {
+      name: "lc_ctrl_jtag_alert_test"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+run_alert_test", "+en_scb=0", "+jtag_csr=1"]
+      reseed: 50
     }
   ]
 


### PR DESCRIPTION
Split JTAG CSR test into separate standard tests via the TLUL or JTAG interface
and a test to check for deadlocks between interfaces by performing
simultaneous accesses.

Added randomized RTL parameters test.

Unified all test names as lc_ctrl_...




Signed-off-by: Nigel Scales <nigel.scales@gmail.com>