### PR TITLE
[cdc] Add initial support for VerixCDC

### DIFF
--- a/hw/cdc/tools/dvsim/cdc.mk
+++ b/hw/cdc/tools/dvsim/cdc.mk
@@ -1,0 +1,45 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+export SHELL	:= /bin/bash
+.DEFAULT_GOAL := all
+
+all: build
+
+###################
+## build targets ##
+###################
+build: build_result
+
+gen_sv_flist:
+	@echo "[make]: gen_sv_flist"
+	cd ${build_dir} && ${sv_flist_gen_cmd} ${sv_flist_gen_opts}
+
+pre_build: gen_sv_flist
+	@echo "[make]: pre_build"
+	mkdir -p ${build_dir}
+ifneq (${pre_build_cmds},)
+	cd ${build_dir} && ${pre_build_cmds}
+endif
+
+do_build: pre_build
+	@echo "[make]: do_build"
+	cd ${sv_flist_gen_dir} && ${build_cmd} ${build_opts} 2>&1 | tee ${build_log}
+
+post_build: do_build
+	@echo "[make]: post_build"
+ifneq (${post_build_cmds},)
+	cd ${build_dir} && ${post_build_cmds}
+endif
+
+build_result: post_build
+	@echo "[make]: build_result"
+	${report_cmd} ${report_opts}
+
+.PHONY: build \
+        gen_sv_flist \
+        pre_build \
+        do_build \
+        post_build \
+        build_result

--- a/hw/cdc/tools/dvsim/common_cdc_cfg.hjson
+++ b/hw/cdc/tools/dvsim/common_cdc_cfg.hjson
@@ -1,0 +1,72 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  flow:             cdc
+  cdc_root:         "{proj_root}/hw/cdc"
+  flow_makefile:    "{cdc_root}/tools/dvsim/cdc.mk"
+
+  import_cfgs:      [// Common server configuration for results upload
+                     "{proj_root}/hw/data/common_project_cfg.hjson",
+                     "{cdc_root}/tools/dvsim/{tool}.hjson"]
+
+  // Default directory structure for the output
+  dut:              "{name}"
+  params:           ""
+  build_dir:        "{scratch_path}/{build_mode}"
+  build_log:        "{build_dir}/cdc.log"
+
+  tool:             "verixcdc"
+
+  // We rely on Fusesoc to generate the file list for us
+  sv_flist_gen_cmd:   "fusesoc"
+  fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
+  sv_flist_gen_opts:  ["--cores-root {proj_root}",
+                       "run"
+                       "{sv_flist_gen_flags}",
+                       "--target=syn",
+                       "--tool icarus",
+                       "--build-root={build_dir}",
+                       "--setup",
+                       "{fusesoc_core}"]
+  sv_flist_gen_dir:   "{build_dir}/syn-icarus"
+  sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
+  sv_flist_gen_flags: ["--flag=fileset_{design_level}"]
+
+  // Determines which message severities to print into report summaries.
+  report_severities: ["review", "warning", "error"]
+  // Determines which message severities lead to a pass/fail.
+  fail_severities: ["review", "warning", "error"]
+  // Define message bucket categories and severities.
+  message_buckets: [
+    {category: "flow",  severity: "info",     label: ""},
+    {category: "flow",  severity: "warning",  label: ""},
+    {category: "flow",  severity: "error",    label: ""},
+    {category: "sdc",   severity: "info",     label: "SDC Infos"},
+    {category: "sdc",   severity: "review",   label: "SDC Reviews"},
+    {category: "sdc",   severity: "warning",  label: "SDC Warnings"},
+    {category: "sdc",   severity: "error",    label: "SDC Erros"}
+    {category: "setup", severity: "info",     label: ""},
+    {category: "setup", severity: "review",   label: ""},
+    {category: "setup", severity: "warning",  label: ""},
+    {category: "setup", severity: "error",    label: ""},
+    {category: "cdc",   severity: "info",     label: "CDC Infos"},
+    {category: "cdc",   severity: "review",   label: "CDC Reviews"},
+    {category: "cdc",   severity: "warning",  label: "CDC Warnings"},
+    {category: "cdc",   severity: "error",    label: "CDC Erros"}
+  ]
+  // Restrict the maximum message count in each bucket
+  max_msg_count: 1000
+
+  // TODO(#9079): Need to align with new parser mechanism.
+  build_fail_patterns: []
+
+  exports: [
+    { CDC_ROOT:     "{cdc_root}" },
+    { FOUNDRY_ROOT: "{foundry_root}" },
+    { BUILD_DIR:    "{build_dir}" },
+    { DUT:          "{dut}" },
+    { PARAMS:       "{params}" },
+    { SV_FLIST:     "{sv_flist}" }
+  ]
+}

