### PR TITLE
[csrng/rtl] sw port data attack check added

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -316,6 +316,14 @@
                 Writing a zero resets this status bit.
                 '''
         }
+        { bits: "12",
+          name: "CS_BUS_CMP_ALERT",
+          desc: '''
+                This bit is set when the software application port genbits bus value is equal
+                to the prior valid value on the bus, indicating a possible attack.
+                Writing a zero resets this status bit.
+                '''
+        }
       ]
     },
     {

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -182,6 +182,10 @@ package csrng_reg_pkg;
       logic        d;
       logic        de;
     } read_int_state_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } cs_bus_cmp_alert;
   } csrng_hw2reg_recov_alert_sts_reg_t;
 
   typedef struct packed {
@@ -327,13 +331,13 @@ package csrng_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    csrng_hw2reg_intr_state_reg_t intr_state; // [187:180]
-    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [179:176]
-    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [175:174]
-    csrng_hw2reg_genbits_reg_t genbits; // [173:142]
-    csrng_hw2reg_int_state_val_reg_t int_state_val; // [141:110]
-    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [109:94]
-    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [93:88]
+    csrng_hw2reg_intr_state_reg_t intr_state; // [189:182]
+    csrng_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [181:178]
+    csrng_hw2reg_genbits_vld_reg_t genbits_vld; // [177:176]
+    csrng_hw2reg_genbits_reg_t genbits; // [175:144]
+    csrng_hw2reg_int_state_val_reg_t int_state_val; // [143:112]
+    csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [111:96]
+    csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [95:88]
     csrng_hw2reg_err_code_reg_t err_code; // [87:36]
     csrng_hw2reg_tracking_sm_obs_reg_t tracking_sm_obs; // [35:0]
   } csrng_hw2reg_t;
@@ -408,7 +412,7 @@ package csrng_reg_pkg;
     4'b 0001, // index[10] CSRNG_INT_STATE_NUM
     4'b 1111, // index[11] CSRNG_INT_STATE_VAL
     4'b 0011, // index[12] CSRNG_HW_EXC_STS
-    4'b 0001, // index[13] CSRNG_RECOV_ALERT_STS
+    4'b 0011, // index[13] CSRNG_RECOV_ALERT_STS
     4'b 1111, // index[14] CSRNG_ERR_CODE
     4'b 0001, // index[15] CSRNG_ERR_CODE_TEST
     4'b 0001, // index[16] CSRNG_SEL_TRACKING_SM

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -168,6 +168,8 @@ module csrng_reg_top (
   logic recov_alert_sts_sw_app_enable_field_alert_wd;
   logic recov_alert_sts_read_int_state_field_alert_qs;
   logic recov_alert_sts_read_int_state_field_alert_wd;
+  logic recov_alert_sts_cs_bus_cmp_alert_qs;
+  logic recov_alert_sts_cs_bus_cmp_alert_wd;
   logic err_code_sfifo_cmd_err_qs;
   logic err_code_sfifo_genbits_err_qs;
   logic err_code_sfifo_cmdreq_err_qs;
@@ -864,6 +866,31 @@ module csrng_reg_top (
 
     // to register interface (read)
     .qs     (recov_alert_sts_read_int_state_field_alert_qs)
+  );
+
+  //   F[cs_bus_cmp_alert]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_cs_bus_cmp_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_cs_bus_cmp_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.cs_bus_cmp_alert.de),
+    .d      (hw2reg.recov_alert_sts.cs_bus_cmp_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_cs_bus_cmp_alert_qs)
   );
 
 
@@ -1782,6 +1809,8 @@ module csrng_reg_top (
   assign recov_alert_sts_sw_app_enable_field_alert_wd = reg_wdata[1];
 
   assign recov_alert_sts_read_int_state_field_alert_wd = reg_wdata[2];
+
+  assign recov_alert_sts_cs_bus_cmp_alert_wd = reg_wdata[12];
   assign err_code_test_we = addr_hit[15] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
@@ -1863,6 +1892,7 @@ module csrng_reg_top (
         reg_rdata_next[0] = recov_alert_sts_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_sw_app_enable_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_read_int_state_field_alert_qs;
+        reg_rdata_next[12] = recov_alert_sts_cs_bus_cmp_alert_qs;
       end
 
       addr_hit[14]: begin


### PR DESCRIPTION
For the software port only, the returned genbits will have a repeated data check before genbits are returned to the register interface.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>