### PR TITLE
[clkmgr] Make jitter enable a multi-bit signal for redundancy.

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -195,10 +195,15 @@
       hwaccess: "hro",
       fields: [
         {
-          bits: "0",
+          mubi: true,
+          bits: "3:0",
           name: "VAL",
-          desc: "Enable jittery clock"
-          resval: "0"
+          desc: '''
+            Enable jittery clock.
+            A value of kMultiBitBool4False disables the jittery clock,
+            while all other values enable jittery clock.
+          ''',
+          resval: false
         }
       ]
     },

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -74,6 +74,8 @@
 
   import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::MuBi4True;
+  import prim_mubi_pkg::mubi4_t;
+  import prim_mubi_pkg::mubi4_test_true_loose;
 
   ////////////////////////////////////////////////////
   // Divided clocks
@@ -491,7 +493,7 @@
   assign hw2reg.clk_hints_status.${clk}_val.d = ${clk}_en;
 % endfor
 
-  assign jitter_en_o = reg2hw.jitter_enable.q;
+  assign jitter_en_o = mubi4_test_true_loose(mubi4_t'(reg2hw.jitter_enable.q));
 
   ////////////////////////////////////////////////////
   // Exported clocks

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -58,11 +58,11 @@ interface clkmgr_if (
   } clk_hints_t;
 
   // The CSR values from the testbench side.
-  clk_enables_t        clk_enables_csr;
-  clk_hints_t          clk_hints_csr;
-  lc_ctrl_pkg::lc_tx_t extclk_ctrl_csr_sel;
-  lc_ctrl_pkg::lc_tx_t extclk_ctrl_csr_step_down;
-  logic                jitter_enable_csr;
+  clk_enables_t          clk_enables_csr;
+  clk_hints_t            clk_hints_csr;
+  lc_ctrl_pkg::lc_tx_t   extclk_ctrl_csr_sel;
+  lc_ctrl_pkg::lc_tx_t   extclk_ctrl_csr_step_down;
+  prim_mubi_pkg::mubi4_t jitter_enable_csr;
 
   // The expected and actual divided io clocks.
   logic                exp_clk_io_div2;
@@ -110,7 +110,7 @@ interface clkmgr_if (
     return pwr_o.clk_status;
   endfunction
 
-  function automatic void update_jitter_enable(bit value);
+  function automatic void update_jitter_enable(prim_mubi_pkg::mubi4_t value);
     jitter_enable_csr = value;
   endfunction
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -72,7 +72,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
           if (cfg.clk_rst_vif.rst_n) begin
             @cfg.clkmgr_vif.jitter_enable_csr begin
               cfg.clk_rst_vif.wait_clks(2);
-              `DV_CHECK_EQ(cfg.clkmgr_vif.jitter_en_o, cfg.clkmgr_vif.jitter_enable_csr,
+              `DV_CHECK_EQ(cfg.clkmgr_vif.jitter_en_o,
+                           prim_mubi_pkg::mubi4_test_true_loose(cfg.clkmgr_vif.jitter_enable_csr),
                            "Mismatching jitter enable output")
             end
           end
@@ -82,7 +83,8 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
           if (cfg.clk_rst_vif.rst_n) begin
             @cfg.clkmgr_vif.jitter_en_o begin
               cfg.clk_rst_vif.wait_clks(2);
-              `DV_CHECK_EQ(cfg.clkmgr_vif.jitter_en_o, cfg.clkmgr_vif.jitter_enable_csr,
+              `DV_CHECK_EQ(cfg.clkmgr_vif.jitter_en_o,
+                           prim_mubi_pkg::mubi4_test_true_loose(cfg.clkmgr_vif.jitter_enable_csr),
                            "Mismatching jitter enable output")
             end
           end

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -23,12 +23,12 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
   // This needs to be done outside the various CSR tests, since they update the jitter_enable
   // CSR, but the scoreboard is disabled for those tests.
   task test_jitter();
-    csr_wr(.ptr(ral.jitter_enable), .value(1'b1));
-    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(1'b1));
+    csr_wr(.ptr(ral.jitter_enable), .value(prim_mubi_pkg::MuBi4True));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(prim_mubi_pkg::MuBi4True));
     // And set it back.
     cfg.clk_rst_vif.wait_clks(6);
-    csr_wr(.ptr(ral.jitter_enable), .value(1'b0));
-    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(1'b0));
+    csr_wr(.ptr(ral.jitter_enable), .value('0));
+    csr_rd_check(.ptr(ral.jitter_enable), .compare_value('0));
   endtask
 
   // Flips all clk_enables bits from the reset value with all enabled. All is checked

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -193,10 +193,15 @@
       hwaccess: "hro",
       fields: [
         {
-          bits: "0",
+          mubi: true,
+          bits: "3:0",
           name: "VAL",
-          desc: "Enable jittery clock"
-          resval: "0"
+          desc: '''
+            Enable jittery clock.
+            A value of kMultiBitBool4False disables the jittery clock,
+            while all other values enable jittery clock.
+          ''',
+          resval: false
         }
       ]
     },

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -80,6 +80,8 @@
 
   import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::MuBi4True;
+  import prim_mubi_pkg::mubi4_t;
+  import prim_mubi_pkg::mubi4_test_true_loose;
 
   ////////////////////////////////////////////////////
   // Divided clocks
@@ -1185,7 +1187,7 @@
   assign hw2reg.clk_hints_status.clk_io_div4_otbn_val.de = 1'b1;
   assign hw2reg.clk_hints_status.clk_io_div4_otbn_val.d = clk_io_div4_otbn_en;
 
-  assign jitter_en_o = reg2hw.jitter_enable.q;
+  assign jitter_en_o = mubi4_test_true_loose(mubi4_t'(reg2hw.jitter_enable.q));
 
   ////////////////////////////////////////////////////
   // Exported clocks

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -40,7 +40,7 @@ package clkmgr_reg_pkg;
   } clkmgr_reg2hw_extclk_ctrl_reg_t;
 
   typedef struct packed {
-    logic        q;
+    logic [3:0]  q;
   } clkmgr_reg2hw_jitter_enable_reg_t;
 
   typedef struct packed {
@@ -193,9 +193,9 @@ package clkmgr_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_alert_test_reg_t alert_test; // [119:116]
-    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [115:108]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [107:107]
+    clkmgr_reg2hw_alert_test_reg_t alert_test; // [122:119]
+    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [118:111]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [110:107]
     clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [106:103]
     clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [102:98]
     clkmgr_reg2hw_io_measure_ctrl_reg_t io_measure_ctrl; // [97:77]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -190,8 +190,8 @@ module clkmgr_reg_top (
   logic [3:0] extclk_ctrl_step_down_qs;
   logic [3:0] extclk_ctrl_step_down_wd;
   logic jitter_enable_we;
-  logic jitter_enable_qs;
-  logic jitter_enable_wd;
+  logic [3:0] jitter_enable_qs;
+  logic [3:0] jitter_enable_wd;
   logic clk_enables_we;
   logic clk_enables_clk_io_div4_peri_en_qs;
   logic clk_enables_clk_io_div4_peri_en_wd;
@@ -561,9 +561,9 @@ module clkmgr_reg_top (
 
   // R[jitter_enable]: V(False)
   prim_subreg #(
-    .DW      (1),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
+    .RESVAL  (4'h5)
   ) u_jitter_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -1562,7 +1562,7 @@ module clkmgr_reg_top (
   assign extclk_ctrl_step_down_wd = reg_wdata[7:4];
   assign jitter_enable_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign jitter_enable_wd = reg_wdata[0];
+  assign jitter_enable_wd = reg_wdata[3:0];
   assign clk_enables_we = addr_hit[4] & reg_we & !reg_error;
 
   assign clk_enables_clk_io_div4_peri_en_wd = reg_wdata[0];
@@ -1637,7 +1637,7 @@ module clkmgr_reg_top (
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[0] = jitter_enable_qs;
+        reg_rdata_next[3:0] = jitter_enable_qs;
       end
 
       addr_hit[4]: begin


### PR DESCRIPTION
Fixes #8980

Signed-off-by: Timothy Chen <timothytim@google.com>