--- a/hw/cdc/tools/dvsim/verixcdc.hjson
+++ b/hw/cdc/tools/dvsim/verixcdc.hjson
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Environment variables that are needed in the CDC script
+  exports: [
+    { CONSTRAINT:         "{sdc_file}" },
+    { FOUNDRY_CONSTRAINT: "{foundry_sdc_file}" },
+    { CDC_WAIVER_FILE:    "{cdc_waiver_file}" }
+    { ENV_FILE:           "{env_file}" }
+  ]
+
+  // Tool invocation
+  build_cmd:  "{job_prefix} vcdc "
+  build_opts: ["-i {cdc_root}/tools/{tool}/run-cdc.tcl"]
+
+  // CDC-specific results parsing script that is called after running the tool
+  report_cmd: "{proj_root}/util/dvsim/{tool}-report-parser.py"
+  report_opts: ["--repdir {build_dir} ",
+                "--outfile {build_dir}/results.hjson"]
+}

--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -1,0 +1,110 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+#####################
+##  PREPARE FLOW   ##
+#####################
+
+proc get_env_var {name} {
+  if {[info exists ::env($name)]} {
+    set val "[set ::env([set name])]"
+    puts "::env($name) = $val"
+    return $val
+  } else {
+    puts "ERROR: Script run without $name environment variable."
+    quit
+  }
+}
+
+set FOUNDRY_ROOT       [get_env_var "FOUNDRY_ROOT"]
+set SV_FLIST           [get_env_var "SV_FLIST"]
+set BUILD_DIR          [get_env_var "BUILD_DIR"]
+set DUT                [get_env_var "DUT"]
+set CONSTRAINT         [get_env_var "CONSTRAINT"]
+set FOUNDRY_CONSTRAINT [get_env_var "FOUNDRY_CONSTRAINT"]
+set PARAMS             [get_env_var "PARAMS"]
+set CDC_WAIVER_FILE    [get_env_var "CDC_WAIVER_FILE"]
+set ENV_FILE           [get_env_var "ENV_FILE"]
+
+# Used to disable some SDC constructs that are not needed by CDC.
+set IS_CDC_RUN 1
+
+########################
+## Library Setup      ##
+########################
+
+# if the foundry root is specified, some more library setup is needed.
+if {$FOUNDRY_ROOT != ""} {
+  # TODO: add lib setup tcl file here
+  # this PRIM_DEFAULT_IMPL selects the appropriate technology by defining
+  # PRIM_DEFAULT_IMPL=prim_pkg::Impl<tech identifier>
+  # PRIM_DEFAULT_IMPL is set inside the library setup script
+  set DEFINE "PRIM_DEFAULT_IMPL=${PRIM_DEFAULT_IMPL}+${PRIM_STD_CELL_VARIANT}"
+  source "${FOUNDRY_ROOT}/cdc/verixcdc/setup.tcl"
+} else {
+  set DEFINE ""
+}
+
+########################
+## Configure CDC Tool ##
+########################
+
+# TODO: potentially more settings are needed.
+# set ri_enable_sva false
+set ri_create_outputs_in_create_env true
+set ri_print_module_nand2_counts true
+# enable analysis of large arrays
+set ri_max_total_range_bits 100000
+
+#########################
+## Analyze & Elaborate ##
+#########################
+
+if {$DEFINE != ""} {
+  analyze -sverilog +define+${DEFINE} -f ${SV_FLIST}
+} else {
+  analyze -sverilog -f ${SV_FLIST}
+}
+
+if {$PARAMS != ""} {
+  elaborate -params "$PARAMS" $DUT
+} else {
+  elaborate $DUT
+}
+
+#########################
+## Apply Constraints   ##
+#########################
+
+read_sdc $CONSTRAINT
+if {$FOUNDRY_CONSTRAINT != ""} {
+  read_sdc $FOUNDRY_CONSTRAINT
+}
+
+############################
+## Apply Environment File ##
+############################
+
+if {$ENV_FILE != ""} {
+  read_env $ENV_FILE
+}
+
+#########################
+## Run CDC             ##
+#########################
+
+analyze_intent
+verify_cdc
+
+#########################
+## Read in Waivers     ##
+#########################
+
+source $CDC_WAIVER_FILE
+
+#########################
+## Write out report    ##
+#########################
+
+report_policy -verbose -skip_empty_summary_status -compat -output vcdc.rpt ALL

