### PR TITLE
[dv] Test security countermeasures

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -16,6 +16,7 @@ package cip_base_pkg;
   import push_pull_agent_pkg::*;
   import mem_model_pkg::*;
   import prim_mubi_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:dv:push_pull_agent
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:mem_model
+      - lowrisc:dv:sec_cm
       - lowrisc:opentitan:bus_params_pkg
     files:
       - cip_base_pkg.sv
@@ -29,6 +30,7 @@ filesets:
       - seq_lib/cip_base_vseq.sv: {is_include_file: true}
       - seq_lib/cip_base_vseq__tl_errors.svh: {is_include_file: true}
       - seq_lib/cip_base_vseq__shadow_reg_errors.svh: {is_include_file: true}
+      - seq_lib/cip_base_vseq__sec_cm_fi.svh: {is_include_file: true}
       - seq_lib/cip_tl_seq_item.sv: {is_include_file: true}
       - seq_lib/cip_tl_host_single_seq.sv: {is_include_file: true}
       - cip_base_test.sv: {is_include_file: true}

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -86,6 +86,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
 
   `include "cip_base_vseq__tl_errors.svh"
   `include "cip_base_vseq__shadow_reg_errors.svh"
+  `include "cip_base_vseq__sec_cm_fi.svh"
 
   virtual task post_apply_reset(string reset_kind = "HARD");
     super.post_apply_reset(reset_kind);
@@ -387,6 +388,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       "mem_partial_access":            run_mem_partial_access_vseq(num_times);
       "csr_mem_rw_with_rand_reset":    run_csr_mem_rw_with_rand_reset_vseq(num_times);
       "csr_mem_rw":                    run_csr_mem_rw_vseq(num_times);
+      "sec_cm_fi":                     run_sec_cm_fi_vseq(num_times);
       default:                         run_csr_vseq_wrapper(num_times);
     endcase
   endtask

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO, only support testing hardened count for now
+virtual task run_sec_cm_fi_vseq(int num_times = 1);
+  pre_run_sec_cm_fi_vseq();
+  for (int trans = 1; trans <= num_times; trans++) begin
+    `uvm_info(`gfn, $sformatf("Running run_sec_cm_fi_vseq %0d/%0d", trans, num_times), UVM_LOW)
+    test_sec_cm_fi();
+  end
+  post_run_sec_cm_fi_vseq();
+endtask : run_sec_cm_fi_vseq
+
+// callback task for extended class. We can disable assertions in this task
+virtual task pre_run_sec_cm_fi_vseq();
+endtask : pre_run_sec_cm_fi_vseq
+
+// callback task for extended class
+virtual task post_run_sec_cm_fi_vseq();
+endtask : post_run_sec_cm_fi_vseq
+
+// User should extend this task to add additional check, such as
+// - Check that err_code/fault_status is updated correctly and preserved until reset.
+// - Verify any operations that follow fail (as applicable).
+// refer to ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv as an example
+virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
+  // TODO, it's better to unify these to one alert
+  string sec_cm_alert_name = cfg.tl_intg_alert_name;
+
+  `DV_CHECK_FATAL(sec_cm_alert_name inside {cfg.list_of_alerts},
+                  $sformatf("sec_cm_alert_name (%s) is not inside %p",
+                            sec_cm_alert_name, cfg.list_of_alerts))
+
+  `uvm_info(`gfn, $sformatf("expected fatal alert is triggered for %s", if_proxy.sec_cm_type.name),
+            UVM_LOW)
+
+  // This is a fatal alert and design keeps sending it until reset is issued.
+  // Check alerts are triggered for a few times
+  repeat (5) begin
+    wait_alert_trigger(sec_cm_alert_name, .wait_complete(1));
+  end
+endtask : check_sec_cm_fi_resp
+
+virtual task test_sec_cm_fi();
+  sec_cm_base_if_proxy if_proxy_q[$] = sec_cm_pkg::sec_cm_if_proxy_q;
+
+  if_proxy_q.shuffle();
+  while (if_proxy_q.size) begin
+    sec_cm_base_if_proxy if_proxy = if_proxy_q.pop_front();
+
+    sec_cm_fi_ctrl_svas(if_proxy, .enable(0));
+    sec_cm_inject_fault(if_proxy);
+
+    // Randomly force the cnt to normal value (error will be cleared) to make sure design latches
+    // the error
+    if ($urandom_range(0, 1)) begin
+      sec_cm_restore_fault(if_proxy);
+    end
+
+    check_sec_cm_fi_resp(if_proxy);
+
+    sec_cm_fi_ctrl_svas(if_proxy, .enable(1));
+    // issue hard reset for fatal alert to recover
+    dut_init("HARD");
+  end
+endtask : test_sec_cm_fi
+
+virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);
+  if_proxy.inject_fault();
+endtask : sec_cm_inject_fault
+
+virtual task sec_cm_restore_fault(sec_cm_base_if_proxy if_proxy);
+  if_proxy.restore_fault();
+endtask : sec_cm_restore_fault
+
+virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
+endfunction : sec_cm_fi_ctrl_svas

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -76,6 +76,10 @@
   `define DV_STRINGIFY(I_) `"I_`"
 `endif
 
+`ifndef DUT_HIER_STR
+  `define DUT_HIER_STR `DV_STRINGIFY(`DUT_HIER)
+`endif
+
 // Common check macros used by DV_CHECK error and fatal macros.
 // Note: Should not be called by user code
 `ifndef DV_CHECK

--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Generic countermeasure interface for hardened counter
+//
+// This contains a proxy class and store the object in sec_cm_pkg, which can be used in vseq to
+// control inject_fault and restore_fault
+interface prim_count_if #(
+  parameter int Width = 2,
+  parameter prim_count_pkg::prim_count_style_e CntStyle = prim_count_pkg::DupCnt
+) (
+  input clk_i,
+  input rst_ni);
+
+  localparam int ErrorToAlertMaxCycles = 5;
+
+  string msg_id = $sformatf("%m");
+
+  prim_count_pkg::prim_count_style_e cnt_style = CntStyle;
+
+  string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
+  string signal_forced;
+
+  class prim_count_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
+    `uvm_object_new
+
+    logic[Width-1:0] orig_value;
+
+    virtual task inject_fault();
+      logic[Width-1:0] force_value;
+
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_read(signal_forced, orig_value))
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value, force_value != orig_value;)
+      uvm_hdl_deposit(signal_forced, force_value);
+      `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
+                                  signal_forced, orig_value, force_value), UVM_LOW)
+
+      @(posedge clk_i);
+    endtask
+
+    virtual task restore_fault();
+      uvm_hdl_deposit(signal_forced, orig_value);
+      `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
+                UVM_LOW)
+    endtask
+  endclass
+
+  prim_count_if_proxy if_proxy;
+
+  initial begin
+    case (cnt_style)
+      prim_count_pkg::CrossCnt: signal_forced = $sformatf("%s.up_cnt_q", path);
+      prim_count_pkg::DupCnt: signal_forced = $sformatf("%s.up_cnt_q[0]", path);
+      default: `uvm_fatal(msg_id, $sformatf("unsupported style %s", cnt_style.name()))
+    endcase
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced), , msg_id)
+
+    // Store the proxy object for TB to use
+    if_proxy = new("if_proxy");
+    if_proxy.sec_cm_type = sec_cm_pkg::SecCmPrimCount;
+    if_proxy.path = path;
+    sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
+
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+  end
+endinterface

--- a/hw/dv/sv/sec_cm/sec_cm.core
+++ b/hw/dv/sv/sec_cm/sec_cm.core
@@ -1,0 +1,24 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:sec_cm"
+description: "Common interfaces used in DV"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:prim:alert
+      - lowrisc:prim:count
+      - lowrisc:dv:dv_utils
+    files:
+      - sec_cm_pkg.sv
+      - sec_cm_base_if_proxy.sv: {is_include_file: true}
+      - prim_count_if.sv
+      - sec_cm_bind.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/sec_cm/sec_cm_base_if_proxy.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_base_if_proxy.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the base proxy class for all the sec_cm interfaces.
+virtual class sec_cm_base_if_proxy extends uvm_object;
+  sec_cm_type_e sec_cm_type;
+  string path;
+
+  `uvm_object_new
+
+  pure virtual task inject_fault();
+  pure virtual task restore_fault();
+endclass

