### PR TITLE
[sw/silicon_creator] flash_ctrl changes

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -13,6 +13,24 @@
 #include "flash_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+static_assert(kFlashCtrlRegionData == 0u,
+              "Incorrect enum value for kFlashCtrlRegionData");
+static_assert(kFlashCtrlRegionInfo0 ==
+                  1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT,
+              "Incorrect enum value for kFlashCtrlRegionInfo0");
+static_assert(kFlashCtrlRegionInfo1 ==
+                  (1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT |
+                   1u << FLASH_CTRL_CONTROL_INFO_SEL_OFFSET),
+              "Incorrect enum value for kFlashCtrlRegionInfo1");
+static_assert(kFlashCtrlRegionInfo2 ==
+                  (1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT |
+                   2u << FLASH_CTRL_CONTROL_INFO_SEL_OFFSET),
+              "Incorrect enum value for kFlashCtrlRegionInfo2");
+static_assert(kFlashCtrlErasePage == 0u,
+              "Incorrect enum value for kFlashCtrlErasePage");
+static_assert(kFlashCtrlEraseBank == 1u << FLASH_CTRL_CONTROL_ERASE_SEL_BIT,
+              "Incorrect enum value for kFlashCtrlEraseBank");
+
 enum {
   kBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR,
 };
@@ -37,25 +55,6 @@ static rom_error_t transaction_start(uint32_t addr, uint32_t word_count,
   // Set the operation of the transaction: read, program, or erase.
   uint32_t control_reg_val =
       bitfield_field32_write(0, FLASH_CTRL_CONTROL_OP_FIELD, op);
-
-  // Ensure special enum values match register definitions.
-  static_assert(kFlashCtrlRegionData == 0u,
-                "Incorrect enum value for kFlashCtrlRegionData");
-  static_assert(
-      kFlashCtrlRegionInfo0 == 1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT,
-      "Incorrect enum value for kFlashCtrlRegionInfo0");
-  static_assert(
-      kFlashCtrlRegionInfo1 == (1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT |
-                                1u << FLASH_CTRL_CONTROL_INFO_SEL_OFFSET),
-      "Incorrect enum value for kFlashCtrlRegionInfo1");
-  static_assert(
-      kFlashCtrlRegionInfo2 == (1u << FLASH_CTRL_CONTROL_PARTITION_SEL_BIT |
-                                2u << FLASH_CTRL_CONTROL_INFO_SEL_OFFSET),
-      "Incorrect enum value for kFlashCtrlRegionInfo2");
-  static_assert(kFlashCtrlErasePage == 0u,
-                "Incorrect enum value for kFlashCtrlErasePage");
-  static_assert(kFlashCtrlEraseBank == 1u << FLASH_CTRL_CONTROL_ERASE_SEL_BIT,
-                "Incorrect enum value for kFlashCtrlEraseBank");
 
   // Set the partition.
   control_reg_val |= (uint32_t)region;

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -65,19 +65,19 @@ typedef enum flash_crtl_partition {
   /**
    * Select the data partition.
    */
-  kFlashCtrlRegionData = 0x0000,
+  kFlashCtrlPartitionData = 0x0000,
   /**
    * Select the info partition of type 0.
    */
-  kFlashCtrlRegionInfo0 = 0x0100,
+  kFlashCtrlPartitionInfo0 = 0x0100,
   /**
    * Select the info partition of type 1.
    */
-  kFlashCtrlRegionInfo1 = 0x0300,
+  kFlashCtrlPartitionInfo1 = 0x0300,
   /**
    * Select the info partition of type 2.
    */
-  kFlashCtrlRegionInfo2 = 0x0500,
+  kFlashCtrlPartitionInfo2 = 0x0500,
 } flash_ctrl_partition_t;
 
 /**
@@ -103,18 +103,7 @@ typedef enum flash_crtl_partition {
  * otherwise.
  */
 rom_error_t flash_ctrl_read(uint32_t addr, uint32_t word_count,
-                            flash_ctrl_partition_t region, uint32_t *data);
-
-typedef enum flash_ctrl_erase_type {
-  /**
-   * Erase a page.
-   */
-  kFlashCtrlErasePage = 0x0000,
-  /**
-   * Erase a bank.
-   */
-  kFlashCtrlEraseBank = 0x0080,
-} flash_ctrl_erase_type_t;
+                            flash_ctrl_partition_t partition, uint32_t *data);
 
 /**
  * Perform a program transaction.
@@ -137,8 +126,19 @@ typedef enum flash_ctrl_erase_type {
  * otherwise.
  */
 rom_error_t flash_ctrl_prog(uint32_t addr, uint32_t word_count,
-                            flash_ctrl_partition_t region,
+                            flash_ctrl_partition_t partition,
                             const uint32_t *data);