--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verix CDC waiver file
+
+# TODO: need to add more common waivers here. We may have to break this into
+# multiple files.
+#
+# set_rule_status -rule { S_CONF_ENV } -status { Waived } -expression { } \
+#   -comment {}
+# set_rule_status -rule { S_CONF_ENV } -status { Waived } -all_rule_data \
+#   -comment {}

--- a/hw/top_earlgrey/cdc/chip_earlgrey_asic_cdc_cfg.hjson
+++ b/hw/top_earlgrey/cdc/chip_earlgrey_asic_cdc_cfg.hjson
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Top level dut name (sv module).
+  name: chip_earlgrey_asic
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:systems:chip_earlgrey_asic:0.1
+
+  import_cfgs: [// Project wide common synthesis config file
+                "{proj_root}/hw/cdc/tools/dvsim/common_cdc_cfg.hjson"]
+
+  tool: verixcdc
+
+  // Overrides
+  overrides: [
+    {
+      name: design_level
+      value: "top"
+    }
+  ]
+
+  // Timing constraints for this module
+  sdc_file: "{proj_root}/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc"
+
+  // Verix environment file with additional definitions (may have to populate later)
+  env_file: ""
+
+  // Main CDC waiver file
+  cdc_waiver_file: "{proj_root}/hw/top_earlgrey/cdc/cdc_waivers.tcl"
+
+  // Technology path for this module (empty for open-source runs)
+  foundry_root: ""
+
+  // Technology specific timing constraints for this module (empty for open-source runs)
+  foundry_sdc_file: ""
+}

--- a/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
@@ -17,12 +17,15 @@ puts "Applying constraints for top level"
 # Architectural CGs #
 #####################
 
-# in synthesis, we treat all clock networks as ideal nets.
-# architecturally insterted CGs however can be interpreted as
-# sequential cells by the tool, hence stopping automatic propagation
-# of ideal network attributes. therefore, we go through the design and
-# declare all architectural CG outputs as ideal.
-set_ideal_network [get_pins -hier u_clkgate/Q]
+# This is not needed by CDC runs
+if {!$IS_CDC_RUN} {
+    # in synthesis, we treat all clock networks as ideal nets.
+    # architecturally insterted CGs however can be interpreted as
+    # sequential cells by the tool, hence stopping automatic propagation
+    # of ideal network attributes. therefore, we go through the design and
+    # declare all architectural CG outputs as ideal.
+    set_ideal_network [get_pins -hier u_clkgate/Q]
+}
 
 #####################
 # main clock        #
@@ -55,7 +58,7 @@ set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} [get_clocks USB_CLK]
 set USBDEV_IOMUX_PATH top_earlgrey/u_usbdev/i_usbdev_iomux/cdc_io_to_usb/gen_*u_impl_*/u_sync_1/gen_*u_impl*
 set USBDEV_OUTREG_PATH top_earlgrey/u_usbdev/usbdev_impl/u_usb_fs_nb_pe/u_usb_fs_tx
 # This requires knowledge of actual pin names, which are different depending on