--- a/hw/dv/sv/sec_cm/sec_cm_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_bind.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module sec_cm_bind();
+  bind prim_count prim_count_if #(.CntStyle(CntStyle), .Width(Width)) u_prim_count_if (.*);
+endmodule

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package sec_cm_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import prim_alert_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // package variables
+  string msg_id = "sec_cm_pkg";
+
+  typedef enum int {
+    SecCmPrimCount,
+    SecCmPrimFsm
+  } sec_cm_type_e;
+
+  `include "sec_cm_base_if_proxy.sv"
+
+  // store all the sec_cm proxy classes
+  sec_cm_base_if_proxy sec_cm_if_proxy_q[$];
+endpackage

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -66,7 +66,8 @@
                "+define+UVM_REG_ADDR_WIDTH={tl_aw}",
                "+define+UVM_REG_DATA_WIDTH={tl_dw}",
                "+define+UVM_REG_BYTENABLE_WIDTH={tl_dbw}",
-               "+define+SIMULATION"]
+               "+define+SIMULATION",
+               "+define+DUT_HIER={dut_instance}"]
 
   run_opts: ["+UVM_NO_RELNOTES",
              "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]

--- a/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  tests: [
+    {
+      name: "{name}_sec_cm"
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+run_sec_cm_fi", "+en_scb=0"]
+      reseed: 5
+    }
+  ]
+}

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1165,5 +1165,8 @@ module flash_ctrl
   `ASSERT(OutofBoundsReq_A, unused_op_valid & op_addr_oob |-> ~flash_phy_req.req)
 
   // add more assertions
