### PR TITLE
[dv/clkmgr rstmgr] Fix post_apply_reset issue

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -27,7 +27,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   bit do_clear_all_interrupts = 1'b1;
 
   // knobs to enable alert auto reponse, once disabled it won't be able to enable again unless
-  // dut_init is issued
+  // reset is issued
   bit en_auto_alerts_response = 1'b1;
 
   // knobs to lock shadow register write access if fatal storage error occurred
@@ -84,10 +84,6 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   `include "cip_base_vseq__tl_errors.svh"
   `include "cip_base_vseq__shadow_reg_errors.svh"
-
-  virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init(reset_kind);
-  endtask
 
   virtual task post_apply_reset(string reset_kind = "HARD");
     super.post_apply_reset(reset_kind);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -187,6 +187,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   endtask
 
   task post_apply_reset(string reset_kind = "HARD");
+    super.post_apply_reset(reset_kind);
     cfg.io_clk_rst_vif.wait_clks(POST_APPLY_RESET_CYCLES);
   endtask
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -74,6 +74,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   endtask
 
   task post_apply_reset(string reset_kind = "HARD");
+    super.post_apply_reset(reset_kind);
     `uvm_info(`gfn, "waiting for fast active after applying reset", UVM_MEDIUM)
     wait_for_fast_fsm_active();
   endtask


### PR DESCRIPTION
This PR fixes the regression error where tl_integrity error failed on
both clkmgr and rstmgr.
The reason is that `post_apply_reset` task did not call super task.
This PR also removes dut_init in cip_base_vseq as there is nothing to
override.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>