### PR TITLE
[sw/silicon_creator] Add boot_data write support and functests

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.h
+++ b/sw/device/silicon_creator/lib/boot_data.h
@@ -119,6 +119,17 @@ static_assert(kBootDataIdentifier != kBootDataInvalidatedIdentifier,
  */
 rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data);
 
+/**
+ * Writes the given boot data to the flash info partition.
+ *
+ * This function updates the `identifier`, `counter`, and `digest` fields of the
+ * given `boot_data` before writing it to the flash.
+ *
+ * @param boot_data[out] Boot data.
+ * @return The result of the operation.
+ */
+rom_error_t boot_data_write(const boot_data_t *boot_data);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus


### PR DESCRIPTION
This PR adds write support for `boot_data` that is responsible for storing the data required for managing the chip's boot flow and ownership ([doc](https://docs.google.com/document/d/1zZqJVGfuHfmOE_IKImtfUApikre2jrOuaPAsNXHJKiQ/edit), [slides](https://docs.google.com/presentation/d/187_h7g1IDyliZMsJxU5jhIXConAps0LeRfXaTbKTPrE/edit#slide=id.p)).

The implementation currently uses the legacy `flash_ctrl` driver. I'm working on updating the mask rom `flash_ctrl` driver for integration.