-# whether we run this with tech libs or not.
+# whether we run this with tech lizbs or not.
 if {$FOUNDRY_ROOT != ""} {
     set USB_N_PIN  gen_flops[2]*.u_size_only_reg/D
     set USB_P_PIN  gen_flops[3]*.u_size_only_reg/D
@@ -67,7 +70,7 @@ if {$FOUNDRY_ROOT != ""} {
     set USB_P_PIN  d_i[3]
     set USB_PIN    d_i[1]
     set USB_D_PIN  u_usb_d_flop/gen_*u_impl*/q_o[0]
-    set USB_OE_PIN u_oe_flop_flop/gen_*u_impl*/q_o[0]
+    set USB_OE_PIN u_oe_flop/gen_*u_impl*/q_o[0]
 }
 
 set_max_delay 3 -from [get_ports USB_N] -to [get_pins ${USBDEV_IOMUX_PATH}/${USB_N_PIN}]
@@ -87,14 +90,27 @@ set IO_TCK_PERIOD [expr $IO_TCK_TARGET_PERIOD*$CLK_PERIOD_FACTOR]
 create_clock -name IO_CLK -period ${IO_TCK_PERIOD} [get_pins ${IO_CLK_PIN}]
 set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} [get_clocks IO_CLK]
 
-# generated clocks (div2/div4)
-create_generated_clock -name IO_DIV2_CLK -divide_by 2 \
-    -source [get_pins top_earlgrey/u_clkmgr_aon/u_no_scan_io_div2_div/u_clk_mux/gen_*u_impl*/u_size_only_mux2/D1] \
-    [get_pins top_earlgrey/u_clkmgr_aon/u_no_scan_io_div2_div/u_clk_mux/gen_*u_impl*/u_size_only_inv/${DRIVING_CELL_PIN}]
+# This requires knowledge of actual pin names, which are different depending on
+# whether we run this with tech libs or not.
+if {$FOUNDRY_ROOT != ""} {
+    set CLK_MUX_SRC_NAME u_size_only_mux2/D1
+    set CLK_MUX_DST_NAME u_size_only_inv/${DRIVING_CELL_PIN}
+} else {
+    # this is only used by SDC on generic views
+    set CLK_MUX_SRC_NAME clk0_i
+    set CLK_MUX_DST_NAME clk_o
+}
 
+# generated clocks (div2/div4)
+set CLK_MUX_PATH top_earlgrey/u_clkmgr_aon/u_no_scan_io_div2_div/u_clk_mux/gen_*u_impl*
+create_generated_clock -name IO_DIV2_CLK -divide_by 2 \
+    -source [get_pins ${CLK_MUX_PATH}/${CLK_MUX_SRC_NAME}] \
+            [get_pins ${CLK_MUX_PATH}/${CLK_MUX_DST_NAME}]
+
+set CLK_MUX_PATH top_earlgrey/u_clkmgr_aon/u_no_scan_io_div4_div/u_clk_mux/gen_*u_impl*
 create_generated_clock -name IO_DIV4_CLK -divide_by 4 \
-    -source [get_pins top_earlgrey/u_clkmgr_aon/u_no_scan_io_div4_div/u_clk_mux/gen_*u_impl*/u_size_only_mux2/D1] \
-    [get_pins top_earlgrey/u_clkmgr_aon/u_no_scan_io_div4_div/u_clk_mux/gen_*u_impl*/u_size_only_inv/${DRIVING_CELL_PIN}]
+    -source [get_pins ${CLK_MUX_PATH}/${CLK_MUX_SRC_NAME}] \
+            [get_pins ${CLK_MUX_PATH}/${CLK_MUX_DST_NAME}]
 
 # TODO: these are dummy constraints and likely incorrect, need to properly constrain min/max
 # note that due to the muxing, additional timing views with set_case_analysis may be needed.
