### PR TITLE
[fpv] solve regression same tb issue

### DIFF
--- a/hw/formal/tools/dvsim/common_formal_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_formal_cfg.hjson
@@ -53,7 +53,7 @@
     // Add formal sub_flow to the scratch path
     {
       name:  scratch_path
-      value: "{scratch_base_path}/{dut}-{flow}-{sub_flow}-{tool}"
+      value: "{scratch_base_path}/{name}-{flow}-{sub_flow}-{tool}"
     }
   ]
 }

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -64,7 +64,7 @@
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                build_opts: ["-define OutSelDnCnt 0", "-define CntStyle DupCnt"]
-               rel_path: "hw/ip/prim/prim_count/{sub_flow}/{tool}"
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                // TODO: turn on coverage once design finalizes on issue #8343.
                cov: false
              }
@@ -74,7 +74,7 @@
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                build_opts: ["-define OutSelDnCnt 0",  "-define CntStyle CrossCnt"]
-               rel_path: "hw/ip/prim/prim_count/{sub_flow}/{tool}"
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                // TODO: turn on coverage once design finalizes on issue #8343.
                cov: false
              }
@@ -84,7 +84,7 @@
                fusesoc_core: lowrisc:fpv:prim_count_fpv
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                build_opts: ["-define OutSelDnCnt 1", "-define CntStyle CrossCnt"]
-               rel_path: "hw/ip/prim/prim_count/{sub_flow}/{tool}"
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                // TODO: turn on coverage once design finalizes on issue #8343.
                cov: false
              }


### PR DESCRIPTION
The three prim_counter has the same tb name, but different parameters.
So when dvsim create default scratch areas, we cannot use {dut} names,
but actual testbench {name} to create individual test scratch area.

This PR also changes {rel_path} so they each have their own reports
folder.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>