### PR TITLE
[spi_device] Fix lint errors

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -548,6 +548,8 @@ module spi_device
   assign mailbox_addr   = { reg2hw.mailbox_addr.q[31:MailboxAw],
                             {MailboxAw{1'b0}}
                           };
+  logic unused_mailbox_addr;
+  assign unused_mailbox_addr = ^reg2hw.mailbox_addr.q[MailboxAw-1:0];
 
   // Passthrough config: value shall be stable while SPI transaction is active
   //assign cmd_filter = reg2hw.cmd_filter.q;

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -567,14 +567,17 @@ module spi_passthrough
   // rely on the synthesis tool not to generate the unneeded flops but must explicitly waive lint
   // warnings about unused fields.
   logic unused_cmd_info_fields;
-  assign unused_cmd_info_fields = &{1'b0,
-                                    cmd_info.opcode,
-                                    cmd_info.addr_en,
-                                    cmd_info.addr_swap_en,
-                                    cmd_info.addr_4b_affected,
-                                    cmd_info.opcode,
-                                    cmd_info.upload,
-                                    cmd_info.busy};
+  assign unused_cmd_info_fields = &{
+    1'b0,
+    cmd_info.valid, // valid bit is checked before latching into cmd_info
+    cmd_info.opcode,
+    cmd_info.addr_en,
+    cmd_info.addr_swap_en,
+    cmd_info.addr_4b_affected,
+    cmd_info.opcode,
+    cmd_info.upload,
+    cmd_info.busy
+  };
 
   always_comb begin
     cmd_info_d = '0;

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -191,6 +191,7 @@ module spi_readcmd
 
   logic unused_cmd_info_members;
   assign unused_cmd_info_members = ^{
+    cmd_info_i.valid,         // cmdparse checks the valid bit
     cmd_info_i.addr_en,       // Always assume Readcmd has addr_en set
     cmd_info_i.addr_swap_en,  // address swap feature is used in Passthrough
     cmd_info_i.opcode,        // Does not need to check opcode. (fixed slot)

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -187,6 +187,7 @@ module spid_upload
 
   logic unused_cmdinfo;
   assign unused_cmdinfo = ^{
+    cmd_info_i.valid,         // cmdparse checks the valid bit
     cmd_info_i.addr_swap_en,
     cmd_info_i.dummy_en,
     cmd_info_i.dummy_size,


### PR DESCRIPTION
After introducing the valid bit in cmd_info, lint error occurs (UNUSED).
This commit fixed the erros and also adding mailbox_addr LSBs to unused
signals.
