### PR TITLE
[csrng/rtl] replace gen command rep counter with hardened version

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:count
       - lowrisc:prim:assert
       - lowrisc:prim:lc_sync
       - lowrisc:ip:tlul

--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -524,6 +524,16 @@
                 This bit will stay set until firmware clears it.
                 '''
         }
+        { bits: "26",
+          name: "CMD_GEN_CNT_ERR",
+          desc: '''
+                This bit will be set to one when an Generate command counter fatal error
+                has been detected.
+                This error will signal a fatal alert, and also
+                an interrupt if enabled.
+                This bit will stay set until firmware clears it.
+                '''
+        }
         { bits: "28",
           name: "FIFO_WRITE_ERR",
           desc: '''

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -184,6 +184,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [2:0]             ctr_drbg_gen_sfifo_ggenbits_err;
   logic                   block_encrypt_sfifo_blkenc_err_sum;
   logic [2:0]             block_encrypt_sfifo_blkenc_err;
+  logic                   cmd_gen_cnt_err_sum;
   logic                   cmd_stage_sm_err_sum;
   logic                   main_sm_err_sum;
   logic                   main_sm_err;
@@ -288,6 +289,7 @@ module csrng_core import csrng_pkg::*; #(
   logic [NApps-1:0]          cmd_stage_sfifo_genbits_err_wr;
   logic [NApps-1:0]          cmd_stage_sfifo_genbits_err_rd;
   logic [NApps-1:0]          cmd_stage_sfifo_genbits_err_st;
+  logic [NApps-1:0]          cmd_gen_cnt_err;
   logic [NApps-1:0]          cmd_stage_sm_err;
 
   logic [NApps-1:0]          cmd_stage_vld;
@@ -517,6 +519,8 @@ module csrng_core import csrng_pkg::*; #(
          err_code_test_bit[24];
   assign aes_cipher_sm_err_sum = aes_cipher_sm_err ||
          err_code_test_bit[25];
+  assign cmd_gen_cnt_err_sum = (|cmd_gen_cnt_err) ||
+         err_code_test_bit[26];
   assign fifo_write_err_sum =
          block_encrypt_sfifo_blkenc_err[2] ||
          ctr_drbg_gen_sfifo_ggenbits_err[2] ||
@@ -639,6 +643,9 @@ module csrng_core import csrng_pkg::*; #(
   assign hw2reg.err_code.aes_cipher_sm_err.d = 1'b1;
   assign hw2reg.err_code.aes_cipher_sm_err.de = cs_enable && aes_cipher_sm_err_sum;
 
+  assign hw2reg.err_code.cmd_gen_cnt_err.d = 1'b1;
+  assign hw2reg.err_code.cmd_gen_cnt_err.de = cs_enable && cmd_gen_cnt_err_sum;
+
 
  // set the err code type bits
   assign hw2reg.err_code.fifo_write_err.d = 1'b1;
@@ -748,6 +755,7 @@ module csrng_core import csrng_pkg::*; #(
       .genbits_fips_o      (genbits_stage_fips[ai]),
       .cmd_stage_sfifo_cmd_err_o (cmd_stage_sfifo_cmd_err[ai]),
       .cmd_stage_sfifo_genbits_err_o (cmd_stage_sfifo_genbits_err[ai]),
+      .cmd_gen_cnt_err_o  (cmd_gen_cnt_err[ai]),
       .cmd_stage_sm_err_o (cmd_stage_sm_err[ai])
     );
 

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -276,6 +276,10 @@ package csrng_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } cmd_gen_cnt_err;
+    struct packed {
+      logic        d;
+      logic        de;
     } fifo_write_err;
     struct packed {
       logic        d;
@@ -323,14 +327,14 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [185:178]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [177:174]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [173:172]
-    csrng_hw2reg_genbits_reg_t genbits; // [171:140]
-    csrng_hw2reg_int_state_val_reg_t int_state_val; // [139:108]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [107:92]
-    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [91:86]
-    csrng_hw2reg_err_code_reg_t err_code; // [85:36]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [187:180]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [179:176]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [175:174]
+    csrng_hw2reg_genbits_reg_t genbits; // [173:142]
+    csrng_hw2reg_int_state_val_reg_t int_state_val; // [141:110]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [109:94]
+    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [93:88]
+    csrng_hw2reg_err_code_reg_t err_code; // [87:36]
     csrng_hw2reg_tracking_sm_obs_reg_t tracking_sm_obs; // [35:0]
   } csrng_hw2reg_t;
 

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -190,6 +190,7 @@ module csrng_reg_top (
   logic err_code_drbg_updbe_sm_err_qs;
   logic err_code_drbg_updob_sm_err_qs;
   logic err_code_aes_cipher_sm_err_qs;
+  logic err_code_cmd_gen_cnt_err_qs;
   logic err_code_fifo_write_err_qs;
   logic err_code_fifo_read_err_qs;
   logic err_code_fifo_state_err_qs;
@@ -1417,6 +1418,31 @@ module csrng_reg_top (
     .qs     (err_code_aes_cipher_sm_err_qs)
   );
 
+  //   F[cmd_gen_cnt_err]: 26:26
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_err_code_cmd_gen_cnt_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.cmd_gen_cnt_err.de),
+    .d      (hw2reg.err_code.cmd_gen_cnt_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_cmd_gen_cnt_err_qs)
+  );
+
   //   F[fifo_write_err]: 28:28
   prim_subreg #(
     .DW      (1),
@@ -1862,6 +1888,7 @@ module csrng_reg_top (
         reg_rdata_next[23] = err_code_drbg_updbe_sm_err_qs;
         reg_rdata_next[24] = err_code_drbg_updob_sm_err_qs;
         reg_rdata_next[25] = err_code_aes_cipher_sm_err_qs;
+        reg_rdata_next[26] = err_code_cmd_gen_cnt_err_qs;
         reg_rdata_next[28] = err_code_fifo_write_err_qs;
         reg_rdata_next[29] = err_code_fifo_read_err_qs;
         reg_rdata_next[30] = err_code_fifo_state_err_qs;


### PR DESCRIPTION
The generate command has a field that needs to be captured in csrng and decremented as bits are returned back to the requester.
The prim_count module is being used to do this function.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>