### PR TITLE
[flash_ctrl/dv] Fix small bank erase bkdr bug & make info1 read-only by default

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -140,7 +140,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     max_flash_ops_per_cfg = 50;
 
     op_readonly_on_info_partition = 0;
-    op_readonly_on_info1_partition = 0;
+    // info1 partition will be read-only by default
+    op_readonly_on_info1_partition = 1;
 
     op_erase_type_bank_pc = 20;
     op_max_words = 512;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -58,6 +58,10 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
       FlashPartRedundancy   :/ cfg.seq_cfg.op_on_redundancy_partition_pc
     };
 
+    // Bank erase is supported only for data & 1st info partitions
+    flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
+        flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+
     if (cfg.seq_cfg.op_readonly_on_info_partition) {
       flash_op.partition == FlashPartInfo ->
         flash_op.op == flash_ctrl_pkg::FlashOpRead;


### PR DESCRIPTION
Hi,
This PR mainly came to fix small bug in bank erase back-door check.
The problem is that the back-door interface uses overall address instead of relative address. Each bank has its own back-door interface and so when the interface of bank1 is asked to read the overall address of bank1 starting address it reports an overflow error, since this address is larger then its defined range.
In addition, this PR is making info1 partition to be read-only by default and allowing bank erase to be sent only to data and 1st info partition.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>