+
+typedef enum flash_ctrl_erase_type {
+  /**
+   * Erase a page.
+   */
+  kFlashCtrlEraseTypePage = 0x0000,
+  /**
+   * Erase a bank.
+   */
+  kFlashCtrlEraseTypeBank = 0x0080,
+} flash_ctrl_erase_type_t;
 
 /**
  * Invoke a blocking erase transaction.
@@ -158,8 +158,8 @@ rom_error_t flash_ctrl_prog(uint32_t addr, uint32_t word_count,
  * transaction, `kErrorFlashCtrlInternal` if the operations fails, `kErrorOk`
  * otherwise.
  */
-rom_error_t flash_ctrl_erase(uint32_t addr, flash_ctrl_partition_t region,
-                             flash_ctrl_erase_type_t type);
+rom_error_t flash_ctrl_erase(uint32_t addr, flash_ctrl_partition_t partition,
+                             flash_ctrl_erase_type_t erase_type);
 
 typedef enum flash_ctrl_exec {
   kFlashCtrlExecDisable = kMultiBitBool4False,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -65,19 +65,19 @@ typedef enum flash_crtl_partition {
   /**
    * Select the data partition.
    */
-  kFlashCtrlPartitionData = 0x0000,
+  kFlashCtrlPartitionData = 0,
   /**
    * Select the info partition of type 0.
    */
-  kFlashCtrlPartitionInfo0 = 0x0100,
+  kFlashCtrlPartitionInfo0 = (0 << 1) | 1,
   /**
    * Select the info partition of type 1.
    */
-  kFlashCtrlPartitionInfo1 = 0x0300,
+  kFlashCtrlPartitionInfo1 = (1 << 1) | 1,
   /**
    * Select the info partition of type 2.
    */
-  kFlashCtrlPartitionInfo2 = 0x0500,
+  kFlashCtrlPartitionInfo2 = (2 << 1) | 1,
 } flash_ctrl_partition_t;
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -76,10 +76,9 @@ class TransferTest : public FlashCtrlTest {
 
   void ExpectWaitForDone(bool done, bool error) {
     EXPECT_ABS_READ32(base_ + FLASH_CTRL_OP_STATUS_REG_OFFSET,
-                      {{FLASH_CTRL_OP_STATUS_DONE_BIT, done}});
+                      {{FLASH_CTRL_OP_STATUS_DONE_BIT, done},
+                       {FLASH_CTRL_OP_STATUS_ERR_BIT, error}});
     if (done) {
-      EXPECT_ABS_READ32(base_ + FLASH_CTRL_OP_STATUS_REG_OFFSET,
-                        {{FLASH_CTRL_OP_STATUS_ERR_BIT, error}});
       EXPECT_ABS_WRITE32(base_ + FLASH_CTRL_OP_STATUS_REG_OFFSET, 0u);
     }
   }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -114,20 +114,21 @@ class TransferTest : public FlashCtrlTest {
 
 TEST_F(TransferTest, ReadBusy) {
   ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_read(0, 0, kFlashCtrlRegionData, NULL),
+  EXPECT_EQ(flash_ctrl_read(0, 0, kFlashCtrlPartitionData, NULL),
             kErrorFlashCtrlBusy);
 }
 
 TEST_F(TransferTest, ProgBusy) {
   ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_prog(0, 4, kFlashCtrlRegionData, NULL),
+  EXPECT_EQ(flash_ctrl_prog(0, 4, kFlashCtrlPartitionData, NULL),
             kErrorFlashCtrlBusy);
 }
 
 TEST_F(TransferTest, EraseBusy) {
   ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_erase(0, kFlashCtrlRegionData, kFlashCtrlErasePage),
-            kErrorFlashCtrlBusy);
+  EXPECT_EQ(
+      flash_ctrl_erase(0, kFlashCtrlPartitionData, kFlashCtrlEraseTypePage),
+      kErrorFlashCtrlBusy);
 }
 
 TEST_F(TransferTest, ReadDataOk) {
@@ -136,7 +137,7 @@ TEST_F(TransferTest, ReadDataOk) {
   ExpectReadData(words_);
   ExpectWaitForDone(true, false);
   std::vector<uint32_t> words_out(words_.size());
-  EXPECT_EQ(flash_ctrl_read(0x01234567, words_.size(), kFlashCtrlRegionData,
+  EXPECT_EQ(flash_ctrl_read(0x01234567, words_.size(), kFlashCtrlPartitionData,
                             &words_out.front()),
             kErrorOk);
   EXPECT_EQ(words_out, words_);
@@ -147,7 +148,7 @@ TEST_F(TransferTest, ProgDataOk) {
                       words_.size());
   ExpectProgData(words_);
   ExpectWaitForDone(true, false);
-  EXPECT_EQ(flash_ctrl_prog(0x01234567, words_.size(), kFlashCtrlRegionData,
+  EXPECT_EQ(flash_ctrl_prog(0x01234567, words_.size(), kFlashCtrlPartitionData,
                             &words_.front()),
             kErrorOk);
 }
@@ -156,9 +157,9 @@ TEST_F(TransferTest, EraseDataPageOk) {
   ExpectTransferStart(0, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_ERASE, 0x01234567,
                       1);
   ExpectWaitForDone(true, false);
-  EXPECT_EQ(
-      flash_ctrl_erase(0x01234567, kFlashCtrlRegionData, kFlashCtrlErasePage),
-      kErrorOk);
+  EXPECT_EQ(flash_ctrl_erase(0x01234567, kFlashCtrlPartitionData,
+                             kFlashCtrlEraseTypePage),
+            kErrorOk);
 }
 
 TEST_F(TransferTest, ProgAcrossWindows) {
@@ -196,7 +197,7 @@ TEST_F(TransferTest, ProgAcrossWindows) {
   EXPECT_EQ(iter + half_step, many_words.end());
 
   EXPECT_EQ(flash_ctrl_prog(kWinSize / 2, many_words.size(),
-                            kFlashCtrlRegionData, &many_words.front()),
+                            kFlashCtrlPartitionData, &many_words.front()),
             kErrorOk);
 }
 
@@ -206,7 +207,7 @@ TEST_F(TransferTest, TransferInternalError) {
   ExpectReadData(words_);
   ExpectWaitForDone(true, true);
   std::vector<uint32_t> words_out(words_.size());
-  EXPECT_EQ(flash_ctrl_read(0x01234567, words_.size(), kFlashCtrlRegionData,
+  EXPECT_EQ(flash_ctrl_read(0x01234567, words_.size(), kFlashCtrlPartitionData,
                             &words_out.front()),
             kErrorFlashCtrlInternal);
 }


### PR DESCRIPTION
This PR includes some `flash_ctrl` changes that don't depend on #9015 (split into multiple commits):
* Move static_asserts out of `transaction_start()`,
* Remove `check_errors()` from `flash_ctrl.c` since we can use `OP_STATUS.ERR` that we already read,
* Rename some enums and parameters for consistency,
* Improve `transaction_start()` interface by introducing a `transaction_params_t` struct (also modifies the values of `flash_ctrl_partition_t` constants),
* Add missing comments for `fifo_push()` and `fifo_read()` (skipped `is_busy()` because I think we should remove it, will be addressed in another PR).
* Simplify `flash_ctrl_prog()` loop by moving the word_count calculation for the first write out of the loop.