@@ -223,7 +239,7 @@ set_output_delay ${SPI_DEV_OUT_DEL} [get_ports SPI_DEV_D3]   -clock SPI_DEV_CLK
 set_false_path -through [get_pins top_earlgrey/u_spi_device/cio_csb_i] \
                -through [get_pins top_earlgrey/u_spi_device/cio_sd_en_o*]
 set_false_path -through [get_pins top_earlgrey/u_spi_device/cio_csb_i] \
-    -through [get_pins top_earlgrey/u_spi_device/cio_sd_o*]
+               -through [get_pins top_earlgrey/u_spi_device/cio_sd_o*]
 
 ##################
 # SPI HOST clock #
@@ -234,15 +250,23 @@ set_false_path -through [get_pins top_earlgrey/u_spi_device/cio_csb_i] \
 # During pre-layout, the SPI_HOST_CLK source latencies are estimanted to account for
 # pad and logic latencies.  After CTS, source latency must be removed as all clocks are propagated
 
-set CLK_DIV_PIN top_earlgrey/u_spi_host0/u_spi_core/u_fsm/u_sck_flop/gen_*u_impl*/gen_flops[0]*.u_size_only_reg/Q
+# This requires knowledge of actual pin names, which are different depending on
+# whether we run this with tech libs or not.
+if {$FOUNDRY_ROOT != ""} {
+    set REG_PIN  gen_flops[0]*.u_size_only_reg/Q
+} else {
+    set REG_PIN  q_o[0]
+}
+
+set CLK_DIV_PIN top_earlgrey/u_spi_host0/u_spi_core/u_fsm/u_sck_flop/gen_*u_impl*/${REG_PIN}
 
 # internal divided by 2 clock (fastest spi host configuration)
 create_generated_clock -name SPI_HOST_INT_CLK -source [get_pins ${IO_CLK_PIN}] \
-    -divide_by 2 [get_pins ${CLK_DIV_PIN}] -add
+                       -divide_by 2 [get_pins ${CLK_DIV_PIN}]
 
 # cascaded generated clock on the port
 create_generated_clock -name SPI_HOST_CLK -source [get_pins ${CLK_DIV_PIN}] \
-    -divide_by 1 [get_ports SPI_HOST_CLK] -add
+                       -divide_by 1 [get_ports SPI_HOST_CLK]
 
 # Approximate source latency
 # The following must be removed after CTS when clocks actually propagate
@@ -411,20 +435,24 @@ set_false_path -from [get_ports IOC7] -to [get_ports IOR*]
 # I/O drive/load    #
 #####################
 
-# attach load and drivers to IOs to get a more realistic estimate
-set_driving_cell -no_design_rule -lib_cell ${DRIVING_PAD} -pin ${DRIVING_PAD_PIN} [all_inputs]
-set_load [load_of ${LOAD_PAD_LIB}/${LOAD_PAD}/${LOAD_PAD_PIN}] [all_outputs]
+# This is not needed by CDC runs
+if {!$IS_CDC_RUN} {
+    # attach load and drivers to IOs to get a more realistic estimate
+    set_driving_cell -no_design_rule -lib_cell ${DRIVING_PAD} -pin ${DRIVING_PAD_PIN} [all_inputs]
+    set_load [load_of ${LOAD_PAD_LIB}/${LOAD_PAD}/${LOAD_PAD_PIN}] [all_outputs]
+}
 
 ###################################
 # Size Only and Don't touch Cells #
 ###################################
 
-# this is for architectural clock buffers, inverters and muxes
-set_size_only -all_instances [get_cells -h *u_size_only*] true
-
-# do not touch pad cells
-set_dont_touch [get_cells -h *u_pad_macro*]
-
+# This is not needed by CDC runs
+if {!$IS_CDC_RUN} {
+    # this is for architectural clock buffers, inverters and muxes
+    set_size_only -all_instances [get_cells -h *u_size_only*] true
+    # do not touch pad cells
+    set_dont_touch [get_cells -h *u_pad_macro*]
+}
 puts "Done applying constraints for top level"
 
 ##########################################