-
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,
+                                         alert_tx_o[0])
 endmodule

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1166,5 +1166,8 @@ module flash_ctrl
   `ASSERT(OutofBoundsReq_A, unused_op_valid & op_addr_oob |-> ~flash_phy_req.req)
 
   // add more assertions
-
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,
+                                         alert_tx_o[0])
 endmodule

--- a/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_pkg.sv
@@ -14,6 +14,7 @@ package keymgr_env_pkg;
   import csr_utils_pkg::*;
   import keymgr_ral_pkg::*;
   import kmac_app_agent_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -171,7 +171,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
                               current_state.name, operation.name, is_good_op), UVM_MEDIUM)
 
     // wait for status to get out of OpWip and check
-    csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip),
+    csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip), .timeout_ns(100_000),
                  .compare_op(CompareOpNe), .spinwait_delay_ns($urandom_range(0, 100)));
 
     exp_status = is_good_op ? keymgr_pkg::OpDoneSuccess : keymgr_pkg::OpDoneFail;

--- a/hw/ip/keymgr/dv/keymgr_sim.core
+++ b/hw/ip/keymgr/dv/keymgr_sim.core
@@ -11,6 +11,7 @@ filesets:
 
   files_dv:
     depend:
+      - lowrisc:dv:sec_cm
       - lowrisc:dv:keymgr_test
       - lowrisc:dv:keymgr_sva
     files:

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -33,11 +33,12 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 
   // Add additional tops for simulation.
-  sim_tops: ["keymgr_bind"]
+  sim_tops: ["keymgr_bind", "sec_cm_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -653,4 +653,8 @@ module keymgr
   `ASSERT_INIT(FaultCntMatch_A, FaultLastPos == AsyncFaultLastIdx + SyncFaultLastIdx)
   `ASSERT_INIT(ErrCntMatch_A, ErrLastPos == AsyncErrLastIdx + SyncErrLastIdx)
 
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CtrlCntAlertCheck_A, u_ctrl.u_cnt, alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(KmacIfCntAlertCheck_A, u_kmac_if.u_cnt, alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ReseedCtrlCntAlertCheck_A, u_reseed_ctrl.u_reseed_cnt,
+                                         alert_tx_o[0])
 endmodule // keymgr

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1172,5 +1172,8 @@ module flash_ctrl
   `ASSERT(OutofBoundsReq_A, unused_op_valid & op_addr_oob |-> ~flash_phy_req.req)
 
   // add more assertions
-
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,
+                                         alert_tx_o[0])
 endmodule


### PR DESCRIPTION
I closed #8385 to make some changes. But looks like I'm not able to re-open it any more.
So this is created.

Only support testing prim_count and enable this test in keymgr
Also reduce timeout for spinwait of op_status in keymgr
Add assertion for prim_count in keymgr and flash_ctrl

Signed-off-by: Weicai Yang <weicai@google.com>