### PR TITLE
[sw/testing] Make `CHECK_BUFFER` consistent with other `CHECK*` macros.

### DIFF
--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -22,8 +22,8 @@
  * Checks that the given condition is true. If the condition is false, this
  * function logs and then aborts.
  *
- * @param condition an expression to check.
- * @param ... arguments to a LOG_* macro, which are evaluated if the check
+ * @param condition An expression to check.
+ * @param ... Arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
 #define CHECK(condition, ...)                             \
@@ -53,24 +53,32 @@
  * Prints differences between `actual_` and `expected_` before assigning the
  * comparison `result_` value.
  *
- * @param[out] result_ Result of the comparison.
  * @param actual_ Buffer containing actual values.
  * @param expected_ Buffer containing expected values.
  * @param num_items_ Number of items to compare.
+ * @param ... Arguments to a LOG_* macro, which are evaluated if the check.
  */
-#define CHECK_BUFFER(result_, actual_, expected_, num_items_)                 \
-  do {                                                                        \
-    /* `sizeof(actual_[0])` is used to determine the size of each item in the \
-     * buffer. */                                                             \
-    if (memcmp(actual_, expected_, num_items_ * sizeof(actual_[0])) != 0) {   \
-      for (size_t i = 0; i < num_items_; ++i) {                               \
-        LOG_ERROR("[%d] actual = 0x%x; expected = 0x%x", i, actual_[i],       \
-                  expected_[i]);                                              \
-      }                                                                       \
-      result_ = false;                                                        \
-    } else {                                                                  \
-      result_ = true;                                                         \
-    }                                                                         \
+#define CHECK_BUFFER(actual_, expected_, num_items_, ...)                      \
+  do {                                                                         \
+    /* `sizeof(actual_[0])` is used to determine the size of each item in the  \
+     * buffer. */                                                              \
+    if (memcmp(actual_, expected_, num_items_ * sizeof(actual_[0])) != 0) {    \
+      for (size_t i = 0; i < num_items_; ++i) {                                \
+        LOG_INFO("[%d] actual = 0x%x; expected = 0x%x", i, actual_[i],         \
+                 expected_[i]);                                                \
+      }                                                                        \
+      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) {                      \
+        LOG_ERROR("CHECK-BUFFER-fail: " #actual_ "does not match" #expected_); \
+      } else {                                                                 \
+        LOG_ERROR("CHECK-BUFFER-fail: " __VA_ARGS__);                          \
+      }                                                                        \
+      /* Currently, this macro will call into                                  \
+          the test failure code, which logs                                    \
+          "FAIL" and aborts. In the future,                                    \
+          we will try to condition on whether                                  \
+          or not this is a test.*/                                             \
+      test_status_set(kTestStatusFailed);                                      \
+    }                                                                          \
   } while (false)
 
 /**
@@ -78,8 +86,8 @@
  * different dif_result_t value (defined in sw/device/lib/dif/dif_base.h), this
  * function logs and then aborts.
  *
- * @param DIF call to invoke and check its return value.
- * @param ... arguments to a LOG_* macro, which are evaluated if the check
+ * @param dif_call DIF call to invoke and check its return value.
+ * @param ... Arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
 #define CHECK_DIF_OK(dif_call, ...)                       \

--- a/sw/device/lib/testing/rstmgr_testutils.c
+++ b/sw/device/lib/testing/rstmgr_testutils.c
@@ -18,51 +18,39 @@ bool rstmgr_testutils_is_reset_info(const dif_rstmgr_t *rstmgr,
   return actual_info == info;
 }
 
-bool rstmgr_testutils_compare_alert_info(
+void rstmgr_testutils_compare_alert_info(
     const dif_rstmgr_t *rstmgr,
     dif_rstmgr_alert_info_dump_segment_t *expected_alert_dump,
     size_t dump_size) {
   size_t size_read;
-  bool compare_ok;
   dif_rstmgr_alert_info_dump_segment_t
       actual_alert_dump[DIF_RSTMGR_ALERT_INFO_MAX_SIZE];
 
   if (expected_alert_dump == 0 || dump_size == 0) {
-    return true;
+    return;
   }
 
   CHECK_DIF_OK(dif_rstmgr_alert_info_dump_read(
       rstmgr, actual_alert_dump, DIF_RSTMGR_ALERT_INFO_MAX_SIZE, &size_read));
   CHECK(dump_size <= size_read);
-  CHECK_BUFFER(compare_ok, actual_alert_dump, expected_alert_dump, dump_size);
-  if (!compare_ok) {
-    LOG_ERROR("rstmgr alert_info CSR mismatch");
-    test_status_set(kTestStatusFailed);
-  }
-  return compare_ok;
+  CHECK_BUFFER(actual_alert_dump, expected_alert_dump, dump_size);
 }
 
-bool rstmgr_testutils_compare_cpu_info(
+void rstmgr_testutils_compare_cpu_info(
     const dif_rstmgr_t *rstmgr,
     dif_rstmgr_cpu_info_dump_segment_t *expected_cpu_dump, size_t dump_size) {
   size_t size_read;
-  bool compare_ok;
   dif_rstmgr_cpu_info_dump_segment_t
       actual_cpu_dump[DIF_RSTMGR_CPU_INFO_MAX_SIZE];
 
   if (expected_cpu_dump == 0 || dump_size == 0) {
-    return true;
+    return;
   }
 
   CHECK_DIF_OK(dif_rstmgr_cpu_info_dump_read(
       rstmgr, actual_cpu_dump, DIF_RSTMGR_CPU_INFO_MAX_SIZE, &size_read));
   CHECK(dump_size <= size_read);
-  CHECK_BUFFER(compare_ok, actual_cpu_dump, expected_cpu_dump, dump_size);
-  if (!compare_ok) {
-    LOG_ERROR("rstmgr cpu_info CSR mismatch");
-    test_status_set(kTestStatusFailed);
-  }
-  return compare_ok;
+  CHECK_BUFFER(actual_cpu_dump, expected_cpu_dump, dump_size);
 }
 
 void rstmgr_testutils_pre_reset(const dif_rstmgr_t *rstmgr) {
@@ -88,8 +76,7 @@ void rstmgr_testutils_post_reset(
         "Unexpected reset_info CSR mismatch, expected 0x%x, got 0x%x",
         expected_reset_info, actual_reset_info);
 
-  CHECK(rstmgr_testutils_compare_alert_info(rstmgr, expected_alert_dump,
-                                            alert_dump_size));
-  CHECK(rstmgr_testutils_compare_cpu_info(rstmgr, expected_cpu_dump,
-                                          cpu_dump_size));
+  rstmgr_testutils_compare_alert_info(rstmgr, expected_alert_dump,
+                                      alert_dump_size);
+  rstmgr_testutils_compare_cpu_info(rstmgr, expected_cpu_dump, cpu_dump_size);
 }

--- a/sw/device/lib/testing/rstmgr_testutils.h
+++ b/sw/device/lib/testing/rstmgr_testutils.h
@@ -30,10 +30,8 @@ bool rstmgr_testutils_is_reset_info(const dif_rstmgr_t *rstmgr,
  * @param rstmgr A reset manager handle.
  * @param expected_alert_dump An array holding the expected alert dump.
  * @param dump_size The size of the expected_alert_dump array.
- *
- * @return The result of the comparison.
  */
-bool rstmgr_testutils_compare_alert_info(
+void rstmgr_testutils_compare_alert_info(
     const dif_rstmgr_t *rstmgr,
     dif_rstmgr_alert_info_dump_segment_t *expected_alert_dump,
     size_t dump_size);
@@ -48,10 +46,8 @@ bool rstmgr_testutils_compare_alert_info(
  * @param rstmgr A reset manager handle.
  * @param expected_cpu_dump An array holding the expected cpu dump.
  * @param dump_size The size of the expected_cpu_dump array.
- *
- * @return The result of the comparison.
  */
-bool rstmgr_testutils_compare_cpu_info(
+void rstmgr_testutils_compare_cpu_info(
     const dif_rstmgr_t *rstmgr,
     dif_rstmgr_cpu_info_dump_segment_t *expected_cpu_dump, size_t dump_size);
 

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -46,12 +46,11 @@ static void check_internal_state(const dif_csrng_t *csrng,
   CHECK(got.reseed_counter == expected->reseed_counter);
   CHECK(got.fips_compliance == expected->fips_compliance);
 
-  bool result = false;
-  CHECK_BUFFER(result, got.v, expected->v, ARRAYSIZE(expected->v));
-  CHECK(result, "CSRNG internal V buffer mismatch.");
+  CHECK_BUFFER(got.v, expected->v, ARRAYSIZE(expected->v),
+               "CSRNG internal V buffer mismatch.");
 
-  CHECK_BUFFER(result, got.key, expected->key, ARRAYSIZE(expected->key));
-  CHECK(result, "CSRNG internal K buffer mismatch.");
+  CHECK_BUFFER(got.key, expected->key, ARRAYSIZE(expected->key),
+               "CSRNG internal K buffer mismatch.");
 }
 
 /**
@@ -125,9 +124,8 @@ static void fips_generate_kat(const dif_csrng_t *csrng) {
       0x2581f391, 0x80b1dc2f, 0xdf82ab22, 0x771c619b, 0xd40fccb1, 0x87189e99,
       0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9};
 
-  bool result = false;
-  CHECK_BUFFER(result, got, kExpectedOutput, kExpectedOutputLen);
-  CHECK(result, "Generate command KAT output mismatch");
+  CHECK_BUFFER(got, kExpectedOutput, kExpectedOutputLen,
+               "Generate command KAT output mismatch");
 }
 
 /**


### PR DESCRIPTION
The `CHECK_BUFFER(...)` macro in `sw/device/lib/testing/check.h` has a slightly different format than other `CHECK*(...)` macros. Specifically it does not set the test status directly, and does not support printing a user-supplied error message. The result tests having to call the `CHECK_BUFFER(...)` macro followed by the `CHECK(...)` macro in test code.

This PR makes the `CHECK_BUFFER(...)` macro look more like the `CHECK(...)` macro.

This fixed #9002.

Signed-off-by: Timothy Trippel <ttrippel@google.com>