### PR TITLE
[sw] handle DWARF5 sections

### DIFF
--- a/sw/device/info_sections.ld
+++ b/sw/device/info_sections.ld
@@ -65,6 +65,9 @@
 .debug_ranges 0x0 : { *(.debug_ranges) }
 .debug_str 0x0 : { *(.debug_str) }
 .debug_frame 0x0 : { *(.debug_frame) }
+.debug_line_str 0x0 : { *(.debug_line_str) }
+.debug_loclists 0x0 : { *(.debug_loclists) }
+.debug_rnglists 0x0 : { *(.debug_rnglists) }
 
 /* Discarded Sections (Not needed in device images). */
 /DISCARD/ : {


### PR DESCRIPTION
When (cross-)building with GCC 11, we are getting new DWARF5 debug
sections. Ensure they are properly handled by the linker script rather
than failing the build with warnings such as:
```
bin/ld: warning: orphan section `.debug_rnglists' from
`sw/device/lib/dif/libsw_lib_dif_spi_device.a(dif_spi_device.c.o)' being
placed in section `.debug_rnglists'
```

Fixes #9023

Signed-off-by: Vincent Palatin <vpalatin@rivosinc.com>