### PR TITLE
[bazel] add rules for new targets and fix unittest

### DIFF
--- a/sw/device/lib/base/freestanding/BUILD
+++ b/sw/device/lib/base/freestanding/BUILD
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "freestanding",
+    hdrs = [
+        "assert.h",
+        "float.h",
+        "iso646.h",
+        "limits.h",
+        "stdalign.h",
+        "stdarg.h",
+        "stdbool.h",
+        "stddef.h",
+        "stdint.h",
+        "stdnoreturn.h",
+    ],
+)

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -19,9 +19,9 @@ cc_library(
     ],
     deps = [
         ":base",
-        "//sw/device/lib/base",
         "//hw/ip/adc_ctrl/data:adc_ctrl_regs",
-    ]
+        "//sw/device/lib/base",
+    ],
 )
 
 cc_test(
@@ -40,7 +40,7 @@ cc_test(
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing",
         "@googletest//:gtest_main",
-    ]
+    ],
 )
 
 cc_library(
@@ -61,12 +61,12 @@ cc_library(
 cc_test(
     name = "clkmgr_unittest",
     srcs = [
-        "dif_clkmgr_unittest.cc",
         "autogen/dif_clkmgr_autogen.c",
         "autogen/dif_clkmgr_autogen.h",
         "autogen/dif_clkmgr_autogen_unittest.cc",
         "dif_clkmgr.c",
         "dif_clkmgr.h",
+        "dif_clkmgr_unittest.cc",
     ],
     defines = [
         "MOCK_MMIO=1",

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -7,7 +7,6 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
-#include "sw/device/lib/testing/entropy_testutils.h"
 
 extern "C" {
 #include "aes_regs.h"  // Generated.

--- a/sw/device/lib/runtime/hart.h
+++ b/sw/device/lib/runtime/hart.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_LIB_RUNTIME_HART_H_
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdnoreturn.h>
 
 #include "sw/device/lib/base/stdasm.h"

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/stdasm.h"


### PR DESCRIPTION
building with bazel I came across a few issues
* remove an included header that's only implemented for riscv targets
from the dif_aes_unittest
* added a freestanding library
* ran buildifier which caught a late change I missed on my last bazel
commit
* included stdint in a couple header files that use it.

Signed-off-by: Drew Macrae <drewmacrae@google.com>