--- a/util/dvsim/CdcCfg.py
+++ b/util/dvsim/CdcCfg.py
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r'''
+Class describing lint configuration object
+'''
+
+import logging as log
+from pathlib import Path
+
+from tabulate import tabulate
+
+from LintCfg import LintCfg
+from utils import subst_wildcards, check_bool
+from MsgBuckets import MsgBuckets
+
+
+class CdcCfg(LintCfg):
+    '''Derivative class for linting purposes.'''
+
+    flow = 'cdc'
+
+    def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
+        super().__init__(flow_cfg_file, hjson_data, args, mk_config)
+
+        self.results_title = f'{self.name.upper()} CDC Results'

--- a/util/dvsim/CfgFactory.py
+++ b/util/dvsim/CfgFactory.py
@@ -9,6 +9,7 @@ import os
 from CfgJson import load_hjson
 
 import FormalCfg
+import CdcCfg
 import LintCfg
 import SimCfg
 import SynCfg
@@ -40,6 +41,7 @@ def _load_cfg(path, initial_values):
                            .format(path))
 
     classes = [
+        CdcCfg.CdcCfg,
         LintCfg.LintCfg,
         SynCfg.SynCfg,
         FormalCfg.FormalCfg,

--- a/util/dvsim/LintCfg.py
+++ b/util/dvsim/LintCfg.py
@@ -37,8 +37,10 @@ class LintCfg(OneShotCfg):
 
         super().__init__(flow_cfg_file, hjson_data, args, mk_config)
 
-        # Convert to boolean if needed.
-        self.is_style_lint = check_bool(self.is_style_lint)
+        if self.is_style_lint == '':
+            self.is_style_lint = False
+        else:
+            self.is_style_lint = check_bool(self.is_style_lint)
 
         # Set the title for lint results.
         if self.is_style_lint:

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -286,7 +286,7 @@ def parse_args():
               "optional for running simulations (where it can "
               "be set in an .hjson file), but is required for "
               "other flows. Possible tools include: vcs, "
-              "xcelium, ascentlint, veriblelint, verilator, dc."))
+              "xcelium, ascentlint, verixcdc, veriblelint, verilator, dc."))
 
     parser.add_argument("--list",
                         "-l",

--- a/util/dvsim/verixcdc-report-parser.py
+++ b/util/dvsim/verixcdc-report-parser.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+r"""Parses cdc report and dump filtered messages in hjson format.
+"""
+import argparse
+import logging as log
+import re
+import sys
+import os
+import hjson
+
+from pathlib import Path
+from LintParser import LintParser
+
+
+def extract_rule_patterns(file_path: Path):
+    '''
+    This parses the CDC summary table to get the message totals,
+    rule names and corresponding severities.
+    '''
+
+    rule_patterns = []
+    full_file = ''
+    try:
+        with Path(file_path).open() as f:
+            full_file = f.read()
+    except IOError:
+        # We will attempt read this file again in a second pass to parse out
+        # the details, this error will get caught and reported.
+        pass
+
+    category = ''
+    severity = ''
+    known_rule_names = {}
+    total_msgs = 0
+    # extract the summary table
+    m = re.findall(
+        r'^Summary of Policy: ALL((?:.|\n|\r\n)*)Rule Details of Policy: ALL',
+        full_file, flags=re.MULTILINE)
+    if m:
+        # step through the table and identify rule names and their
+        # category and severity
+        for line in m[0].split('\n'):
+            if re.match(r'^POLICY\s+ALL', line):
+                total = re.findall(r'^POLICY\s+ALL\s+([0-9]+)', line)
+                total_msgs = int(total[0])
+            elif re.match(r'^ GROUP\s+SDC_ENV_LINT', line):
+                category = 'sdc'
+            elif re.match(r'^ GROUP\s+VCDC_SETUP_CHECKS', line):
+                category = 'setup'
+            elif re.match(r'^ GROUP\s+VCDC_ANALYSIS_CHECKS', line):
+                category = 'cdc'
+            elif re.match(r'^ GROUP\s+ERROR', line):
+                severity = 'error'
+            elif re.match(r'^ GROUP\s+WARNING', line):
+                severity = 'warning'
+            elif re.match(r'^ GROUP\s+INFO', line):
+                severity = 'info'
+            elif re.match(r'^ GROUP\s+REVIEW', line):
+                severity = 'review'
+            elif re.match(r'^  INSTANCE', line):
+                # we've found a new rule. convert it to a known rule pattern
+                # with the correct category and severity
+                rule = re.findall(
+                    r'^  INSTANCE\s+([a-zA-Z0-9\_]+)\s+([0-9\_]+)', line)
+                name = rule[0][0]
+                count = int(rule[0][1])
+                # a few rules produce messages with different severities but
+                # the same rule labels. for simplicity, we promote messages
+                # from lower severity buckets to the severity bucket where
+                # this rule name has first been encountered. since higher
+                # severity messages are listed first in this summary table, it
+                # is straightforward to check whether the rule name has
+                # already appeared in a higher severity bucket.
+                if name in known_rule_names:
+                    msg_group = known_rule_names[name]
+                    log.warning('Rule {} is reported in multiple severity '
+                                'classes. All messages of this rule are '
+                                'promoted to {}'.format(name, msg_group))
+
+                else:
+                    msg_group = category + '_' + severity
+                    known_rule_names.update({name: msg_group})
+                    rule_patterns.append((msg_group, r'^{}:.*'.format(name)))
+
+    return rule_patterns
+
+
+# Reuse the lint parser, but add more buckets.
+class CdcParser(LintParser):
+
+    def __init__(self) -> None:
+        self.buckets = {
+            'flow_info': [],
+            'flow_warning': [],
+            'flow_error': [],
+            'sdc_info': [],
+            'sdc_review': [],
+            'sdc_warning': [],
+            'sdc_error': [],
+            'setup_info': [],
+            'setup_review': [],
+            'setup_warning': [],
+            'setup_error': [],
+            'cdc_info': [],
+            'cdc_review': [],
+            'cdc_warning': [],
+            'cdc_error': [],
+            # this bucket is temporary and will be removed at the end of the
+            # parsing pass.
+            'fusesoc-error': []
+        }
+        self.severities = {
+            'flow_info': 'info',
+            'flow_warning': 'warning',
+            'flow_error': 'error',
+            'sdc_info': 'info',
+            'sdc_review': 'warning',
+            'sdc_warning': 'warning',
+            'sdc_error': 'error',
+            'setup_info': 'info',
+            'setup_review': 'warning',
+            'setup_warning': 'warning',
+            'setup_error': 'error',
+            'cdc_info': 'info',
+            'cdc_review': 'warning',
+            'cdc_warning': 'warning',
+            'cdc_error': 'error'
+        }
+
+
+# TODO(#9079): this script will be removed long term once the
+# parser has been merged with the Dvsim core code.
+def main():
+    parser = argparse.ArgumentParser(
+        description="""This script parses AscentLint log and report files from
+        a lint run, filters the messages and creates an aggregated result
+        .hjson file with lint messages and their severities.
+
+        The script returns nonzero status if any warnings or errors are
+        present.
+        """)
+    parser.add_argument('--repdir',
+                        type=lambda p: Path(p).resolve(),
+                        default="./",
+                        help="""The script searches the 'vcdc.log' and
+                        'vcdc.rpt' files in this directory.
+                        Defaults to './'""")
+
+    parser.add_argument('--outfile',
+                        type=lambda p: Path(p).resolve(),
+                        default="./results.hjson",
+                        help="""Path to the results Hjson file.
+                        Defaults to './results.hjson'""")
+
+    args = parser.parse_args()
+
+    # Define warning/error patterns for each logfile
+    parser_args = {}
+
+    # Patterns for lint.log
+    parser_args.update({
+        args.repdir.joinpath('build.log'): [
+        # If lint warnings have been found, the lint tool will exit
+        # with a nonzero status code and fusesoc will always spit out
+        # an error like
+        #
+        #    ERROR: Failed to build ip:core:name:0.1 : 'make' exited with an error code
+        #
+        # If we found any other warnings or errors, there's no point in
+        # listing this too. BUT we want to make sure we *do* see this
+        # error if there are no other errors or warnings, since that
+        # shows something has come unstuck. (Probably the lint tool
+        # spat out a warning that we don't understand)
+        ("fusesoc-error",
+         r"^ERROR: Failed to build .* : 'make' exited with an error code")
+        ]
+    })
+
+    # Patterns for vcdc.log
+    parser_args.update({
+        args.repdir.joinpath('syn-icarus/vcdc.log'): [
+            ("error", r"^FlexNet Licensing error.*"),
+            ("error", r"^Error: .*"),
+            ("error", r"^ERROR.*"),
+            ("error", r"^  ERR .*"),
+            ("warning", r"^Warning: .*"),
+            # We ignore several messages here:
+            # #25010: unused signals
+            # #25011: unused signals
+            # #25012: unused port
+            # #25013: unused signals
+            # #26038: unused or RTL constant
+            # #39035: parameter becomes local
+            # #39122: non-positive repeat
+            # #39491: parameter in package
+            ("warning", r"^  "
+                         "(?!WARN \[#25010\])"
+                         "(?!WARN \[#25011\])"
+                         "(?!WARN \[#25012\])"
+                         "(?!WARN \[#25013\])"
+                         "(?!WARN \[#26038\])"
+                         "(?!WARN \[#39035\])"
+                         "(?!WARN \[#39122\])"
+                         "(?!WARN \[#39491\])"
+                         "WARN .*"),
+            ("info", r"^  INFO .*")
+        ]
+    })
+
+    # The CDC messages are a bit more involved to parse out, since we
+    # need to know the names and associated severities to do this.
+    # The tool prints out an overview table in the report, which we are
+    # going to parse first in order to get this information.
+    # This is then used to construct the regex patterns to look for
+    # in a second pass to get the actual CDC messages.
+    cdc_rule_patterns = extract_rule_patterns(
+        args.repdir.joinpath('syn-icarus/vcdc.rpt'))
+
+    # Patterns for vcdc.rpt
+    parser_args.update({
+        args.repdir.joinpath('syn-icarus/vcdc.rpt'): cdc_rule_patterns
+    })
+
+    # Parse logs
+    parser = CdcParser()
+    num_messages = parser.get_results(parser_args)
+
+    # Write out results file
+    parser.write_results_as_hjson(args.outfile)
+
+    # return nonzero status if any warnings or errors are present
+    # lint infos do not count as failures
+    if num_messages['error'] > 0 or num_messages['warning'] > 0:
+        log.info("Found %d lint errors and %d lint warnings",
+                 num_messages['error'],
+                 num_messages['warning'])
+        sys.exit(1)
+
+    log.info("Lint logfile parsed succesfully")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This reuses the `LintCfg` flow from DVsim and introduces a flow configuration for CDC runs with VerixCDC.

Although the flow reuses the `LintCfg` class for reporting purposes, the actual setup in terms of run scripts is more similar to the synthesis flow since the CDC flow relies on an SDC file and a more involved run`script (i.e., the tool is not run directly through FuseSoC as the other lint tools are).

CDC waivers have to be specified in one common waiver TCL file at the moment, although we are likely going to split this out into multiple waiver files to make this more manageable.

This PR also tunes the open-source SDC file a bit so that it can be shared between synthesis and CDC.
In particular
- we have to omit certain constraints like `size_only` in CDC runs, since the tool does not understand them,
- and we have to change the hierarchical paths of hookup buffers/regs since in case the open-source view is used (this is currently done by checking whether the foundry lib path has been specified or not).

-------------------------------------------------------

~~Note that this PR is dependent on an update of the LintCfg class and associated lint parser scripts (#8907), and some SDC updates and hookup buffer changes in #9032~~.

Hence, only the last three commits are relevant here.